### PR TITLE
Localize the FAQ.

### DIFF
--- a/WcaOnRails/app/views/static_pages/_faq_search_form.html.erb
+++ b/WcaOnRails/app/views/static_pages/_faq_search_form.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <%= search_competition %>
+  <input id="competitions_search" class="wca-autocomplete wca-autocomplete-only_one wca-autocomplete-competitions_search"></input>
+  <script>
+    (function() {
+      $('#competitions_search').wcaAutocomplete();
+      $('#competitions_search')[0].selectize.on('change', function(competitionId) {
+        location.href = "/competitions/" + competitionId;
+      });
+    })();
+  </script>
+</div>

--- a/WcaOnRails/app/views/static_pages/faq.html.erb
+++ b/WcaOnRails/app/views/static_pages/faq.html.erb
@@ -13,18 +13,7 @@ faq_variables = {
                       else
                         t('faq.create_an_account_and_claim', here: link_to(t('common.here'), new_user_registration_path))
                       end,
-  comp_search_form: "<div>
-        %{search_competition}
-        <input id=\"competitions_search\" class=\"wca-autocomplete wca-autocomplete-only_one wca-autocomplete-competitions_search\"></input>
-        <script>
-          (function() {
-            $('#competitions_search').wcaAutocomplete();
-            $('#competitions_search')[0].selectize.on('change', function(competitionId) {
-              location.href = \"/competitions/\" + competitionId;
-            });
-          })();
-        </script>
-      </div>" % { search_competition: t('faq.search_for_competition') },
+  comp_search_form: render("faq_search_form", search_competition: t('faq.search_for_competition')),
 }
 %>
 <div class="container">

--- a/WcaOnRails/app/views/static_pages/faq.html.erb
+++ b/WcaOnRails/app/views/static_pages/faq.html.erb
@@ -1,5 +1,32 @@
-<% provide(:title, 'Frequently Asked Questions') %>
+<% provide(:title, t('faq.title')) %>
 
+<%
+faq_variables = {
+  profile_edit_path: profile_edit_path,
+  current_user_status: if current_user
+                         t('faq.already_logged_in')
+                       else
+                         t('faq.create_an_account', here: link_to(t('common.here'), new_user_registration_path))
+                       end,
+  current_user_claim: if current_user
+                        t('faq.claim_your_wca_id', here: link_to(t('common.here'), profile_claim_wca_id_path))
+                      else
+                        t('faq.create_an_account_and_claim', here: link_to(t('common.here'), new_user_registration_path))
+                      end,
+  comp_search_form: "<div>
+        %{search_competition}
+        <input id=\"competitions_search\" class=\"wca-autocomplete wca-autocomplete-only_one wca-autocomplete-competitions_search\"></input>
+        <script>
+          (function() {
+            $('#competitions_search').wcaAutocomplete();
+            $('#competitions_search')[0].selectize.on('change', function(competitionId) {
+              location.href = \"/competitions/\" + competitionId;
+            });
+          })();
+        </script>
+      </div>" % { search_competition: t('faq.search_for_competition') },
+}
+%>
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
@@ -13,103 +40,14 @@
   <% @answers_markup = capture do %>
     <ul id="faq-list" class="list-group">
 
-      <%= add_answer "How do I obtain a WCA ID and a WCA profile?" do %>
-        If you have never competed before, go to a <a href="/results/competitions.php">competition</a>!
-        A WCA ID and WCA profile will be created for you when the results from your first
-        competition are uploaded.
-      <% end %>
 
