### PR TITLE
Change nag_needed for results.

### DIFF
--- a/WcaOnRails/app/jobs/submit_results_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_results_nag_job.rb
@@ -3,7 +3,7 @@ class SubmitResultsNagJob < ActiveJob::Base
   queue_as :default
 
   def nag_needed(competition)
-    (competition.results_nag_sent_at || competition.end_date) <= 1.week.ago
+    (competition.results_nag_sent_at || competition.end_date) <= 8.days.ago
   end
 
   def perform


### PR DESCRIPTION
Currently we're sending nags on a friday if the competition ended on saturday. We should send the nag on sunday to make sure a week has passed.