### PR TITLE
Some fixes to translation.

### DIFF
--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= label_tag "events" do %>
     <%= t 'competitions.competition_form.events' %>
-    <button type="button" id="select-all-events" class="btn btn-primary btn-xs"><%= t 'competitions.index.all' %></button>
+    <button type="button" id="select-all-events" class="btn btn-primary btn-xs"><%= t 'competitions.index.all_events' %></button>
     <button type="button" id="clear-all-events" class="btn btn-default btn-xs"><%= t 'competitions.index.clear' %></button>
   <% end %>
   <div id="events">
@@ -86,7 +86,7 @@
 
 
 <div id="delegate" class="form-group delegate-selector">
-  <%= label_tag(:delegate) %>
+  <%= label_tag(t('layouts.navigation.delegate')) %>
   <input id="delegate" name="delegate" class="wca-autocomplete wca-autocomplete-only_one wca-autocomplete-only_delegates wca-autocomplete-users_search"></input>
 </div>
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -626,7 +626,7 @@ en:
     #context: on the competition's index page
     index:
       title: "Competitions"
-      all: "All"
+      all_events: "All"
       all_years: "All Years"
       clear: "Clear"
       list: "List"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -1149,7 +1149,7 @@ fr:
       #original_hash: db98a68
       title: Compétitions
       #original_hash: 6a72085
-      all: Toutes
+      all_events: Toutes
       #original_hash: 6d76b81
       all_years: Toutes les années
       #original_hash: 719ea39

--- a/WcaOnRails/config/locales/pl.yml
+++ b/WcaOnRails/config/locales/pl.yml
@@ -1169,7 +1169,7 @@ pl:
       #original_hash: db98a68
       title: Zawody
       #original_hash: 6a72085
-      all: Wszystkie
+      all_events: Wszystkie
       #original_hash: 6d76b81
       all_years: Z wszystkich lat
       #original_hash: 719ea39

--- a/WcaOnRails/config/locales/pt-BR.yml
+++ b/WcaOnRails/config/locales/pt-BR.yml
@@ -1125,7 +1125,7 @@ pt-BR:
       #original_hash: db98a68
       title: Competições
       #original_hash: 6a72085
-      all: Todas
+      all_events: Todos
       #original_hash: 6d76b81
       all_years: Todos os anos
       #original_hash: 719ea39
@@ -1211,7 +1211,7 @@ pt-BR:
       #original_hash: b727e58
       contact_html: >-
         Informação de contato opcional. Se você não preencher este campo, os
-        emails dos organizadores serão mostrados. %{md}. Example: [Texto
+        emails dos organizadores serão mostrados. %{md}. Exemplo: [Texto
         mostrado](mailto:alguem@email.com)
       #original_hash: c5497bc
       events: Eventos


### PR DESCRIPTION
The competitions.index.all is misleading. I thought it was "all competitions", but it's "all events".

Also fixing my newly introduced delegate search box at competitions to use the delegate key.