### PR TITLE
Allow delegates to submit delegate reports at any time.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -91,7 +91,7 @@ wca.competitionsToMarkers = function(map, competitions) {
       content: contentString
     });
 
-    if (c.is_over) {
+    if (c.is_probably_over) {
       iconImage = 'https://maps.google.com/mapfiles/ms/icons/blue.png';
     } else {
       iconImage = 'https://maps.google.com/mapfiles/ms/icons/red.png';

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -439,7 +439,7 @@ class CompetitionsController < ApplicationController
       competitions += current_user.person.competitions
     end
     competitions = competitions.uniq.sort_by { |comp| comp.start_date || Date.today + 20.year }.reverse
-    @past_competitions, @not_past_competitions = competitions.partition(&:is_over?)
+    @past_competitions, @not_past_competitions = competitions.partition(&:is_probably_over?)
   end
 
   private def competition_params

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -175,7 +175,7 @@ class Competition < ActiveRecord::Base
   end
 
   def user_should_post_delegate_report?(user)
-    persisted? && delegate_report.can_be_posted? && !delegate_report.posted? && delegates.include?(user)
+    persisted? && is_over? && !delegate_report.posted? && delegates.include?(user)
   end
 
   def warnings_for(user)

--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -34,17 +34,6 @@ Gen 3 Display: 0"
     end
   end
 
-  validate :only_post_after_competition
-  def only_post_after_competition
-    if posted? && !can_be_posted?
-      errors.add(:posted, "cannot be posted yet")
-    end
-  end
-
-  def can_be_posted?
-    competition.is_over?
-  end
-
   def posted?
     !!posted_at
   end

--- a/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
@@ -53,7 +53,7 @@
                 report_class = report_and_results_class(days_report)
                 report_content = "#{pluralize(days_report, "day")} after"
               else
-                if competition.is_over?
+                if competition.is_probably_over?
                   days_report = (Date.today - competition.end_date).to_i
                   report_class = report_and_results_class(days_report)
                   report_content = "pending"
@@ -66,7 +66,7 @@
                results_class = report_and_results_class(days_results)
                results_content = "#{pluralize(days_results, "day")} after"
               else
-                if competition.is_over?
+                if competition.is_probably_over?
                   days_results = (Date.today - competition.end_date).to_i
                   results_class = report_and_results_class(days_results)
                   results_content = "pending"

--- a/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
@@ -36,7 +36,7 @@
           longitude_degrees: c.longitude_degrees,
           cityName: c.cityName,
           marker_date: c.start_date.to_formatted_s(:long),
-          is_over: c.is_over?,
+          is_probably_over: c.is_probably_over?,
           url: competition_path(c),
         }
       end.to_json.html_safe %>;

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -4,9 +4,9 @@
     <% if index > 0 && competition.year != competitions[index - 1].year && params[:event_ids].empty? %>
       <li class="list-group-item break"><%= competition.year %></li>
     <% end %>
-    <li class="list-group-item <%= competition.is_over? ? "past" : "not-past" %>">
+    <li class="list-group-item <%= competition.is_probably_over? ? "past" : "not-past" %>">
       <span class="date">
-        <% if competition.is_over? %>
+        <% if competition.is_probably_over? %>
           <% if competition.results_posted? %>
             <%= icon('check-circle', title: t('competitions.index.tooltips.hourglass.posted'), class: "results-posted-indicator", data: { toggle: "tooltip" }) %>
           <% else %>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -55,7 +55,7 @@
               <% if current_user.can_edit_delegate_report?(competition.delegate_report) %>
                 <%= link_to icon('pencil-square-o'), delegate_report_edit_path(competition), title: t('.edit_report'), 'data-toggle': 'tooltip' %>
               <% end %>
-              <% if competition.is_over? && competition.delegates.include?(current_user) && !competition.delegate_report.posted? %>
+              <% if competition.user_should_post_delegate_report?(current_user) %>
                 <%= icon('warning', title: t('.missing_report'), 'data-toggle': 'tooltip') %>
               <% end %>
             </td>

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -20,7 +20,7 @@
 
     <%= f.button :submit, class: "btn-primary" %>
     <% is_actually_posted = DelegateReport.find(@delegate_report).posted? %>
-    <% if @delegate_report.can_be_posted? && !is_actually_posted %>
+    <% if !is_actually_posted %>
       <%= button_tag(type: 'submit',
                      name: "delegate_report[posted]",
                      value: true,

--- a/WcaOnRails/app/views/delegates/stats.html.erb
+++ b/WcaOnRails/app/views/delegates/stats.html.erb
@@ -18,7 +18,7 @@
     </thead>
     <tbody>
       <% @delegates.each do |delegate| %>
-        <% competitions = delegate.delegated_competitions.order(:year, :month, :day).select(&:is_over?) %>
+        <% competitions = delegate.delegated_competitions.order(:year, :month, :day).select(&:is_probably_over?) %>
         <tr class="<%= delegate.delegate_status %>">
           <td class="delegate"><%= delegate.name %></td>
           <td class="position"><%= delegate.delegate_status.humanize %></td>

--- a/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
@@ -54,11 +54,12 @@ describe DelegateReportsController do
       expect(comp.delegate_report.remarks).to eq "My new remarks"
     end
 
-    it "can edit report before comp is over, and can post report" do
+    it "can edit and post report before comp is over" do
       # Update comp to be in the future.
       comp.start_date = 1.day.from_now.strftime("%F")
       comp.end_date = 1.day.from_now.strftime("%F")
       comp.save!
+      expect(comp.is_probably_over?).to eq false
 
       post :update, competition_id: comp.id, delegate_report: { remarks: "My new remarks", posted: false }
       comp.reload

--- a/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
@@ -54,7 +54,7 @@ describe DelegateReportsController do
       expect(comp.delegate_report.remarks).to eq "My new remarks"
     end
 
-    it "can edit report before comp is over, but cannot post report" do
+    it "can edit report before comp is over, and can post report" do
       # Update comp to be in the future.
       comp.start_date = 1.day.from_now.strftime("%F")
       comp.end_date = 1.day.from_now.strftime("%F")
@@ -67,8 +67,8 @@ describe DelegateReportsController do
 
       post :update, competition_id: comp.id, delegate_report: { remarks: "My newer remarks", posted: true }
       comp.reload
-      expect(comp.delegate_report.remarks).to eq "My new remarks"
-      expect(comp.delegate_report.posted?).to eq false
+      expect(comp.delegate_report.remarks).to eq "My newer remarks"
+      expect(comp.delegate_report.posted?).to eq true
     end
 
     it "can post report and cannot edit report if it's posted" do

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Competition do
   it "handles missing start/end_date" do
     competition = FactoryGirl.build :competition, start_date: nil, end_date: nil
     competition2 = FactoryGirl.build :competition, start_date: nil, end_date: nil
-    expect(competition.is_over?).to be false
+    expect(competition.is_probably_over?).to be false
     expect(competition.started?).to be false
     expect(competition.in_progress?).to be false
     expect(competition.dangerously_close_to?(competition2)).to be false
@@ -213,7 +213,7 @@ RSpec.describe Competition do
     it "displays info if competition is finished but results aren't posted" do
       competition = FactoryGirl.build :competition, starts: 1.month.ago
       expect(competition).to be_valid
-      expect(competition.is_over?).to be true
+      expect(competition.is_probably_over?).to be true
       expect(competition.results_posted?).to be false
       expect(competition.info_for(nil)[:upload_results]).to eq "This competition is over, we are working to upload the results as soon as possible!"
     end


### PR DESCRIPTION
See discussion here: https://github.com/thewca/worldcubeassociation.org/pull/1206/files#r98485399.

Also renamed `Competition.is_over?` to `Competition.is_probably_over?`.

This fixes #737.