### PR TITLE
Minor improvements to the reject an avatar notification email.

### DIFF
--- a/WcaOnRails/app/mailers/avatars_mailer.rb
+++ b/WcaOnRails/app/mailers/avatars_mailer.rb
@@ -6,7 +6,7 @@ class AvatarsMailer < ApplicationMailer
 
     mail(
       to: user.email,
-      reply_to: "notifications@worldcubeassociation.org",
+      reply_to: "results@worldcubeassociation.org",
       subject: "Your avatar has been rejected",
     )
   end

--- a/WcaOnRails/app/views/avatars_mailer/notify_user_of_avatar_rejection.html.erb
+++ b/WcaOnRails/app/views/avatars_mailer/notify_user_of_avatar_rejection.html.erb
@@ -9,4 +9,4 @@
   </p>
 <% end %>
 
-<p>Please provide more suitable picture.</p>
+<p>Please provide a more suitable picture.</p>

--- a/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AvatarsMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq "Your avatar has been rejected"
       expect(mail.to).to eq [user.email]
-      expect(mail.reply_to).to eq ["notifications@worldcubeassociation.org"]
+      expect(mail.reply_to).to eq ["results@worldcubeassociation.org"]
       expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
     end
 


### PR DESCRIPTION
Fixing a minor grammar error, and changing the `reply_to` address to the results team (which is now responsible for handling profile picture requests).