### PR TITLE
Oh boy it's easy it mix up events and competition events.

### DIFF
--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -163,7 +163,7 @@ after "development:users" do
     users.each_with_index do |user, i|
       accepted_at = i % 4 == 0 ? Time.now : nil
       registration_competition_events = competition.competition_events.sample(rand(1..competition.competition_events.count))
-      FactoryGirl.create(:registration, user: user, competition: competition, accepted_at: accepted_at, events: registration_competition_events)
+      FactoryGirl.create(:registration, user: user, competition: competition, accepted_at: accepted_at, competition_events: registration_competition_events)
     end
   end
 end


### PR DESCRIPTION
This fixes #951. I'm going to merge this up immediately as it's a straightfoward fix of a pretty annoying bug for developers.

@larspetrus, do you think we should add seeding our database to our automated testing? That would have caught this.