### PR TITLE
Change Cubing China website's protocol to https:

### DIFF
--- a/WcaOnRails/app/views/static_pages/organisations.html.erb
+++ b/WcaOnRails/app/views/static_pages/organisations.html.erb
@@ -33,7 +33,7 @@
        {
          country: "China",
          name: "Cubing China",
-         url: "http://cubingchina.com",
+         url: "https://cubingchina.com",
          logo: "cubing_china.png",
        },
        {


### PR DESCRIPTION
Cubing China has ported to use secure communication.