### PR TITLE
Don't allow removing events that have people registered for them.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -66,6 +66,16 @@ class Competition < ActiveRecord::Base
     end
   end
 
+  validate :cannot_remove_event_with_registrants
+  def cannot_remove_event_with_registrants
+    if eventSpecs_change
+      removed_events_with_registrations = registrations.all.map { |r| (r.events - self.events) }.flatten(1).uniq
+      if removed_events_with_registrations.length > 0
+        errors.add(:eventSpecs, "There are still people registered for #{removed_events_with_registrations.map(&:name).to_sentence}")
+      end
+    end
+  end
+
   before_validation :clone_competition, on: [:create]
   def clone_competition
     if competition_id_to_clone.present?

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe Competition do
     expect(competition.events.map(&:id)).to eq [ "333", "444" ]
   end
 
+  it "doesn't allow removing an event with registrations" do
+    competition = FactoryGirl.create :competition, :registration_open, eventSpecs: "333 444"
+    registration = FactoryGirl.create :registration, eventIds: "444", competition: competition
+    competition.eventSpecs = "333"
+    expect(competition.save).to eq false
+    expect(competition.errors.messages[:eventSpecs]).to eq ["There are still people registered for 4x4 Cube"]
+  end
+
   it "validates event ids" do
     competition = FactoryGirl.build :competition, eventSpecs: "333 333wtf"
     expect(competition).to be_invalid


### PR DESCRIPTION
This fixes #377.

We should also clear up our database to remove any registrations for events that weren't offered. Here's what I see currently in the database:

