### PR TITLE
Added a new entry to the FAQ

### DIFF
--- a/WcaOnRails/app/views/static_pages/faq.html.erb
+++ b/WcaOnRails/app/views/static_pages/faq.html.erb
@@ -3,6 +3,7 @@
 <%
 faq_variables = {
   profile_edit_path: profile_edit_path,
+  preferences_edit_path: profile_edit_path + "?section=preferences",
   current_user_status: if current_user
                          t('faq.already_logged_in')
                        else

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -810,6 +810,12 @@ en:
           2: "WCA accounts allow you to prove to us who you are. This allows you to add a picture to your WCA profile, and allows you to register for competitions. This will protect you from other people pretending to be you."
           #context: Yup, nothing to translate here! Just hit "Use the original version"
           3: "%{current_user_status}"
+      'results':
+        title: "When are the results of a WCA competition uploaded to the WCA website?"
+        content:
+          '1': "After a competition has ended, the WCA Delegate has to double-check all score sheets and person data to eliminate possible errors. Once this is done, the results are sent to the WCA Results Team (WRT), which is responsible for uploading competition results and maintaining the WCA database. The WRT finally uploads the results to the WCA database as soon as possible."
+          '2': "Depending on the size of the competition and the delegate's personal schedule, all this can take only a day or up to a week. Please be patient."
+          '3': "Additionally, if you have connected your WCA account with your WCA ID (see below), you can enable email notifications about your results submission <a href='%{preferences_edit_path}'>here</a>."
       7:
         title: "How do I change my profile picture?"
         #context: Paragraph of the answer to "How do I change my profile picture?"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -716,6 +716,12 @@ fr:
           1: "Lorsque vous participez à votre première compétition WCA, un ID WCA est créé pour vous. Lorsque les résultats de cette compétition seront mis en ligne, votre profil WCA sera créé, avec les résultats de chaque compétition à laquelle vous avez participé."
           2: "Les comptes WCA vous permette de nous prouver qui vous êtes. Cela vous permet également d'ajouter une photo à votre profil WCA, et de vous inscrire à des compétitions. Cela empêche également d'autres gens de se faire passer pour vous."
           3: "%{current_user_status}"
+      'results':
+        title: "Quand est-ce que sont mis en ligne les résultats d'une compétition WCA sur le site de la WCA ?"
+        content:
+          '1': "Après qu'une compétition soit terminée, le Délégué WCA doit vérifier la saisie de toutes les feuilles de score ainsi que les informations des participants, afin d'éliminer d'éventuelles erreurs. Une fois cela fait, les résultats sont envoyés à la WCA Results Team (WRT), qui est en charge de mettre en ligne les résultats et de maintenir la base de données de la WCA. Enfin la WRT rentre les résultats dans la base de données de la WCA dès que possible."
+          '2': "En fonction de la taille de la compétition et de la disponibilité du Délégué, tout cela peut prendre entre un jour et une semaine. Merci d'être patient."
+          '3': "Si vous avez lié votre compte WCA à votre ID WCA, vous pouvez également activer les notifications par email concernant vos résultats <a href='%{preferences_edit_path}'>ici</a>."
       7:
         title: "Comment puis-je changer ma photo de profil ?"
         content:


### PR DESCRIPTION
As per @SAuroux request, fixes #1096.

Screenshot:

![faq-entry](https://cloud.githubusercontent.com/assets/1007485/21985122/8f23d3c0-dbf9-11e6-97f5-0b152745d6f0.png)

Some note for the software team:
When introducing numbering in #1079 I overlooked that we may want to add entry in between...
Instead of finding some number that may be suitable I just chose a relevant key name.
The numbering has actually no impact on the order they are displayed in the FAQ, only the relative order of the keys matters.
Do you think it's worth to change the other entries to use key related to the entry?
If we want to change it we should do it now, before too many translations are impacted.

