### PR TITLE
Fix performance issues when exporting to CSV

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -91,15 +91,13 @@ class RegistrationsController < ApplicationController
     end
   end
 
-  private def selected_registrations_from_params
-    params[:selected_registrations].map { |r| r.split('-')[1] }.map do |registration_id|
-      competition_from_params.registrations.find_by_id!(registration_id)
-    end
+  private def selected_registrations_ids
+    params[:selected_registrations].map { |r| r.split('-')[1] }
   end
 
   def export
     @competition = competition_from_params
-    @registrations = selected_registrations_from_params
+    @registrations = @competition.registrations.includes(:user, :events).find(selected_registrations_ids)
 
     respond_to do |format|
       format.csv do
@@ -112,7 +110,7 @@ class RegistrationsController < ApplicationController
   def do_actions_for_selected
     @show_events = params[:show_events] == "true"
     @competition = competition_from_params
-    registrations = selected_registrations_from_params
+    registrations = @competition.registrations.find(selected_registrations_ids)
 
     case params[:registrations_action]
     when "accept-selected"

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -115,8 +115,7 @@ class Registration < ApplicationRecord
   end
 
   def last_payment_date
-    sorted_payments = registration_payments.sort_by { |p| p.created_at }
-    sorted_payments.first&.created_at
+    registration_payments.map(&:created_at).max
   end
 
   def outstanding_entry_fees

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -115,7 +115,8 @@ class Registration < ApplicationRecord
   end
 
   def last_payment_date
-    registration_payments.order(created_at: :desc).first&.created_at
+    sorted_payments = registration_payments.sort_by { |p| p.created_at }
+    sorted_payments.first&.created_at
   end
 
   def outstanding_entry_fees


### PR DESCRIPTION
@Luis-J-Ianez noticed rendering the export for WC was taking so long the request would time out.

I suspected a n+1 query and found a bit more :)
We used to do one find per registration (this is also true for any other action, such as accept or reject a registration)!
So I rewrote the `selected_registrations_from_params` to use an array, [Rails doc](http://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find) indicates that if any of the id is not found, it *does* raise `RecordNotFound`, so I think this is a better alternative.
There was also two undetected n+1 queries, one when accessing the user's info, one when accessing the events.

While debugging this I also noticed an important amount of queries on `registration_payments` (despite the includes [here](https://github.com/thewca/worldcubeassociation.org/blob/16a773270128ed36dc6065b2879eb3e6a7a6b5ca/WcaOnRails/app/controllers/registrations_controller.rb#L31)!).

Turns out my way of writing `last_payment` using `registration_payments.order(created_at: :desc).first&.created_at` was enforcing a new request, so I rewrote the logic using plain ruby on the included array.
