### PR TITLE
Competition date fields

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -85,9 +85,9 @@ class CompetitionsController < ApplicationController
     if @present_selected
       @competitions = @competitions.not_over
     elsif @recent_selected
-      @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) between ? and ?", (Date.today - Competition::RECENT_DAYS), Date.today).reverse_order
+      @competitions = @competitions.where("end_date between ? and ?", (Date.today - Competition::RECENT_DAYS), Date.today).reverse_order
     else
-      @competitions = @competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) < ?", Date.today).reverse_order
+      @competitions = @competitions.where("end_date < ?", Date.today).reverse_order
       unless params[:year] == "all years"
         @competitions = @competitions.where(year: params[:year])
       end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -27,7 +27,7 @@ class Competition < ApplicationRecord
            allow_nil: true,
            with_model_currency: :currency_code
 
-  scope :not_over, -> { where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Datetime) >= ?", Date.today) }
+  scope :not_over, -> { where("end_date >= ?", Date.today) }
   scope :belongs_to_region, lambda { |region_id|
     joins(:country).where(
       "countryId = :region_id OR Countries.continentId = :region_id", region_id: region_id
@@ -545,7 +545,7 @@ class Competition < ApplicationRecord
   end
 
   def nearby_competitions(days, distance)
-    Competition.where("ABS(DATEDIFF(?, CONCAT(year, '-', month, '-', day))) <= ? AND id <> ?", start_date, days, id)
+    Competition.where("ABS(DATEDIFF(?, start_date)) <= ? AND id <> ?", start_date, days, id)
                .select { |c| kilometers_to(c) <= distance }
                .sort_by { |c| kilometers_to(c) }
   end
@@ -760,7 +760,7 @@ class Competition < ApplicationRecord
       if !start_date
         raise WcaExceptions::BadApiParameter.new("Invalid start: '#{params[:start]}'")
       end
-      competitions = competitions.where("CAST(CONCAT(year,'-',month,'-',day) as Date) >= ?", start_date)
+      competitions = competitions.where("start_date >= ?", start_date)
     end
 
     if params[:end].present?
@@ -768,7 +768,7 @@ class Competition < ApplicationRecord
       if !end_date
         raise WcaExceptions::BadApiParameter.new("Invalid end: '#{params[:end]}'")
       end
-      competitions = competitions.where("CAST(CONCAT(endYear,'-',endMonth,'-',endDay) as Date) <= ?", end_date)
+      competitions = competitions.where("end_date <= ?", end_date)
     end
 
     query&.split&.each do |part|

--- a/WcaOnRails/db/migrate/20170215221832_add_proper_date_fields_to_competition.rb
+++ b/WcaOnRails/db/migrate/20170215221832_add_proper_date_fields_to_competition.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class AddProperDateFieldsToCompetition < ActiveRecord::Migration
+  def up
+    add_column :Competitions, :start_date, :date
+    add_index :Competitions, :start_date
+    add_column :Competitions, :end_date, :date
+    add_index :Competitions, :end_date
+
+    execute <<-SQL
+      UPDATE Competitions SET start_date=CONCAT(year, '-', month, '-', day) WHERE year != 0 AND month != 0 AND day != 0;
+    SQL
+
+    execute <<-SQL
+      UPDATE Competitions SET end_date=CONCAT(endYear, '-', endMonth, '-', endDay) WHERE endYear != 0 AND endMonth != 0 AND endDay != 0;
+    SQL
+  end
+
+  def down
+    remove_column :Competitions, :end_date
+    remove_column :Competitions, :start_date
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -54,11 +54,15 @@ CREATE TABLE `Competitions` (
   `announced_at` datetime DEFAULT NULL,
   `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `currency_code` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `connected_stripe_account_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
   `endYear` smallint(6) NOT NULL DEFAULT '0',
+  `connected_stripe_account_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `end_date` date DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
-  KEY `index_Competitions_on_countryId` (`countryId`)
+  KEY `index_Competitions_on_countryId` (`countryId`),
+  KEY `index_Competitions_on_start_date` (`start_date`),
+  KEY `index_Competitions_on_end_date` (`end_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1206,3 +1210,5 @@ INSERT INTO schema_migrations (version) VALUES ('20161227202950');
 INSERT INTO schema_migrations (version) VALUES ('20170121202850');
 
 INSERT INTO schema_migrations (version) VALUES ('20170212005142');
+
+INSERT INTO schema_migrations (version) VALUES ('20170215221832');

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CompetitionsController do
       end
     end
 
-    describe "selecting present/past competitions" do
+    describe "selecting present/past/recent competitions" do
       let!(:past_comp1) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 1.year.ago) }
       let!(:past_comp2) { FactoryGirl.create(:competition, :confirmed, :visible, starts: 3.years.ago) }
       let!(:in_progress_comp1) { FactoryGirl.create(:competition, :confirmed, :visible, starts: Date.today, ends: 1.day.from_now) }
@@ -74,6 +74,16 @@ RSpec.describe CompetitionsController do
         it "competitions are sorted descending by date" do
           get :index, params: { state: :past, year: "all years" }
           expect(assigns(:competitions)).to eq [past_comp1, past_comp2]
+        end
+      end
+
+      context "when recent is selected" do
+        before do
+          get :index, state: :recent
+        end
+
+        it "shows in progress competition that ends today" do
+          expect(assigns(:competitions)).to match_array [in_progress_comp2]
         end
       end
     end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -106,29 +106,26 @@ RSpec.describe Competition do
     expect(competition.endDay).to eq 1
   end
 
-  describe "validates date formats" do
-    let(:competition) do
-      c = FactoryGirl.create :competition
-      # Clear any instance variables the Competition may have from being created.
-      Competition.find(c.id)
-    end
+  describe "invalid date formats become nil" do
+    let(:competition) { FactoryGirl.create :competition }
 
     it "start_date" do
-      competition.start_date = "1987-12-04f"
-      expect(competition).to be_invalid
-      expect(competition.errors.messages[:start_date]).to eq ["invalid"]
+      competition.start_date = "i am not a date"
+      expect(competition.start_date).to eq nil
     end
 
     it "end_date" do
-      competition.end_date = "1987-12-04f"
-      expect(competition).to be_invalid
-      expect(competition.errors.messages[:end_date]).to eq ["invalid"]
+      competition.end_date = "i am also not a date"
+      expect(competition.end_date).to eq nil
     end
   end
 
   it "requires that both dates are empty or both are valid" do
     competition = FactoryGirl.create :competition
+    expect(competition).to be_valid
+
     competition.start_date = "1987-12-04"
+    competition.end_date = ""
     expect(competition).to be_invalid
 
     competition.end_date = "1987-12-05"
@@ -233,12 +230,7 @@ RSpec.describe Competition do
   it "knows the calendar" do
     competition = FactoryGirl.create :competition
     competition.start_date = "1987-0-04"
-    competition.end_date = "1987-12-05"
-    expect(competition).to be_invalid
-
-    competition.start_date = "1987-4-04"
-    competition.end_date = "1987-33-05"
-    expect(competition).to be_invalid
+    expect(competition.start_date).to eq nil
   end
 
   it "gracefully handles multiyear competitions" do


### PR DESCRIPTION
Added proper start_date and end_date fields to the Competitions table. PHP still reads the
old 6 unpacked fields, which we keep in sync with the start_date and
end_date fields.

This allowed us to remove all the weird SQL queries that `CONCAT` dates together.

If this goes well, there's opportunity for similar cleanup of the Persons table.