### PR TITLE
Add countryId to the set of columns we group by when computing the Concise* tables.

### DIFF
--- a/webroot/results/admin/compute_auxiliary_data.php
+++ b/webroot/results/admin/compute_auxiliary_data.php
@@ -127,7 +127,7 @@ function computeConciseRecords () {
         ( SELECT   MIN($valueSource * 1000000000 + result.id) valueAndId
           FROM     Results result, Competitions competition, Events event
           WHERE    $valueSource>0 AND competition.id = competitionId AND event.id = eventId AND event.rank < 990
-          GROUP BY personId, eventId, year ) helper,
+          GROUP BY personId, result.countryId, eventId, year ) helper,
         Results      result,
         Competitions competition,
         Countries    country


### PR DESCRIPTION
This fixes the behavior when competitors change nationalities within one
calendar year.

Before:

![image](https://cloud.githubusercontent.com/assets/277474/23768439/d07caff0-04c0-11e7-87e1-67fe7f643a06.png)

After:

```
SQL query: SELECT * FROM `ConciseSingleResults` WHERE personId="2009SULE01" and year=2010 LIMIT 0, 25 ;
Rows: 18

id	best	valueAndId	personId	eventId	countryId	continentId	year	month	day
144142	741	741000144142	2009SULE01	222	Macedonia	_Europe	2010	8	21
144197	1877	1877000144197	2009SULE01	333	Macedonia	_Europe	2010	8	21
144356	15847	15847000144356	2009SULE01	333bf	Macedonia	_Europe	2010	8	21
144311	990120001	990120001000144311	2009SULE01	333mbf	Macedonia	_Europe	2010	8	21
111480	3722	3722000111480	2009SULE01	333oh	Macedonia	_Europe	2010	2	13
144166	11916	11916000144166	2009SULE01	444	Macedonia	_Europe	2010	8	21
111373	4336	4336000111373	2009SULE01	pyram	Macedonia	_Europe	2010	2	13
144324	10590	10590000144324	2009SULE01	sq1	Macedonia	_Europe	2010	8	21
167453	597	597000167453	2009SULE01	222	Norway	_Europe	2010	11	27
167516	11130	11130000167516	2009SULE01	333	Norway	_Europe	2010	11	27
167674	9871	9871000167674	2009SULE01	333bf	Norway	_Europe	2010	11	27
167701	990348404	990348404000167701	2009SULE01	333mbf	Norway	_Europe	2010	11	27
167639	5018	5018000167639	2009SULE01	333oh	Norway	_Europe	2010	11	27
167574	12184	12184000167574	2009SULE01	444	Norway	_Europe	2010	11	27
167615	29769	29769000167615	2009SULE01	555	Norway	_Europe	2010	11	27
167740	5491	5491000167740	2009SULE01	clock	Norway	_Europe	2010	11	27
167781	1884	1884000167781	2009SULE01	pyram	Norway	_Europe	2010	11	27
167794	4905	4905000167794	2009SULE01	sq1	Norway	_Europe	2010	11	27
```

Note how Ramadan Sulejman now shows up on both of these pages:

https://staging.worldcubeassociation.org/results/events.php?eventId=333&regionId=Macedonia&years=only%2B2010&show=100%2BPersons&single=Single
https://staging.worldcubeassociation.org/results/events.php?eventId=333&regionId=Norway&years=only%2B2010&show=100%2BPersons&single=Single