### PR TITLE
Improve _error_messages partial to link directly to the problematic fields if they exist.

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -148,8 +148,8 @@ module ApplicationHelper
 
   def simple_form_for(resource, options = {}, &block)
     super do |f|
-      error_messages = render('shared/error_messages', object: f.object)
       form = capture(f, &block)
+      error_messages = render('shared/error_messages', f: f)
       error_messages + form
     end
   end

--- a/WcaOnRails/app/views/shared/_error_messages.html.erb
+++ b/WcaOnRails/app/views/shared/_error_messages.html.erb
@@ -1,10 +1,17 @@
-<% if object.errors.any? %>
+<% if f.object.errors.any? %>
   <div id="error_explanation">
     <%= alert :danger do %>
-      <%= t 'wca.errors.messages.form_error', count: object.errors.count %>
+      <%= t 'wca.errors.messages.form_error', count: f.object.errors.count %>
       <ul>
-        <% object.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
+        <% f.object.errors.each do |attribute, msg| %>
+          <li>
+            <% if f.generated_attribute_inputs.include?(attribute) %>
+              <a href="#<%= f.id_for(attribute) %>"><strong><%= f.object.class.human_attribute_name(attribute) %></strong></a>
+            <% else %>
+              <strong><%= f.object.class.human_attribute_name(attribute) %></strong>
+            <% end %>
+            <%= msg %>
+        </li>
         <% end %>
       </ul>
     <% end %>

--- a/WcaOnRails/config/initializers/simple_form_builder_extensions.rb
+++ b/WcaOnRails/config/initializers/simple_form_builder_extensions.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Add a id_for method to simple forms.
+# Inspired by http://stackoverflow.com/a/4820814
+
+module SimpleForm
+  class FormBuilder
+    def id_for(method, options={})
+      InstanceTagWithIdFor.new(object_name, method, self, options).id_for(options)
+    end
+
+    attr_accessor :generated_attribute_inputs
+    old_input = instance_method(:input)
+    define_method(:input) do |attribute_name, options = {}, &block|
+      @generated_attribute_inputs ||= []
+      @generated_attribute_inputs << attribute_name
+      old_input.bind(self).call(attribute_name, options, &block)
+    end
+  end
+end
+
+class InstanceTagWithIdFor < ActionView::Helpers::Tags::Base
+  def id_for(options)
+    add_default_name_and_id(options)
+    options['id']
+  end
+end


### PR DESCRIPTION
This fixes #1011 and adds a cool new feature.

This should make people's lives easier when dealing with errors from very tall forms.

![image](https://cloud.githubusercontent.com/assets/277474/20362201/840b82d8-abef-11e6-85f5-f09be4d46082.png)

![image](https://cloud.githubusercontent.com/assets/277474/20362206/88188114-abef-11e6-8ab9-16024a9d7b5b.png)
