### PR TITLE
Don't crash on startup if wca-regulations.json is missing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ env:
 before_install:
   # The Stripe API requires a newer version of openssl
   - sudo apt-get update && sudo apt-get install --only-upgrade openssl
-  - pip install --user wrc
-  - git clone --depth=1 https://github.com/thewca/wca-regulations.git
-  - wrc wca-regulations -o WcaOnRails/app/views/regulations --target=json
   # Travis has an old install of PhantomJS without .bind() support, here we upgrade to
   # version 2.0.0
   # From https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to

--- a/WcaOnRails/app/controllers/server_status_controller.rb
+++ b/WcaOnRails/app/controllers/server_status_controller.rb
@@ -3,10 +3,14 @@ class ServerStatusController < ApplicationController
   MINUTES_IN_WHICH_A_JOB_SHOULD_HAVE_STARTED_RUNNING = 5
 
   def index
+    @everything_good = true
+
     @jobs_that_should_have_run_by_now = Delayed::Job.where(attempts: 0).where('created_at < ?', MINUTES_IN_WHICH_A_JOB_SHOULD_HAVE_STARTED_RUNNING.minutes.ago)
     @oldest_job_that_should_have_run_by_now = @jobs_that_should_have_run_by_now.order(:created_at).first
+    @everything_good &&= @oldest_job_that_should_have_run_by_now.blank?
 
-    @everything_good = @oldest_job_that_should_have_run_by_now.nil?
+    @regulations_load_error = Regulation.regulations_load_error
+    @everything_good &&= @regulations_load_error.blank?
 
     @ref_english = Locale.new('en')
     @bad_keys_by_type_by_locale = {}

--- a/WcaOnRails/app/models/regulation.rb
+++ b/WcaOnRails/app/models/regulation.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
 class Regulation < SimpleDelegator
-  REGULATIONS = JSON.parse(File.read(Rails.root.to_s + "/app/views/regulations/wca-regulations.json")).freeze
+  REGULATIONS_JSON_PATH = Rails.root.to_s + "/app/views/regulations/wca-regulations.json"
+
+  def self.reload_regulations
+    @regulations = JSON.parse(File.read(REGULATIONS_JSON_PATH)).freeze
+    @regulations_load_error = nil
+  rescue StandardError => error
+    @regulations = []
+    @regulations_load_error = error
+  end
+
+  reload_regulations
+
+  class << self
+    attr_accessor :regulations_load_error
+  end
 
   def limit(number)
     first(number)
   end
 
   def self.search(query, *)
-    matched_regulations = REGULATIONS.dup
+    matched_regulations = @regulations.dup
     query.downcase.split.each do |part|
       matched_regulations.select! do |reg|
         %w(content_html id).any? { |field| reg[field].downcase.include?(part) }

--- a/WcaOnRails/app/views/server_status/index.html.erb
+++ b/WcaOnRails/app/views/server_status/index.html.erb
@@ -9,6 +9,7 @@
   <% else %>
     <%= alert :danger, "Check below, something may be wrong." %>
   <% end %>
+
   <% kind_class = @oldest_job_that_should_have_run_by_now ? "danger" : "success" %>
   <div class="panel panel-<%= kind_class %>">
     <div class="panel-heading">
@@ -31,6 +32,21 @@
       </h3>
     </div>
   </div>
+
+  <% kind_class = @regulations_load_error ? "danger" : "success" %>
+  <div class="panel panel-<%= kind_class %>">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        <span class="label label-<%= kind_class %>">Regulations</span>
+        <% if @regulations_load_error %>
+          Error while loading regulations: <%= @regulations_load_error %>.
+        <% else %>
+          Looking good!
+        <% end %>
+      </h3>
+    </div>
+  </div>
+
   <% (I18n.available_locales - [:en]).each do |locale| %>
     <%
       bad_keys_by_type = @bad_keys_by_type_by_locale[locale]

--- a/WcaOnRails/spec/controllers/server_status_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/server_status_controller_spec.rb
@@ -2,26 +2,62 @@
 require 'rails_helper'
 
 RSpec.describe ServerStatusController, type: :controller do
-  it "finds the oldest job that has been waiting to run" do
-    _old_job = Delayed::Job.create(created_at: 10.minutes.ago, handler: "")
-    oldest_job = Delayed::Job.create(created_at: 15.minutes.ago, handler: "")
-
-    get :index
-
-    oldest_job_that_should_have_run_by_now = assigns(:oldest_job_that_should_have_run_by_now)
-    expect(oldest_job_that_should_have_run_by_now).to eq oldest_job
-
-    expect(assigns(:everything_good)).to eq false
+  before :each do
+    allow(File).to receive(:read).with(any_args).and_call_original
+    allow(File).to receive(:read).with(Regulation::REGULATIONS_JSON_PATH).and_return("{}")
+    Regulation.reload_regulations
   end
 
-  it "ignores young jobs" do
-    _young_job = Delayed::Job.create(created_at: 1.minutes.ago, handler: "")
-
+  it "is happy" do
     get :index
 
-    oldest_job_that_should_have_run_by_now = assigns(:oldest_job_that_should_have_run_by_now)
-    expect(oldest_job_that_should_have_run_by_now).to eq nil
-
     expect(assigns(:everything_good)).to eq true
+  end
+
+  context "jobs" do
+    it "finds the oldest job that has been waiting to run" do
+      _old_job = Delayed::Job.create(created_at: 10.minutes.ago, handler: "")
+      oldest_job = Delayed::Job.create(created_at: 15.minutes.ago, handler: "")
+
+      get :index
+
+      oldest_job_that_should_have_run_by_now = assigns(:oldest_job_that_should_have_run_by_now)
+      expect(oldest_job_that_should_have_run_by_now).to eq oldest_job
+
+      expect(assigns(:everything_good)).to eq false
+    end
+
+    it "ignores young jobs" do
+      _young_job = Delayed::Job.create(created_at: 1.minutes.ago, handler: "")
+
+      get :index
+
+      oldest_job_that_should_have_run_by_now = assigns(:oldest_job_that_should_have_run_by_now)
+      expect(oldest_job_that_should_have_run_by_now).to eq nil
+
+      expect(assigns(:everything_good)).to eq true
+    end
+  end
+
+  context "regulations" do
+    it "warns about missing regulations" do
+      allow(File).to receive(:read).with(any_args).and_call_original
+      allow(File).to receive(:read).with(Regulation::REGULATIONS_JSON_PATH).and_raise(Errno::ENOENT.new)
+      Regulation.reload_regulations
+
+      get :index
+
+      expect(assigns(:everything_good)).to eq false
+    end
+
+    it "warns about malformed regulations" do
+      allow(File).to receive(:read).with(any_args).and_call_original
+      allow(File).to receive(:read).with(Regulation::REGULATIONS_JSON_PATH).and_return("i am definitely not json")
+      Regulation.reload_regulations
+
+      get :index
+
+      expect(assigns(:everything_good)).to eq false
+    end
   end
 end


### PR DESCRIPTION
Instead, we have a warning on `/server-status` if anything looks wrong.
This fixes #1063.

## good

![image](https://cloud.githubusercontent.com/assets/277474/22399554/79270994-e553-11e6-9aa0-38d0dd1dba31.png)

## bad

![image](https://cloud.githubusercontent.com/assets/277474/22402632/0114b1b2-e5b3-11e6-986d-393480cd2269.png)

