### PR TITLE
Set up a standalone mysql instance on Amazon RDS

### DIFF
--- a/chef/roles/wca.json
+++ b/chef/roles/wca.json
@@ -32,8 +32,6 @@
     "recipe[timezone_lwrp]",
     "recipe[wca::base]",
     "recipe[wca]",
-    "recipe[wca::forum]",
-    "recipe[wca::phpMyAdmin]",
     "recipe[wca::regulations]",
     "recipe[wca::email]",
     "recipe[wca::cronjobs]",

--- a/chef/site-cookbooks/wca/recipes/forum.rb
+++ b/chef/site-cookbooks/wca/recipes/forum.rb
@@ -1,9 +1,0 @@
-secrets = WcaHelper.get_secrets(self)
-username, repo_root = WcaHelper.get_username_and_repo_root(self)
-
-template "#{repo_root}/webroot/forum/config.php" do
-  source "forum_config.php.erb"
-  variables({
-    secrets: secrets,
-  })
-end

--- a/chef/site-cookbooks/wca/templates/forum_config.php.erb
+++ b/chef/site-cookbooks/wca/templates/forum_config.php.erb
@@ -2,10 +2,10 @@
 // phpBB 3.0.x auto-generated configuration file
 // Do not change anything in this file!
 $dbms = 'mysqli';
-$dbhost = 'localhost';
+$dbhost = '<%= @db['host'] %>';
 $dbport = '';
 $dbname = 'cubing_phpbb';
-$dbuser = 'root';
+$dbuser = '<%= @db['user'] %>';
 $dbpasswd = '<%= @secrets['mysql_password'] %>';
 $table_prefix = 'phpbb3_';
 $acm_type = 'file';

--- a/chef/site-cookbooks/wca/templates/my.cnf.erb
+++ b/chef/site-cookbooks/wca/templates/my.cnf.erb
@@ -1,5 +1,8 @@
 [client]
 default-character-set          = utf8
-socket                         = /var/run/mysqld/mysqld.sock
+host                           = <%= @db['host'] %>
+<% if @db['socket'] %>
+socket                         = <%= @db['socket'] %>
+<% end %>
 user                           = root
 password                       = <%= @secrets['mysql_password'] %>

--- a/chef/site-cookbooks/wca/templates/phpMyAdmin_config.inc.php.erb
+++ b/chef/site-cookbooks/wca/templates/phpMyAdmin_config.inc.php.erb
@@ -11,10 +11,15 @@ $i = 0;
 /* Server: localhost [1] */
 $i++;
 $cfg['Servers'][$i]['verbose'] = '';
-$cfg['Servers'][$i]['host'] = 'localhost';
 $cfg['Servers'][$i]['port'] = '';
-$cfg['Servers'][$i]['socket'] = '/var/run/mysqld/mysqld.sock';
+<% if @db['socket'] %>
+$cfg['Servers'][$i]['host'] = '<%= @db['host'] %>';
+$cfg['Servers'][$i]['socket'] = '<% @db['socket'] %>';
 $cfg['Servers'][$i]['connect_type'] = 'socket';
+<% else %>
+$cfg['Servers'][$i]['host'] = '<%= @db['host'] %>';
+$cfg['Servers'][$i]['connect_type'] = 'tcp';
+<% end %>
 $cfg['Servers'][$i]['auth_type'] = 'config';
 $cfg['Servers'][$i]['user'] = 'root';
 $cfg['Servers'][$i]['password'] = '<%= @secrets['mysql_password'] %>';

--- a/chef/site-cookbooks/wca/templates/results_config.php.erb
+++ b/chef/site-cookbooks/wca/templates/results_config.php.erb
@@ -2,8 +2,8 @@
 // THIS FILE CAME FROM webroot/results/includes/_config.php.template
 // data here is loaded into configuration class.  Should be accessed by via configuration object (global $config in _framework file).
 
-$config['database']['host'] = 'localhost';
-$config['database']['user'] = 'root';
+$config['database']['host'] = '<%= @db['host'] %>';
+$config['database']['user'] = '<%= @db['user'] %>';
 $config['database']['pass'] = '<%= @secrets['mysql_password'] %>';
 $config['database']['name'] = 'cubing';
 $config['database']['port'] = 3306;


### PR DESCRIPTION
As per @coder13's comment [here](https://github.com/thewca/worldcubeassociation.org/issues/1058#issuecomment-282505950), I'd like to experiment with a standalone mysql instance. I spun up an AWS `db.t2.small`:

![image](https://cloud.githubusercontent.com/assets/277474/23344764/d447ff8c-fc36-11e6-8445-a582082243c7.png)

The mysql server is *not* publicly accessible, you have to be on our AWS virtual private cloud (VPC) to access it. In practice, this just means you have to ssh to one of our EC2 servers before you can talk to mysql.

I'm currently testing this out by spinning up a production server with my changes:

```
~/gitting/worldcubeassociation.org @kaladin> ssh -i "~/.ssh/jfly-kaladin-arch.pem" ubuntu@ec2-54-218-134-110.us-west-2.compute.amazonaws.com -A 'sudo wget https://raw.githubusercontent.com/jfly/worldcubeassociation.org/standalone-mysql/scripts/wca-bootstrap.sh -O /tmp/wca-bootstrap.sh && sudo -E bash /tmp/wca-bootstrap.sh production'
```

I will update this once my test finishes and I get things working =)