### PR TITLE
Add data range feature to the competitions index

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -63,7 +63,8 @@ onPage('competitions#index', function() {
 
   $form.on('change', '#events, #region, #state, #display, #status, #delegate', submitForm)
        .on('click', '#clear-all-events, #select-all-events', submitForm)
-       .on('input', '#search', _.debounce(submitForm, TEXT_INPUT_DEBOUNCE_MS));
+       .on('input', '#search', _.debounce(submitForm, TEXT_INPUT_DEBOUNCE_MS))
+       .on('dp.change','#from_date, #to_date', submitForm);
 
   $('#competition-query-form').on('ajax:send', function() {
     $('#loading').show();

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -128,17 +128,17 @@ $venue-map-wrapper-height: 400px;
   margin: 20px 0;
 
   #region,
-  #search-field,
-  #from-date-field,
-  #to-date-field {
+  #search-field {
     font-size: 12px;
     font-weight: normal;
     display: block;
   }
 
-  #from-date-field,
-  #to-date-field {
+  .custom-control {
     width: 100px;
+    @media (max-width: $screen-sm) {
+      display: inline-block;
+    }
   }
 
   #clear-all-events,

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -128,10 +128,17 @@ $venue-map-wrapper-height: 400px;
   margin: 20px 0;
 
   #region,
-  #search-field {
+  #search-field,
+  #from-date-field,
+  #to-date-field {
     font-size: 12px;
     font-weight: normal;
     display: block;
+  }
+
+  #from-date-field,
+  #to-date-field {
+    width: 100px;
   }
 
   #clear-all-events,

--- a/WcaOnRails/app/assets/stylesheets/wca-autocomplete.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca-autocomplete.scss
@@ -50,6 +50,12 @@
     padding-right: 12px + $search-icon-size;
   }
 