```ruby
irb(main):004:0> Competition.all.map { |c| [ c.id, c.registrations.all.map { |r| (r.events - c.events).map(&:id) }.flatten(1).uniq ] }.reject { |c_events| c_events[1].length == 0 }
=> [["360DegreeWellnessOpen2014", ["minx"]], ["ArchenaOpen2014", ["555bf"]], ["ArchenaOpen2015", ["555bf"]], ["AsturiasOpen2015", ["555bf"]], ["BahiaInglesaSummer2010", ["333oh"]], ["BarcelonaFMEOpen2015", ["555bf"]], ["BarcelonaWinterOpen2012", ["444bf"]], ["BasauriOpen2013", ["444bf"]], ["BigCubesSummer2009", ["magic"]], ["Borneo2010", ["magic"]], ["BulacanOpen2009", ["333mbf"]], ["Cagayan2012", ["555", "333bf", "333mbf"]], ["CannesOpen2013", ["magic", "mmagic"]], ["CastellonOpen2011", ["555bf"]], ["CCCAutumnOpen2014", ["333fm"]], ["CebuMasters2009", ["333bf", "sq1", "clock", "333mbf", "magic"]], ["CebuOpen2009", ["333mbf"]], ["CebuOpen2010", ["minx", "666", "magic"]], ["CelebesOpen2013", ["444bf"]], ["CerbunaOpen2015", ["555bf"]], ["CGJVSpeedcubingOpen2015", ["skewb"]], ["ChampagneOpen2014", ["333ft", "clock"]], ["ChampagneOpen2015", ["sq1"]], ["ClashOfCubersDavao2015", ["minx"]], ["CubaoOpen2013", ["555"]], ["DanishSpecial2009", ["555bf"]], ["DanishSpecial2013", ["666"]], ["DolmenOpen2012", ["clock", "pyram"]], ["DrexelWinter2010", ["mmagic"]], ["DubaiOpen2009", ["333bf", "333oh"]], ["Dvina32015", ["555bf"]], ["EkbOpen2015", ["555bf"]], ["EstonianOpen2013", ["555bf"]], ["EuskadiOpen2014", ["333ft"]], ["FinnishChampionship2014", ["sq1", "666", "777"]], ["FinnishOpen2010", ["666", "777"]], ["FinnishOpen2011", ["333ft", "sq1"]], ["FinnishOpen2012", ["333ft"]], ["FinnishOpen2013", ["333mbf"]], ["FortalezaOpen2013", ["333fm"]], ["FortLeeWinter2009", ["333mbf", "444bf"]], ["FrenchOpen2010", ["333fm", "666", "777", "444bf", "555bf", "333mbf"]], ["GaleriesDorianOpen2014", ["555"]], ["GijonOpen2014", ["444bf"]], ["GoianiaOpen2012", ["555bf"]], ["GoianiaOpen2013", ["444bf", "555bf"]], ["HalloweenOpen2010", ["pyram"]], ["HelsinkiOpen2009", ["333ft", "222"]], ["HelsinkiOpen2010", ["555"]], ["HoChiMinh2013", ["minx"]], ["HoChiMinhCityOpen2010", ["333fm"]], ["HungarianNationals2016", ["333fm"]], ["ItalianOpen2012", ["333ft"]], ["ItalianOpen2013", ["333ft"]], ["JawaTimurOpen2014", ["sq1"]], ["KharkivSpecial2015", ["pyram"]], ["KirkkonummiOpen2016", ["333fm"]], ["KotkaOpen2011", ["333fm", "magic", "mmagic", "444bf", "555bf"]], ["KubeKingsWeekend2015", ["333ft"]], ["LatvianOpen2013", ["clock"]], ["LutskOpen2013", ["555"]], ["MADCubeWeekend2015", ["555bf"]], ["MadridOpen2009", ["333fm", "333ft"]], ["MagicOpen2011", ["magic", "mmagic"]], ["Mallorca2014", ["555bf"]], ["MantuaOpen2010", ["mmagic"]], ["MarikinaCity2014", ["333oh", "444", "555", "333bf", "minx", "sq1", "333mbf"]], ["MilanBlindDay2011", ["222", "333oh", "666"]], ["MITFall2009", ["555bf"]], ["MoldavianNationalsWinter2016", ["333bf"]], ["MoscowSouthWestOpen2015", ["333fm"]], ["MoscowSpringOpen2015", ["sq1"]], ["MossoroOpen2013", ["333fm"]], ["MPEIOpen2010", ["sq1"]], ["MumbaiOpen2011", ["333mbf"]], ["NantesOpen2009", ["666", "777"]], ["NaonedOpen2012", ["666"]], ["NeptuneOpen2011", ["666", "777"]], ["NorwegianChampionship2014", ["555bf"]], ["NovoHamburgoII2012", ["sq1"]], ["OdessaOpen2014", ["333fm"]], ["OficinaOpen2012", ["333fm", "444bf"]], ["OleksandriiaOpen2014", ["333fm", "333ft", "minx", "sq1", "clock", "666", "777"]], ["PhilippineOpen2013", ["333mbf"]], ["PhilippineOpen2014", ["333fm", "333ft", "444bf"]], ["PhilippineOpen2015", ["555bf"]], ["PistayDayat2014", ["333oh"]], ["PodolianOpen2012", ["clock"]], ["PueblaOpen2009", ["444bf"]], ["RizalOpen2009", ["333mbf", "mmagic"]], ["RobinsonsGalleriaOpen2011", ["magic"]], ["Roraima2012", ["minx"]], ["SafeHaven2010", ["555"]], ["SaintPetersburgOpen2009", ["666", "777"]], ["SaintPetersburgWelcomeTo2016", ["444bf", "555bf", "333mbf", "333ft"]], ["SanPabloCityOpen2013", ["555", "333bf"]], ["SantaremOpen2015", ["333oh"]], ["SantiagoOpen2009", ["333mbf"]], ["ShaastraOpen2011", ["333mbf"]], ["SpanishChampionship2009", ["333fm"]], ["StockholmOpen2014", ["777"]], ["TallinnOpen2011", ["mmagic"]], ["TCAChampionship2011", ["333fm"]], ["TelesisOpen2014", ["sq1"]], ["ThailandChampionship2013", ["444bf"]], ["TrinomaOpen2011", ["555"]], ["TunisiaOpen2014", ["444", "555"]], ["UkraineOpen2012", ["333fm"]], ["UkrainianNationals2014", ["555bf"]], ["UkrainianOpen2015", ["555bf"]], ["UPennSpring2009", ["pyram"]], ["UPVOpen2014", ["555bf"]], ["UralWinter2015", ["444bf"]], ["UtahSummer2010", ["444bf", "mmagic"]], ["VantaaOpen2013", ["333ft"]], ["VargardaOpen2012", ["666", "777"]], ["VilladeCatral2014", ["333fm"]], ["YuzhnoukrainskOpen2015", ["minx"]], ["ZaragozaOpen2016", ["555bf"]]]
```