### PR TITLE
Results wiki

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -51,3 +51,4 @@
 @import "search_results";
 @import "delegate_reports";
 @import "competition_tabs";
+@import "wiki_pages";

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -342,3 +342,12 @@ textarea {
 .CodeMirror-scroll {
   min-height: 50px;
 }
+
+.markdown-editor.large {
+  ~ .CodeMirror {
+    &,
+    .CodeMirror-scroll {
+      min-height: 200px;
+    }
+  }
+};

--- a/WcaOnRails/app/assets/stylesheets/wiki_pages.scss
+++ b/WcaOnRails/app/assets/stylesheets/wiki_pages.scss
@@ -1,0 +1,26 @@
+.wiki-page {
+  .title {
+    @extend h1;
+
+    &:after {
+      content: '';
+      display: block;
+      border: 3px solid $blue;
+      margin-top: 10px;
+      width: 50px;
+      border-radius: 2px;
+    }
+  }
+
+  .content {
+    margin: 20px 0;
+  }
+
+  .info {
+    font-style: italic;
+  }
+
+  .actions {
+    margin-top: 20px;
+  }
+}

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -39,16 +39,15 @@ class WikiPagesController < ApplicationController
 
   def destroy
     WikiPage.find(params[:id]).destroy
-    flash[:success] = "Wiki page successfully deleted.";
+    flash[:success] = "Wiki page successfully deleted."
     redirect_to wiki_url
   end
 
-  private
-    def wiki_page_params
-      params.require(:wiki_page).permit(:title, :content)
-    end
+  private def wiki_page_params
+    params.require(:wiki_page).permit(:title, :content)
+  end
 
-    def wiki_from_params
-      WikiPage.find(params[:id])
-    end
+  private def wiki_from_params
+    WikiPage.find(params[:id])
+  end
 end

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -1,20 +1,46 @@
 class WikiPagesController < ApplicationController
   def index
+    @wiki_pages = WikiPage.all
   end
 
   def new
+    @wiki_page = current_user.wiki_pages.build
   end
 
   def create
+    @wiki_page = current_user.wiki_pages.build(wiki_page_params)
+
+    if @wiki_page.save
+      flash[:success] = "Wiki page successfully created."
+      redirect_to wiki_page_url(@wiki_page)
+    else
+      render :new
+    end
+  end
+
+  def show
+    @wiki_page = WikiPage.find(params[:id])
   end
 
   def edit
+    @wiki_page = WikiPage.find(params[:id])
   end
 
   def update
+    @wiki_page = WikiPage.find(params[:id])
+
+    if @wiki_page.update(wiki_page_params)
+      flash[:success] = "Wiki page successfully updated."
+      redirect_to wiki_page_url(@wiki_page)
+    else
+      render :edit
+    end
   end
 
   def destroy
+    WikiPage.find(params[:id]).destroy
+    flash[:success] = "Wiki page successfully deleted.";
+    redirect_to wiki_url
   end
 
   private

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -1,4 +1,10 @@
 class WikiPagesController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { redirect_unless_user(:can_view_wiki?) }
+  before_action -> { redirect_unless_user(:can_manage_wiki?) }, only: %i(
+    new create edit update destroy
+  )
+
   def index
     @wiki_pages = WikiPage.all
   end

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -19,15 +19,15 @@ class WikiPagesController < ApplicationController
   end
 
   def show
-    @wiki_page = WikiPage.find(params[:id])
+    @wiki_page = wiki_from_params
   end
 
   def edit
-    @wiki_page = WikiPage.find(params[:id])
+    @wiki_page = wiki_from_params
   end
 
   def update
-    @wiki_page = WikiPage.find(params[:id])
+    @wiki_page = wiki_from_params
 
     if @wiki_page.update(wiki_page_params)
       flash[:success] = "Wiki page successfully updated."
@@ -46,5 +46,9 @@ class WikiPagesController < ApplicationController
   private
     def wiki_page_params
       params.require(:wiki_page).permit(:title, :content)
+    end
+
+    def wiki_from_params
+      WikiPage.find(params[:id])
     end
 end

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -46,7 +46,7 @@ class WikiPagesController < ApplicationController
   def destroy
     WikiPage.find(params[:id]).destroy
     flash[:success] = "Wiki page successfully deleted."
-    redirect_to wiki_url
+    redirect_to wiki_pages_url
   end
 
   private def wiki_page_params

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class WikiPagesController < ApplicationController
   before_action :authenticate_user!
   before_action -> { redirect_unless_user(:can_view_wiki?) }

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -1,0 +1,24 @@
+class WikiPagesController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+    def wiki_page_params
+      params.require(:wiki_page).permit(:title, :content)
+    end
+end

--- a/WcaOnRails/app/controllers/wiki_pages_controller.rb
+++ b/WcaOnRails/app/controllers/wiki_pages_controller.rb
@@ -45,7 +45,7 @@ class WikiPagesController < ApplicationController
   end
 
   def destroy
-    WikiPage.find(params[:id]).destroy
+    WikiPage.find(params[:id]).destroy!
     flash[:success] = "Wiki page successfully deleted."
     redirect_to wiki_pages_url
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -20,6 +20,8 @@ class User < ActiveRecord::Base
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
   has_many :user_preferred_events, dependent: :destroy
   has_many :preferred_events, through: :user_preferred_events, source: :event
+  has_many :user_preferred_events
+  has_many :wiki_pages, foreign_key: :author_id
 
   accepts_nested_attributes_for :user_preferred_events, allow_destroy: true
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -431,6 +431,10 @@ class User < ActiveRecord::Base
     board_member? || senior_delegate? || admin?
   end
 
+  # Now we have single wiki and it's meant for Results Team.
+  alias can_manage_wiki? results_team?
+  alias can_view_wiki? results_team?
+
   def get_cannot_delete_competition_reason(competition)
     # Only allow results admins and competition delegates to delete competitions.
     if !can_manage_competition?(competition)

--- a/WcaOnRails/app/models/wiki_page.rb
+++ b/WcaOnRails/app/models/wiki_page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class WikiPage < ActiveRecord::Base
   belongs_to :author, class_name: 'User', foreign_key: :author_id
 

--- a/WcaOnRails/app/models/wiki_page.rb
+++ b/WcaOnRails/app/models/wiki_page.rb
@@ -3,4 +3,5 @@ class WikiPage < ActiveRecord::Base
 
   validates :title, presence: true
   validates :content, presence: true
+  validates :author, presence: true
 end

--- a/WcaOnRails/app/models/wiki_page.rb
+++ b/WcaOnRails/app/models/wiki_page.rb
@@ -1,3 +1,6 @@
 class WikiPage < ActiveRecord::Base
   belongs_to :author, class_name: 'User', foreign_key: :author_id
+
+  validates :title, presence: true
+  validates :content, presence: true
 end

--- a/WcaOnRails/app/models/wiki_page.rb
+++ b/WcaOnRails/app/models/wiki_page.rb
@@ -1,0 +1,3 @@
+class WikiPage < ActiveRecord::Base
+  belongs_to :author, class_name: 'User', foreign_key: :author_id
+end

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -129,7 +129,7 @@
                 <li role="presentation" class="dropdown-header">
                   <%= t '.results_team' %>
                 </li>
-                <li><%= link_to t('.wiki'), wiki_path %></li>
+                <li><%= link_to t('.wiki'), wiki_pages_path %></li>
                 <li><%= link_to t('.results_admin'), admin_path %></li>
                 <li><%= link_to t('.competitions'), competitions_path %></li>
                 <li><%= link_to t('.results_phpmyadmin'), '/results/admin/phpMyAdmin/' %></li>

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -150,7 +150,7 @@
               <% end %>
 
               <li class="divider"></li>
-              <li><%= link_to t('.wiki'), wiki_pages_path %></li>
+              <li><%= link_to t('.wiki'), wiki_path %></li>
               <li><%= link_to t('.api'), api_path %></li>
               <li><%= link_to t('.manage_app'), oauth_applications_path %></li>
               <li><%= link_to t('.manage_auth_app'), oauth_authorized_applications_path %></li>

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -129,6 +129,7 @@
                 <li role="presentation" class="dropdown-header">
                   <%= t '.results_team' %>
                 </li>
+                <li><%= link_to t('.wiki'), wiki_path %></li>
                 <li><%= link_to t('.results_admin'), admin_path %></li>
                 <li><%= link_to t('.competitions'), competitions_path %></li>
                 <li><%= link_to t('.results_phpmyadmin'), '/results/admin/phpMyAdmin/' %></li>
@@ -150,7 +151,6 @@
               <% end %>
 
               <li class="divider"></li>
-              <li><%= link_to t('.wiki'), wiki_path %></li>
               <li><%= link_to t('.api'), api_path %></li>
               <li><%= link_to t('.manage_app'), oauth_applications_path %></li>
               <li><%= link_to t('.manage_auth_app'), oauth_authorized_applications_path %></li>

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -150,6 +150,7 @@
               <% end %>
 
               <li class="divider"></li>
+              <li><%= link_to t('.wiki'), wiki_pages_path %></li>
               <li><%= link_to t('.api'), api_path %></li>
               <li><%= link_to t('.manage_app'), oauth_applications_path %></li>
               <li><%= link_to t('.manage_auth_app'), oauth_authorized_applications_path %></li>

--- a/WcaOnRails/app/views/wiki_pages/_wiki_page_form.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/_wiki_page_form.html.erb
@@ -1,0 +1,9 @@
+<%= simple_form_for @wiki_page, url: submit_url do |f| %>
+ <%= render 'shared/error_messages', object: f.object %>
+
+ <%= f.input :title %>
+ <%= f.input :content, input_html: { class: "markdown-editor large" } %>
+
+ <%= link_to icon(:undo, "Back to wiki"), wiki_path, class: "btn btn-default" %>
+ <%= f.submit submit_text, class: "btn btn-primary" %>
+<% end %>

--- a/WcaOnRails/app/views/wiki_pages/_wiki_page_form.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/_wiki_page_form.html.erb
@@ -4,6 +4,6 @@
  <%= f.input :title %>
  <%= f.input :content, input_html: { class: "markdown-editor large" } %>
 
- <%= link_to icon(:undo, "Back to wiki"), wiki_path, class: "btn btn-default" %>
+ <%= link_to icon(:undo, "Back to wiki"), wiki_pages_path, class: "btn btn-default" %>
  <%= f.submit submit_text, class: "btn btn-primary" %>
 <% end %>

--- a/WcaOnRails/app/views/wiki_pages/_wiki_page_form.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/_wiki_page_form.html.erb
@@ -1,9 +1,9 @@
 <%= simple_form_for @wiki_page, url: submit_url do |f| %>
- <%= render 'shared/error_messages', object: f.object %>
+  <%= render 'shared/error_messages', object: f.object %>
 
- <%= f.input :title %>
- <%= f.input :content, input_html: { class: "markdown-editor large" } %>
+  <%= f.input :title %>
+  <%= f.input :content, input_html: { class: "markdown-editor large" } %>
 
- <%= link_to icon(:undo, "Back to wiki"), wiki_pages_path, class: "btn btn-default" %>
- <%= f.submit submit_text, class: "btn btn-primary" %>
+  <%= link_to icon(:undo, "Back to wiki"), wiki_pages_path, class: "btn btn-default" %>
+  <%= f.submit submit_text, class: "btn btn-primary" %>
 <% end %>

--- a/WcaOnRails/app/views/wiki_pages/edit.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/edit.html.erb
@@ -1,0 +1,5 @@
+<% provide(:title, "Edit wiki page") %>
+
+<div class="container">
+  <%= render "wiki_page_form", submit_url: wiki_page_path(@wiki_page), submit_text: "Save" %>
+</div>

--- a/WcaOnRails/app/views/wiki_pages/index.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/index.html.erb
@@ -1,0 +1,3 @@
+Posts here!
+
+<%= link_to icon(:plus, "New page") %>

--- a/WcaOnRails/app/views/wiki_pages/index.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/index.html.erb
@@ -4,11 +4,11 @@
   <h1><%= yield(:title) %></h1>
 
   <div class="wiki-pages">
-    <ul class="list-unstyled">
+    <div class="list-group">
       <% @wiki_pages.each do |wiki_page| %>
-        <li><%= link_to wiki_page.title, wiki_page_path(wiki_page) %></li>
+        <%= link_to wiki_page.title, wiki_page_path(wiki_page), class: "list-group-item" %>
       <% end %>
-    </ul>
+    </div>
   </div>
 
   <%= link_to icon(:plus, "New page"), new_wiki_page_path, class: "btn btn-primary" %>

--- a/WcaOnRails/app/views/wiki_pages/index.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/index.html.erb
@@ -1,3 +1,13 @@
-Posts here!
+<% provide(:title, 'Wiki') %>
 
-<%= link_to icon(:plus, "New page") %>
+<div class="container">
+  <h1><%= yield(:title) %></h1>
+
+  <div class="wiki-pages">
+    <% @wiki_pages.each do |wiki_page| %>
+    <%= link_to wiki_page.title, wiki_page_path(wiki_page) %>
+    <% end %>
+  </div>
+
+  <%= link_to icon(:plus, "New page"), new_wiki_page_path, class: "btn btn-primary" %>
+</div>

--- a/WcaOnRails/app/views/wiki_pages/index.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/index.html.erb
@@ -4,9 +4,11 @@
   <h1><%= yield(:title) %></h1>
 
   <div class="wiki-pages">
-    <% @wiki_pages.each do |wiki_page| %>
-    <%= link_to wiki_page.title, wiki_page_path(wiki_page) %>
-    <% end %>
+    <ul class="list-unstyled">
+      <% @wiki_pages.each do |wiki_page| %>
+        <li><%= link_to wiki_page.title, wiki_page_path(wiki_page) %></li>
+      <% end %>
+    </ul>
   </div>
 
   <%= link_to icon(:plus, "New page"), new_wiki_page_path, class: "btn btn-primary" %>

--- a/WcaOnRails/app/views/wiki_pages/new.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/new.html.erb
@@ -1,1 +1,5 @@
-New post form =)
+<% provide(:title, "New wiki page") %>
+
+<div class="container">
+  <%= render "wiki_page_form", submit_url: wiki_pages_path, submit_text: "Create" %>
+</div>

