### PR TITLE
Set delegates as Reply-To for the notify_users_of_id_claim_possibility email.

### DIFF
--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -19,6 +19,7 @@ class CompetitionsMailer < ApplicationMailer
     mail(
       to: user.email,
       subject: "The results of #{competition.name} are posted",
+      reply_to: competition.delegates.pluck(:email),
     )
   end
 


### PR DESCRIPTION
This fixes #1098.

@viroulep, were there other emails you had in mind for this? I could only find this one (`notify_users_of_id_claim_possibility`).