### PR TITLE
Don't assume that the user signing up knows what a WCA delegate is.

### DIFF
--- a/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
+++ b/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
@@ -6,15 +6,15 @@
   </p>
 <% elsif @user.unconfirmed_person.user && !@user.unconfirmed_person.user.dummy_account? %>
   <p>
-    <%= t '.already_assigned_html', link_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank"), link_delegate:link_to("delegate", delegates_path) %>
+    <%= t '.already_assigned_html', link_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank"), link_delegate: delegates_path %>
   </p>
 <% elsif !@user.unconfirmed_person.dob %>
   <p>
-  <%= t '.missing_dob_html', link_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank"), link_result_team:mail_to("results@worldcubeassociation.org", "Results team", target: "_blank") %>
+  <%= t '.missing_dob_html', link_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank"), link_result_team: mail_to("results@worldcubeassociation.org", "Results team", target: "_blank") %>
   </p>
 <% else %>
   <p>
-  <%= t '.select_delegate' %>
+  <%= t '.select_delegate_html', link_delegate: delegates_path %>
   </p>
 
   <div class="form-group radio_buttons optional">

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -447,8 +447,8 @@ en:
       board_member_cannot_resign: "You cannot resign from your role as a board member! Find another board member to fire you."
       avatar_requires_wca_id: "requires a WCA ID to be assigned"
     select_nearby_delegate:
-      select_delegate: "In order to assign you your WCA ID, we need a delegate to confirm your identify. Please enter your birthdate and select the delegate you think knows you best."
-      already_assigned_html: "WCA ID %{link_id} is already assigned to a different account. If you believe this was done in error, contact your local %{link_delegate}."
+      select_delegate_html: "In order to assign you your WCA ID, we need a <a href='%{link_delegate}' target='_blank'>WCA delegate</a> to confirm your identify. Please enter your birthdate and select the delegate you think knows you best."
+      already_assigned_html: "WCA ID %{link_id} is already assigned to a different account. If you believe this was done in error, contact your local <a href='%{link_delegate}' target='_blank'>WCA delegate</a>."
       missing_dob_html: "WCA ID %{link_id} does not have a birthdate assigned. Please contact the %{link_result_team} to fix this."
       unknown_wca_id_html: "WCA ID %{link_id} does not exist."
   registrations:

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -441,8 +441,8 @@ fr:
       board_member_cannot_resign: "Vous ne pouvez pas démissioner de votre poste de membre du Board ! Trouvez un autre membre pour vous rétrograder."
       avatar_requires_wca_id: "requiert d'avoir un ID WCA"
     select_nearby_delegate:
-      select_delegate: "Afin d'associer votre ID WCA à votre compte, nous avons besoin qu'un Délégué confirme votre identité. Merci de sélectionner le Délégué le plus adapté selon vous, et entrez votre date de naissance."
-      already_assigned_html: "L'ID WCA %{link_id} est déjà associé à un compte différent. Si vous pensez que c'est une erreur, merci de contacter votre Délégué local %{link_delegate}."
+      select_delegate_html: "Afin d'associer votre ID WCA à votre compte, nous avons besoin qu'un <a href='%{link_delegate}' target='_blank'>Délégué WCA</a> confirme votre identité. Merci de sélectionner le Délégué le plus adapté selon vous, et entrez votre date de naissance."
+      already_assigned_html: "L'ID WCA %{link_id} est déjà associé à un compte différent. Si vous pensez que c'est une erreur, merci de contacter votre <a href='%{link_delegate}' target='_blank'>Délégué WCA</a> local."
       missing_dob_html: "L'ID WCA %{link_id} n'a pas de date de naissance associée. Merci de contacter la %{link_result_team} pour corriger le problème."
       unknown_wca_id_html: "L'ID WCA %{link_id} n'existe pas."
   registrations:


### PR DESCRIPTION
This came up in a email sent to webmaster@cusa and results@wca:

> we tried to sign up as we've always done in the past, the system would not let us in thru cubingusa.com’s linking of accounts process to WCA. It says the birthdate does not match, however it never asks for a birthdate. It also asks for a delegate that can verify his identity, yet his 2 friends who he went to competitions with last year’s ID’s do not come up as options.

Clearly, this person does not know what a WCA delegate is. If you look at our current sign_up page, you can't blame 'em:

![2016-12-02_11 51 24_696x229_kaladin](https://cloud.githubusercontent.com/assets/277474/20848148/ac0b5798-b885-11e6-8645-bdda66be2b91.png)

I've updated it to explicitly state "WCA delegate", and link to our [delegates page](https://www.worldcubeassociation.org/delegates) which has a nice friendly description of what a delegate is:

![image](https://cloud.githubusercontent.com/assets/277474/20848338/8dd115e6-b886-11e6-9e5a-832a79240da9.png)
