### PR TITLE
Added back an analogous index to what I removed in PR #926

### DIFF
--- a/WcaOnRails/db/migrate/20160930213354_convert_event_id_to_competition_event_id.rb
+++ b/WcaOnRails/db/migrate/20160930213354_convert_event_id_to_competition_event_id.rb
@@ -12,9 +12,11 @@ class ConvertEventIdToCompetitionEventId < ActiveRecord::Migration
     remove_column :registration_events, :event_id
 
     rename_table :registration_events, :registration_competition_events
+    add_index :registration_competition_events, [:registration_id, :competition_event_id], name: "index_reg_events_reg_id_comp_event_id"
   end
 
   def down
+    remove_index :registration_competition_events, [:registration_id, :competition_event_id], name: "index_reg_events_reg_id_comp_event_id"
     rename_table :registration_competition_events, :registration_events
 
     add_column :registration_events, :event_id, :string

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -722,8 +722,9 @@ CREATE TABLE `registration_competition_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `registration_id` int(11) DEFAULT NULL,
   `competition_event_id` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=20230 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  PRIMARY KEY (`id`),
+  KEY `index_reg_events_reg_id_comp_event_id` (`registration_id`,`competition_event_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=20428 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
See https://github.com/thewca/worldcubeassociation.org/pull/926/files#diff-936601d80bc7bcec46fbc92a13eda087R11.

When I ran `SHOW PROCESSLIST` on production earlier today, I saw the following query that had been working for 2241 seconds:

```
mysql> SHOW FULL PROCESSLIST;
...
| 712615 | root | localhost | cubing | Query   | 2241 | Sending data                    | SELECT `registrations`.`id` FROM `registrations` LEFT OUTER JOIN `users` ON `users`.`id` = `registrations`.`user_id` LEFT OUTER JOIN `registration_competition_events` ON `registration_competition_events`.`registration_id` = `registrations`.`id` LEFT OUTER JOIN `registration_competition_events` `registration_competition_events_registrations_join` ON `registration_competition_events_registrations_join`.`registration_id` = `registrations`.`id` LEFT OUTER JOIN `competition_events` ON `competition_events`.`id` = `registration_competition_events_registrations_join`.`competition_event_id` LEFT OUTER JOIN `Events` ON `Events`.`id` = `competition_events`.`event_id` WHERE `registrations`.`competitionId` = 'UKChampionship2016' AND (`registrations`.`accepted_at` IS NOT NULL)  ORDER BY users.name                                                                                                                                                                                                                                       |
```

Without the index I've added in this PR, here's the DESCRIBE on this query:

```
MariaDB [wca_development]> describe SELECT `registrations`.`id` FROM `registrations` LEFT OUTER JOIN `users` ON `users`.`id` = `registrations`.`user_id` LEFT OUTER JOIN `registration_competition_events` ON `registration_competition_events`.`registration_id` = `registrations`.`id` LEFT OUTER JOIN `registration_competition_events` `registration_competition_events_registrations_join` ON `registration_competition_events_registrations_join`.`registration_id` = `registrations`.`id` LEFT OUTER JOIN `competition_events` ON `competition_events`.`id` = `registration_competition_events_registrations_join`.`competition_event_id` LEFT OUTER JOIN `Events` ON `Events`.`id` = `competition_events`.`event_id` WHERE `registrations`.`competitionId` = 'UKChampionship2016' AND (`registrations`.`accepted_at` IS NOT NULL)  ORDER BY users.name;
+------+-------------+----------------------------------------------------+--------+--------------------------------------------------+--------------------------------------------------+---------+-----------------------------------------------------------------------------------------+------+---------------------------------------------------------------------+
| id   | select_type | table                                              | type   | possible_keys                                    | key                                              | key_len | ref                                                                                     | rows | Extra                                                               |
+------+-------------+----------------------------------------------------+--------+--------------------------------------------------+--------------------------------------------------+---------+-----------------------------------------------------------------------------------------+------+---------------------------------------------------------------------+
|    1 | SIMPLE      | registrations                                      | ref    | index_registrations_on_competitionId_and_user_id | index_registrations_on_competitionId_and_user_id | 98      | const                                                                                   |    1 | Using index condition; Using where; Using temporary; Using filesort |
|    1 | SIMPLE      | users                                              | eq_ref | PRIMARY                                          | PRIMARY                                          | 4       | wca_development.registrations.user_id                                                   |    1 | Using where                                                         |
|    1 | SIMPLE      | registration_competition_events                    | ALL    | NULL                                             | NULL                                             | NULL    | NULL                                                                                    | 9367 | Using where; Using join buffer (flat, BNL join)                     |
|    1 | SIMPLE      | registration_competition_events_registrations_join | ALL    | NULL                                             | NULL                                             | NULL    | NULL                                                                                    | 9367 | Using where; Using join buffer (incremental, BNL join)              |
|    1 | SIMPLE      | competition_events                                 | eq_ref | PRIMARY                                          | PRIMARY                                          | 4       | wca_development.registration_competition_events_registrations_join.competition_event_id |    1 | Using where                                                         |
+------+-------------+----------------------------------------------------+--------+--------------------------------------------------+--------------------------------------------------+---------+-----------------------------------------------------------------------------------------+------+---------------------------------------------------------------------+
```

