### PR TITLE
Add missing space to nginx logs.

### DIFF
--- a/chef/site-cookbooks/wca/templates/nginx.conf.erb
+++ b/chef/site-cookbooks/wca/templates/nginx.conf.erb
@@ -24,7 +24,7 @@ http {
   ##
   log_format upstream_time '$remote_addr - $remote_user [$time_local] '
                            '"$request" $status $body_bytes_sent '
-                           '"$http_referer" "$http_user_agent"'
+                           '"$http_referer" "$http_user_agent" '
                            'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
   access_log /var/log/nginx/access.log upstream_time;
   error_log /var/log/nginx/error.log;


### PR DESCRIPTION
Whoops! I thought I had fixed this already.