### PR TITLE
Fix registration events duplication on update

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -140,7 +140,7 @@ class Registration < ActiveRecord::Base
   def events_to_associated_events(events)
     events.map do |event|
       competition_event = competition.competition_events.find_by!(event: event)
-      registration_competition_events.find_by_competition_event_id(event.id) || registration_competition_events.build(competition_event: competition_event)
+      registration_competition_events.find_by_competition_event_id(competition_event.id) || registration_competition_events.build(competition_event: competition_event)
     end
   end
 end

--- a/WcaOnRails/db/migrate/20161018220122_clean_duplicated_registration_competition_events.rb
+++ b/WcaOnRails/db/migrate/20161018220122_clean_duplicated_registration_competition_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class CleanDuplicatedRegistrationCompetitionEvents < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      DELETE FROM registration_competition_events
+      WHERE registration_competition_events.id NOT IN (
+        SELECT minid
+        FROM (
+          SELECT MIN(id) as minid
+          FROM registration_competition_events
+          GROUP BY registration_id, competition_event_id
+        ) as keep
+      )
+    SQL
+  end
+end

--- a/WcaOnRails/db/migrate/20161018220122_clean_duplicated_registration_competition_events.rb
+++ b/WcaOnRails/db/migrate/20161018220122_clean_duplicated_registration_competition_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class CleanDuplicatedRegistrationCompetitionEvents < ActiveRecord::Migration
-  def change
+  def up
     execute <<-SQL
       DELETE FROM registration_competition_events
       WHERE registration_competition_events.id NOT IN (
@@ -12,5 +12,12 @@ class CleanDuplicatedRegistrationCompetitionEvents < ActiveRecord::Migration
         ) as keep
       )
     SQL
+
+    add_index :registration_competition_events, [:registration_id, :competition_event_id],
+              unique: true, name: "idx_registration_competition_events_on_reg_id_and_comp_event_id"
+  end
+
+  def down
+    remove_index :registration_competition_events, name: "idx_registration_competition_events_on_reg_id_and_comp_event_id"
   end
 end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1115,3 +1115,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160914122252');
 INSERT INTO schema_migrations (version) VALUES ('20160930213354');
 
 INSERT INTO schema_migrations (version) VALUES ('20161011005956');
+
+INSERT INTO schema_migrations (version) VALUES ('20161018220122');

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -723,8 +723,9 @@ CREATE TABLE `registration_competition_events` (
   `registration_id` int(11) DEFAULT NULL,
   `competition_event_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_registration_competition_events_on_reg_id_and_comp_event_id` (`registration_id`,`competition_event_id`),
   KEY `index_reg_events_reg_id_comp_event_id` (`registration_id`,`competition_event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=20428 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=18568 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
Fixes #957.

I think about an appropriate migration now, that will clean the duplications.