-      <%= add_answer "How can I find a WCA competition?" do %>
-        Check out our list of <%= link_to "competitions", "/results/competitions.php" %>!
-      <% end %>
-
-      <%= add_answer "How can I register for a competition? Who can I refer to if I have problems registering for a competition?" do %>
-        Many competitions do registration right here on the WCA website, but some use their
-        own systems. You should contact the organizers of the competition you want
-        to compete in for more details.
-
-        <div>
-          Search for a competition here:
-          <input id="competitions_search" class="wca-autocomplete wca-autocomplete-only_one wca-autocomplete-competitions_search"></input>
-          <script>
-            (function() {
-              $('#competitions_search').wcaAutocomplete();
-              $('#competitions_search')[0].selectize.on('change', function(competitionId) {
-                location.href = "/competitions/" + competitionId;
-              });
-            })();
-          </script>
-        </div>
-      <% end %>
-
-      <%= add_answer "What are the requirements for attending a WCA competition? What do I need to know before attending a WCA competition?" do %>
-        In general, there are not many requirements for a person to participate
-        at a WCA competition. However, all participants of a competition are expected
-        to have a good understanding of the
-        <a href="https://www.worldcubeassociation.org/regulations/">WCA regulations</a>.
-        In addition, we would recommend having a look at
-        <%= link_to "Cubing USA's competitor tutorial", "http://www.cubingusa.com/ctutorial.php", target: "_blank" %>, which gives several nice hints for newcomers.
-      <% end %>
-
-      <%= add_answer "How can I have a WCA Competition in my hometown?" do %>
-        <p>
-          If you are interested in organizing a competition, it's highly recommended to attend at least one or two competitions as a competitor to learn from the experience.
-        </p>
-        <p>
-          WCA Competitions must follow the <%= link_to "WCA Regulations", "https://www.worldcubeassociation.org/regulations/", target: "_blank" %>. The organization team doesn't have to know the regulations by heart, however, a deep knowledge of the basics of the regulations would definitely help in correctly organizing the competition.
-        </p>
-        <p>
-          After that, the organization team must contact a nearby <%= link_to "WCA Delegate", "https://www.worldcubeassociation.org/delegates", target: "_blank" %>. The supervision of a WCA Delegate is required in order to make a competition officially sanctioned by the WCA. The WCA Delegate will help guide the organization on how to host a successful competition.
-        </p>
-        <p>
-          Visit <%= link_to "this guide", "https://www.cubingusa.com/cguide.php", target: "_blank" %> for further information. (Any conflict between the information presented in this supplementary resource and the WCA Regulations is superseded by the WCA Regulations.)
-        </p>
-      <% end %>
-
-      <%= add_answer "What are the WCA accounts for? What is the difference between WCA accounts and WCA profiles?" do %>
-        <p>
-          You are assigned a WCA ID when you first participate in a WCA
-          sanctioned competition. When the results from that competition are uploaded,
-          your WCA profile will be created, with results from every competition you have
-          been to.
-        </p>
-
-        <p>
-          WCA accounts allow you to prove to us who you are. This allows you
-          to add a picture to your WCA profile, and allows you
-          to register for competitions. This will protect you from
-          other people pretending to be you.
-        </p>
-
-        <p>
-          <% if current_user %>
-            You are already logged in with a WCA account.
-          <% else %>
-            You can create an account <%= link_to "here", new_user_registration_path %>.
+      <% t('faq.answers').values.each do |faq| %>
+        <%= add_answer faq[:title] do %>
+          <% faq[:content].values.each do |paragraph| %>
+            <p>
+              <%= raw paragraph % faq_variables %>
+            </p>
           <% end %>
-        </p>
-      <% end %>
-
-      <%= add_answer "How do I change my profile picture?" do %>
-        <p>
-          First, you need to
-          <a href="#how-do-i-connect-my-wca-account-with-my-wca-id">
-            create a WCA account and connect it to your WCA ID.
-          </a>
-        </p>
-        <p>
-          After you have connected your WCA account and your WCA ID, go to your
-          <%= link_to "edit profile page", profile_edit_path %> to change your
-          profile picture.
-        </p>
-      <% end %>
-
-      <%= add_answer "How do I connect my WCA account with my WCA ID?" do %>
-        <% if current_user %>
-          You can claim your WCA ID <%= link_to "here", profile_claim_wca_id_path %>.
-        <% else %>
-          Create an account <%= link_to "here", new_user_registration_path %>. After you log in with
-          your new account, you will be asked to claim your WCA ID.
         <% end %>
       <% end %>
     </ul>
