### PR TITLE
Show a general tab when the user goes back to an empty hash

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competition_tabs.js
+++ b/WcaOnRails/app/assets/javascripts/competition_tabs.js
@@ -1,16 +1,15 @@
 onPage("competitions#show", function() {
-  showTab(window.location.hash || '#general-info');
+  showTabFromHash();
 
   $('a[data-toggle="tab"]').on('show.bs.tab', function(e) {
     window.location.hash = $(e.target).attr('href');
   });
 
   // Update the displayed tab when the back/forward is clicked changing the hash.
-  $(window).on('hashchange', function() {
-    showTab(window.location.hash);
-  });
+  $(window).on('hashchange', showTabFromHash);
 
-  function showTab(id) {
+  function showTabFromHash() {
+    id = window.location.hash || '#general-info';
     $('a[href="' + id + '"]').tab('show');
   }
 });


### PR DESCRIPTION
It's an improvement to the #974.
Quiet tricky: when a user goes to a competition page without any hash, then switches to another tab, then moves back, he should see the general tab even though the hash is empty.