### PR TITLE
Delegates admin page tweaks requested by Ilkyoo

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -526,8 +526,13 @@ class User < ApplicationRecord
     if admin? || board_member?
       fields += %i(delegate_status senior_delegate_id region)
     end
-    if user.any_kind_of_delegate? && (user == self || user.senior_delegate == self || admin? || board_member?)
-      fields += %i(location_description phone_number notes)
+    if user.any_kind_of_delegate?
+      if user == self
+        fields += %i(location_description phone_number)
+      end
+      if user.senior_delegate == self || admin? || board_member?
+        fields += %i(notes)
+      end
     end
     if admin? || any_kind_of_delegate?
       fields += %i(

--- a/WcaOnRails/app/views/delegates/stats.html.erb
+++ b/WcaOnRails/app/views/delegates/stats.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, 'Delegates stats') %>
 
-<div class="container">
+<div class="container-fluid">
   <h1><%= yield(:title) %></h1>
 
   <%= wca_table table_class: "delegates-stats-table", striped: false,
@@ -13,6 +13,7 @@
         <th class="last" data-sortable="true">Last delegated</th>
         <th class="first" data-sortable="true">First delegated</th>
         <th class="total" data-sortable="true">Total delegated</th>
+        <th>Phone number</th>
         <th></th>
       </tr>
     </thead>
@@ -20,13 +21,20 @@
       <% @delegates.each do |delegate| %>
         <% competitions = delegate.delegated_competitions.order(:start_date).select(&:is_probably_over?) %>
         <tr class="<%= delegate.delegate_status %>">
-          <td class="delegate"><%= delegate.name %></td>
+          <td class="delegate" data-toggle="tooltip" data-placement="top" data-container="body" title="<%= delegate.notes %>">
+            <%= delegate.name %>
+            <%= link_to icon("pencil"), edit_user_path(delegate) %>
+            <%= mail_to delegate.email, icon("envelope"), target: "_blank", class: "hide-new-window-icon" %>
+          </td>
           <td class="position"><%= delegate.delegate_status.humanize %></td>
-          <td class="region"><%= delegate.region %></td>
+          <td class="region"><%= delegate.region %> (<%= delegate.location_description %>)</td>
           <td class="last"><%= competitions&.last&.start_date %></td>
           <td class="first"><%= competitions&.first&.start_date %></td>
           <td class="total"><%= competitions&.count %></td>
-          <td><%= link_to "History", competitions_path(display: "admin", years: "all", delegate: delegate.id), target: "_blank" %></td>
+          <td><%= delegate.phone_number %></td>
+          <td>
+            <%= link_to "History", competitions_path(display: "admin", years: "all", delegate: delegate.id) %>
+          </td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
- Added email and user edit link to delegates admin page
- Added a phone number column.
- Expanded the region column to include the `location_description` field.
- When you hover over someone's name you see their notes
- I changed the container to `container-fluid` to make space for all this extra stuff

![image](https://cloud.githubusercontent.com/assets/277474/25028263/e44d7560-2067-11e7-9189-ba7ef91d12a9.png)
