### PR TITLE
Add .byebug_history to .gitignore.

### DIFF
--- a/WcaOnRails/.gitignore
+++ b/WcaOnRails/.gitignore
@@ -24,3 +24,5 @@ public/assets/**
 
 # Unicorn pid
 pids/*.pid
+
+.byebug_history


### PR DESCRIPTION
 I think this started appearing after all the gem updates we recently performed.