--- a/WcaOnRails/app/views/wiki_pages/new.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/new.html.erb
@@ -1,0 +1,1 @@
+New post form =)

--- a/WcaOnRails/app/views/wiki_pages/show.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/show.html.erb
@@ -1,12 +1,22 @@
 <%= provide(:title, "Wiki") %>
 
 <div class="container">
-  <h3><%= @wiki_page.title %></h3>
-  <div class="content">
-    <%= md @wiki_page.content %>
-  </div>
-  <%= link_to icon(:undo, "Back to wiki"), wiki_path, class: "btn btn-default" %>
-  <%= link_to icon(:pencil, "Edit"), edit_wiki_page_path(@wiki_page), class: "btn btn-primary" %>
-  <%= link_to icon(:trash, "Delete"), wiki_page_path(@wiki_page), method: :delete, class: "btn btn-danger",
-              data: { confirm: "Are you sure you want to delete this wiki page?" } %>
+  <article class="wiki-page">
+    <header class="title">
+      <%= @wiki_page.title %>
+    </header>
+    <main class="content">
+      <%= md @wiki_page.content %>
+    </main>
+    <aside class="info">
+      Created by <%= @wiki_page.author.name %> on <%= @wiki_page.created_at.strftime "%d %b %Y at %R" %>
+      Last update on <%= @wiki_page.updated_at.strftime "%d %b %Y at %R" %>
+    </aside>
+    <nav class="actions">
+      <%= link_to icon(:undo, "Back to wiki"), wiki_path, class: "btn btn-default" %>
+      <%= link_to icon(:pencil, "Edit"), edit_wiki_page_path(@wiki_page), class: "btn btn-primary" %>
+      <%= link_to icon(:trash, "Delete"), wiki_page_path(@wiki_page), method: :delete, class: "btn btn-danger",
+      data: { confirm: "Are you sure you want to delete this wiki page?" } %>
+    </nav>
+  </article>
 </div>

