### PR TITLE
Be explicit: production and staging servers always run in rails's production mode.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -102,11 +102,6 @@ rebuild_rails() {
   (
     cd WcaOnRails
 
-    if [ "$(git rev-parse --abbrev-ref HEAD)" == "production" ]; then
-      export RAILS_ENV=production
-    else
-      export RAILS_ENV=development
-    fi
     bundle install
     bundle exec rake assets:clean assets:precompile
 
@@ -122,5 +117,12 @@ rebuild_rails() {
 }
 
 cd "$(dirname "$0")"/..
+
+if [ "$(hostname)" == "production" ] || [ "$(hostname)" == "staging" ]; then
+  export RAILS_ENV=production
+else
+  export RAILS_ENV=development
+fi
+
 allowed_commands="pull_latest restart_app rebuild_rails rebuild_regs"
 source scripts/_parse_args.sh


### PR DESCRIPTION
Without this change, it's impossible to deploy code to staging because we don't install the development gems on staging.