### PR TITLE
Gender related changes

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -65,7 +65,7 @@ Metrics/ParameterLists:
   CountKeywordArgs: false
 
 Metrics/PerceivedComplexity:
-  Max: 23
+  Max: 25
 
 Metrics/LineLength:
   Max: 245

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -48,10 +48,14 @@ class AdminController < ApplicationController
             flash.now[:warning] = "The change you made may have affected national and continental records, be sure to run
             <a href='/results/admin/check_regional_record_markers.php'>check_regional_record_markers</a>.".html_safe
           end
+        else
+          flash.now[:danger] = "Error while fixing #{@person.name}."
         end
       when "update"
         if @person.update_using_sub_id(person_params)
           flash.now[:success] = "Successfully updated #{@person.name}."
+        else
+          flash.now[:danger] = "Error while updating #{@person.name}."
         end
       end
     else

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -90,7 +90,7 @@ class UsersController < ApplicationController
     dangerous_change = current_user == @user && [:password, :password_confirmation, :email].any? { |attribute| user_params.key? attribute }
     if dangerous_change ? @user.update_with_password(user_params) : @user.update_attributes(user_params)
       if current_user == @user
-        # Sign in the user by passing validation in case their password changed
+        # Sign in the user, bypassing validation in case their password changed
         bypass_sign_in @user
       end
       flash[:success] = if @user.confirmation_sent_at != old_confirmation_sent_at

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -10,6 +10,8 @@ class Person < ApplicationRecord
   has_many :ranksAverage, primary_key: "wca_id", foreign_key: "personId", class_name: "RanksAverage"
   has_many :ranksSingle, primary_key: "wca_id", foreign_key: "personId", class_name: "RanksSingle"
 
+  enum gender: (User::ALLOWABLE_GENDERS.map { |g| [g, g.to_s] }.to_h)
+
   scope :current, -> { where(subId: 1) }
 
   scope :in_region, lambda { |region_id|

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -49,6 +49,13 @@ class User < ApplicationRecord
 
   ALLOWABLE_GENDERS = [:m, :f, :o].freeze
   enum gender: (ALLOWABLE_GENDERS.map { |g| [g, g.to_s] }.to_h)
+  GENDER_LABEL_METHOD = lambda do |g|
+    {
+      m: I18n.t('wca.devise.gender.male'),
+      f: I18n.t('wca.devise.gender.female'),
+      o: I18n.t('wca.devise.gender.other_gender'),
+    }[g]
+  end
 
   enum delegate_status: {
     candidate_delegate: "candidate_delegate",
@@ -135,6 +142,8 @@ class User < ApplicationRecord
         dob_form_path = Rails.application.routes.url_helpers.contact_dob_path
         if !unconfirmed_person.dob
           errors.add(:dob_verification, I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path).html_safe)
+        elsif unconfirmed_person.gender.blank?
+          errors.add(:gender, I18n.t('users.errors.wca_id_no_gender_html').html_safe)
         elsif !already_assigned_to_user && unconfirmed_person.dob != dob_verification_date
           # Note that we don't verify DOB for WCA IDs that have already been
           # claimed. This protects people from DOB guessing attacks.

--- a/WcaOnRails/app/views/admin/edit_person.html.erb
+++ b/WcaOnRails/app/views/admin/edit_person.html.erb
@@ -22,7 +22,7 @@
         <%= f.input :name %>
         <%= f.input :countryId, collection: Country.real, value_method: lambda { |c| c.id }, label_method: lambda { |c| c.name } %>
 
-        <%= f.input :gender, collection: [:m, :f], label_method: lambda { |g| { m: "Male", f: "Female" }[g] } %>
+        <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: User::GENDER_LABEL_METHOD %>
         <%= f.input :dob, as: :date_picker %>
 
         <button type="submit" name="method" value="fix" class="btn btn-primary">

--- a/WcaOnRails/app/views/devise/registrations/new.html.erb
+++ b/WcaOnRails/app/views/devise/registrations/new.html.erb
@@ -45,7 +45,7 @@
             <%# Copied from app/views/users/edit.html.erb %>
             <%= f.input :name %>
             <%= f.input :dob, as: :date_picker %>
-            <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] } %>
+            <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: User::GENDER_LABEL_METHOD %>
             <%= f.input :country_iso2, collection: Country.all_sorted_by(I18n.locale, real: true), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name } %>
 
           </div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -71,7 +71,7 @@
 
         <%= f.input :name, disabled: !editable_fields.include?(:name) %>
         <%= f.input :dob, as: :date_picker, disabled: !editable_fields.include?(:dob) %>
-        <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: lambda { |g| { m: t('wca.devise.gender.male'), f: t('wca.devise.gender.female'), o: t('wca.devise.gender.other_gender') }[g] }, disabled: !editable_fields.include?(:gender) %>
+        <%= f.input :gender, collection: User::ALLOWABLE_GENDERS, label_method: User::GENDER_LABEL_METHOD, disabled: !editable_fields.include?(:gender) %>
         <%= f.input :country_iso2, collection: Country.all_sorted_by(I18n.locale, real: true), value_method: lambda { |c| c.iso2 }, label_method: lambda { |c| c.name }, disabled: !editable_fields.include?(:country_iso2) %>
 
         <% if current_user.can_view_all_users? %>

