### PR TITLE
Use the Unicode Collation Algorithm to do a locale aware string sort.

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -68,6 +68,7 @@ gem 'delayed_job_active_record'
 gem 'daemons'
 gem 'i18n-country-translations'
 gem 'http_accept_language'
+gem 'twitter_cldr'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     byebug (9.0.6)
     call_with_params (0.0.2)
       activesupport (>= 3.0.0)
+    camertron-eprun (1.1.1)
     capybara (2.12.0)
       addressable
       mime-types (>= 1.16)
@@ -131,6 +132,7 @@ GEM
       activesupport (>= 3.2.0)
       json (>= 1.7)
       mime-types (>= 1.16)
+    cldr-plurals-runtime-rb (1.0.1)
     cliver (0.3.2)
     cocoon (1.2.9)
     coderay (1.1.1)
@@ -467,6 +469,10 @@ GEM
     time_will_tell (0.1.0)
       railties (>= 3.2)
     tins (1.13.2)
+    twitter_cldr (4.2.0)
+      camertron-eprun
+      cldr-plurals-runtime-rb (~> 1.0)
+      tzinfo
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.4)
@@ -572,6 +578,7 @@ DEPENDENCIES
   test_after_commit
   therubyracer
   time_will_tell
+  twitter_cldr
   uglifier
   unicorn
   valid_email

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -18,10 +18,12 @@ class Continent < ActiveRecord::Base
   end
 
   ALL_CONTINENTS_WITH_NAME_AND_ID_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    [locale, Continent.all.map do |country|
+    continents = Country.localized_sort_by!(locale, Continent.all.map do |country|
       # We want a localized continent name, but a constant id across languages
       [country.name_in(locale), country.id]
       # Now we want to sort continents according to their localized name
-    end.sort!(&Country::COMPARE_LOCALIZED_NAMES.curry[locale])]
+    end) { |localized_name, _id| localized_name }
+
+    [locale, continents]
   end].freeze
 end

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -24,27 +24,54 @@ class Country < ActiveRecord::Base
     c_all_by_id.values.select { |c| c.iso2 == iso2 }.first
   end
 
-  COMPARE_LOCALIZED_NAMES = lambda do |locale, a, b|
-    # We have transformations to apply on the names before we compare them,
-    # they depend on the locale, and the default is to transliterate them.
-    name_a, name_b = if locale == :"zh-CN"
-                       [a.first.encode(Encoding::GBK), b.first.encode(Encoding::GBK)]
-                     else
-                       # We transliterate names so that country/continents starting with accent
-                       # don't end up at the very bottom of the list because of the accents
-                       [I18n.transliterate(a.first), I18n.transliterate(b.first)]
-                     end
-    name_a <=> name_b
+  def self.localized_sort_by!(wca_locale, array, &block)
+    # Unfortunately, it looks like the set of languages supported by
+    # twitter-cldr-rb is not exactly the same as the languages we support, so I
+    # had to add special mappings for pt-BR, zh-CN, and zh-TW.
+
+    # https://www.w3.org/International/articles/language-tags/ says:
+    # "Although for common uses of language tags it is not likely that you will need
+    # to specify the script, there are one or two situations that have been
+    # crying out for it for some time. One such example is Chinese. There are
+    # many Chinese dialects, often mutually unintelligible, but these dialects
+    # are all written using either Simplified or Traditional Chinese script.
+    # People typically want to label Chinese text as either Simplified or
+    # Traditional, but until recently there was no way to do so. People had to
+    # bend something like zh-CN (meaning Chinese as spoken in China) to mean
+    # Simplified Chinese, even in Singapore, and zh-TW (meaning Chinese as
+    # spoken in Taiwan) for Traditional Chinese. (Other people, however, use
+    # zh-HK for Traditional Chinese.) The availability of zh-Hans and zh-Hant
+    # for Chinese written in Simplified and Traditional scripts should improve
+    # consistency and accuracy, and is already becoming widely used, although
+    # of course you may need to continue to use the old language tags in some
+    # cases for consistency."
+
+    # So it is tempting to say that we should rename our locales as follows:
+    # zh-CN -> zh-Hans and zh-Tw -> zh-Hant
+
+    # However, Devise and Rails contain a lot of translations we use, and they
+    # also use zh-CN and zh-TW, so we probably want to stick with those.
+
+    cldr_locale = {
+      'pt-BR': 'pt',
+      'zh-CN': 'zh',
+      'zh-TW': 'zh-Hant',
+    }.fetch(wca_locale, wca_locale)
+    collator = TwitterCldr::Collation::Collator.new(cldr_locale)
+
+    array.sort_by! { |element| collator.get_sort_key(block.call(element)) }
   end
 
   ALL_COUNTRIES_WITH_NAME_AND_ID_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    [locale, Country.all.map do |country|
+    countries = localized_sort_by!(locale, Country.all.map do |country|
       # We want a localized country name, but a constant id across languages
       # NOTE: it means "search" will behave weirdly as it still searches by English
       # name (eg: searching for "Tunisie" in French won't match competitions in
       # "Tunisia" even if the country displayed is actually "Tunisie"...)
       [country.name_in(locale), country.id]
       # Now we want to sort countries according to their localized name
-    end.sort!(&COMPARE_LOCALIZED_NAMES.curry[locale])]
+    end) { |localized_name, _id| localized_name }
+
+    [locale, countries]
   end].freeze
 end


### PR DESCRIPTION
This should sort traditional Chinese correctly, and hopefully any future languages we run into.

Unfortunately, it looks like the [set of languages supported by twitter-cldr-rb](https://github.com/twitter/twitter-cldr-rb/tree/master/resources/collation/tailoring) is not exactly the same as the languages we support, so I had to add special mappings for `pt-BR`, `zh-CN`, and `zh-TW`.

https://www.w3.org/International/articles/language-tags/ says:

> Although for common uses of language tags it is not likely that you will need to specify the script, there are one or two situations that have been crying out for it for some time. One such example is Chinese. There are many Chinese dialects, often mutually unintelligible, but these dialects are all written using either Simplified or Traditional Chinese script. People typically want to label Chinese text as either Simplified or Traditional, but until recently there was no way to do so. People had to bend something like zh-CN (meaning Chinese as spoken in China) to mean Simplified Chinese, even in Singapore, and zh-TW (meaning Chinese as spoken in Taiwan) for Traditional Chinese. (Other people, however, use zh-HK for Traditional Chinese.) The availability of zh-Hans and zh-Hant for Chinese written in Simplified and Traditional scripts should improve consistency and accuracy, and is already becoming widely used, although of course you may need to continue to use the old language tags in some cases for consistency.

So maybe our translations should actually be renamed as follows: `zh-CN -> zh-Hans` and `zh-Tw -> zh-Hant`?