### PR TITLE
Add all/clear buttons to the associated events picker

### DIFF
--- a/WcaOnRails/app/assets/javascripts/associated-events-picker.js
+++ b/WcaOnRails/app/assets/javascripts/associated-events-picker.js
@@ -1,0 +1,10 @@
+$(function() {
+  function checkboxesSetter(value) {
+    return function() {
+      $(this).closest('.form-group').find('.event-checkbox input[type="checkbox"]').prop('checked', value);
+    };
+  }
+
+  $('.select-all-events').on('click', checkboxesSetter(true));
+  $('.clear-all-events').on('click', checkboxesSetter(false));
+});

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -22,7 +22,11 @@ Note: form_builder.object is the object having associated events.
 %>
 
 <div class="form-group <%= "has-error" unless errors.empty? %>">
-  <%= label_tag events_association_name, label, class: "associated-events-label" %>
+  <%= label_tag events_association_name, class: "associated-events-label" do %>
+    <%= label %>
+    <button type="button" class="btn btn-primary btn-xs select-all-events"><%= t 'competitions.index.all_events' %></button>
+    <button type="button" class="btn btn-default btn-xs clear-all-events"><%= t 'competitions.index.clear' %></button>
+  <% end %>
   <div id="<%= events_association_name %>" class="associated-events">
     <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>
       <span class="event-checkbox <%= "disabled" if disabled %>">


### PR DESCRIPTION
Fixes #1375.

@jfly concerning [your comment](https://github.com/thewca/worldcubeassociation.org/issues/1375#issuecomment-285351492) - this PR doesn't even touch the competition events form directly. Instead it extends the associated events picker with the utility that always makes sense (if it won't at some point, we can simply add an option to the picker to disable this).

- Registration

![screenshot from 2017-03-18 01-12-25](https://cloud.githubusercontent.com/assets/17034772/24067049/2c627792-0b78-11e7-8584-eb4b90bc0b86.png)

- Competition

![screenshot from 2017-03-18 01-12-36](https://cloud.githubusercontent.com/assets/17034772/24067050/2c635cf2-0b78-11e7-8706-cfaa5f46dccf.png)

- User profile

![screenshot from 2017-03-18 01-12-44](https://cloud.githubusercontent.com/assets/17034772/24067051/2c65979c-0b78-11e7-9bd9-50b83f06e90e.png)
