### PR TITLE
Refunds now have a reference to the original payment - fixes #1264

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -245,7 +245,7 @@ class RegistrationsController < ApplicationController
       refund.amount,
       refund.currency,
       refund.id,
-      refund.charge,
+      payment.id,
     )
 
     flash[:success] = 'Payment was refunded'

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -126,16 +126,18 @@ class Registration < ActiveRecord::Base
     )
   end
 
-  def record_refund(amount, currency_code, stripe_refund_id, stripe_charge_id)
+  def record_refund(
+    amount,
+    currency_code,
+    stripe_refund_id,
+    refunded_registration_payment_id
+  )
     registration_payments.create!(
       amount_lowest_denomination: amount * -1,
       currency_code: currency_code,
       stripe_charge_id: stripe_refund_id,
-      refunded_at: Time.now,
+      refunded_registration_payment_id: refunded_registration_payment_id,
     )
-    payment = RegistrationPayment.find_by_stripe_charge_id(stripe_charge_id)
-    payment.refunded_at = Time.now
-    payment.save!
   end
 
   # Since Registration.events only includes saved events

--- a/WcaOnRails/app/models/registration_payment.rb
+++ b/WcaOnRails/app/models/registration_payment.rb
@@ -6,4 +6,8 @@ class RegistrationPayment < ActiveRecord::Base
            as: "amount",
            allow_nil: true,
            with_model_currency: :currency_code
+
+  def amount_available_for_refund
+    amount_lowest_denomination + RegistrationPayment.where(refunded_registration_payment_id: id).sum("amount_lowest_denomination")
+  end
 end

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -39,7 +39,7 @@
         <p>
           <%= wca_local_time(payment.created_at) %>
           <%= humanized_money_with_symbol payment.amount %>
-          <% if payment.refunded_at.nil? %>
+          <% if payment.amount_available_for_refund > 0 %>
             <%= form_tag registration_payment_refund_path(@registration, payment), method: :post do %>
               <%= submit_tag t('registrations.refund'), class: "btn btn-warning" %>
             <% end %>

--- a/WcaOnRails/db/migrate/20170212005142_modify_registration_payments_for_partial_refunds.rb
+++ b/WcaOnRails/db/migrate/20170212005142_modify_registration_payments_for_partial_refunds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class ModifyRegistrationPaymentsForPartialRefunds < ActiveRecord::Migration
+  def change
+    add_column :registration_payments, :refunded_registration_payment_id, :int
+    remove_column :registration_payments, :refunded_at, :datetime
+
+    add_index :registration_payments, :refunded_registration_payment_id, name: "idx_reg_payments_on_refunded_registration_payment_id"
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -777,12 +777,13 @@ CREATE TABLE `registration_payments` (
   `amount_lowest_denomination` int(11) DEFAULT NULL,
   `currency_code` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `stripe_charge_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `refunded_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
+  `refunded_registration_payment_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `index_registration_payments_on_stripe_charge_id` (`stripe_charge_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=37 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  KEY `index_registration_payments_on_stripe_charge_id` (`stripe_charge_id`),
+  KEY `idx_reg_payments_on_refunded_registration_payment_id` (`refunded_registration_payment_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1202,3 +1203,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161226223701');
 INSERT INTO schema_migrations (version) VALUES ('20161227202950');
 
 INSERT INTO schema_migrations (version) VALUES ('20170121202850');
+
+INSERT INTO schema_migrations (version) VALUES ('20170212005142');


### PR DESCRIPTION
When a refund is created, it stores the original Stripe charge id.
This will enable for partial refunds and the calculation of how much
has been refunded for a particular payment to date.