### PR TITLE
Update wording of registration emails - Fixes #960

### DIFF
--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
@@ -12,6 +12,12 @@
     You asked for withdrawal
   </li>
   <li>
+    You didn't meet the registration criteria (for example, paying the registration fee in advance)
+  </li>
+  <li>
+    The competitor limit has been reached and there are no more spots available
+  </li>
+  <li>
     You registered twice or more times
   </li>
 </ul>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
@@ -10,6 +10,8 @@
 
 <p>
   You will be emailed when your registration is approved.
+  Please note that registrations are not automatically approved.
+  To see the approval criteria visit the competition website or contact the organisers.
   You can also check the status of your registration
   <%= link_to "here", competition_register_url(@competition) %>.
 </p>


### PR DESCRIPTION
Here's a preview from mailcatcher of the registration deletion email.
![registration-deleted](https://cloud.githubusercontent.com/assets/4403168/19582914/4718987c-9784-11e6-8c84-2ede9360a61a.png)

Since the new registration email now get queued, I wasn't sure how to fire them off and have them sent to mailcatcher. Is there an easy way to do this?