### PR TITLE
Send devise related emails synchronously. We don't want malformed email

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -310,11 +310,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  # From https://github.com/plataformatec/devise#activejob-integration
-  def send_devise_notification(notification, *args)
-    devise_mailer.send(notification, self, *args).deliver_later
-  end
-
   def country
     Country.find_by_iso2(country_iso2)
   end


### PR DESCRIPTION
addresses that people use to register for accounts to cause job
failures. See #934 for more details.