### PR TITLE
Remove --show-progress option for wget.

### DIFF
--- a/WcaOnRails/lib/tasks/db.rake
+++ b/WcaOnRails/lib/tasks/db.rake
@@ -67,7 +67,7 @@ namespace :db do
           dump_filename = "wca-developer-database-dump.sql"
           zip_filename = "wca-developer-database-dump.zip"
 
-          LogTask.log_task("Downloading #{dev_db_dump_url}") { `wget --show-progress #{dev_db_dump_url}` }
+          LogTask.log_task("Downloading #{dev_db_dump_url}") { `wget #{dev_db_dump_url}` }
           LogTask.log_task("Unzipping #{zip_filename}") { `unzip #{zip_filename}` }
 
           config = ActiveRecord::Base.connection_config


### PR DESCRIPTION
Unfortunately, Ubuntu 14.04 comes with wget v1.15, which does not
support the --show-progress command line option introduced in v1.16.

This is needed to get chef working on staging again (currently it fails because it cannot import the developer database dump from production).