@@ -124,6 +62,6 @@
   <%= @answers_markup %>
 
   <p>
-    If none of these answers helped, please <%= link_to "contact us", contact_path %>!
+    <%= t('faq.contact_html', contact_us: link_to(t('faq.contact_us'), contact_path)) %>
   </p>
 </div>

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -95,6 +95,7 @@ ignore_unused:
   - 'simple_form.{error_notification,required}.:'
   # We iterate through the children, so we use all of them
   - 'users.edit.avatar_guidelines.*'
+  - 'faq.answers.*'
   # Mark all events/continents/countries as used.
   # FYI if a language doesn't translate one of them, it will appear in the missing keys, as long as it exists in English
   - 'events.*'

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -761,3 +761,62 @@ en:
       no_persons_found: "No person matches the given criteria."
   posts:
     confirm_delete_post: "Are you sure you want to delete this post? This action is not reversible."
+  #context: FAQ page
+  faq:
+    title: "Frequently Asked Questions"
+    contact_html: "If none of these answers helped, please %{contact_us}!"
+    contact_us: "contact us"
+    search_for_competition: "Search for a competition here:"
+    already_logged_in: "You are already logged in with a WCA account."
+    create_an_account: "You can create an account %{here}."
+    claim_your_wca_id: "You can claim your WCA ID %{here}."
+    create_an_account_and_claim: "Create an account %{here}. After you log in with your new account, you will be asked to claim your WCA ID."
+    answers:
+      1:
+        title: "How do I obtain a WCA ID and a WCA profile?"
+        #context: Answer to "How do I obtain a WCA ID..."
+        content:
+          1: "If you have never competed before, go to a <a href='/competitions'>competition</a>!  A WCA ID and WCA profile will be created for you when the results from your first competition are uploaded."
+      2:
+        #context: Answer to "How can I find a WCA competition"
+        title: "How can I find a WCA competition?"
+        content:
+          1: "Check out our list of <a href='/competitions'>competitions</a>"
+      3:
+        #context: Answer to "How can I register for a competition? ..."
+        title: "How can I register for a competition? Who can I refer to if I have problems registering for a competition?"
+        content:
+          1: "Many competitions do registration right here on the WCA website, but some use their own systems. You should contact the organizers of the competition you want to compete in for more details. %{comp_search_form}"
+      4:
+        title: "What are the requirements for attending a WCA competition? What do I need to know before attending a WCA competition?"
+        #context: Answer to "What are the requirements for attending a WCA competitions? ..."
+        content:
+          1: "In general, there are not many requirements for a person to participate at a WCA competition. However, all participants of a competition are expected to have a good understanding of the <a href='https://www.worldcubeassociation.org/regulations/'>WCA regulations</a>. In addition, we would recommend having a look at <a target='_blank' href='http://www.cubingusa.com/ctutorial.php'>Cubing USA's competitor tutorial</a>, which gives several nice hints for newcomers."
+      5:
+        title: "How can I have a WCA Competition in my hometown?"
+        #context: Paragraph of the answer to "How can I have a WCA competition in my hometown?"
+        content:
+          1: "If you are interested in organizing a competition, it's highly recommended to attend at least one or two competitions as a competitor to learn from the experience."
+          2: "WCA Competitions must follow the <a target='_blank' href='https://www.worldcubeassociation.org/regulations/'>WCA Regulations</a>. The organization team doesn't have to know the regulations by heart, however, a deep knowledge of the basics of the regulations would definitely help in correctly organizing the competition."
+          3: "After that, the organization team must contact a nearby <a target='_blank' href='https://www.worldcubeassociation.org/delegates'>WCA Delegate</a>. The supervision of a WCA Delegate is required in order to make a competition officially sanctioned by the WCA. The WCA Delegate will help guide the organization on how to host a successful competition."
+          4: "Visit <a target='_blank' href='https://www.cubingusa.com/cguide.php'>this guide</a> for further information. (Any conflict between the information presented in this supplementary resource and the WCA Regulations is superseded by the WCA Regulations.)"
+      6:
+        title: "What are the WCA accounts for? What is the difference between WCA accounts and WCA profiles?"
+        #context: Paragraph of the answer to "What are the WCA accounts for? ..."
+        content:
+          1: "You are assigned a WCA ID when you first participate in a WCA sanctioned competition. When the results from that competition are uploaded, your WCA profile will be created, with results from every competition you have been to."
+          2: "WCA accounts allow you to prove to us who you are. This allows you to add a picture to your WCA profile, and allows you to register for competitions. This will protect you from other people pretending to be you."
+          #context: Yup, nothing to translate here! Just hit "Use the original version"
+          3: "%{current_user_status}"
+      7:
+        title: "How do I change my profile picture?"
+        #context: Paragraph of the answer to "How do I change my profile picture?"
+        content:
+          1: "First, you need to <a href='#how-do-i-connect-my-wca-account-with-my-wca-id'>create a WCA account and connect it to your WCA ID.</a>"
+          2: "After you have connected your WCA account and your WCA ID, go to your <a href='%{profile_edit_path}'>edit profile page</a> to change your profile picture."
+      8:
+        title: "How do I connect my WCA account with my WCA ID?"
+        #context: Answer to "How do I connect my WCA account ...?"
+        content:
+          #context: Yup, nothing to translate here! Just hit "Use the original version"
+          1: "%{current_user_claim}"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -679,3 +679,51 @@ fr:
       no_persons_found: "Personne ne correspond aux critères donnés."
   posts:
     confirm_delete_post: "Êtes-vous sûr de vouloir supprimer ce post ? Cette action n'est pas réversible."
