### PR TITLE
Added validations to the Results and SolveTime classes.

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -54,3 +54,6 @@ Style/SignalException:
 Style/ClassVars:
   Exclude:
     - app/models/country.rb
+
+Style/IfInsideElse:
+  Enabled: false

--- a/WcaOnRails/app/models/light_result.rb
+++ b/WcaOnRails/app/models/light_result.rb
@@ -4,6 +4,8 @@ require 'solve_time'
 # This is an alternative to `Result` used for performance reasons.
 # See also the comment in `app/models/competition.rb`.
 class LightResult
+  include ResultMethods
+
   attr_accessor :muted
 
   attr_reader :value1,
@@ -49,58 +51,5 @@ class LightResult
 
   def roundId
     round.id
-  end
-
-  def results_path
-    "/results/p.php?i=#{personId}"
-  end
-
-  def wca_id
-    @personId
-  end
-
-  def best_solve
-    SolveTime.new(eventId, :single, best)
-  end
-
-  def average_solve
-    SolveTime.new(eventId, :average, average)
-  end
-
-  def best_index
-    sorted_solves_with_index.min[1]
-  end
-
-  def missed_combined_round_cutoff?
-    sorted_solves_with_index.length < format.expected_solve_count
-  end
-
-  private def sorted_solves_with_index
-    @sorted_solves_with_index ||= solves.each_with_index.reject { |s, _| s.skipped? }.sort
-  end
-
-  def solves
-    @solves ||= [SolveTime.new(eventId, :single, value1),
-                 SolveTime.new(eventId, :single, value2),
-                 SolveTime.new(eventId, :single, value3),
-                 SolveTime.new(eventId, :single, value4),
-                 SolveTime.new(eventId, :single, value5)]
-  end
-
-  def worst_index
-    sorted_solves_with_index.max[1]
-  end
-
-  def trimmed_indices
-    if missed_combined_round_cutoff?
-      # When you miss the cutoff for a combined round, you don't
-      # get an average, therefore none of the solves were trimmed.
-      []
-    else
-      sorted_solves = sorted_solves_with_index
-      trimmed_solves_with_index = sorted_solves[0...format.trim_fastest_n]
-      trimmed_solves_with_index += sorted_solves[(sorted_solves.length - format.trim_slowest_n)...sorted_solves.length]
-      trimmed_solves_with_index.map { |_, i| i }
-    end
   end
 end

--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -56,9 +56,9 @@ class Result < ActiveRecord::Base
     return "Invalid round" unless round
     return "Cannot skip all solves." if solve_times.all?(&:skipped?)
 
-    last_unskipped_index = solve_times.rindex(&:unskipped?) || 0
-    first_skipped_index = solve_times.index(&:skipped?) || Float::INFINITY
-    return "Skipped solves must all come at the end." if last_unskipped_index > first_skipped_index
+    unless solve_times.drop_while(&:unskipped?).all?(&:skipped?)
+      return "Skipped solves must all come at the end."
+    end
 
     unskipped_count = solve_times.count(&:unskipped?)
     if round.combined?

--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -1,14 +1,84 @@
 # frozen_string_literal: true
 class Result < ActiveRecord::Base
+  include ResultMethods
+
   self.table_name = "Results"
 
   belongs_to :competition, foreign_key: :competitionId
+  belongs_to :country, foreign_key: :countryId
   belongs_to :person, -> { current }, primary_key: :wca_id, foreign_key: :personId
   belongs_to :round, foreign_key: :roundId
   belongs_to :event, foreign_key: :eventId
+  belongs_to :format, foreign_key: :formatId
 
   scope :podium, -> { joins(:round).merge(Round.final_rounds).where(pos: [1..3]).where("best > 0") }
   scope :winners, -> { joins(:round, :event).merge(Round.final_rounds).where("pos = 1 and best > 0").order("Events.rank") }
