### PR TITLE
Split can_edit_users? condition into can_view_all_users? and can_edit _user?(). Fixes #1081.

### DIFF
--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -9,8 +9,8 @@ class UsersController < ApplicationController
   def index
     params[:order] = params[:order] == "asc" ? "asc" : "desc"
 
-    unless current_user&.can_edit_users?
-      flash[:danger] = "You cannot edit users"
+    unless current_user&.can_view_all_users?
+      flash[:danger] = "You cannot view users"
       redirect_to root_url
     end
 
@@ -113,7 +113,7 @@ class UsersController < ApplicationController
   end
 
   private def redirect_if_cannot_edit_user(user)
-    unless current_user && (current_user.can_edit_users? || current_user == user)
+    unless current_user&.can_edit_user?(user)
       flash[:danger] = "You cannot edit this user"
       redirect_to root_url
       return true

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -130,7 +130,7 @@ class User < ActiveRecord::Base
       end
 
       dob_verification_date = Date.safe_parse(dob_verification, nil)
-      if unconfirmed_person && (!current_user || !current_user.can_edit_users?)
+      if unconfirmed_person && (!current_user || !current_user.can_view_all_users?)
         if !unconfirmed_person.dob
           errors.add(:dob_verification, I18n.t('users.errors.wca_id_no_birthdate_html').html_safe)
         elsif !already_assigned_to_user && unconfirmed_person.dob != dob_verification_date
@@ -357,9 +357,17 @@ class User < ActiveRecord::Base
     delegate_status.present?
   end
 
-  def can_edit_users?
-    organizes_comp_with_wca_registration = organized_competitions.not_over.exists?(use_wca_registration: true)
-    admin? || board_member? || results_team? || any_kind_of_delegate? || organizes_comp_with_wca_registration
+  def can_view_all_users?
+    admin? || board_member? || results_team? || any_kind_of_delegate?
+  end
+
+  def can_edit_user?(user)
+    self == user || can_view_all_users? || organizer_for?(user)
+  end
+
+  def organizer_for?(user)
+    # If the user is a newcomer, allow organizers of the competition that the user is registered for to edit that user's name.
+    user.competitions_registered_for.not_over.joins(:competition_organizers).pluck("competition_organizers.organizer_id").include?(self.id)
   end
 
   def can_admin_results?
@@ -528,8 +536,7 @@ class User < ActiveRecord::Base
         remove_avatar
       )
     end
-    # If the user is a newcomer allow organizers of the competition that he is registered for to edit his name.
-    if user.wca_id.blank? && user.competitions_registered_for.not_over.joins(:competition_organizers).pluck("competition_organizers.organizer_id").include?(self.id)
+    if user.wca_id.blank? && organizer_for?(user)
       fields << :name
     end
     fields

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -107,7 +107,7 @@
                 <% end %>
               </li>
               <li><%= link_to t('.edit_profile'), profile_edit_path %></li>
-              <% if current_user.can_edit_users? %>
+              <% if current_user.can_view_all_users? %>
                 <li class="divider"></li>
                 <li role="presentation" class="dropdown-header">
                   <%= t '.administration' %>

--- a/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
+++ b/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
@@ -3,7 +3,7 @@
     <%= mail_to delegate.email, target: "_blank", class: "hide-new-window-icon" do %>
       <span class="glyphicon glyphicon-envelope"></span>
     <% end %>
-    <% if current_user&.can_edit_users? %>
+    <% if current_user&.can_edit_user?(delegate) %>
       <%= link_to edit_user_path(delegate.id) do %>
         <span class="glyphicon glyphicon-pencil"></span>
       <% end %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -74,7 +74,7 @@
         <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] }, disabled: !editable_fields.include?(:gender) %>
         <%= f.input :country_iso2, collection: Country.real, value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name }, disabled: !editable_fields.include?(:country_iso2) %>
 
-        <% if current_user.can_edit_users? %>
+        <% if current_user.can_view_all_users? %>
           <div class="row" id="wca_id">
             <div class="col-xs-6">
               <% if @user.unconfirmed_wca_id.present? %>
@@ -112,7 +112,7 @@
           </p>
         <% end %>
 
-        <% if current_user.can_edit_users? %>
+        <% if current_user.can_view_all_users? %>
           <%= f.input :delegate_status, collection: User.delegate_statuses.keys, label_method: lambda { |k| k.titleize }, disabled: !editable_fields.include?(:senior_delegate_id) %>
           <%= f.association :senior_delegate, disabled: !editable_fields.include?(:senior_delegate_id) %>
           <%= f.input :region, disabled: !editable_fields.include?(:region) %>

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -546,11 +546,36 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "#can_edit_users?" do
+  describe "#can_view_all_users?" do
     let(:competition) { FactoryGirl.create(:competition, :registration_open, :with_organizer, starts: 1.month.from_now) }
 
-    it "returns true if a user is an organizer of an upcoming comp using registration system" do
-      expect(competition.organizers.first.can_edit_users?).to eq true
+    it "returns false if the user is an organizer of an upcoming comp using registration system" do
+      organizer = competition.organizers.first
+      expect(organizer.can_view_all_users?).to eq false
+    end
+
+    it "returns true for board" do
+      board_member = FactoryGirl.create :board_member
+      expect(board_member.can_view_all_users?).to eq true
+    end
+
+    it "returns false for normal user" do
+      normal_user = FactoryGirl.create :user
+      expect(normal_user.can_view_all_users?).to eq false
+    end
+  end
+
+  describe "#can_edit_user?" do
+    let(:user) { FactoryGirl.create :user }
+
+    it "returns true for board" do
+      board_member = FactoryGirl.create :board_member
+      expect(board_member.can_edit_user?(user)).to eq true
+    end
+
+    it "returns false for normal user" do
+      normal_user = FactoryGirl.create :user
+      expect(normal_user.can_edit_user?(user)).to eq false
     end
   end
 
@@ -560,6 +585,7 @@ RSpec.describe User, type: :model do
 
     it "allows organizers of upcoming competitions to edit newcomer names" do
       organizer = competition.organizers.first
+      expect(organizer.can_edit_user?(registration.user)).to eq true
       expect(organizer.editable_fields_of_user(registration.user).to_a).to eq [:name]
     end
   end


### PR DESCRIPTION
Organizers can now only edit users for their competitions.