+  faq:
+    title: "Questions Fréqentes"
+    contact_html: "Si aucune de ces réponses ne vous a aidé, %{contact_us} !"
+    contact_us: "contactez nous"
+    search_for_competition: "Vous pouvez rechercher une compétition ici :"
+    already_logged_in: "Vous êtes déjà connecté avec votre compte WCA."
+    create_an_account: "Vous pouvez créer un compte %{here}."
+    claim_your_wca_id: "Vous pouvez réclamer votre ID WCA %{here}."
+    create_an_account_and_claim: "Créez un compte %{here}. Lors de la création du compte on vous demandera votre ID WCA."
+    answers:
+      1:
+        title: "Comment puis-je obtenir un ID WCA et un profil WCA ?"
+        content:
+          1: "Si vous n'avez encore jamais participé à une compétition, allez à une <a href='/competitions'>compétition</a> ! Un ID WCA et son profil seront créés pour vous lorsque les résultats de votre première compétition seront mis en ligne."
+      2:
+        title: "Comment puis-je trouver une compétition WCA ?"
+        content:
+          1: "Allez voir la liste des <a href='/competitions'>compétitions</a>"
+      3:
+        title: "Comment puis-je m'inscrire à une compétition ? À qui puis-je m'adresser si j'ai un problème lors de l'inscription à une compétition ?"
+        content:
+          1: "Pour beaucoup de compétitions l'inscription se fait ici sur le site de la WCA, mais certaines utilisent leur propre système. Vous devriez contacter les organisateurs de la compétition à laquelle vous voulez participer pour avoir plus de détails. %{comp_search_form}"
+      4:
+        title: "Quels sont les prérequis pour venir à une compétition WCA ? Que dois-je savoir avant de venir à une compétition WCA ?"
+        content:
+          1: "Il n'y a généralement pas beaucoup de prérequis pour qu'une personne puisse participer à une compétition WCA. Il est attendu que tous les participants aux compétitions aient une bonne compréhension du <a href='https://www.worldcubeassociation.org/regulations/translations/french'>Règlement WCA</a>. Additionnellement, il est recommandé de lire les tutoriels à destination des compétiteurs (en Français sur le <a target='_blank' href='http://www.speedcubingfrance.org/speedcubing/tutos/'>site de l'AFS</a>), qui contiennent des indications pour les nouveaux participants."
+      5:
+        title: "Comment puis-je organiser une compétition dans ma ville ?"
+        content:
+          1: "Si l'organisation de compétition vous intéresse, il est très fortement recommandé de participer à plusieurs compétitions comme un compétiteur, afin d'avoir un peu d'expérience."
+          2: "Les compétitions WCA doivent respecter le <a target='_blank' href='https://www.worldcubeassociation.org/regulations/translations/french'>Règlement WCA</a>. L'équipe d'organisation n'a pas besoin de connaître le Règlement par cœur, mais une connaissance approfondie des bases du Règlement aidera considérablement à l'organisation de la compétition."
+          3: "Après ça, l'équipe d'organisation doit contacter un <a target='_blank' href='https://www.worldcubeassociation.org/delegates'>Délégué WCA</a>. La présence d'un Délégué WCA est obligatoire pour permettre à la compétition d'être reconnue par la WCA. Le Délégué WCA fournira de l'aide à l'équipe d'organisation pour assurer le succès de l'organisation de la compétition."
+          4: "Visitez <a target='_blank' href='https://docs.google.com/document/d/19Y66EYz4JYrcVmzE8zmnOHCppGJGDg0sBDQaUv54sJg/edit?usp=sharing'>ce document</a> pour plus d'informations. (En cas de conflit entre les informations présentes dans ce document et le Règlement WCA, les informations présente dans le Règlement WCA doivent être prises en compte."
+      6:
+        title: "À quoi servent les comptes WCA ? Quelle est la différence entre les comptes WCA et les profils WCA ?"
+        content:
+          1: "Lorsque vous participez à votre première compétition WCA, un ID WCA est créé pour vous. Lorsque les résultats de cette compétition seront mis en ligne, votre profil WCA sera créé, avec les résultats de chaque compétition à laquelle vous avez participé."
+          2: "Les comptes WCA vous permette de nous prouver qui vous êtes. Cela vous permet également d'ajouter une photo à votre profil WCA, et de vous inscrire à des compétitions. Cela empêche également d'autres gens de se faire passer pour vous."
+          3: "%{current_user_status}"
+      7:
+        title: "Comment puis-je changer ma photo de profil ?"
+        content:
+          1: "Tout d'abord, vous aurez besoin de <a href='#how-do-i-connect-my-wca-account-with-my-wca-id'>créer un compte WCA et de le lier à votre ID WCA</a>."
+          2: "Une fois votre compte WCA et votre ID WCA liés, allez sur la <a href='%{profile_edit_path}'>page d'édition de profil</a> pour changer votre photo de profil."
+      8:
+        title: "Comment puis-je lier mon compte WCA à mon ID WCA ?"
+        content:
+          1: "%{current_user_claim}"


### PR DESCRIPTION
While going over issues I noticed in #289 @Luis-J-Ianez requested the FAQ to be translated.

Given the rest of the website can be translated, there is no reason to not include the FAQ :)
It's also a good opportunity to link to country/language specific resources.
Eg: in the translation I linked to the French national association tutorials instead of CubingUSA's, as we have a translation for them there!

Localization was a bit tricky: the FAQ is not only text, but also some variables and fields (there is even a field to search competitions!).
I think translating multiple paragraphs at once is too big for @jonatanklosko's app right now, which is why I nested several keys per answer in the locale file (one key is one paragraph).

I'm unsure about the proper way of managing the `faq_variables` hash in the view, so feel free to suggest something better!