### PR TITLE
Fix sorting countries in forms

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -142,7 +142,7 @@ module ApplicationHelper
   def region_option_tags(selected_id: nil)
     regions = {
       t('common.continent') => Continent::ALL_CONTINENTS_WITH_NAME_AND_ID_BY_LOCALE[I18n.locale],
-      t('common.country') => Country::ALL_COUNTRIES_BY_LOCALE[I18n.locale].map { |country| [country.name, country.id] },
+      t('common.country') => Country.all_sorted_by(I18n.locale).map { |country| [country.name, country.id] },
     }
 
     content_tag(:option, t('common.all_regions'), value: "all") + grouped_options_for_select(regions, selected_id)

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -141,7 +141,7 @@ module ApplicationHelper
 
   def region_option_tags(selected_id: nil)
     regions = {
-      t('common.continent') => Continent::ALL_CONTINENTS_WITH_NAME_AND_ID_BY_LOCALE[I18n.locale],
+      t('common.continent') => Continent::ALL_SORTED_BY_LOCALE[I18n.locale].map { |continent| [continent.name, continent.id] },
       t('common.country') => Country.all_sorted_by(I18n.locale).map { |country| [country.name, country.id] },
     }
 

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -142,7 +142,7 @@ module ApplicationHelper
   def region_option_tags(selected_id: nil)
     regions = {
       t('common.continent') => Continent::ALL_CONTINENTS_WITH_NAME_AND_ID_BY_LOCALE[I18n.locale],
-      t('common.country') => Country::ALL_COUNTRIES_WITH_NAME_AND_ID_BY_LOCALE[I18n.locale],
+      t('common.country') => Country::ALL_COUNTRIES_BY_LOCALE[I18n.locale].map { |country| [country.name, country.id] },
     }
 
     content_tag(:option, t('common.all_regions'), value: "all") + grouped_options_for_select(regions, selected_id)

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -18,7 +18,7 @@ class Continent < ApplicationRecord
   end
 
   ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    continents = Country.localized_sort_by!(locale, Continent.all.to_a) { |continent| continent.name_in(locale) }
+    continents = I18nUtils.localized_sort_by!(locale, Continent.all.to_a) { |continent| continent.name_in(locale) }
     [locale, continents]
   end].freeze
 end

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -17,13 +17,8 @@ class Continent < ApplicationRecord
     I18n.t(recordName, scope: :continents, locale: locale)
   end
 
-  ALL_CONTINENTS_WITH_NAME_AND_ID_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    continents = Country.localized_sort_by!(locale, Continent.all.map do |country|
-      # We want a localized continent name, but a constant id across languages
-      [country.name_in(locale), country.id]
-      # Now we want to sort continents according to their localized name
-    end) { |localized_name, _id| localized_name }
-
+  ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
+    continents = Country.localized_sort_by!(locale, Continent.all.to_a) { |continent| continent.name_in(locale) }
     [locale, continents]
   end].freeze
 end

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -28,49 +28,8 @@ class Country < ApplicationRecord
     c_all_by_id.values.select { |c| c.iso2 == iso2 }.first
   end
 
