### PR TITLE
Restore WCA name for Korea.

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     XS: "Multiple Countries (South America)"
     MO: "Macao"
     HK: "Hong Kong"
+    KR: "Korea"
   continents:
     AfR: "Africa"
     AsR: "Asia"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -26,6 +26,7 @@ fr:
     XS: "Pays multiple (Amérique du Sud)"
     MO: "Macau"
     HK: "Hong Kong"
+    KR: "République de Corée"
   continents:
     AfR: "Afrique"
     AsR: "Asie"


### PR DESCRIPTION
Korea was also affected by the use of `i18n-country-translations`.