And the same query with the new `index_reg_events_reg_id_comp_event_id` I just added:

```
MariaDB [wca_development]> describe SELECT `registrations`.`id` FROM `registrations` LEFT OUTER JOIN `users` ON `users`.`id` = `registrations`.`user_id` LEFT OUTER JOIN `registration_competition_events` ON `registration_competition_events`.`registration_id` = `registrations`.`id` LEFT OUTER JOIN `registration_competition_events` `registration_competition_events_registrations_join` ON `registration_competition_events_registrations_join`.`registration_id` = `registrations`.`id` LEFT OUTER JOIN `competition_events` ON `competition_events`.`id` = `registration_competition_events_registrations_join`.`competition_event_id` LEFT OUTER JOIN `Events` ON `Events`.`id` = `competition_events`.`event_id` WHERE `registrations`.`competitionId` = 'UKChampionship2016' AND (`registrations`.`accepted_at` IS NOT NULL)  ORDER BY users.name;
+------+-------------+----------------------------------------------------+--------+--------------------------------------------------+--------------------------------------------------+---------+-----------------------------------------------------------------------------------------+------+---------------------------------------------------------------------+
| id   | select_type | table                                              | type   | possible_keys                                    | key                                              | key_len | ref                                                                                     | rows | Extra                                                               |
+------+-------------+----------------------------------------------------+--------+--------------------------------------------------+--------------------------------------------------+---------+-----------------------------------------------------------------------------------------+------+---------------------------------------------------------------------+
|    1 | SIMPLE      | registrations                                      | ref    | index_registrations_on_competitionId_and_user_id | index_registrations_on_competitionId_and_user_id | 98      | const                                                                                   |    1 | Using index condition; Using where; Using temporary; Using filesort |
|    1 | SIMPLE      | users                                              | eq_ref | PRIMARY                                          | PRIMARY                                          | 4       | wca_development.registrations.user_id                                                   |    1 | Using where                                                         |
|    1 | SIMPLE      | registration_competition_events                    | ref    | index_reg_events_reg_id_comp_event_id            | index_reg_events_reg_id_comp_event_id            | 5       | wca_development.registrations.id                                                        |    1 | Using where; Using index                                            |
|    1 | SIMPLE      | registration_competition_events_registrations_join | ref    | index_reg_events_reg_id_comp_event_id            | index_reg_events_reg_id_comp_event_id            | 5       | wca_development.registrations.id                                                        |    1 | Using where; Using index                                            |
|    1 | SIMPLE      | competition_events                                 | eq_ref | PRIMARY                                          | PRIMARY                                          | 4       | wca_development.registration_competition_events_registrations_join.competition_event_id |    1 | Using where                                                         |
+------+-------------+----------------------------------------------------+--------+--------------------------------------------------+--------------------------------------------------+---------+-----------------------------------------------------------------------------------------+------+---------------------------------------------------------------------+
5 rows in set (0.00 sec)                                                                                                
```