### PR TITLE
Add base entry fee to competitions form - Fixes #733

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -28,6 +28,7 @@ gem 'time_will_tell'
 gem 'redcarpet', '~> 3.3'
 gem 'world-flags', git: 'git://github.com/world-flags/world-flags.git'
 gem 'bootstrap-table-rails'
+gem 'money-rails'
 
 # Pointing to jfly/carrierwave-crop which has a workaround for
 #  https://github.com/brianreavis/selectize.js/issues/953

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -255,6 +255,16 @@ GEM
     mini_magick (4.2.7)
     mini_portile2 (2.0.0)
     minitest (5.8.3)
+    monetize (1.4.0)
+      money (~> 6.7)
+    money (6.7.1)
+      i18n (>= 0.6.4, <= 0.7.0)
+      sixarm_ruby_unaccent (>= 1.1.1, < 2)
+    money-rails (1.7.0)
+      activesupport (>= 3.0)
+      monetize (~> 1.4.0)
+      money (~> 6.7)
+      railties (>= 3.0)
     multi_json (1.11.0)
     mysql2 (0.3.18)
     nenv (0.2.0)
@@ -380,6 +390,7 @@ GEM
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
+    sixarm_ruby_unaccent (1.1.1)
     slop (3.6.0)
     spring (1.7.2)
     spring-commands-rspec (1.0.4)
@@ -478,6 +489,7 @@ DEPENDENCIES
   mail_form
   mini_magick
   momentjs-rails (~> 2.9)!
+  money-rails
   mysql2
   newrelic_rpm
   nokogiri

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -361,6 +361,8 @@ class CompetitionsController < ApplicationController
       :guests_enabled,
       :being_cloned_from_id,
       :clone_tabs,
+      :base_entry_fee_lowest_denomination,
+      :currency_code,
     ]
     if @competition && @competition.isConfirmed? && !current_user.can_admin_results?
       # If the competition is confirmed, non admins are not allowed to change anything.

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -24,6 +24,11 @@ class Competition < ActiveRecord::Base
 
   accepts_nested_attributes_for :competition_events, allow_destroy: true
 
+  monetize :base_entry_fee_lowest_denomination,
+           as: "base_entry_fee",
+           allow_nil: true,
+           with_model_currency: :currency_code
+
   CLONEABLE_ATTRIBUTES = %w(
     cityName
     countryId
@@ -39,6 +44,8 @@ class Competition < ActiveRecord::Base
     remarks
     use_wca_registration
     guests_enabled
+    base_entry_fee_lowest_denomination
+    currency_code
   ).freeze
   UNCLONEABLE_ATTRIBUTES = %w(
     id

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -219,6 +219,9 @@
 
     <% end %>
 
+    <%= f.input :currency_code, collection: Money::Currency.table.values, label_method: lambda { |c| c[:name]  }, value_method: lambda { |c| c[:iso_code] }  %>
+    <%= f.input :base_entry_fee_lowest_denomination %>
+
     <%= f.input :use_wca_registration %>
 
     <div class="wca-registration-options">

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -38,6 +38,11 @@
         <dt><%= t '.contact' %></dt>
         <dd><%=md competition.contact %></dd>
       <% end %>
+
+      <% if competition.base_entry_fee %>
+        <dt><%= t '.entry_fee' %></dt>
+        <dd><%= humanized_money_with_symbol competition.base_entry_fee %></dd>
+      <% end %>
     </dl>
   </div>
 

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -69,6 +69,12 @@
           <% end %>
         </div>
 
+        <% if @competition.base_entry_fee %>
+          <%= alert :info do %>
+            <%= t 'registrations.entry_fee' %><strong><%= humanized_money_with_symbol @competition.base_entry_fee %></strong>
+          <% end %>
+        <% end %>
+
         <% url = @registration.new_record? ? competition_registrations_path(@competition)
                                            : registration_path(@registration) %>
         <%= horizontal_simple_form_for @registration, url: url, html: { class: 'are-you-sure no-submit-on-enter' } do |f| %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -129,6 +129,9 @@ en:
         external_website: "Website"
         generate_website: "I would like to use WCA website instead of an external one for additional informations."
 
+        base_entry_fee_lowest_denomination: "Base entry fee in the lowest denomination"
+        currency_code: "Currency code"
+
         delegate_ids: "WCA delegate(s)"
         organizer_ids: "Organizers(s)"
         contact: "Contact"
@@ -229,6 +232,8 @@ en:
         countryId: ""
         end_date: ""
         generate_website: ""
+        base_entry_fee_lowest_denomination: 'The base entry fee for the competition. This is recorded in the lowest denomination for the specified currency. Eg. cents for USD. The entry fee will be displayed on the competition information page and the registration page if used. Note that the WCA site does not yet have payment support. The software team is working towards this and you can track the progress on <a href="https://github.com/thewca/worldcubeassociation.org/issues?q=is%3Aopen+is%3Aissue+label%3Apayments">GitHub</a>.'
+        currency_code: "The currency code for entry fees."
         guests_enabled: ""
         id: ""
         isConfirmed: ""
@@ -519,6 +524,7 @@ en:
     please_fix_profile_html: "In order to register for this %{comp}, you must fix the following problems with your %{profile}:"
     can_register: "You can register for %{comp} below."
     have_registered: "You have registered for %{comp}. You can see your registration information below."
+    entry_fee: "The entry fee is "
     contact_organizer: "Contact the organizer if you wish to make a change."
     waiting_list: "You are currently number %{i} of %{n} on the waiting list."
     accepted: "Your registration has been accepted!"
@@ -554,6 +560,7 @@ en:
         one: "WCA Delegate"
         other: "WCA Delegates"
       contact: "Contact"
+      entry_fee: "Entry Fee"
       information: "Information"
     index:
       title: "Competitions"

--- a/WcaOnRails/db/migrate/20161031215932_add_entry_fees_to_competitions.rb
+++ b/WcaOnRails/db/migrate/20161031215932_add_entry_fees_to_competitions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddEntryFeesToCompetitions < ActiveRecord::Migration
+  def change
+    add_column :Competitions, :base_entry_fee_lowest_denomination, :integer
+    add_column :Competitions, :currency_code, :string
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -52,6 +52,8 @@ CREATE TABLE `Competitions` (
   `results_nag_sent_at` datetime DEFAULT NULL,
   `generate_website` tinyint(1) DEFAULT NULL,
   `announced_at` datetime DEFAULT NULL,
+  `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
+  `currency_code` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -1142,3 +1144,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161011005956');
 INSERT INTO schema_migrations (version) VALUES ('20161018220122');
 
 INSERT INTO schema_migrations (version) VALUES ('20161026201019');
+
+INSERT INTO schema_migrations (version) VALUES ('20161031215932');
+


### PR DESCRIPTION
I've recorded the entry fee in cents. Payments sent to stripe need to be in cents so this simplifies this aspect, and also Japanese Yen doesn't have dollars as such. There is a display divisor on the currencies table which would need to be used for display purposes.

I'm thinking that if an entry fee is entered it could be displayed in an automatically generated tab like the General Info tab.