### PR TITLE
Set up unicorn worker killer.

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -101,5 +101,6 @@ end
 
 group :production do
   gem 'unicorn'
+  gem 'unicorn-worker-killer'
   gem 'newrelic_rpm'
 end

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
     font-awesome-sass (4.4.0)
       sass (>= 3.2)
     formatador (0.2.5)
+    get_process_mem (0.2.1)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     guard (2.12.5)
@@ -430,6 +431,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
     uniform_notifier (1.9.0)
     valid_email (0.0.11)
       activemodel
@@ -520,9 +524,10 @@ DEPENDENCIES
   time_will_tell
   uglifier
   unicorn
+  unicorn-worker-killer
   valid_email
   web-console
   world-flags!
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/WcaOnRails/config.ru
+++ b/WcaOnRails/config.ru
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 # This file is used by Rack-based servers to start the application.
 
+# See https://github.com/kzk/unicorn-worker-killer#usage
+require 'unicorn/worker_killer'
+use Unicorn::WorkerKiller::MaxRequests, 3072, 4096
+use Unicorn::WorkerKiller::Oom, (192 * (1024**2)), (256 * (1024**2))
+
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application


### PR DESCRIPTION
This fixes #1059.

Just getting the conversation started. The numbers here came directly from https://github.com/kzk/unicorn-worker-killer#usage, and may not be appropriate for us. Here's some coarse analysis of our unicorn workers on production right now:

```
~ @production> ps -eo rss,comm,pid,args | grep -i 'unicorn worker' | grep -v grep
232292 ruby2.3        22581 unicorn worker[0] -D -c config/unicorn.rb                                  
179348 ruby2.3        22599 unicorn worker[2] -D -c config/unicorn.rb                                  
273352 ruby2.3        28219 unicorn worker[1] -D -c config/unicorn.rb                                  
~ @production> kill 28219
~ @production> ps -eo rss,comm,pid,args | grep -i 'unicorn worker' | grep -v grep
232292 ruby2.3        22581 unicorn worker[0] -D -c config/unicorn.rb                                  
179348 ruby2.3        22599 unicorn worker[2] -D -c config/unicorn.rb                                  
118092 ruby2.3        25510 unicorn worker[1] -D -c config/unicorn.rb                                  
~ @production> ps -eo rss,comm,pid,args | grep -i 'unicorn worker' | grep -v grep
232292 ruby2.3        22581 unicorn worker[0] -D -c config/unicorn.rb                                  
179348 ruby2.3        22599 unicorn worker[2] -D -c config/unicorn.rb                                  
135688 ruby2.3        25510 unicorn worker[1] -D -c config/unicorn.rb                                  
~ @production> ps -eo rss,comm,pid,args | grep -i 'unicorn worker' | grep -v grep
232292 ruby2.3        22581 unicorn worker[0] -D -c config/unicorn.rb                                  
179348 ruby2.3        22599 unicorn worker[2] -D -c config/unicorn.rb                                  
143816 ruby2.3        25510 unicorn worker[1] -D -c config/unicorn.rb                     
~ @production> date && ps -eo rss,comm,pid,args | grep -i "unicorn worker" | grep -v grep
Sat Dec 31 04:35:07 UTC 2016
269624 ruby2.3        22581 unicorn worker[0] -D -c config/unicorn.rb                                  
260340 ruby2.3        22599 unicorn worker[2] -D -c config/unicorn.rb                                  
183944 ruby2.3        25510 unicorn worker[1] -D -c config/unicorn.rb                                  
~ @kaladin> ssh wca 'date && ps -eo rss,comm,pid,args | grep -i "unicorn worker" | grep -v grep'
Sat Dec 31 07:22:28 UTC 2016
263560 ruby2.3        22581 unicorn worker[0] -D -c config/unicorn.rb                                  
267632 ruby2.3        22599 unicorn worker[2] -D -c config/unicorn.rb                                  
187676 ruby2.3        25510 unicorn worker[1] -D -c config/unicorn.rb                                  

```

The first column is RSS (resident set size), and is the statistic that unicorn-worker uses to determine if it is time to restart a worker. You can see above that PID 28219 was using 273352 kilobytes of RSS, and after killing it manually, the replacement process came in at 118092 kilobytes and has been slowly climbing since then.

After switching to a `t2.medium` aws server:

```
/ @kaladin> ssh wca 'date && ps -eo rss,comm,pid,args | grep -i "unicorn worker" | grep -v grep'
Tue Jan 10 00:08:10 UTC 2017
181812 ruby2.3        26962 unicorn worker[0] -D -c config/unicorn.rb                                  
242244 ruby2.3        26965 unicorn worker[1] -D -c config/unicorn.rb                                  
224020 ruby2.3        26968 unicorn worker[2] -D -c config/unicorn.rb                                  
178716 ruby2.3        26971 unicorn worker[3] -D -c config/unicorn.rb                                  
170592 ruby2.3        26974 unicorn worker[4] -D -c config/unicorn.rb                                  
174868 ruby2.3        26977 unicorn worker[5] -D -c config/unicorn.rb                                  
```