### PR TITLE
Two performance improvements for Person Search.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/persons.js
+++ b/WcaOnRails/app/assets/javascripts/persons.js
@@ -11,6 +11,7 @@ var personsTableAjax = {
     });
   },
   doAjax: function(options) {
+    $('.pagination li').addClass('disabled');
     return wca.cancelPendingAjaxAndAjax('persons-index', options);
   },
 };

--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -4,7 +4,7 @@ class PersonsController < ApplicationController
     respond_to do |format|
       format.html
       format.js do
-        persons = Person.in_region(params[:region]).order(:name, :countryId)
+        persons = Person.in_region(params[:region]).order(:name)
         params[:search]&.split&.each do |part|
           persons = persons.where("rails_persons.name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
         end


### PR DESCRIPTION
1. Disable the pagination controls while a page is being loaded. This stops manual flooding of the server with more requests than it can handle.
2. Sort the results on `name` only, so the DB can use that index.