### PR TITLE
Add support for competitions on New Year's eve

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -270,7 +270,7 @@ $venue-map-wrapper-height: 400px;
       .date {
         float: inherit;
         margin-right: 20px;
-        min-width: 150px;
+        min-width: 180px;
         text-align: left;
         display: inline-block;
       }

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -76,11 +76,11 @@ class CompetitionsController < ApplicationController
     @competitions = Competition.where(showAtAll: true).order(:year, :month, :day)
 
     if @present_selected
-      @competitions = @competitions.where("CAST(CONCAT(year,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today)
+      @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today)
     elsif @recent_selected
-      @competitions = @competitions.where("CAST(CONCAT(year,'-',endMonth,'-',endDay) as Datetime) between ? and ?", (Date.today - Competition::RECENT_DAYS), Date.today).reverse_order
+      @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) between ? and ?", (Date.today - Competition::RECENT_DAYS), Date.today).reverse_order
     else
-      @competitions = @competitions.where("CAST(CONCAT(year,'-',endMonth,'-',endDay) as Datetime) < ?", Date.today).reverse_order
+      @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) < ?", Date.today).reverse_order
       unless params[:year] == "all years"
         @competitions = @competitions.where(year: params[:year])
       end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -630,7 +630,7 @@ en:
       not_all_delegates: "are not all delegates"
       registration_close_after_open: "registration close must be after registration open"
       end_date_before_start: "End date cannot be before start date."
-      span_multiple_years: "Competition dates cannot span multiple years."
+      span_too_many_days: "Competition cannot last more than %{max_days} days."
     unscheduled: "unscheduled"
     new:
       create_competition: "Create competition"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -624,7 +624,7 @@ fr:
       not_all_delegates: "ne sont pas tous des délégués"
       registration_close_after_open: "doit être après l'ouverture des inscriptions."
       end_date_before_start: "ne peut pas être avant la date de début."
-      span_multiple_years: "Les dates de la compétition ne peuvent pas être sur plusieurs années."
+      span_too_many_days: "La compétition ne peut pas durer plus de %{max_days} jours."
     unscheduled: "non prévue"
     new:
       create_competition: "Créer une compétition"