--- a/WcaOnRails/app/views/wiki_pages/show.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/show.html.erb
@@ -1,0 +1,12 @@
+<%= provide(:title, "Wiki") %>
+
+<div class="container">
+  <h3><%= @wiki_page.title %></h3>
+  <div class="content">
+    <%= md @wiki_page.content %>
+  </div>
+  <%= link_to icon(:undo, "Back to wiki"), wiki_path, class: "btn btn-default" %>
+  <%= link_to icon(:pencil, "Edit"), edit_wiki_page_path(@wiki_page), class: "btn btn-primary" %>
+  <%= link_to icon(:trash, "Delete"), wiki_page_path(@wiki_page), method: :delete, class: "btn btn-danger",
+              data: { confirm: "Are you sure you want to delete this wiki page?" } %>
+</div>

--- a/WcaOnRails/app/views/wiki_pages/show.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/show.html.erb
@@ -13,7 +13,7 @@
       Last update on <%= @wiki_page.updated_at.strftime "%d %b %Y at %R" %>
     </aside>
     <nav class="actions">
-      <%= link_to icon(:undo, "Back to wiki"), wiki_path, class: "btn btn-default" %>
+      <%= link_to icon(:undo, "Back to wiki"), wiki_pages_path, class: "btn btn-default" %>
       <%= link_to icon(:pencil, "Edit"), edit_wiki_page_path(@wiki_page), class: "btn btn-primary" %>
       <%= link_to icon(:trash, "Delete"), wiki_page_path(@wiki_page), method: :delete, class: "btn btn-danger",
       data: { confirm: "Are you sure you want to delete this wiki page?" } %>

