### PR TITLE
Sort registrations by payment date.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -36,3 +36,19 @@ onPage('registrations#index', function() {
   // This makes the interface resemble the order.
   $('.name .sortable').addClass('asc');
 });
+
+function comparePaymentDate(a, b) {
+  var elemA = $(a);
+  var elemB = $(b);
+  var paidA = elemA.data("paidDate");
+  var paidB = elemB.data("paidDate");
+  if (paidA !== "" && paidB !== "") {
+    // Both have paid, compare their last payment dates
+    return paidA.localeCompare(paidB);
+  } else if (paidA === "" && paidB === "") {
+    // None have paid, compare their registration dates
+    return elemA.data("registeredAt").localeCompare(elemB.data("registeredAt"));
+  } else {
+    return paidA === "" ? 1 : -1;
+  }
+}

--- a/WcaOnRails/app/helpers/registrations_helper.rb
+++ b/WcaOnRails/app/helpers/registrations_helper.rb
@@ -27,4 +27,13 @@ module RegistrationsHelper
                sign_in: link_to(sign_in, competition_register_require_sign_in_path(comp)),
                here: link_to(here, new_user_registration_path, target: "_blank")))
   end
+
+  def registration_date_and_tooltip(competition, registration)
+    if @competition.using_stripe_payments?
+      [registration.last_payment_date&.to_date || I18n.t('registrations.list.not_paid'),
+       I18n.t('registrations.list.payment_requested_on', date: registration.created_at)]
+    else
+      [registration.created_at.to_date, registration.created_at]
+    end
+  end
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -444,7 +444,7 @@ class Competition < ApplicationRecord
   end
 
   def using_stripe_payments?
-    connected_stripe_account_id
+    connected_stripe_account_id && has_entry_fee?
   end
 
   def can_edit_registration_fees?

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -114,6 +114,10 @@ class Registration < ApplicationRecord
     )
   end
 
+  def last_payment_date
+    registration_payments.order(created_at: :desc).first&.created_at
+  end
+
   def outstanding_entry_fees
     entry_fee - paid_entry_fees
   end

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -39,7 +39,9 @@
                 </th>
               <% end %>
             <% end %>
-            <th class="registration-date" data-sortable="true" data-field="registration-date"><%= t 'registrations.list.registered' %></th>
+            <th class="registration-date" data-sortable="true" data-sorter="comparePaymentDate" data-field="registration-date">
+              <%= @competition.using_stripe_payments? ? t('registrations.list.registered.with_stripe') : t('registrations.list.registered.without_stripe') %>
+            </th>
             <th class="guests"><%= t 'activerecord.attributes.registration.guests' %></th>
             <th class="comments"><%= t 'activerecord.attributes.registration.comments' %></th>
             <th class="paid"><%= t 'activerecord.attributes.registration.paid_entry_fees' %></th>
@@ -80,9 +82,10 @@
                   </td>
                 <% end %>
               <% end %>
-              <td>
-                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.created_at %>">
-                  <%= registration.created_at.to_date %>
+              <td class="text-center">
+                <% registered_date, date_tooltip = registration_date_and_tooltip(@competition, registration) %>
+                <span data-toggle="tooltip" data-placement="left" title="<%= date_tooltip %>" data-paid-date="<%= registration.last_payment_date %>" data-registered-at="<%= registration.created_at %>">
+                  <%= registered_date %>
                 </span>
               </td>
               <td class="guests">
@@ -94,7 +97,9 @@
                 </span>
               </td>
               <td class="entry_fee">
-                <%= humanized_money_with_symbol registration.paid_entry_fees %>
+                <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.last_payment_date %>">
+                  <%= humanized_money_with_symbol registration.paid_entry_fees %>
+                </span>
               </td>
               <td>
                 <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -659,7 +659,12 @@ en:
       waiting_list: "Waiting List"
       approved_registrations: "Approved registrations"
       deleted_registrations: "Deleted registrations"
-      registered: "Registered"
+      not_paid: "Not paid"
+      registered:
+        without_stripe: "Registered on"
+        with_stripe: "Paid on"
+      #context: date is the registration creation date, eg: "2016-12-01 16:18:56 UTC"
+      payment_requested_on: "Payment requested on: %{date}"
       total: "Total"
     new_registration:
       title: "Register for %{comp}"


### PR DESCRIPTION
This intend to fix sorting for competition with entry fees: usually a registration is complete when paid, but the website only enable sorting by registration creation date.

The sort acts as follow :
 - Paid registration are sorted by last payment date
 - Unpaid registrations are sorted by registration date

I also added the last payment date as a tooltip for the "paid" field (before it was simply the paid amount, just as in the table cell, which was not very useful).

Known limitations:
 - If for some reasons the payment wasn't full (?!) it is still considered as paid
 - Staff member can usually register free of charge, since there is no way (currently) to know if a competitor is also staff, they are sorted as "unpaid". The "workaround" is to handle these cases manually.

These changes doesn't change the behavior when there are no registration fees, and will make life a lot easier for competition with registration fees on the WCA website. (also cc @KitClement because he'd like to see this implemented too :))