--- a/WcaOnRails/db/migrate/20161122162029_add_end_year_to_competitions.rb
+++ b/WcaOnRails/db/migrate/20161122162029_add_end_year_to_competitions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddEndYearToCompetitions < ActiveRecord::Migration
+  def change
+    add_column :Competitions, :endYear, :smallint, unsigned: true, null: false, default: 0
+    Competition.update_all("endYear=year")
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -54,6 +54,7 @@ CREATE TABLE `Competitions` (
   `announced_at` datetime DEFAULT NULL,
   `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `currency_code` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `endYear` smallint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -1148,3 +1149,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161026201019');
 INSERT INTO schema_migrations (version) VALUES ('20161031215932');
 
 INSERT INTO schema_migrations (version) VALUES ('20161118141833');
+
+INSERT INTO schema_migrations (version) VALUES ('20161122162029');

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -250,7 +250,7 @@ describe CompetitionsController do
         expect(new_comp.isConfirmed).to eq false
         expect(new_comp.results_posted_at).to eq nil
         # We don't want to clone its dates.
-        %w(year month day endMonth endDay).each do |attribute|
+        %w(year month day endYear endMonth endDay).each do |attribute|
           expect(new_comp.send(attribute)).to eq 0
         end
 

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -93,16 +93,17 @@ RSpec.describe Competition do
     expect(competition).to be_invalid
   end
 
-  it "populates year, month, day, endMonth, endDay" do
+  it "populates year, month, day, endYear, endMonth, endDay" do
     competition = FactoryGirl.create :competition
-    competition.start_date = "1987-11-06"
-    competition.end_date = "1987-12-07"
+    competition.start_date = "1987-12-31"
+    competition.end_date = "1988-01-01"
     competition.save!
     expect(competition.year).to eq 1987
-    expect(competition.month).to eq 11
-    expect(competition.day).to eq 6
-    expect(competition.endMonth).to eq 12
-    expect(competition.endDay).to eq 7
+    expect(competition.month).to eq 12
+    expect(competition.day).to eq 31
+    expect(competition.endYear).to eq 1988
+    expect(competition.endMonth).to eq 1
+    expect(competition.endDay).to eq 1
   end
 
   describe "validates date formats" do
@@ -141,11 +142,12 @@ RSpec.describe Competition do
     expect(competition).to be_invalid
   end
 
-  it "requires that competition starts and ends in the same year" do
+  it "last less than MAX_SPAN_DAYS days" do
     competition = FactoryGirl.create :competition
-    competition.start_date = "1987-12-06"
-    competition.end_date = "1988-12-07"
+    competition.start_date = 1.days.ago.strftime("%F")
+    competition.end_date = Competition::MAX_SPAN_DAYS.days.from_now.strftime("%F")
     expect(competition).to be_invalid
+    expect(competition.errors.messages[:end_date]).to eq [I18n.t('competitions.errors.span_too_many_days', max_days: Competition::MAX_SPAN_DAYS)]
   end
 
   it "requires competition name is not greater than 50 characters" do

--- a/webroot/results/admin/check_regional_record_markers.php
+++ b/webroot/results/admin/check_regional_record_markers.php
@@ -135,7 +135,7 @@ function computeRegionalRecordMarkers ( $valueId, $valueName ) {
         AND competition.id = result.competitionId
         AND country.id     = result.countryId
         AND event.id       = result.eventId
-        AND year*10000 + if(endMonth,endMonth,month)*100 + if(endDay,endDay,day) < $startDate
+        AND endYear*10000 + if(endMonth,endMonth,month)*100 + if(endDay,endDay,day) < $startDate
       GROUP BY eventId, countryId");
     while( $row = mysql_fetch_row( $results ) ) {
       list( $eventId, $countryId, $continentId, $value, $valueFormat ) = $row;
@@ -149,7 +149,7 @@ function computeRegionalRecordMarkers ( $valueId, $valueName ) {
   #--- Otherwise we need the endDate of each competition
   else {
     $competitions = dbQuery("
-      SELECT id, year*10000 + if(endMonth,endMonth,month)*100 + if(endDay,endDay,day) endDate
+      SELECT id, endYear*10000 + if(endMonth,endMonth,month)*100 + if(endDay,endDay,day) endDate
       FROM   Competitions competition");
     foreach ( $competitions as $competition )
       $endDate[$competition['id']] = $competition['endDate'];

--- a/webroot/results/admin/validate_media.php
+++ b/webroot/results/admin/validate_media.php
@@ -94,7 +94,7 @@ function showMedia () {
   $media = dbQuery("
     SELECT media.*,
            competition.year, competition.month, competition.day,
-           competition.endMonth, competition.endDay,
+           competition.endYear, competition.endMonth, competition.endDay,
            competition.countryId, competition.cityName,
            cellName,
            country.name AS countryName

--- a/webroot/results/includes/_framework.php
+++ b/webroot/results/includes/_framework.php
@@ -124,10 +124,14 @@ function competitionDate ( $competition ) {
   $date = $month ? $months[$month] : '&nbsp;';
   if( $day )
     $date .= " $day";
+  if( $endYear != $year )
+    $date .= " $year";
   if( $endMonth != $month )
     $date .= " - " . $months[$endMonth] . " $endDay";
   elseif( $endDay != $day )
     $date .= "-$endDay";
+  if( $endYear )
+    $date .= " $endYear";
   return $date;
 }
 


### PR DESCRIPTION
We need support for this as there will be a competition on new year's eve this year!
I wasn't sure about how to change the validation, I believe the goal was to prevent a competition from spaning over a too long time range, so I assumed checking that a competition last less than a week would be enough.
Summary of the changes:
- Adds an endYear column to the Competitions table
- Change the validation from "cannot span over multiple years" to "cannot span over multiple weeks"
- Update the spec to also test a valid multi year competition