### PR TITLE
Remove WCA ID from avatar approval page

### DIFF
--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -20,7 +20,7 @@
       <% @users.each do |user| %>
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title"><%= link_to "#{user.name} (#{user.wca_id})", "/results/p.php?i=#{user.wca_id}" %></h3>
+            <h3 class="panel-title"><%= link_to user.name, edit_user_path(user) %></h3>
           </div>
           <div class="panel-body">
             <div class="row">

--- a/WcaOnRails/spec/mailers/previews/wca_id_claim_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/wca_id_claim_mailer_preview.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 # Preview all emails at http://localhost:3000/rails/mailers/wca_id_claim_mailer
 class WcaIdClaimMailerPreview < ActionMailer::Preview
-
   def notify_delegate_of_wca_id_claim
     ActiveRecord::Base.transaction do
       user_claiming_wca_id = User.where.not(unconfirmed_wca_id: nil).first
@@ -9,4 +8,8 @@ class WcaIdClaimMailerPreview < ActionMailer::Preview
     end
   end
 
+  def notify_user_of_delegate_demotion
+    user_claiming_wca_id = User.where.not(unconfirmed_wca_id: nil).first
+    WcaIdClaimMailer.notify_user_of_delegate_demotion(user_claiming_wca_id, user_claiming_wca_id.delegate_to_handle_wca_id_claim)
+  end
 end


### PR DESCRIPTION
Remove WCA ID from avatar approval page. It doesn't make sense to put a
WCA ID there anyways, as we plan to let people upload profile pictures even
if they don't have a WCA ID yet.

As a side effect, this does fix #1116. I realize this feels like a cop out, but going through our code base and making sure all our names are surrounded in `<bdi>` tags would be a serious effort. More importantly, I don't think there's any good way to make sure that people remember to do so in the future. I think this is a pragmatic solution to our current problem, and *now* I am more supportive of splitting the name field into name and local name.