### PR TITLE
Localize Registrations mailer.

### DIFF
--- a/WcaOnRails/app/helpers/mailers_helper.rb
+++ b/WcaOnRails/app/helpers/mailers_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module MailersHelper
+  def localized_mail(locale, headers = {}, &block)
+    I18n.with_locale locale do
+      mail(headers, &block)
+    end
+  end
+end

--- a/WcaOnRails/app/mailers/registrations_mailer.rb
+++ b/WcaOnRails/app/mailers/registrations_mailer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class RegistrationsMailer < ApplicationMailer
+  include MailersHelper
 
   def notify_organizers_of_new_registration(registration)
     @registration = registration
@@ -33,45 +34,33 @@ class RegistrationsMailer < ApplicationMailer
 
   def notify_registrant_of_new_registration(registration)
     @registration = registration
-    I18n.with_locale @registration.user.locale do
-      mail(
-        to: registration.email,
-        reply_to: registration.competition.organizers_or_delegates.map(&:email),
-        subject: I18n.t('registrations.mailer.new.mail_subject', comp_name: registration.competition.name),
-      )
-    end
+    localized_mail @registration.user.locale,
+                   to: registration.email,
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
+                   subject: I18n.t('registrations.mailer.new.mail_subject', comp_name: registration.competition.name)
   end
 
   def notify_registrant_of_accepted_registration(registration)
     @registration = registration
-    I18n.with_locale @registration.user.locale do
-      mail(
-        to: registration.email,
-        reply_to: registration.competition.organizers_or_delegates.map(&:email),
-        subject: I18n.t('registrations.mailer.accepted.mail_subject', comp_name: registration.competition.name),
-      )
-    end
+    localized_mail @registration.user.locale,
+                   to: registration.email,
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
+                   subject: I18n.t('registrations.mailer.accepted.mail_subject', comp_name: registration.competition.name)
   end
 
   def notify_registrant_of_pending_registration(registration)
     @registration = registration
-    I18n.with_locale @registration.user.locale do
-      mail(
-        to: registration.email,
-        reply_to: registration.competition.organizers_or_delegates.map(&:email),
-        subject: I18n.t('registrations.mailer.pending.mail_subject', comp_name: registration.competition.name),
-      )
-    end
+    localized_mail @registration.user.locale,
+                   to: registration.email,
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
+                   subject: I18n.t('registrations.mailer.pending.mail_subject', comp_name: registration.competition.name)
   end
 
   def notify_registrant_of_deleted_registration(registration)
     @registration = registration
-    I18n.with_locale @registration.user.locale do
-      mail(
-        to: registration.email,
-        reply_to: registration.competition.organizers_or_delegates.map(&:email),
-        subject: I18n.t('registrations.mailer.deleted.mail_subject', comp_name: registration.competition.name),
-      )
-    end
+    localized_mail @registration.user.locale,
+                   to: registration.email,
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
+                   subject: I18n.t('registrations.mailer.deleted.mail_subject', comp_name: registration.competition.name)
   end
 end

--- a/WcaOnRails/app/mailers/registrations_mailer.rb
+++ b/WcaOnRails/app/mailers/registrations_mailer.rb
@@ -33,37 +33,45 @@ class RegistrationsMailer < ApplicationMailer
 
   def notify_registrant_of_new_registration(registration)
     @registration = registration
-    mail(
-      to: registration.email,
-      reply_to: registration.competition.organizers_or_delegates.map(&:email),
-      subject: "You have registered for #{registration.competition.name}",
-    )
+    I18n.with_locale @registration.user.locale do
+      mail(
+        to: registration.email,
+        reply_to: registration.competition.organizers_or_delegates.map(&:email),
+        subject: I18n.t('registrations.mailer.new.mail_subject', comp_name: registration.competition.name),
+      )
+    end
   end
 
   def notify_registrant_of_accepted_registration(registration)
     @registration = registration
-    mail(
-      to: registration.email,
-      reply_to: registration.competition.organizers_or_delegates.map(&:email),
-      subject: "Your registration for #{registration.competition.name} has been accepted",
-    )
+    I18n.with_locale @registration.user.locale do
+      mail(
+        to: registration.email,
+        reply_to: registration.competition.organizers_or_delegates.map(&:email),
+        subject: I18n.t('registrations.mailer.accepted.mail_subject', comp_name: registration.competition.name),
+      )
+    end
   end
 
   def notify_registrant_of_pending_registration(registration)
     @registration = registration