-  def self.localized_sort_by!(wca_locale, array, &block)
-    # Unfortunately, it looks like the set of languages supported by
-    # twitter-cldr-rb is not exactly the same as the languages we support, so I
-    # had to add special mappings for pt-BR, zh-CN, and zh-TW.
-
-    # https://www.w3.org/International/articles/language-tags/ says:
-    # "Although for common uses of language tags it is not likely that you will need
-    # to specify the script, there are one or two situations that have been
-    # crying out for it for some time. One such example is Chinese. There are
-    # many Chinese dialects, often mutually unintelligible, but these dialects
-    # are all written using either Simplified or Traditional Chinese script.
-    # People typically want to label Chinese text as either Simplified or
-    # Traditional, but until recently there was no way to do so. People had to
-    # bend something like zh-CN (meaning Chinese as spoken in China) to mean
-    # Simplified Chinese, even in Singapore, and zh-TW (meaning Chinese as
-    # spoken in Taiwan) for Traditional Chinese. (Other people, however, use
-    # zh-HK for Traditional Chinese.) The availability of zh-Hans and zh-Hant
-    # for Chinese written in Simplified and Traditional scripts should improve
-    # consistency and accuracy, and is already becoming widely used, although
-    # of course you may need to continue to use the old language tags in some
-    # cases for consistency."
-
-    # So it is tempting to say that we should rename our locales as follows:
-    # zh-CN -> zh-Hans and zh-Tw -> zh-Hant
-
-    # However, Devise and Rails contain a lot of translations we use, and they
-    # also use zh-CN and zh-TW, so we probably want to stick with those.
-
-    cldr_locale = {
-      'pt-BR': 'pt',
-      'zh-CN': 'zh',
-      'zh-TW': 'zh-Hant',
-      # See https://github.com/thewca/worldcubeassociation.org/issues/1339
-      'sl': 'hr',
-    }.fetch(wca_locale, wca_locale)
-
-    collator = TwitterCldr::Collation::Collator.new(cldr_locale)
-
-    array.sort_by! { |element| collator.get_sort_key(block.call(element)) }
-  end
-
   ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    countries = localized_sort_by!(locale, Country.all.to_a) { |country| country.name_in(locale) }
+    countries = I18nUtils.localized_sort_by!(locale, Country.all.to_a) { |country| country.name_in(locale) }
     [locale, countries]
   end].freeze
 

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -69,8 +69,12 @@ class Country < ApplicationRecord
     array.sort_by! { |element| collator.get_sort_key(block.call(element)) }
   end
 
-  ALL_COUNTRIES_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
+  ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
     countries = localized_sort_by!(locale, Country.all.to_a) { |country| country.name_in(locale) }
     [locale, countries]
   end].freeze
+
+  def self.all_sorted_by(locale, real: false)
+    real ? ALL_SORTED_BY_LOCALE[locale].select(&:real?) : ALL_SORTED_BY_LOCALE[locale]
+  end
 end

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -3,10 +3,12 @@ class Country < ApplicationRecord
   include Cachable
   self.table_name = "Countries"
 
+  MULTIPLE_COUNTRIES_IDS = %w(XA XE XS).freeze
+
   belongs_to :continent, foreign_key: :continentId
   has_many :competitions, foreign_key: :countryId
 
-  scope :uncached_real, -> { where.not(id: %w(XA XE XS)) }
+  scope :uncached_real, -> { where.not(id: MULTIPLE_COUNTRIES_IDS) }
 
   def name
     I18n.t(iso2, scope: :countries)
@@ -21,7 +23,7 @@ class Country < ApplicationRecord
   end
 
   def real?
-    !%w(XA XE XS).include?(id)
+    !MULTIPLE_COUNTRIES_IDS.include?(id)
   end
 
   def self.find_by_iso2(iso2)

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -6,7 +6,7 @@ class Country < ApplicationRecord
   belongs_to :continent, foreign_key: :continentId
   has_many :competitions, foreign_key: :countryId
 
-  scope :uncached_real, -> { where("name not like 'Multiple Countries%'") }
+  scope :uncached_real, -> { where.not(id: %w(XA XE XS)) }
 
   def name
     I18n.t(iso2, scope: :countries)
@@ -21,7 +21,7 @@ class Country < ApplicationRecord
   end
 
   def real?
-    !read_attribute(:name).include?('Multiple Countries')
+    !%w(XA XE XS).include?(id)
   end
 
   def self.find_by_iso2(iso2)

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -46,7 +46,7 @@
             <%= f.input :name %>
             <%= f.input :dob, as: :date_picker %>
             <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] } %>
-            <%= f.input :country_iso2, collection: Country::ALL_COUNTRIES_BY_LOCALE[I18n.locale].select(&:real?), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name } %>
+            <%= f.input :country_iso2, collection: Country.all_sorted_by(I18n.locale, real: true), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name } %>
 
           </div>
         </div>

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -46,7 +46,7 @@
             <%= f.input :name %>
             <%= f.input :dob, as: :date_picker %>
             <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] } %>
