### PR TITLE
Check available locales are activated in momentjs

### DIFF
--- a/WcaOnRails/spec/i18n_locale_files_spec.rb
+++ b/WcaOnRails/spec/i18n_locale_files_spec.rb
@@ -14,3 +14,13 @@ describe "Locale files content" do
     end
   end
 end
+
+describe "Momentjs activation" do
+  let(:file_content) { File.read(Rails.root.join('app', 'assets', 'javascripts', 'application.js')) }
+
+  (I18n.available_locales - [:en]).each do |locale|
+    context "for #{locale} the app/assets/javascripts/application.js file" do
+      it { expect(file_content).to include("//= require moment/#{locale}.js") }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1074.

I dont think we can automatically generate a part of `application.js` to load the available locales in momentjs, but at least we can ensure we won't forget to do so when adding a translation!

