### PR TITLE
Do not allow assigning a WCA ID that is missing a birthdate.

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -167,6 +167,14 @@ class User < ActiveRecord::Base
     end
   end
 
+  validate :person_must_have_dob
+  def person_must_have_dob
+    p = person || unconfirmed_person
+    if p && p.dob.nil?
+      errors.add(:wca_id, I18n.t('users.errors.wca_id_no_birthdate_html'))
+    end
+  end
+
   # To handle profile pictures that predate our user account system, we created
   # a bunch of dummy accounts (accounts with no password). When someone finally
   # claims their WCA ID, we want to delete the dummy account and copy over their

--- a/WcaOnRails/spec/factories/persons.rb
+++ b/WcaOnRails/spec/factories/persons.rb
@@ -15,6 +15,12 @@ FactoryGirl.define do
     month 4
     day 4
 
+    trait :missing_dob do
+      year 0
+      month 0
+      day 0
+    end
+
     factory :person_with_multiple_sub_ids do
       after(:create) do |person|
         person.update_using_sub_id!(name: "new #{person.name}")

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe User, type: :model do
 
   describe "WCA ID" do
     let(:user) { FactoryGirl.create :user_with_wca_id }
+    let(:birthdayless_person) { FactoryGirl.create :person, :missing_dob }
 
     it "validates WCA ID" do
       user = FactoryGirl.build :user, wca_id: "2005FLEI02"
@@ -146,6 +147,12 @@ RSpec.describe User, type: :model do
       user.person.name = "New name"
       user.person.save!
       expect(user).to be_valid
+    end
+
+    it "does not allow assigning a birthdateless WCA ID to a user" do
+      user.wca_id = birthdayless_person.wca_id
+      expect(user).to be_invalid
+      expect(user.errors.messages[:wca_id]).to eq [ I18n.t('users.errors.wca_id_no_birthdate_html') ]
     end
 
     it "nullifies empty WCA IDs" do


### PR DESCRIPTION
This fixes #1173.

There are currently 17 users in our database that have a `wca_id` with no date of birth. You can see them all by running this query:

```
select * from users join Persons on Persons.id = users.wca_id where Persons.year = 0 AND Persons.month = 0 AND Persons.day = 0 LIMIT 0, 250 ;
```

Of those 17, 2 are regular users, 14 are dummy accounts, and 1 is the account we created for Brandon Blankenship, who delegated Florida Open 2007: https://www.worldcubeassociation.org/competitions/FloridaOpen2007, apparently we don't have his birthday =(

I've contacted the Results team to discuss how to deal with these 17 accounts.