### PR TITLE
Fix payment opening

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -122,6 +122,10 @@ class Registration < ApplicationRecord
     (pending? || accepted?) && competition.using_stripe_payments? && outstanding_entry_fees > 0
   end
 
+  def show_payment_form?
+    competition.registration_opened? && has_to_pay_fee_here?
+  end
+
   def show_details?
     competition.registration_opened? || !(new_or_deleted?)
   end

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -59,51 +59,52 @@
       <% end %>
     <% end %>
 
-    <%# Note: this is displayed even if registrations are closed, intentionally %>
-    <% if @registration.has_to_pay_fee_here? %>
-      <div class="panel panel-info">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <%= t 'registrations.payment_form.title'%>
-          </h4>
+    <% if user_may_register %>
+      <% if @registration.show_payment_form? %>
+        <div class="panel panel-info">
+          <div class="panel-heading">
+            <h4 class="panel-title">
+              <%= t 'registrations.payment_form.title'%>
+            </h4>
+          </div>
+          <div class="panel-body">
+            <%= render "payment_form" %>
+          </div>
         </div>
-        <div class="panel-body">
-          <%= render "payment_form" %>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
 
-    <% should_collapse = @registration.has_to_pay_fee_here? %>
-    <% if user_may_register && @registration.show_details? %>
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          <h4 class="panel-title">
-            <%= render "register_panel_title", foldable: should_collapse do %>
-              <span><%= t 'registrations.panel_title' %></span>
+      <% should_collapse = @registration.has_to_pay_fee_here? %>
+      <% if @registration.show_details? %>
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <h4 class="panel-title">
+              <%= render "register_panel_title", foldable: should_collapse do %>
+                <span><%= t 'registrations.panel_title' %></span>
+              <% end %>
+            </h4>
+          </div>
+          <div id="register-panel" class="panel-body <%= "collapse" if should_collapse %>">
+            <p>
+              <% if @registration.new_or_deleted? %>
+                <%= t('registrations.check_registration_information') %>
+              <% elsif @registration.accepted? %>
+                <%= t('registrations.accepted') %>
+              <% elsif @registration.pending? %>
+                <%= t('registrations.waiting_list') %>
+              <% end %>
+            </p>
+            <hr/>
+            <%= render "register_form" %>
+          </div>
+          <div class="panel-footer">
+            <% if @competition.registration_past? %>
+              <%= t('registrations.closed_html', days: closes_in_days, time: wca_local_time(@competition.registration_close)) %>
+            <% else %>
+              <%= t('registrations.will_close_html', days: closes_in_days, time: wca_local_time(@competition.registration_close)) %>
             <% end %>
-          </h4>
+          </div>
         </div>
-        <div id="register-panel" class="panel-body <%= "collapse" if should_collapse %>">
-          <p>
-            <% if @registration.new_or_deleted? %>
-              <%= t('registrations.check_registration_information') %>
-            <% elsif @registration.accepted? %>
-              <%= t('registrations.accepted') %>
-            <% elsif @registration.pending? %>
-              <%= t('registrations.waiting_list') %>
-            <% end %>
-          </p>
-          <hr/>
-          <%= render "register_form" %>
-        </div>
-        <div class="panel-footer">
-          <% if @competition.registration_past? %>
-            <%= t('registrations.closed_html', days: closes_in_days, time: wca_local_time(@competition.registration_close)) %>
-          <% else %>
-            <%= t('registrations.will_close_html', days: closes_in_days, time: wca_local_time(@competition.registration_close)) %>
-          <% end %>
-        </div>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Initially I was thinking that we may want to let the payment form displayed after registrations are closed, but right now it's also displayed if the registrations are not opened yet, which definitely not fine.

Just fixing this so that the payment form is only displayed when registration are opened.
(The diff is ugly because I factorized a condition)