+
+  validate :validate_each_solve
+  def validate_each_solve
+    solve_times.each_with_index do |solve_time, i|
+      unless solve_time.valid?
+        errors.add(:"value#{i + 1}", solve_time.errors.messages[:base].join(" "))
+      end
+    end
+  end
+
+  validate :validate_best
+  def validate_best
+    correct_best_solve_time = sorted_solves.first
+    if correct_best_solve_time && correct_best_solve_time.wca_value != best
+      errors.add(:best, "should be #{correct_best_solve_time.wca_value}")
+    end
+  end
+
+  def hlp
+    ActionController::Base.helpers
+  end
+
+  validate :validate_number_of_solves
+  def validate_number_of_solves
+    return errors.add(:competitionId, "invalid") unless competition
+    return errors.add(:countryId, "invalid") unless country
+    return errors.add(:roundId, "invalid") unless round
+    return errors.add(:eventId, "invalid") unless event
+    return errors.add(:formatId, "invalid") unless format
+    return errors.add(:base, "Cannot skip all solves.") if solve_times.all?(&:skipped?)
+
+    last_unskipped_index = solve_times.rindex(&:unskipped?) || 0
+    first_skipped_index = solve_times.index(&:skipped?) || Float::INFINITY
+    return "Skipped solves must all come at the end." if last_unskipped_index > first_skipped_index
+
+    unskipped_count = solve_times.length - solve_times.count(&:skipped?)
+    if round.combined?
+      if unskipped_count > format.expected_solve_count
+        return errors.add(:base, "Expected at most #{hlp.pluralize(format.expected_solve_count, 'solve')}, but found #{unskipped_count}.")
+      end
+    else
+      if unskipped_count != format.expected_solve_count
+        return errors.add(:base, "Expected #{hlp.pluralize(format.expected_solve_count, 'solve')}, but found #{unskipped_count}.")
+      end
+    end
+  end
+
+  validate :validate_average
+  def validate_average
+    # Don't try to validate the average unless everything else is correct.
+    # It doesn't make sense to try to compute the average unless the result
+    # has the correct number of solves in it.
+    return unless errors.blank?
+
+    if eventId == "333fm"
+      sum_moves = counting_solve_times.sum(&:move_count)
+      correct_average_wca_value = 100 * sum_moves / counting_solve_times.length
+    else
+      sum_centis = counting_solve_times.sum(&:time_centiseconds)
+      correct_average_wca_value = sum_centis / counting_solve_times.length
+    end
+
+    if correct_average_wca_value != average
+      errors.add(:average, "should be #{correct_average_wca_value}")
+    end
+  end
 
   def to_s(field)
     SolveTime.new(eventId, field, send(field)).clock_format

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -6,4 +6,9 @@ class Round < ActiveRecord::Base
   has_many :results, foreign_key: :roundId
 
   scope :final_rounds, -> { where("final = 1") }
+
+  # TODO: move to database https://github.com/thewca/worldcubeassociation.org/issues/979
+  def combined?
+    %w(c d e g h).include?(id)
+  end
 end

--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -13,7 +13,7 @@
         { text: "Approve pictures", path: admin_avatars_path, fa_icon: "camera", notification_count: @pending_avatars_count },
         { text: "Approve media", path: "/results/admin/validate_media.php", fa_icon: "picture-o", notification_count: @pending_media_count },
 
-        { text: "Check results", path: "/results/admin/check_results.php", fa_icon: "check" },
+        { text: "Check results", path: admin_check_results_path, fa_icon: "check" },
         { text: "Create newcomers", path: "/results/admin/persons_finish_unfinished.php", fa_icon: "user-plus" },
         { text: "Check existing people", path: "/results/admin/persons_check_finished.php", fa_icon: "check" },
         { text: "Check rounds", path: "/results/admin/check_rounds.php", fa_icon: "check" },

--- a/WcaOnRails/app/views/competitions/_results_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_results_table.html.erb
@@ -86,7 +86,7 @@
         <% trimmed_indices = result.trimmed_indices %>
         <% best_index = result.best_index %>
         <% worst_index = result.worst_index %>
-        <% result.solves.each_with_index do |solve, i| %>
+        <% result.solve_times.each_with_index do |solve_time, i| %>
           <% classes = "solve#{i + 1}" %>
           <% classes << " trimmed" if trimmed_indices.include?(i) %>
           <% classes << " best" if i == best_index %>
@@ -95,7 +95,7 @@
           <%# Note: It's important that there not be any spaces around the solve,
                     otherwise it screws up the :before and :after rules for trimmed
                     solves %>
-          <td class="<%= classes %>"><%= solve.clock_format %></td>
+          <td class="<%= classes %>"><%= solve_time.clock_format %></td>
         <% end %>
 
         <% # Extra column for .table-greedy-last-column %>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
   get '/admin/edit_person' => 'admin#edit_person'
   patch '/admin/update_person' => 'admin#update_person'
   get '/admin/person_data' => 'admin#person_data'
+  get '/admin/check_results' => 'admin/check_results#index'
 
   get '/search' => 'search_results#index'
 

--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -7,7 +7,13 @@ after "development:users" do
     end
 
     def random_wca_value
