### PR TITLE
Remove Rails version from the chef

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -113,9 +113,6 @@ package 'imagemagick'
 ruby_version = File.read("#{repo_root}/WcaOnRails/.ruby-version").match(/\d+\.\d+/)[0]
 node.default['brightbox-ruby']['version'] = ruby_version
 include_recipe "brightbox-ruby"
-gem_package "rails" do
-  version "4.2.1"
-end
 chef_env_to_rails_env = {
   "development" => "development",
   "staging" => "production",


### PR DESCRIPTION
On the staging
```sh
~/worldcubeassociation.org @staging> gem list | grep rails
rails (4.2.1)
rails-deprecated_sanitizer (1.0.3)
rails-dom-testing (1.0.8)
rails-html-sanitizer (1.0.3)
sprockets-rails (3.2.0)

~/worldcubeassociation.org @staging> sudo gem uninstall rails
Successfully uninstalled rails-4.2.1

~/worldcubeassociation.org @staging> gem list | grep rails
rails-deprecated_sanitizer (1.0.3)
rails-dom-testing (1.0.8)
rails-html-sanitizer (1.0.3)
sprockets-rails (3.2.0)

~/worldcubeassociation.org @staging> cd WcaOnRails/

~/worldcubeassociation.org/WcaOnRails @staging> bundle list | grep rails
  * autoprefixer-rails (6.7.6)
  * bootstrap-table-rails (1.11.0)
  * datetimepicker-rails (4.7.16 36d21ce)
  * dotenv-rails (2.2.0)
  * jquery-rails (4.2.2)
  * lodash-rails (4.17.4)
  * momentjs-rails (2.17.1 ea58a20)
  * money-rails (1.8.0)
  * premailer-rails (1.9.5)
  * rails (5.0.1)
  * rails-assets-autoNumeric (2.0.7)
  * rails-assets-autosize (3.0.20)
  * rails-assets-simplemde (1.10.1)
  * rails-dom-testing (2.0.2)
  * rails-html-sanitizer (1.0.3)
  * rails-i18n (5.0.3)
  * sass-rails (5.0.6)
  * selectize-rails (0.12.1 fe39d6e)
  * sprockets-rails (3.2.0)
```

After running the chef, everything still works fine =)