### PR TITLE
Don't show links to edit avatar unless the current user is actually allowed to edit the users avatar.

### DIFF
--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -69,13 +69,13 @@ class UsersController < ApplicationController
 
   def edit_avatar_thumbnail
     @user = user_to_edit
-    return if redirect_if_cannot_edit_user(@user)
+    return if redirect_unless_user(:can_change_users_avatar?, @user)
   end
 
   def edit_pending_avatar_thumbnail
     @user = user_to_edit
     @pending_avatar = true
-    return if redirect_if_cannot_edit_user(@user)
+    return if redirect_unless_user(:can_change_users_avatar?, @user)
     render :edit_avatar_thumbnail
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -380,6 +380,10 @@ class User < ApplicationRecord
     self == user || can_view_all_users? || organizer_for?(user)
   end
 
+  def can_change_users_avatar?(user)
+    user.wca_id.present? && self.editable_fields_of_user(user).include?(:pending_avatar)
+  end
+
   def organizer_for?(user)
     # If the user is a newcomer, allow organizers of the competition that the user is registered for to edit that user's name.
     user.competitions_registered_for.not_over.joins(:competition_organizers).pluck("competition_organizers.organizer_id").include?(self.id)

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -59,7 +59,7 @@
       <li><a href="#preferences" data-toggle="tab"><%= t '.preferences' %></a></li>
       <li><a href="#password" data-toggle="tab"><%= t '.password' %></a></li>
     <% end %>
-    <% if @user.wca_id.present? %>
+    <% if current_user.can_change_users_avatar?(@user) %>
       <li><a href="#avatar" data-toggle="tab">Avatar</a></li>
     <% end %>
   </ul>
@@ -180,7 +180,7 @@
       </div>
     <% end %>
 
-    <% if @user.wca_id.present? %>
+    <% if current_user.can_change_users_avatar?(@user) %>
       <div class="tab-pane active" id="avatar">
         <%= simple_form_for @user, html: { multipart: true, class: 'are-you-sure' } do |f| %>
           <%= hidden_field_tag "section", "avatar" %>


### PR DESCRIPTION
This was pointed out by Ilya.