-      rand(5000..100000)
+      r = rand(5000..100000)
+
+      # Solves over 10 minutes must be rounded to the nearest second.
+      if r > 10 * 60 * 100
+        r = 100 * (r / 100)
+      end
+      r
     end
   end
 
@@ -50,7 +56,7 @@ after "development:users" do
       %w(1 2 f).each do |roundId|
         users.each_with_index do |competitor, i|
           person = competitor.person
-          Result.create!(
+          result = Result.new(
             pos: i+1,
             personId: person.wca_id,
             personName: person.name,
@@ -64,11 +70,12 @@ after "development:users" do
             value3: random_wca_value,
             value4: random_wca_value,
             value5: random_wca_value,
-            best: random_wca_value,
-            average: random_wca_value,
             regionalSingleRecord: i == 0 ? "WR" : "",
             regionalAverageRecord: i == 0 ? "WR" : "",
           )
+          result.average = result.compute_correct_average
+          result.best = result.compute_correct_best
+          result.save!
         end
       end
     end

--- a/WcaOnRails/lib/result_methods.rb
+++ b/WcaOnRails/lib/result_methods.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+module ResultMethods
+  def results_path
+    "/results/p.php?i=#{personId}"
+  end
+
+  def wca_id
+    @personId
+  end
+
+  def best_solve
+    SolveTime.new(eventId, :single, best)
+  end
+
+  def average_solve
+    SolveTime.new(eventId, :average, average)
+  end
+
+  def best_index
+    sorted_solves_with_index.min[1]
+  end
+
+  def missed_combined_round_cutoff?
+    sorted_solves_with_index.length < format.expected_solve_count
+  end
+
+  private def sorted_solves
+    @sorted_solves ||= solve_times.reject(&:skipped?).sort
+  end
+
+  private def sorted_solves_with_index
+    @sorted_solves_with_index ||= solve_times.each_with_index.reject { |s, _| s.skipped? }.sort
+  end
+
+  def solve_times
+    @solve_times ||= [SolveTime.new(eventId, :single, value1),
+                      SolveTime.new(eventId, :single, value2),
+                      SolveTime.new(eventId, :single, value3),
+                      SolveTime.new(eventId, :single, value4),
+                      SolveTime.new(eventId, :single, value5)]
+  end
+
+  def worst_index
+    sorted_solves_with_index.max[1]
+  end
+
+  def trimmed_indices
+    if missed_combined_round_cutoff?
+      # When you miss the cutoff for a combined round, you don't
+      # get an average, therefore none of the solves were trimmed.
+      []
+    else
+      sorted_solves = sorted_solves_with_index
+      trimmed_solves_with_index = sorted_solves[0...format.trim_fastest_n]
+      trimmed_solves_with_index += sorted_solves[(sorted_solves.length - format.trim_slowest_n)...sorted_solves.length]
+      trimmed_solves_with_index.map { |_, i| i }
+    end
+  end
+
+  def counting_solve_times
+    unless @counting
+      @counting = []
+      solve_times.each_with_index do |solve_time, i|
+        if !trimmed_indices.include?(i) && i < format.expected_solve_count
+          @counting << solve_time
+        end
+      end
+    end
+    @counting
+  end
+
+  # When someone changes an attribute, clear our cached values.
+  def write_attribute(attr, value)
+    @sorted_solves_with_index = nil
+    @solve_times = nil
+    @counting = nil
+    super
+  end
+end

--- a/WcaOnRails/lib/result_methods.rb
+++ b/WcaOnRails/lib/result_methods.rb
@@ -25,11 +25,11 @@ module ResultMethods
   end
 
   private def sorted_solves
-    @sorted_solves ||= solve_times.reject(&:skipped?).sort
+    @sorted_solves ||= solve_times.reject(&:skipped?).sort.freeze
   end
 
   private def sorted_solves_with_index
-    @sorted_solves_with_index ||= solve_times.each_with_index.reject { |s, _| s.skipped? }.sort
+    @sorted_solves_with_index ||= solve_times.each_with_index.reject { |s, _| s.skipped? }.sort.freeze
   end
 
   def solve_times
@@ -37,7 +37,7 @@ module ResultMethods
                       SolveTime.new(eventId, :single, value2),
                       SolveTime.new(eventId, :single, value3),
                       SolveTime.new(eventId, :single, value4),
-                      SolveTime.new(eventId, :single, value5)]
+                      SolveTime.new(eventId, :single, value5)].freeze
   end
 
   def worst_index

