### PR TITLE
Simplified cache key to only update registration index every 2 minutes.

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -57,7 +57,7 @@ class RegistrationsController < ApplicationController
 
   def index
     @competition = competition_from_params
-    @registrations = @competition.registrations.accepted.includes(:user, :events, :competition_events).order("users.name").all
+    @registrations = @competition.registrations.accepted.includes(:user, :events, :competition_events).order("users.name")
   end
 
   def edit

--- a/WcaOnRails/app/views/registrations/index.html.erb
+++ b/WcaOnRails/app/views/registrations/index.html.erb
@@ -5,6 +5,7 @@
     # See https://github.com/thewca/worldcubeassociation.org/issues/1434.
   %>
   <% cache ["registrations_index", @competition.id, I18n.locale], expires_in: 2.minutes do %>
+    (<%= t 'common.last_updated_html', last_updated: wca_local_time(Time.now) %>)
     <%= wca_table data: { toggle: "table" } do %>
       <thead>
         <tr>

--- a/WcaOnRails/app/views/registrations/index.html.erb
+++ b/WcaOnRails/app/views/registrations/index.html.erb
@@ -1,7 +1,10 @@
 <% provide(:title, I18n.t('registrations.list.title', comp: @competition.name)) %>
 
 <%= render layout: "nav" do %>
-  <% cache ["registrations_index", @competition.events.map(&:id).sort, @registrations.map(&:id).sort, @registrations.map(&:updated_at).max, @registrations.map { |r| r.user.updated_at }.max, I18n.locale] do %>
+  <%# Simplified cache key to see if this helps us with performance issues.
+    # See https://github.com/thewca/worldcubeassociation.org/issues/1434.
+  %>
+  <% cache ["registrations_index", @competition.id, I18n.locale], expires_in: 2.minutes do %>
     <%= wca_table data: { toggle: "table" } do %>
       <thead>
         <tr>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -121,6 +121,7 @@ en:
     these_events:
       one: "this event"
       other: "these %{count} events"
+    last_updated_html: "last updated %{last_updated}"
   #context: Key used in the OAuth part of the site (checkout the /oauth/applications page for more details)
   oauth:
     applications:


### PR DESCRIPTION
Related to #1434.

![image](https://cloud.githubusercontent.com/assets/277474/23923687/dbcabcaa-08c4-11e7-9ba9-ba2c869d8326.png)
