### PR TITLE
Localize mail subject according to user's locale

### DIFF
--- a/WcaOnRails/app/helpers/mailers_helper.rb
+++ b/WcaOnRails/app/helpers/mailers_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module MailersHelper
-  def localized_mail(locale, headers = {}, &block)
+  def localized_mail(locale, subject_lambda, headers = {}, &block)
     I18n.with_locale locale do
+      headers[:subject] = subject_lambda.call
       mail(headers, &block)
     end
   end

--- a/WcaOnRails/app/mailers/registrations_mailer.rb
+++ b/WcaOnRails/app/mailers/registrations_mailer.rb
@@ -35,32 +35,32 @@ class RegistrationsMailer < ApplicationMailer
   def notify_registrant_of_new_registration(registration)
     @registration = registration
     localized_mail @registration.user.locale,
+                   -> { I18n.t('registrations.mailer.new.mail_subject', comp_name: registration.competition.name) },
                    to: registration.email,
-                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
-                   subject: I18n.t('registrations.mailer.new.mail_subject', comp_name: registration.competition.name)
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email)
   end
 
   def notify_registrant_of_accepted_registration(registration)
     @registration = registration
     localized_mail @registration.user.locale,
+                   -> { I18n.t('registrations.mailer.accepted.mail_subject', comp_name: registration.competition.name) },
                    to: registration.email,
-                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
-                   subject: I18n.t('registrations.mailer.accepted.mail_subject', comp_name: registration.competition.name)
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email)
   end
 
   def notify_registrant_of_pending_registration(registration)
     @registration = registration
     localized_mail @registration.user.locale,
+                   -> { I18n.t('registrations.mailer.pending.mail_subject', comp_name: registration.competition.name) },
                    to: registration.email,
-                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
-                   subject: I18n.t('registrations.mailer.pending.mail_subject', comp_name: registration.competition.name)
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email)
   end
 
   def notify_registrant_of_deleted_registration(registration)
     @registration = registration
     localized_mail @registration.user.locale,
+                   -> { I18n.t('registrations.mailer.deleted.mail_subject', comp_name: registration.competition.name) },
                    to: registration.email,
-                   reply_to: registration.competition.organizers_or_delegates.map(&:email),
-                   subject: I18n.t('registrations.mailer.deleted.mail_subject', comp_name: registration.competition.name)
+                   reply_to: registration.competition.organizers_or_delegates.map(&:email)
   end
 end

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -53,6 +53,12 @@ FactoryGirl.define do
       end
     end
 
+    trait :french_locale do
+      after(:create) do |user|
+        user.preferred_locale = :fr
+      end
+    end
+
     wca_id { person&.wca_id }
 
     factory :user_with_wca_id, traits: [:wca_id]


### PR DESCRIPTION
I noticed this bug in one competitor's mail to software, mail subject is actually translated in organizer/delegate's locale!

An alternative fix would be to put `locale: @registration.user.locale` at the end of the `subject:`, but that felt a bit awkward since we do a `with_locale` in the called function.