### PR TITLE
Don't show past competitions that you only registered for.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -415,7 +415,7 @@ class CompetitionsController < ApplicationController
   end
 
   def my_competitions
-    competitions = (current_user.delegated_competitions + current_user.organized_competitions + current_user.competitions_registered_for)
+    competitions = (current_user.delegated_competitions + current_user.organized_competitions + current_user.competitions_registered_for.not_over)
     if current_user.person
       competitions += current_user.person.competitions
     end

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -685,6 +685,7 @@ RSpec.describe CompetitionsController do
     let!(:registration3) { FactoryGirl.create(:registration, competition: past_competition1, user: registered_user) }
     let!(:registration4) { FactoryGirl.create(:registration, competition: past_competition3, user: organizer) }
     let!(:registration5) { FactoryGirl.create(:registration, competition: future_competition3, user: delegate) }
+    let!(:past_rejected_registration) { FactoryGirl.create(:registration, :pending, competition: past_competition3, user: registered_user) }
     let!(:results_person) { FactoryGirl.create(:person, wca_id: "2014PLUM01", name: "Jeff Plumb") }
     let!(:results_user) { FactoryGirl.create :user, name: "Jeff Plumb", wca_id: "2014PLUM01" }
     let!(:result) { FactoryGirl.create(:result, person: results_person, competitionId: past_competition1.id) }
@@ -718,7 +719,7 @@ RSpec.describe CompetitionsController do
       it 'shows my upcoming and past competitions' do
         get :my_competitions
         expect(assigns(:not_past_competitions)).to eq [future_competition1, future_competition3]
-        expect(assigns(:past_competitions)).to eq [past_competition1]
+        expect(assigns(:past_competitions)).to eq []
       end
     end
 
@@ -730,7 +731,7 @@ RSpec.describe CompetitionsController do
       it 'shows my upcoming and past competitions' do
         get :my_competitions
         expect(assigns(:not_past_competitions)).to eq [future_competition1, future_competition2, future_competition3]
-        expect(assigns(:past_competitions)).to eq [past_competition1, past_competition3]
+        expect(assigns(:past_competitions)).to eq [past_competition1]
       end
     end
 


### PR DESCRIPTION
You must have organized, delegated, or competed in a past competition
for it to show up under your "my competitions". This fixes #1407.

Note: An interesting (possibly undesirable) side effect of this is that virtually every competition you compete at will disappear from your "My competitions" list while you wait for results to be uploaded.