### PR TITLE
Update from nginx 1.8.0 to 1.11.8.

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -172,9 +172,9 @@ bash "build nginx" do
   code <<-EOH
     set -e # exit on error
     cd /tmp
-    wget http://nginx.org/download/nginx-1.8.0.tar.gz
-    tar xvf nginx-1.8.0.tar.gz
-    cd nginx-1.8.0
+    wget http://nginx.org/download/nginx-1.11.8.tar.gz
+    tar xvf nginx-1.11.8.tar.gz
+    cd nginx-1.11.8
     ./configure --sbin-path=/usr/local/sbin --with-http_ssl_module --with-http_auth_request_module --with-http_gzip_static_module --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log
     make
     sudo make install


### PR DESCRIPTION
In PR #1034, we added `$upstream_connect_time` to our nginx config, but it turns out that variable was added in [nginx 1.9.1](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#variables). These changes update us to the latest version of nginx.

When I merged up #1034, I must have forgotten to run chef, which is why we never noticed this. @pedrosino just noticed this while running `vagrant up all` locally.

I've tested this out on staging, and it required a little bit of manual intervention to fix (I had to [delete /usr/local/sbin/nginx by hand](https://github.com/thewca/worldcubeassociation.org/blob/43c5d0f135cc015967680991591c189d8392d107/chef/site-cookbooks/wca/recipes/default.rb#L184), and restarting the old nginx didn't work, so I had to kill it manually and start up the new one manually). The simplest way of deploying this would be to spin up a new server, which I plan to do tomorrow morning.