--- a/WcaOnRails/app/views/wiki_pages/show.html.erb
+++ b/WcaOnRails/app/views/wiki_pages/show.html.erb
@@ -9,8 +9,8 @@
       <%= md @wiki_page.content %>
     </main>
     <aside class="info">
-      Created by <%= @wiki_page.author.name %> on <%= @wiki_page.created_at.strftime "%d %b %Y at %R" %>
-      Last update on <%= @wiki_page.updated_at.strftime "%d %b %Y at %R" %>
+      Created by <%= @wiki_page.author.name %> on <%= I18n.l @wiki_page.created_at.to_date, format: :long %>
+      Last update on <%= I18n.l @wiki_page.updated_at.to_date, format: :long %>
     </aside>
     <nav class="actions">
       <%= link_to icon(:undo, "Back to wiki"), wiki_pages_path, class: "btn btn-default" %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -179,6 +179,9 @@ en:
         description: "Description"
       vote:
         comment: "Comment"
+      wiki_page:
+        title: "Title"
+        content: "Content"
   simple_form:
     "yes": "Yes"
     "no": "No"
@@ -283,6 +286,9 @@ en:
         name: ""
       vote:
         comment: ""
+      wiki_page:
+        title: ""
+        content: ""
     options:
       registration:
         status:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -375,6 +375,7 @@ en:
       sign_up: "Sign up"
       notifications: "Notifications"
       edit_profile: "Edit profile"
