### PR TITLE
Added a feature test of changing competition ids.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -331,6 +331,14 @@ class CompetitionsController < ApplicationController
         redirect_to edit_competition_path(@competition)
       end
     else
+      # Changing the competition id breaks all our associations, and our view
+      # code was not written to handle this. Rather than trying to update our view
+      # code, just revert the attempted id change. The user will have to deal with
+      # editing the ID text box manually. This will go away once we have proper
+      # immutable ids for competitions.
+      if @competition.id_changed?
+        @competition.id = @competition.id_was
+      end
       render :edit
     end
   end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -629,11 +629,11 @@ en:
       create_competition: "Create competition"
       note_clone: "To clone an existing competition visit the information page for that competition and click the \"Clone\" link in the menu."
     update_events:
-      update_success: "Successfully updated the competition events"
+      update_success: "Successfully updated the competition events."
     update:
-      save_success: "Successfully saved competition"
+      save_success: "Successfully saved competition."
       confirm_success: "Successfully confirmed competition. Check your email, and wait for the Board to announce it!"
-      delete_success: "Successfully deleted competition %{id}"
+      delete_success: "Successfully deleted competition %{id}."
     time_until_competition:
       competition_in: "Competition is in %{n_days}."
       competition_was: "Competition was %{n_days} ago."

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -33,6 +33,7 @@ FactoryGirl.define do
     venueAddress "My backyard street"
     external_website "https://www.worldcubeassociation.org"
     showAtAll false
+    isConfirmed false
 
     guests_enabled true
 

--- a/WcaOnRails/spec/features/competition_management_spec.rb
+++ b/WcaOnRails/spec/features/competition_management_spec.rb
@@ -23,5 +23,35 @@ RSpec.feature "Competition management" do
 
       expect(page).to have_text("Successfully confirmed competition.")
     end
+
+    scenario "change competition id" do
+      competition = FactoryGirl.create(:competition, :with_delegate)
+      visit edit_competition_path(competition)
+      fill_in "ID", with: "NewId2016"
+      click_button "Update Competition"
+
+      expect(page).to have_text("Successfully saved competition.")
+      expect(Competition.find("NewId2016")).not_to be_nil
+    end
+
+    scenario "change competition id with validation error" do
+      competition = FactoryGirl.create(:competition, :with_delegate, id: "OldId2016")
+      visit edit_competition_path(competition)
+      fill_in "ID", with: "NewId2016"
+      fill_in "Name", with: "Name that does not end in a year"
+      click_button "Update Competition"
+
+      expect(page).to have_text("Name must end with a year")
+      expect(page).to have_selector("input#competition_id[value='OldId2016']")
+
+      fill_in "Name", with: "Name that does end in 2016"
+      fill_in "ID", with: "NewId2016"
+      click_button "Update Competition"
+
+      expect(page).to have_text("Successfully saved competition.")
+      c = Competition.find("NewId2016")
+      expect(c).not_to be_nil
+      expect(c.name).to eq "Name that does end in 2016"
+    end
   end
 end


### PR DESCRIPTION
Turns out it wasn't actually possible to change a competition id, validations and view code
would break if you tried. This should fix that and make sure we don't
break it again.