### PR TITLE
Display a status page for translations

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -51,3 +51,4 @@
 @import "search_results";
 @import "delegate_reports";
 @import "competition_tabs";
+@import "server_status";

--- a/WcaOnRails/app/assets/stylesheets/server_status.scss
+++ b/WcaOnRails/app/assets/stylesheets/server_status.scss
@@ -1,5 +1,6 @@
 .panel-warning > .heading-as-link:hover {
   @extend a.list-group-item-warning:hover;
+  cursor: pointer;
 }
 
 .heading-as-link > .panel-title > a {

--- a/WcaOnRails/app/assets/stylesheets/server_status.scss
+++ b/WcaOnRails/app/assets/stylesheets/server_status.scss
@@ -1,0 +1,16 @@
+.panel-warning > .heading-as-link:hover {
+  @extend a.list-group-item-warning:hover;
+}
+
+.heading-as-link > .panel-title > a {
+  text-decoration: none;
+}
+
+ul.locale-list-keys {
+  margin: 0;
+  li {
+    @extend .text-center;
+    margin: 3px;
+    border-radius: 3px;
+  }
+}

--- a/WcaOnRails/app/controllers/server_status_controller.rb
+++ b/WcaOnRails/app/controllers/server_status_controller.rb
@@ -8,6 +8,16 @@ class ServerStatusController < ApplicationController
 
     @everything_good = @oldest_job_that_should_have_run_by_now.nil?
 
+    @ref_english = Locale.new('en')
+    @status_locales = {}
+    @total_missing_outdated = 0
+    (I18n.available_locales - [:en]).each do |l|
+      ref_locale = Locale.new(l, true)
+      missing, outdated = ref_locale.compare_to(@ref_english)
+      @total_missing_outdated += missing.size + outdated.size
+      @status_locales[l] = { missing: missing, outdated: outdated }
+    end
+
     if !@everything_good
       render status: 503
     end

--- a/WcaOnRails/app/helpers/server_status_helper.rb
+++ b/WcaOnRails/app/helpers/server_status_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module ServerStatusHelper
+  def css_classes(missing_keys_empty, outdated_keys_empty)
+    if missing_keys_empty && outdated_keys_empty
+      class_heading = ""
+      class_panel = class_missing = class_outdated = "success"
+      title = "All good, the translation is up to date!"
+    elsif missing_keys_empty && !outdated_keys_empty
+      class_heading = "heading-as-link"
+      class_missing = "success"
+      class_panel = class_outdated = "warning"
+      title = "Some items in the translation are outdated"
+    elsif outdated_keys_empty && !missing_keys_empty
+      class_heading = "heading-as-link"
+      class_panel = "warning"
+      class_missing = "danger"
+      class_outdated = "success"
+      title = "Some items in the translation are missing"
+    else
+      # The only other choice is that both lists are not empty
+      class_heading = "heading-as-link"
+      class_panel = class_outdated = "warning"
+      class_missing = "danger"
+      title = "Some items in the translation are missing and some others are outdated"
+    end
+    [class_heading, class_panel, class_missing, class_outdated, title]
+  end
+end

--- a/WcaOnRails/app/views/server_status/index.html.erb
+++ b/WcaOnRails/app/views/server_status/index.html.erb
@@ -2,31 +2,131 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
-  <% if @everything_good %>
+  <% if @everything_good && @total_missing_outdated == 0 %>
     <%= alert :success, "We're fine. We're all fine here, now, thank you. How are you?" %>
+  <% elsif @everything_good %>
+    <%= alert :warning, "The server is alright, but some translations would enjoy an update." %>
   <% else %>
     <%= alert :danger, "Check below, something may be wrong." %>
   <% end %>
+<%
+    kind_class = if @oldest_job_that_should_have_run_by_now
+                   "danger"
+                 else
+                   "success"
+                 end
+%>
+    <div class="panel panel-<%= kind_class %>">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          <span class="label label-<%= kind_class %>">Jobs</span>
 
-  <ul>
-    <li>
-      <% if @oldest_job_that_should_have_run_by_now %>
-        <span class="label label-warning">Jobs</span>
+          <% if @oldest_job_that_should_have_run_by_now %>
+            Uh oh!
+            Job <%= @oldest_job_that_should_have_run_by_now.id %> was created
+            <%= time_ago_in_words @oldest_job_that_should_have_run_by_now.created_at %>
+            ago and still has not run.
+            <%= @jobs_that_should_have_run_by_now.count %>
+            <%= "job".pluralize(@jobs_that_should_have_run_by_now.count) %>
+            <%= "is".pluralize(@jobs_that_should_have_run_by_now.count) %>
+            waiting to run.
 
-        Uh oh!
-        Job <%= @oldest_job_that_should_have_run_by_now.id %> was created
-        <%= time_ago_in_words @oldest_job_that_should_have_run_by_now.created_at %>
-        ago and still has not run.
-        <%= @jobs_that_should_have_run_by_now.count %>
-        <%= "job".pluralize(@jobs_that_should_have_run_by_now.count) %>
-        <%= "is".pluralize(@jobs_that_should_have_run_by_now.count) %>
-        waiting to run.
-
-      <% else %>
-        <span class="label label-success">Jobs</span>
-
-        Looking good!
-      <% end %>
-    </li>
-  </ul>
+          <% else %>
+            Looking good!
+          <% end %>
+        </h3>
+      </div>
+    </div>
+  <% (I18n.available_locales - [:en]).each do |l| %>
+    <% missing = @status_locales[l][:missing] %>
+    <% outdated = @status_locales[l][:outdated] %>
+    <% all_empty = (missing.empty? && outdated.empty?) %>
+    <%
+       if all_empty
+         class_missing = class_outdated = class_panel = "success"
+         title = "All good, the translation is up to date!"
+       elsif missing.empty?
+         class_panel = "warning"
+         class_outdated = "warning"
+         class_missing = "success"
+         title = "Some items in the translation are outdated"
+       elsif outdated.empty?
+         class_panel = "warning"
+         class_outdated = "success"
+         class_missing = "danger"
+         title = "Some items in the translation are missing"
+       else
+         class_panel = "warning"
+         class_outdated = "warning"
+         class_missing = "danger"
+         title = "Some items in the translation are missing and some other are outdated"
+       end
+    %>
+    <div class="panel panel-<%= class_panel %>">
+      <div class="panel-heading heading-as-link">
+        <h3 class="panel-title">
+        <% unless all_empty %>
+          <a data-toggle="collapse" href="#collapse-<%= l.to_s %>">
+        <% else %>
+          <div>
+        <% end %>
+            <span class="label label-<%= class_panel %>">i18n</span>
+            <span class="label label-<%= class_panel %>"><%= "#{l}" %></span>
+            <span class="badge"><%= missing.size + outdated.size %></span>
+            <%= title %>
+            <% unless all_empty %>
+              <span class="collapse-indicator"></span>
+            <% end %>
+        <% unless all_empty %>
+          </a>
+        <% else %>
+          </div>
+        <% end %>
+        </h3>
+      </div>
+        <div id="collapse-<%= l.to_s %>" class="panel-collapse collapse panel-body row">
+          <div class="col-md-6">
+            <div class="panel panel-<%= class_missing %>">
+              <div class="panel-heading panel-title text-center">
+                Missing
+                <span class="badge"><%= missing.size %></span>
+              </div>
+              <% unless missing.empty? %>
+                <div class="panel-body">
+                  <ul class="list-group row locale-list-keys">
+                    <% missing.each do |key| %>
+                      <div class="col-md-6">
+                        <li class="list-group-item"><%= key %></li>
+                      </div>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="panel panel-<%= class_outdated %>">
+              <div class="panel-heading panel-title text-center">
+                Outdated
+                <span class="badge"><%= outdated.size %></span>
+                <!--
+                  These keys are translated, but the English version has changed since the translation:
+                -->
+              </div>
+              <% unless outdated.empty? %>
+                <div class="panel-body">
+                  <ul class="list-group row locale-list-keys">
+                    <% outdated.each do |key| %>
+                      <div class="col-md-6">
+                        <li class="list-group-item"><%= key %></li>
+                      </div>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+    </div>
+  <% end %>
 </div>

--- a/WcaOnRails/app/views/server_status/index.html.erb
+++ b/WcaOnRails/app/views/server_status/index.html.erb
@@ -9,81 +9,46 @@
   <% else %>
     <%= alert :danger, "Check below, something may be wrong." %>
   <% end %>
-<%
-    kind_class = if @oldest_job_that_should_have_run_by_now
-                   "danger"
-                 else
-                   "success"
-                 end
-%>
-    <div class="panel panel-<%= kind_class %>">
-      <div class="panel-heading">
-        <h3 class="panel-title">
-          <span class="label label-<%= kind_class %>">Jobs</span>
+  <% kind_class = @oldest_job_that_should_have_run_by_now ? "danger" : "success" %>
+  <div class="panel panel-<%= kind_class %>">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        <span class="label label-<%= kind_class %>">Jobs</span>
 
-          <% if @oldest_job_that_should_have_run_by_now %>
-            Uh oh!
-            Job <%= @oldest_job_that_should_have_run_by_now.id %> was created
-            <%= time_ago_in_words @oldest_job_that_should_have_run_by_now.created_at %>
-            ago and still has not run.
-            <%= @jobs_that_should_have_run_by_now.count %>
-            <%= "job".pluralize(@jobs_that_should_have_run_by_now.count) %>
-            <%= "is".pluralize(@jobs_that_should_have_run_by_now.count) %>
-            waiting to run.
+        <% if @oldest_job_that_should_have_run_by_now %>
+          Uh oh!
+          Job <%= @oldest_job_that_should_have_run_by_now.id %> was created
+          <%= time_ago_in_words @oldest_job_that_should_have_run_by_now.created_at %>
+          ago and still has not run.
+          <%= @jobs_that_should_have_run_by_now.count %>
+          <%= "job".pluralize(@jobs_that_should_have_run_by_now.count) %>
+          <%= "is".pluralize(@jobs_that_should_have_run_by_now.count) %>
+          waiting to run.
 
-          <% else %>
-            Looking good!
-          <% end %>
-        </h3>
-      </div>
+        <% else %>
+          Looking good!
+        <% end %>
+      </h3>
     </div>
+  </div>
   <% (I18n.available_locales - [:en]).each do |l| %>
     <% missing = @status_locales[l][:missing] %>
     <% outdated = @status_locales[l][:outdated] %>
     <% all_empty = (missing.empty? && outdated.empty?) %>
-    <%
-       if all_empty
-         class_missing = class_outdated = class_panel = "success"
-         title = "All good, the translation is up to date!"
-       elsif missing.empty?
-         class_panel = "warning"
-         class_outdated = "warning"
-         class_missing = "success"
-         title = "Some items in the translation are outdated"
-       elsif outdated.empty?
-         class_panel = "warning"
-         class_outdated = "success"
-         class_missing = "danger"
-         title = "Some items in the translation are missing"
-       else
-         class_panel = "warning"
-         class_outdated = "warning"
-         class_missing = "danger"
-         title = "Some items in the translation are missing and some other are outdated"
-       end
-    %>
+    <% class_heading, class_panel, class_missing, class_outdated, title = css_classes(missing.empty?, outdated.empty?) %>
     <div class="panel panel-<%= class_panel %>">
-      <div class="panel-heading heading-as-link">
+      <div class="panel-heading <%= class_heading %>" data-toggle="collapse" data-target="#collapse-<%= l %>">
         <h3 class="panel-title">
-        <% unless all_empty %>
-          <a data-toggle="collapse" href="#collapse-<%= l.to_s %>">
-        <% else %>
-          <div>
-        <% end %>
-            <span class="label label-<%= class_panel %>">i18n</span>
-            <span class="label label-<%= class_panel %>"><%= "#{l}" %></span>
-            <span class="badge"><%= missing.size + outdated.size %></span>
-            <%= title %>
-            <% unless all_empty %>
-              <span class="collapse-indicator"></span>
-            <% end %>
-        <% unless all_empty %>
-          </a>
-        <% else %>
-          </div>
-        <% end %>
+          <span class="label label-<%= class_panel %>">i18n</span>
+          <span class="label label-<%= class_panel %>"><%= l %></span>
+          <span class="badge"><%= missing.size + outdated.size %></span>
+          <%= title %>
+          <% unless all_empty %>
+            <span class="collapse-indicator"></span>
+          <% end %>
         </h3>
       </div>
+      <% unless all_empty %>
         <div id="collapse-<%= l.to_s %>" class="panel-collapse collapse panel-body row">
           <div class="col-md-6">
             <div class="panel panel-<%= class_missing %>">
@@ -127,6 +92,7 @@
             </div>
           </div>
         </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -462,12 +462,12 @@ en:
       save: "Save"
       guidelines: "Guidelines"
       avatar_guidelines:
-        1: "All avatars should be pictures of real persons."
-        2: "The person shown must be you."
-        3: "If there is more than one person on the avatar, it should be clear who of them is you."
-        4: "Your head, but not necessarily the full face, should be visible."
-        5: "The avatar must not include texts other than regular background texts."
-        6: "The avatar must be submitted in correct orientation."
+        '1': "All avatars should be pictures of real persons."
+        '2': "The person shown must be you."
+        '3': "If there is more than one person on the avatar, it should be clear who of them is you."
+        '4': "Your head, but not necessarily the full face, should be visible."
+        '5': "The avatar must not include texts other than regular background texts."
+        '6': "The avatar must be submitted in correct orientation."
 
     #context: when an error occured during the edition
     errors:
@@ -774,57 +774,57 @@ en:
     claim_your_wca_id: "You can claim your WCA ID %{here}."
     create_an_account_and_claim: "Create an account %{here}. After you log in with your new account, you will be asked to claim your WCA ID."
     answers:
-      1:
+      '1':
         title: "How do I obtain a WCA ID and a WCA profile?"
         #context: Answer to "How do I obtain a WCA ID..."
         content:
-          1: "If you have never competed before, go to a <a href='/competitions'>competition</a>!  A WCA ID and WCA profile will be created for you when the results from your first competition are published."
-      2:
+          '1': "If you have never competed before, go to a <a href='/competitions'>competition</a>!  A WCA ID and WCA profile will be created for you when the results from your first competition are published."
+      '2':
         #context: Answer to "How can I find a WCA competition"
         title: "How can I find a WCA competition?"
         content:
-          1: "Check out our list of <a href='/competitions'>competitions</a>"
-      3:
+          '1': "Check out our list of <a href='/competitions'>competitions</a>"
+      '3':
         #context: Answer to "How can I register for a competition? ..."
         title: "How can I register for a competition? Who can I refer to if I have problems registering for a competition?"
         content:
-          1: "Many competitions do registration right here on the WCA website, but some use their own systems. You should contact the organizers of the competition you want to compete in for more details. %{comp_search_form}"
-      4:
+          '1': "Many competitions do registration right here on the WCA website, but some use their own systems. You should contact the organizers of the competition you want to compete in for more details. %{comp_search_form}"
+      '4':
         title: "What are the requirements for attending a WCA competition? What do I need to know before attending a WCA competition?"
         #context: Answer to "What are the requirements for attending a WCA competitions? ..."
         content:
-          1: "In general, there are not many requirements for a person to participate at a WCA competition. However, all participants of a competition are expected to have a good understanding of the <a href='https://www.worldcubeassociation.org/regulations/'>WCA regulations</a>. In addition, we would recommend having a look at <a target='_blank' href='http://www.cubingusa.com/ctutorial.php'>Cubing USA's competitor tutorial</a>, which gives several nice hints for newcomers."
-      5:
+          '1': "In general, there are not many requirements for a person to participate at a WCA competition. However, all participants of a competition are expected to have a good understanding of the <a href='https://www.worldcubeassociation.org/regulations/'>WCA regulations</a>. In addition, we would recommend having a look at <a target='_blank' href='http://www.cubingusa.com/ctutorial.php'>Cubing USA's competitor tutorial</a>, which gives several nice hints for newcomers."
+      '5':
         title: "How can I have a WCA Competition in my hometown?"
         #context: Paragraph of the answer to "How can I have a WCA competition in my hometown?"
         content:
-          1: "If you are interested in organizing a competition, it's highly recommended to attend at least one or two competitions as a competitor to learn from the experience."
-          2: "WCA Competitions must follow the <a target='_blank' href='https://www.worldcubeassociation.org/regulations/'>WCA Regulations</a>. The organization team doesn't have to know the regulations by heart, however, a deep knowledge of the basics of the regulations would definitely help in correctly organizing the competition."
-          3: "After that, the organization team must contact a nearby <a target='_blank' href='https://www.worldcubeassociation.org/delegates'>WCA Delegate</a>. The supervision of a WCA Delegate is required in order to make a competition officially sanctioned by the WCA. The WCA Delegate will help guide the organization on how to host a successful competition."
-          4: "Visit <a target='_blank' href='https://www.cubingusa.com/cguide.php'>this guide</a> for further information. (Any conflict between the information presented in this supplementary resource and the WCA Regulations is superseded by the WCA Regulations.)"
-      6:
+          '1': "If you are interested in organizing a competition, it's highly recommended to attend at least one or two competitions as a competitor to learn from the experience."
+          '2': "WCA Competitions must follow the <a target='_blank' href='https://www.worldcubeassociation.org/regulations/'>WCA Regulations</a>. The organization team doesn't have to know the regulations by heart, however, a deep knowledge of the basics of the regulations would definitely help in correctly organizing the competition."
+          '3': "After that, the organization team must contact a nearby <a target='_blank' href='https://www.worldcubeassociation.org/delegates'>WCA Delegate</a>. The supervision of a WCA Delegate is required in order to make a competition officially sanctioned by the WCA. The WCA Delegate will help guide the organization on how to host a successful competition."
+          '4': "Visit <a target='_blank' href='https://www.cubingusa.com/cguide.php'>this guide</a> for further information. (Any conflict between the information presented in this supplementary resource and the WCA Regulations is superseded by the WCA Regulations.)"
+      '6':
         title: "What are the WCA accounts for? What is the difference between WCA accounts and WCA profiles?"
         #context: Paragraph of the answer to "What are the WCA accounts for? ..."
         content:
-          1: "You are assigned a WCA ID when the results from your first WCA sanctioned competition are published."
-          2: "WCA accounts allow you to prove to us who you are. This allows you to add a picture to your WCA profile, and allows you to register for competitions. This will protect you from other people pretending to be you."
+          '1': "You are assigned a WCA ID when the results from your first WCA sanctioned competition are published."
+          '2': "WCA accounts allow you to prove to us who you are. This allows you to add a picture to your WCA profile, and allows you to register for competitions. This will protect you from other people pretending to be you."
           #context: Yup, nothing to translate here! Just hit "Use the original version"
-          3: "%{current_user_status}"
+          '3': "%{current_user_status}"
       'results':
         title: "When are the results of a WCA competition uploaded to the WCA website?"
         content:
           '1': "After a competition has ended, the WCA Delegate has to double-check all score sheets and person data to eliminate possible errors. Once this is done, the results are sent to the WCA Results Team (WRT), which is responsible for uploading competition results and maintaining the WCA database. The WRT finally uploads the results to the WCA database as soon as possible."
           '2': "Depending on the size of the competition and the delegate's personal schedule, all this can take only a day or up to a week. Please be patient."
           '3': "Additionally, if you have connected your WCA account with your WCA ID (see below), you can enable email notifications about your results submission <a href='%{preferences_edit_path}'>here</a>."
-      7:
+      '7':
         title: "How do I change my profile picture?"
         #context: Paragraph of the answer to "How do I change my profile picture?"
         content:
-          1: "First, you need to <a href='#how-do-i-connect-my-wca-account-with-my-wca-id'>create a WCA account and connect it to your WCA ID.</a>"
-          2: "After you have connected your WCA account and your WCA ID, go to your <a href='%{profile_edit_path}'>edit profile page</a> to change your profile picture."
-      8:
+          '1': "First, you need to <a href='#how-do-i-connect-my-wca-account-with-my-wca-id'>create a WCA account and connect it to your WCA ID.</a>"
+          '2': "After you have connected your WCA account and your WCA ID, go to your <a href='%{profile_edit_path}'>edit profile page</a> to change your profile picture."
+      '8':
         title: "How do I connect my WCA account with my WCA ID?"
         #context: Answer to "How do I connect my WCA account ...?"
         content:
           #context: Yup, nothing to translate here! Just hit "Use the original version"
-          1: "%{current_user_claim}"
+          '1': "%{current_user_claim}"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -409,12 +409,12 @@ fr:
       save: "Sauvegarder"
       guidelines: "Recommendations"
       avatar_guidelines:
-        1: "Toutes les photos doivent être des photos de personnes réelles."
-        2: "La personne sur la photo doit être vous."
-        3: "S'il y a plus d'une personne sur la photo, il devrait être facile de vous identifier."
-        4: "Votre tête, mais pas nécessairement tout votre visage, devrait être visible."
-        5: "La photo de doit pas avoir d'autres textes que ceux présents en arrière plan."
-        6: "La photo doit être soumise dans la bonne orientation."
+        '1': "Toutes les photos doivent être des photos de personnes réelles."
+        '2': "La personne sur la photo doit être vous."
+        '3': "S'il y a plus d'une personne sur la photo, il devrait être facile de vous identifier."
+        '4': "Votre tête, mais pas nécessairement tout votre visage, devrait être visible."
+        '5': "La photo de doit pas avoir d'autres textes que ceux présents en arrière plan."
+        '6': "La photo doit être soumise dans la bonne orientation."
 
     errors:
       not_found: "introuvable"
@@ -687,47 +687,47 @@ fr:
     claim_your_wca_id: "Vous pouvez réclamer votre ID WCA %{here}."
     create_an_account_and_claim: "Créez un compte %{here}. Lors de la création du compte on vous demandera votre ID WCA."
     answers:
-      1:
+      '1':
         title: "Comment puis-je obtenir un ID WCA et un profil WCA ?"
         content:
-          1: "Si vous n'avez encore jamais participé à une compétition, allez à une <a href='/competitions'>compétition</a> ! Un ID WCA et son profil seront créés pour vous lorsque les résultats de votre première compétition seront mis en ligne."
-      2:
+          '1': "Si vous n'avez encore jamais participé à une compétition, allez à une <a href='/competitions'>compétition</a> ! Un ID WCA et son profil seront créés pour vous lorsque les résultats de votre première compétition seront mis en ligne."
+      '2':
         title: "Comment puis-je trouver une compétition WCA ?"
         content:
-          1: "Allez voir la liste des <a href='/competitions'>compétitions</a>"
-      3:
+          '1': "Allez voir la liste des <a href='/competitions'>compétitions</a>"
+      '3':
         title: "Comment puis-je m'inscrire à une compétition ? À qui puis-je m'adresser si j'ai un problème lors de l'inscription à une compétition ?"
         content:
-          1: "Pour beaucoup de compétitions l'inscription se fait ici sur le site de la WCA, mais certaines utilisent leur propre système. Vous devriez contacter les organisateurs de la compétition à laquelle vous voulez participer pour avoir plus de détails. %{comp_search_form}"
-      4:
+          '1': "Pour beaucoup de compétitions l'inscription se fait ici sur le site de la WCA, mais certaines utilisent leur propre système. Vous devriez contacter les organisateurs de la compétition à laquelle vous voulez participer pour avoir plus de détails. %{comp_search_form}"
+      '4':
         title: "Quels sont les prérequis pour venir à une compétition WCA ? Que dois-je savoir avant de venir à une compétition WCA ?"
         content:
-          1: "Il n'y a généralement pas beaucoup de prérequis pour qu'une personne puisse participer à une compétition WCA. Il est attendu que tous les participants aux compétitions aient une bonne compréhension du <a href='https://www.worldcubeassociation.org/regulations/translations/french'>Règlement WCA</a>. Additionnellement, il est recommandé de lire les tutoriels à destination des compétiteurs (en Français sur le <a target='_blank' href='http://www.speedcubingfrance.org/speedcubing/tutos/'>site de l'AFS</a>), qui contiennent des indications pour les nouveaux participants."
-      5:
+          '1': "Il n'y a généralement pas beaucoup de prérequis pour qu'une personne puisse participer à une compétition WCA. Il est attendu que tous les participants aux compétitions aient une bonne compréhension du <a href='https://www.worldcubeassociation.org/regulations/translations/french'>Règlement WCA</a>. Additionnellement, il est recommandé de lire les tutoriels à destination des compétiteurs (en Français sur le <a target='_blank' href='http://www.speedcubingfrance.org/speedcubing/tutos/'>site de l'AFS</a>), qui contiennent des indications pour les nouveaux participants."
+      '5':
         title: "Comment puis-je organiser une compétition dans ma ville ?"
         content:
-          1: "Si l'organisation de compétition vous intéresse, il est très fortement recommandé de participer à plusieurs compétitions comme un compétiteur, afin d'avoir un peu d'expérience."
-          2: "Les compétitions WCA doivent respecter le <a target='_blank' href='https://www.worldcubeassociation.org/regulations/translations/french'>Règlement WCA</a>. L'équipe d'organisation n'a pas besoin de connaître le Règlement par cœur, mais une connaissance approfondie des bases du Règlement aidera considérablement à l'organisation de la compétition."
-          3: "Après ça, l'équipe d'organisation doit contacter un <a target='_blank' href='https://www.worldcubeassociation.org/delegates'>Délégué WCA</a>. La présence d'un Délégué WCA est obligatoire pour permettre à la compétition d'être reconnue par la WCA. Le Délégué WCA fournira de l'aide à l'équipe d'organisation pour assurer le succès de l'organisation de la compétition."
-          4: "Visitez <a target='_blank' href='https://docs.google.com/document/d/19Y66EYz4JYrcVmzE8zmnOHCppGJGDg0sBDQaUv54sJg/edit?usp=sharing'>ce document</a> pour plus d'informations. (En cas de conflit entre les informations présentes dans ce document et le Règlement WCA, les informations présente dans le Règlement WCA doivent être prises en compte."
-      6:
+          '1': "Si l'organisation de compétition vous intéresse, il est très fortement recommandé de participer à plusieurs compétitions comme un compétiteur, afin d'avoir un peu d'expérience."
+          '2': "Les compétitions WCA doivent respecter le <a target='_blank' href='https://www.worldcubeassociation.org/regulations/translations/french'>Règlement WCA</a>. L'équipe d'organisation n'a pas besoin de connaître le Règlement par cœur, mais une connaissance approfondie des bases du Règlement aidera considérablement à l'organisation de la compétition."
+          '3': "Après ça, l'équipe d'organisation doit contacter un <a target='_blank' href='https://www.worldcubeassociation.org/delegates'>Délégué WCA</a>. La présence d'un Délégué WCA est obligatoire pour permettre à la compétition d'être reconnue par la WCA. Le Délégué WCA fournira de l'aide à l'équipe d'organisation pour assurer le succès de l'organisation de la compétition."
+          '4': "Visitez <a target='_blank' href='https://docs.google.com/document/d/19Y66EYz4JYrcVmzE8zmnOHCppGJGDg0sBDQaUv54sJg/edit?usp=sharing'>ce document</a> pour plus d'informations. (En cas de conflit entre les informations présentes dans ce document et le Règlement WCA, les informations présente dans le Règlement WCA doivent être prises en compte."
+      '6':
         title: "À quoi servent les comptes WCA ? Quelle est la différence entre les comptes WCA et les profils WCA ?"
         content:
-          1: "Lorsque vous participez à votre première compétition WCA, un ID WCA est créé pour vous. Lorsque les résultats de cette compétition seront mis en ligne, votre profil WCA sera créé, avec les résultats de chaque compétition à laquelle vous avez participé."
-          2: "Les comptes WCA vous permette de nous prouver qui vous êtes. Cela vous permet également d'ajouter une photo à votre profil WCA, et de vous inscrire à des compétitions. Cela empêche également d'autres gens de se faire passer pour vous."
-          3: "%{current_user_status}"
+          '1': "Lorsque vous participez à votre première compétition WCA, un ID WCA est créé pour vous. Lorsque les résultats de cette compétition seront mis en ligne, votre profil WCA sera créé, avec les résultats de chaque compétition à laquelle vous avez participé."
+          '2': "Les comptes WCA vous permette de nous prouver qui vous êtes. Cela vous permet également d'ajouter une photo à votre profil WCA, et de vous inscrire à des compétitions. Cela empêche également d'autres gens de se faire passer pour vous."
+          '3': "%{current_user_status}"
       'results':
         title: "Quand est-ce que sont mis en ligne les résultats d'une compétition WCA sur le site de la WCA ?"
         content:
           '1': "Après qu'une compétition soit terminée, le Délégué WCA doit vérifier la saisie de toutes les feuilles de score ainsi que les informations des participants, afin d'éliminer d'éventuelles erreurs. Une fois cela fait, les résultats sont envoyés à la WCA Results Team (WRT), qui est en charge de mettre en ligne les résultats et de maintenir la base de données de la WCA. Enfin la WRT rentre les résultats dans la base de données de la WCA dès que possible."
           '2': "En fonction de la taille de la compétition et de la disponibilité du Délégué, tout cela peut prendre entre un jour et une semaine. Merci d'être patient."
           '3': "Si vous avez lié votre compte WCA à votre ID WCA, vous pouvez également activer les notifications par email concernant vos résultats <a href='%{preferences_edit_path}'>ici</a>."
-      7:
+      '7':
         title: "Comment puis-je changer ma photo de profil ?"
         content:
-          1: "Tout d'abord, vous aurez besoin de <a href='#how-do-i-connect-my-wca-account-with-my-wca-id'>créer un compte WCA et de le lier à votre ID WCA</a>."
-          2: "Une fois votre compte WCA et votre ID WCA liés, allez sur la <a href='%{profile_edit_path}'>page d'édition de profil</a> pour changer votre photo de profil."
-      8:
+          '1': "Tout d'abord, vous aurez besoin de <a href='#how-do-i-connect-my-wca-account-with-my-wca-id'>créer un compte WCA et de le lier à votre ID WCA</a>."
+          '2': "Une fois votre compte WCA et votre ID WCA liés, allez sur la <a href='%{profile_edit_path}'>page d'édition de profil</a> pour changer votre photo de profil."
+      '8':
         title: "Comment puis-je lier mon compte WCA à mon ID WCA ?"
         content:
-          1: "%{current_user_claim}"
+          '1': "%{current_user_claim}"


### PR DESCRIPTION
Fixes #847.

http://internationalize.herokuapp.com/ will add a hash of the original value to the translated keys in the file, ie it will output something like this:

```yml
fr:
  countries:
    #original_hash: 3f8c9de
    XA: Pays multiple (Asie)
    #original_hash: 090f3ce
    XE: Pays multiple (Europe)
```

To parse contextual comment in the original file, Jonatan uses some regexp on the whole file, at every key of the file (see the original code [here](https://github.com/viroulep/internationalize/blob/b33561347e0f67fb8b0f4d57f6a42034b93dbc95/client/app/services/translation-utils.service.js#L194-L220)).

It works pretty fast there, I adapted it in ruby (see [here](https://github.com/thewca/worldcubeassociation.org/pull/1090/files#diff-42ebd3a672fdd4205143d95c39ddd848R27)) and it worked ok for the small locale files I tested it on.
However I just tried using it on the current French one, and it's insanely slow (ie: not usable!).
I'm not aware of the performance differences between regexp in js and in ruby, if any.
Some questions for you:
 - is there a way to improve the regexp speed? FYI right now the French locale generated ~500 regexp on a ~30kB text.
 - I'm very very tempted to build a very small parser that would iterate through the file line per line, making it ~500 very simple regexp on ~60B text, do you think it would be a good alternative?
 - Is extending the ruby YAML library a good idea?

Feedback on other part of the code is welcome too, even if it's still a wip :)

Here is a screenshot to have an idea of what it looks like:
![status-locale](https://cloud.githubusercontent.com/assets/1007485/21870544/2b529b3c-d85d-11e6-9b37-ada23805e4e7.png)
