### PR TITLE
Background workers now on supervisor, fixes #967

### DIFF
--- a/chef/roles/wca.json
+++ b/chef/roles/wca.json
@@ -38,6 +38,7 @@
     "recipe[wca::email]",
     "recipe[wca::cronjobs]",
     "recipe[wca::newrelic]",
+    "recipe[wca::supervisor]",
     "recipe[wca::backup]"
   ],
   "env_run_lists": {

--- a/chef/site-cookbooks/wca/recipes/supervisor.rb
+++ b/chef/site-cookbooks/wca/recipes/supervisor.rb
@@ -1,0 +1,16 @@
+username, repo_root = WcaHelper.get_username_and_repo_root(self)
+
+package 'supervisor'
+
+template "/etc/supervisor/conf.d/workers.conf" do
+  source "workers.conf.erb"
+  variables({
+    repo_root: repo_root,
+  })
+  notifies :run, 'execute[supervisor-update]', :delayed
+end
+
+execute "supervisor-update" do
+  command "supervisorctl update"
+  action :nothing
+end

--- a/chef/site-cookbooks/wca/templates/workers.conf.erb
+++ b/chef/site-cookbooks/wca/templates/workers.conf.erb
@@ -1,0 +1,16 @@
+<% rails_root = "#{@repo_root}/WcaOnRails" %>
+
+[program:mailer_worker]
+directory=<%= rails_root %>
+command=<%= rails_root %>/bin/rake jobs:work
+environment=QUEUE="mailers",RAILS_ENV="production"
+autorestart=true
+
+[program:everything_worker]
+directory=<%= rails_root %>
+command=<%= rails_root %>/bin/rake jobs:work
+environment=RAILS_ENV="production"
+autorestart=true
+
+[group:workers]
+programs=mailer_worker,everything_worker

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -103,10 +103,11 @@ restart_dj() {
     cd WcaOnRails
 
     # Kill all delayed_job workers (ignore if they were not running).
+    # This bit will disappear once we've switched to supervisor
     pkill -f "wca_worker/delayed_job" || true
-    # Restart delayed_job worker.
-    bin/delayed_job -p wca_worker --pool=mailers:1 --pool=*:1 start
   )
+
+  sudo supervisorctl restart workers:*
 }
 
 rebuild_rails() {


### PR DESCRIPTION
Deployed on staging and it seems to work:
```
Chef Client finished, 14/147 resources updated in 25.33579045 seconds
~/worldcubeassociation.org @staging> sudo supervisorctl status
workers:everything_worker        RUNNING    pid 8282, uptime 0:02:03
workers:mailer_worker            RUNNING    pid 8281, uptime 0:02:03
~/worldcubeassociation.org @staging> 

~/worldcubeassociation.org @staging> ./scripts/deploy.sh restart_dj
++ for command in '"$@"'
++ restart_dj
++ cd WcaOnRails
++ pkill -f wca_worker/delayed_job
++ true
++ sudo supervisorctl restart 'workers:*'
mailer_worker: stopped
everything_worker: stopped
mailer_worker: started
everything_worker: started
~/worldcubeassociation.org @staging>
```