### PR TITLE
Added a rounds table to explicitly track the rounds of a competition.

### DIFF
--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -3,4 +3,14 @@ class CompetitionEvent < ApplicationRecord
   belongs_to :competition
   belongs_to :event
   has_many :registration_competition_events, dependent: :destroy
+  has_many :rounds, -> { order(:number) }
+  accepts_nested_attributes_for :rounds, allow_destroy: true
+
+  validate do
+    remaining_rounds = rounds.reject(&:marked_for_destruction?)
+    numbers = remaining_rounds.map(&:number).sort
+    if numbers != (1..remaining_rounds.length).to_a
+      errors.add(:rounds, "#{numbers} is wrong")
+    end
+  end
 end

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class Round < ApplicationRecord
+  belongs_to :competition_event
+  has_one :event, through: :competition_event
+  belongs_to :format
+
+  MAX_NUMBER = 4
+  validates_numericality_of :number,
+                            only_integer: true,
+                            greater_than_or_equal_to: 1,
+                            less_than_or_equal_to: MAX_NUMBER
+
+  validate do
+    unless event.preferred_formats.find_by_format_id(format_id)
+      errors.add(:format, "'#{format_id}' is not allowed for '#{event.id}'")
+    end
+  end
+end

--- a/WcaOnRails/db/migrate/20170406170418_create_rounds.rb
+++ b/WcaOnRails/db/migrate/20170406170418_create_rounds.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class CreateRounds < ActiveRecord::Migration[5.0]
+  def change
+    create_table :rounds do |t|
+      t.integer :competition_event_id, null: false
+      t.string :format_id, null: false
+      t.integer :number, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :rounds, [:competition_event_id, :number]
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -829,6 +829,25 @@ CREATE TABLE `registrations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `rounds`
+--
+
+DROP TABLE IF EXISTS `rounds`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `rounds` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `competition_event_id` int(11) NOT NULL,
+  `format_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `number` int(11) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `schema_migrations`
 --
 
@@ -1128,6 +1147,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170228140556'),
 ('20170320222511'),
 ('20170402223714'),
-('20170404184332');
+('20170404184332'),
+('20170406170418');
 
 

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -250,6 +250,19 @@ module DatabaseDumper
         ),
       ),
     }.freeze,
+    "rounds" => {
+      where_clause: "JOIN competition_events ON competition_events.id = competition_event_id #{JOIN_WHERE_VISIBLE_COMP}",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competition_event_id
+          format_id
+          number
+          created_at
+          updated_at
+        ),
+      ),
+    }.freeze,
     "RoundTypes" => {
       where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
     transient do
       starts 1.year.ago
       ends { starts }
+      event_ids { %w(333 333oh) }
     end
 
     start_date { starts.nil? ? nil : starts.strftime("%F") }
@@ -34,7 +35,7 @@ FactoryGirl.define do
       results_posted_at Time.now
     end
 
-    events { Event.where(id: %w(333 333oh)) }
+    events { Event.where(id: event_ids) }
 
     venue "My backyard"
     venueAddress "My backyard street"

--- a/WcaOnRails/spec/factories/rounds.rb
+++ b/WcaOnRails/spec/factories/rounds.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :round do
+    transient do
+      competition { FactoryGirl.create :competition }
+      event_id "333"
+      format_id "a"
+    end
+
+    format { Format.c_find(format_id) }
+    competition_event { competition.competition_events.find_by_event_id!(event_id) }
+    number 1
+  end
+end

--- a/WcaOnRails/spec/models/competition_event_spec.rb
+++ b/WcaOnRails/spec/models/competition_event_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CompetitionEvent do
+  let(:competition) { FactoryGirl.create :competition, event_ids: %w(333 444) }
+  let(:competition_event) { competition.competition_events.find_by_event_id("333") }
+
+  it "it's okay if there are no rounds yet" do
+    expect(competition_event).to be_valid
+  end
+
+  context "number" do
+    it "must start at 1" do
+      build_rounds([3])
+      expect(competition_event).to be_invalid_with_errors(rounds: ["[3] is wrong"])
+    end
+
+    it "must be contiguous" do
+      build_rounds([1, 3])
+      expect(competition_event).to be_invalid_with_errors(rounds: ["[1, 3] is wrong"])
+    end
+
+    it "cannot have duplicates" do
+      build_rounds([1, 2, 2, 3])
+      expect(competition_event).to be_invalid_with_errors(rounds: ["[1, 2, 2, 3] is wrong"])
+    end
+
+    it "cannot remove a round in the middle" do
+      build_rounds([1, 2, 3])
+      competition_event.save!
+      expect(competition_event.rounds.length).to eq 3
+
+      mark_rounds_for_destruction([2])
+      expect(competition_event).to be_invalid_with_errors(rounds: ["[1, 3] is wrong"])
+    end
+  end
+
+  def build_rounds(round_numbers)
+    competition_event.rounds_attributes = round_numbers.map { |n| { number: n, format_id: "a" } }
+  end
+
+  def mark_rounds_for_destruction(round_numbers)
+    competition_event.rounds_attributes = competition_event.rounds.map do |round|
+      { id: round.id, _destroy: round_numbers.include?(round.number) ? "1" : "0" }
+    end
+  end
+end

--- a/WcaOnRails/spec/models/round_spec.rb
+++ b/WcaOnRails/spec/models/round_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Round do
+  it "defines a valid Round" do
+    round = FactoryGirl.build :round
+    expect(round).to be_valid
+  end
+
+  context "format" do
+    it "allows average of 5 for 333" do
+      round = FactoryGirl.build :round, event_id: "333", format_id: "a"
+      expect(round).to be_valid
+    end
+
+    it "rejects mean of 3 for 333" do
+      round = FactoryGirl.build :round, event_id: "333", format_id: "m"
+      expect(round).to be_invalid_with_errors(format: ["'m' is not allowed for '333'"])
+    end
+  end
+end

--- a/WcaOnRails/spec/support/be_invalid_with_errors.rb
+++ b/WcaOnRails/spec/support/be_invalid_with_errors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_invalid_with_errors do |errors|
+  match do |ar_object|
+    !ar_object.valid? && errors.all? { |k, v| ar_object.errors[k] == v }
+  end
+
+  failure_message do |ar_object|
+    if ar_object.valid?
+      "expected to find the following errors: #{errors}"
+    else
+      "expected that #{ar_object} would be invalid"
+    end
+  end
+end


### PR DESCRIPTION
Intentionally very simple. This is just the table, the models, and the validations. #1500 tracks future work after this gets merged.

I'm intentionally *not* planning to touch any PHP code as part of this. Currently, this table is just for competition planning purposes only, although in the fullness of time, I think it would make sense for us to keep this table in sync with the posted results for a competition.