### PR TITLE
Update the recaptcha gem

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rdoc (4.3.0)
-    recaptcha (4.3.0)
+    recaptcha (4.3.1)
       json
     redcarpet (3.4.0)
     ref (2.0.0)


### PR DESCRIPTION
I got an error after running `bundle update` and I guess it's caused be the recent gems update.

> Your bundle is locked to recaptcha (4.3.0), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed
> sources, that means the author of recaptcha (4.3.0) has removed it. You'll need to update your bundle to a different version of recaptcha (4.3.0) that
> hasn't been removed in order to install.

Updating the gem did the trick.