### PR TITLE
Fix the logic for saved_and_unsaved_events.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -263,11 +263,11 @@ class CompetitionsController < ApplicationController
   end
 
   def edit_events
-    @competition = Competition.find(params[:id])
+    @competition = Competition.includes(:events).find(params[:id])
   end
 
   def update_events
-    @competition = Competition.find(params[:id])
+    @competition = Competition.includes(:events).find(params[:id])
     if @competition.update_attributes(competition_params)
       flash[:success] = t('.update_success')
       redirect_to edit_events_path(@competition)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -567,7 +567,7 @@ class Competition < ApplicationRecord
   # select events, unsaved events are still presented if
   # there are any validation issues on the form.
   def saved_and_unsaved_events
-    competition_events.includes(:event).reject(&:marked_for_destruction?).map(&:event).sort_by(&:rank)
+    competition_events.reject(&:marked_for_destruction?).map(&:event)
   end
 
   def nearby_competitions(days, distance)

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -162,12 +162,7 @@ class Registration < ApplicationRecord
   # select events, unsaved events are still presented if
   # there are any validation issues on the form.
   def saved_and_unsaved_events
-    registration_competition_events
-      .joins(:competition_event)
-      .joins(:event)
-      .reject(&:marked_for_destruction?)
-      .map(&:event)
-      .sort_by(&:rank)
+    registration_competition_events.reject(&:marked_for_destruction?).map(&:event)
   end
 
   def waiting_list_info


### PR DESCRIPTION
 - The joins were not necessary and did not achieve the desired behavior
 - `saved_and_unsaved_events` is used as a set, so no sorting is needed