### PR TITLE
Use default currency if it's empty

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -109,7 +109,8 @@ class Registration < ActiveRecord::Base
   def paid_entry_fees
     Money.new(
       registration_payments.sum(:amount_lowest_denomination),
-      competition.currency_code,
+      # FIXME: see https://github.com/thewca/worldcubeassociation.org/issues/1257
+      (competition.currency_code.blank? ? Money.default_currency : competition.currency_code),
     )
   end
 


### PR DESCRIPTION
Quickfix for #1257.

It's messing up an important number of competitions' registrations list, so merging this asap.