-    mail(
-      to: registration.email,
-      reply_to: registration.competition.organizers_or_delegates.map(&:email),
-      subject: "You have been moved to the waiting list for #{registration.competition.name}",
-    )
+    I18n.with_locale @registration.user.locale do
+      mail(
+        to: registration.email,
+        reply_to: registration.competition.organizers_or_delegates.map(&:email),
+        subject: I18n.t('registrations.mailer.pending.mail_subject', comp_name: registration.competition.name),
+      )
+    end
   end
 
   def notify_registrant_of_deleted_registration(registration)
     @registration = registration
-    mail(
-      to: registration.email,
-      reply_to: registration.competition.organizers_or_delegates.map(&:email),
-      subject: "Your registration for #{registration.competition.name} has been deleted",
-    )
+    I18n.with_locale @registration.user.locale do
+      mail(
+        to: registration.email,
+        reply_to: registration.competition.organizers_or_delegates.map(&:email),
+        subject: I18n.t('registrations.mailer.deleted.mail_subject', comp_name: registration.competition.name),
+      )
+    end
   end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -329,6 +329,10 @@ class User < ActiveRecord::Base
     Country.find_by_iso2(country_iso2)
   end
 
+  def locale
+    preferred_locale || I18n.default_locale
+  end
+
   def software_team?
     team_member?('software')
   end

--- a/WcaOnRails/app/views/registrations_mailer/_organizers_or_delegates_signature.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/_organizers_or_delegates_signature.html.erb
@@ -1,3 +1,3 @@
 <p>
-  Regards, <%= users_to_sentence @competition.organizers_or_delegates %>.
+  <%= t 'registrations.mailer.regards', people: users_to_sentence(@competition.organizers_or_delegates) %>
 </p>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_accepted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_accepted_registration.html.erb
@@ -1,12 +1,11 @@
 <% @competition = @registration.competition %>
 
 <p>
-  Your registration for <%= link_to @competition.name, competition_url(@competition) %> has been accepted.
-  As always, you can check the status of your registration <%= link_to "here", competition_register_url(@competition) %>.
+  <%= t 'registrations.mailer.accepted.message_html', comp_name: link_to(@competition.name, competition_url(@competition)), here: link_to(t('common.here'), competition_register_url(@competition)) %>
 </p>
 
 <p>
-  We look forward to seeing you at <%= @competition.name %>!
+  <%= t 'registrations.mailer.accepted.see_you_soon', comp_name: @competition.name %>
 </p>
 
 <%= render partial: 'organizers_or_delegates_signature' %>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
@@ -1,29 +1,29 @@
 <% @competition = @registration.competition %>
 
 <p>
-  Your registration for <%= link_to @competition.name, competition_url(@competition) %> has been deleted. Possible causes are:
+  <%= t 'registrations.mailer.deleted.message_html', comp_name: link_to(@competition.name, competition_url(@competition)) %>
 </p>
 
 <ul>
   <li>
-    You did not submit all the required details
+    <%= t 'registrations.mailer.deleted.causes.missing_info' %>
   </li>
   <li>
-    You asked for withdrawal
+    <%= t 'registrations.mailer.pending.causes.withdrawal' %>
   </li>
   <li>
-    You didn't meet the registration criteria (for example, paying the registration fee in advance)
+    <%= t 'registrations.mailer.deleted.causes.incomplete' %>
   </li>
   <li>
-    The competitor limit has been reached and there are no more spots available
+    <%= t 'registrations.mailer.deleted.causes.registrations_full' %>
   </li>
   <li>
-    You registered twice or more times
+    <%= t 'registrations.mailer.deleted.causes.multiple_registrations' %>
   </li>
 </ul>
 
 <p>
-  If you think this is an error, please reply to this email.
+  <%= t 'registrations.mailer.pending.email_if_error' %>
 </p>
 
 <%= render partial: 'organizers_or_delegates_signature' %>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_new_registration.html.erb
