### PR TITLE
Implement a locale selector.

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -59,6 +59,7 @@ gem 'api-pagination'
 gem 'delayed_job_active_record'
 gem 'daemons'
 gem 'i18n-country-translations'
+gem 'http_accept_language'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -215,6 +215,7 @@ GEM
     highline (1.7.8)
     hitimes (1.2.2)
     htmlentities (4.3.4)
+    http_accept_language (2.1.0)
     i18n (0.7.0)
     i18n-country-translations (1.2.4)
       i18n (~> 0.5)
@@ -496,6 +497,7 @@ DEPENDENCIES
   font-awesome-sass
   guard-rspec
   high_voltage
+  http_accept_language
   i18n-country-translations
   i18n-spec
   i18n-tasks (~> 0.9.5)

--- a/WcaOnRails/config/application.rb
+++ b/WcaOnRails/config/application.rb
@@ -3,6 +3,7 @@ require File.expand_path('../boot', __FILE__)
 require_relative '../lib/middlewares/fix_accept_header'
 require_relative '../lib/middlewares/warden_user_logger'
 require_relative '../lib/wca_exceptions'
+require_relative 'locales/locales'
 
 require 'rails/all'
 
@@ -61,7 +62,7 @@ module WcaOnRails
     end
 
     # Setup available locales
-    I18n.available_locales = [:en, :fr]
+    I18n.available_locales = Locales::AVAILABLE.keys
 
     config.middleware.use Middlewares::FixAcceptHeader
     config.middleware.use Middlewares::WardenUserLogger, logger: -> (s) { Rails.logger.info(s) }

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -418,6 +418,11 @@ en:
       manage_auth_app: "Manage authorized applications"
   #context: Key used in the context of editing a user profile
   users:
+    #context: when updating their locale (language)
+    update_locale:
+      success: "Updated locale."
+      failure: "Unable to update your profile."
+      unavailable: "Requested locale is not available."
     #context: related to claiming a WCA ID
     claim_wca_id:
       title: "Claim WCA ID"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -367,6 +367,10 @@ fr:
       manage_app: "Gérer vos applications"
       manage_auth_app: "Gérer vos applications authentifiées"
   users:
+    update_locale:
+      success: "Langue mise à jour."
+      failure: "Impossible de mettre à jour vos préférences."
+      unavailable: "La langue demandée n'est pas disponible."
     claim_wca_id:
       title: "Réclamer un ID WCA"
       competition: "compétition"

--- a/WcaOnRails/config/locales/locales.rb
+++ b/WcaOnRails/config/locales/locales.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Locales
+  AVAILABLE = {
+    "en": {
+      "flag_id": "gb",
+      "name": "English",
+    },
+    "fr": {
+      "flag_id": "fr",
+      "name": "Français",
+    },
+  }.freeze
+end

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -115,6 +115,8 @@ Rails.application.routes.draw do
 
   get '/render_markdown' => 'markdown_renderer#render_markdown'
 
+  patch '/update_locale/:locale' => 'application#update_locale', as: :update_locale
+
   namespace :api do
     get '/', to: redirect('/api/v0')
     namespace :v0 do

--- a/WcaOnRails/db/migrate/20161227202950_add_preferred_locale_to_users.rb
+++ b/WcaOnRails/db/migrate/20161227202950_add_preferred_locale_to_users.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddPreferredLocaleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :preferred_locale, :string
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -903,6 +903,7 @@ CREATE TABLE `users` (
   `location_description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `phone_number` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `notes` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `preferred_locale` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
@@ -1171,3 +1172,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161212200704');
 INSERT INTO schema_migrations (version) VALUES ('20161226223701');
 
 INSERT INTO schema_migrations (version) VALUES ('20161221205552');
+
+INSERT INTO schema_migrations (version) VALUES ('20161227202950');

--- a/WcaOnRails/spec/controllers/application_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ApplicationController do
+  describe "GET #update_locale" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    it "updates the user preferred locale and the session locale" do
+      sign_in user
+      expect(user.preferred_locale).to be_nil
+      expect(session[:locale]).not_to eq "fr"
+      patch :update_locale, locale: :fr
+      user.reload
+      expect(user.preferred_locale).to eq "fr"
+      expect(session[:locale]).to eq "fr"
+    end
+  end
+end

--- a/WcaOnRails/spec/support/locale_reset.rb
+++ b/WcaOnRails/spec/support/locale_reset.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+RSpec.configure do |config|
+  config.after(:each) do
+    I18n.locale = :en
+  end
+end


### PR DESCRIPTION
Fixes #595.

This implements:
 - a new `preferred_locale` field for users
 - a locale selector based on the available locales (see the last screenshot in #595)
 - some basic inference of the locale if the session variable is not set

I don't intend to merge this right away as it will make all the i18n things visible (and the public documentation is not ready yet), but I expect some reviews and I think it has a low potential of conflict with further changes to the website.

