### PR TITLE
Allow organizers to change names of registered newcomers

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -76,7 +76,7 @@ class CompetitionsController < ApplicationController
     @competitions = Competition.where(showAtAll: true).order(:year, :month, :day)
 
     if @present_selected
-      @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today)
+      @competitions = @competitions.present
     elsif @recent_selected
       @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) between ? and ?", (Date.today - Competition::RECENT_DAYS), Date.today).reverse_order
     else

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -76,7 +76,7 @@ class CompetitionsController < ApplicationController
     @competitions = Competition.where(showAtAll: true).order(:year, :month, :day)
 
     if @present_selected
-      @competitions = @competitions.present
+      @competitions = @competitions.not_over
     elsif @recent_selected
       @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) between ? and ?", (Date.today - Competition::RECENT_DAYS), Date.today).reverse_order
     else

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -29,7 +29,7 @@ class Competition < ActiveRecord::Base
            allow_nil: true,
            with_model_currency: :currency_code
 
-  scope :present, -> { where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today) }
+  scope :not_over, -> { where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today) }
 
   CLONEABLE_ATTRIBUTES = %w(
     cityName

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -29,6 +29,8 @@ class Competition < ActiveRecord::Base
            allow_nil: true,
            with_model_currency: :currency_code
 
+  scope :present, -> { where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today) }
+
   CLONEABLE_ATTRIBUTES = %w(
     cityName
     countryId

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -358,7 +358,7 @@ class User < ActiveRecord::Base
   end
 
   def can_edit_users?
-    organizes_comp_with_wca_registration = organized_competitions.present.exists?(use_wca_registration: true)
+    organizes_comp_with_wca_registration = organized_competitions.not_over.exists?(use_wca_registration: true)
     admin? || board_member? || results_team? || any_kind_of_delegate? || organizes_comp_with_wca_registration
   end
 
@@ -528,7 +528,7 @@ class User < ActiveRecord::Base
       fields << :remove_avatar
     end
     # If the user is a newcomer allow organizers of the competition that he is registered for to edit his name.
-    if user.wca_id.blank? && user.competitions_registered_for.present.joins(:competition_organizers).pluck("competition_organizers.organizer_id").include?(self.id)
+    if user.wca_id.blank? && user.competitions_registered_for.not_over.joins(:competition_organizers).pluck("competition_organizers.organizer_id").include?(self.id)
       fields << :name
     end
     fields

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -358,7 +358,8 @@ class User < ActiveRecord::Base
   end
 
   def can_edit_users?
-    admin? || board_member? || results_team? || any_kind_of_delegate?
+    organizes_comp_with_wca_registration = organized_competitions.present.exists?(use_wca_registration: true)
+    admin? || board_member? || results_team? || any_kind_of_delegate? || organizes_comp_with_wca_registration
   end
 
   def can_admin_results?
@@ -525,6 +526,10 @@ class User < ActiveRecord::Base
       fields << :avatar_crop_x << :avatar_crop_y << :avatar_crop_w << :avatar_crop_h
       fields << :pending_avatar_crop_x << :pending_avatar_crop_y << :pending_avatar_crop_w << :pending_avatar_crop_h
       fields << :remove_avatar
+    end
+    # If the user is a newcomer allow organizers of the competition that he is registered for to edit his name.
+    if user.wca_id.blank? && user.competitions_registered_for.present.joins(:competition_organizers).pluck("competition_organizers.organizer_id").include?(self.id)
+      fields << :name
     end
     fields
   end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -545,4 +545,22 @@ RSpec.describe User, type: :model do
       user.notify_of_results_posted(competition)
     end
   end
+
+  describe "#can_edit_users?" do
+    let(:competition) { FactoryGirl.create(:competition, :registration_open, :with_organizer, starts: 1.month.from_now) }
+
+    it "returns true if a user is an organizer of an upcoming comp using registration system" do
+      expect(competition.organizers.first.can_edit_users?).to eq true
+    end
+  end
+
+  describe "#editable_fields_of_user" do
+    let(:competition) { FactoryGirl.create(:competition, :registration_open, :with_organizer, starts: 1.month.from_now) }
+    let(:registration) { FactoryGirl.create(:registration, :newcomer, competition: competition) }
+
+    it "allows organizers of upcoming competitions to edit newcomer names" do
+      organizer = competition.organizers.first
+      expect(organizer.editable_fields_of_user(registration.user).to_a).to eq [:name]
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1036.
This makes organizers of upcoming competitions that use the WCA registration system able to change names of newcomers registered for it.