### PR TITLE
Events associations attribute name i18n.

### DIFF
--- a/WcaOnRails/app/views/competitions/edit_events.html.erb
+++ b/WcaOnRails/app/views/competitions/edit_events.html.erb
@@ -21,7 +21,6 @@
       <% if always_show || !selected_events.empty? %>
         <%= render "shared/associated_events_picker",
           form_builder: f,
-          label: label,
           disabled: disable_form,
           events_association_name: :competition_events, allowed_events: allowed_events,
           selected_events: selected_events %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -1,7 +1,6 @@
 <%#
 Variables:
  - form_builder
- - label
  - disabled
  - events_association_name -> name of the associated events relation
  - allowed_events -> a relation or an Array of Event objects that should be shown (all by default)
@@ -11,10 +10,10 @@ Note: form_builder.object is the object having associated events.
 %>
 
 <%
-  label ||= t('registrations.events')
   disabled ||= false
   allowed_events ||= Event.official
 
+  label = I18n.t("activerecord.attributes.#{form_builder.object.class.name.underscore}.#{events_association_name}")
   using_competition_events = events_association_name == :registration_competition_events
   all_events = form_builder.object.events_to_associated_events(allowed_events)
   errors = form_builder.object.errors.messages[events_association_name] || []

--- a/WcaOnRails/app/views/shared/_error_messages.html.erb
+++ b/WcaOnRails/app/views/shared/_error_messages.html.erb
@@ -5,7 +5,7 @@
       <ul>
         <% f.object.errors.each do |attribute, msg| %>
           <li>
-            <% if f.generated_attribute_inputs.include?(attribute) %>
+            <% if f.generated_attribute_inputs&.include?(attribute) %>
               <a href="#<%= f.id_for(attribute) %>"><strong><%= f.object.class.human_attribute_name(attribute) %></strong></a>
             <% else %>
               <strong><%= f.object.class.human_attribute_name(attribute) %></strong>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -154,7 +154,7 @@
         <%= simple_form_for @user do |f| %>
           <%= hidden_field_tag "section", "preferences" %>
 
-          <%= render "shared/associated_events_picker", form_builder: f, label: t('.preferred_events'), disabled: !editable_fields.include?(:preferred_events),
+          <%= render "shared/associated_events_picker", form_builder: f, disabled: !editable_fields.include?(:preferred_events),
                                                         events_association_name: :user_preferred_events, selected_events: @user.preferred_events %>
           <span class="help-block"><%= t '.preferred_events_desc' %></span>
 

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -114,8 +114,6 @@ ignore_unused:
   - 'continents.*'
   - 'countries.*'
 # - 'simple_form.{placeholders,hints,labels}.*'
-  # Used for displaying an error message for this attribute. i18n-tasks doesn't know about it because we use associated_events_picker
-  - 'activerecord.attributes.registration.registration_competition_events'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -160,13 +160,12 @@ en:
         location_description: "Location description"
         phone_number: "Phone number"
         notes: "Notes"
+        user_preferred_events: "Preferred events"
       #context: a competition
       competition:
         id: "ID"
-
         isConfirmed: "Do not let organizers edit this competition"
         showAtAll: "Make competition visible to the public"
-
         name: "Name"
         cellName: "Competition nickname"
         countryId: "Country"
@@ -174,21 +173,16 @@ en:
         venue: "Venue"
         venueAddress: "Venue address"
         venueDetails: "Venue details"
-
         start_date: "Start date"
         end_date: "End date"
-
         external_website: "Website"
         generate_website: "I would like to use WCA website instead of an external one for additional information."
-
         base_entry_fee_lowest_denomination: "Base entry fee in the lowest denomination"
         currency_code: "Currency code"
-
         delegate_ids: "WCA delegate(s)"
         organizer_ids: "Organizer(s)"
         contact: "Contact"
         information: "Information"
-
         use_wca_registration: "I would like to use the WCA website for registration"
         guests_enabled: "Guests"
         receive_registration_emails: "Notify me by email when someone registers for this competition"
@@ -196,6 +190,7 @@ en:
         registration_close: "Registration close"
         remarks: "Remarks"
         clone_tabs: "I would like to clone all tabs with additional information as well"
+        competition_events: "Events"
       #context: a registration to a competition
       registration:
         guests: "Guests"
@@ -485,7 +480,6 @@ en:
       preferences: "Preferences"
       password: "Password"
       member_of: "Member of"
-      preferred_events: "Preferred events"
       preferred_events_desc: "Selecting your preferred events makes registration for competitions quicker."
       please_fix_profile: "In order to register for competitions, you need to fix the following problems:"
       profile: "Profile"
@@ -543,7 +537,6 @@ en:
       unknown_wca_id_html: "WCA ID %{link_id} does not exist."
   #context: Key used when dealing with registration to a competition
   registrations:
-    events: "Events"
     #context: and when an error is found
     errors:
       need_name: "Need a name"
@@ -670,7 +663,7 @@ en:
     can_register: "You can register for %{comp} below."
     check_registration_information: "Please check the information about registration to find out if you need to do something else, like paying a registration fee."
     have_registered: "You have registered for %{comp}. You can see your registration information below."
-    entry_fee: "The entry fee is %{fee}" 
+    entry_fee: "The entry fee is %{fee}"
     contact_organizer: "Contact the organizer if you wish to make a change."
     waiting_list: "Your registration is pending. For approval, you may need to pay a registration fee. Check the competition website for details."
     accepted: "Your registration has been accepted!"


### PR DESCRIPTION
A general fix for #1153 events association name problem. Now both label and the error massage should be internationalized well for each events relation.