### PR TITLE
Temporarily remove the accept-language logic

### DIFF
--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
     # If the locale for the session is not set, we want to infer it from the following sources:
     #  - the current user preferred locale
     #  - the Accept-Language http header
-    session[:locale] ||= current_user&.preferred_locale || http_accept_language.preferred_language_from(I18n.available_locales)
+    session[:locale] ||= current_user&.preferred_locale
     I18n.locale = session[:locale] || I18n.default_locale
   end
 


### PR DESCRIPTION
I totally forgot about that, and some people can already see the translated website accidentally, by having the correct accept-language header!

Merging this as soon as the tests passed.