### PR TITLE
Speed up Person Search by removing the join to Countries.

### DIFF
--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -8,7 +8,7 @@ class PersonsController < ApplicationController
       format.js do
         persons = Person.order(:name, :countryId)
         if params[:region] != "all"
-          country_ids = Continent::c_all_by_id[params[:region]]&.countries&.map(&:id) || params[:region]
+          country_ids = Continent.c_all_by_id[params[:region]]&.countries&.map(&:id) || params[:region]
           persons = persons.where(countryId: country_ids)
         end
         params[:search]&.split&.each do |part|

--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 class PersonsController < ApplicationController
   def index
-    params[:region] ||= "all"
-
     respond_to do |format|
       format.html
       format.js do
-        persons = Person.order(:name, :countryId)
-        if params[:region] != "all"
-          country_ids = Continent.c_all_by_id[params[:region]]&.countries&.map(&:id) || params[:region]
-          persons = persons.where(countryId: country_ids)
-        end
+        persons = Person.in_region(params[:region]).order(:name, :countryId)
         params[:search]&.split&.each do |part|
           persons = persons.where("rails_persons.name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
         end

--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -6,16 +6,14 @@ class PersonsController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        persons = Person.joins("JOIN Countries ON countryId = Countries.id")
+        persons = Person.order(:name, :countryId)
         if params[:region] != "all"
-          persons = persons.where("countryId = :region OR continentId = :region", region: params[:region])
+          country_ids = Continent::c_all_by_id[params[:region]]&.countries&.map(&:id) || params[:region]
+          persons = persons.where(countryId: country_ids)
         end
-        if params[:search].present?
-          params[:search].split.each do |part|
-            persons = persons.where("rails_persons.name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
-          end
+        params[:search]&.split&.each do |part|
+          persons = persons.where("rails_persons.name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
         end
-        persons = persons.order(:name, :countryId)
 
         render json: {
           total: persons.count,

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -5,6 +5,10 @@ class Continent < ActiveRecord::Base
 
   has_many :countries, foreign_key: :continentId
 
+  def self.country_ids(continent_id)
+    self.c_all_by_id[continent_id]&.countries&.map(&:id)
+  end
+
   def name
     I18n.t(recordName, scope: :continents)
   end

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -6,7 +6,7 @@ class Continent < ActiveRecord::Base
   has_many :countries, foreign_key: :continentId
 
   def self.country_ids(continent_id)
-    self.c_all_by_id[continent_id]&.countries&.map(&:id)
+    c_all_by_id[continent_id]&.countries&.map(&:id)
   end
 
   def name

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -11,10 +11,9 @@ class Person < ActiveRecord::Base
 
   scope :current, -> { where(subId: 1) }
 
-  scope :in_region, lambda { |region|
-    unless region.blank? || region == 'all'
-      country_ids = Continent.c_all_by_id[region]&.countries&.map(&:id) || region
-      where(countryId: country_ids)
+  scope :in_region, lambda { |region_id|
+    unless region_id.blank? || region_id == 'all'
+      where(countryId: (Continent.country_ids(region_id) || region_id))
     end
   }
 

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -11,6 +11,13 @@ class Person < ActiveRecord::Base
 
   scope :current, -> { where(subId: 1) }
 
+  scope :in_region, -> (region) {
+    unless region.blank? || region == 'all'
+      country_ids = Continent.c_all_by_id[region]&.countries&.map(&:id) || region
+      where(countryId: country_ids)
+    end
+  }
+
   validates :name, presence: true
   validates :countryId, presence: true
 

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -11,7 +11,7 @@ class Person < ActiveRecord::Base
 
   scope :current, -> { where(subId: 1) }
 
-  scope :in_region, -> (region) {
+  scope :in_region, lambda { |region|
     unless region.blank? || region == 'all'
       country_ids = Continent.c_all_by_id[region]&.countries&.map(&:id) || region
       where(countryId: country_ids)


### PR DESCRIPTION
I started looking at speeding up the Person search. It turns out that removing the join to Countries changes the empty/full search from 850ms to 150ms on my machine. With a search string, both take around 150ms. The empty/full search was 26% of all requests last we looked, so this should substantially lower the average query time.
