### PR TITLE
Added a (paginated) API to access our delegates.

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -115,4 +115,8 @@ class Api::V0::ApiController < ApplicationController
 
     paginate json: competitions
   end
+
+  def delegates
+    paginate json: User.delegates
+  end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -633,7 +633,7 @@ class User < ApplicationRecord
       },
     }
 
-    if doorkeeper_token
+    if doorkeeper_token && doorkeeper_token.resource_owner_id == self.id
       if doorkeeper_token.scopes.exists?("dob")
         json[:dob] = self.dob
       end
@@ -641,6 +641,13 @@ class User < ApplicationRecord
       if doorkeeper_token.scopes.exists?("email")
         json[:email] = self.email
       end
+    end
+
+    # Delegates's emails and regions are public information.
+    if self.any_kind_of_delegate?
+      json[:email] = self.email
+      json[:region] = self.region
+      json[:senior_delegate_id] = self.senior_delegate_id
     end
 
     json

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
       get '/users/:id' => 'api#show_user_by_id', constraints: { id: /\d+/ }
       get '/users/:wca_id' => 'api#show_user_by_wca_id'
       get '/competitions' => 'api#competitions'
+      get '/delegates' => 'api#delegates'
       resources :competitions, only: [:show]
     end
   end


### PR DESCRIPTION
CubingUSA needs this in order to automate membership of the "usa delegates" mailing list.

```
~/gitting/worldcubeassociation.org/WcaOnRails @kaladin> curl -s "localhost:3000/api/v0/delegates" | jq
[
  {
    "class": "user",
    "url": "/results/p.php?i=2003BRUC01",
    "id": 1,
    "wca_id": "2003BRUC01",
    "name": "Ron van Bruchem",
    "gender": "m",
    "country_iso2": "NL",
    "delegate_status": "board_member",
    "created_at": "2013-01-12T11:29:06.000Z",
    "updated_at": "2017-03-08T15:02:54.000Z",
    "teams": [],
    "avatar": {
      "url": "/uploads/user/avatar/2003BRUC01/1441150538.jpg",
      "thumb_url": "/uploads/user/avatar/2003BRUC01/1441150538_thumb.jpg",
      "is_default": false
    },
    "email": "1@worldcubeassociation.org",
    "region": "World (Netherlands)",
    "senior_delegate_id": null
  },
  {
    "class": "user",
    "url": "/results/p.php?i=2008AURO01",
    "id": 2,
    "wca_id": "2008AURO01",
    "name": "Sébastien Auroux",
    "gender": "m",
    "country_iso2": "DE",
    "delegate_status": "delegate",
    "created_at": "2012-07-25T05:42:29.000Z",
    "updated_at": "2017-02-09T21:10:18.000Z",
    "teams": [
      {
        "friendly_id": "results",
        "leader": true
      },
      {
        "friendly_id": "software",
        "leader": false
      }
    ],
    "avatar": {
      "url": "/uploads/user/avatar/2008AURO01/1441150539.jpg",
      "thumb_url": "/uploads/user/avatar/2008AURO01/1441150539_thumb.jpg",
      "is_default": false
    },
    "email": "2@worldcubeassociation.org",
    "region": "Germany",
    "senior_delegate_id": 248
  },
  ...
```