### PR TITLE
Remove key that users never actually end up seeing.

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -123,7 +123,7 @@ class Registration < ActiveRecord::Base
   validate :user_can_register_for_competition
   private def user_can_register_for_competition
     if user&.cannot_register_for_competition_reasons.present?
-      errors.add(:user_id, I18n.t('registrations.errors.can_register'))
+      errors.add(:user_id, user.cannot_register_for_competition_reasons.to_sentence)
     end
   end
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -552,7 +552,6 @@ en:
       comp_not_found: "Competition not found"
       registration_closed: "Competition registration is closed"
       cannot_be_deleted_and_accepted: "A registration cannot be deleted and accepted at the same time."
-      can_register: "User must be able to register for competition"
       must_register: "must register for at least one event"
     registration_info_people:
       #context: pluralization of "x first-timer(s)"


### PR DESCRIPTION
(Noticed by @claster.)

The relevant code is [here](https://github.com/jfly/worldcubeassociation.org/blob/1a20dad042ffa31c431b68ed59a75de4478bb8d1/WcaOnRails/app/models/registration.rb#L123-L128). This is the message we display when someone attempts to register for a competition but they have not filled out [all the information we require in order to register](https://github.com/jfly/worldcubeassociation.org/blob/1a20dad042ffa31c431b68ed59a75de4478bb8d1/WcaOnRails/app/models/user.rb#L466-L501). In practice, this never actually happens, because [we don't present the user with a registration button](https://github.com/jfly/worldcubeassociation.org/blob/1a20dad042ffa31c431b68ed59a75de4478bb8d1/WcaOnRails/app/views/registrations/register.html.erb#L42) if they aren't allowed to register. However, we still have to enforce this on our backend.

This PR will fail because there are translations still defining this key I deleted. I'm going to take this as an opportunity to address #1161. (edit: this is fixed in #1204, just waiting for that to get merged)