--- a/WcaOnRails/lib/solve_time.rb
+++ b/WcaOnRails/lib/solve_time.rb
@@ -116,6 +116,7 @@ class SolveTime
   def skipped?
     wca_value == SKIPPED_VALUE
   end
+
   def unskipped?
     !skipped?
   end

--- a/WcaOnRails/lib/solve_time.rb
+++ b/WcaOnRails/lib/solve_time.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class SolveTime
+  include ActiveModel::Model
+  include Comparable
+
   EMPTY_STRING = ''
   CLOCK_FORMAT = "%d:%02d:%02d.%02d"
   DOT_STRING = "."
@@ -9,22 +12,94 @@ class SolveTime
   DNS_STRING = "DNS"
   QUESTION_STRING = "?:??:??"
 
-  include Comparable
-
-  attr_reader :wca_value
   def initialize(event_id, field, wca_value)
-    raise "Unrecognized wca_value: #{wca_value}" if wca_value < -2
     @event_id = event_id
     @field = field
-    @wca_value = wca_value
+    self.wca_value = wca_value
   end
 
-  DNF_VALUE = -1
-  DNF = SolveTime.new(nil, nil, DNF_VALUE)
-  DNS_VALUE = -2
-  DNS = SolveTime.new(nil, nil, DNS_VALUE)
-  SKIPPED_VALUE = 0
-  SKIPPED = SolveTime.new(nil, nil, SKIPPED_VALUE)
+  attr_reader :wca_value, :time_centiseconds, :move_count
+  def wca_value=(wca_value)
+    @wca_value = wca_value
+    @move_count = nil
+    @attempted = nil
+    @solved = nil
+    @time_centiseconds = nil
+
+    if @event_id == '333fm'
+      # The average field for 333fm is pretty weird. It's the sum
+      # of the solves, multiplied by 100.
+      # Otherwise, wca_value is simply the number of moves.
+      @move_count = @field == :average ? ( wca_value / 100.0 ) : wca_value
+    elsif multi_blind?
+      mb_value = wca_value
+      # Extract wca_value parts.
+      old = mb_value / 1000000000 != 0
+      if old
+        time_seconds = mb_value % 100000
+        mb_value = mb_value / 100000
+        @attempted = mb_value % 100
+        mb_value = mb_value / 100
+        @solved = 99 - mb_value % 100
+      else
+        missed = mb_value % 100
+        mb_value = mb_value / 100
+        time_seconds = mb_value % 100000
+        mb_value = mb_value / 100000
+        difference = 99 - ( mb_value % 100 )
+        @solved = difference + missed
+        @attempted = @solved + missed
+      end
+
+      @time_centiseconds = time_seconds == 99999 ? nil : time_seconds * 100
+    else
+      @time_centiseconds = wca_value
+    end
+  end
+
+  def recompute_wca_value
+    if @event_id == '333fm'
+      @wca_value = @move_count
+    elsif multi_blind?
+      missed = @attempted - @solved
+      dd = 99 - ( @solved - missed )
+      ttttt = time_centiseconds / 100
+
+      if @event_id == "333mbf"
+        mm = missed
+        @wca_value = (dd * 1e7 + ttttt * 1e2 + mm).to_i
+      elsif @event_id == "333mbo"
+        ss = @solved
+        aa = @attempted
+        @wca_value = (1 * 1e8 + ss * 1e7 + aa * 1e5 + ttttt).to_i
+      else
+        raise
+      end
+    else
+      @wca_value = time_centiseconds
+    end
+  end
+
+  def time_centiseconds=(time_centiseconds)
+    @time_centiseconds = time_centiseconds
+    recompute_wca_value
+  end
+
+  def solved=(solved)
+    raise "solved out of range" unless (0...100).cover?(solved)
+    @solved = solved
+    recompute_wca_value
+  end
+
+  def attempted=(attempted)
+    raise "attempted out of range" unless (0...100).cover?(attempted)
+    @attempted = attempted
+    recompute_wca_value
+  end
+
+  def multi_blind?
+    @event_id == '333mbf' || @event_id == '333mbo'
+  end
 
   def dn?
     dnf? || dns?
@@ -40,6 +115,17 @@ class SolveTime
 
   def skipped?
     wca_value == SKIPPED_VALUE
+  end
+  def unskipped?
+    !skipped?
+  end
+
+  def time_seconds
+    time_centiseconds / 100.0
+  end
+
+  def time_minutes
+    time_seconds / 60.0
   end
 
   protected def to_orderable