+      wiki: "Wiki"
       api: "API"
       manage_app: "Manage your applications"
       manage_auth_app: "Manage authorized applications"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -114,7 +114,6 @@ Rails.application.routes.draw do
   get '/render_markdown' => 'markdown_renderer#render_markdown'
 
   resources :wiki_pages
-  get '/wiki' => 'wiki_pages#index', as: :wiki
 
   namespace :api do
     get '/', to: redirect('/api/v0')

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -114,7 +114,7 @@ Rails.application.routes.draw do
   get '/render_markdown' => 'markdown_renderer#render_markdown'
 
   resources :wiki_pages
-  get '/wiki' => 'wiki_pages#index'
+  get '/wiki' => 'wiki_pages#index', as: :wiki
 
   namespace :api do
     get '/', to: redirect('/api/v0')

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -113,6 +113,9 @@ Rails.application.routes.draw do
 
   get '/render_markdown' => 'markdown_renderer#render_markdown'
 
+  resources :wiki_pages
+  get '/wiki' => 'wiki_pages#index'
+
   namespace :api do
     get '/', to: redirect('/api/v0')
     namespace :v0 do

--- a/WcaOnRails/db/migrate/20160822122458_create_wiki_pages.rb
+++ b/WcaOnRails/db/migrate/20160822122458_create_wiki_pages.rb
@@ -1,0 +1,11 @@
+class CreateWikiPages < ActiveRecord::Migration
+  def change
+    create_table :wiki_pages do |t|
+      t.references :author
+      t.string :title
+      t.text :content
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/WcaOnRails/db/migrate/20160822122458_create_wiki_pages.rb
+++ b/WcaOnRails/db/migrate/20160822122458_create_wiki_pages.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreateWikiPages < ActiveRecord::Migration
   def change
     create_table :wiki_pages do |t|

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -915,6 +915,24 @@ CREATE TABLE `votes` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `wiki_pages`
+--
+
+DROP TABLE IF EXISTS `wiki_pages`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `wiki_pages` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `author_id` int(11) DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8_unicode_ci,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Final view structure for view `rails_persons`
 --
 
