### PR TITLE
Do not allow carriage returns in our codebase.

### DIFF
--- a/config/pre_commit.rb
+++ b/config/pre_commit.rb
@@ -1,6 +1,6 @@
 failed = false
 
-illegal_strs = [ "<" * 3, "\t" ]
+illegal_strs = [ "<" * 3, "\t", "\r" ]
 ARGV.each do |file|
   File.foreach(file).with_index do |line, line_num|
     illegal_strs.each do |illegal_str|


### PR DESCRIPTION
This fixes #1200.

Proof that this does something:

```
~/gitting/worldcubeassociation.org @kaladin> unix2dos WcaOnRails/app/controllers/registrations_controller.rb 
~/gitting/worldcubeassociation.org/WcaOnRails @kaladin> bundle exec pre-commit run git
...
WcaOnRails/app/controllers/registrations_controller.rb:245:60 Found illegal string 
WcaOnRails/app/controllers/registrations_controller.rb:246:6 Found illegal string 
WcaOnRails/app/controllers/registrations_controller.rb:247:4 Found illegal string 

pre-commit: You can bypass this check using `git commit -n`
```