@@ -1,19 +1,15 @@
 <% @competition = @registration.competition %>
 
 <p>
-  You just registered for <%= link_to @competition.name, competition_url(@competition) %>.
+  <%= t 'registrations.mailer.new.registered_html', comp_name: link_to(@competition.name, competition_url(@competition)) %>
 </p>
 
 <p>
-  Your registration is on the waiting list, which currently has <%= @competition.registrations.pending.count %> <%= "person".pluralize(@competition.registrations.pending.count) %> on it.
+  <%= t 'registrations.mailer.new.on_waiting_list', n_total: @competition.registrations.pending.count, people: t('registrations.registration_info_people.person', count: @competition.registrations.pending.count) %>
 </p>
 
 <p>
-  You will be emailed when your registration is approved.
-  Please note that registrations are not automatically approved.
-  To see the approval criteria visit the competition website or contact the organisers.
-  You can also check the status of your registration
-  <%= link_to "here", competition_register_url(@competition) %>.
+  <%= t 'registrations.mailer.new.approval_info_html', here: link_to(t('common.here'), competition_register_url(@competition)) %>
 </p>
 
 <%= render partial: 'organizers_or_delegates_signature' %>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_pending_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_pending_registration.html.erb
@@ -1,20 +1,20 @@
 <% @competition = @registration.competition %>
 
 <p>
-  Your registration for <%= link_to @competition.name, competition_url(@competition) %> has been moved to the waiting list. Possible causes are:
+  <%= t 'registrations.mailer.pending.moved_html', comp_name: link_to(@competition.name, competition_url(@competition)) %>
 </p>
 
 <ul>
   <li>
-    Your registration was accidentally accepted
+    <%= t 'registrations.mailer.pending.causes.accepted' %>
   </li>
   <li>
-    You asked for withdrawal
+    <%= t 'registrations.mailer.pending.causes.withdrawal' %>
   </li>
 </ul>
 
 <p>
-  If you think this is an error, please reply to this email.
+  <%= t 'registrations.mailer.pending.email_if_error' %>
 </p>
 
 <%= render partial: 'organizers_or_delegates_signature' %>

--- a/WcaOnRails/config/environments/development.rb
+++ b/WcaOnRails/config/environments/development.rb
@@ -52,9 +52,9 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   # One can activate/test the fallback to English using :
-  # config.i18n.fallbacks = true
+  config.i18n.fallbacks = true
   # Raises error for missing translations
-  config.action_view.raise_on_missing_translations = true
+  # config.action_view.raise_on_missing_translations = true
 
   config.after_initialize do
     Bullet.enable = true

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -587,6 +587,50 @@ en:
     edit_registration:
       #context: the title for a specific registration to a competition
       title: "%{person} for %{comp}"
+    #context: text appearing in mails sent to competitors during registration
+    mailer:
+      #context: "people" is replaced by the organizers and Delegates' names
+      regards: "Regards, %{people}."
+      #context: for a new registration
+      new:
+        #context: "comp_name" contains the competition's name
+        mail_subject: "You have registered for %{comp_name}"
+        #context: "comp_name" contains the competition's name
+        registered_html: "You just registered for %{comp_name}."
+        #context: "n_total" will be replaced by the total number of registrations on waiting list, and "people" by the pluralization of "person" in your language (key registrations.registration_info_people.person)
+        on_waiting_list: "Your registration is on the waiting list, which currently has %{n_total} %{people} on it."
+        #context: "here" is replaced by a link to view the registration
+        approval_info_html: "You will be emailed when your registration is approved. Please note that registrations are not automatically approved. To see the approval criteria visit the competition website or contact the organisers. You can also check the status of your registration %{here}."
+      #context: when registration is accepted
+      accepted:
+        #context: "comp_name" contains the competition's name
+        mail_subject: "Your registration for %{comp_name} has been accepted"
+        #context: "comp_name" contains the competition's name, and "here" is replaced by a link to edit the registration
+        message_html: "Your registration for %{comp_name} has been accepted. As always, you can check the status of your registration %{here}."
+        #context: "comp_name" contains the competition's name
+        see_you_soon: "We look forward to seeing you at %{comp_name}!"
+      #context: when registration is moved to waiting list
+      pending:
+        #context: "comp_name" contains the competition's name
+        mail_subject: "You have been moved to the waiting list for %{comp_name}"
+        #context: "comp_name" contains the competition's name
+        moved_html: "Your registration for %{comp_name} has been moved to the waiting list. Possible causes are:"
+        #context: this key is one of the reasons explaining why a registration could be moved to the waiting list
+        causes:
+          accepted: "Your registration was accidentally accepted"
+          withdrawal: "You asked for withdrawal"
+        email_if_error: "If you think this is an error, please reply to this email."
+      #context: when registration is deleted
+      deleted:
+        #context: "comp_name" contains the competition's name
+        mail_subject: "Your registration for %{comp_name} has been deleted"
+        message_html: "Your registration for %{comp_name} has been deleted. Possible causes are:"
+        #context: this key is one of the reasons explaining why a registration could be deleted
+        causes:
+          missing_info: "You did not submit all the required details"
+          incomplete: "You didn't meet the registration criteria (for example, paying the registration fee in advance)"
+          registrations_full: "The competitor limit has been reached and there are no more spots available"
+          multiple_registrations: "You registered twice or more times"
     #context: on the registrations list
     list:
       title: "Registrations for %{comp}"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -982,6 +982,32 @@ fr:
     edit_registration:
       #original_hash: 2d15eae
       title: '%{person} pour %{comp}'
