### PR TITLE
Deleted registrations will be marked as such - fixes #1005

### DIFF
--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -5,11 +5,14 @@ onPage('registrations#edit_registrations', function() {
     var $selectedRows = $registrationsTable.find("tr.selected");
     $('.selected-registrations-actions').toggle($selectedRows.length > 0);
 
-    var $selectedApprovedRows = $selectedRows.filter(".registration-accepted");
-    $('.selected-approved-registrations-actions').toggle($selectedApprovedRows.length > 0);
+    var $selectedPendingDeletedRows = $selectedRows.filter(".registration-pending, .registration-deleted");
+    $('.selected-pending-deleted-registrations-actions').toggle($selectedPendingDeletedRows.length > 0);
 
-    var $selectedPendingRows = $selectedRows.filter(".registration-pending");
-    $('.selected-pending-registrations-actions').toggle($selectedPendingRows.length > 0);
+    var $selectedApprovedDeletedRows = $selectedRows.filter(".registration-accepted, .registration-deleted");
+    $('.selected-approved-deleted-registrations-actions').toggle($selectedApprovedDeletedRows.length > 0);
+
+    var $selectedPendingApprovedRows = $selectedRows.filter(".registration-pending, .registration-accepted");
+    $('.selected-pending-approved-registrations-actions').toggle($selectedPendingApprovedRows.length > 0);
 
     var emails = $selectedRows.find("a[href^=mailto]").map(function() { return this.href.match(/^mailto:(.*)/)[1]; }).toArray();
     document.getElementById("email-selected").href = "mailto:?bcc=" + emails.join(",");

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -225,7 +225,7 @@ class RegistrationsController < ApplicationController
     params[:registration][:deleted_at] = nil
     params[:registration][:accepted_at] = nil
     if current_user.can_manage_competition?(competition_from_params)
-      permitted_params << [
+      permitted_params += [
         :accepted_by,
         :deleted_by,
       ]

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -719,6 +719,7 @@ class Competition < ActiveRecord::Base
       users.name select_name,
       users.wca_id select_wca_id,
       registrations.accepted_at,
+      registrations.deleted_at,
       Countries.name select_country,
       registration_competition_events.competition_event_id,
       RanksAverage.worldRank average_rank,

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -27,12 +27,19 @@ class Registration < ActiveRecord::Base
     end
   end
 
+  validate :registration_cannot_be_deleted_and_accepted_simultaneously
+  private def registration_cannot_be_deleted_and_accepted_simultaneously
+    if deleted? && accepted?
+      errors.add(:registration_competition_events, I18n.t('registrations.errors.cannot_be_deleted_and_accepted'))
+    end
+  end
+
   def deleted?
     !deleted_at.nil?
   end
 
   def accepted?
-    !deleted? && !accepted_at.nil?
+    !accepted_at.nil? && !deleted?
   end
 
   def pending?

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 class Registration < ActiveRecord::Base
-  scope :pending, -> { where(accepted_at: nil) }
-  scope :accepted, -> { where.not(accepted_at: nil) }
+  scope :pending, -> { where(accepted_at: nil).where(deleted_at: nil) }
+  scope :accepted, -> { where.not(accepted_at: nil).where(deleted_at: nil) }
+  scope :deleted, -> { where.not(deleted_at: nil) }
 
   belongs_to :competition
   belongs_to :user
+  belongs_to :accepted_user, foreign_key: "accepted_by", class_name: "User"
+  belongs_to :deleted_user, foreign_key: "deleted_by", class_name: "User"
   has_many :registration_competition_events
   has_many :competition_events, through: :registration_competition_events
   has_many :events, through: :competition_events
@@ -24,12 +27,30 @@ class Registration < ActiveRecord::Base
     end
   end
 
-  def pending?
-    accepted_at.nil?
+  def deleted?
+    !deleted_at.nil?
   end
 
   def accepted?
-    !pending?
+    !deleted? && !accepted_at.nil?
+  end
+
+  def pending?
+    !accepted? && !deleted?
+  end
+
+  def checked_status
+    if accepted?
+      return :accepted
+    elsif pending?
+      return :pending
+    else
+      return :deleted
+    end
+  end
+
+  def new_or_deleted?
+    new_record? || deleted?
   end
 
   def name

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -400,7 +400,7 @@ class User < ActiveRecord::Base
   end
 
   def can_edit_registration?(registration)
-    can_manage_competition?(registration.competition) || (registration.pending? && registration.user_id == self.id)
+    can_manage_competition?(registration.competition) || (!registration.accepted? && registration.user_id == self.id)
   end
 
   def can_confirm_competition?(competition)

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -473,7 +473,7 @@ class User < ActiveRecord::Base
                            # Not using _html suffix as automatic html_safe is available only from
                            # the view helper
                            I18n.t('users.edit.cannot_edit.reason.assigned')
-                         elsif user_to_edit == self && !(admin? || any_kind_of_delegate?) && user_to_edit.registrations.count > 0
+                         elsif user_to_edit == self && !(admin? || any_kind_of_delegate?) && user_to_edit.registrations.accepted.count > 0
                            I18n.t('users.edit.cannot_edit.reason.registered')
                          end
     if cannot_edit_reason

--- a/WcaOnRails/app/views/registrations/do_actions_for_selected.js.erb
+++ b/WcaOnRails/app/views/registrations/do_actions_for_selected.js.erb
@@ -13,8 +13,9 @@ $('#pending-registrations-count').removeClass("label-danger label-success")
 var $registrationsTable = $('.registrations-table:not(.floatThead-table)');
 var $pendingTable = $registrationsTable.filter('.pending');
 var $acceptedTable = $registrationsTable.filter('.accepted');
+var $deletedTable = $registrationsTable.filter('.deleted');
 
-var selectedRows = $pendingTable.bootstrapTable('getSelections').concat($acceptedTable.bootstrapTable('getSelections'));
+var selectedRows = $pendingTable.bootstrapTable('getSelections').concat($acceptedTable.bootstrapTable('getSelections')).concat($deletedTable.bootstrapTable('getSelections'));
 var selectedRowIds = selectedRows.map(function(row) { return row._id }); // row._id contains <tr> id
 
 $registrationsTable.each(function() {
@@ -29,18 +30,21 @@ $registrationsTable.each(function() {
   $acceptedTable.bootstrapTable('append', selectedRows);
 <% when "reject-selected" %>
   $pendingTable.bootstrapTable('append', selectedRows);
+<% when "delete-selected" %>
+  $deletedTable.bootstrapTable('append', selectedRows);
 <% end %>
 
 $('.registrations-table.floatThead').floatThead('reflow');
 
-$pendingTable.find('tbody tr').removeClass('registration-accepted').addClass('registration-pending');
-$acceptedTable.find('tbody tr').removeClass('registration-pending').addClass('registration-accepted');
+$pendingTable.find('tbody tr').removeClass('registration-accepted').removeClass('registration-deleted').addClass('registration-pending');
+$acceptedTable.find('tbody tr').removeClass('registration-pending').removeClass('registration-deleted').addClass('registration-accepted');
+$deletedTable.find('tbody tr').removeClass('registration-pending').removeClass('registration-accepted').addClass('registration-deleted');
 
 $registrationsTable.bootstrapTable('uncheckAll');
 $registrationsTable.find('tr.selected').removeClass('selected');
 
 // Update registration table footers with summary info
-<% [:pending, :accepted].each do |status| %>
+<% [:pending, :accepted, :deleted].each do |status| %>
   <% registrations = @competition.registrations.includes(:events, :user).send(status) %>
   $<%= status %>Table.find('tfoot').replaceWith('<%=j render "edit_registrations_table_footer", registrations: registrations %>');
 <% end %>

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -37,7 +37,7 @@
     </div>
     <% if @registration.accepted_at %>
       <div>
-        Accepted on <%= wca_local_time(@registration.accepted_at) %> by <%= @registration.accepted_user.name %>
+        Accepted on <%= wca_local_time(@registration.accepted_at) %> by <%= @registration.accepted_user.name unless @registration.accepted_user.nil? %>
       </div>
     <% end %>
     <% if @registration.deleted_at %>

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -5,20 +5,10 @@
     <%= hidden_field_tag :from_admin_view, "1" %>
     <%= f.hidden_field :updated_at %>
 
-    <% if @registration.user %>
-      <%= alert :info do %>
-        <%= t('registrations.registered_with_account_html', here: link_to(t('common.here'), edit_user_path(@registration.user))) %>
-      <% end %>
-      <%= @registration.name %>
-    <% else %>
-      <%= alert :info, "This person did not register with an account. You can edit their personal information below." %>
-
-      <%# We can remove this code once competitions only have registrations with accounts. See https://github.com/thewca/worldcubeassociation.org/issues/275 %>
-      <%= f.input :name %>
-      <%= f.input :birthday, as: :date_picker %>
-      <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: "Male", f: "Female", o: "Other" }[g] } %>
-      <%= f.input :countryId, collection: Country.real, value_method: :id, label_method: :name %>
+    <%= alert :info do %>
+      <%= t('registrations.registered_with_account_html', here: link_to(t('common.here'), edit_user_path(@registration.user))) %>
     <% end %>
+    <h4><%= @registration.name %></h4>
 
     <%= render "shared/associated_events_picker",
                form_builder: f,
@@ -33,14 +23,27 @@
 
     <%= f.input :comments %>
 
-    <%= f.input :status, as: :radio_buttons, collection: [:a, :p], checked: @registration.accepted? ? :a : :p, include_blank: false %>
+    <%= f.input :status, as: :radio_buttons, collection: [:accepted, :pending, :deleted], checked: @registration.checked_status, include_blank: false %>
 
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">
         <%= f.submit class: "btn btn-default" %>
-        <%= link_to t('registrations.delete'), registration_path(@registration), method: :delete, class: "btn btn-danger", data: { confirm: t('registrations.admin_delete_confirm', name: @registration.name), toggle: "tooltip" }, title: t('registrations.delete_tooltip', name: @registration.name, mail: @registration.email) %>
       </div>
     </div>
+    <hr />
+    <div>
+      <h4>Registration History</h4>
+      Created on <%= wca_local_time(@registration.created_at) %> by <%= @registration.user.name %>
+    </div>
+    <% if @registration.accepted_at %>
+      <div>
+        Accepted on <%= wca_local_time(@registration.accepted_at) %> by <%= @registration.accepted_user.name %>
+      </div>
+    <% end %>
+    <% if @registration.deleted_at %>
+      <div>
+        Deleted on <%= wca_local_time(@registration.deleted_at) %> by <%= @registration.deleted_user.name %>
+      </div>
+    <% end %>
   <% end %>
-
 <% end %>

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -3,11 +3,13 @@
 <%= render layout: 'nav' do %>
 
   <%= form_for @competition, url: competition_registrations_do_actions_for_selected_path(@competition), remote: true do |f| %>
-    <% [:pending, :accepted].each do |status| %>
+    <% [:pending, :accepted, :deleted].each do |status| %>
       <% if :pending == status %>
         <h2><%= t 'registrations.list.waiting_list' %></h2>
-      <% else %>
+      <% elsif :accepted == status %>
         <h2><%= t 'registrations.list.approved_registrations' %></h2>
+      <% else %>
+        <h2><%= t 'registrations.list.deleted_registrations' %></h2>
       <% end %>
       <% registrations = @competition.registrations.public_send(status).includes(:user, :events) %>
       <%= wca_table table_class: "registrations-table #{status}",
@@ -42,7 +44,7 @@
 
         <tbody>
           <% registrations.each do |registration| %>
-            <tr id="registration-<%= registration.id %>" class="<%= registration.pending? ? "registration-pending" : "" %> <%= registration.accepted? ? "registration-accepted" : "" %>">
+            <tr id="registration-<%= registration.id %>" class="registration-<%= registration.checked_status %>">
               <td></td>
 
               <td>
@@ -108,13 +110,13 @@
       <a href="#" id="email-selected" target="_blank" class="btn btn-info selected-registrations-actions">
         <%= icon 'envelope', t('registrations.list.email') %>
       </a>
-      <button type="submit" class="btn btn-success selected-pending-registrations-actions" name="registrations_action" value="accept-selected">
+      <button type="submit" class="btn btn-success selected-pending-deleted-registrations-actions" name="registrations_action" value="accept-selected">
         <%= icon 'check', t('registrations.list.approve') %>
       </button>
-      <button type="submit" class="btn btn-warning selected-approved-registrations-actions" name="registrations_action" value="reject-selected">
+      <button type="submit" class="btn btn-warning selected-approved-deleted-registrations-actions" name="registrations_action" value="reject-selected">
         <%= icon 'times', t('registrations.list.reject') %>
       </button>
-      <button type="submit" class="btn btn-danger selected-registrations-actions" name="registrations_action" value="delete-selected">
+      <button type="submit" class="btn btn-danger selected-pending-approved-registrations-actions" name="registrations_action" value="delete-selected">
         <%= icon 'trash', t('registrations.list.delete') %>
       </button>
     </div>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -51,7 +51,7 @@
         <% end %>
       <% else %>
         <div>
-          <% if @registration.new_record? %>
+          <% if @registration.new_or_deleted? %>
             <%= t 'registrations.can_register', comp: @competition.name %>
           <% else %>
             <%= t 'registrations.have_registered', comp: @competition.name %>
@@ -91,7 +91,7 @@
 
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
-              <% if @registration.new_record? %>
+              <% if @registration.new_or_deleted? %>
                 <%= f.submit t('registrations.register'), class: "btn btn-success" %>
               <% elsif current_user.can_edit_registration?(@registration) %>
                 <%= f.submit t('registrations.update'), class: "btn btn-success" %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -145,14 +145,12 @@ en:
         remarks: "Remarks"
         clone_tabs: "I would like to clone all tabs with additional information as well"
       registration:
-        countryId: "Country"
         guests: "Guests"
         comments: "Comments"
         status: "Status"
         # We can remove the following 3 keys once https://github.com/thewca/worldcubeassociation.org/issues/275 is done! (spec will complain anyway)
         name: "Name"
         birthday: "Birthday"
-        gender: "Gender"
       competition_tab:
         content: "Content"
         name: "Name"
@@ -275,12 +273,8 @@ en:
         multiple: ""
         question: ""
       registration:
-        birthday: ""
         comments: ""
-        countryId: ""
-        gender: ""
         guests: ""
-        name: ""
         status: ""
       team:
         description: ""
@@ -291,8 +285,9 @@ en:
     options:
       registration:
         status:
-          a: "Accepted"
-          p: "Waiting list"
+          accepted: "Accepted"
+          pending: "Waiting list"
+          deleted: "Deleted"
       competition:
         guests_enabled:
           "true": "Ask about guests"
@@ -500,6 +495,7 @@ en:
       delete: "Delete"
       waiting_list: "Waiting List"
       approved_registrations: "Approved registrations"
+      deleted_registrations: "Deleted registrations"
       registered: "Registered"
       total: "Total"
     new_registration:
@@ -510,9 +506,7 @@ en:
     register: "Register!"
     update: "Update Registration"
     delete: "Delete"
-    delete_tooltip: "Delete registration. This will email %{name} at %{mail}."
     delete_confirm: "Are you sure you want to delete your registration?"
-    admin_delete_confirm: "Are you sure you want to delete %{name}'s registration?"
     delete_registration: "Delete registration."
     will_open_html: "Registration will open in <strong>%{days}</strong> on %{time}."
     will_close_html: "Registration closes in <strong>%{days}</strong> on %{time}."

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -455,6 +455,7 @@ en:
       need_country: "Need a country"
       comp_not_found: "Competition not found"
       registration_closed: "Competition registration is closed"
+      cannot_be_deleted_and_accepted: "A registration cannot be deleted and accepted at the same time."
       can_register: "User must be able to register for competition"
       must_register: "must register for at least one event"
     registration_info_people:

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -143,13 +143,11 @@ fr:
         remarks: "Remarques"
         clone_tabs: "Je souhaite cloner les onglets ainsi que les informations additionnelles également."
       registration:
-        countryId: "Pays"
         guests: "Accompagnateurs"
         comments: "Commentaires"
         status: "Statut"
         name: "Nom"
         birthday: "Date de naissance"
-        gender: "Genre"
       competition_tab:
         content: "Contenu"
         name: "Nom"
@@ -274,12 +272,8 @@ fr:
         multiple: ""
         question: ""
       registration:
-        birthday: ""
         comments: ""
-        countryId: ""
-        gender: ""
         guests: ""
-        name: ""
         status: ""
       team:
         description: ""
@@ -290,8 +284,8 @@ fr:
     options:
       registration:
         status:
-          a: "Acceptée"
-          p: "En attente"
+          accepted: "Acceptée"
+          pending: "En attente"
       competition:
         guests_enabled:
           "true": "Ne PAS demander de renseigner les accompagnateurs"
@@ -506,9 +500,7 @@ fr:
     register: "Je m'inscris !"
     update: "Mettre à jour"
     delete: "Supprimer"
-    delete_tooltip: "Supprime l'inscription. Cela enverra un email à %{name} à l'adresse %{mail}"
     delete_confirm: "Êtes vous sûr de vouloir supprimer votre inscription ?"
-    admin_delete_confirm: "Êtes vous sûr de vouloir supprimer l'inscription de %{name} ?"
     delete_registration: "Supprimer l'inscription"
     will_open_html: "Les inscriptions ouvriront dans <strong>%{days}</strong> le %{time}."
     will_close_html: "Les inscriptions ferment dans <strong>%{days}</strong> le %{time}."

--- a/WcaOnRails/db/migrate/20161122014040_add_tracking_to_registrations.rb
+++ b/WcaOnRails/db/migrate/20161122014040_add_tracking_to_registrations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class AddTrackingToRegistrations < ActiveRecord::Migration
+  def change
+    add_column :registrations, :accepted_by, :integer
+    add_column :registrations, :deleted_at, :datetime
+    add_column :registrations, :deleted_by, :integer
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -779,9 +779,11 @@ CREATE TABLE `registrations` (
   `updated_at` datetime NOT NULL,
   `guests` int(11) NOT NULL DEFAULT '0',
   `accepted_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=84281 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  `accepted_by` int(11) DEFAULT NULL,
+  `deleted_at` datetime DEFAULT NULL,
+  `deleted_by` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=86147 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1153,3 +1155,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161118141833');
 INSERT INTO schema_migrations (version) VALUES ('20161122162029');
 
 INSERT INTO schema_migrations (version) VALUES ('20161117085757');
+
+INSERT INTO schema_migrations (version) VALUES ('20161122014040');

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -131,8 +131,26 @@ describe UsersController do
       expect(user.reload.preferred_events.map(&:id)).to eq %w(333 444 clock)
     end
 
-    context "after registering for a competition" do
-      let!(:registration) { FactoryGirl.create(:registration, user: user) }
+    context "after creating a pending registration" do
+      let!(:registration) { FactoryGirl.create(:registration, :pending, user: user) }
+      it "user can change name" do
+        sign_in user
+        patch :update, id: user.id, user: { name: "Johnny 5" }
+        expect(user.reload.name).to eq "Johnny 5"
+      end
+    end
+
+    context "after having a registration deleted" do
+      let!(:registration) { FactoryGirl.create(:registration, :deleted, user: user) }
+      it "user can change name" do
+        sign_in user
+        patch :update, id: user.id, user: { name: "Johnny 5" }
+        expect(user.reload.name).to eq "Johnny 5"
+      end
+    end
+
+    context "after registration is accepted for a competition" do
+      let!(:registration) { FactoryGirl.create(:registration, :accepted, user: user) }
 
       it "user cannot change name" do
         sign_in user

--- a/WcaOnRails/spec/factories/registrations.rb
+++ b/WcaOnRails/spec/factories/registrations.rb
@@ -14,6 +14,10 @@ FactoryGirl.define do
       accepted_at Time.now
     end
 
+    trait :deleted do
+      deleted_at Time.now
+    end
+
     trait :pending do
       accepted_at nil
     end

--- a/WcaOnRails/spec/features/register_for_competition_spec.rb
+++ b/WcaOnRails/spec/features/register_for_competition_spec.rb
@@ -61,8 +61,9 @@ RSpec.feature "Registering for a competition" do
 
     scenario "deleting registration" do
       visit edit_registration_path(registration)
-      click_link "Delete"
-      expect(Registration.find_by_id(registration.id)).to eq nil
+      choose "Deleted"
+      click_button "Update Registration"
+      expect(Registration.find_by_id(registration.id).deleted?).to eq true
     end
   end
 end


### PR DESCRIPTION
New columns deleted_at, and deleted_by have been added to the
registrations table to track when a registration is deleted.

A new column accepted_by has also been added to record the user id
of the person who accepted the registration.

A user can still only have 1 registration per competition. If the
registration is 'deleted' and then the user registers again, the
original registration will be updated and the deleted_at column
will be set to null.