### PR TITLE
Add missing index back to structure.sql file - Fixes #1336

### DIFF
--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -806,7 +806,8 @@ CREATE TABLE `registrations` (
   `accepted_by` int(11) DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `deleted_by` int(11) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=86147 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
An earlier commit accidentally removed this index from the structure file.
The index still exists in production hence no migration is necessary.