### PR TITLE
Convert table to use utf8mb4 instead of utf8

### DIFF
--- a/WcaOnRails/config/database.yml
+++ b/WcaOnRails/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: mysql2
   pool: 5
   timeout: 5000
-  encoding: utf8
+  encoding: utf8mb4
   host: 127.0.0.1
   port: 3306
   username: root

--- a/WcaOnRails/db/migrate/20170404184332_convert_utf8_to_utf8mb4.rb
+++ b/WcaOnRails/db/migrate/20170404184332_convert_utf8_to_utf8mb4.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# See https://gist.github.com/tjh/1711329#gistcomment-2046518.
+class ConvertUtf8ToUtf8mb4 < ActiveRecord::Migration[5.0]
+  def db
+    ActiveRecord::Base.connection
+  end
+
+  def up
+    # Foreign keys prevent us from changing the character set of certain columns. You get errors like:
+    #  Mysql2::Error: Cannot change column 'id': used in a foreign key constraint 'fk_rails_8d2986d7ea' of table 'wca_development.preferred_formats'
+    # Foreign keys have caused us other problems, so I'm taking this as an opportunity to get rid of all of them.
+    remove_foreign_key :competition_events, name: :fk_rails_ba6cfdafb1
+    remove_foreign_key :poll_options, name: :poll_options_ibfk_1
+    remove_foreign_key :preferred_formats, name: :fk_rails_8d2986d7ea
+    remove_foreign_key :preferred_formats, name: :fk_rails_c3e0098ed3
+    remove_foreign_key :votes, name: :votes_ibfk_1
+
+    execute "ALTER DATABASE `#{db.current_database}` CHARACTER SET utf8mb4;"
+    db.tables.each do |table|
+      next if %w(ar_internal_metadata schema_migrations).include?(table)
+      next if db.views.include?(table) # Skip views. This will not be necessary in Rails 5.1, when `db.tables` will change to only return actual tables.
+      execute "ALTER TABLE `#{table}` CHARACTER SET = utf8mb4;"
+      db.columns(table).each do |column|
+        case column.sql_type
+        when /([a-z]*)text/i
+          execute "ALTER TABLE `#{table}` CHANGE `#{column.name}` `#{column.name}` #{$1.upcase}TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+        when /((?:var)?char)\(([0-9]+)\)/i
+          # InnoDB has a maximum index length of 767 bytes, so for utf8 or utf8mb4
+          # columns, you can index a maximum of 255 or 191 characters, respectively.
+          # If you currently have utf8 columns with indexes longer than 191 characters,
+          # you will need to index a smaller number of characters.
+          indexed_column = db.indexes(table).any? { |index| index.columns.include?(column.name) }
+
+          sql_type = indexed_column && $2.to_i > 191 ? "#{$1}(191)" : column.sql_type.upcase
+          default = column.default.nil? ? '' : "DEFAULT '#{column.default}'"
+          null = column.null ? '' : 'NOT NULL'
+          execute "ALTER TABLE `#{table}` CHANGE `#{column.name}` `#{column.name}` #{sql_type} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci #{default} #{null};"
+        end
+      end
+    end
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -7,7 +7,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+/*!40101 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -23,27 +23,27 @@ DROP TABLE IF EXISTS `Competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Competitions` (
-  `id` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `cityName` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `information` mediumtext COLLATE utf8_unicode_ci,
+  `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cityName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `information` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endMonth` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endDay` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `venue` varchar(240) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `venueAddress` varchar(120) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `venueDetails` varchar(120) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `external_website` varchar(200) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `cellName` varchar(45) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `venue` varchar(240) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `venueAddress` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `venueDetails` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `external_website` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `showAtAll` tinyint(1) NOT NULL DEFAULT '0',
   `latitude` int(11) DEFAULT NULL,
   `longitude` int(11) DEFAULT NULL,
   `isConfirmed` tinyint(1) NOT NULL DEFAULT '0',
-  `contact` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `remarks` text COLLATE utf8_unicode_ci,
+  `contact` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `registration_open` datetime DEFAULT NULL,
   `registration_close` datetime DEFAULT NULL,
   `use_wca_registration` tinyint(1) NOT NULL DEFAULT '0',
@@ -53,9 +53,9 @@ CREATE TABLE `Competitions` (
   `generate_website` tinyint(1) DEFAULT NULL,
   `announced_at` datetime DEFAULT NULL,
   `base_entry_fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
-  `currency_code` varchar(255) COLLATE utf8_unicode_ci DEFAULT 'USD',
+  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
   `endYear` smallint(6) NOT NULL DEFAULT '0',
-  `connected_stripe_account_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `connected_stripe_account_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
@@ -64,7 +64,7 @@ CREATE TABLE `Competitions` (
   KEY `index_Competitions_on_countryId` (`countryId`),
   KEY `index_Competitions_on_start_date` (`start_date`),
   KEY `index_Competitions_on_end_date` (`end_date`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -76,18 +76,18 @@ DROP TABLE IF EXISTS `CompetitionsMedia`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `CompetitionsMedia` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `type` varchar(15) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `text` varchar(100) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `uri` text COLLATE utf8_unicode_ci NOT NULL,
-  `submitterName` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `submitterComment` text COLLATE utf8_unicode_ci NOT NULL,
-  `submitterEmail` varchar(45) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `type` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `text` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `submitterName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `submitterComment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `submitterEmail` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `timestampSubmitted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `timestampDecided` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `status` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11611 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -101,14 +101,14 @@ CREATE TABLE `ConciseAverageResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
   `valueAndId` bigint(22) DEFAULT NULL,
-  `personId` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -122,14 +122,14 @@ CREATE TABLE `ConciseSingleResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
   `valueAndId` bigint(22) DEFAULT NULL,
-  `personId` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -140,14 +140,14 @@ DROP TABLE IF EXISTS `Continents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Continents` (
-  `id` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `recordName` char(3) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `recordName` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `latitude` int(11) NOT NULL DEFAULT '0',
   `longitude` int(11) NOT NULL DEFAULT '0',
   `zoom` tinyint(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -158,14 +158,14 @@ DROP TABLE IF EXISTS `Countries`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Countries` (
-  `id` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `iso2` char(2) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `iso2` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `iso2` (`iso2`),
   KEY `fk_continents` (`continentId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -176,13 +176,13 @@ DROP TABLE IF EXISTS `Events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Events` (
-  `id` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(54) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(54) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `format` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `format` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 PACK_KEYS=0;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -193,15 +193,15 @@ DROP TABLE IF EXISTS `Formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Formats` (
-  `id` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `sort_by` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `sort_by_second` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `sort_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sort_by_second` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `expected_solve_count` int(11) NOT NULL,
   `trim_fastest_n` int(11) NOT NULL,
   `trim_slowest_n` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -212,17 +212,17 @@ DROP TABLE IF EXISTS `InboxPersons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxPersons` (
-  `id` varchar(10) COLLATE utf8_unicode_ci NOT NULL,
-  `wcaId` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `countryId` char(2) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wcaId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `dob` date NOT NULL,
-  `competitionId` varchar(32) COLLATE utf8_unicode_ci NOT NULL,
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   KEY `InboxPersons_fk_country` (`countryId`),
   KEY `InboxPersons_id` (`wcaId`),
   KEY `InboxPersons_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -233,12 +233,12 @@ DROP TABLE IF EXISTS `InboxResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxResults` (
-  `personId` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+  `personId` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `competitionId` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -250,7 +250,7 @@ CREATE TABLE `InboxResults` (
   KEY `InboxResults_fk_event` (`eventId`),
   KEY `InboxResults_fk_format` (`formatId`),
   KEY `InboxResults_fk_round` (`roundTypeId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=0;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 PACK_KEYS=0;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -261,22 +261,22 @@ DROP TABLE IF EXISTS `Persons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Persons` (
-  `id` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `subId` tinyint(6) NOT NULL DEFAULT '1',
-  `name` varchar(80) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(6) NOT NULL DEFAULT '0',
   `month` tinyint(4) NOT NULL DEFAULT '0',
   `day` tinyint(4) NOT NULL DEFAULT '0',
-  `comments` varchar(40) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `comments` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rails_id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`rails_id`),
   UNIQUE KEY `index_Persons_on_id_and_subId` (`id`,`subId`),
   KEY `Persons_fk_country` (`countryId`),
   KEY `Persons_id` (`id`),
   KEY `Persons_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=143 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=71976 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -288,8 +288,8 @@ DROP TABLE IF EXISTS `RanksAverage`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksAverage` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -297,7 +297,7 @@ CREATE TABLE `RanksAverage` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=197 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=190040 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -309,8 +309,8 @@ DROP TABLE IF EXISTS `RanksSingle`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksSingle` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -318,7 +318,7 @@ CREATE TABLE `RanksSingle` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=197 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=225464 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -331,13 +331,13 @@ DROP TABLE IF EXISTS `Results`;
 CREATE TABLE `Results` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `personId` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `personName` varchar(80) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `competitionId` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personName` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -345,8 +345,8 @@ CREATE TABLE `Results` (
   `value5` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
-  `regionalSingleRecord` char(3) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `regionalAverageRecord` char(3) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `regionalSingleRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `regionalAverageRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `Results_fk_tournament` (`competitionId`),
@@ -359,7 +359,7 @@ CREATE TABLE `Results` (
   KEY `Results_regionalSingleRecordCheckSpeedup` (`eventId`,`competitionId`,`roundTypeId`,`countryId`,`best`),
   KEY `Results_fk_competitor` (`personId`),
   KEY `index_Results_on_competitionId_and_updated_at` (`competitionId`,`updated_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=1448123 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB AUTO_INCREMENT=1485960 DEFAULT CHARSET=utf8mb4 PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -370,13 +370,13 @@ DROP TABLE IF EXISTS `RoundTypes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RoundTypes` (
-  `id` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `name` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `final` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -388,16 +388,32 @@ DROP TABLE IF EXISTS `Scrambles`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Scrambles` (
   `scrambleId` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) COLLATE utf8_unicode_ci NOT NULL COMMENT 'matches Competitions.id',
-  `eventId` varchar(6) COLLATE utf8_unicode_ci NOT NULL COMMENT 'matches Events.id',
-  `roundTypeId` char(1) COLLATE utf8_unicode_ci NOT NULL,
-  `groupId` varchar(3) COLLATE utf8_unicode_ci NOT NULL COMMENT 'from A to ZZZ',
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `groupId` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `isExtra` tinyint(1) NOT NULL,
   `scrambleNum` int(11) NOT NULL,
-  `scramble` varchar(500) COLLATE utf8_unicode_ci NOT NULL,
+  `scramble` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`scrambleId`),
   KEY `competitionId` (`competitionId`,`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=479848 DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `ar_internal_metadata`
+--
+
+DROP TABLE IF EXISTS `ar_internal_metadata`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ar_internal_metadata` (
+  `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -409,7 +425,7 @@ DROP TABLE IF EXISTS `competition_delegates`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_delegates` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -418,7 +434,7 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6257 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6257 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -430,13 +446,12 @@ DROP TABLE IF EXISTS `competition_events`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `event_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
-  KEY `fk_rails_ba6cfdafb1` (`event_id`),
-  CONSTRAINT `fk_rails_ba6cfdafb1` FOREIGN KEY (`event_id`) REFERENCES `Events` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=9350 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  KEY `fk_rails_ba6cfdafb1` (`event_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=36750 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -448,7 +463,7 @@ DROP TABLE IF EXISTS `competition_organizers`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_organizers` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `organizer_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -457,7 +472,7 @@ CREATE TABLE `competition_organizers` (
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6300 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6300 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -469,13 +484,13 @@ DROP TABLE IF EXISTS `competition_tabs`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_tabs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `content` text COLLATE utf8_unicode_ci,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `display_order` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_tabs_on_display_order_and_competition_id` (`display_order`,`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1189 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -489,14 +504,14 @@ CREATE TABLE `completed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text COLLATE utf8_unicode_ci NOT NULL,
+  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
-  `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `completed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -510,18 +525,18 @@ CREATE TABLE `delayed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text COLLATE utf8_unicode_ci NOT NULL,
-  `last_error` text COLLATE utf8_unicode_ci,
+  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `locked_at` datetime DEFAULT NULL,
   `failed_at` datetime DEFAULT NULL,
-  `locked_by` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `queue` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `locked_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `delayed_jobs_priority` (`priority`,`run_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -533,21 +548,21 @@ DROP TABLE IF EXISTS `delegate_reports`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `delegate_reports` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `equipment` text COLLATE utf8_unicode_ci,
-  `venue` text COLLATE utf8_unicode_ci,
-  `organization` text COLLATE utf8_unicode_ci,
-  `schedule_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `incidents` text COLLATE utf8_unicode_ci,
-  `remarks` text COLLATE utf8_unicode_ci,
-  `discussion_url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `equipment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `venue` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `organization` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `schedule_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `incidents` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `discussion_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `posted_by_user_id` int(11) DEFAULT NULL,
   `posted_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1003 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3781 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -561,15 +576,15 @@ CREATE TABLE `oauth_access_grants` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) NOT NULL,
   `application_id` int(11) NOT NULL,
-  `token` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `expires_in` int(11) NOT NULL,
-  `redirect_uri` text COLLATE utf8_unicode_ci NOT NULL,
+  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `revoked_at` datetime DEFAULT NULL,
-  `scopes` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_grants_on_token` (`token`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -583,17 +598,17 @@ CREATE TABLE `oauth_access_tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) DEFAULT NULL,
   `application_id` int(11) DEFAULT NULL,
-  `token` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `refresh_token` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `refresh_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `expires_in` int(11) DEFAULT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
-  `scopes` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_tokens_on_token` (`token`),
   UNIQUE KEY `index_oauth_access_tokens_on_refresh_token` (`refresh_token`),
   KEY `index_oauth_access_tokens_on_resource_owner_id` (`resource_owner_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -605,19 +620,19 @@ DROP TABLE IF EXISTS `oauth_applications`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `oauth_applications` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `uid` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `secret` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `redirect_uri` text COLLATE utf8_unicode_ci NOT NULL,
-  `scopes` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `uid` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `owner_id` int(11) DEFAULT NULL,
-  `owner_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `owner_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -629,18 +644,18 @@ DROP TABLE IF EXISTS `old_registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `old_registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `personId` varchar(10) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `birthYear` smallint(6) unsigned NOT NULL DEFAULT '0',
   `birthMonth` tinyint(4) unsigned NOT NULL DEFAULT '0',
   `birthDay` tinyint(4) unsigned NOT NULL DEFAULT '0',
-  `email` varchar(80) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `guests_old` text COLLATE utf8_unicode_ci,
-  `comments` text COLLATE utf8_unicode_ci NOT NULL,
-  `ip` varchar(16) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `email` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `guests_old` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -648,7 +663,7 @@ CREATE TABLE `old_registrations` (
   `accepted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competitionId_and_user_id` (`competitionId`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=86141 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=86141 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -660,12 +675,11 @@ DROP TABLE IF EXISTS `poll_options`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `poll_options` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `description` varchar(200) COLLATE utf8_unicode_ci NOT NULL,
+  `description` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `poll_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `poll_id` (`poll_id`) USING BTREE,
-  CONSTRAINT `poll_options_ibfk_1` FOREIGN KEY (`poll_id`) REFERENCES `polls` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  KEY `poll_id` (`poll_id`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -677,15 +691,15 @@ DROP TABLE IF EXISTS `polls`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `polls` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `question` text COLLATE utf8_unicode_ci NOT NULL,
+  `question` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `multiple` tinyint(1) NOT NULL,
   `deadline` datetime NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `comment` text COLLATE utf8_unicode_ci,
+  `comment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `confirmed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -697,9 +711,9 @@ DROP TABLE IF EXISTS `posts`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `posts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `body` text COLLATE utf8_unicode_ci NOT NULL,
-  `slug` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `slug` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sticky` tinyint(1) NOT NULL DEFAULT '0',
   `author_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
@@ -709,7 +723,7 @@ CREATE TABLE `posts` (
   UNIQUE KEY `index_posts_on_slug` (`slug`),
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`world_readable`,`sticky`,`created_at`),
   KEY `index_posts_on_world_readable_and_created_at` (`world_readable`,`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=5126 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7114 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -720,14 +734,12 @@ DROP TABLE IF EXISTS `preferred_formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `preferred_formats` (
-  `event_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `format_id` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `format_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `ranking` int(11) NOT NULL,
   UNIQUE KEY `index_preferred_formats_on_event_id_and_format_id` (`event_id`,`format_id`),
-  KEY `fk_rails_c3e0098ed3` (`format_id`),
-  CONSTRAINT `fk_rails_8d2986d7ea` FOREIGN KEY (`event_id`) REFERENCES `Events` (`id`),
-  CONSTRAINT `fk_rails_c3e0098ed3` FOREIGN KEY (`format_id`) REFERENCES `Formats` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  KEY `fk_rails_c3e0098ed3` (`format_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -766,7 +778,7 @@ CREATE TABLE `registration_competition_events` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_registration_competition_events_on_reg_id_and_comp_event_id` (`registration_id`,`competition_event_id`),
   KEY `index_reg_events_reg_id_comp_event_id` (`registration_id`,`competition_event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=18568 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=514141 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -780,15 +792,15 @@ CREATE TABLE `registration_payments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `registration_id` int(11) DEFAULT NULL,
   `amount_lowest_denomination` int(11) DEFAULT NULL,
-  `currency_code` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `stripe_charge_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `refunded_registration_payment_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_registration_payments_on_stripe_charge_id` (`stripe_charge_id`),
   KEY `idx_reg_payments_on_refunded_registration_payment_id` (`refunded_registration_payment_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -800,9 +812,9 @@ DROP TABLE IF EXISTS `registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `comments` text COLLATE utf8_unicode_ci NOT NULL,
-  `ip` varchar(16) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `competition_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -813,7 +825,7 @@ CREATE TABLE `registrations` (
   `deleted_by` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=86147 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=141178 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -846,7 +858,7 @@ CREATE TABLE `team_members` (
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=66 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -858,13 +870,13 @@ DROP TABLE IF EXISTS `teams`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `teams` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `friendly_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `description` text COLLATE utf8_unicode_ci,
+  `friendly_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -877,10 +889,10 @@ DROP TABLE IF EXISTS `user_preferred_events`;
 CREATE TABLE `user_preferred_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `event_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_user_preferred_events_on_user_id_and_event_id` (`user_id`,`event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=44542 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -892,29 +904,29 @@ DROP TABLE IF EXISTS `users`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `encrypted_password` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `reset_password_token` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `encrypted_password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `reset_password_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `reset_password_sent_at` datetime DEFAULT NULL,
   `remember_created_at` datetime DEFAULT NULL,
   `sign_in_count` int(11) NOT NULL DEFAULT '0',
   `current_sign_in_at` datetime DEFAULT NULL,
   `last_sign_in_at` datetime DEFAULT NULL,
-  `current_sign_in_ip` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `last_sign_in_ip` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `confirmation_token` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `current_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `confirmation_token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `confirmed_at` datetime DEFAULT NULL,
   `confirmation_sent_at` datetime DEFAULT NULL,
-  `unconfirmed_email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `unconfirmed_email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `delegate_status` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `delegate_status` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `senior_delegate_id` int(11) DEFAULT NULL,
-  `region` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `wca_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `avatar` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `pending_avatar` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `region` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wca_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pending_avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `saved_avatar_crop_x` int(11) DEFAULT NULL,
   `saved_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_avatar_crop_w` int(11) DEFAULT NULL,
@@ -923,23 +935,23 @@ CREATE TABLE `users` (
   `saved_pending_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_w` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_h` int(11) DEFAULT NULL,
-  `unconfirmed_wca_id` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `unconfirmed_wca_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id_to_handle_wca_id_claim` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
-  `gender` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `country_iso2` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `gender` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `country_iso2` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `results_notifications_enabled` tinyint(1) DEFAULT '0',
-  `location_description` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `phone_number` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `notes` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `preferred_locale` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `location_description` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `phone_number` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `notes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `preferred_locale` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB AUTO_INCREMENT=6453 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=52728 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -954,7 +966,7 @@ CREATE TABLE `vote_options` (
   `vote_id` int(11) NOT NULL,
   `poll_option_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -967,13 +979,16 @@ DROP TABLE IF EXISTS `votes`;
 CREATE TABLE `votes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
-  `comment` varchar(200) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `comment` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `poll_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `index_votes_on_user_id` (`user_id`),
-  CONSTRAINT `votes_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+  KEY `index_votes_on_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping routines for database 'wca_development'
+--
 
 --
 -- Final view structure for view `rails_persons`
@@ -1112,6 +1127,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170223153915'),
 ('20170228140556'),
 ('20170320222511'),
-('20170402223714');
+('20170402223714'),
+('20170404184332');
 
 

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -515,7 +515,7 @@ module DatabaseDumper
 
     LogTask.log_task "Creating temporary database '#{dump_db_name}'" do
       ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{dump_db_name}")
-      ActiveRecord::Base.connection.execute("CREATE DATABASE #{dump_db_name} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+      ActiveRecord::Base.connection.execute("CREATE DATABASE #{dump_db_name} DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci")
       self.mysql("SOURCE #{Rails.root.join('db', 'structure.sql')}", dump_db_name)
     end
 

--- a/WcaOnRails/spec/lib/database_dumper_spec.rb
+++ b/WcaOnRails/spec/lib/database_dumper_spec.rb
@@ -7,7 +7,7 @@ def with_database(db_name)
   old_connection_config = ActiveRecord::Base.connection_config
   begin
     ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{db_name}")
-    ActiveRecord::Base.connection.execute("CREATE DATABASE #{db_name} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci")
+    ActiveRecord::Base.connection.execute("CREATE DATABASE #{db_name} DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci")
     connection_config = old_connection_config.merge(database: db_name, connect_flags: Mysql2::Client::MULTI_STATEMENTS)
     ActiveRecord::Base.establish_connection(connection_config)
     yield

--- a/chef/site-cookbooks/wca/templates/my.cnf.erb
+++ b/chef/site-cookbooks/wca/templates/my.cnf.erb
@@ -1,5 +1,5 @@
 [client]
-default-character-set          = utf8
+default-character-set          = utf8mb4
 host                           = <%= @db['host'] %>
 <% if @db['socket'] %>
 socket                         = <%= @db['socket'] %>

--- a/scripts/db.sh
+++ b/scripts/db.sh
@@ -45,7 +45,7 @@ elif [ "$COMMAND" == "import" ] || [ "$COMMAND" == "drop_and_import" ]; then
   for sql_file in $FOLDER/*.sql; do
     db_name=`basename $sql_file .sql`
     echo "Importing $db_name database..."
-    mysql "$@" -e "CREATE DATABASE IF NOT EXISTS $db_name DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci;"
+    mysql "$@" -e "CREATE DATABASE IF NOT EXISTS $db_name DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci;"
     mysql "$@" $db_name -e "SOURCE $sql_file"
   done
 fi


### PR DESCRIPTION
This is so annoying of Mysql. See #1489.

This migration will take a while to run. Here's the result of running it locally on a fresh import of the developer database:

```
== 20170404184332 ConvertUtf8ToUtf8mb4: migrated (2607.9259s) =================
```