### PR TITLE
Add Japanese translation

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -27,6 +27,7 @@
 //= require moment
 //= require moment/fr.js
 //= require moment/it.js
+//= require moment/ja.js
 //= require moment/pl.js
 //= require moment/pt-br.js
 //= require moment/zh-cn.js

--- a/WcaOnRails/config/locales/carrierwave.ja.yml
+++ b/WcaOnRails/config/locales/carrierwave.ja.yml
@@ -1,0 +1,14 @@
+ja:
+  errors:
+    messages:
+      carrierwave_processing_error: 処理できませんでした
+      carrierwave_integrity_error: は許可されていないファイルタイプです
+      carrierwave_download_error: はダウンロードできません
+      extension_white_list_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+      extension_black_list_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
+      content_type_white_list_error: "%{content_type}ファイルのアップロードは許可されていません"
+      content_type_black_list_error: "%{content_type}ファイルのアップロードは許可されていません"
+      rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      min_size_error: "ファイルを%{min_size}バイト以上のサイズにしてください"
+      max_size_error: "ファイルを%{max_size}バイト以下のサイズにしてください"

--- a/WcaOnRails/config/locales/ja.yml
+++ b/WcaOnRails/config/locales/ja.yml
@@ -1,0 +1,1752 @@
+ja:
+  countries:
+    #original_hash: 3f8c9de
+    XA: 複数国（アジア）
+    #original_hash: 090f3ce
+    XE: 複数国（ヨーロッパ）
+    #original_hash: 459f987
+    XS: 複数国（南アメリカ）
+    #original_hash: 918c53a
+    MO: マカオ
+    #original_hash: 2f488ff
+    HK: 香港
+    #original_hash: 4e8bd04
+    KR: 韓国
+  continents:
+    #original_hash: 1d35114
+    AfR: アフリカ
+    #original_hash: a173e72
+    AsR: アジア
+    #original_hash: 576347e
+    ER: ヨーロッパ
+    #original_hash: 247ce5d
+    NAR: 北アメリカ
+    #original_hash: 3642950
+    OcR: オセアニア
+    #original_hash: b1ffb4c
+    SAR: 南アメリカ
+  events:
+    #original_hash: 3732390
+    '222': 2x2x2 キューブ
+    #original_hash: bfbe360
+    '333': ルービックキューブ
+    #original_hash: 2ee5b5a
+    '444': 4x4x4 キューブ
+    #original_hash: b7a99fa
+    '555': 5x5x5 キューブ
+    #original_hash: 4e3ea57
+    '666': 6x6x6 キューブ
+    #original_hash: b567fc4
+    '777': 7x7x7 キューブ
+    #original_hash: 29d5411
+    333bf: 3x3x3 目隠し
+    #original_hash: 31ed23f
+    333oh: 3x3x3 片手
+    #original_hash: 0a5e7bf
+    333fm: 3x3x3 最少手数
+    #original_hash: be41d70
+    333ft: 3x3x3 足
+    #original_hash: d542376
+    minx: メガミンクス
+    #original_hash: 8216a66
+    pyram: ピラミンクス
+    #original_hash: 1551a2c
+    sq1: スクエア 1
+    #original_hash: 23c2fdf
+    clock: ルービッククロック
+    #original_hash: 64a56a2
+    skewb: スキューブ
+    #original_hash: 5bae501
+    444bf: 4x4x4 目隠し
+    #original_hash: aea5216
+    555bf: 5x5x5 目隠し
+    #original_hash: cedbf87
+    333mbf: 3x3x3 複数目隠し
+    #original_hash: 3988358
+    magic: ルービックマジック
+    #original_hash: c962425
+    mmagic: マスターマジック
+    #original_hash: c6ad2af
+    333mbo: 旧 3x3x3 複数目隠し
+  rounds:
+    '0':
+      #original_hash: 4d618bb
+      name: 予選ラウンド
+      #original_hash: 2ffe44e
+      cellName: 予選
+    '1':
+      #original_hash: 1e725b6
+      name: 1 回戦
+      #original_hash: 916a78d
+      cellName: 1 回戦
+    '2':
+      #original_hash: 985c8d0
+      name: 2 回戦
+      #original_hash: 2a4bcae
+      cellName: 2 回戦
+    '3':
+      #original_hash: e2f74d2
+      name: 準決勝
+      #original_hash: e2f74d2
+      cellName: 準決勝
+    b:
+      #original_hash: 327c999
+      name: B 決勝
+      #original_hash: 327c999
+      cellName: B 決勝
+    c:
+      #original_hash: b2d26f4
+      name: 複合決勝
+      #original_hash: b2d26f4
+      cellName: 複合決勝
+    d:
+      #original_hash: c6136b1
+      name: 複合 1 回戦
+      #original_hash: dffa9ea
+      cellName: 複合 1 回戦
+    e:
+      #original_hash: 659c53f
+      name: 複合 2 回戦
+      #original_hash: b6e1e1c
+      cellName: 複合 2 回戦
+    f:
+      #original_hash: 672b22c
+      name: 決勝
+      #original_hash: 672b22c
+      cellName: 決勝
+    g:
+      #original_hash: e861dcf
+      #original_hash: 4c66ad0
+      name: 複合 3 回戦
+      #original_hash: 86f4b05
+      #original_hash: 4c66ad0
+      cellName: 複合 3 回戦
+    h:
+      name: 複合予選
+      cellName: 複合予選
+  common:
+    #original_hash: 2513cf0
+    continent: 大陸
+    #original_hash: d523ebb
+    country: 国
+    #original_hash: 0154c0d
+    here: こちら
+    #original_hash: 77003d0
+    best: ベスト
+    #original_hash: dd11868
+    single: 単発
+    #original_hash: 15f86c0
+    average: 平均
+    #original_hash: e7f6fc5
+    solves: 内訳
+    user:
+      #original_hash: 603a218
+      wca_id: WCA ID
+      #original_hash: e0f64f7
+      citizen_of: 国籍
+    #original_hash: 3fc0ba1
+    all_regions: 全地域
+    errors:
+      #original_hash: 81f344a
+      invalid: 無効
+    #original_hash: 49d0140
+    days:
+      one: '1 日'
+      other: "%{count} 日"
+    #original_hash: 203e1b3
+    these_events:
+      one: "この種目"
+      other: "これら %{count} 種目"
+  oauth:
+    applications:
+      #original_hash: 0c4ea38
+      your_apps: OAuth アプリケーション
+      #original_hash: 6403f2b
+      new: 新規登録
+      #original_hash: 709a232
+      name: アプリ名
+      #original_hash: f6f1389
+      callback_url: コールバック Url
+      #original_hash: 89ff312
+      owner: 所有者
+      #original_hash: 557031c
+      application_id: アプリケーション ID
+      #original_hash: c3cd636
+      actions: 操作
+      #original_hash: f4e7a87
+      secret: シークレットキー
+      #original_hash: c23540e
+      scopes: スコープ
+      #original_hash: 3b0d449
+      callback_urls: コールバック Urls
+  activerecord:
+    attributes:
+      user:
+        #original_hash: eeb6920
+        name: フルネーム
+        #original_hash: 603a218
+        wca_id: WCA ID
+        #original_hash: cb77bea
+        unconfirmed_wca_id: WCA ID（未確認）
+        #original_hash: 8ed8874
+        login: メールアドレスまたは WCA ID
+        #original_hash: 1528d10
+        country_iso2: 国籍
+        #original_hash: ab58155
+        dob: 生年月日
+        #original_hash: ab58155
+        dob_verification: 生年月日
+        #original_hash: 8a754c6
+        gender: 性別
+        #original_hash: 84add5b
+        email: メールアドレス
+        #original_hash: 8be3c94
+        password: パスワード
+        #original_hash: 19dff4d
+        current_password: 現在のパスワード
+        #original_hash: 786b8af
+        password_confirmation: パスワード確認
+        #original_hash: ced7b30
+        remember_me: 保存する
+        #original_hash: 102efae
+        pending_avatar: 新しいプロフィール画像をアップロードする
+        #original_hash: 58e0c56
+        remove_avatar: プロフィール画像を削除する
+        #original_hash: 9af9099
+        results_notifications_enabled: 自分の結果が反映されたらメール通知を受信する。
+        #original_hash: de60ab8
+        delegate_status: 代理人ステータス
+        #original_hash: 0f21717
+        region: 国籍
+        #original_hash: a10b651
+        location_description: 所在地
+        #original_hash: 8961d3b
+        phone_number: 電話番号
+        #original_hash: 7044004
+        notes: メモ
+      competition:
+        #original_hash: 89f89c0
+        id: ID
+        #original_hash: 7f3d889
+        isConfirmed: 主催者がこの大会を編集することを許可しない
+        #original_hash: d493e6a
+        showAtAll: 大会を一般公開する
+        #original_hash: 709a232
+        name: 大会名
+        #original_hash: b649210
+        cellName: 大会名略称
+        #original_hash: d523ebb
+        countryId: 開催国
+        #original_hash: 25b7b06
+        cityName: 都市名
+        #original_hash: 67cd406
+        venue: 会場
+        #original_hash: 486f8fb
+        venueAddress: 会場所在地
+        #original_hash: 08767af
+        venueDetails: 会場詳細
+        #original_hash: ff99f5b
+        start_date: 開始日
+        #original_hash: 89d10cd
+        end_date: 終了日
+        #original_hash: 2e8a57c
+        external_website: ウェブサイト
+        #original_hash: 692e1f9
+        generate_website: 追加情報用の外部ウェブサイトを用意せずに WCA ウェブサイトを使用する
+        #original_hash: 3d53469
+        base_entry_fee_lowest_denomination: 基本参加費
+        #original_hash: 28a6fbb
+        currency_code: 通貨コード
+        #original_hash: 5b2fe69
+        delegate_ids: WCA 代理人
+        #original_hash: 958562e
+        organizer_ids: 主催者
+        #original_hash: b37456c
+        contact: 連絡先
+        #original_hash: 0eb5ed5
+        information: 情報
+        #original_hash: 87b7d5f
+        use_wca_registration: 参加申し込みに WCA ウェブサイトを使用する
+        #original_hash: 3c23a67
+        guests_enabled: ゲスト
+        #original_hash: 089cbfd
+        receive_registration_emails: 大会に参加申し込みがあったとき電子メールで通知する
+        #original_hash: d4aeed9
+        registration_open: 参加申し込みを開始する
+        #original_hash: f8153a2
+        registration_close: 参加申し込みを停止する
+        #original_hash: d7020f4
+        remarks: 備考
+        #original_hash: c305010
+        clone_tabs: すべてのタブを追加情報とともに複製する
+      registration:
+        #original_hash: 3c23a67
+        guests: ゲスト
+        #original_hash: fce06e2
+        comments: コメント
+        #original_hash: bae7d5b
+        status: ステータス
+        #original_hash: 709a232
+        name: 名前
+        #original_hash: a6b9d69
+        birthday: 誕生日
+      competition_tab:
+        #original_hash: 4f9be05
+        content: 内容
+        #original_hash: 709a232
+        name: 名前
+      delegate_report:
+        #original_hash: 983d541
+        discussion_url: Google グループ上のディスカッション url
+        #original_hash: 65a9b28
+        schedule_url: スケジュール url
+        #original_hash: 36155d4
+        equipment: 備品
+        #original_hash: 67cd406
+        venue: 開催地
+        #original_hash: 519255a
+        organization: 組織
+        #original_hash: 5e326b1
+        incidents: インシデント
+        #original_hash: d7020f4
+        remarks: 備考
+      person:
+        #original_hash: 8c41ae8
+        wca_id: 個人
+        #original_hash: d523ebb
+        countryId: 国
+        #original_hash: ab58155
+        dob: 誕生日
+        #original_hash: 8a754c6
+        gender: 性別
+        #original_hash: 709a232
+        name: 名前
+      poll:
+        #original_hash: 002ff59
+        question: 質問
+        #original_hash: 2b12f36
+        deadline: 締切
+      post:
+        #original_hash: 768e0c1
+        title: タイトル
+        #original_hash: 718a7e8
+        body: 本文
+        #original_hash: 6f915a2
+        sticky: 付箋
+      team:
+        #original_hash: 709a232
+        name: 名前
+        #original_hash: 55f8ebc
+        description: 説明
+      vote:
+        #original_hash: 153d7a5
+        comment: コメント
+  simple_form:
+    #original_hash: 5397e05
+    'yes': はい
+    #original_hash: 816c52f
+    'no': いいえ
+    required:
+      #original_hash: 1a77d41
+      text: 必須
+      #original_hash: df58248
+      mark: '*'
+      #original_hash: da39a3e
+      html: ''
+    error_notification:
+      #original_hash: d70e9cb
+      default_message: '以下のエラー内容をご確認ください:'
+    labels:
+      contact:
+        #original_hash: 709a232
+        name: 氏名
+        #original_hash: 3fa6f5f
+        your_email: メールアドレス
+        #original_hash: 68f4145
+        message: 備考
+    hints:
+      user:
+        #original_hash: 87e1e6f
+        dob: '生年月日をすべて半角で記入してください。 (2000年1月23日生の場合: 2000-01-23)'
+        #original_hash: 5106479
+        name: >-
+          氏名 (英字) を「名姓」の順に記入してください。姓名ともに頭文字のみ大文字にしてください (中島 悠 の場合: Yu
+          Nakajima)  。
+        #original_hash: c03b949
+        email: メールアドレスを変更する場合は、確認メールによる認証が必要となります。
+        #original_hash: bfd11f4
+        pending_avatar: プロフィール画像の変更は、 WCA 理事の承認後に反映されます。
+        #original_hash: da39a3e
+        country_iso2: ''
+        #original_hash: da39a3e
+        current_password: ''
+        #original_hash: da39a3e
+        delegate_status: ''
+        #original_hash: da39a3e
+        dob_verification: ''
+        #original_hash: da39a3e
+        gender: ''
+        #original_hash: da39a3e
+        login: ''
+        #original_hash: da39a3e
+        password: ''
+        #original_hash: da39a3e
+        password_confirmation: ''
+        #original_hash: da39a3e
+        region: ''
+        #original_hash: da39a3e
+        remember_me: ''
+        #original_hash: da39a3e
+        remove_avatar: ''
+        #original_hash: da39a3e
+        results_notifications_enabled: ''
+        #original_hash: da39a3e
+        unconfirmed_wca_id: ''
+        #original_hash: da39a3e
+        wca_id: ''
+        #original_hash: da39a3e
+        location_description: ''
+        #original_hash: da39a3e
+        phone_number: ''
+        #original_hash: da39a3e
+        notes: ''
+      competition:
+        #original_hash: 2c812a0
+        name: >-
+          大会の正式名称 (英名) 。ただし、 (1) 必ず末尾に年号を含める (例 : JRCA Kansai Winter 2017) (2)
+          語頭を大文字にする (3) 英数字と - & . : ' および半角スペースのみ使用可。
+        #original_hash: 525fcc8
+        cellName: 大会名の略称 (Kansai 2017 など正式名が短い場合は正式名と重複可)
+        #original_hash: bce4589
+        cityName: '開催都市名 (例 : Kawasaki, Kanagawa や Shibuya, Tokyo など「市区町村, 都道府県」の順)'
+        #original_hash: 17c8ff8
+        information: >-
+          大会の概要 (例 : UT Open 2010 is the first students-organized competition in
+          Japan.)
+        #original_hash: 0708400
+        delegate_ids: 'WCA 代理人 (例 : Yuji Suse)'
+        #original_hash: 517d376
+        organizer_ids: 大会運営チーム (WCA アカウントが必要です)
+        #original_hash: cabe7fb
+        external_website: 大会ウェブサイトの URL
+        #original_hash: 9965635
+        registration_open: 申込受付期間 (世界標準時。日本時間 -9 時間)
+        #original_hash: f688881
+        remarks: WCA 理事へのコメント (大会期日 1 か月以内の申請の場合の理由など、特別必要な場合のみ)
+        #original_hash: da39a3e
+        clone_tabs: ''
+        #original_hash: da39a3e
+        countryId: ''
+        #original_hash: da39a3e
+        end_date: ''
+        #original_hash: da39a3e
+        generate_website: ''
+        #original_hash: b61cbfa
+        base_entry_fee_lowest_denomination: '基本参加費 (1000)'
+        #original_hash: 866bc05
+        currency_code: 通貨単位
+        #original_hash: da39a3e
+        guests_enabled: ''
+        #original_hash: da39a3e
+        id: ''
+        #original_hash: da39a3e
+        isConfirmed: ''
+        #original_hash: da39a3e
+        receive_registration_emails: ''
+        #original_hash: da39a3e
+        registration_close: ''
+        #original_hash: da39a3e
+        showAtAll: ''
+        #original_hash: da39a3e
+        start_date: ''
+        #original_hash: da39a3e
+        use_wca_registration: ''
+        #original_hash: da39a3e
+        venueAddress: ''
+      contact:
+        #original_hash: da39a3e
+        message: ''
+        #original_hash: da39a3e
+        name: ''
+        #original_hash: da39a3e
+        your_email: ''
+      post:
+        #original_hash: 53c16eb
+        body: >-
+          Use the &lt;!-- break --&gt; tag to show a preview on the home page.
+          Any post on the home page will show all text before this divider. The
+          actual post will display the full body.
+        #original_hash: da39a3e
+        sticky: ''
+        #original_hash: da39a3e
+        title: ''
+      delegate_report:
+        #original_hash: 4eefb60
+        schedule_url: タイムスケジュールページの URL
+        #original_hash: 1a68719
+        equipment: 使用ディスプレイのバージョンおよび数 (使用しなかったものについては - を削除してください)
+        #original_hash: 4658dd9
+        venue: 会場に関する事項 (部屋、照明、アクセス、本部や導線など会場配置、騒音等) とその対処
+        #original_hash: f8de509
+        organization: 運営チームに関する事項 (運営にあたっての働きや問題点、運営能力の成長等)
+        #original_hash: 715f020
+        incidents: >-
+          インシデントに関する事項 (1. や 2.
+          など番号をつけて箇条書きにしてください。通常の +2 や DNF などは除きます。フィードバックを求める記述も可。WDC の裁定を求める場合それを明記してください)
+        #original_hash: f30abdc
+        remarks: その他報告事項 (コミュニティーの変化、地域的の今後の計画等ほか、前項までで省いた軽微な事項も構いません)
+        #original_hash: da39a3e
+        discussion_url: ''
+      competition_tab:
+        #original_hash: e396d28
+        name: '例: 参加費徴収、表彰、渡航、宿泊施設等'
+        #original_hash: da39a3e
+        content: ''
+      person:
+        #original_hash: 498f4c5
+        dob: '生年月日は半角英数で (西暦)-(月)-(日) の形式で記入してください (2000年1月23日生の場合: 2000-01-23)。'
+        #original_hash: da39a3e
+        countryId: ''
+        #original_hash: da39a3e
+        gender: ''
+        #original_hash: da39a3e
+        name: ''
+        #original_hash: da39a3e
+        person1_wca_id: ''
+        #original_hash: da39a3e
+        person2_wca_id: ''
+        #original_hash: da39a3e
+        wca_id: ''
+      poll:
+        #original_hash: da39a3e
+        comment: ''
+        #original_hash: da39a3e
+        multiple: ''
+        #original_hash: da39a3e
+        question: ''
+      registration:
+        #original_hash: da39a3e
+        comments: ''
+        #original_hash: da39a3e
+        guests: ''
+        #original_hash: da39a3e
+        status: ''
+      team:
+        #original_hash: da39a3e
+        description: ''
+        #original_hash: da39a3e
+        friendly_id: ''
+        #original_hash: da39a3e
+        name: ''
+      vote:
+        #original_hash: da39a3e
+        comment: ''
+    options:
+      registration:
+        status:
+          #original_hash: 61a0572
+          accepted: 登録済
+          #original_hash: a6b2452
+          pending: キャンセル待ちリスト
+          #original_hash: 441bda6
+          deleted: 削除
+      competition:
+        guests_enabled:
+          #original_hash: cb8809d
+          'true': Ask about guests
+          #original_hash: f8c2332
+          'false': Do NOT ask about guests
+  errors:
+    messages:
+      #original_hash: dc2367c
+      wrong_size: 'はファイルサイズが不適切です (%{file_size} に変更してください) 。'
+      #original_hash: 1531237
+      size_too_small: 'はファイルサイズが小さすぎます (%{file_size} 以上にしてください)。'
+      #original_hash: a2a43b3
+      size_too_big: 'はファイルサイズが大きすぎます (%{file_size} 以下にしてください) 。'
+  devise:
+    failure:
+      #original_hash: 1186218
+      invalid: メールアドレス、 WCA ID 、パスワード内に誤りがあります。
+      #original_hash: 1186218
+      not_found_in_database: メールアドレス、 WCA ID 、パスワード内に誤りがあります。
+  wca:
+    errors:
+      messages:
+        #original_hash: e88f903
+        form_error:
+          one: "1 件の誤りがあります。"
+          other: "%{count} 件の誤りがあります。"
+    doorkeeper:
+      applications:
+        help:
+          #original_hash: 5545f6c
+          scopes_html: >-
+            Separate scopes with spaces. Leave blank to use the default
+            scope(s). See <a
+            href="https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/config/initializers/doorkeeper.rb#L2-L8"
+            target="_blank">here</a> for a list of supported scopes.
+      scopes:
+        #original_hash: 1920e95
+        public: >-
+          Access your public data (name, WCA ID, gender, citizenship, and
+          profile picture)
+        #original_hash: d4003be
+        dob: Access your date of birth
+        #original_hash: 17aa24f
+        email: Access your email address
+    devise:
+      #original_hash: 06184f5
+      no_account: No account?
+      #original_hash: a268696
+      have_competed: WCA 公式大会に参加したことがあります (JRCA の大会情報にて告知される大会・公式記録会は WCA 公式大会です) 。
+      #original_hash: dcd1d70
+      have_never_competed: WCA 公式大会に参加したことがありません。
+      #original_hash: 86a60c9
+      let_us_know: 以前に WCA 公式大会に参加したことがありますか？
+      #original_hash: f9f512b
+      welcome_back: こんにちは！WCA アカウントの作成には WCA ID が必要です。
+      #original_hash: 669fb57
+      welcome: 'こんにちは！はじめに、個人情報収集についてご確認ください。生年月日は本人の許可なく公開されることはありません。'
+      gender:
+        #original_hash: 3f3a489
+        male: 男性
+        #original_hash: b7c17e9
+        female: 女性
+        #original_hash: 6e6a6f2
+        other_gender: その他
+  layouts:
+    navigation:
+      #original_hash: 0eb5ed5
+      information: Information
+      #original_hash: 9ac918a
+      about: WCA について
+      #original_hash: d8fd3e4
+      delegates: WCA 代理人
+      #original_hash: 0ef06c8
+      organizations: 各国の団体
+      #original_hash: d790b40
+      faq: よくある質問
+      #original_hash: a34b69f
+      contact: お問い合わせ
+      #original_hash: cf1d2c9
+      forum: フォーラム
+      #original_hash: 4fa8cc8
+      tools: ツール
+      #original_hash: 83fce83
+      logo: ロゴ
+      #original_hash: db98a68
+      competitions: 大会
+      #original_hash: 6a72085
+      all: 全ての大会
+      #original_hash: 775d458
+      my_competitions: 自分の大会
+      #original_hash: 32fde96
+      new_competition: 新着
+      #original_hash: 612e12d
+      results: 大会結果
+      #original_hash: f5fe73c
+      rankings: ランキング
+      #original_hash: e51c552
+      records: 記録
+      #original_hash: f3cf96e
+      persons: 競技者検索
+      #original_hash: 5b72b5a
+      my_results: 自分の記録
+      #original_hash: 2086b21
+      statistics: 統計情報
+      #original_hash: 82dabd0
+      multimedia: Multimedia
+      #original_hash: 4fd2a7f
+      db_export: Database Export
+      #original_hash: 1fa73f3
+      regulations: 大会規則
+      #original_hash: 141d1d7
+      guidelines: ガイドライン
+      #original_hash: c4622c3
+      scrambles: スクランブル
+      #original_hash: 90ccd64
+      history: 過去の大会規則
+      #original_hash: 8ad8302
+      translations: 各国語訳
+      #original_hash: b8be3d1
+      administration: 管理
+      #original_hash: b7ee3c4
+      manage_users: ユーザー管理
+      #original_hash: 12ab214
+      delegate: 代理人メニュー
+      #original_hash: 2f4bd74
+      panel: Panel
+      #original_hash: d3a928c
+      results_team: Results team
+      #original_hash: 4e7afeb
+      results_admin: Admin
+      #original_hash: f158a5a
+      results_phpmyadmin: phpMyAdmin
+      #original_hash: aee74b8
+      new_post: New Post
+      #original_hash: 0d67445
+      team_leader: Team leader
+      #original_hash: dc1649a
+      sign_out: ログアウト
+      #original_hash: 753a22b
+      notifications: お知らせ
+      #original_hash: 15141ea
+      edit_profile: プロフィール編集
+      #original_hash: d93d10f
+      api: API
+      #original_hash: 5524aab
+      manage_app: Manage your applications
+      #original_hash: 0e8b212
+      manage_auth_app: Manage authorized applications
+  users:
+    update_locale:
+      #original_hash: 4cde9bc
+      success: 言語を更新しました。
+      #original_hash: dcc2f49
+      failure: プロフィールを更新できません。
+      #original_hash: c29870c
+      unavailable: その言語は指定できません。
+    claim_wca_id:
+      #original_hash: f28bf87
+      title: WCA ID 連携
+      #original_hash: 1b44f6d
+      competition: 大会
+      #original_hash: b396bfa
+      already_have_html: '既に WCA ID %{wca_id} が登録されています'
+      #original_hash: 87f1062
+      already_claimed_html: 'WCA ID %{wca_id} との連携を申請しました。ご不明な点は %{delegate} にお問い合わせください。'
+      #original_hash: 0660b5d
+      info_competed_before: 大会に参加したことがある場合は、WCA ID をアカウントに連携することができます。
+      #original_hash: 7d605f8
+      info_never_competed_html: '大会に参加したことがない場合、ぜひ %{comp} に参加しましょう！初めて参加した大会結果の公表の際に WCA ID が発行されます。'
+      #original_hash: f28bf87
+      submit_value: WCA ID と連携する
+    edit_avatar_thumbnail:
+      #original_hash: 79f14eb
+      current: '現在のプロフィール画像:'
+      #original_hash: b42ba27
+      new: '新しいプロフィール画像:'
+      #original_hash: efc007a
+      save: 保存
+    edit:
+      #original_hash: 9239ee2
+      general: 一般
+      #original_hash: 84add5b
+      email: メールアドレス
+      #original_hash: 9dfd349
+      preferences: お気に入り種目
+      #original_hash: 8be3c94
+      password: パスワード
+      #original_hash: 3fc6dbe
+      member_of: 所属
+      #original_hash: 57eaf24
+      preferred_events: お気に入り種目
+      #original_hash: 42619dd
+      preferred_events_desc: お気に入り種目を登録しておくと、大会申し込みが簡単です。
+      #original_hash: b402e03
+      please_fix_profile: '大会申し込みのためには、以下の問題を修正してください:'
+      #original_hash: ff4fc02
+      profile: プロフィール
+      #original_hash: 7b2c7f1
+      approve: 承認
+      #original_hash: 85de4b8
+      unconfirmed_email: 'メールアドレス (%{email}) が確認できません。'
+      #original_hash: 8a770cf
+      pending_mail_confirmation: '新しいメールアドレス %{email} の確認を待っています'
+      #original_hash: 0340b0b
+      pending_avatar_confirmation: 新しいプロフィール画像の確認を待っています
+      #original_hash: 7b06f03
+      pending_claim_confirmation_html: '%{delegate} による WCA ID %{wca_id} の確認待ちです。'
+      #original_hash: fc7269a
+      pending_claim_mail_confirmation_html: 'WCA ID %{wca_id} の連携をリクエストしました。メールアドレスが確認でき次第、WCA 代理人 %{delegate} に通知されます。'
+      #original_hash: 1cde7e6
+      your_thumbnail: 'サムネイル:'
+      #original_hash: af18820
+      edit_thumbnail: クリックでサムネイルの編集
+      #original_hash: cf65c6e
+      manage_pending: Manage pending avatars
+      #original_hash: 2d2ae5d
+      have_no_wca_id_html: 'WCA ID が登録されていません。大会に参加したことがある場合は、%{here} で WCA ID をアカウントを登録してください。'
+      #original_hash: 29e25b5
+      have_wca_id_html: 'あなたの WCA IDは %{link_id} です。'
+      cannot_edit:
+        #original_hash: 8501c74
+        msg: >-
+          氏名、生年月日、性別、国籍は変更できません。理由: %{reason}。変更が必要な場合は、<a
+          href='%{delegate_url}'>WCA 代理人</a>に連絡してください。
+        reason:
+          #original_hash: 370ff12
+          assigned: WCA ID が登録されています
+          #original_hash: 1c4670f
+          registered: 大会に参加申し込み済みです
+      #original_hash: efc007a
+      save: 保存
+      #original_hash: 141d1d7
+      guidelines: ガイドライン
+      avatar_guidelines:
+        #original_hash: 255f28c
+        '1': プロフィール画像は実在の人物の写真を利用してください。
+        #original_hash: 9126b0c
+        '2': 写っている人はあなた本人でなくてはいけません。
+        #original_hash: de9b742
+        '3': もしプロフィール画像に複数人が写っている場合は、どれがあなたかわかるようにしてください。
+        #original_hash: 4083c00
+        '4': あなたの顔が見えるようにしてください。
+        #original_hash: ebbbf8a
+        '5': プロフィール画像は文字を含んではいけません (背景に写り込んでいる場合を除く)。
+        #original_hash: cc5f23a
+        '6': プロフィール画像は正しい向きで登録しなければいけません。
+    errors:
+      #original_hash: 094b763
+      not_found: not found
+      #original_hash: 49a6fe4
+      already_assigned: 既に他のユーザーに登録されています
+      #original_hash: 4bef62b
+      dob_incorrect_html: >-
+        データベースと一致しません。もし正しい日付を正しい形式 (YYYY-MM-DD) で入力しているのにこのエラーが出る場合は、<a
+        href='mailto:results@worldcubeassociation.org' target='_blank'>WCA
+        Results Team</a> にメールしてください。その際、名前と誕生日の確認できる身分証明書 (運転免許証など)
+        の写真を添付してください。
+      #original_hash: 0fbcefd
+      unique: ユニークな値を入力してください
+      #original_hash: 26f70ed
+      dob_past: 過去の日付を入力してください
+      #original_hash: f599dc5
+      must_be_senior: must be a senior delegate
+      #original_hash: 2e582eb
+      must_not_be_present: must not be present
+      #original_hash: b2c4ecc
+      senior_has_delegate: cannot demote senior delegate with subordinate delegates
+      #original_hash: 48653a9
+      already_have_id: '既に WCA ID %{wca_id} が登録されているため、WCA ID が登録できません'
+      #original_hash: eeb76a7
+      wca_id_no_birthdate_html: >-
+        この WCA ID には生年月日が登録されていません。氏名と生年月日が確認できる身分証明書 (運転免許証など) の写真を <a
+        href='mailto:results@worldcubeassociation.org' target='_blank'>WCA
+        Results Team</a> にメールしてください。
+      #original_hash: 49083d8
+      board_member_cannot_resign: >-
+        WCA 理事登録を自分自身で解除することはできません。他の理事に依頼してください。
+      #original_hash: d02c03b
+      avatar_requires_wca_id: WCA ID の連携が必要です
+    successes:
+      messages:
+        #original_hash: 31bd401
+        account_updated: アカウント更新完了
+        #original_hash: 49e5851
+        wca_id_claimed: 'WCA ID %{wca_id} を連携を申請しました。メールを確認し、%{user} の承認をお待ちください。'
+        #original_hash: dc89669
+        account_updated_confirm: 'アカウントが更新されました。%{email} にメールを送信しました。新しいメールアドレスをの確認が必要です。'
+    select_nearby_delegate:
+      #original_hash: 2b11120
+      select_delegate_html: >-
+        WCA IDの登録には、<a href='%{link_delegate}'
+        target='_blank'>WCA 代理人</a>による本人確認が必要です。生年月日を入力し、最も身近な WCA 代理人を選択してください。
+      #original_hash: d69cf94
+      already_assigned_html: >-
+        WCA ID %{link_id} は既に別のアカウントと連携されています。これが誤りと思われる場合は <a
+        href='%{link_delegate}' target='_blank'>WCA 代理人</a>にご連絡ください。
+      #original_hash: 3391b0b
+      missing_dob_html: 'WCA ID %{link_id} は生年月日が登録されていません。%{link_result_team} にご連絡ください。'
+      #original_hash: 92aa857
+      unknown_wca_id_html: 'WCA ID %{link_id} は存在しません'
+  registrations:
+    #original_hash: c5497bc
+    events: 競技種目
+    errors:
+      #original_hash: 44ab952
+      need_name: 名前を入力してください
+      #original_hash: 6f64c57
+      need_gender: 性別を入力してください
+      #original_hash: ebf1ecb
+      need_dob: 生年月日を入力してください
+      #original_hash: d84a54f
+      need_country: 国籍を入力してください
+      #original_hash: cec28a0
+      comp_not_found: 大会が見つかりません
+      #original_hash: cb763b8
+      registration_closed: 大会申し込みは終了しています
+      #original_hash: e0bb243
+      cannot_be_deleted_and_accepted: 参加申し込みの削除と承認を同時に行うことはできません。
+      #original_hash: bf9a828
+      can_register: User must be able to register for competition
+      #original_hash: a38d024
+      must_register: 1 つ以上の競技種目の選択が必要です
+    registration_info_people:
+      #original_hash: bdf1f11
+      newcomer:
+        one: 人の初参加者
+        other: 人の初参加者
+      #original_hash: bc010e3
+      returner:
+        one: 人の大会経験者
+        other: 人の大会経験者
+      #original_hash: b7da17a
+      person:
+        one: 人
+        other: 人
+    flash:
+      #original_hash: da7ec53
+      not_using_wca: この大会は WCA 大会申し込みシステムを利用していません
+      #original_hash: d528030
+      accepted_and_mailed:
+        one: 参加申し込みが完了しました。メールをご確認ください。
+        other: 参加申し込みが完了しました。メールをご確認ください。
+      #original_hash: 42ea8de
+      rejected_and_mailed:
+        one: 申し込みはキャンセル待ちに登録されました。
+        other: 申し込みはキャンセル待ちに登録されました。
+      #original_hash: a360b31
+      deleted_and_mailed:
+        one: 参加申し込みが削除されました。
+        other: 参加申し込みが削除されました。
+      #original_hash: c3aa289
+      single_deletion_and_mail: '参加申し込みが削除されました。%{mail} にメールを送信しました。'
+      #original_hash: d8f067f
+      cannot_delete: 参加申し込みを削除できません。
+      #original_hash: 82b3899
+      updated: 申し込み内容を更新しました
+      #original_hash: 856484a
+      failed: 申し込み内容を更新できません
+      #original_hash: 016b4ae
+      deleted: '%{comp} の参加申し込みを削除しました'
+      #original_hash: 648424f
+      registered: 参加申し込みが完了しました。
+    edit_registration:
+      #original_hash: 2d15eae
+      title: '%{person} for %{comp}'
+    list:
+      #original_hash: 8b7631c
+      title: '%{comp} の参加申し込み一覧'
+      #original_hash: 5301648
+      edit: 編集
+      #original_hash: 0ab725c
+      country_plural:
+        one: "国数 1"
+        other: "国数 %{count}"
+      #original_hash: 1feee0e
+      export_csv: CSV に出力
+      #original_hash: 84add5b
+      email: メールアドレス
+      #original_hash: 7b2c7f1
+      approve: 承認
+      #original_hash: 2b03b59
+      reject: 否認
+      #original_hash: f6fdbe4
+      delete: 削除
+      #original_hash: 92d40dc
+      waiting_list: キャンセル待ちリスト
+      #original_hash: 06f7d1a
+      approved_registrations: 承認済み参加申し込み
+      #original_hash: bff04e8
+      deleted_registrations: 削除済み参加申し込み
+      #original_hash: a844fcf
+      registered: 申し込み済み
+      #original_hash: b25928c
+      total: トータル
+    new_registration:
+      #original_hash: 8b9f726
+      title: '%{comp} 参加申し込み'
+    #original_hash: 7cae988
+    registered_with_account_html: 'WCA アカウントを利用して申し込み済みです。プロフィール情報の変更はこちら %{here}。'
+    #original_hash: ada2e9e
+    sign_in: ログイン
+    #original_hash: 5d45a00
+    profile: プロフィール
+    #original_hash: c0063c3
+    register: 申し込み実行
+    #original_hash: a9af643
+    update: 申し込みが更新されました
+    #original_hash: f6fdbe4
+    delete: 削除
+    #original_hash: b72119a
+    delete_confirm: 本当に参加申し込みを削除してよろしいですか？
+    #original_hash: cfc4865
+    delete_registration: 参加申し込みを削除しました。
+    #original_hash: e9ddc6e
+    will_open_html: '参加申し込みは <strong>%{days}</strong> 日後 %{time} に開始します。'
+    #original_hash: 34eb009
+    will_close_html: '参加申し込みは <strong>%{days}</strong> 日後 %{time} に終了します。'
+    #original_hash: dc8a520
+    closed_html: '参加申し込みは <strong>%{days}</strong> 日前の %{time} に終了しました。'
+    #original_hash: 2e7024d
+    please_sign_in_past_html: >-
+      申し込み状況の確認には%{sign_in}が必要です。WCA アカウントをを持っていない場合は %{here}
+      で作成できますが、この大会の申し込みは既に終了しています。
+    #original_hash: 7753b2e
+    please_sign_in_not_yet_open_html: >-
+      申し込み状況の確認には%{sign_in}が必要です。WCA アカウントをを持っていない場合は %{here}
+      で作成できますが、この大会の申し込みはまだ開始していません。
+    #original_hash: e1301c4
+    please_sign_in_html: >-
+      %{comp} の参加申し込みには%{sign_in}が必要です。WCA アカウントをを持っていない場合は %{here}
+      で作成できます。
+    #original_hash: 89b4e7f
+    greeting: 'こんにちは、%{name} さん！'
+    #original_hash: fb34a17
+    please_fix_profile_html: '%{comp} に参加申し込みするには、%{profile} 中の次の問題を解消してください:'
+    #original_hash: 855ca9c
+    can_register: 'この下で %{comp} に参加申し込みできます。'
+    #original_hash: ea2b586
+    have_registered: '%{comp} に参加申し込み済みです。申し込み情報は下部に記載されています。'
+    #original_hash: 4d966e0
+    entry_fee: '基本参加費:'
+    #original_hash: 3c9141f
+    contact_organizer: 変更が必要な場合は運営チームにお尋ねください。
+    #original_hash: 06d52b5
+    waiting_list: 'あなたはキャンセル待ちリスト %{n} 人中 %{i} 番目です。'
+    #original_hash: 58b1a3c
+    accepted: 参加申し込みが完了しました！
+    #original_hash: 4cf01a2
+    preferred_events_prompt_html: '参加申し込みを簡単にするため、お気に入り種目を設定できます %{link}。'
+  competitions:
+    messages:
+      #original_hash: 7b80062
+      not_visible: この大会は非公開です。
+      #original_hash: c1d4926
+      name_too_long: 大会名が 32 文字を超えています。短い名前が好ましいので変更してください。
+      #original_hash: 1a20fae
+      must_have_events: 大会内容を確定する前に 1 個以上の競技種目を追加してください。
+      #original_hash: e390250
+      create_success: 大会が新規作成されました！
+      #original_hash: afe3a23
+      results_preview_alert: まだ送信されていない結果を表示しています。
+      #original_hash: 07de612
+      upload_results: この大会は終了しています。現在、結果をアップロードする作業中です。
+      #original_hash: a0168ee
+      in_progress: 'この大会は開催中です。%{date} より後に結果が表示されます。'
+      #original_hash: 3322400
+      tooltip_registered: すでに登録済みです。
+      #original_hash: f2d092f
+      tooltip_waiting_list: 現在キャンセル待ちです。
+      #original_hash: 9ecd976
+      confirmed_visible: この大会は承認済みで公開されています。
+      #original_hash: fa186a9
+      confirmed_not_visible: この大会は承認済みですが非公開です。
+      #original_hash: a66bbe3
+      not_confirmed_visible: この大会は未承認ですが公開されています。
+      #original_hash: 0f44e45
+      not_confirmed_not_visible: この大会は未承認で非公開です。
+    my_competitions:
+      #original_hash: 5c6d3ea
+      title: 自分の大会
+      #original_hash: 6e79aaf
+      disclaimer: WCA 申し込みシステムを使用した大会のみここに表示されます。
+      #original_hash: 94a2fc8
+      past_competitions: 過去の大会
+    competition_info:
+      #original_hash: eb9a4bc
+      date: 日付
+      #original_hash: 4271627
+      city: 都市
+      #original_hash: 67cd406
+      venue: 会場
+      #original_hash: d70f93d
+      address: 所在地
+      #original_hash: dc3decb
+      details: 詳細
+      #original_hash: 2e8a57c
+      website: ウェブサイト
+      #original_hash: 680567f
+      organizer_plural:
+        one: 主催者
+        other: 主催者
+      #original_hash: 6afa61e
+      delegate:
+        one: WCA 代理人
+        other: WCA 代理人
+      #original_hash: b37456c
+      contact: 連絡先
+      #original_hash: a428739
+      entry_fee: 基本参加費
+      #original_hash: 0eb5ed5
+      information: 情報
+    index:
+      #original_hash: db98a68
+      title: 大会一覧
+      #original_hash: 6a72085
+      all_events: 全種目
+      #original_hash: 6d76b81
+      all_years: 全ての年
+      #original_hash: 719ea39
+      clear: クリア
+      #original_hash: a1fffaa
+      list: リスト
+      #original_hash: ab478f3
+      map: 地図
+      #original_hash: 0f21717
+      region: 地域
+      #original_hash: bce0641
+      search: 検索
+      #original_hash: a725020
+      state: ステータス
+      #original_hash: 4e9f7a3
+      present: 現在
+      #original_hash: 76eec76
+      recent: 最近
+      #original_hash: 405c12f
+      past: 過去
+      #original_hash: 52c30f8
+      past_from: '%{year} 年の大会'
+      #original_hash: 7cff459
+      past_all: 過去の全ての大会
+      titles:
+        #original_hash: 69447c9
+        in_progress: 開催中の大会
+        #original_hash: 9e66032
+        past: '%{year} 年の大会'
+        #original_hash: f628f0e
+        past_all: 過去の全ての大会
+        #original_hash: cbe8a54
+        recent: '%{count} 日以内に開催された最近の大会'
+        #original_hash: 914742f
+        upcoming: 予定されている大会
+      #original_hash: 6684214
+      no_access: このページへのアクセス権がありません。
+      tooltips:
+        hourglass:
+          #original_hash: b5183e1
+          ended: '%{days} 日前に終了しました。'
+          #original_hash: 1dccb27
+          in_progress: 開催中！
+          #original_hash: 1157462
+          posted: 大会結果は送信済みです。
+          #original_hash: 89bcc37
+          starts_in: '%{days} 日後に開始します。'
+        #original_hash: ccd2db9
+        search: 大会名、都市名
+        #original_hash: 3bc8082
+        recent: '過去 %{count} 日'
+      #original_hash: 8b09d74
+      no_comp_found: 大会が見つかりませんでした。
+      #original_hash: 7008166
+      no_comp_match: '%{events} が開催される大会はありません。種目数を減らして検索してみてください。'
+    my_competitions_table:
+      #original_hash: 5301648
+      edit: 編集
+      #original_hash: dddbe64
+      registrations: 大会申し込み
+      #original_hash: 4f98e6d
+      results_up: 競技結果更新！
+      #original_hash: 87ab5db
+      report: 代理人レポートを読む
+      #original_hash: b4ca252
+      edit_report: レポートを編集する
+      #original_hash: e590657
+      missing_report: レポートが投稿されていません
+      #original_hash: 7fc0b5f
+      no_upcoming_competitions_html: '予定されている大会はありません。%{link} をご覧ください。'
+      #original_hash: 9104a03
+      no_past_competitions: 過去に参加した大会はありません。
+    competition_form:
+      #original_hash: f957dcb
+      supports_md_html: >-
+        <a href='https://daringfireball.net/projects/markdown/basics'
+        target='_blank'>Markdown</a> が使えます
+      #original_hash: 9d9126e
+      venue_html: >-
+        大会が開催される会場。%{md}。例: [Takatsu Civic
+        Hall](http://www.city.kawasaki.jp/takatsu/category/111-11-1-0-0-0-0-0-0-0.html)。
+      #original_hash: 2651d1a
+      venue_details_html: '会場の詳細 (例: 12階)。%{md}'
+      #original_hash: b727e58
+      contact_html: >-
+        連絡先 (任意)。記入しない場合、主催者のメールアドレスが公開されます。%{md}。例: [Text to
+        display](mailto:some@email.com)
+      #original_hash: c5497bc
+      events: 競技種目
+      #original_hash: ae66391
+      unoff_events: 非公式競技種目
+      #original_hash: 815d5c3
+      locked_edit_html: 'この大会は公開済みで編集できません。変更が必要な場合は %{board} に連絡してください。'
+      #original_hash: ce33e21
+      confirmed_not_visible_html: 'この大会は公開準備中です。%{board} が公開するまでお待ちください。'
+      #original_hash: e94cba8
+      is_visible: この大会は公開済みです。内容の変更は公開情報に反映されます。
+      #original_hash: 34862bb
+      awaiting_confirmation_html: '入力欄をすべて記入して、%{board} に提出する準備ができたら「確定」をクリックしてください。'
+      #original_hash: 7586b02
+      submit_modify_value: 競技種目を編集する
+      #original_hash: 8966fd0
+      submit_create_value: 大会を新規作成する
+      #original_hash: 40b0dfd
+      submit_update_value: 大会を更新する
+      #original_hash: 04a2122
+      submit_confirm_value: 確定
+      #original_hash: f6fdbe4
+      submit_delete_value: 削除
+      #original_hash: 1ca19b1
+      submit_confirm: 内容を確認してください。確定後はすべての情報は変更できなくなります。確定後、理事が受理したことを通知する電子メールを確認してください。
+      #original_hash: 4c7deb7
+      submit_delete: この大会を削除してもいいですか？削除は元に戻せません。
+      #original_hash: 8ebebca
+      coordinates: 緯度・経度
+    errors:
+      #original_hash: f7ef9f6
+      invalid_name_message: >-
+        必ず年を末尾にすること。以下の文字のみ使用すること: 英数字、ダッシュ(-)、アンパサンド(&)、ピリオド(.), コロン(:),
+        アポストロフィ('), スペース( )
+      #original_hash: 8e8f765
+      cannot_manage: 大会を管理できません。
+      #original_hash: 0acc454
+      cannot_delete_public: 公開済みの大会は削除できません。
+      #original_hash: 3935fd6
+      cannot_delete_confirmed: 確定済みの大会は削除できません。
+      #original_hash: 191df37
+      must_contain_event: この大会には 1 個以上の競技種目を追加する必要があります
+      #original_hash: 112490b
+      must_contain_delegate: 1 人以上の WCA 代理人を追加する必要があります
+      #original_hash: 0b2b56b
+      not_all_delegates: は全員代理人ではありません
+      #original_hash: 43a23c2
+      registration_close_after_open: 申し込み締め切りは申し込み開始より後である必要があります
+      #original_hash: 43a83a9
+      end_date_before_start: 終了日は開始日より後である必要があります
+      #original_hash: be3933b
+      span_too_many_days: '%{max_days} 日間を超える大会は開催できません。'
+    #original_hash: f42a238
+    unscheduled: スケジュール未定
+    new:
+      #original_hash: 1208df7
+      create_competition: 大会新規作成
+      #original_hash: c02a415
+      note_clone: 既存の大会をコピーするには、その大会の情報ページのメニューから「コピーを作成」をクリックしてください。
+    update_events:
+      #original_hash: 00204fa
+      update_success: 競技種目が更新されました。
+    update:
+      #original_hash: 5fb2f57
+      save_success: 大会が保存されました。
+      #original_hash: 9d1649e
+      confirm_success: 大会を確定しました。電子メールを確認して理事が公表するまでお待ちください。
+      #original_hash: 28567f0
+      delete_success: '大会 %{id} を削除しました。'
+    time_until_competition:
+      #original_hash: b0f330f
+      competition_in: '大会開始は %{n_days} 後です。'
+      #original_hash: e6e096a
+      competition_was: '大会は %{n_days} 前に終了しました。'
+    nearby_competitions:
+      #original_hash: 241801a
+      competitions:
+        zero: "そのような大会はありません"
+        one: "1 つの大会"
+        other: "%{count} 個の大会"
+      #original_hash: e3528ec
+      label: '周辺で開催される大会 (%{days} 日以内かつ %{kms} km 以内)'
+      #original_hash: 3446062
+      label_admin: '過去 %{days} 日'
+      #original_hash: 07a1cf0
+      nearby_admin: '%{x_competitions} は、%{kms} km 以内かつ %{days} 日以内に開催されます。'
+      #original_hash: feefb46
+      no_comp_nearby: 周辺で開催される大会はありません！
+      #original_hash: 7e76950
+      no_date_yet: この大会の日付が設定されていません。
+      #original_hash: 82a95d2
+      no_location_yet: この大会の開催場所が設定されていません。
+      #original_hash: 9eb8f46
+      within: '%{days} 日以内'
+      #original_hash: d97d1ee
+      show: 表示
+      #original_hash: 709a232
+      name: 名前
+      #original_hash: adc24b7
+      delegates: 代理人
+      #original_hash: eb9a4bc
+      date: 日付
+      #original_hash: d219c68
+      location: 場所
+      #original_hash: 4232080
+      distance: 距離
+      #original_hash: 51de2b8
+      before: 前
+      #original_hash: 405906c
+      after: 後
+    #original_hash: 06b01c4
+    announcements: 告知
+    #original_hash: 5b9523f
+    upload_results: 結果をアップロード
+    #original_hash: 47dfd90
+    post_announcement: 大会告知を投稿する
+    show:
+      #original_hash: b0fe391
+      general_info: お知らせ
+    nav:
+      menu:
+        #original_hash: 612e12d
+        results: 大会結果
+        #original_hash: 02ae2bd
+        podiums: 入賞者
+        #original_hash: 6a72085
+        all: 全ての結果
+        #original_hash: aaefdb6
+        by_person: 競技者ごと
+        #original_hash: 4b631f6
+        info: 情報
+        #original_hash: 5301648
+        edit: 編集
+        #original_hash: d8cdb57
+        clone: コピーを作成
+        #original_hash: 2b92094
+        orga_view: 主催者モード
+        #original_hash: c6171f8
+        event_view: 競技種目を編集
+        #original_hash: 76bfdcf
+        admin_view: 管理者モード
+        #original_hash: a857eb4
+        tabs: タブ管理
+        #original_hash: 4c9f914
+        delegate_report: 代理人レポート
+        #original_hash: b233e77
+        registration: 申し込み
+        #original_hash: d672995
+        register: 申し込む
+        #original_hash: 855bd26
+        competitors: 競技者一覧
+    results_table:
+      #original_hash: 3e9a6b5
+      wca_profile: WCAプロフィール
+      #original_hash: ad8919a
+      event: 種目
+      #original_hash: ec7b598
+      round: ラウンド
+      #original_hash: 709a232
+      name: 名前
+  competition_tabs:
+    headers:
+      #original_hash: 2a4d562
+      tabs: タブ
+      #original_hash: 709a232
+      name: 名前
+    form_elements:
+      #original_hash: 90f8dcb
+      create_button: タブを作成
+      #original_hash: 8d5b6f9
+      goto_button: '%{tab_name} タブへ移動'
+      #original_hash: 6f23a36
+      new_tab: 新規タブ
+      #original_hash: 5301648
+      edit: 編集
+      #original_hash: fb91e24
+      update: 更新
+      #original_hash: f6fdbe4
+      delete: 削除
+      #original_hash: 14e49c1
+      confirm_delete: '%{tab_name} タブを削除してよろしいですか？'
+      #original_hash: ce1bf0b
+      back_to_tabs: タブへ戻る
+    new:
+      #original_hash: 73ed8c2
+      new_tab_title: '%{comp_name} への新規タブ'
+    index:
+      #original_hash: a857eb4
+      tabs_list_title: タブを管理
+      #original_hash: 40f9491
+      tabs_introduction_text: ここで大会情報ページに表示されるタブの追加・編集ができます。
+    edit:
+      #original_hash: 5f1f5b8
+      edit_tab_title: '%{tab_name} タブを編集'
+  notifications:
+    #original_hash: 10bcdbd
+    connect_wca_id: WCA ID をアカウントに連携しましょう！
+  persons:
+    index:
+      #original_hash: 5934b4c
+      name_or_wca_id: 名前または WCA ID
+      #original_hash: 709a232
+      name: 名前
+      #original_hash: d523ebb
+      country: 国
+      #original_hash: 02ae2bd
+      podiums: 入賞者
+      #original_hash: 56656a0
+      no_persons_found: キーワードにマッチする検索結果はありません。
+  posts:
+    #original_hash: 2a7da42
+    confirm_delete_post: この投稿を削除してよいですか？削除は元に戻せません。
+  faq:
+    #original_hash: d790b40
+    title: よくある質問
+    #original_hash: 3451241
+    contact_html: 'このページで解決しない問題がある場合、%{contact_us}!'
+    #original_hash: 6cf2723
+    contact_us: お問い合わせください
+    #original_hash: 9100be3
+    search_for_competition: '大会を検索するにはここから:'
+    #original_hash: cba12bc
+    already_logged_in: すでに WCA アカウントにログインしています。
+    #original_hash: 5b7fa52
+    create_an_account: 'ここからアカウントを作成できます: %{here}'
+    #original_hash: f8c910c
+    claim_your_wca_id: 'ここで WCA ID を連携できます: %{here}'
+    #original_hash: 4dfb4c7
+    create_an_account_and_claim: 'アカウントを作成してください: %{here}。作成したアカウントにログインした後、WCA ID 連携を申請できます。'
+    answers:
+      '1':
+        #original_hash: f79b522
+        title: WCA ID と WCA プロフィールはどのように取得できますか？
+        content:
+          #original_hash: b645fe1
+          '1': >-
+            まだ公式大会に出場したことが無い場合、<a
+            href='/competitions'>大会ページ</a>から最寄りの大会を検索しましょう! WCA ID と WCA
+            プロフィールは最初に出場した大会結果の公開と同時に作成されます。
+      '2':
+        #original_hash: eb948e7
+        title: WCA 公式大会はどのように探せますか？
+        content:
+          #original_hash: d195cec
+          '1': <a href='/competitions'>大会リスト</a> をご覧ください。
+      '3':
+        #original_hash: af6ad12
+        title: 大会に申し込みたいのですがどうすればいいですか？申し込み時に問題が発生した場合どこに連絡したらよいですか？
+        content:
+          #original_hash: 7b91db1
+          '1': >-
+            一部の大会は WCA
+            サイト上で申し込みできますが、専用サイトで申し込む大会もあります。詳細は大会の主催者にお問い合わせください。%{comp_search_form}
+      '4':
+        #original_hash: 9a5ae28
+        title: WCA 公式大会に参加する資格はありますか？WCA 公式大会に参加する前に知っておくことはありますか？
+        content:
+          #original_hash: 40aa9c0
+          '1': >-
+            ほとんどの WCA 公式大会には特別な資格は不要です。ただし、参加者は<a
+            href='https://www.worldcubeassociation.org/regulations/'>大会規則</a>を知っていることが望まれます。特に初参加者の方は、競技の流れ等を理解するために以下のページや動画をご覧ください。<a
+            target='_blank' href='http://www.cubingusa.com/ctutorial.php'>Cubing
+            USA's competitor tutorial</a> (英語)、<a target='_blank'
+            href='https://www.youtube.com/watch?v=xSrw4YO00uo'>tribox
+            による競技の流れチュートリアル動画</a> (日本語)。
+      '5':
+        #original_hash: 3b657aa
+        title: 地元で WCA 公式大会を開催できますか？
+        content:
+          #original_hash: 3d4eb1c
+          '1': 大会を主催したい場合、経験を積むために最低でも数回は競技者として大会に参加することが強く推奨されます。
+          #original_hash: be305b8
+          '2': >-
+            WCA 公式大会は、<a target='_blank'
+            href='https://www.worldcubeassociation.org/regulations/'>WCA
+            大会規則</a>を遵守して開催される必要があります。主催者は大会規則を暗記までする必要はありませんが、大会規則の要点を理解して正当な大会を運営する必要があります。
+          #original_hash: dbd72c2
+          '3': >-
+            次のステップとして、大会主催者は身近な<a target='_blank'
+            href='https://www.worldcubeassociation.org/delegates'>WCA
+            代理人</a>に連絡を取る必要があります。WCA 公式大会として認められるには、WCA 代理人による監督が必須です。
+          #original_hash: 809f53a
+          '4': >-
+            より詳細は、<a target='_blank'
+            href='https://www.cubingusa.com/cguide.php'>CubingUSA による大会運営ガイド
+            (英語)</a> をご覧ください。※このガイドの内容と WCA 大会規則が矛盾する場合、WCA 大会規則が優先されます。
+      '6':
+        #original_hash: 8005a61
+        title: WCA アカウントとは何ですか？WCA アカウントと WCA プロフィールは別物ですか？
+        content:
+          #original_hash: 57a3767
+          '1': WCA 公式大会に初めて出場したときに WCA ID が発行されます。
+          #original_hash: c5ad7a3
+          '2': >-
+            WCA アカウントとは、WCA ID と連携した WCA サイト上でのアカウントです。WCA アカウントを作成することで、WCA
+            プロフィールに写真を追加したり、大会に申し込むことができます。
+          #original_hash: 9ff083a
+          '3': '%{current_user_status}'
+      '7':
+        #original_hash: d7ee9bd
+        title: プロフィール写真を変更したいのですが？
+        content:
+          #original_hash: e619524
+          '1': >-
+            まず、<a href='#how-do-i-connect-my-wca-account-with-my-wca-id'>WCA
+            アカウントを作成して WCA ID を連携</a>してください。
+          #original_hash: 56a8f26
+          '2': >-
+            WCA アカウントに WCA ID を連携したら、<a
+            href='%{profile_edit_path}'>プロフィール編集ページ</a>でプロフィール写真を変更しましょう。
+      '8':
+        #original_hash: 1d61217
+        title: WCA アカウントに WCA ID を連携したいのですが？
+        content:
+          #original_hash: 07bb6ec
+          '1': '%{current_user_claim}'
+      results:
+        #original_hash: 9aae576
+        title: WCA 公式大会の結果はいつ WCA サイトに反映されますか？
+        content:
+          #original_hash: 890d879
+          '1': >-
+            大会終了後、WCA 代理人は全記録と競技者データを再チェックします。この作業が終了後、競技結果は WCA Results Team
+            (WRT) に送られます。WRT は競技結果のアップロードと WCA データベースを管理するチームで、WRT
+            がデータをアップロードした後に競技結果が公開されます。
+          #original_hash: b6a68ab
+          '2': 大会の規模と代理人の都合により、競技結果の公開に最大 1 週間要することがあります。
+          #original_hash: bf8adbe
+          '3': >-
+            WCA アカウントに WCA ID を連携している場合 (以下参照)、自分の競技結果に関する<a
+            href='%{preferences_edit_path}'>電子メールでの通知</a>を受け取ることができます。
+  about:
+    #original_hash: 9ac918a
+    title: WCA について
+    mission:
+      #original_hash: e4698d4
+      title: ミッション
+      paragraphs:
+        #original_hash: 16ad45e
+        '1': >-
+          World Cube Association は全 Rubik ブランドパズルと側面を回転させて揃えるタイプのパズル (いわゆる
+          'twisty puzzle') の大会を管理します。代表的なものは、ハンガリーの Rubik 教授が発明した Rubik's Cube
+          (ルービックキューブ) です。このようなパズルの中から WCA の公式種目が選ばれます。
+        #original_hash: c8ecd24
+        '2': World Cube Association は世界中の大会を組織化します。大会は各国の大会を運営する団体の支援により開催されます。
+        #original_hash: 20e0550
+        '3': >-
+          World Cube Association の目的は<br
+          /><strong>公平な環境の下、たくさんの大会をたくさんの国々で、たくさんの人々がたくさん楽しめるようにすること</strong>です。
+        #original_hash: bee3687
+        '4': >-
+          World Cube Association の精神は<br />
+          <strong>世界中の人々が、友好的な雰囲気の中で楽しみ、お互いに助け合い、正々堂々ふるまうこと</strong>です。
+    structure:
+      #original_hash: 9482c5d
+      title: 組織
+      #original_hash: d855b50
+      board_html: >-
+        World Cube Association は <strong>WCA 理事</strong>が指揮をとります。WCA
+        理事は以下のメンバーで構成されます:
+      #original_hash: b0c72a9
+      committees: '以下の委員会は WCA の業務活動を担当します:'
+      wdc:
+        #original_hash: 853bffa
+        name_html: <strong>WCA Disciplinary Committee (WDC)</strong>
+        #original_hash: 286fdf8
+        description: >-
+          この委員会は、WCA 大会規則違反疑いのような特別な事例を WCA 理事に通告し、WCA 公式大会に関する重要な個人的事案がある場合は
+          WCA メンバーと連絡を取ります。
+      wrc:
+        #original_hash: 4aa147f
+        name_html: <strong>WCA Regulations Committee (WRC)</strong>
+        #original_hash: 13ada5b
+        description: この委員会は、WCA 大会規則の管理を担当します。
+      results:
+        #original_hash: 3e819b8
+        name_html: <strong>WCA Results team</strong>
+        #original_hash: 439ffae
+        description: このチームは、全競技結果の管理を担当します。
+      software:
+        #original_hash: ea7f654
+        name_html: <strong>WCA Software team</strong>
+        #original_hash: ec961e4
+        description: このチームは、WCA のソフトウェア (ウェブサイト、スクランブル、ワークブック、管理ツール) の管理を担当します。
+      #original_hash: f2ceade
+      delegates_html: >-
+        <strong>WCA 代理人</strong> は、全 WCA 公式大会が WCA
+        の目的、大会規則、精神に従って開催されているかを確認する責任があります。<strong>WCA Senior
+        Delegates</strong>、<strong>WCA Delegates</strong>、<strong>WCA Candidate
+        Delegates</strong> から構成されます %{see_link}。WCA Senior Delegate は WCA
+        代理人の任務に加えて、その地域の代理人を管理する責任があり、地域の問題に関する連絡を受けることができます。新規の代理人は最初に WCA
+        Candidate Delegate として登録され、WCA 代理人になる前に大会運営能力を評価される必要があります。
+      #original_hash: 27d18ac
+      see_link_html: '(参照: %{link})'
+      #original_hash: 5b01fcc
+      members_html: 全競技者は、最初の WCA 公式大会で <strong>WCA メンバー</strong> になります。
+  delegates_page:
+    #original_hash: d8fd3e4
+    title: WCA 代理人
+    #original_hash: 0a89b0f
+    acknowledges: 'WCA は以下のメンバーを WCA 公式大会での代理人として認める:'
+    table:
+      #original_hash: 709a232
+      name: 名前
+      #original_hash: c3f104d
+      role: 役職
+      #original_hash: 0f21717
+      region: 国
+  national_organizations:
+    #original_hash: 0ef06c8
+    title: 各国の団体
+    #original_hash: f9a7f4d
+    content: 'WCA は以下の団体を各国の団体として認める:'
+  contact:
+    #original_hash: a34b69f
+    title: 連絡先
+    #original_hash: b5c2eaa
+    info_alert_html: '本ページ記載の連絡先に連絡する前に、%{link} をご覧ください。'
+    #original_hash: 2b023eb
+    questions_and_comments_html: >-
+      ウェブサイトへの質問、コメント、提案は、<a
+      href='/contact/website'>連絡フォーム</a>からお問い合わせください。特定の地域や大会に関することは、お近くの
+      %{link} にお問い合わせください。
+    #original_hash: 4a30d30
+    committees_and_teams_html: <u>委員会・チーム</u>
+    board:
+      #original_hash: ccad374
+      name_html: <strong>WCA 理事</strong>
+      #original_hash: 7ee8e36
+      info: '(担当: WCA 組織、代理人レポート、大会の承認、一般的な問い合わせ)'
+    wdc:
+      #original_hash: 562e197
+      info: '(担当: WCA 理事に対する中立した立場からの助言・調査、個人的な問題に関する相談)'
+    wrc:
+      #original_hash: 4a256f0
+      info: '(担当: WCA 大会規則の管理)'
+    results:
+      #original_hash: 899dc9c
+      info: '(担当: 競技結果、結果訂正)'
+    software:
+      #original_hash: 325ab0a
+      info: '(担当: WCA のソフトウェアの管理)'
+  score_tools:
+    #original_hash: ea9d41d
+    title: WCA 記録ツール
+    paragraphs:
+      #original_hash: ec3e0ab
+      '1': >-
+        WCA は大会準備と大会中に <a href="http://cubecomps.com">Cube Comps</a>
+        を使用することを強く推奨します。Cube Comps
+        は記録入力に加え、記録カードの印刷や複数ユーザによるデータ入力を可能にした便利なオンラインシステムです。Luis J. Iáñez
+        により作成されました。オープンソースです。
+      #original_hash: 7438b0d
+      '2': >-
+        スコアシートとスクランブルは、WCA Results Team に送信する前に、データ生成と %{workbook_link}
+        を用いたエラーチェックする必要があります。
+      #original_hash: 975e59b
+      '3': >-
+        最新バージョンの WCA 公式大会スコアシートはこちらからダウンロードできます: <br /><a
+        href="/files/results.xls" target="_blank">WCA 公式大会スコアシート</a>。
+  logo:
+    #original_hash: c72c969
+    title: WCA ロゴ
+    paragraphs:
+      #original_hash: c092e13
+      '1': >-
+        WCA ロゴは Justin Eastman さんが 2005 年 1 月のデザインコンテストで作成しました。<br
+        />デザイン、色、Rubik's Cube / 3x3x3 キューブだけを特定に表現していない点が採用した理由です。
+      #original_hash: f228da2
+      '2': >-
+        3 種類のロゴがあります: <a href="/files/WCAlogo_XL.jpg">大きいサイズ</a> (46 KB, 1756 px
+        by 1068 px)、<a href="/files/WCAlogo.svg">ベクター画像</a>、<a
+        href="/files/WCAlogo_notext.svg">テキスト無しベクター画像</a>。
+      #original_hash: dcb1ad6
+      '3': >-
+        3D バージョンのロゴです。ベトナムの Vu Minh Tan さんがデザインしました: <a
+        href="/files/WCALogo3D.png">PNG 形式</a> (2.1 MB)、<a
+        href="/files/WCALogo3Dsmall.png">PNG 形式 (小さいサイズ)</a> (0.25 MB)。
+      #original_hash: 545fcd9
+      '4': >-
+        WCA 公式大会の主催者は WCA ロゴを WCA 公式大会に限り、ウェブサイト、衣類、ギフト、装飾に使用することができます。<br
+        />その他の方やその他の目的で WCA ロゴを使用する場合は、<a
+        href="mailto:board@worldcubeassociation.org">WCA 理事</a>の承認が必要です。
+  workbook_assistant:
+    #original_hash: e442ea4
+    title: WCA Workbook Assistant
+    #original_hash: a7c307f
+    download: Download WCA Workbook Assistant
+    #original_hash: cf1b916
+    last_update: Last update
+    #original_hash: feece00
+    version_history: version history
+    #original_hash: 8f3f4c0
+    header: How to process results and scrambles before submitting them to the WCA
+    step1:
+      #original_hash: c0450b1
+      title: 'Step 1: Open the workbook with the results'
+      #original_hash: 656d70d
+      content_html: >-
+        Open the workbook using the <em>Open...</em> button or by dragging the
+        workbook file and dropping it on the application window.
+    step2:
+      #original_hash: 3ad9881
+      title: 'Step 2: Add the TNoodle scrambles'
+      #original_hash: 080acc0
+      content_html: >-
+        Add the TNoodle scrambles using the <em>Add...</em> button or by
+        dragging the TNoodle file and dropping it on the application window.
+        Make sure you use either the .zip file  or the .json file generated by
+        TNoodle.
+      #original_hash: 6cc90b8
+      content2_html: >-
+        You can add multiple scramble files in case the scrambles where
+        generated in parts or extra scrambles had to be generated during the
+        competition.
+    step3:
+      #original_hash: b2d01b3
+      title: 'Step 3: Match the scrambles with the results'
+      #original_hash: 36383b1
+      content_html: >-
+        The WCA Workbook Assistant automatically links the scrambles with the
+        rounds that were held. In some cases, like when multiple scramble files
+        were generated, the selection needs to be done manually because there
+        are several possible options.
+      #original_hash: e869c1e
+      content2_html: >-
+        Manually selecting scrambles can be done by double clicking the
+        <em>Scrambles</em> cell in the sheet overview panel.
+      #original_hash: 8f4fdfd
+      content3_html: >-
+        It is only possible to select one round from the scramble files for each
+        round for which there are results. If a situation arises where scrambles
+        for a single round were generated as separate rounds in TNoodle, you
+        can use the <em>Edit groups...</em> button to edit the groups in the
+        scramble files and move them from one round to another or delete them.
+      #original_hash: 94353f2
+      content4_html: >-
+        In this example, an extra set scrambles was generated to have two groups
+        for the first round of skewb instead of one group.
+      #original_hash: 68c5b18
+      content5_html: >-
+        The scrambles for the additional group can be dragged and dropped on the
+        round that was generated originally. This moves the two groups together
+        in one round.
+    step4:
+      #original_hash: ed940d2
+      title: 'Step 4: Fix any errors reported by the application'
+      #original_hash: df2cf58
+      content_html: >-
+        The results are checked for data entry mistakes. Rounds that have errors
+        will be marked with a red icon in the sheet overview panel.
+      #original_hash: 7fbf6b8
+      content2_html: >-
+        When selecting a sheet with errors in the sheet overview panel, the
+        application will list the details in the validation errors panel on the
+        bottom left.
+      #original_hash: 0600502
+      content3_html: >-
+        Mistakes can be fixed by opening the workbook in a spreadsheet
+        application and editing and saving it from there. The updated workbook
+        can then be loaded again in the WCA Workbook Assistant by pressing the
+        <em>Refresh</em> button. This will only reload the results but will
+        leave all the other changes you made intact, like the scrambles that
+        were added.
+    step5:
+      #original_hash: 536ec4d
+      title: 'Step 5: Select the competition ID'
+      #original_hash: 5aeb5bd
+      content_html: >-
+        Select the correct competition ID by clicking the <em>Select...</em>
+        button next to the <em>Competition ID</em> field.
+      #original_hash: 3acf7d0
+      content2_html: A dialog will show up with a list of competitions to choose from.
+      #original_hash: ceeb6fe
+      content3_html: >-
+        You can filter the list by typing a part of the name of the competition
+        or the WCA Delegate.
+      #original_hash: 5ca74eb
+      content4_html: >-
+        To start off with, only competitions that took place less than one week
+        ago or that will take place less than one week in the future will be
+        shown. If you need to select a competition outside of this time window,
+        deselect <em>Only show current competitions</em>.
+    step6:
+      #original_hash: 52bb1f6
+      title: 'Step 6: Export the results data to JSON'
+      #original_hash: 6bfee23
+      content_html: >-
+        Save the results data to a JSON file using the <em>Export results
+        JSON...</em> button on the bottom right.
+    step7:
+      #original_hash: 09fa37d
+      title: 'Step 7: Send the results JSON to the WCA'
+      #original_hash: 9be089f
+      content_html: >-
+        E-mail the JSON file exported by the WCA Workbook Assistant to <a
+        href="mailto:results@worldcubeassociation.org">results@worldcubeassociation.org</a>

--- a/WcaOnRails/config/locales/locales.rb
+++ b/WcaOnRails/config/locales/locales.rb
@@ -13,6 +13,10 @@ module Locales
       "flag_id": "it",
       "name": "Italiano",
     },
+    "ja": {
+      "flag_id": "jp",
+      "name": "日本語",
+    },
     "pl": {
       "flag_id": "pl",
       "name": "Polski",


### PR DESCRIPTION
We have finished Japanese translation.
I checked that this translation is up-to-date to the latest English version.
Note that our language code is `ja` but country code is `jp`, so I chose `jp` as `flag_id` in `locales.rb`.
Could you please update this to the staging environment? We'd like to check it before the production is released.