### PR TITLE
Update url on the users index page

### DIFF
--- a/WcaOnRails/app/assets/javascripts/persons.js
+++ b/WcaOnRails/app/assets/javascripts/persons.js
@@ -13,18 +13,16 @@ var personsTableAjax = {
 
 onPage('persons#index', function() {
   var $table = $('.persons-table');
+  var options = $table.bootstrapTable('getOptions');
 
-  // Set pagination page from params.
-  var pageNumber = $.getUrlParam('page');
-  if(pageNumber) {
-    $table.bootstrapTable('refreshOptions', { pageNumber: parseInt(pageNumber) });
-  }
+  // Set the table options from the url params.
+  options.pageNumber = parseInt($.getUrlParam('page')) || options.pageNumber;
+  // Load the data using the options set above.
+  $table.bootstrapTable('refresh');
 
   function reloadPersons() {
     $('#search-box i').removeClass('fa-search').addClass('fa-spinner fa-spin');
-
-    $table.bootstrapTable('getOptions').pageNumber = 1;
-
+    options.pageNumber = 1;
     $table.bootstrapTable('refresh');
   }
 
@@ -35,8 +33,10 @@ onPage('persons#index', function() {
     $('#search-box i').removeClass('fa-spinner fa-spin').addClass('fa-search');
 
     // Update params in the url.
-    var params = personsTableAjax.queryParams(); // Get region and search params.
-    params.page = $table.bootstrapTable('getOptions').pageNumber;
+    var params = personsTableAjax.queryParams({
+      // Extended with region and search params.
+      page: options.pageNumber
+    });
     var url = location.toString();
     url = url.replace(/persons.*/, 'persons?' + $.param(params));
     history.replaceState(null, null, url);

--- a/WcaOnRails/app/assets/stylesheets/persons.scss
+++ b/WcaOnRails/app/assets/stylesheets/persons.scss
@@ -1,10 +1,4 @@
 #persons-index {
-  #persons-query-fields {
-    #search-box {
-      margin: 15px 0;
-    }
-  }
-
   .persons-table {
     .name {
       width: 40%;

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -342,3 +342,8 @@ textarea {
 .CodeMirror-scroll {
   min-height: 50px;
 }
+
+
+.bs-table-query-fields {
+  margin: 15px 0;
+}

--- a/WcaOnRails/app/views/persons/index.html.erb
+++ b/WcaOnRails/app/views/persons/index.html.erb
@@ -3,7 +3,7 @@
 <div class="container" id="persons-index">
   <h2><%= yield(:title) %></h2>
 
-  <div id="persons-query-fields" class="form-inline">
+  <div id="persons-query-fields" class="form-inline bs-table-query-fields">
     <div class="form-group">
       <%= select_tag(:region, region_option_tags(selected_id: params[:region]), class: "form-control") %>
     </div>

--- a/WcaOnRails/app/views/users/index.html.erb
+++ b/WcaOnRails/app/views/users/index.html.erb
@@ -1,9 +1,9 @@
 <% provide(:title, 'Users') %>
 
 <div class="container">
-  <h1><%= yield(:title) %></h1>
+  <h2><%= yield(:title) %></h2>
 
-  <div id="users-query-fields" class="form-inline">
+  <div id="users-query-fields" class="form-inline bs-table-query-fields">
     <div id="search-box" class="form-group">
       <div class="input-group">
         <%= content_tag :span, icon("search"), class: "input-group-addon" %>

--- a/WcaOnRails/app/views/users/index.html.erb
+++ b/WcaOnRails/app/views/users/index.html.erb
@@ -6,7 +6,9 @@
   <div id="users-query-fields" class="form-inline bs-table-query-fields">
     <div id="search-box" class="form-group">
       <div class="input-group">
-        <%= content_tag :span, icon("search"), class: "input-group-addon" %>
+        <%= content_tag :span, icon("search"), class: "input-group-addon",
+                               data: { toggle: "tooltip", placement: "top" },
+                               title: "Type name, WCA ID, email, or country. Use a space to separate them." %>
         <%= text_field_tag :search, params[:search], class: "form-control" %>
       </div>
     </div>

--- a/WcaOnRails/app/views/users/index.html.erb
+++ b/WcaOnRails/app/views/users/index.html.erb
@@ -3,9 +3,19 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
+  <div id="users-query-fields" class="form-inline">
+    <div id="search-box" class="form-group">
+      <div class="input-group">
+        <%= content_tag :span, icon("search"), class: "input-group-addon" %>
+        <%= text_field_tag :search, params[:search], class: "form-control" %>
+      </div>
+    </div>
+  </div>
+
   <%= wca_table table_class: "users-table",
                 data: { toggle: "table", pagination: "true", side_pagination: "server", url: users_url,
-                        search: "true", sort_name: "name", undefined_text: "" } do %>
+                        query_params: "usersTableAjax.queryParams", ajax: "usersTableAjax.doAjax",
+                        sort_name: "name", undefined_text: "" } do %>
     <thead>
       <tr>
         <th class="wca-id" data-field="wca_id" data-sortable="true">WCA ID</th>


### PR DESCRIPTION
Fixes #852.

I've added our custom search form on the users index page, the same way we have it on the persons index.
This is quiet redundant, but I cannot see any better way. Hopefully we will benefit from it later by adding more form elements.

In addition this cleans the `persons.js` file a bit.

If you feel like it's an overkill, or it's just not worth having that much code to achieve the goal, we can abandon this.