### PR TITLE
Remove cloudfront config

### DIFF
--- a/WcaOnRails/config/environments/production.rb
+++ b/WcaOnRails/config/environments/production.rb
@@ -72,10 +72,6 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   if ENVied.WCA_LIVE_SITE
-    # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-    # Cloudfront! https://console.aws.amazon.com/cloudfront/home
-    config.action_controller.asset_host = 'https://d1qsrrpnlo9sni.cloudfront.net'
-
     config.action_mailer.smtp_settings = {
       address: "email-smtp.us-west-2.amazonaws.com",
       port: 587,


### PR DESCRIPTION
This is okay to do because www.worldcubeassociation.org is now CNAMED directly to cloudfront, so all our static *and* dynamic assets go through cloudfront now.

This has some dramatic latency affects for people in far parts of the world, because now they talk to their nearby AWS cloudfront edge location over the public internet, and then traffic travels over AWS fiber directly to our AWS EC2 server, rather than bouncing around the public internet.  @Baiqiang reports from China:

> the index loads in about 600ms on the CDN
> the wca.org loads from 900ms to 10 seconds:joy:
> it's not stable if i don't use a proxy
> the average is like 2 or 3 seconds

Part of the problem @Baiqiang sees is that currently *sometimes* the latency is not so bad, and sometimes the latency skyrockets to 10 seconds (it averages out to 2 to 3 seconds). Going through cloudfront, our homepage seems to reliably load in 600ms for him.