### PR TITLE
Add maskmoney to improve UI

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -77,6 +77,7 @@ source 'https://rails-assets.org' do
   # https://github.com/NextStepWebs/simplemde-markdown-editor/issues/407 and
   # https://github.com/tenex/rails-assets/issues/367.
   gem 'rails-assets-simplemde', '1.10.1'
+  gem 'rails-assets-autoNumeric'
 end
 
 group :development, :test do

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -341,6 +341,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-assets-autoNumeric (2.0.7)
     rails-assets-autosize (3.0.20)
     rails-assets-simplemde (1.10.1)
     rails-controller-testing (1.0.1)
@@ -544,6 +545,7 @@ DEPENDENCIES
   premailer-rails
   rack-cors
   rails (= 5.0.1)
+  rails-assets-autoNumeric!
   rails-assets-autosize!
   rails-assets-simplemde (= 1.10.1)!
   rails-controller-testing
@@ -573,4 +575,4 @@ DEPENDENCIES
   world-flags!
 
 BUNDLED WITH
-   1.14.3
+   1.14.4

--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -47,6 +47,9 @@
 //= require autosize
 //= require simplemde
 //= require jquery_plugins
+//= require autoNumeric
+//= require currencies-data
+//= require currencies
 //= require_self
 //= require_tree .
 