+    mailer:
+      regards: "Cordialement, %{people}."
+      new:
+        mail_subject: "Vous êtes inscrit à la compétition %{comp_name}"
+        registered_html: "Vous venez juste de vous inscrire à la compétition %{comp_name}."
+        on_waiting_list: "Votre inscription est en attente, il y a actuellement %{n_total} %{people} en attente."
+        approval_info_html: "Un email vous sera envoyé lorsque votre inscription sera acceptée. Les inscriptions sont approuvées manuellement. Pour voir les conditions d'acceptation des inscriptions, visitez le site internet de la compétition ou contactez les organisateurs. Vous pouvez visualiser l'état de votre inscription %{here}."
+      accepted:
+        mail_subject: "Votre inscription à la compétition %{comp_name} a été acceptée"
+        message_html: "Votre inscription à la compétition %{comp_name} a été acceptée. Comme toujours, vous pouvez vérifier le statut de votre inscription %{here}."
+        see_you_soon: "À bientôt pour le %{comp_name} !"
+      pending:
+        mail_subject: "Votre inscription pour la compétition %{comp_name} a été placée sur liste d'attente"
+        moved_html: "Votre inscription pour la compétition %{comp_name} a été placée sur liste d'attente. Voici une liste de raisons possibles :"
+        causes:
+          accepted: "Votre inscription a été accidentellement acceptée"
+          withdrawal: "Vous avez demandé a être retiré"
+        email_if_error: "Si vous pensez que c'est une erreur, merci de répondre à cet email."
+      deleted:
+        mail_subject: "Votre inscription à la compétition %{comp_name} a été supprimée"
+        message_html: "Votre inscription à la compétition %{comp_name} a été supprimée. Voici une liste de raisons possibles :"
+        causes:
+          missing_info: "Vous n'avez pas indiqué tous les détails demandés"
+          incomplete: "Vous n'avez pas rempli tous les critères d'inscription (comme par exemple payer les frais d'inscription)"
+          registrations_full: "La limite du nombre de compétiteurs a été atteinte et il n'y a plus de place disponible"
+          multiple_registrations: "Vous vous êtes inscrits plusieurs fois"
     list:
       #original_hash: 8b7631c
       title: 'Inscriptions pour %{comp}'


### PR DESCRIPTION
Fixes #1147.

I still need to handle @jfly suggestion about indicating in which locale the mail has been sent, but I think the "big" part is ready for review.

In order to test this quickly I had to turn the `deliver_later` in the whole RegistrationsController like [here](https://github.com/viroulep/worldcubeassociation.org/blob/b651b42c1afdbcf183a4dc2d2d9569be7404ac91/WcaOnRails/app/controllers/registrations_controller.rb#L83) to `deliver_now` (saying this in case someone is willing to pull these changes into their local repo ;))
