### PR TITLE
Added a `rake db:dump:development` script

### DIFF
--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -1,0 +1,536 @@
+# frozen_string_literal: true
+
+module DatabaseDumper
+  JOIN_WHERE_VISIBLE_COMP = "JOIN Competitions ON Competitions.id=competition_id WHERE showAtAll=1"
+
+  def self.actions_to_column_sanitizers(columns_by_action)
+    {}.tap do |column_sanitizers|
+      columns_by_action.each do |action, columns|
+        case action
+        when :copy, :db_default
+          columns.each do |column|
+            column_sanitizers[column] = action
+          end
+        when :fake_values
+          columns.each do |column, column_sanitizer|
+            column_sanitizers[column] = column_sanitizer
+          end
+        else
+          raise "Unrecognized action #{action}"
+        end
+      end
+    end
+  end
+
+  TABLE_SANITIZERS = {
+    "Competitions" => {
+      where_clause: "WHERE showAtAll = TRUE",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          name
+          cityName
+          countryId
+          information
+          year
+          month
+          day
+          endYear
+          endMonth
+          endDay
+          start_date
+          end_date
+          venue
+          venueAddress
+          venueDetails
+          external_website
+          cellName
+          showAtAll
+          latitude
+          longitude
+          isConfirmed
+          contact
+          registration_open
+          registration_close
+          use_wca_registration
+          guests_enabled
+          results_posted_at
+          results_nag_sent_at
+          generate_website
+          announced_at
+          base_entry_fee_lowest_denomination
+          currency_code
+        ),
+        db_default: %w(
+          connected_stripe_account_id
+        ),
+        fake_values: {
+          "remarks" => "'remarks to the board here'",
+        },
+      ),
+    }.freeze,
+    "CompetitionsMedia" => {
+      where_clause: "WHERE status = 'accepted'",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competitionId
+          type
+          text
+          uri
+          timestampSubmitted
+          timestampDecided
+          status
+        ),
+        fake_values: {
+          "submitterName" => "'mr. media submitter'",
+          "submitterComment" => "'a comment about this media'",
+          "submitterEmail" => "'mediasubmitter@example.com'",
+        },
+      ),
+    }.freeze,
+    "ConciseAverageResults" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          average
+          continentId
+          countryId
+          day
+          eventId
+          id
+          month
+          personId
+          valueAndId
+          year
+        ),
+      ),
+    }.freeze,
+    "ConciseSingleResults" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          best
+          continentId
+          countryId
+          day
+          eventId
+          id
+          month
+          personId
+          valueAndId
+          year
+        ),
+      ),
+    }.freeze,
+    "Continents" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          latitude
+          longitude
+          name
+          recordName
+          zoom
+        ),
+      ),
+    }.freeze,
+    "Countries" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          continentId
+          iso2
+          name
+        ),
+      ),
+    }.freeze,
+    "Events" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          cellName
+          format
+          name
+          rank
+        ),
+      ),
+    }.freeze,
+    "Formats" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          expected_solve_count
+          name
+          sort_by
+          sort_by_second
+          trim_fastest_n
+          trim_slowest_n
+        ),
+      ),
+    }.freeze,
+    "InboxPersons" => :skip_all_rows,
+    "InboxResults" => :skip_all_rows,
+    "Persons" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          comments
+          countryId
+          gender
+          name
+          rails_id
+          subId
+        ),
+        db_default: %w(comments),
+        fake_values: {
+          "year" => "1954",
+          "month" => "12",
+          "day" => "4",
+        },
+      ),
+    }.freeze,
+    "RanksAverage" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          best
+          continentRank
+          countryRank
+          eventId
+          personId
+          worldRank
+        ),
+      ),
+    }.freeze,
+    "RanksSingle" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          best
+          continentRank
+          countryRank
+          eventId
+          personId
+          worldRank
+        ),
+      ),
+    }.freeze,
+    "Results" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          average
+          best
+          competitionId
+          countryId
+          eventId
+          formatId
+          personId
+          personName
+          pos
+          regionalAverageRecord
+          regionalSingleRecord
+          roundId
+          updated_at
+          value1
+          value2
+          value3
+          value4
+          value5
+        ),
+      ),
+    }.freeze,
+    "Rounds" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          cellName
+          final
+          name
+          rank
+        ),
+      ),
+    }.freeze,
+    "Scrambles" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          competitionId
+          eventId
+          groupId
+          isExtra
+          roundId
+          scramble
+          scrambleId
+          scrambleNum
+        ),
+      ),
+    }.freeze,
+    "ar_internal_metadata" => :skip_all_rows,
+    "competition_delegates" => {
+      where_clause: JOIN_WHERE_VISIBLE_COMP,
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competition_id
+          created_at
+          delegate_id
+          receive_registration_emails
+          updated_at
+        ),
+      ),
+    }.freeze,
+    "competition_events" => {
+      where_clause: JOIN_WHERE_VISIBLE_COMP,
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competition_id
+          event_id
+        ),
+      ),
+    }.freeze,
+    "competition_organizers" => {
+      where_clause: JOIN_WHERE_VISIBLE_COMP,
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competition_id
+          created_at
+          organizer_id
+          receive_registration_emails
+          updated_at
+        ),
+      ),
+    }.freeze,
+    "competition_tabs" => {
+      where_clause: JOIN_WHERE_VISIBLE_COMP,
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competition_id
+          content
+          display_order
+          name
+        ),
+      ),
+    }.freeze,
+    "completed_jobs" => :skip_all_rows,
+    "delayed_jobs" => :skip_all_rows,
+    "delegate_reports" => :skip_all_rows,
+    "oauth_access_grants" => :skip_all_rows,
+    "oauth_access_tokens" => :skip_all_rows,
+    "oauth_applications" => :skip_all_rows,
+    "old_registrations" => :skip_all_rows,
+    "poll_options" => :skip_all_rows,
+    "polls" => :skip_all_rows,
+    "posts" => {
+      where_clause: "WHERE world_readable = TRUE",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          author_id
+          body
+          created_at
+          slug
+          sticky
+          title
+          updated_at
+          world_readable
+        ),
+      ),
+    }.freeze,
+    "preferred_formats" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          event_id
+          format_id
+          ranking
+        ),
+      ),
+    }.freeze,
+    "rails_persons" => :skip_all_rows,
+    "registration_competition_events" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competition_event_id
+          registration_id
+        ),
+      ),
+    }.freeze,
+    "registration_payments" => :skip_all_rows,
+    "registrations" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          accepted_at
+          accepted_by
+          competition_id
+          created_at
+          deleted_at
+          deleted_by
+          guests
+          updated_at
+          user_id
+        ),
+        db_default: %w(ip),
+        fake_values: {
+          "comments" => "''", # Can't use :db_default here because comments does not have a default value.
+        },
+      ),
+    }.freeze,
+    "schema_migrations" => :skip_all_rows, # This is populated when loading our schema dump
+    "team_members" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          created_at
+          end_date
+          start_date
+          team_id
+          team_leader
+          updated_at
+          user_id
+        ),
+      ),
+    }.freeze,
+    "teams" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          created_at
+          description
+          friendly_id
+          name
+          updated_at
+        ),
+      ),
+    }.freeze,
+    "user_preferred_events" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          event_id
+          user_id
+        ),
+      ),
+    }.freeze,
+    "users" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          avatar
+          confirmed_at
+          country_iso2
+          created_at
+          current_sign_in_at
+          delegate_id_to_handle_wca_id_claim
+          delegate_status
+          gender
+          last_sign_in_at
+          location_description
+          name
+          region
+          results_notifications_enabled
+          saved_avatar_crop_h
+          saved_avatar_crop_w
+          saved_avatar_crop_x
+          saved_avatar_crop_y
+          saved_pending_avatar_crop_h
+          saved_pending_avatar_crop_w
+          saved_pending_avatar_crop_x
+          saved_pending_avatar_crop_y
+          senior_delegate_id unconfirmed_wca_id
+          updated_at
+          wca_id
+        ),
+        db_default: %w(
+          confirmation_sent_at
+          confirmation_token
+          current_sign_in_ip
+          encrypted_password
+          last_sign_in_ip
+          notes
+          pending_avatar
+          phone_number
+          preferred_locale
+          remember_created_at
+          reset_password_sent_at
+          reset_password_token
+          sign_in_count
+          unconfirmed_email
+        ),
+        fake_values: {
+          "dob" => "'1954-12-04'",
+          "email" => "CONCAT(id, '@worldcubeassociation.org')",
+        },
+      ),
+    }.freeze,
+    "vote_options" => :skip_all_rows,
+    "votes" => :skip_all_rows,
+  }.freeze
+
+  def self.development_dump(dump_filename)
+    dump_db_name = "wca_development_db_dump"
+
+    LogTask.log_task "Creating temporary database '#{dump_db_name}'" do
+      ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{dump_db_name}")
+      ActiveRecord::Base.connection.execute("CREATE DATABASE #{dump_db_name} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+      self.mysql("SOURCE #{Rails.root.join('db', 'structure.sql')}", dump_db_name)
+    end
+
+    LogTask.log_task "Populating sanitized tables in '#{dump_db_name}'" do
+      TABLE_SANITIZERS.each do |table_name, table_sanitizer|
+        next if table_sanitizer == :skip_all_rows
+
+        column_sanitizers = table_sanitizer[:column_sanitizers].select do |column_name, column_sanitizer|
+          column_sanitizer != :db_default
+        end
+
+        column_expressions = column_sanitizers.map do |column_name, column_sanitizer|
+          column_sanitizer == :copy ? "#{table_name}.#{column_name}" : "#{column_sanitizer} as #{column_name}"
+        end.join(", ")
+
+        populate_table_sql = "INSERT INTO #{dump_db_name}.#{table_name} (#{column_sanitizers.keys.join(", ")}) SELECT #{column_expressions} FROM #{table_name} #{table_sanitizer[:where_clause]}"
+        ActiveRecord::Base.connection.execute(populate_table_sql)
+      end
+    end
+
+    LogTask.log_task "Dumping '#{dump_db_name}' to '#{dump_filename}'" do
+      self.mysqldump(dump_db_name, dump_filename)
+    end
+  ensure
+    ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{dump_db_name}")
+  end
+
+  def self.mysql_cli_creds
+    config = ActiveRecord::Base.connection_config
+    "--user=#{config[:username]} --password=#{config[:password] || "''"} --host=#{config[:host]}"
+  end
+
+  def self.mysql(command, database = nil)
+    `mysql #{self.mysql_cli_creds} #{database} -e '#{command}'`
+  end
+
+  def self.mysqldump(db_name, dest_filename)
+    `mysqldump #{self.mysql_cli_creds} #{db_name} -r #{dest_filename}`
+  end
+end

--- a/WcaOnRails/lib/log_task.rb
+++ b/WcaOnRails/lib/log_task.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module LogTask
+  def self.log_task(description, &block)
+    print "#{description}..."
+    time = Benchmark.realtime(&block)
+    puts format("done in %.2fs", time)
+  end
+end

--- a/WcaOnRails/lib/tasks/db.rake
+++ b/WcaOnRails/lib/tasks/db.rake
@@ -35,4 +35,57 @@ namespace :db do
       exit error_count > 0 ? 1 : 0
     end
   end
+
+  namespace :dump do
+    desc 'Generates a dump of our database with sensitive information stripped, safe for public viewing.'
+    task development: :environment do
+      Dir.mktmpdir do |dir|
+        FileUtils.cd dir do
+          dump_filename = "wca-developer-database-dump.sql"
+          zip_filename = "wca-developer-database-dump.zip"
+          DatabaseDumper.development_dump(dump_filename)
+
+          LogTask.log_task "Zipping '#{dump_filename}' to '#{zip_filename}'" do
+            `zip #{zip_filename} #{dump_filename}`
+            raise "zip returned: #{$CHILD_STATUS.exitstatus}" unless $CHILD_STATUS.success?
+          end
+
+          public_zip_path = Rails.root.join('public', 'wst', zip_filename)
+          FileUtils.mkpath(File.dirname(public_zip_path))
+          FileUtils.mv(zip_filename, public_zip_path)
+        end
+      end
+    end
+  end
+
+  namespace :load do
+    desc 'Download and import the publicly accessible database dump from the production server'
+    task development: :environment do
+      Dir.mktmpdir do |dir|
+        FileUtils.cd dir do
+          dev_db_dump_url = "https://www.worldcubeassociation.org/wst/wca-developer-database-dump.zip"
+          dump_filename = "wca-developer-database-dump.sql"
+          zip_filename = "wca-developer-database-dump.zip"
+
+          LogTask.log_task("Downloading #{dev_db_dump_url}") { `wget --show-progress #{dev_db_dump_url}` }
+          LogTask.log_task("Unzipping #{zip_filename}") { `unzip #{zip_filename}` }
+
+          config = ActiveRecord::Base.connection_config
+          LogTask.log_task "Clobbering contents of '#{config[:database]}' with #{dump_filename}" do
+            DatabaseDumper.mysql("DROP DATABASE IF EXISTS #{config[:database]}")
+            DatabaseDumper.mysql("CREATE DATABASE #{config[:database]}")
+            DatabaseDumper.mysql("SOURCE #{dump_filename}", config[:database])
+          end
+
+          default_password = 'wca'
+          LogTask.log_task "Setting all user passwords to '#{default_password}'" do
+            User.find_each do |user|
+              user.password = default_password
+              user.save(validate: false) # Lots of users in the real database do not pass validations.
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/WcaOnRails/public/wst/.gitignore
+++ b/WcaOnRails/public/wst/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -72,6 +72,10 @@ FactoryGirl.define do
       isConfirmed true
     end
 
+    trait :not_visible do
+      showAtAll false
+    end
+
     trait :visible do
       with_delegate
       showAtAll true

--- a/WcaOnRails/spec/lib/database_dumper_spec.rb
+++ b/WcaOnRails/spec/lib/database_dumper_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require 'tempfile'
+require 'rails_helper'
+require 'database_dumper'
+
+def with_database(db_name)
+  old_connection_config = ActiveRecord::Base.connection_config
+  begin
+    ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{db_name}")
+    ActiveRecord::Base.connection.execute("CREATE DATABASE #{db_name} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+    connection_config = old_connection_config.merge(database: db_name, connect_flags: Mysql2::Client::MULTI_STATEMENTS)
+    ActiveRecord::Base.establish_connection(connection_config)
+    yield
+  ensure
+    ActiveRecord::Base.establish_connection(old_connection_config)
+    ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{db_name}")
+  end
+end
+
+RSpec.describe "DatabaseDumper" do
+  it "defines sanitizers for precisely the tables and columns that exist" do
+    expect(DatabaseDumper::TABLE_SANITIZERS.keys).to match_array ActiveRecord::Base.connection.data_sources
+    DatabaseDumper::TABLE_SANITIZERS.each do |table_name, table_sanitizer|
+      next if table_sanitizer == :skip_all_rows
+      puts "Checking for table sanitizer of table '#{table_name}'"
+      where_clause = table_sanitizer[:where_clause]
+      expect(where_clause).to_not be_nil
+      column_sanitizers = table_sanitizer[:column_sanitizers]
+      column_names = ActiveRecord::Base.connection.columns(table_name).map(&:name)
+
+      expect(column_sanitizers.keys).to match_array(column_names)
+    end
+  end
+
+  # The default database cleaning method of transation does not work for this test
+  # because we close and recreate our database connection inside of the test. Use
+  # truncation so we don't leave a dirty database behind.
+  it "works", clean_db_with_truncation: true do
+    not_visible_competition = FactoryGirl.create :competition, :not_visible, :with_delegate
+    visible_competition = FactoryGirl.create :competition, :visible, remarks: "Super secret message to the Board"
+    user = FactoryGirl.create :user
+
+    dump_file = Tempfile.new
+    DatabaseDumper.development_dump(dump_file.path)
+    dump_file.rewind
+    sql = dump_file.read
+    dump_file.close
+
+    with_database "wca_db_dump_test" do
+      ActiveRecord::Base.connection.execute(sql)
+      # We have to walk over all the results from the previous multistatement query
+      # in order to wait for the entire query to finish.
+      while ActiveRecord::Base.connection.raw_connection.next_result
+      end
+      ActiveRecord::Base.connection.reconnect!
+
+      expect(Competition.count).to eq 1
+      visible_competition = Competition.find(visible_competition.id)
+      expect(visible_competition.remarks).to eq "remarks to the board here"
+
+      expect(CompetitionDelegate.find_by_competition_id(not_visible_competition.id)).to eq nil
+
+      user = User.find(user.id)
+      expect(user.dob).to eq Date.new(1954, 12, 4)
+    end
+  end
+end

--- a/WcaOnRails/spec/support/database_cleaner.rb
+++ b/WcaOnRails/spec/support/database_cleaner.rb
@@ -9,8 +9,16 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, js: true) do
+  def set_truncation_strategy
     DatabaseCleaner.strategy = :truncation, { except: TestDbManager::CONSTANT_TABLES }
+  end
+
+  config.before(:each, clean_db_with_truncation: true) do
+    set_truncation_strategy
+  end
+
+  config.before(:each, js: true) do
+    set_truncation_strategy
   end
 
   config.before(:each) do


### PR DESCRIPTION
This script generates a database dump that is safe for the public to download. This will be useful for our staging server
and for developers who want to get started with a more realistic
database than our seeds create.

Unfortunately, I fear that actually trying to run this script on production is going
to kill our server =(

This fixes #994.