@@ -65,53 +151,24 @@ class SolveTime
     end
 
     if @event_id == '333fm'
-      if @field == :average
-        # The average field for 333fm is pretty weird. It's the sum
-        # of the solves, multiplied by 100 and rounded to the nearest integer.
-        return "%.2f" % ( wca_value / 100.0 )
-      end
-
-      # Otherwise, wca_value is simply the number of moves.
-      wca_value.to_s
-
-    elsif @event_id == '333mbf' || @event_id == '333mbo'
-
-      mb_value = wca_value
-      # Extract wca_value parts.
-      old = mb_value / 1000000000 != 0
-      if old
-        time = mb_value % 100000
-        mb_value = mb_value / 100000
-        attempted = mb_value % 100
-        mb_value = mb_value / 100
-        solved = 99 - mb_value % 100
-      else
-        missed = mb_value % 100
-        mb_value = mb_value / 100
-        time = mb_value % 100000
-        mb_value = mb_value / 100000
-        difference = 99 - ( mb_value % 100 )
-        solved = difference + missed
-        attempted = solved + missed
-      end
-
+      format_str = (@field == :average ? "%.2f" : "%.0f")
+      format_str % @move_count
+    elsif multi_blind?
       # Build time string.
-      if time == 99999
+      if time_centiseconds.nil?
         result = QUESTION_STRING
       else
         result = EMPTY_STRING
-        while time >= 60
-          result = ":%02d#{result}" % ( time % 60 )
-          time = time / 60
+        time_seconds = time_centiseconds / 100
+        while time_seconds >= 60
+          result = ":%02d#{result}" % ( time_seconds % 60 )
+          time_seconds = time_seconds / 60
         end
-        result = "#{time}#{result}"
+        result = "#{time_seconds}#{result}"
       end
 
-      "#{solved}/#{attempted} #{result}"
-
+      "#{@solved}/#{@attempted} #{result}"
     else
-
-      time_centiseconds = wca_value
       hours = time_centiseconds / 360000
       minutes = (time_centiseconds % 360000) / 6000
       seconds = (time_centiseconds % 6000) / 100
@@ -124,4 +181,40 @@ class SolveTime
       clock_format
     end
   end
+
+  validate :wca_value_valid
+  def wca_value_valid
+    unless wca_value >= -2
+      errors.add(:base, "invalid")
+    end
+  end
+
+  # Enforce https://www.worldcubeassociation.org/regulations/#H1b.
+  validate :multiblind_time_limit
+  def multiblind_time_limit
+    return unless @event_id == "333mbf"
+
+    time_limit_minutes = [ 60, @attempted * 10 ].min
+    if time_minutes > time_limit_minutes
+      errors.add(:base, "should be less than or equal to #{time_limit_minutes} minutes")
+    end
+  end
+
+  validate :times_over_10_minutes_must_be_rounded, if: :timed_event?
+  def times_over_10_minutes_must_be_rounded
+    if time_minutes > 10 && time_centiseconds % 100 > 0
+      errors.add(:base, "times over 10 minutes should be rounded")
+    end
+  end
+
+  def timed_event?
+    @event_id != "333fm"
+  end
+
+  DNF_VALUE = -1
+  DNF = SolveTime.new(nil, nil, DNF_VALUE)
+  DNS_VALUE = -2
+  DNS = SolveTime.new(nil, nil, DNS_VALUE)
+  SKIPPED_VALUE = 0
+  SKIPPED = SolveTime.new(nil, nil, SKIPPED_VALUE)
 end

--- a/WcaOnRails/spec/factories/results.rb
+++ b/WcaOnRails/spec/factories/results.rb
@@ -3,12 +3,13 @@ FactoryGirl.define do
   factory :result do
     transient do
       person { FactoryGirl.create(:person) }
+      competition { FactoryGirl.create(:competition) }
     end
 
     personId { person.wca_id }
     personName { person.name }
     countryId { person.countryId }
-    competitionId "USNationals2010"
+    competitionId { competition.id }
     pos 1
     eventId "333oh"
     roundId "f"

--- a/WcaOnRails/spec/lib/solve_time_spec.rb
+++ b/WcaOnRails/spec/lib/solve_time_spec.rb
@@ -18,13 +18,14 @@ describe "SolveTime" do
     expect(solve_time(0).skipped?).to eq true
   end
 
