### PR TITLE
More complete check before assigning someone a WCA ID.

### DIFF
--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -101,6 +101,16 @@ class Person < ActiveRecord::Base
     end
   end
 
+  # Note this is very similar to the cannot_register_for_competition_reasons method in user.rb.
+  def cannot_be_assigned_to_user_reasons
+    [].tap do |reasons|
+      reasons << I18n.t('users.errors.wca_id_no_name_html') if name.blank?
+      reasons << I18n.t('users.errors.wca_id_no_gender_html') if gender.blank?
+      reasons << I18n.t('users.errors.wca_id_no_birthdate_html') if dob.blank?
+      reasons << I18n.t('users.errors.wca_id_no_citizenship_html') if country_iso2.blank?
+    end
+  end
+
   def likely_delegates
     all_delegates = competitions.order(:year, :month, :day).map(&:delegates).flatten.select(&:any_kind_of_delegate?)
     if all_delegates.empty?

--- a/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
+++ b/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
@@ -10,11 +10,12 @@
   </p>
 <% elsif !@user.unconfirmed_person.dob %>
   <p>
-  <%= t '.missing_dob_html', link_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank"), link_result_team: mail_to("results@worldcubeassociation.org", "Results team", target: "_blank") %>
+    <%= t '.missing_dob_html', link_id: render("shared/wca_id", wca_id: @user.unconfirmed_wca_id, target: "_blank") %>
+    <%= t '.contact_results_team_html' %>
   </p>
 <% else %>
   <p>
-  <%= t '.select_delegate_html', link_delegate: delegates_path %>
+    <%= t '.select_delegate_html', link_delegate: delegates_path %>
   </p>
 
   <div class="form-group radio_buttons optional">

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -523,6 +523,9 @@ en:
       senior_has_delegate: "cannot demote senior delegate with subordinate delegates"
       already_have_id: "cannot claim a WCA ID because you already have WCA ID %{wca_id}"
       wca_id_no_birthdate_html: "We do not have a birthdate recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> with a photo of any legal document (ID card, driver license, etc) where your name and date of birth are visible."
+      wca_id_no_gender_html: "We do not have a gender recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
+      wca_id_no_citizenship_html: "We do not have a citizenship recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
+      wca_id_no_name_html: "We do not have a name recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
       board_member_cannot_resign: "You cannot resign from your role as a board member! Find another board member to fire you."
       avatar_requires_wca_id: "requires a WCA ID to be assigned"
     #context: when an action was successful
@@ -534,7 +537,8 @@ en:
     select_nearby_delegate:
       select_delegate_html: "In order to assign you your WCA ID, we need a <a href='%{link_delegate}' target='_blank'>WCA delegate</a> to confirm your identify. Please enter your birthdate and select the delegate you think knows you best."
       already_assigned_html: "WCA ID %{link_id} is already assigned to a different account. If you believe this was done in error, contact your local <a href='%{link_delegate}' target='_blank'>WCA delegate</a>."
-      missing_dob_html: "WCA ID %{link_id} does not have a birthdate assigned. Please contact the %{link_result_team} to fix this."
+      missing_dob_html: "WCA ID %{link_id} does not have a birthdate assigned."
+      contact_results_team_html: "Please contact the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
       unknown_wca_id_html: "WCA ID %{link_id} does not exist."
   #context: Key used when dealing with registration to a competition
   registrations:

--- a/WcaOnRails/spec/factories/persons.rb
+++ b/WcaOnRails/spec/factories/persons.rb
@@ -21,6 +21,10 @@ FactoryGirl.define do
       day 0
     end
 
+    trait :missing_gender do
+      gender ""
+    end
+
     factory :person_with_multiple_sub_ids do
       after(:create) do |person|
         person.update_using_sub_id!(name: "new #{person.name}")

--- a/WcaOnRails/spec/features/claim_wca_id_spec.rb
+++ b/WcaOnRails/spec/features/claim_wca_id_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Claim WCA ID" do
       # Select item with selectize.
       page.find("div.user_unconfirmed_wca_id input").native.send_key(:return)
 
-      expect(page.find("#select-nearby-delegate-area")).to have_content "WCA ID #{person_without_dob.wca_id} does not have a birthdate assigned. Please contact the Results team to fix this."
+      expect(page.find("#select-nearby-delegate-area")).to have_content "WCA ID #{person_without_dob.wca_id} does not have a birthdate assigned. Please contact the WCA Results Team to resolve this."
     end
   end
 end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe User, type: :model do
   describe "WCA ID" do
     let(:user) { FactoryGirl.create :user_with_wca_id }
     let(:birthdayless_person) { FactoryGirl.create :person, :missing_dob }
+    let(:genderless_person) { FactoryGirl.create :person, :missing_gender }
 
     it "validates WCA ID" do
       user = FactoryGirl.build :user, wca_id: "2005FLEI02"
@@ -153,6 +154,12 @@ RSpec.describe User, type: :model do
       user.wca_id = birthdayless_person.wca_id
       expect(user).to be_invalid
       expect(user.errors.messages[:wca_id]).to eq [ I18n.t('users.errors.wca_id_no_birthdate_html') ]
+    end
+
+    it "does not allow assigning a genderless WCA ID to a user" do
+      user.wca_id = genderless_person.wca_id
+      expect(user).to be_invalid
+      expect(user.errors.messages[:wca_id]).to eq [ I18n.t('users.errors.wca_id_no_gender_html') ]
     end
 
     it "nullifies empty WCA IDs" do


### PR DESCRIPTION
See #1174 and #1173, which only checked for birthdates, but we also care about name, citizenship, and gender. I think that in practice, we'll never have missing names or citizenships, but I don't know if our php admin scripts actually check for that.

Please note, this does not require someone to identify as "male" or "female", that's what our "other" option is for.