### PR TITLE
Make a delegate selector on competitions index.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -58,7 +58,7 @@ onPage('competitions#index', function() {
     $form.trigger('submit.rails');
   }
 
-  $form.on('change', '#events, #region, #state, #display, #status', submitForm)
+  $form.on('change', '#events, #region, #state, #display, #status, #delegate', submitForm)
        .on('click', '#clear-all-events, #select-all-events', submitForm)
        .on('input', '#search', _.debounce(submitForm, TEXT_INPUT_DEBOUNCE_MS));
 

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -159,6 +159,11 @@ $venue-map-wrapper-height: 400px;
   &.admin .admin-selectors {
     display: inline-block;
   }
+
+  .delegate-selector {
+    display: inline-block;
+    width: 300px;
+  }
 }
 
 .same-line {

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -84,6 +84,12 @@
   </div>
 </div>
 
+
+<div id="delegate" class="form-group delegate-selector">
+  <%= label_tag(:delegate) %>
+  <input id="delegate" name="delegate" class="wca-autocomplete wca-autocomplete-only_one wca-autocomplete-only_delegates wca-autocomplete-users_search"></input>
+</div>
+
 <div id="display" class="form-group">
   <div class="btn-group btn-group-justified" data-toggle="buttons">
     <label id="display-list" class="btn btn-info">

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -646,7 +646,7 @@ en:
           posted: "Results are posted!"
           starts_in: "Starts in %{days}"
         #context: the "search" button
-        search: "Name, city, venue, delegate(s), country or month"
+        search: "Name, city, venue, country or month"
         #context: the "recent" button
         recent: "Last %{count} days"
       no_comp_found: "No competitions found."


### PR DESCRIPTION
Following on #1101 , this adds a textbox to search for a delegate at competitions index.

After discussing with @jfly, this should be useful (and available) for regular user too (not just when display=admin)

![florida](https://cloud.githubusercontent.com/assets/1881933/22088627/a4799a5a-ddcc-11e6-92b6-0479a3474055.png)
