### PR TITLE
Fixed bug where "can find by name" would actually find 2 people instead

### DIFF
--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -60,7 +60,8 @@ describe Api::V0::ApiController do
   end
 
   describe 'GET #users_search' do
-    let!(:user) { FactoryGirl.create(:user_with_wca_id, name: "Jeremy") }
+    let(:person) { FactoryGirl.create(:person, name: "Jeremy", wca_id: "2005FLEI01") }
+    let!(:user) { FactoryGirl.create(:user, person: person) }
 
     it 'requires query parameter' do
       get :users_search
@@ -102,15 +103,15 @@ describe Api::V0::ApiController do
     end
 
     context 'Person without User' do
-      let!(:person) { FactoryGirl.create(:person, name: "Bob") }
+      let!(:userless_person) { FactoryGirl.create(:person, name: "Bob") }
 
       it "can find by wca_id" do
-        get :users_search, q: person.wca_id, persons_table: true
+        get :users_search, q: userless_person.wca_id, persons_table: true
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json["result"].length).to eq 1
-        expect(json["result"][0]["id"]).to eq person.wca_id
-        expect(json["result"][0]["wca_id"]).to eq person.wca_id
+        expect(json["result"][0]["id"]).to eq userless_person.wca_id
+        expect(json["result"][0]["wca_id"]).to eq userless_person.wca_id
         expect(json['result'][0]['avatar']['url']).to eq "/assets/missing_avatar_thumb.png"
         expect(json['result'][0]['avatar']['thumb_url']).to eq "/assets/missing_avatar_thumb.png"
         expect(json['result'][0]['avatar']['is_default']).to eq true
@@ -121,8 +122,8 @@ describe Api::V0::ApiController do
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json["result"].length).to eq 1
-        expect(json["result"][0]["id"]).to eq person.wca_id
-        expect(json["result"][0]["wca_id"]).to eq person.wca_id
+        expect(json["result"][0]["id"]).to eq userless_person.wca_id
+        expect(json["result"][0]["wca_id"]).to eq userless_person.wca_id
       end
     end
 

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -51,8 +51,9 @@ FactoryGirl.define do
       transient do
         person { FactoryGirl.create(:person, name: name, countryId: Country.find_by_iso2(country_iso2).id, gender: gender, dob: dob.strftime("%F")) }
       end
-      wca_id { person.wca_id }
     end
+
+    wca_id { person&.wca_id }
 
     factory :user_with_wca_id, traits: [:wca_id]
 


### PR DESCRIPTION
of the expected 1, because another person was sometimes getting created
with WCA IDs like "2016FBOL01", which have a "bo" in them. I changed the
test to explictly set the WCA ID so this will not happen anymore.