-  describe "clock_format" do
-    it "prefixes with 0 for times less than 1 second" do
-      expect(solve_time(94).clock_format).to eq "0.94"
-    end
+  context "333mbf" do
+    it "set number attempted" do
+      solve_time = SolveTime.new("333mbf", :single, 0)
+      solve_time.attempted = 3
+      solve_time.solved = 2
+      solve_time.time_centiseconds = 3 * 60 * 100 + 5800
 
-    it "does not prefix with 0 for times between 1 and 10 seconds" do
-      expect(solve_time(500).clock_format).to eq "5.00"
+      expect(solve_time.clock_format).to eq "2/3 3:58"
     end
   end
 
@@ -46,6 +47,62 @@ describe "SolveTime" do
 
     it "treats DNS as worse than a finished solve" do
       expect(SolveTime::DNF > solve_time(30)).to eq true
+    end
+  end
+
+  describe "clock_format" do
+    it "prefixes with 0 for times less than 1 second" do
+      expect(solve_time(94).clock_format).to eq "0.94"
+    end
+
+    it "does not prefix with 0 for times between 1 and 10 seconds" do
+      expect(solve_time(500).clock_format).to eq "5.00"
+    end
+
+    it "formats just seconds" do
+      expect(solve_time(4242).clock_format).to eq "42.42"
+    end
+
+    it "formats minutes" do
+      expect(solve_time(3 * 60 * 100 + 4242).clock_format).to eq "3:42.42"
+    end
+
+    it "formats hours" do
+      expect(solve_time(2 * 60 * 100 * 60 + 3 * 60 * 100 + 4242).clock_format).to eq "2:03:42.42"
+    end
+
+    describe "333fm" do
+      it "formats best" do
+        solve_time = SolveTime.new('333fm', :single, 32)
+        expect(solve_time.clock_format).to eq "32"
+      end
+
+      it "formats average" do
+        solve_time = SolveTime.new('333fm', :average, 3267)
+        expect(solve_time.clock_format).to eq "32.67"
+
+        solve_time = SolveTime.new('333fm', :average, 2500)
+        expect(solve_time.clock_format).to eq "25.00"
+      end
+    end
+
+    describe "333mbf" do
+      it "formats best" do
+        solve_time = SolveTime.new('333mbf', :single, 580325400)
+        expect(solve_time.clock_format).to eq "41/41 54:14"
+      end
+    end
+
+    describe "333mbo" do
+      it "formats best" do
+        solve_time = SolveTime.new('333mbo', :single, 1960706900)
+        expect(solve_time.clock_format).to eq "3/7 1:55:00"
+      end
+
+      it "handles missing times" do
+        solve_time = SolveTime.new('333mbo', :single, 969999900)
+        expect(solve_time.clock_format).to eq "3/3 ?:??:??"
+      end
     end
   end
 end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -633,7 +633,7 @@ RSpec.describe Competition do
   end
 
   context "competitors" do
-    let!(:competition) { FactoryGirl.build(:competition) }
+    let!(:competition) { FactoryGirl.create(:competition) }
 
     it "works" do
       FactoryGirl.create_list :result, 2, competition: competition

--- a/WcaOnRails/spec/models/light_result_spec.rb
+++ b/WcaOnRails/spec/models/light_result_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe LightResult do
     it "combined round and didn't make cutoff" do
       result = build_result "eventId" => "333", "value1" => 20, "value2" => 10, "value3" => 60, "value4" => SolveTime::SKIPPED_VALUE, "value5" => SolveTime::SKIPPED_VALUE, "average" => SolveTime::SKIPPED_VALUE, "formatId" => "a"
       expect(result.format.expected_solve_count).to eq 5
