### PR TITLE
Don't allow BOM markers.

### DIFF
--- a/config/pre_commit.rb
+++ b/config/pre_commit.rb
@@ -1,12 +1,17 @@
 failed = false
 
-illegal_strs = [ "<" * 3, "\t", "\r" ]
+illegal_strs = {
+  ("<" * 3) => "conflict marker",
+  "\t" => "tab",
+  "\r" => "carriage return",
+  "\uFEFF" => "byte order marker (BOM)",
+}
 ARGV.each do |file|
   File.foreach(file).with_index do |line, line_num|
-    illegal_strs.each do |illegal_str|
+    illegal_strs.each do |illegal_str, description|
       index = line.index illegal_str
       if index
-        STDERR.puts "#{file}:#{line_num+1}:#{index+1} Found illegal string #{illegal_str}"
+        STDERR.puts "#{file}:#{line_num+1}:#{index+1} Found illegal string: #{description}"
         failed = true
       end
     end


### PR DESCRIPTION
Also changed pre_commit error messages to make it clearer what went
wrong when invisible characters are found. Printing out the string we
found doesn't really help!
This fixes #1218.