### PR TITLE
Avoid double load of person search results on page load.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/persons.js
+++ b/WcaOnRails/app/assets/javascripts/persons.js
@@ -1,6 +1,10 @@
 // Add params from the search fields to the bootstrap-table for on Ajax request.
 var personsTableAjax = {
   queryParams: function(params) {
+    if (personsTableAjax.queriesOK !== true) {
+      return false; // Stop Bootstrap Table's uncontrollable initial load
+    }
+
     return $.extend(params || {}, {
       region: $('#region').val(),
       search: $('#search').val(),
@@ -20,6 +24,12 @@ onPage('persons#index', function() {
     options.pageNumber = 1;
     $table.bootstrapTable('refresh');
   }
+
+  // Set the table options from the url params.
+  options.pageNumber = parseInt($.getUrlParam('page')) || options.pageNumber;
+  // Load the data using the options set above.
+  personsTableAjax.queriesOK = true;
+  $table.bootstrapTable('refresh');
 
   $('#region').on('change', reloadPersons);
   $('#search').on('input', _.debounce(reloadPersons, TEXT_INPUT_DEBOUNCE_MS));

--- a/WcaOnRails/app/assets/javascripts/persons.js
+++ b/WcaOnRails/app/assets/javascripts/persons.js
@@ -15,11 +15,6 @@ onPage('persons#index', function() {
   var $table = $('.persons-table');
   var options = $table.bootstrapTable('getOptions');
 
-  // Set the table options from the url params.
-  options.pageNumber = parseInt($.getUrlParam('page')) || options.pageNumber;
-  // Load the data using the options set above.
-  $table.bootstrapTable('refresh');
-
   function reloadPersons() {
     $('#search-box i').removeClass('fa-search').addClass('fa-spinner fa-spin');
     options.pageNumber = 1;


### PR DESCRIPTION
Currently, the person search will do the Ajax search twice when the page is first loaded. I assume the first one is done automatically by Bootstrap. This removes the second one.

I couldn't find any case when the `options.pageNumber` assignment was needed, so that goes too.