### PR TITLE
Update TNoodle to 0.11.3

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -28,12 +28,12 @@ class Api::V0::ApiController < ApplicationController
   def scramble_program
     render json: {
       "current" => {
-        "name" => "TNoodle-WCA-0.11.1",
+        "name" => "TNoodle-WCA-0.11.3",
         "information" => "#{root_url}regulations/scrambles/",
-        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.11.1.jar",
+        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.11.3.jar",
       },
       "allowed" => [
-        "TNoodle-WCA-0.11.1",
+        "TNoodle-WCA-0.11.3",
       ],
       "history" => [
         "TNoodle-0.7.4",       # 2013-01-01
@@ -46,7 +46,8 @@ class Api::V0::ApiController < ApplicationController
         "TNoodle-WCA-0.8.4",   # 2014-02-10
         "TNoodle-WCA-0.9.0",   # 2015-03-30
         "TNoodle-WCA-0.10.0",  # 2015-06-30
-        "TNoodle-WCA-0.11.1"   # 2016-04-04
+        "TNoodle-WCA-0.11.1",  # 2016-04-04
+        "TNoodle-WCA-0.11.3"   # 2016-10-17
       ],
     }
   end

--- a/WcaOnRails/app/views/regulations/scrambles/index.html.erb
+++ b/WcaOnRails/app/views/regulations/scrambles/index.html.erb
@@ -1,14 +1,14 @@
 <% provide(:title, 'WCA Scrambles') %>
 <div class="container">
   <h1>WCA Scrambles</h1>
-  <p>The current official scramble program is <em>TNoodle-WCA-0.11.1</em>. It generates high-quality scramble sequences for all the events of a competition at once.</p>
+  <p>The current official scramble program is <em>TNoodle-WCA-0.11.3</em>. It generates high-quality scramble sequences for all the events of a competition at once.</p>
   <center>
     <span style="font-size: 200%; line-height: 150%; padding: 0.5em;">
       Download the official scramble program:<br/>
-      <strong><%= link_to "TNoodle-WCA-0.11.1.jar", "./tnoodle/TNoodle-WCA-0.11.1.jar" %></strong>
+      <strong><%= link_to "TNoodle-WCA-0.11.3.jar", "./tnoodle/TNoodle-WCA-0.11.3.jar" %></strong>
     </span>
     <br/>
-    Last official change: April 4, 2016
+    Last official change: October 17, 2016
   </center>
   <h2>Important Notes for Delegates</h2>
   <ul>
@@ -19,7 +19,7 @@
   <h2>Detailed Instructions for TNoodle</h2>
   <p>TNoodle requires <%= link_to "Java", "https://www.java.com/en/" %> to be installed on your computer.</p>
   <ol>
-    <li>Run the <code>TNoodle-WCA-0.11.1.jar</code> file on your computer.<br />It will open the page <%= link_to nil, "http://localhost:2014/scramble" %> in your browser.</li>
+    <li>Run the <code>TNoodle-WCA-0.11.3.jar</code> file on your computer.<br />It will open the page <%= link_to nil, "http://localhost:2014/scramble" %> in your browser.</li>
     <li>Enter the details for your competition (competition name, number of rounds for each event, details for each round).<br />
       If you would like to password protect the file, enter a password.</li>
     <li>Wait for the loading bar to finish and click the "Scramble!" button that appears.<br />
@@ -47,6 +47,7 @@
     <li><%= link_to "TNoodle-WCA-0.8.4", "./tnoodle/old/TNoodle-WCA-0.8.4.jar" %> (2014-02-10)</li>
     <li><%= link_to "TNoodle-WCA-0.9.0", "./tnoodle/old/TNoodle-WCA-0.9.0.jar" %> (2015-03-30)</li>
     <li><%= link_to "TNoodle-WCA-0.10.0", "./tnoodle/old/TNoodle-WCA-0.10.0.jar" %> (2015-06-30)</li>
-    <li><%= link_to "TNoodle-WCA-0.11.1", "./tnoodle/TNoodle-WCA-0.11.1.jar" %> (2016-04-04)</li>
+    <li><%= link_to "TNoodle-WCA-0.11.1", "./tnoodle/old/TNoodle-WCA-0.11.1.jar" %> (2016-04-04)</li>
+    <li><%= link_to "TNoodle-WCA-0.11.3", "./tnoodle/TNoodle-WCA-0.11.3.jar" %> (2016-10-17)</li>
   </ul>
 </div>

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -320,7 +320,7 @@ describe Api::V0::ApiController do
       get :scramble_program
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.11.1"
+      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.11.3"
     end
   end
 


### PR DESCRIPTION
Update the `regulations/scrambles` page and the API to TNoodle 0.11.3.
This should be merged just after #938.
