### PR TITLE
Add permanent link for database export by simply setting up a symlink for each of the zip files.

### DIFF
--- a/webroot/results/admin/export/template.export.html
+++ b/webroot/results/admin/export/template.export.html
@@ -35,9 +35,15 @@
     <p>On this page we offer the WCA results for download in several formats so you can use/analyze them at large. We will usually update after each competition weekend when the results are finalized. The files are numbered and dated so you can see whether you have the newest version already.</p>
 
     <dl>
-      <dt>SQL: <a href='[sqlZipFile]'>[sqlZipFile]</a> ([sqlZipFileSize])</dt>
+      <dt>
+          SQL: <a href='[sqlZipFile]'>[sqlZipFile]</a> ([sqlZipFileSize])
+               <small>(<a href='WCA_export.sql.zip'>permalink</a>)</small>
+      </dt>
       <dd>SQL statements, for import into SQL databases.</dd>
-      <dt>TSV: <a href='[tsvZipFile]'>[tsvZipFile]</a> ([tsvZipFileSize])</dt>
+      <dt>
+          TSV: <a href='[tsvZipFile]'>[tsvZipFile]</a> ([tsvZipFileSize])
+               <small>(<a href='WCA_export.tsv.zip'>permalink</a>)</small>
+      </dt>
       <dd>Tab-separated values, for spreadsheets in OpenOffice.org, Excel, etc.</dd>
     </dl>
 

--- a/webroot/results/admin/export_public.php
+++ b/webroot/results/admin/export_public.php
@@ -210,6 +210,8 @@ function exportPublic ( $sources ) {
   #--- Move new files to public directory
   echo '<p><b>Move new files to public directory</b></p>';
   mySystem( "mv $sqlZipFile $tsvZipFile ../../misc/" );
+  mySystem( "rm -rf ../../misc/WCA_export.sql.zip && ln -s $sqlZipFile ../../misc/WCA_export.sql.zip" );
+  mySystem( "rm -rf ../../misc/WCA_export.tsv.zip && ln -s $sqlZipFile ../../misc/WCA_export.tsv.zip" );
   mySystem( "mv export.html ../../misc/" );
 
   #------------------------------------------


### PR DESCRIPTION
(Pair programmed with @coder13)

Dead simple, but it works. This fixes #60.

You can see it live on https://staging.worldcubeassociation.org/results/misc/export.html.

![image](https://cloud.githubusercontent.com/assets/277474/20405844/cfffc0a2-acbf-11e6-8d69-9fed633a01cf.png)
