### PR TITLE
Add persons and registrations to WCIF.

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -23,7 +23,8 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     # This is all the associations we may need for the WCIF!
     includes_associations = [
       {
-        registrations: [:user, :events],
+        registrations: [{ user: { person: [:ranksSingle, :ranksAverage] } },
+                        :events],
       },
       :delegates,
       :organizers,

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -810,17 +810,15 @@ class Competition < ApplicationRecord
     managers = self.managers
     persons_wcif = registrations.map do |r|
       managers.delete(r.user)
-      r.user.to_wcif(r.to_wcif)
+      r.user.to_wcif(self, r.to_wcif)
     end
     # Note: unregistered managers may generate N+1 queries on their personal bests,
     # but that's fine because there are very few of them!
-    persons_wcif += managers.map(&:to_wcif)
+    persons_wcif += managers.map { |m| m.to_wcif(self) }
     {
       "formatVersion" => "1.0",
       "id" => id,
       "name" => name,
-      "organizers" => organizers.map(&:id),
-      "delegates" => delegates.map(&:id),
       "persons" => persons_wcif,
       "events" => competition_events.map(&:to_wcif),
     }

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -807,10 +807,21 @@ class Competition < ApplicationRecord
 
   # See https://github.com/thewca/worldcubeassociation.org/wiki/wcif
   def to_wcif
+    officials = (organizers + delegates).uniq
+    persons_wcif = registrations.map do |r|
+      officials.delete(r.user)
+      r.user.to_wcif(r.to_wcif)
+    end
+    persons_wcif += officials.map(&:to_wcif)
+
     {
-      "formatVersion" => "1.0",
-      "id" => self.id,
-      "events" => self.competition_events.map(&:to_wcif),
+      "format_version" => "1.0",
+      "id" => id,
+      "name" => name,
+      "organizers" => organizers.map(&:id),
+      "delegates" => delegates.map(&:id),
+      "persons" => persons_wcif,
+      "events" => competition_events.map(&:to_wcif),
     }
   end
 

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -807,15 +807,16 @@ class Competition < ApplicationRecord
 
   # See https://github.com/thewca/worldcubeassociation.org/wiki/wcif
   def to_wcif
-    officials = (organizers + delegates).uniq
+    comp_managers = managers
     persons_wcif = registrations.map do |r|
-      officials.delete(r.user)
+      comp_managers.delete(r.user)
       r.user.to_wcif(r.to_wcif)
     end
-    persons_wcif += officials.map(&:to_wcif)
-
+    # Note: unregistered managers may generate N+1 queries on their personal bests,
+    # but that's fine because there are very few of them!
+    persons_wcif += comp_managers.map(&:to_wcif)
     {
-      "format_version" => "1.0",
+      "formatVersion" => "1.0",
       "id" => id,
       "name" => name,
       "organizers" => organizers.map(&:id),

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -807,14 +807,14 @@ class Competition < ApplicationRecord
 
   # See https://github.com/thewca/worldcubeassociation.org/wiki/wcif
   def to_wcif
-    comp_managers = managers
+    managers = self.managers
     persons_wcif = registrations.map do |r|
-      comp_managers.delete(r.user)
+      managers.delete(r.user)
       r.user.to_wcif(r.to_wcif)
     end
     # Note: unregistered managers may generate N+1 queries on their personal bests,
     # but that's fine because there are very few of them!
-    persons_wcif += comp_managers.map(&:to_wcif)
+    persons_wcif += managers.map(&:to_wcif)
     {
       "formatVersion" => "1.0",
       "id" => id,

--- a/WcaOnRails/app/models/concerns/personal_best.rb
+++ b/WcaOnRails/app/models/concerns/personal_best.rb
@@ -9,9 +9,9 @@ module PersonalBest
     {
       "eventId": eventId,
       "best": best,
-      "worldRank": worldRank,
-      "continentRank": continentRank,
-      "countryRank": countryRank,
+      "worldRanking": worldRank,
+      "continentalRanking": continentRank,
+      "nationalRanking": countryRank,
       "type": type,
     }
   end

--- a/WcaOnRails/app/models/concerns/personal_best.rb
+++ b/WcaOnRails/app/models/concerns/personal_best.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module PersonalBest
+  extend ActiveSupport::Concern
+
+  def rank_to_wcif(type)
+    {
+      "eventId": eventId,
+      "best": best,
+      "worldRank": worldRank,
+      "continentRank": continentRank,
+      "countryRank": countryRank,
+      "type": type,
+    }
+  end
+end

--- a/WcaOnRails/app/models/ranks_average.rb
+++ b/WcaOnRails/app/models/ranks_average.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class RanksAverage < ApplicationRecord
+  include PersonalBest
   self.table_name = "RanksAverage"
+
+  def to_wcif
+    rank_to_wcif("average")
+  end
 
   def to_s(field)
     SolveTime.new(eventId, :average, send(field)).clock_format

--- a/WcaOnRails/app/models/ranks_single.rb
+++ b/WcaOnRails/app/models/ranks_single.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class RanksSingle < ApplicationRecord
+  include PersonalBest
   self.table_name = "RanksSingle"
+
+  def to_wcif
+    rank_to_wcif("single")
+  end
 
   def to_s(field)
     SolveTime.new(eventId, :best, send(field)).clock_format

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -171,6 +171,22 @@ class Registration < ApplicationRecord
     OpenStruct.new(index: index, length: pending_registrations.length)
   end
 
+  def to_wcif
+    {
+      "id" => id,
+      "event_ids" => events.map(&:id),
+      "status" => if accepted?
+                    'accepted'
+                  elsif deleted?
+                    'deleted'
+                  else
+                    'pending'
+                  end,
+      "guests" => guests,
+      "comments" => comments,
+    }
+  end
+
   validate :user_can_register_for_competition
   private def user_can_register_for_competition
     if user&.cannot_register_for_competition_reasons.present?

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -174,7 +174,7 @@ class Registration < ApplicationRecord
   def to_wcif
     {
       "id" => id,
-      "event_ids" => events.map(&:id),
+      "eventIds" => events.map(&:id),
       "status" => if accepted?
                     'accepted'
                   elsif deleted?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -675,8 +675,8 @@ class User < ApplicationRecord
   end
 
   def to_wcif(registration = nil)
+    person_pb = [person&.ranksAverage, person&.ranksSingle].compact.flatten
     {
-      "id" => 0,
       "name" => name,
       "wcaUserId" => id,
       "wcaId" => wca_id,
@@ -690,6 +690,7 @@ class User < ApplicationRecord
         "url" => avatar.url,
         "thumbUrl" => avatar.url(:thumb),
       },
+      "personalBests" => person_pb.map(&:to_wcif),
     }
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -674,6 +674,25 @@ class User < ApplicationRecord
     json
   end
 
+  def to_wcif(registration = nil)
+    {
+      "id" => 0,
+      "name" => name,
+      "wca_user_id" => id,
+      "wca_id" => wca_id,
+      "gender" => gender,
+      # /wcif is restricted to user who can manage the competition,
+      # we can include private data
+      "birthdate" => dob.to_s,
+      "email" => email,
+      "registration" => registration,
+      "avatar" => {
+        "url" => avatar.url,
+        "thumb_url" => avatar.url(:thumb),
+      },
+    }
+  end
+
   # Devise's method overriding! (the unwanted lines are commented)
   # We have the separate form for updating password and it requires current_password to be entered.
   # So we don't want to remove the password and password_confirmation if they are in the params and are blank.

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -678,8 +678,8 @@ class User < ApplicationRecord
     {
       "id" => 0,
       "name" => name,
-      "wca_user_id" => id,
-      "wca_id" => wca_id,
+      "wcaUserId" => id,
+      "wcaId" => wca_id,
       "gender" => gender,
       # /wcif is restricted to user who can manage the competition,
       # we can include private data
@@ -688,7 +688,7 @@ class User < ApplicationRecord
       "registration" => registration,
       "avatar" => {
         "url" => avatar.url,
-        "thumb_url" => avatar.url(:thumb),
+        "thumbUrl" => avatar.url(:thumb),
       },
     }
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -674,14 +674,16 @@ class User < ApplicationRecord
     json
   end
 
-  def to_wcif(registration = nil)
+  def to_wcif(competition, registration = nil)
     person_pb = [person&.ranksAverage, person&.ranksSingle].compact.flatten
     {
       "name" => name,
       "wcaUserId" => id,
       "wcaId" => wca_id,
+      "delegatesCompetition" => competition.delegates.include?(self),
+      "organizesCompetition" => competition.organizers.include?(self),
       "gender" => gender,
-      # /wcif is restricted to user who can manage the competition,
+      # /wcif is restricted to users who can manage the competition,
       # we can include private data
       "birthdate" => dob.to_s,
       "email" => email,

--- a/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
@@ -277,9 +277,7 @@ RSpec.describe Api::V0::CompetitionsController do
           "formatVersion" => "1.0",
           "id" => "TestComp2014",
           "name" => "Test Comp 2014",
-          "organizers" => [],
-          "delegates" => [delegate.id],
-          "persons" => [delegate.to_wcif],
+          "persons" => [delegate.to_wcif(competition)],
           "events" => [
             {
               "id" => "333",

--- a/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Api::V0::CompetitionsController do
         expect(response.status).to eq 200
         parsed_body = JSON.parse(response.body)
         expect(parsed_body).to eq(
-          "format_version" => "1.0",
+          "formatVersion" => "1.0",
           "id" => "TestComp2014",
           "name" => "Test Comp 2014",
           "organizers" => [],

--- a/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe Api::V0::CompetitionsController do
         :competition,
         :with_delegate,
         id: "TestComp2014",
+        name: "Test Comp 2014",
         start_date: "2014-02-03",
         end_date: "2014-02-05",
         external_website: "http://example.com",
@@ -273,8 +274,12 @@ RSpec.describe Api::V0::CompetitionsController do
         expect(response.status).to eq 200
         parsed_body = JSON.parse(response.body)
         expect(parsed_body).to eq(
-          "formatVersion" => "1.0",
+          "format_version" => "1.0",
           "id" => "TestComp2014",
+          "name" => "Test Comp 2014",
+          "organizers" => [],
+          "delegates" => [delegate.id],
+          "persons" => [delegate.to_wcif],
           "events" => [
             {
               "id" => "333",


### PR DESCRIPTION
Fixes #796.
cc @coder13 since I just noticed he was assigned to it.
Can I take on the issue?

This is more a base for discussions than an actual PR: it lacks tests, and some implementation details are unclear.
Basically I was trying to fill the need for the following statement:
"I have an external app where I'm authenticated, and I would like the registrations details for comp 'someid', which I can manage."

Interestingly the "big JSON" linked in #796 doesn't specify how a registration should looks like, so I improvised.

I'll put comments on the few unclear things I'm thinking about.