### PR TITLE
There's no need to select registration_competition_events.

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -54,7 +54,7 @@ class RegistrationsController < ApplicationController
 
   def index
     @competition = competition_from_params
-    @registrations = @competition.registrations.accepted.includes(:user, :registration_competition_events, :events).order("users.name")
+    @registrations = @competition.registrations.accepted.includes(:user, :events).order("users.name")
   end
 
   def edit

--- a/WcaOnRails/app/views/registrations/index.html.erb
+++ b/WcaOnRails/app/views/registrations/index.html.erb
@@ -51,7 +51,7 @@
             <% end %>
 
             <td class="event-count">
-              <%= registration.registration_competition_events.length %>
+              <%= registration.events.length %>
             </td>
             <!-- Extra column for .table-greedy-last-column -->
             <td></td>


### PR DESCRIPTION
@pingskills noticed that the generated SQL in #947 was unecessarily complicated. This should be faster and still correct behavior.