### PR TITLE
Trick to avoid a warning in i18n-tasks

### DIFF
--- a/WcaOnRails/app/views/static_pages/faq.html.erb
+++ b/WcaOnRails/app/views/static_pages/faq.html.erb
@@ -29,13 +29,13 @@ faq_variables = {
   %>
   <% @answers_markup = capture do %>
     <ul id="faq-list" class="list-group">
-
-
+      <% answers_in_english = t("faq.answers", locale: :en) %>
+      <% localized_answers = t("faq.answers") %>
       <% # We want to iterate through the *English* entries: so that if the translation doesn't have it, it will fall back to English. %>
-      <% t('faq.answers', locale: :en).each do |key, faq| %>
+      <% answers_in_english.deep_merge(localized_answers).each do |key, value| %>
         <% # We include the original question in English so that the anchors (and urls!) stay the same across languages. %>
-        <%= add_answer({ question: t("faq.answers.#{key}.title"), original_question: faq[:title] }) do %>
-          <% t("faq.answers.#{key}.content").values.each do |paragraph| %>
+        <%= add_answer({ question: value[:title], original_question: answers_in_english[key][:title] }) do %>
+          <% value[:content].values.each do |paragraph| %>
             <p>
               <%= raw paragraph % faq_variables %>
             </p>


### PR DESCRIPTION
Fixes #1176.

@jfly interestingly, adding the key to the ignored keys doesn't work!
I tried ignoring both `faq.answers`, `faq.answers.*`, and even `faq.*`, but the warning was still present...

I found a way to trick `i18n-tasks` out of this warning, but I don't like the idea of modifying our code to "fix" a warning that should be ignored...

Not sure why `i18n-tasks` is behaving like that; I'd guess it has something to do with the fact that we don't use a direct child of `faq.answers`.
For the record I also tried ignoring `faq.answers.*.{title,content}` without success.