### PR TITLE
When a missing interpolation key is found for a non :en locale, don't raise an error.

### DIFF
--- a/WcaOnRails/config/initializers/i18n_ignore_missing_interpolation_argument.rb
+++ b/WcaOnRails/config/initializers/i18n_ignore_missing_interpolation_argument.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+I18n.config.missing_interpolation_argument_handler = lambda do |missing_key, provided_hash, string|
+  if I18n.locale == :en
+    # We only want to raise exceptions for English. This allows development to continue
+    # in English, without being held up by slow translations.
+    #  https://github.com/thewca/worldcubeassociation.org/issues/1259
+    fail MissingInterpolationArgument.new(missing_key, provided_hash, string)
+  else
+    "UNKNOWN_INTERPOLATION_KEY_FOUND_IN_TRANSLATION (#{missing_key})"
+  end
+end


### PR DESCRIPTION
Instead, just report it missing. This fixes #1259.

Some digging led me to this handy [`missing_interpolation_argument_handler=` method](https://github.com/svenfuchs/i18n/blob/v0.7.0/lib/i18n/config.rb#L107), called from [here](https://github.com/svenfuchs/i18n/blob/v0.7.0/lib/i18n/interpolate/ruby.rb#L29).

## Testing it out

With this change:

```
~/gitting/worldcubeassociation.org/WcaOnRails @kaladin> git diff
diff --git a/WcaOnRails/config/locales/en.yml b/WcaOnRails/config/locales/en.yml
index cb2815ef..6bbb50ad 100644
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -683,7 +683,7 @@ en:
       create_success: "Successfully created new competition!"
       results_preview_alert: "You are viewing results that have not been posted yet."
       upload_results: "This competition is over, we are working to upload the results as soon as possible!"
-      in_progress: "This competition is ongoing. Come back after %{date} to see the results!"
+      in_progress: "This competition is ongoing. %{jeremytest} Come back after %{date} to see the results!"
       tooltip_registered: "You are registered."
       tooltip_waiting_list: "You are currently on the waiting list."
       confirmed_visible: "This competition is confirmed and visible"
diff --git a/WcaOnRails/config/locales/es.yml b/WcaOnRails/config/locales/es.yml
index b1cc7c88..9add245c 100644
--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -1224,7 +1224,7 @@ es:
         sus resultados cuanto antes.
       #original_hash: a0168ee
       in_progress: >-
-        Esta competición se está celebrando ahora. Vuelve después de %{date}
+        Esta competición se está celebrando ahora. %{jeremytest} Vuelve después de %{date}
         para consultar sus resultados.
       #original_hash: 3322400
       tooltip_registered: Estás registrado.
```

### I see the following in Spanish:

![image](https://cloud.githubusercontent.com/assets/277474/22563788/e5869eba-e936-11e6-94d9-74c3390199d4.png)

### But it still crashes in English (as desired):

![image](https://cloud.githubusercontent.com/assets/277474/22563802/f0d57df4-e936-11e6-8937-093954a06283.png)
