### PR TITLE
Fixed bug where we were still referencing the nonexistant guests_old field.

### DIFF
--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -76,10 +76,8 @@
                 </span>
               </td>
               <td class="guests">
-                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %> <%= registration.guests_old %>">
+                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.guests %>">
                   <%= registration.guests %>
-                  <% #https://github.com/thewca/worldcubeassociation.org/issues/403 %>
-                  <%= registration.guests_old %>
                 </span>
               </td>
               <td class="comments">

--- a/WcaOnRails/spec/features/registration_management_spec.rb
+++ b/WcaOnRails/spec/features/registration_management_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Registration management" do
+  let(:delegate) { FactoryGirl.create :delegate }
+  let(:competition) { FactoryGirl.create :competition, :registration_open, delegates: [delegate] }
+
+  let!(:user1) { FactoryGirl.create :user, name: "Johnny Bravo" }
+  let!(:registration1) { FactoryGirl.create :registration, user: user1, competition: competition }
+
+  context "when signed in as competition delegate" do
+    before :each do
+      sign_in delegate
+    end
+
+    scenario "smoke test" do
+      visit competition_edit_registrations_path(competition)
+      expect(page).to have_text("Johnny Bravo")
+    end
+  end
+end


### PR DESCRIPTION
I added a very basic feature test (smoke test) to help catch silly errors like this.