@@ -1118,3 +1136,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160930213354');
 INSERT INTO schema_migrations (version) VALUES ('20161011005956');
 
 INSERT INTO schema_migrations (version) VALUES ('20161018220122');
+
+INSERT INTO schema_migrations (version) VALUES ('20160822122458');

--- a/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WikiPagesController, type: :controller do
+
+end

--- a/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe WikiPagesController, type: :controller do
-
 end

--- a/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
@@ -1,4 +1,144 @@
 require 'rails_helper'
 
+def does_not_have_access_and(expect_to_be_redirected_somewhere)
+  let(:wiki_page) { FactoryGirl.create :wiki_page, title: "Title" }
+
+  describe "GET #new" do
+    before { get :new }
+    send expect_to_be_redirected_somewhere
+  end
+
+  describe "POST #create" do
+    before { post :create, wiki_page: { title: "Title" } }
+    send expect_to_be_redirected_somewhere
+  end
+
+  describe "GET #index" do
+    before { get :index }
+    send expect_to_be_redirected_somewhere
+  end
+
+  describe "GET #show" do
+    before { get :show, id: wiki_page }
+    send expect_to_be_redirected_somewhere
+  end
+
+  describe "GET #edit" do
+    before { get :edit, id: wiki_page }
+    send expect_to_be_redirected_somewhere
+  end
+
+  describe "PATCH #update" do
+    before { patch :update, id: wiki_page, wiki_page: { title: "New Title" } }
+    send expect_to_be_redirected_somewhere
+
+    it "does not change the wiki page" do
+      expect(wiki_page.title).to eq "Title"
+    end
+  end
+
+  describe "DELETE #destroy" do
+    before { delete :destroy, id: wiki_page }
+    send expect_to_be_redirected_somewhere
+
+    it "does not delete the wiki page" do
+      expect(WikiPage.exists?(wiki_page.id)).to eq true
+    end
+  end
+end
+
 RSpec.describe WikiPagesController, type: :controller do
