### PR TITLE
Rename `redirect_unless_user` to `redirect_to_root_unless_user` etc

### DIFF
--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AdminController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_admin_results?) }
+  before_action -> { redirect_to_root_unless_user(:can_admin_results?) }
 
   before_action :compute_navbar_data
   def compute_navbar_data

--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -73,14 +73,12 @@ class ApplicationController < ActionController::Base
     super
   end
 
-  private def redirect_unless_user(action, *args)
-    redirected = false
-    unless current_user && current_user.send(action, *args)
+  private def redirect_to_root_unless_user(action, *args)
+    redirected = !current_user&.send(action, *args)
+    if redirected
       flash[:danger] = "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"
       redirect_to root_url
-      redirected = true
     end
-
     redirected
   end
 end

--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -74,11 +74,11 @@ class ApplicationController < ActionController::Base
   end
 
   private def redirect_to_root_unless_user(action, *args)
-    redirected = !current_user&.send(action, *args)
-    if redirected
+    redirecting = !current_user&.send(action, *args)
+    if redirecting
       flash[:danger] = "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"
       redirect_to root_url
     end
-    redirected
+    redirecting
   end
 end

--- a/WcaOnRails/app/controllers/competition_tabs_controller.rb
+++ b/WcaOnRails/app/controllers/competition_tabs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class CompetitionTabsController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_manage_competition?, competition_from_params) }
+  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }
 
   def index
     @competition = competition_from_params

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -10,7 +10,7 @@ class CompetitionsController < ApplicationController
     :show_all_results,
     :show_results_by_person,
   ]
-  before_action -> { redirect_unless_user(:can_admin_results?) }, only: [
+  before_action -> { redirect_to_root_unless_user(:can_admin_results?) }, only: [
     :post_announcement,
     :post_results,
     :admin_edit,
@@ -24,9 +24,9 @@ class CompetitionsController < ApplicationController
     end
   end
 
-  before_action -> { redirect_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :update_events, :payment_setup, :revoke_stripe_access]
+  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :update_events, :payment_setup, :revoke_stripe_access]
 
-  before_action -> { redirect_unless_user(:can_create_competitions?) }, only: [:new, :create]
+  before_action -> { redirect_to_root_unless_user(:can_create_competitions?) }, only: [:new, :create]
 
   def new
     @competition = Competition.new

--- a/WcaOnRails/app/controllers/delegate_reports_controller.rb
+++ b/WcaOnRails/app/controllers/delegate_reports_controller.rb
@@ -12,21 +12,21 @@ class DelegateReportsController < ApplicationController
 
   def show
     @competition = competition_from_params
-    return if redirect_unless_user(:can_view_delegate_report?, @competition.delegate_report)
+    redirect_to_root_unless_user(:can_view_delegate_report?, @competition.delegate_report) && return
 
     @delegate_report = @competition.delegate_report
   end
 
   def edit
     @competition = competition_from_params
-    return if redirect_unless_user(:can_edit_delegate_report?, @competition.delegate_report)
+    redirect_to_root_unless_user(:can_edit_delegate_report?, @competition.delegate_report) && return
 
     @delegate_report = @competition.delegate_report
   end
 
   def update
     @competition = competition_from_params
-    return if redirect_unless_user(:can_edit_delegate_report?, @competition.delegate_report)
+    redirect_to_root_unless_user(:can_edit_delegate_report?, @competition.delegate_report) && return
 
     @delegate_report = @competition.delegate_report
     @delegate_report.current_user = current_user

--- a/WcaOnRails/app/controllers/delegates_controller.rb
+++ b/WcaOnRails/app/controllers/delegates_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class DelegatesController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_admin_results?) }
+  before_action -> { redirect_to_root_unless_user(:can_admin_results?) }
 
   def stats
     @delegates = User.delegates

--- a/WcaOnRails/app/controllers/delegates_panel_controller.rb
+++ b/WcaOnRails/app/controllers/delegates_panel_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class DelegatesPanelController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_view_crash_course?) }
-  before_action -> { redirect_unless_user(:can_update_crash_course?) }, only: [:edit_crash_course, :update_crash_course]
+  before_action -> { redirect_to_root_unless_user(:can_view_crash_course?) }
+  before_action -> { redirect_to_root_unless_user(:can_update_crash_course?) }, only: [:edit_crash_course, :update_crash_course]
 
   def index
   end

--- a/WcaOnRails/app/controllers/polls_controller.rb
+++ b/WcaOnRails/app/controllers/polls_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class PollsController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_create_poll?) }, only: [:new, :create, :update, :destroy]
-  before_action -> { redirect_unless_user(:can_vote_in_poll?) }, only: [:index, :vote, :results]
+  before_action -> { redirect_to_root_unless_user(:can_create_poll?) }, only: [:new, :create, :update, :destroy]
+  before_action -> { redirect_to_root_unless_user(:can_vote_in_poll?) }, only: [:index, :vote, :results]
 
   def index
     @polls = current_user.can_create_poll? ? Poll.all : Poll.confirmed

--- a/WcaOnRails/app/controllers/posts_controller.rb
+++ b/WcaOnRails/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :rss, :show]
-  before_action -> { redirect_unless_user(:can_create_posts?) }, except: [:index, :rss, :show]
+  before_action -> { redirect_to_root_unless_user(:can_create_posts?) }, except: [:index, :rss, :show]
 
   def index
     @posts = Post.where(world_readable: true).order(sticky: :desc, created_at: :desc).includes(:author).page(params[:page])

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -22,7 +22,7 @@ class RegistrationsController < ApplicationController
     end
   end
 
-  before_action -> { redirect_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit_registrations, :do_actions_for_selected, :edit, :refund_payment]
+  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit_registrations, :do_actions_for_selected, :edit, :refund_payment]
 
   def edit_registrations
     @competition = competition_from_params

--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_manage_teams?) }, except: [:edit, :update]
-  before_action -> { redirect_unless_user(:can_edit_team?, team_from_params) }, only: [:edit, :update]
+  before_action -> { redirect_to_root_unless_user(:can_manage_teams?) }, except: [:edit, :update]
+  before_action -> { redirect_to_root_unless_user(:can_edit_team?, team_from_params) }, only: [:edit, :update]
 
   def index
     @teams = Team.all

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -69,13 +69,14 @@ class UsersController < ApplicationController
 
   def edit_avatar_thumbnail
     @user = user_to_edit
-    return if redirect_unless_user(:can_change_users_avatar?, @user)
+    redirect_to_root_unless_user(:can_change_users_avatar?, @user)
   end
 
   def edit_pending_avatar_thumbnail
     @user = user_to_edit
     @pending_avatar = true
-    return if redirect_unless_user(:can_change_users_avatar?, @user)
+    redirect_to_root_unless_user(:can_change_users_avatar?, @user) && return
+
     render :edit_avatar_thumbnail
   end
 

--- a/WcaOnRails/app/controllers/votes_controller.rb
+++ b/WcaOnRails/app/controllers/votes_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class VotesController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_unless_user(:can_vote_in_poll?) }
+  before_action -> { redirect_to_root_unless_user(:can_vote_in_poll?) }
 
   def vote
     @poll = Poll.find(params[:id])


### PR DESCRIPTION
As discussed in #1360

- Rename `redirect_unless_user` to `redirect_to_root_unless_user`.
- Replace `return if redirect_unless_user(:can_blah)` pattern with `redirect_to_root_unless_user(:can_blah) && return` (Rubocop dislikes `and return`).
- Rewrite `redirect_to_root_unless_use()` to only compute the result once.