### PR TITLE
I18n events and rounds

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -228,10 +228,10 @@ class CompetitionsController < ApplicationController
               event = Event.c_find(result.eventId)
               record_strs = []
               if result.regionalSingleRecord == code
-                record_strs << "#{event.cellName} #{result.to_s :best} (single)"
+                record_strs << "#{event.name_in(:en)} #{result.to_s :best} (single)"
               end
               if result.regionalAverageRecord == code
-                record_strs << "#{event.cellName} #{result.to_s :average} (average)"
+                record_strs << "#{event.name_in(:en)} #{result.to_s :average} (average)"
               end
               record_strs
             end.flatten

--- a/WcaOnRails/app/models/event.rb
+++ b/WcaOnRails/app/models/event.rb
@@ -22,6 +22,10 @@ class Event < ActiveRecord::Base
     I18n.t(id, scope: :events, locale: locale)
   end
 
+  def cellName
+    fail "#cellName is deprecated, and will eventually be removed. Use #name instead. See https://github.com/thewca/worldcubeassociation.org/issues/1054."
+  end
+
   scope :official, -> { where("rank < 990") }
   scope :deprecated, -> { where("rank between 990 and 999") }
 

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -7,6 +7,14 @@ class Round < ActiveRecord::Base
 
   scope :final_rounds, -> { where("final = 1") }
 
+  def name
+    I18n.t("rounds.#{id}.name")
+  end
+
+  def cellName
+    I18n.t("rounds.#{id}.cellName")
+  end
+
   # TODO: move to database https://github.com/thewca/worldcubeassociation.org/issues/979
   def combined?
     %w(c d e g h).include?(id)

--- a/WcaOnRails/app/views/competitions/_results_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_results_table.html.erb
@@ -44,7 +44,7 @@
             <% if !result.muted %>
               <%= link_to competition_results_all_path(@competition, anchor: "e#{result.event.id}") do %>
                 <span class="cubing-icon event-<%= result.event.id %>"></span>
-                <%= result.event.cellName %>
+                <%= result.event.name %>
               <% end %>
             <% end %>
           </td>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -59,6 +59,41 @@ en:
     magic: "Rubik's Magic"
     mmagic: "Master Magic"
     333mbo: "Rubik's Cube: Multiple blind old style"
+  #context: Round name
+  rounds:
+    "0":
+      name: "Qualification round"
+      cellName: "Qualification"
+    "1":
+      name: "First round"
+      cellName: "First"
+    "2":
+      name: "Second round"
+      cellName: "Second"
+    "3":
+      name: "Semi Final"
+      cellName: "Semi Final"
+    "b":
+      name: "B Final"
+      cellName: "B Final"
+    "c":
+      name: "Combined Final"
+      cellName: "Combined Final"
+    "d":
+      name: "Combined First round"
+      cellName: "Combined First"
+    "e":
+      name: "Combined Second round"
+      cellName: "Combined Second"
+    "f":
+      name: "Final"
+      cellName: "Final"
+    "g":
+      name: "Combined Third round"
+      cellName: "Combined Third"
+    "h":
+      name: "Combined qualification"
+      cellName: "Combined qualification"
   #context: Common word used in multiple places on the website
   common:
     continent: "Continent"

--- a/WcaOnRails/db/seeds/events.seeds.rb
+++ b/WcaOnRails/db/seeds/events.seeds.rb
@@ -20,6 +20,6 @@ sql = "INSERT INTO `Events` (`id`, `name`, `rank`, `format`, `cellName`) VALUES
 ('333mbf', '3x3x3 Multi-Blind', 180, 'multi', '3x3x3 Multi-Blind'),
 ('magic', 'Rubik''s Magic', 997, 'time', 'Rubik''s Magic'),
 ('mmagic', 'Master Magic', 998, 'time', 'Master Magic'),
-('333mbo', 'Rubik''s Cube: Multi blind old style', 999, 'multi', '3x3 multi blind old');"
+('333mbo', 'Rubik''s Cube: Multi blind old style', 999, 'multi', 'Rubik''s Cube: Multi blind old style');"
 
 ActiveRecord::Base.connection.execute(sql)


### PR DESCRIPTION
This fixes #1156 and #1166.

Now I see this:

![image](https://cloud.githubusercontent.com/assets/277474/22394654/f3b27b2c-e4da-11e6-9806-31d3f2e57441.png)

All our languages are missing translations for `rounds.1.name` (except for `en`). Once we merge this up, our translators will be able to do their jobs =)