### PR TITLE
Make updates to Users invalidate the cache

### DIFF
--- a/WcaOnRails/app/views/registrations/index.html.erb
+++ b/WcaOnRails/app/views/registrations/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, I18n.t('registrations.list.title', comp: @competition.name)) %>
 
 <%= render layout: "nav" do %>
-  <% cache ["registrations_index", @competition.events, @registrations.pluck(:id), @registrations.maximum(:updated_at)] do %>
+  <% cache ["registrations_index", @competition.events, @registrations.pluck(:id), @registrations.maximum(:updated_at), @registrations.maximum(:'users.updated_at')] do %>
     <%= wca_table data: { toggle: "table" } do %>
       <thead>
         <tr>


### PR DESCRIPTION
Fixes #1012.

Any update to any registered users will now invalidate the cache.
I tested this by enabling the cache locally and reproducing the bug.

Interestingly any update to any registration invalidates the whole thing, do you think it's worth to implement nested caching to invalidate a single registration line?
I don't think it's necessary but I just wonder if it has been considered.