@@ -232,6 +235,10 @@ $(function() {
   $('[data-toggle="tooltip"]').tooltip();
   $('[data-toggle="popover"]').popover();
   $('input.wca-autocomplete').wcaAutocomplete();
+
+  // Activate currency masks for the relevant fields
+  $('input.wca-currency-mask').wcaSetupCurrencyMask();
+
   $('.markdown-editor').each(function() {
     var editor = new SimpleMDE({
       element: this,

--- a/WcaOnRails/app/assets/javascripts/currencies-data.js.erb
+++ b/WcaOnRails/app/assets/javascripts/currencies-data.js.erb
@@ -1,0 +1,14 @@
+window.wca = window.wca || {};
+<%
+  # Select currencies, for all the iso_code is matching the hash key.
+  # However for 2 currencies (JPY, GHS) there is a second currency with the same iso_code but a different key.
+  # They exist for backward compatibilities reason (see here: https://github.com/RubyMoney/money/blob/190683e7b84b66d11b83b7be32d019cf3c2fc114/config/currency_backwards_compatible.json), and we actually don't use them.
+  selected_currencies = Money::Currency.table.select { |k,v| k.to_s == v[:iso_code].downcase }
+  currencies_info_hash = Hash[selected_currencies.map do |k,v|
+    [v[:iso_code], {:symbol => v[:symbol],
+                    :symbol_first => v[:symbol_first],
+                    :subunit_to_unit => v[:subunit_to_unit]}]
+  end]
+%>
+wca._currenciesInfo =
+<%= raw(JSON.pretty_generate(currencies_info_hash, indent: '', object_nl: '', array_nl: '', space: '', space_after: '')) %>;

--- a/WcaOnRails/app/assets/javascripts/currencies.js
+++ b/WcaOnRails/app/assets/javascripts/currencies.js
@@ -1,0 +1,71 @@
+window.wca = window.wca || {};
+
+wca.getCurrencyInfo = function(isoCode) {
+  return wca._currenciesInfo[isoCode] || wca._currenciesInfo.USD;
+};
+
+// Create a mask for an amount input in the given currency, using autoNumeric
+// 'action' can be either "init" or "update"
+// 'elemId' is a selector for the targeted input field
+wca.applyCurrencyMask = function(action, elemId, currencyIsoCode) {
+  var entry = wca.getCurrencyInfo(currencyIsoCode);
+  var currentVal = 0;
+
+  // Get current val
+  if (action == "update") {
+    currentVal = wca.getValueInCurrency(elemId);
+  } else if (action == "init") {
+    currentVal = $(elemId).val();
+  } else {
+    throw 'Unsupported action for currency mask';
+  }
+
+  // Reconfigure
+  $.data($(elemId)[0], "current_subunit_to_unit", entry.subunit_to_unit);
+  $(elemId).autoNumeric(action, {
+    currencySymbol: entry.symbol,
+    currencySymbolPlacement: (entry.symbol_first) ? 'p' : 's',
+    // If the currency has no subunit (subunit_to_unit is 1), then we don't need
+    // decimals. For currencies with subunits we want to show decimals.
+    decimalPlacesOverride: (entry.subunit_to_unit == 1) ? 0 : 2,
+    showWarnings: false,
+  });
+
+  // Set new val
+  $(elemId).autoNumeric('set', currentVal/entry.subunit_to_unit);
+};
+
+wca.removeCurrencyMask = function(elemId) {
+  $(elemId).autoNumeric('destroy');
+};
+
+// Retrieve the real value, in the currency's lowest denomination
+// Assumes autoNumeric is running on elemId, and the number of subunit_to_unit has been set in data
+wca.getValueInCurrency = function(elemId) {
+  var currentVal = $(elemId).autoNumeric('getNumber');
+  var multiplier = $.data($(elemId)[0], "current_subunit_to_unit");
+  // Set back the value to the "lowest denomination" in the currency
+  return currentVal * multiplier;
+};
+
+// Setup the mask for the selected elements
+$.fn.wcaSetupCurrencyMask = function() {
+  this.each(function() {
+    if (this.wcaSetupCurrencyMask)
+      return;
+    this.wcaSetupCurrencyMask = true;
+
+    var currencyIsoCode = $(this).data("currency");
+    var targetElemId = $(this).data("target");
+    var thisElemId = "#" + $(this).attr("id");
+
+    wca.applyCurrencyMask('init',
+        thisElemId,
+        currencyIsoCode);
+
+    // Populate the actual hidden field on change
+    $(thisElemId).change(function() {
+      $(targetElemId).val(wca.getValueInCurrency(thisElemId));
+    });
+  });
+};

--- a/WcaOnRails/app/inputs/money_amount_input.rb
+++ b/WcaOnRails/app/inputs/money_amount_input.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class MoneyAmountInput < SimpleForm::Inputs::Base
+  def input(wrapper_options)
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    actual_field = @builder.hidden_field(attribute_name)
+    input_id = attribute_name.to_s + "_input_field"
+
+    # On page load, inputs with this class get their mask setup
+    merged_input_options[:class] << "wca-currency-mask"
+
+    amount_input = template.content_tag(:input, "",
+                                        value: @builder.object.send(attribute_name),
+                                        id: input_id,
+                                        type: "text",
+                                        'data-target': "##{@builder.object_name}_#{attribute_name}",
+                                        'data-currency': currency,
+                                        class: merged_input_options[:class])
+    actual_field + amount_input
+  end
+
+  def currency
+    @currency ||= options.delete(:currency) || Money.default_currency.iso_code
+  end
+end

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -220,7 +220,15 @@
     <% end %>
 
     <%= f.input :currency_code, collection: Money::Currency.table.values, label_method: lambda { |c| c[:name]  }, value_method: lambda { |c| c[:iso_code] }  %>
-    <%= f.input :base_entry_fee_lowest_denomination %>
+    <%= f.input :base_entry_fee_lowest_denomination, as: :money_amount, currency: @competition.currency_code %>
+    <script>
+      // Setup currency onchange callback
+      $('#competition_currency_code').change(function() {
+        wca.applyCurrencyMask('update',
+                              '#base_entry_fee_lowest_denomination_input_field',
+                              $('#competition_currency_code').val());
+      });
+    </script>
 
     <%= f.input :use_wca_registration %>
 


### PR DESCRIPTION
Fixes #1020.
cc @pingskills 

This is a wip, the implementation works but is dirty.
I'll also try some other masking field extension, because maskmoney is too buggy (I ran into https://github.com/plentz/jquery-maskmoney/issues/123, which seems like very basic usage but has been opened for nearly 3 years...).

I worked my way around it, but it's not very clean.

In any case:
 - we'll need information about currencies (that rails has) in javascript, so we need to have these static data somewhere (where?).
 - we'll probably need the "setMask" function in some other place, so we should probably put it in some more generic javascript (`application.js`?).
- there is a few currency where the lowest denomination is not base 10 (eg: 5, `"MRO":{"symbol":"UM","symbol_first":false,"subunit_to_unit":5}`), not sure what to do here besides removing the mask.