--- a/WcaOnRails/db/migrate/20170418171035_allow_null_gender.rb
+++ b/WcaOnRails/db/migrate/20170418171035_allow_null_gender.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AllowNullGender < ActiveRecord::Migration[5.0]
+  def up
+    change_column_null :InboxPersons, :gender, true
+    execute "UPDATE InboxPersons SET gender=NULL WHERE gender=''"
+
+    change_column_null :Persons, :gender, true
+    execute "UPDATE Persons SET gender=NULL WHERE gender=''"
+  end
+
+  def down
+    change_column_null :Persons, :gender, false, ""
+    change_column_null :InboxPersons, :gender, false, ""
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -216,7 +216,7 @@ CREATE TABLE `InboxPersons` (
   `wcaId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `countryId` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) DEFAULT '',
   `dob` date NOT NULL,
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   KEY `InboxPersons_fk_country` (`countryId`),
@@ -265,7 +265,7 @@ CREATE TABLE `Persons` (
   `subId` tinyint(6) NOT NULL DEFAULT '1',
   `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) DEFAULT '',
   `year` smallint(6) NOT NULL DEFAULT '0',
   `month` tinyint(4) NOT NULL DEFAULT '0',
   `day` tinyint(4) NOT NULL DEFAULT '0',
@@ -1148,4 +1148,5 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170320222511'),
 ('20170402223714'),
 ('20170404184332'),
-('20170406170418');
+('20170406170418'),
+('20170418171035');

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -346,6 +346,7 @@ RSpec.describe User, type: :model do
     end
 
     let!(:person_without_dob) { FactoryGirl.create :person, year: 0, month: 0, day: 0 }
+    let!(:person_without_gender) { FactoryGirl.create :person, gender: nil }
     let!(:user_with_wca_id) { FactoryGirl.create :user_with_wca_id }
 
     it "defines a valid user" do
@@ -391,6 +392,13 @@ RSpec.describe User, type: :model do
       user.dob_verification = "1234-04-03"
       expect(user).to be_invalid
       expect(user.errors.messages[:dob_verification]).to eq [I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path)]
+    end
+
+    it "does not allow claiming wca id Person without gender" do
+      user.unconfirmed_wca_id = person_without_gender.wca_id
+      user.dob_verification = "1234-04-03"
+      expect(user).to be_invalid
+      expect(user.errors.messages[:gender]).to eq [I18n.t('users.errors.wca_id_no_gender_html')]
     end
 
     it "does not show a message about incorrect dob for people who have already claimed their wca id" do

--- a/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
@@ -3,28 +3,42 @@
 require "rails_helper"
 
 RSpec.describe "registrations/export.csv.erb" do
-  it "renders valid csv" do
-    competition = FactoryGirl.create :competition, :registration_open
-    user = FactoryGirl.create(
+  let(:competition) { FactoryGirl.create :competition, :registration_open }
+  let!(:user) {
+    FactoryGirl.create(
       :user,
       name: "Bob",
       country_iso2: "US",
       dob: Date.new(1990, 1, 1),
       gender: "m",
       email: "bob@bob.com",
-    )
-    FactoryGirl.create(
-      :registration,
-      competition: competition,
-      accepted_at: Time.now,
-      user: user,
-      competition_events: [competition.competition_events.find_by!(event_id: "333")],
-      guests: 1,
-    )
+    ).tap do |user|
+      FactoryGirl.create(
+        :registration,
+        competition: competition,
+        accepted_at: Time.now,
+        user: user,
+        competition_events: [competition.competition_events.find_by!(event_id: "333")],
+        guests: 1,
+      )
+    end
+  }
+
+  it "renders valid csv" do
     assign(:competition, competition)
     assign(:registrations, competition.registrations)
-
     render
+
     expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\na,Bob,USA,,1990-01-01,m,1,0,bob@bob.com,1,\"\"\n"
+  end
+
+  it "renders null (missing) gender as empty string" do
+    user.update!(gender: nil)
+
+    assign(:competition, competition)
+    assign(:registrations, competition.registrations)
+    render
+
+    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\na,Bob,USA,,1990-01-01,,1,0,bob@bob.com,1,\"\"\n"
   end
 end

--- a/webroot/results/includes/_framework.php
+++ b/webroot/results/includes/_framework.php
@@ -212,6 +212,7 @@ function wcaDate ( $format='r', $timestamp=false ) {
 function genderText ($gender) {
   if ($gender == 'm') return 'Male';
   if ($gender == 'f') return 'Female';
+  if ($gender == 'o') return '';
   return '';
 }
 


### PR DESCRIPTION
## The problem

There are 2 separate questions here:

1. What values can the gender field take on in our database?
2. How do we render the various values from 1) when displayed on a page?

Currently, the answer to 1) is "m", "f", or "" (empty string). There's a problem with this, as the number of states we can represent in our database is smaller than the number of states the WCA wants to recognize:

A. I identify as male.
B. I identify as female.
C. Neither A nor B applies to me.
D. The WCA never asked me about my gender, presumably because I registered for a competition at the door.

## The change

Wrote a database migration to change all empty string genders to NULL. Going forward, we will never allow an empty string gender, it must be one of "m", "f", "o", or NULL (corresponding to A, B, C, D from above, respectively). When rendering genders, we render both "o" and NULL as "" (empty string).

I've expanded a number of checks to also look for missing (NULL) gender and prompt users to contact the WRT and provide their preferred gender.

## After

After we merge this up, I think the WRT should contact all WCA website accounts connected to a NULL gender and ask them to confirm what gender they'd like to show up on the website. Currently there are only 2 such people (`select Persons.id, Persons.name, Persons.gender from users join Persons on users.wca_id=Persons.id where Persons.gender=""`) @SAuroux, could you take this job on?

Untested, but this hopefully fixes #360. @Luis-J-Ianez, after we merge this up, could you test this out and let us know if #360 is still broken?