### PR TITLE
Nulify empty unconfirmed_wca_id

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -98,8 +98,8 @@ class User < ActiveRecord::Base
 
   before_validation :maybe_clear_claimed_wca_id
   def maybe_clear_claimed_wca_id
-    if !claiming_wca_id && unconfirmed_wca_id_was.present?
-      if wca_id == unconfirmed_wca_id_was || unconfirmed_wca_id.blank?
+    unless claiming_wca_id
+      if (unconfirmed_wca_id_was.present? && wca_id == unconfirmed_wca_id_was) || unconfirmed_wca_id.blank?
         self.unconfirmed_wca_id = nil
         self.delegate_to_handle_wca_id_claim = nil
       end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -457,6 +457,12 @@ RSpec.describe User, type: :model do
         delegate.update!(delegate_status: nil, senior_delegate_id: nil)
       end
     end
+
+    it "when empty, is set to nil" do
+      user = FactoryGirl.create :user, unconfirmed_wca_id: nil
+      user.update! unconfirmed_wca_id: ""
+      expect(user.reload.unconfirmed_wca_id).to eq nil
+    end
   end
 
   it "#teams and #current_teams return unique team names" do


### PR DESCRIPTION
Fixes #889.

Production could be simply fixed by running `User.all.each &:save!` =)