### PR TITLE
Fix the order of closed and open polls

### DIFF
--- a/WcaOnRails/app/controllers/polls_controller.rb
+++ b/WcaOnRails/app/controllers/polls_controller.rb
@@ -6,7 +6,7 @@ class PollsController < ApplicationController
 
   def index
     @polls = current_user.can_create_poll? ? Poll.all : Poll.confirmed
-    @open_polls, @closed_polls = @polls.partition(&:over?)
+    @closed_polls, @open_polls = @polls.partition(&:over?)
   end
 
   def new


### PR DESCRIPTION
Pretty obvious, once creating the recent poll I noticed that *open* and *closed* are swapped. Quite funny that this hasn't been caught so far.