### PR TITLE
Proposal to change data export to daily

### DIFF
--- a/chef/site-cookbooks/wca/recipes/cronjobs.rb
+++ b/chef/site-cookbooks/wca/recipes/cronjobs.rb
@@ -50,7 +50,7 @@ unless node.chef_environment.start_with?("development")
   cron "cronned results scripts" do
     minute '0'
     hour '4'
-    weekday '1,3,5'
+    weekday '*'
 
     path path
     mailto admin_email


### PR DESCRIPTION
I for one would find this useful in fantasy cubing until I implement a full results api and can start querying that for the most updated results.

I believe that since the export was thrice weekly (I may be wrong), comps are more frequent and more people are using the export thus it would be nice to keep it the most updated we can.

I took a quick look at the cpu when the script is running and it jumps from about < 5% to 5-20% so it does not hurt the server that much.