### PR TITLE
Remove DEFINER= from structure.sql.

### DIFF
--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -987,7 +987,6 @@ CREATE TABLE `votes` (
 /*!50001 SET character_set_results     = utf8 */;
 /*!50001 SET collation_connection      = utf8_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments` from `Persons` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;


### PR DESCRIPTION
This was causing problems when doing a development database dump on
production:

```
~/worldcubeassociation.org/WcaOnRails @production> time RACK_ENV=production bin/rake db:dump:development
Creating temporary database 'wca_development_db_dump'...ERROR 1227 (42000) at line 989 in file: '/home/cubing/worldcubeassociation.org/WcaOnRails/db/structure.sql': Access denied; you need (at least one of) the SUPER privilege(s) for this operation
done in 1.36s
```

Removing it doesn't seem to cause any problems.