### PR TITLE
Implement diry hack for @kitclement

### DIFF
--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -59,6 +59,20 @@
       <% end %>
     <% end %>
 
+    <%#
+      Urgg... this is a dirty hack for Kit Clement for RoseCity2017, and should be removed
+      on May 22nd, 2017 (after the competition is over). See:
+       https://github.com/thewca/worldcubeassociation.org/issues/1493
+    %>
+    <% if @competition.id == "RoseCity2017" %>
+      <strong>
+        Please note: payment is not required for those only competing at the Sunday
+        competition at the Hillsdale Library. If you are only competing in the 3x3x3
+        Blindfolded, 4x4x4 Blindfolded, or 3x3x3 Fewest Moves events, skip the
+        payment step and we will approve your registration automatically.
+      </strong>
+    <% end %>
+
     <% if user_may_register %>
       <% show_payment_form = @registration.show_payment_form? %>
       <% if show_payment_form %>


### PR DESCRIPTION
You can see this live on https://staging.worldcubeassociation.org/competitions/RoseCity2017/register:

![image](https://cloud.githubusercontent.com/assets/277474/24598784/21655792-1802-11e7-94d3-e3f197b0b36d.png)

@KitClement has some weird situation going on with his venue that is requiring him to put custom text on the registration page. Neither him nor I think this makes any sense, but I believe this is the minimal effort involved for all parties. Kit will write up a fuller explanation of this on #1493.