### PR TITLE
Debugging timeouts

### DIFF
--- a/WcaOnRails/config/unicorn.rb
+++ b/WcaOnRails/config/unicorn.rb
@@ -1,16 +1,4 @@
 # frozen_string_literal: true
-# Ported from `system` gem, see
-# https://github.com/roja/system/blob/master/lib/system/cpu.rb
-#
-# Copyright (c) 2009-2012 Roja Buck and Ryan Scott Lewis
-def cpu_count
-  return Java::Java.lang.Runtime.getRuntime.availableProcessors if RUBY_PLATFORM == "java"
-  return File.read('/proc/cpuinfo').scan(/^processor\s*:/).size if File.exist?('/proc/cpuinfo')
-  require 'win32ole'
-  WIN32OLE.connect("winmgmts://").ExecQuery("select * from Win32_ComputerSystem").NumberOfProcessors
-rescue LoadError
-  Integer `sysctl -n hw.ncpu 2>/dev/null` rescue 1 # rubocop:disable Style/RescueModifier
-end
 
 dir = File.expand_path(File.dirname(__FILE__) + "/..")
 working_directory dir
@@ -31,7 +19,7 @@ else
   stderr_path "#{dir}/log/unicorn-#{rack_env}.log"
   stdout_path "#{dir}/log/unicorn-#{rack_env}.log"
 
-  worker_processes (cpu_count * 1.5).ceil
+  worker_processes (Etc.nprocessors * 3).ceil
 end
 
 listen "/tmp/unicorn.wca.sock"

--- a/chef/site-cookbooks/wca/templates/nginx.conf.erb
+++ b/chef/site-cookbooks/wca/templates/nginx.conf.erb
@@ -20,8 +20,13 @@ http {
 
   ##
   # Logging Settings
+  # upstream_time from https://www.nginx.com/resources/admin-guide/logging-and-monitoring/
   ##
-  access_log /var/log/nginx/access.log;
+  log_format upstream_time '$remote_addr - $remote_user [$time_local] '
+                           '"$request" $status $body_bytes_sent '
+                           '"$http_referer" "$http_user_agent"'
+                           'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+  access_log /var/log/nginx/access.log upstream_time;
   error_log /var/log/nginx/error.log;
 
   ##


### PR DESCRIPTION
This is a work in progress, I've created this PR to get some comments from folks.

I'm sure you've all been seeing those annoying New Relic ping failure emails. I took some time today to dig into one of the recent alerts.

![2016-12-06_14 17 01_924x429_kaladin](https://cloud.githubusercontent.com/assets/277474/20949702/aa6ca124-bbcf-11e6-80c7-55a00cbcd987.png)

Converting from SF time (UTC-8) to our server clock time (UTC), this downtime was from ~14:55 to 14:57 UTC today December 6th, 2016.

I dug through our production logs to find out what was going on during that time. Here's 

```
/home/cubing/worldcubeassociation.org/WcaOnRails/log/production.log
I, [2016-12-06T14:55:45.936302 #19939]  INFO -- : Started GET "/competitions?utf8=%E2%9C%93&region=all&search=u&year=all+years&state=past&display=list" for 63.147.254.146 at 2016-12-06 14:55:45 +0000
...
I, [2016-12-06T14:56:09.185247 #19939]  INFO -- : Completed 200 OK in 23230ms (Views: 5945.1ms | ActiveRecord: 5149.2ms)
...
I, [2016-12-06T14:56:09.266394 #19939]  INFO -- : Started GET "/competitions?utf8=%E2%9C%93&region=all&search=us+natinals+&year=all+years&state=past&display=list" for 63.147.254.146 at 2016-12-06 14:56:09 +0000
...
I, [2016-12-06T14:56:30.320850 #19939]  INFO -- : Completed 200 OK in 21051ms (Views: 1.4ms | ActiveRecord: 6646.3ms)
...
I, [2016-12-06T14:56:30.323243 #19939]  INFO -- : Started GET "/competitions/RaleighOpen2013/results/podiums" for 23.106.193.127 at 2016-12-06 14:56:30 +0000
...
I, [2016-12-06T14:56:30.511492 #19939]  INFO -- : Completed 200 OK in 187ms (Views: 139.7ms | ActiveRecord: 46.4ms)
```

```
/home/cubing/worldcubeassociation.org/WcaOnRails/log/production.log
I, [2016-12-06T14:55:42.404381 #19942]  INFO -- : Started GET "/competitions?utf8=%E2%9C%93&region=all&search=us+natinals&year=all+years&state=past&display=list" for 63.147.254.146 at 2016-12-06 14:55:42 +0000
...
I, [2016-12-06T14:56:03.300675 #19942]  INFO -- : Completed 200 OK in 20895ms (Views: 1.4ms | ActiveRecord: 6417.5ms)
...
I, [2016-12-06T14:56:03.312479 #19942]  INFO -- : Started HEAD "/" for 50.112.95.211 at 2016-12-06 14:56:03 +0000
...
I, [2016-12-06T14:56:03.447079 #19942]  INFO -- : Completed 200 OK in 130ms (Views: 87.1ms | ActiveRecord: 42.3ms)
```

According to https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks, 50.112.95.211 is an IP controlled by New Relic and is presumably when New Relic declared the issue over.

Strangely, I've been trying and failing to line up the events in log/production.log with /var/log/nginx/access.log (both attached). It is frustrating that nginx does not log request start time in addition to end time.

What I suspect happened is that the ping request occured while both our Unicorn workers were busy handling the very expensive GET /competitions queries above (I've created #1035 to track improving that). We only have 2 unicorn workers:

```
~/worldcubeassociation.org/WcaOnRails @production> ps -ewf | grep "unicorn worker"
cubing   19939 25687  3 Dec05 ?        01:36:25 unicorn worker[0] -D -c config/unicorn.rb             
cubing   19942 25687  3 Dec05 ?        01:36:32 unicorn worker[1] -D -c config/unicorn.rb             
cubing   22714  6718  0 22:10 pts/8    00:00:00 grep unicorn worker
~/worldcubeassociation.org/WcaOnRails @production> 
```

I feel like we should increase the number of workers we have... maybe 3* the number of processors?