### PR TITLE
Added basic /server-status route that currently just looks at the oldest job that's waiting to run.

### DIFF
--- a/WcaOnRails/app/controllers/server_status_controller.rb
+++ b/WcaOnRails/app/controllers/server_status_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class ServerStatusController < ApplicationController
+  def index
+    @oldest_job_that_should_have_run_by_now = Delayed::Job.
+        where(attempts: 0).where('created_at < ?', 5.minutes.ago).
+        order(:created_at).
+        first
+
+    @everything_good = @oldest_job_that_should_have_run_by_now.nil?
+
+    if !@everything_good
+      render status: 503
+    end
+  end
+end

--- a/WcaOnRails/app/views/server_status/index.html.erb
+++ b/WcaOnRails/app/views/server_status/index.html.erb
@@ -1,0 +1,25 @@
+<% provide(:title, 'Server Status') %>
+<div class="container">
+  <h1><%= yield(:title) %></h1>
+
+  <% if @everything_good %>
+    <%= alert :success, "We're fine. We're all fine here, now, thank you. How are you?" %>
+  <% else %>
+    <%= alert :danger, "Check below, something may be wrong." %>
+  <% end %>
+
+  <ul>
+    <li>
+      Jobs:
+      <% if @oldest_job_that_should_have_run_by_now %>
+        <span class="label label-warning">
+          Uh oh! Job <%= @oldest_job_that_should_have_run_by_now.id %> was created
+          <%= time_ago_in_words @oldest_job_that_should_have_run_by_now.created_at %>
+          ago and still has not run.
+        </span>
+      <% else %>
+        <span class="label label-success">Looking good!</span>
+      <% end %>
+    </li>
+  </ul>
+</div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -84,6 +84,7 @@ Rails.application.routes.draw do
   get 'admin/delegates' => 'delegates#stats', as: :delegates_stats
 
   get 'robots' => 'static_pages#robots'
+  get 'server-status' => 'server_status#index'
 
   get 'about' => 'static_pages#about'
   get 'delegates' => 'static_pages#delegates'

--- a/WcaOnRails/spec/controllers/server_status_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/server_status_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ServerStatusController, type: :controller do
+  it "finds the oldest job that has been waiting to run" do
+    _old_job = Delayed::Job.create(created_at: 10.minutes.ago, handler: "")
+    oldest_job = Delayed::Job.create(created_at: 15.minutes.ago, handler: "")
+
+    get :index
+
+    oldest_job_that_should_have_run_by_now = assigns(:oldest_job_that_should_have_run_by_now)
+    expect(oldest_job_that_should_have_run_by_now).to eq oldest_job
+
+    expect(assigns(:everything_good)).to eq false
+  end
+
+  it "ignores young jobs" do
+    _young_job = Delayed::Job.create(created_at: 1.minutes.ago, handler: "")
+
+    get :index
+
+    oldest_job_that_should_have_run_by_now = assigns(:oldest_job_that_should_have_run_by_now)
+    expect(oldest_job_that_should_have_run_by_now).to eq nil
+
+    expect(assigns(:everything_good)).to eq true
+  end
+end


### PR DESCRIPTION
This fixes #47. After we merge this up, I plan to use http://www.host-tracker.com/ (found by @larspetrus) to monitor this page and send us a notification if not all looks well.

Here's what the page looks like when there are no jobs that have been waiting to run:

![image](https://cloud.githubusercontent.com/assets/277474/19408336/36dd629a-926f-11e6-85ef-001486847dc3.png)

Note the nice HTTP 200 error code.

And with a job that has been waiting to run for > 5 minutes:

![image](https://cloud.githubusercontent.com/assets/277474/19408333/1adc072c-926f-11e6-9b72-7cc564b6873e.png)

Note that when there's an error, we return HTTP 503 rather than 200.

I've also deployed this to staging: https://staging.worldcubeassociation.org/server-status.