+
+  .selectize-input,
+  .selectize-input.input-active {
+    display: block;
+  }
+
   .wca-autocomplete-competition {
     .name {
       font-size: 1.5em;

--- a/WcaOnRails/app/inputs/date_picker_input.rb
+++ b/WcaOnRails/app/inputs/date_picker_input.rb
@@ -14,6 +14,26 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
     super.push '' # 'form-control'
   end
 
+  def self.date_options_base
+    {
+      locale: I18n.locale.to_s,
+      format: DatePickerInput.picker_pattern,
+      dayViewHeaderFormat: DatePickerInput.date_view_header_format,
+    }
+  end
+
+  def self.display_pattern
+    I18n.t('datepicker.dformat')
+  end
+
+  def self.picker_pattern
+    I18n.t('datepicker.pformat')
+  end
+
+  def self.date_view_header_format
+    I18n.t('datepicker.dayViewHeaderFormat')
+  end
+
   private
 
   def input_button
@@ -36,35 +56,15 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
 
   def set_value_html_option
     return unless value.present?
-    input_html_options[:value] ||= value.is_a?(String) ? value : I18n.localize(value, format: display_pattern)
+    input_html_options[:value] ||= value.is_a?(String) ? value : I18n.localize(value, format: DatePickerInput.display_pattern)
   end
 
   def value
     object.send(attribute_name) if object.respond_to? attribute_name
   end
 
-  def display_pattern
-    I18n.t('datepicker.dformat')
-  end
-
-  def picker_pattern
-    I18n.t('datepicker.pformat')
-  end
-
-  def date_view_header_format
-    I18n.t('datepicker.dayViewHeaderFormat')
-  end
-
-  def date_options_base
-    {
-      locale: I18n.locale.to_s,
-      format: picker_pattern,
-      dayViewHeaderFormat: date_view_header_format,
-    }
-  end
-
   def date_options
     custom_options = input_html_options[:data][:date_options] || {}
-    date_options_base.merge!(custom_options)
+    DatePickerInput.date_options_base.merge!(custom_options)
   end
 end

--- a/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
@@ -11,6 +11,10 @@
       <div class="col-md-12" id="past-comps">
         <%= render 'index_table', competitions: competitions, title: t('competitions.index.titles.recent', count: Competition::RECENT_DAYS) %>
       </div>
+    <% elsif @custom_selected %>
+      <div class="col-md-12" id="past-comps">
+        <%= render 'index_table', competitions: competitions, title: t('competitions.index.titles.custom') %>
+      </div>
     <% else %>
       <% in_progress_competitions, upcoming_competitions = competitions.partition(&:in_progress?) %>
       <% unless in_progress_competitions.empty? %>

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -73,13 +73,13 @@
 <!-- These fields should be shown when "Custom" state is selected. -->
 <div class="form-group custom-control">
   <%= label_tag(t('competitions.index.from_date')) %>
-  <div id="from-date-field" class="input-group date datetimepicker">
+  <div class="input-group date datetimepicker">
     <%= text_field_tag "from_date", params[:from_date], class: "form-control date_picker", data: { date_options: DatePickerInput.date_options_base } %>
   </div>
 </div>
 <div class="form-group custom-control">
   <%= label_tag(t('competitions.index.to_date')) %>
-  <div id="to-date-field" class="input-group date datetimepicker">
+  <div class="input-group date datetimepicker">
     <%= text_field_tag "to_date", params[:to_date], class: "form-control date_picker", data: { date_options: DatePickerInput.date_options_base } %>
   </div>
 </div>

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -63,6 +63,24 @@
         <% end %>
       </span>
     </label>
+    <label id="custom" class="btn btn-primary">
+      <%= radio_button_tag "state", "custom" %>
+      <span class="caption"><%= t 'competitions.index.custom' %></span>
+    </label>
+  </div>
+</div>
+
+<!-- These fields should be shown when "Custom" state is selected. -->
+<div class="form-group custom-control">
+  <%= label_tag(t('competitions.index.from_date')) %>
+  <div id="from-date-field" class="input-group date datetimepicker">
+    <%= text_field_tag "from_date", params[:from_date], class: "form-control date_picker", data: { date_options: DatePickerInput.date_options_base } %>
+  </div>
+</div>
+<div class="form-group custom-control">
+  <%= label_tag(t('competitions.index.to_date')) %>
+  <div id="to-date-field" class="input-group date datetimepicker">
+    <%= text_field_tag "to_date", params[:to_date], class: "form-control date_picker", data: { date_options: DatePickerInput.date_options_base } %>
   </div>
 </div>
 
@@ -83,7 +101,6 @@
     </label>
   </div>
 </div>
-
 
 <div id="delegate" class="form-group delegate-selector">
   <%= label_tag(t('layouts.navigation.delegate')) %>
@@ -136,6 +153,16 @@
       $past.button('toggle');
     }
   });
+
+  $('#state .btn:not(#custom)').on('click', function() {
+    $('.custom-control').hide();
+  });
+
+  $('#custom').on('click', function() {
+    $('.custom-control').show();
+  });
+
+  $('#state .btn.active').trigger('click');
 
   $('#display-<%= @display %>').button('toggle');
 </script>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -757,10 +757,13 @@ en:
       map: "Map"
       region: "Region"
       search: "Search"
-      state: "State"
+      state: "When"
       present: "Present"
       recent: "Recent"
       past: "Past"
+      custom: "Custom"
+      from_date: "From"
+      to_date: "To"
       #context: selecting a specific year ('year' is a number)
       past_from: "Past from %{year}"
       past_all: "Past from all years"
@@ -772,6 +775,7 @@ en:
         past_all: "Past competitions from all years"
         recent: "Recent competitions (last %{count} days)"
         upcoming: "Upcoming competitions"
+        custom: "Competitions in the selected period of time"
       no_access: "You don't have access to this page!"
       #context: tooltip displayed when hovering
       tooltips:


### PR DESCRIPTION
My friend asked about an ability to find competitions in some range. I discussed with @jfly and decided not to make this a part of the existing UI as it's already full of other controls. When I started to implement this, I rapidly realised that making this as params-only feature would involve some messy code in order to preserve those parameters on the Ajax form request. So what I decided to do is adding `From date` and `To date` to the actual UI, but shown only if one of special params is specified. This should be well both for our code and the user.

![image](https://cloud.githubusercontent.com/assets/17034772/24513282/1b54f9b8-1571-11e7-9d70-207e85080cd7.png)
