### PR TITLE
Change solve time formatter to show multi-blind's time properly

### DIFF
--- a/WcaOnRails/lib/solve_time.rb
+++ b/WcaOnRails/lib/solve_time.rb
@@ -161,11 +161,16 @@ class SolveTime
       else
         result = EMPTY_STRING
         time_seconds = time_centiseconds / 100
-        while time_seconds >= 60
-          result = ":%02d#{result}" % ( time_seconds % 60 )
-          time_seconds = time_seconds / 60
+        # show 2/2 0:XX instead of 2/2 XX
+        if time_seconds < 60
+          result = "0:#{time_seconds}"
+        else
+          while time_seconds >= 60
+            result = ":%02d#{result}" % ( time_seconds % 60 )
+            time_seconds = time_seconds / 60
+          end
+          result = "#{time_seconds}#{result}"
         end
-        result = "#{time_seconds}#{result}"
       end
 
       "#{@solved}/#{@attempted} #{result}"

--- a/WcaOnRails/spec/lib/solve_time_spec.rb
+++ b/WcaOnRails/spec/lib/solve_time_spec.rb
@@ -91,6 +91,11 @@ describe "SolveTime" do
         solve_time = SolveTime.new('333mbf', :single, 580325400)
         expect(solve_time.clock_format).to eq "41/41 54:14"
       end
+
+      it "formats with time less than 60 seconds" do
+        solve_time = SolveTime.new('333mbf', :single, 970005900)
+        expect(solve_time.clock_format).to eq "2/2 0:59"
+      end
     end
 
     describe "333mbo" do

--- a/webroot/results/includes/_values.php
+++ b/webroot/results/includes/_values.php
@@ -52,11 +52,16 @@ function formatValue( $value, $format='time' ) {
       $result = '?:??:??';
     } else {
       $result = "";
-      while( $time >= 60 ){
-        $result = sprintf( ":%02d$result", $time % 60 );
-        $time = intval( $time / 60 );
+      # show 2/2 0:XX instead of 2/2 XX
+      if ($time < 60) {
+        $result = "0:$time";
+      } else {
+        while( $time >= 60 ){
+          $result = sprintf( ":%02d$result", $time % 60 );
+          $time = intval( $time / 60 );
+        }
+        $result = "$time$result";
       }
-      $result = "$time$result";
     }
 
     #--- Alternative (throw out seconds).


### PR DESCRIPTION
Today Kaijun Lin got a 2/2 0:59 for multi-blind on Xi'an New Year 2017 (https://cubingchina.com/live/Xian-New-Year-2017#!/event/333mbf/f/all)
I found that the current formatter would format it as 2/2 59. It looks strange.