-      expect(result.solves).to eq [
+      expect(result.solve_times).to eq [
         solve_time(20), solve_time(10), solve_time(60), SolveTime::SKIPPED, SolveTime::SKIPPED
       ]
     end
@@ -47,7 +47,7 @@ RSpec.describe LightResult do
     it "returns 5 SolveTimes even for a round with 3 solves" do
       result = build_result "eventId" => "333", "value1" => 20, "value2" => 10, "value3" => 60, "value4" => SolveTime::SKIPPED_VALUE, "value5" => SolveTime::SKIPPED_VALUE, "average" => SolveTime::SKIPPED_VALUE, "formatId" => "3"
       expect(result.format.expected_solve_count).to eq 3
-      expect(result.solves).to eq [
+      expect(result.solve_times).to eq [
         solve_time(20), solve_time(10), solve_time(60), SolveTime::SKIPPED, SolveTime::SKIPPED
       ]
     end

--- a/WcaOnRails/spec/models/result_spec.rb
+++ b/WcaOnRails/spec/models/result_spec.rb
@@ -7,63 +7,194 @@ RSpec.describe Result do
     expect(result).to be_valid
   end
 
-  it "formats best just seconds" do
-    result = FactoryGirl.build :result, best: 4242
-    expect(result.to_s :best).to eq "42.42"
-  end
-
-  it "formats best minutes" do
-    result = FactoryGirl.build :result, best: 3*60*100 + 4242
-    expect(result.to_s :best).to eq "3:42.42"
-  end
-
-  it "formats best hours" do
-    result = FactoryGirl.build :result, best: 2*60*100*60 + 3*60*100 + 4242
-    expect(result.to_s :best).to eq "2:03:42.42"
-  end
-
-  describe "333fm" do
-    it "formats best" do
-      result = FactoryGirl.build :result, eventId: "333fm", best: 32
-      expect(result.to_s :best).to eq "32"
+  context "associations" do
+    it "validates competitionId" do
+      result = FactoryGirl.build :result, competitionId: "foo"
+      expect(result).to be_invalid
     end
 
-    it "formats average" do
-      result = FactoryGirl.build :result, eventId: "333fm", average: 3267
-      expect(result.to_s :average).to eq "32.67"
-
-      result.update_attribute(:average, 2500)
-      expect(result.to_s :average).to eq "25.00"
-    end
-  end
-
-  describe "333mbf" do
-    it "formats best" do
-      result = FactoryGirl.build :result, eventId: "333mbf", best: 580325400
-      expect(result.to_s :best).to eq "41/41 54:14"
-    end
-  end
-
-  describe "333mbo" do
-    it "formats best" do
-      result = FactoryGirl.build :result, eventId: "333mbo", best: 1960706900
-      expect(result.to_s :best).to eq "3/7 1:55:00"
+    it "validates countryId" do
+      result = FactoryGirl.build :result, countryId: "foo"
+      expect(result).to be_invalid
     end
 
-    it "handles missing times" do
-      result = FactoryGirl.build :result, eventId: "333mbo", best: 969999900
-      expect(result.to_s :best).to eq "3/3 ?:??:??"
+    it "validates eventId" do
+      result = FactoryGirl.build :result, eventId: "foo"
+      expect(result).to be_invalid
     end
-  end
 
-  describe "person association" do
-    it "always looks for subId 1" do
+    it "validates formatId" do
+      result = FactoryGirl.build :result, formatId: "foo"
+      expect(result).to be_invalid
+    end
+
+    it "validates roundId" do
+      result = FactoryGirl.build :result, roundId: "foo"
+      expect(result).to be_invalid
+    end
+
+    it "person association always looks for subId 1" do
       person1 = FactoryGirl.create :person_with_multiple_sub_ids
       person2 = Person.find_by!(wca_id: person1.wca_id, subId: 2)
       result1 = FactoryGirl.create :result, person: person1
       result2 = FactoryGirl.create :result, person: person2
       expect(result1.person).to eq person1
       expect(result2.person).to eq person1
+    end
+  end
+
+  context "valid" do
+    it "skipped solves must all come at the end" do
+      result = FactoryGirl.build :result, value2: 0
+      expect(result).to be_invalid
+      expect(result.errors.messages[:base]).to eq ["Skipped solves must all come at the end."]
+    end
+
+    it "cannot skip all solves" do
+      result = FactoryGirl.build :result, value1: 0, value2: 0, value3: 0, value4: 0, value5: 0
+      expect(result).to be_invalid
+      expect(result.errors.messages[:base]).to eq ["Cannot skip all solves."]
+    end
+
+    it "values must all be >= -2" do
+      result = FactoryGirl.build :result, value1: 0, value2: -3, value3: 0, value4: 0, value5: 0
+      expect(result).to be_invalid
+      expect(result.errors.messages[:value2]).to eq ["invalid"]
+    end
+
+    it "correctly computes best" do
+      result = FactoryGirl.build :result, value1: 42, value2: 43, value3: 44, value4: 45, value5: 46, best: 42, average: 44
+      expect(result).to be_valid
+
+      result.best = 41
+      expect(result).to be_invalid
+      expect(result.errors.messages[:best]).to eq ["should be 42"]
+    end
+
+    context "correctly computes average" do
+      it "average 5" do
+        result = FactoryGirl.build :result, value1: 42, value2: 43, value3: 44, value4: 45, value5: 46, best: 42, average: 44
+        expect(result).to be_valid
+
+        result.average = 33
+        expect(result).to be_invalid
+        expect(result.errors.messages[:average]).to eq ["should be 44"]
+      end
+
+      it "mean of 3" do
+        result = FactoryGirl.build :result, value1: 42, value2: 43, value3: 44, value4: 45, value5: 46, best: 42, average: 44
+        expect(result).to be_valid
+
+        result.average = 33
+        expect(result).to be_invalid
+        expect(result.errors.messages[:average]).to eq ["should be 44"]
+      end
+
+      it "fmc" do
+        result = FactoryGirl.build :result, eventId: "333fm", formatId: "m", value1: 42, value2: 42, value3: 43, value4: 0, value5: 0, best: 42, average: 4233
+        expect(result).to be_valid
+
+        result.average = 4200
+        expect(result).to be_invalid
+        expect(result.errors.messages[:average]).to eq ["should be 4233"]
+      end
+    end
+
+    context "check number of non-zero solves" do
+      def result_with_n_solves(n, options)
+        result = FactoryGirl.build :result, options
+        (1..5).each do |i|
+          result.send "value#{i}=", i <= n ? 42 : 0
+        end
+        result
+      end
+
+      context "non-combined rounds" do
+        it "format 1" do
+          result = result_with_n_solves(2, roundId: "1", formatId: "1")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected 1 solve, but found 2."]
+        end
+
+        it "format 2" do
+          result = result_with_n_solves(3, roundId: "1", formatId: "2")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected 2 solves, but found 3."]
+        end
+
+        it "format 3" do
+          result = result_with_n_solves(2, roundId: "1", formatId: "3")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected 3 solves, but found 2."]
+        end
+
+        it "format m" do
+          result = result_with_n_solves(2, roundId: "1", formatId: "m")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected 3 solves, but found 2."]
+        end
+
+        it "format a" do
+          result = result_with_n_solves(2, roundId: "1", formatId: "a")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected 5 solves, but found 2."]
+        end
+      end
+
+      context "combined rounds" do
+        it "format 2" do
+          result = result_with_n_solves(3, roundId: "c", formatId: "2")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected at most 2 solves, but found 3."]
+        end
+
+        it "format 3" do
+          result = result_with_n_solves(4, roundId: "c", formatId: "3")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected at most 3 solves, but found 4."]
+        end
+
+        it "format m" do
+          result = result_with_n_solves(4, roundId: "c", formatId: "m")
+          expect(result).to be_invalid
+          expect(result.errors.messages[:base]).to eq ["Expected at most 3 solves, but found 4."]
+        end
+      end
+    end
+
+    it "times over 10 minutes must be rounded" do
+      result = FactoryGirl.build :result, value2: 10*6000 + 4343
+      expect(result).to be_invalid
+      expect(result.errors.messages[:value2]).to eq ["times over 10 minutes should be rounded"]
+
+      result.value2 = 10*6000 + 4300
+      result.average = 6000
+      expect(result).to be_valid
+    end
+
+    context "multibld" do
+      # Enforce https://www.worldcubeassociation.org/regulations/#H1b.
+      it "time must be below one hour" do
+        solve_time = SolveTime.new("333mbf", :single, 0)
+        solve_time.solved = 28
+        solve_time.attempted = 30
+        solve_time.time_centiseconds = 65*60*100
+
+        result = FactoryGirl.build :result, eventId: "333mbf", value1: solve_time.wca_value
+        expect(result).to be_invalid
+        expect(result.errors.messages[:value1]).to eq ["should be less than or equal to 60 minutes"]
+      end
+
+      it "time must be below 30 minutes if they attempted 3 cubes" do
+        solve_time = SolveTime.new("333mbf", :single, 0)
+        solve_time.solved = 2
+        solve_time.attempted = 3
+        solve_time.time_centiseconds = 31*60*100
+
+        result = FactoryGirl.build :result, eventId: "333mbf", value1: solve_time.wca_value
+        expect(result).to be_invalid
+        expect(result.errors.messages[:value1]).to eq ["should be less than or equal to 30 minutes"]
+      end
     end
   end
 end


### PR DESCRIPTION
When working on #977, I ended up doing this, and realized I could merge this up as is right now. I think smaller PRs are always a better thing, so here's a PR that gets us closer to porting the `check_results` script from PHP.

There were a couple of tricky things in here. One in particular is the `ResultMethods` module I created so that Result and LightResult can share the same functionality.

This is basically a port of https://github.com/thewca/worldcubeassociation.org/blob/master/webroot/results/includes/_check.php.
