### PR TITLE
Enable mysql slow query log

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -133,7 +133,7 @@ logrotate_app 'delayed_job-wca' do
   options LOGROTATE_OPTIONS
 
   # According to https://groups.google.com/forum/#!topic/railsmachine-moonshine/vrfNwrqmzOA,
-  # it looks like we have to restart delayed job after after logrotate.
+  # it looks like we have to restart delayed job after logrotate.
   postrotate "#{repo_root}/scripts/deploy.sh restart_dj"
 end
 

--- a/chef/site-cookbooks/wca/templates/mysql-wca.cnf.erb
+++ b/chef/site-cookbooks/wca/templates/mysql-wca.cnf.erb
@@ -3,3 +3,9 @@ skip-networking
 
 # compute_auxiliary_data.php needs more than the default 1M
 max_allowed_packet = 16M
+
+# enable slow query log
+slow_query_log = ON
+long_query_time = 10
+slow_query_log_file = '/var/log/mysql/slow.log'
+log_slow_admin_statements = ON


### PR DESCRIPTION
(This fixes #1080.)

The log will be written to `/var/log/mysq/slow.log`.

Here it is in action on staging. I ran `select sleep(15);` to trigger this:

```
~/worldcubeassociation.org/WcaOnRails @staging> sudo tail -f /var/log/mysql/slow.log
/usr/sbin/mysqld, Version: 5.6.33-0ubuntu0.14.04.1-log ((Ubuntu)). started with:
Tcp port: 0  Unix socket: /var/run/mysqld/mysqld.sock
Time                 Id Command    Argument
# Time: 170130  6:59:51
# User@Host: root[root] @ localhost []  Id:     3
# Query_time: 15.000268  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 0
SET timestamp=1485759591;
select sleep(15);
```

```
mysql> show variables like 'long_query_time';
+-----------------+-----------+
| Variable_name   | Value     |
+-----------------+-----------+
| long_query_time | 10.000000 |
+-----------------+-----------+
1 row in set (0.00 sec)

mysql> show global variables like '%slow%';
+---------------------------+-------------------------+
| Variable_name             | Value                   |
+---------------------------+-------------------------+
| log_slow_admin_statements | ON                      |
| log_slow_slave_statements | OFF                     |
| slow_launch_time          | 2                       |
| slow_query_log            | ON                      |
| slow_query_log_file       | /var/log/mysql/slow.log |
+---------------------------+-------------------------+
5 rows in set (0.00 sec)
```

I opted not to set up logrotate, because it looks like a bit of a hassle (see https://oguya.ch/posts/2016-04-13-safely-rotating-mysql-slow-logs/). As @larspetrus said, hopefully we don't log things to this file all that often =)