-            <%= f.input :country_iso2, collection: Country.real, value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name } %>
+            <%= f.input :country_iso2, collection: Country::ALL_COUNTRIES_BY_LOCALE[I18n.locale].select(&:real?), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name } %>
 
           </div>
         </div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -72,7 +72,7 @@
         <%= f.input :name, disabled: !editable_fields.include?(:name) %>
         <%= f.input :dob, as: :date_picker, disabled: !editable_fields.include?(:dob) %>
         <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] }, disabled: !editable_fields.include?(:gender) %>
-        <%= f.input :country_iso2, collection: Country.real, value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name }, disabled: !editable_fields.include?(:country_iso2) %>
+        <%= f.input :country_iso2, collection: Country::ALL_COUNTRIES_BY_LOCALE[I18n.locale].select(&:real?), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name }, disabled: !editable_fields.include?(:country_iso2) %>
 
         <% if current_user.can_view_all_users? %>
           <div class="row" id="wca_id">

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -72,7 +72,7 @@
         <%= f.input :name, disabled: !editable_fields.include?(:name) %>
         <%= f.input :dob, as: :date_picker, disabled: !editable_fields.include?(:dob) %>
         <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] }, disabled: !editable_fields.include?(:gender) %>
-        <%= f.input :country_iso2, collection: Country::ALL_COUNTRIES_BY_LOCALE[I18n.locale].select(&:real?), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name }, disabled: !editable_fields.include?(:country_iso2) %>
+        <%= f.input :country_iso2, collection: Country.all_sorted_by(I18n.locale, real: true), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name }, disabled: !editable_fields.include?(:country_iso2) %>
 
         <% if current_user.can_view_all_users? %>
           <div class="row" id="wca_id">

--- a/WcaOnRails/lib/i18n_utils.rb
+++ b/WcaOnRails/lib/i18n_utils.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module I18nUtils
+  def self.localized_sort_by!(wca_locale, array, &block)
+    # Unfortunately, it looks like the set of languages supported by
+    # twitter-cldr-rb is not exactly the same as the languages we support, so I
+    # had to add special mappings for pt-BR, zh-CN, and zh-TW.
+
+    # https://www.w3.org/International/articles/language-tags/ says:
+    # "Although for common uses of language tags it is not likely that you will need
+    # to specify the script, there are one or two situations that have been
+    # crying out for it for some time. One such example is Chinese. There are
+    # many Chinese dialects, often mutually unintelligible, but these dialects
+    # are all written using either Simplified or Traditional Chinese script.
+    # People typically want to label Chinese text as either Simplified or
+    # Traditional, but until recently there was no way to do so. People had to
+    # bend something like zh-CN (meaning Chinese as spoken in China) to mean
+    # Simplified Chinese, even in Singapore, and zh-TW (meaning Chinese as
+    # spoken in Taiwan) for Traditional Chinese. (Other people, however, use
+    # zh-HK for Traditional Chinese.) The availability of zh-Hans and zh-Hant
+    # for Chinese written in Simplified and Traditional scripts should improve
+    # consistency and accuracy, and is already becoming widely used, although
+    # of course you may need to continue to use the old language tags in some
+    # cases for consistency."
+
+    # So it is tempting to say that we should rename our locales as follows:
+    # zh-CN -> zh-Hans and zh-Tw -> zh-Hant
+
+    # However, Devise and Rails contain a lot of translations we use, and they
+    # also use zh-CN and zh-TW, so we probably want to stick with those.
+
+    cldr_locale = {
+      'pt-BR': 'pt',
+      'zh-CN': 'zh',
+      'zh-TW': 'zh-Hant',
+      # See https://github.com/thewca/worldcubeassociation.org/issues/1339
+      'sl': 'hr',
+    }.fetch(wca_locale, wca_locale)
+
+    collator = TwitterCldr::Collation::Collator.new(cldr_locale)
+
+    array.sort_by! { |element| collator.get_sort_key(block.call(element)) }
+  end
+end


### PR DESCRIPTION
Fixes #1384.

Currently the constant includes `[localized_name, id]` pairs, which is not general enough to fit the forms, so what I did is to have the whole arrays of `Country` objects instead.

Also it's quite tricky as currently we have *all* countries stored in the constant, whereas in the forms we just need the *real* ones (i.e. not *Multiple Countries (...)*), so additional `select` was necessary.

That's the first reasonable idea that crossed my mind, let me know if you can think of any better way of tackling this issue.