+  context "when not signed in" do
+    does_not_have_access_and "redirects_to_sign_in_page"
+  end
+
+  context "when signed in as normal user" do
+    sign_in { FactoryGirl.create :user }
+    does_not_have_access_and "redirects_to_root_url"
+  end
+
+  context "when signed in as member of team other than results one" do
+    sign_in { FactoryGirl.create :wrc_team }
+    does_not_have_access_and "redirects_to_root_url"
+  end
+
+  context "when signed in as results team member" do
+    let(:results_team_member) { FactoryGirl.create :results_team }
+    let(:wiki_page) { FactoryGirl.create :wiki_page, title: "Title" }
+
+    before do
+      sign_in results_team_member
+    end
+
+    describe "GET #new" do
+      before do
+        get :new
+      end
+
+      it { is_expected.to render_template :new }
+
+      it "assigns new wiki page with appropriate author" do
+        expect(assigns(:wiki_page).author).to eq results_team_member
+      end
+    end
+
+    describe "POST #create" do
+      it "creates a new page" do
+        expect do
+          post :create, wiki_page: { title: "Title", content: "Page body." }
+        end.to change { results_team_member.wiki_pages.count }.by 1
+      end
+
+      it "sets successful flash message" do
+        post :create, wiki_page: { title: "Title", content: "Page body." }
+        expect(flash[:success]).to_not be_empty
+      end
+    end
+
+    describe "GET #index" do
+      before { get :index }
+      it { is_expected.to render_template :index }
+    end
+
+    describe "GET #show" do
+      before { get :show, id: wiki_page }
+      it { is_expected.to render_template :show }
+    end
+
+    describe "GET #edit" do
+      before { get :edit, id: wiki_page }
+
+      it { is_expected.to render_template :edit }
+
+      it "assigns the appropriate wiki page" do
+        expect(assigns(:wiki_page)).to eq wiki_page
+      end
+    end
+
+    describe "PATCH #update" do
+      before { patch :update, id: wiki_page, wiki_page: { title: "New Title" } }
+
+      it "updates the wiki post correctly" do
+        expect(wiki_page.reload.title).to eq "New Title"
+      end
+
+      it "sets successful flash message" do
+        expect(flash[:success]).to_not be_empty
+      end
+    end
+
+    describe "DELETE #destroy" do
+      before { delete :destroy, id: wiki_page }
+
+      it { is_expected.to redirect_to wiki_url }
+
+      it "deletes the wiki page" do
+        expect(WikiPage.exists?(wiki_page.id)).to eq false
+      end
+
+      it "sets successful message" do
+        expect(flash[:success]).to_not be_empty
+      end
+    end
+  end
 end

--- a/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe WikiPagesController, type: :controller do
     describe "DELETE #destroy" do
       before { delete :destroy, id: wiki_page }
 
-      it { is_expected.to redirect_to wiki_url }
+      it { is_expected.to redirect_to wiki_pages_url }
 
       it "deletes the wiki page" do
         expect(WikiPage.exists?(wiki_page.id)).to eq false

--- a/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/wiki_page_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 def does_not_have_access_and(expect_to_be_redirected_somewhere)

--- a/WcaOnRails/spec/factories/wiki_page.rb
+++ b/WcaOnRails/spec/factories/wiki_page.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :wiki_page do
-
+    author
+    title "Awesome wiki page"
+    content "This is example wiki page content"
   end
-
 end

--- a/WcaOnRails/spec/factories/wiki_page.rb
+++ b/WcaOnRails/spec/factories/wiki_page.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :wiki_page do
     author

--- a/WcaOnRails/spec/factories/wiki_page.rb
+++ b/WcaOnRails/spec/factories/wiki_page.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :wiki_page do
+
+  end
+
+end

--- a/WcaOnRails/spec/models/wiki_page_spec.rb
+++ b/WcaOnRails/spec/models/wiki_page_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WikiPage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/WcaOnRails/spec/models/wiki_page_spec.rb
+++ b/WcaOnRails/spec/models/wiki_page_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe WikiPage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "has valid factory" do
+    expect(FactoryGirl.build(:wiki_page)).to be_valid
+  end
 end

--- a/WcaOnRails/spec/models/wiki_page_spec.rb
+++ b/WcaOnRails/spec/models/wiki_page_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe WikiPage, type: :model do

--- a/WcaOnRails/spec/support/controller_macros.rb
+++ b/WcaOnRails/spec/support/controller_macros.rb
@@ -12,6 +12,18 @@ module ControllerMacros
       sign_out :user
     end
   end
+
+  def redirects_to_sign_in_page
+    it "redirects to sign in page" do
+      expect(response).to redirect_to new_user_session_url
+    end
+  end
+
+  def redirects_to_root_url
+    it "redirects to root url" do
+      expect(response).to redirect_to root_url
+    end
+  end
 end
 
 module RequestMacros


### PR DESCRIPTION
Fixes #811. Firstly I thought it would be wiki shared between all teams but Sebastien likes separate one for Results one, so the best way would be to have one wiki per team. This could be done if we have delegates team (there's unfinished PR for that) as they are the second group which would need such thing. So for now I decided to make the wiki available just for Results Team as in the issue.

I've just pushed it to [staging](https://staging.worldcubeassociation.org) so feel free to check it out. Just sign in as results team member (for example `1@worldcubeassociation.org` with password `wca`) and got Wiki from navigation dropdown.
