### PR TITLE
Enable pluralizations spec for locales files.

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -77,6 +77,7 @@ group :development, :test do
   gem 'byebug'
   gem 'web-console'
   gem 'i18n-tasks', '~> 0.9.5'
+  gem 'i18n-spec'
 end
 
 group :development do

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
     i18n-country-translations (1.2.4)
       i18n (~> 0.5)
       railties (>= 4.0)
+    i18n-spec (0.6.0)
+      iso
     i18n-tasks (0.9.5)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
@@ -229,6 +231,8 @@ GEM
       parser (>= 2.2.3.0)
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
+    iso (0.2.2)
+      i18n
     jbuilder (2.2.13)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -493,6 +497,7 @@ DEPENDENCIES
   guard-rspec
   high_voltage
   i18n-country-translations
+  i18n-spec
   i18n-tasks (~> 0.9.5)
   jbuilder
   jquery-rails

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -45,7 +45,7 @@
             <%# Copied from app/views/users/edit.html.erb %>
             <%= f.input :name %>
             <%= f.input :dob, as: :date_picker %>
-            <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other') }[g] } %>
+            <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] } %>
             <%= f.input :country_iso2, collection: Country.real, value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name } %>
 
           </div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -71,7 +71,7 @@
 
         <%= f.input :name, disabled: !editable_fields.include?(:name) %>
         <%= f.input :dob, as: :date_picker, disabled: !editable_fields.include?(:dob) %>
-        <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: "Male", f: "Female", o: "Other" }[g] }, disabled: !editable_fields.include?(:gender) %>
+        <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] }, disabled: !editable_fields.include?(:gender) %>
         <%= f.input :country_iso2, collection: Country.real, value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name }, disabled: !editable_fields.include?(:country_iso2) %>
 
         <% if current_user.can_edit_users? %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -371,7 +371,7 @@ en:
       gender:
         male: "Male"
         female: "Female"
-        other: "Other"
+        other_gender: "Other"
   layouts:
     #context: This key belongs to the navigation bar
     navigation:

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -322,7 +322,7 @@ fr:
       gender:
         male: "Homme"
         female: "Femme"
-        other: "Autre"
+        other_gender: "Autre"
   layouts:
     navigation:
       information: "Information"

--- a/WcaOnRails/spec/i18n_locale_files_spec.rb
+++ b/WcaOnRails/spec/i18n_locale_files_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'i18n-spec'
+
+describe "Locale files content" do
+  Dir.glob(Rails.root.join('config', 'locales', '*.yml')).each do |locale_file|
+    describe locale_file.to_s do
+      it { is_expected.to be_parseable }
+      it { is_expected.to have_valid_pluralization_keys }
+      it { is_expected.to_not have_missing_pluralization_keys }
+      it { is_expected.to have_one_top_level_namespace }
+      it { is_expected.to_not have_legacy_interpolations }
+      it { is_expected.to have_a_valid_locale }
+    end
+  end
+end


### PR DESCRIPTION
While discussing how to handle pluralization with @jonatanklosko, I did some testing with pluralization now that we include `rails-i18n`.

Turns out the support is better but also stricter, here are some observations:
 - pluralization is supported correctly for every language
 - `:zero` is an overridable key, but the others (one, two, few, many, other) are not
 - a missing key will have the same effect as a totally missing translation key, and will crash (no fallback to something else)!

For the record [here](https://github.com/svenfuchs/rails-i18n/tree/master/lib/rails_i18n/common_pluralizations) are the pluralizations available in `rails-i18n`, and each locale is affected one pluralization [here](https://github.com/svenfuchs/rails-i18n/tree/master/rails/pluralization).

Hopefully there is already an `i18n-spec` gem that look at the root locale for a file, get the expected pluralization keys for this locale, and compare this to what is actually there.

Side effect: I had to change the "other" gender key, since the spec would consider it a pluralizable key.