### PR TITLE
Port auxiliary data computation to Rails

### DIFF
--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -77,9 +77,14 @@ class AdminController < ApplicationController
   end
 
   def compute_auxiliary_data
+    @auxiliary_data_start = Timestamp.find_or_create_by(name: 'auxiliary_data_start')
+    @auxiliary_data_end = Timestamp.find_or_create_by(name: 'auxiliary_data_end')
   end
 
   def do_compute_auxiliary_data
-    AuxiliaryDataComputation.compute_everything
+    # Reset the end date. The start date is updated directly before the computation.
+    Timestamp.find_or_create_by(name: 'auxiliary_data_end').update date: nil
+    ComputeAuxiliaryData.perform_later
+    redirect_to admin_compute_auxiliary_data_path
   end
 end

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -75,4 +75,11 @@ class AdminController < ApplicationController
       dob: @person.dob,
     }
   end
+
+  def compute_auxiliary_data
+  end
+
+  def do_compute_auxiliary_data
+    AuxiliaryDataComputation.compute_everything
+  end
 end

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -77,14 +77,10 @@ class AdminController < ApplicationController
   end
 
   def compute_auxiliary_data
-    @auxiliary_data_start = Timestamp.find_or_create_by(name: 'auxiliary_data_start')
-    @auxiliary_data_end = Timestamp.find_or_create_by(name: 'auxiliary_data_end')
   end
 
   def do_compute_auxiliary_data
-    # Reset the end date. The start date is updated directly before the computation.
-    Timestamp.find_or_create_by(name: 'auxiliary_data_end').update date: nil
-    ComputeAuxiliaryData.perform_later
+    ComputeAuxiliaryData.perform_later unless ComputeAuxiliaryData.in_progress?
     redirect_to admin_compute_auxiliary_data_path
   end
 end

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -77,6 +77,7 @@ class AdminController < ApplicationController
   end
 
   def compute_auxiliary_data
+    @reason_not_to_run = ComputeAuxiliaryData.reason_not_to_run
   end
 
   def do_compute_auxiliary_data

--- a/WcaOnRails/app/jobs/application_job.rb
+++ b/WcaOnRails/app/jobs/application_job.rb
@@ -1,20 +1,4 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-  class DeferJob < StandardError
-    attr_reader :wait_time
-    def initialize(wait_time)
-      super
-      @wait_time = wait_time
-    end
-  end
-
-  rescue_from(DeferJob) do |defer_job|
-    retry_job wait: defer_job.wait_time
-  end
-
-  def defer_job_for(wait_time)
-    # This is always caught in the rescue_from above. It allows us to escape out of the job and put it off.
-    raise DeferJob.new(wait_time)
-  end
 end

--- a/WcaOnRails/app/jobs/application_job.rb
+++ b/WcaOnRails/app/jobs/application_job.rb
@@ -1,4 +1,19 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  class DeferJob < StandardError
+    attr_reader :wait_time
+    def initialize(wait_time)
+      super("Delay the job by #{time} s")
+      @wait_time = wait_time
+    end
+  end
+
+  rescue_from(DeferJob) do |defer_job|
+    retry_job wait: defer_job.wait_time
+  end
+
+  def defer_job_for(wait_time)
+    raise DeferJob.new(wait_time)
+  end
 end

--- a/WcaOnRails/app/jobs/application_job.rb
+++ b/WcaOnRails/app/jobs/application_job.rb
@@ -4,7 +4,7 @@ class ApplicationJob < ActiveJob::Base
   class DeferJob < StandardError
     attr_reader :wait_time
     def initialize(wait_time)
-      super("Delay the job by #{time} s")
+      super
       @wait_time = wait_time
     end
   end
@@ -14,6 +14,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def defer_job_for(wait_time)
+    # This is always caught in the rescue_from above. It allows us to escape out of the job and put it off.
     raise DeferJob.new(wait_time)
   end
 end

--- a/WcaOnRails/app/jobs/compute_auxiliary_data.rb
+++ b/WcaOnRails/app/jobs/compute_auxiliary_data.rb
@@ -7,7 +7,7 @@ class ComputeAuxiliaryData < TimedApplicationJob
     # Note: During the results posting process some results may be missing their corresponding WCA ID.
     #       If we detect that (means someone else is posting results at the moment), we defer the computation.
     if Result.exists?(personId: "")
-      defer_job_for 10.minutes
+      defer_job_for 1.minute
     else
       AuxiliaryDataComputation.compute_everything
     end

--- a/WcaOnRails/app/jobs/compute_auxiliary_data.rb
+++ b/WcaOnRails/app/jobs/compute_auxiliary_data.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ComputeAuxiliaryData < ApplicationJob
+  queue_as :default
+
+  def perform
+    Timestamp.find_or_create_by(name: 'auxiliary_data_start').touch :date
+    AuxiliaryDataComputation.compute_everything
+    Timestamp.find_or_create_by(name: 'auxiliary_data_end').touch :date
+  end
+end

--- a/WcaOnRails/app/jobs/compute_auxiliary_data.rb
+++ b/WcaOnRails/app/jobs/compute_auxiliary_data.rb
@@ -3,6 +3,12 @@
 class ComputeAuxiliaryData < TimedApplicationJob
   queue_as :default
 
+  def self.reason_not_to_run
+    if Result.exists?(personId: "")
+      "Some results are missing their corresponding WCA ID, which means that someone hasn't finished submitting results."
+    end
+  end
+
   def perform
     AuxiliaryDataComputation.compute_everything
   end

--- a/WcaOnRails/app/jobs/compute_auxiliary_data.rb
+++ b/WcaOnRails/app/jobs/compute_auxiliary_data.rb
@@ -4,12 +4,6 @@ class ComputeAuxiliaryData < TimedApplicationJob
   queue_as :default
 
   def perform
-    # Note: During the results posting process some results may be missing their corresponding WCA ID.
-    #       If we detect that (means someone else is posting results at the moment), we defer the computation.
-    if Result.exists?(personId: "")
-      defer_job_for 1.minute
-    else
-      AuxiliaryDataComputation.compute_everything
-    end
+    AuxiliaryDataComputation.compute_everything
   end
 end

--- a/WcaOnRails/app/jobs/compute_auxiliary_data.rb
+++ b/WcaOnRails/app/jobs/compute_auxiliary_data.rb
@@ -4,8 +4,14 @@ class ComputeAuxiliaryData < ApplicationJob
   queue_as :default
 
   def perform
-    Timestamp.find_or_create_by(name: 'auxiliary_data_start').touch :date
-    AuxiliaryDataComputation.compute_everything
-    Timestamp.find_or_create_by(name: 'auxiliary_data_end').touch :date
+    # Note: During the results posting process some results may be missing their corresponding WCA ID.
+    #       If we detect that (means someone else is posting results at the moment), we defer the computation.
+    if Result.exists?(personId: "")
+      ComputeAuxiliaryData.set(wait: 10.minutes).perform_later
+    else
+      Timestamp.find_or_create_by(name: 'auxiliary_data_start').touch :date
+      AuxiliaryDataComputation.compute_everything
+      Timestamp.find_or_create_by(name: 'auxiliary_data_end').touch :date
+    end
   end
 end

--- a/WcaOnRails/app/jobs/compute_auxiliary_data.rb
+++ b/WcaOnRails/app/jobs/compute_auxiliary_data.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
-class ComputeAuxiliaryData < ApplicationJob
+class ComputeAuxiliaryData < TimedApplicationJob
   queue_as :default
 
   def perform
     # Note: During the results posting process some results may be missing their corresponding WCA ID.
     #       If we detect that (means someone else is posting results at the moment), we defer the computation.
     if Result.exists?(personId: "")
-      ComputeAuxiliaryData.set(wait: 10.minutes).perform_later
+      defer_job_for 10.minutes
     else
-      Timestamp.find_or_create_by(name: 'auxiliary_data_start').touch :date
       AuxiliaryDataComputation.compute_everything
-      Timestamp.find_or_create_by(name: 'auxiliary_data_end').touch :date
     end
   end
 end

--- a/WcaOnRails/app/jobs/timed_application_job.rb
+++ b/WcaOnRails/app/jobs/timed_application_job.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class TimedApplicationJob < ApplicationJob
+  class DeferJob < StandardError
+    attr_reader :time
+    def initialize(time)
+      super("Delay the job by #{time} s")
+      @time = time
+    end
+  end
+
+  rescue_from(DeferJob) do |defer_job|
+    retry_job wait: defer_job.time
+  end
+
+  def defer_job_for(time)
+    raise DeferJob.new(time)
+  end
+
+  def self.start_timestamp
+    Timestamp.find_or_create_by(name: "#{self.name.underscore}_start")
+  end
+
+  def self.end_timestamp
+    Timestamp.find_or_create_by(name: "#{self.name.underscore}_end")
+  end
+
+  def self.in_progress?
+    self.start_timestamp.date.present? && self.end_timestamp.date.nil?
+  end
+
+  def self.finished?
+    self.end_timestamp.date.present?
+  end
+
+  around_perform do |job, block|
+    job.class.start_timestamp.touch :date
+    job.class.end_timestamp.update! date: nil
+    block.call
+    job.class.end_timestamp.touch :date
+  end
+
+  def self.perform_later
+    # Reset timestamps.
+    self.end_timestamp.update! date: nil
+    super
+  end
+end

--- a/WcaOnRails/app/jobs/timed_application_job.rb
+++ b/WcaOnRails/app/jobs/timed_application_job.rb
@@ -3,11 +3,11 @@
 class TimedApplicationJob < ApplicationJob
   class << self
     def start_timestamp
-      Timestamp.find_or_create_by(name: "#{self.name.underscore}_start")
+      Timestamp.find_or_create_by!(name: "#{self.name.underscore}_start")
     end
 
     def end_timestamp
-      Timestamp.find_or_create_by(name: "#{self.name.underscore}_end")
+      Timestamp.find_or_create_by!(name: "#{self.name.underscore}_end")
     end
 
     def start_date

--- a/WcaOnRails/app/jobs/timed_application_job.rb
+++ b/WcaOnRails/app/jobs/timed_application_job.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 
 class TimedApplicationJob < ApplicationJob
-  class DeferJob < StandardError
-    attr_reader :wait_time
-    def initialize(wait_time)
-      super("Delay the job by #{time} s")
-      @wait_time = wait_time
-    end
-  end
-
-  rescue_from(DeferJob) do |defer_job|
-    retry_job wait: defer_job.wait_time
-  end
-
-  def defer_job_for(wait_time)
-    raise DeferJob.new(wait_time)
-  end
-
   class << self
     def start_timestamp
       Timestamp.find_or_create_by(name: "#{self.name.underscore}_start")

--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -18,7 +18,7 @@
         { text: "Check existing people", path: "/results/admin/persons_check_finished.php", fa_icon: "check" },
         { text: "Check rounds", path: "/results/admin/check_rounds.php", fa_icon: "check" },
         { text: "Check records", path: "/results/admin/check_regional_record_markers.php", fa_icon: "trophy" },
-        { text: "Compute auxiliary data", path: "/results/admin/compute_auxiliary_data.php", fa_icon: "cogs" },
+        { text: "Compute auxiliary data", path: admin_compute_auxiliary_data_path, fa_icon: "cogs" },
         { text: "Update statistics", path: "/results/statistics.php?update8392=1", fa_icon: "area-chart" },
         { text: "Export public", path: "/results/admin/export_public.php", fa_icon: "cloud-upload" },
         { text: "Edit teams", path: teams_path, fa_icon: "users" },

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -15,8 +15,8 @@
       <%= alert :info, "The data is being computed. Thanks for checking =)" %>
     <% elsif ComputeAuxiliaryData.finished? %>
       <%= alert :success do %>
-        Data was last computed <%= time_ago_in_words ComputeAuxiliaryData.end_timestamp.date %> ago
-        and took <%= distance_of_time_in_words ComputeAuxiliaryData.start_timestamp.date, ComputeAuxiliaryData.end_timestamp.date %>
+        Data was last computed <%= time_ago_in_words ComputeAuxiliaryData.end_date %> ago
+        and took <%= distance_of_time_in_words ComputeAuxiliaryData.start_date, ComputeAuxiliaryData.end_date %>
       <% end %>
     <% else %>
       <%= alert :danger, "Oh dear! The data has never been computed!" %>

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -3,6 +3,14 @@
 <div class="container">
   <%= render layout: "nav" do %>
     <h2><%= yield(:title) %></h2>
+    <div>
+      <h4>This script:</h4>
+      <ul class="list-group">
+        <li class="list-group-item">Calculates means for 3x3x3 BLD</li>
+        <li class="list-group-item">Computes some auxiliary tables in the database (ConciseSingleResults, ConciseAverageResults, RanksSingle and RanksAverage).</li>
+        <li class="list-group-item">Clears some cache files (living on the PHP side)</li>
+      </ul>
+    </div>
     <% if @auxiliary_data_start.date.nil? %>
       <%= alert :danger, "Oh dear! The data has never been computed!" %>
     <% elsif @auxiliary_data_end.date.nil? %>

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -11,14 +11,17 @@
         <li class="list-group-item">Clears some cache files (living on the PHP side)</li>
       </ul>
     </div>
-    <% if @auxiliary_data_start.date.nil? %>
-      <%= alert :danger, "Oh dear! The data has never been computed!" %>
-    <% elsif @auxiliary_data_end.date.nil? %>
+    <% if ComputeAuxiliaryData.in_progress? %>
       <%= alert :info, "The data is being computed. Thanks for checking =)" %>
+    <% elsif ComputeAuxiliaryData.finished? %>
+      <%= alert :success do %>
+        Data was last computed <%= time_ago_in_words ComputeAuxiliaryData.end_timestamp.date %> ago
+        and took <%= distance_of_time_in_words ComputeAuxiliaryData.start_timestamp.date, ComputeAuxiliaryData.end_timestamp.date %>
+      <% end %>
     <% else %>
-      <%= alert :success, "Data was last computed #{time_ago_in_words @auxiliary_data_end.date} ago and took #{distance_of_time_in_words @auxiliary_data_start.date, @auxiliary_data_end.date}" %>
+      <%= alert :danger, "Oh dear! The data has never been computed!" %>
     <% end %>
-    <% unless @auxiliary_data_start.date.present? && @auxiliary_data_end.date.nil? # Show unless the data is being computed. %>
+    <% unless ComputeAuxiliaryData.in_progress? %>
       <div>
         <%= link_to "Do it!", admin_compute_auxiliary_data_path, method: :post, class: "btn btn-primary" %>
       </div>

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -16,8 +16,8 @@
         <li class="list-group-item">Clears some cache files (living on the PHP side)</li>
       </ul>
     </div>
-    <% if Result.exists?(personId: "") %>
-      <%= alert :warning, "Some results are missing their corresponding WCA ID, which means that someone hasn't finished submitting results." %>
+    <% if @reason_not_to_run %>
+      <%= alert :warning, @reason_not_to_run %>
     <% else %>
       <% if ComputeAuxiliaryData.in_progress? %>
         <%= alert :info, "The data is being computed. Thanks for checking =)" %>

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -3,6 +3,11 @@
 <div class="container">
   <%= render layout: "nav" do %>
     <h2><%= yield(:title) %></h2>
+    <!-- TODO: Remove together with the PHP CAD script. -->
+    <h3>
+      This is the shiny, new version of the CAD script you know, if you run into problems with it,
+      PLEASE tell the WST, you can access the old script <%= link_to "here", "/results/admin/compute_auxiliary_data.php" %>.
+    </h3>
     <div>
       <h4>This script:</h4>
       <ul class="list-group">
@@ -12,7 +17,7 @@
       </ul>
     </div>
     <% if Result.exists?(personId: "") %>
-      <%= alert :warning, "Some results may be missing their corresponding WCA ID, which means that someone hasn't finished submitting results." %>
+      <%= alert :warning, "Some results are missing their corresponding WCA ID, which means that someone hasn't finished submitting results." %>
     <% else %>
       <% if ComputeAuxiliaryData.in_progress? %>
         <%= alert :info, "The data is being computed. Thanks for checking =)" %>

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -11,20 +11,24 @@
         <li class="list-group-item">Clears some cache files (living on the PHP side)</li>
       </ul>
     </div>
-    <% if ComputeAuxiliaryData.in_progress? %>
-      <%= alert :info, "The data is being computed. Thanks for checking =)" %>
-    <% elsif ComputeAuxiliaryData.finished? %>
-      <%= alert :success do %>
-        Data was last computed <%= time_ago_in_words ComputeAuxiliaryData.end_date %> ago
-        and took <%= distance_of_time_in_words ComputeAuxiliaryData.start_date, ComputeAuxiliaryData.end_date %>
-      <% end %>
+    <% if Result.exists?(personId: "") %>
+      <%= alert :warning, "Some results may be missing their corresponding WCA ID, which means that someone hasn't finished submitting results." %>
     <% else %>
-      <%= alert :danger, "Oh dear! The data has never been computed!" %>
-    <% end %>
-    <% unless ComputeAuxiliaryData.in_progress? %>
-      <div>
-        <%= link_to "Do it!", admin_compute_auxiliary_data_path, method: :post, class: "btn btn-primary" %>
-      </div>
+      <% if ComputeAuxiliaryData.in_progress? %>
+        <%= alert :info, "The data is being computed. Thanks for checking =)" %>
+      <% elsif ComputeAuxiliaryData.finished? %>
+        <%= alert :success do %>
+          Data was last computed <%= time_ago_in_words ComputeAuxiliaryData.end_date %> ago
+          and took <%= distance_of_time_in_words ComputeAuxiliaryData.start_date, ComputeAuxiliaryData.end_date %>
+        <% end %>
+      <% else %>
+        <%= alert :danger, "Oh dear! The data has never been computed!" %>
+      <% end %>
+      <% unless ComputeAuxiliaryData.in_progress? %>
+        <div>
+          <%= link_to "Do it!", admin_compute_auxiliary_data_path, method: :post, class: "btn btn-primary" %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -2,6 +2,18 @@
 
 <div class="container">
   <%= render layout: "nav" do %>
-    <%= link_to "Do!", admin_compute_auxiliary_data_path, method: :post %>
+    <h2><%= yield(:title) %></h2>
+    <% if @auxiliary_data_start.date.nil? %>
+      <%= alert :danger, "Oh dear! The data has never been computed!" %>
+    <% elsif @auxiliary_data_end.date.nil? %>
+      <%= alert :info, "The data is being computed. Thanks for checking =)" %>
+    <% else %>
+      <%= alert :success, "Data was last computed #{time_ago_in_words @auxiliary_data_end.date} ago and took #{distance_of_time_in_words @auxiliary_data_start.date, @auxiliary_data_end.date}" %>
+    <% end %>
+    <% unless @auxiliary_data_start.date.present? && @auxiliary_data_end.date.nil? # Show unless the data is being computed. %>
+      <div>
+        <%= link_to "Do it!", admin_compute_auxiliary_data_path, method: :post, class: "btn btn-primary" %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
+++ b/WcaOnRails/app/views/admin/compute_auxiliary_data.html.erb
@@ -1,0 +1,7 @@
+<% provide(:title, 'Compute Auxiliary Data') %>
+
+<div class="container">
+  <%= render layout: "nav" do %>
+    <%= link_to "Do!", admin_compute_auxiliary_data_path, method: :post %>
+  <% end %>
+</div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -123,6 +123,8 @@ Rails.application.routes.draw do
   get '/admin/edit_person' => 'admin#edit_person'
   patch '/admin/update_person' => 'admin#update_person'
   get '/admin/person_data' => 'admin#person_data'
+  get '/admin/compute_auxiliary_data' => 'admin#compute_auxiliary_data'
+  post '/admin/compute_auxiliary_data' => 'admin#do_compute_auxiliary_data'
 
   get '/search' => 'search_results#index'
 

--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -86,7 +86,7 @@ module AuxiliaryDataComputation
         counter = Hash.new(0)
         current_rank = Hash.new(0)
         previous_value = {}
-        personal_records.each do |event_id, person_id, country_id, continent_id, value|
+        personal_records.each do |_, person_id, country_id, continent_id, value|
           # Update the region states (unless we have ranked this person already,
           # e.g. 2008SEAR01 twice in North America and World because of his two countries).
           ["World", continent_id, country_id].each do |region|

--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -5,6 +5,8 @@ module AuxiliaryDataComputation
     self.compute_best_of_3_in_333bf
     self.compute_concise_results
     self.compute_rank_tables
+
+    self.delete_php_cache # Note: this should go away together with the PHP code.
   end
 
   ## Compute mean for 'best of 3' results in 333bf.
@@ -115,5 +117,10 @@ module AuxiliaryDataComputation
         SQL
       end
     end
+  end
+
+  def self.delete_php_cache
+    cache_files = Dir.glob(Rails.root.join("../webroot/results/generated/cache/*.cache"))
+    FileUtils.rm cache_files
   end
 end

--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module AuxiliaryDataComputation
-
   def self.compute_everything
     self.compute_best_of_3_in_333bf
     self.compute_concise_results

--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module AuxiliaryDataComputation
+
+  def self.compute_everything
+    self.compute_best_of_3_in_333bf
+    self.compute_concise_results
+    self.compute_rank_tables
+  end
+
+  ## Compute mean for 'best of 3' results in 333bf.
+  def self.compute_best_of_3_in_333bf
+    # Set new DNF average where any of three solves is not completed.
+    Result.where(eventId: "333bf", formatId: "3", average: 0)
+          .where("LEAST(value1, value2, value3) < 0")
+          .where.not(value1: 0, value2: 0, value3: 0)
+          .update_all(average: -1)
+    # Set new averages (round times > 10:00).
+    Result.where(eventId: "333bf", formatId: "3", average: 0)
+          .where("LEAST(value1, value2, value3) > 0")
+          .update_all <<-SQL
+            average = IF(
+              (value1 + value2 + value3)/3.0 > 60000,
+              (value1 + value2 + value3)/3.0 - MOD((value1 + value2 + value3)/3.0, 100),
+              (value1 + value2 + value3)/3.0
+            )
+          SQL
+  end
+
+  ## Build 'concise results' tables.
+  def self.compute_concise_results
+    [
+      %w(best ConciseSingleResults),
+      %w(average ConciseAverageResults),
+    ].each do |field, table_name|
+      ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS #{table_name}"
+      ActiveRecord::Base.connection.execute <<-SQL
+        CREATE TABLE #{table_name}
+        SELECT
+          result.id,
+          #{field},
+          valueAndId,
+          personId,
+          eventId,
+          country.id countryId,
+          continentId,
+          year, month, day
+        FROM (
+            SELECT MIN(#{field} * 1000000000 + result.id) valueAndId
+            FROM Results result
+            JOIN Competitions competition ON competition.id = competitionId
+            JOIN Events event ON event.id = eventId AND event.rank < 990
+            WHERE #{field} > 0
+            GROUP BY personId, result.countryId, eventId, year
+          ) MinValuesWithId
+          JOIN Results result ON result.id = valueAndId % 1000000000
+          JOIN Competitions competition ON competition.id = competitionId
+          JOIN Countries country ON country.id = result.countryId
+      SQL
+    end
+  end
+
+  ## Build rank tables.
+  def self.compute_rank_tables
+    [
+      %w(best RanksSingle ConciseSingleResults),
+      %w(average RanksAverage ConciseAverageResults),
+    ].each do |field, table_name, concise_table_name|
+      ActiveRecord::Base.connection.execute "TRUNCATE TABLE #{table_name}"
+      current_country = Person.current.pluck(:wca_id, :countryId).to_h
+      current_continent = Hash.new do |hash, person_id|
+        hash[person_id] = Country.c_find(current_country[person_id]).continentId
+      end
+      # Get all personal records (note: people that changed their country appear once for each country).
+      personal_records_with_event = ActiveRecord::Base.connection.execute <<-SQL
+        SELECT eventId, personId, countryId, continentId, min(#{field}) value
+        FROM #{concise_table_name}
+        WHERE eventId <> '333mbo'
+        GROUP BY personId, countryId, continentId, eventId
+        ORDER BY eventId, value
+      SQL
+      personal_records_with_event.group_by(&:first).each do |event_id, personal_records|
+        personal_rank = Hash.new { |h, k| h[k] = {} }
+        ranked = Hash.new { |h, k| h[k] = {} }
+        counter = Hash.new(0)
+        current_rank = Hash.new(0)
+        previous_value = {}
+        personal_records.each do |event_id, person_id, country_id, continent_id, value|
+          # Update the region states (unless we have ranked this person already,
+          # e.g. 2008SEAR01 twice in North America and World because of his two countries).
+          ["World", continent_id, country_id].each do |region|
+            next if ranked[region][person_id]
+            counter[region] += 1
+            # As we ordered by value it can either be greater or tie the previous one.
+            current_rank[region] = counter[region] if previous_value[region].nil? || value > previous_value[region]
+            previous_value[region] = value
+            ranked[region][person_id] = true
+          end
+          # Set the person's data (first time the current location is matched).
+          personal_rank[person_id][:best] ||= value
+          personal_rank[person_id][:world_rank] ||= current_rank["World"]
+          if continent_id == current_continent[person_id]
+            personal_rank[person_id][:continent_rank] ||= current_rank[continent_id]
+          end
+          if country_id == current_country[person_id]
+            personal_rank[person_id][:country_rank] ||= current_rank[country_id]
+          end
+        end
+        values = personal_rank.map do |person_id, rank_data|
+          # Note: continent_rank and country_rank may be not present because of a country change, in such case we default to 0.
+          "('#{person_id}', '#{event_id}', #{rank_data[:best]}, #{rank_data[:world_rank]}, #{rank_data[:continent_rank] || 0}, #{rank_data[:country_rank] || 0})"
+        end.join(",\n")
+        ActiveRecord::Base.connection.execute <<-SQL
+          INSERT INTO #{table_name} (personId, eventId, best, worldRank, continentRank, countryRank) VALUES
+          #{values}
+        SQL
+      end
+    end
+  end
+end

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -43,4 +43,52 @@ RSpec.describe "AuxiliaryDataComputation" do
       expect(with_completed_solves.reload.average).to eq (10.minutes + 10.seconds) * 100
     end
   end
+
+  describe ".compute_concise_results", clean_db_with_truncation: true do
+    let(:person) { FactoryGirl.create :person, countryId: "China" }
+    let(:competition_2016) { FactoryGirl.create :competition, starts: Date.parse("2016-04-04") }
+    let(:next_competition_2016) { FactoryGirl.create :competition, starts: Date.parse("2016-07-07") }
+    let(:competition_2017) { FactoryGirl.create :competition, starts: Date.parse("2017-08-08") }
+
+    it "creates tables containing best results data for each person per even per year" do
+      FactoryGirl.create :result, eventId: "333", best: 700, average: 800, competition: competition_2016, person: person
+      FactoryGirl.create :result, eventId: "333", best: 750, average: 850, competition: competition_2016, person: person
+      FactoryGirl.create :result, eventId: "333", best: 800, average: 900, competition: competition_2017, person: person
+      FactoryGirl.create :result, eventId: "222", best: 100, average: 150, competition: competition_2017, person: person
+      AuxiliaryDataComputation.compute_concise_results
+      # Concise single results
+      concise_single_results = ActiveRecord::Base.connection.execute "SELECT eventId, personId, year, best FROM ConciseSingleResults"
+      expect(concise_single_results).to match_array [
+        ["333", person.wca_id, 2016, 700],
+        ["333", person.wca_id, 2017, 800],
+        ["222", person.wca_id, 2017, 100],
+      ]
+      # Concise average results
+      concise_average_results = ActiveRecord::Base.connection.execute "SELECT eventId, personId, year, average FROM ConciseAverageResults"
+      expect(concise_average_results).to match_array [
+        ["333", person.wca_id, 2016, 800],
+        ["333", person.wca_id, 2017, 900],
+        ["222", person.wca_id, 2017, 150],
+      ]
+    end
+
+    it "creates multiple entries for people that have switched country in the middle of a year" do
+      FactoryGirl.create :result, eventId: "333", best: 700, average: 800, competition: competition_2016, person: person
+      person.update_using_sub_id! countryId: "Chile"
+      FactoryGirl.create :result, eventId: "333", best: 750, average: 850, competition: next_competition_2016, person: person
+      AuxiliaryDataComputation.compute_concise_results
+      # Concise single results
+      concise_single_results = ActiveRecord::Base.connection.execute "SELECT eventId, personId, countryId, year, best FROM ConciseSingleResults"
+      expect(concise_single_results).to match_array [
+        ["333", person.wca_id, "China", 2016, 700],
+        ["333", person.wca_id, "Chile", 2016, 750],
+      ]
+      # Concise average results
+      concise_average_results = ActiveRecord::Base.connection.execute "SELECT eventId, personId, countryId, year, average FROM ConciseAverageResults"
+      expect(concise_average_results).to match_array [
+        ["333", person.wca_id, "China", 2016, 800],
+        ["333", person.wca_id, "Chile", 2016, 850],
+      ]
+    end
+  end
 end

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe "AuxiliaryDataComputation" do
     end
 
     it "rounds averages over 10 minutes to down to full seconds" do
-      over_10 = (10.minutes + 10.5.seconds) * 100 # In centiseconds.
-      with_completed_solves = create_new_333bld_result value1: over_10, value2: over_10, value3: over_10
+      over10 = (10.minutes + 10.5.seconds) * 100 # In centiseconds.
+      with_completed_solves = create_new_333bld_result value1: over10, value2: over10, value3: over10
       AuxiliaryDataComputation.compute_best_of_3_in_333bf
-      expect(with_completed_solves.reload.average).to eq (10.minutes + 10.seconds) * 100
+      expect(with_completed_solves.reload.average).to eq((10.minutes + 10.seconds) * 100)
     end
   end
 
@@ -135,7 +135,7 @@ RSpec.describe "AuxiliaryDataComputation" do
         # Note: the continent is still USA, so continentRank shouldn't be affected.
         expect(rank_333(new_canadian, ranks_type)).to include(worldRank: 2, continentRank: 1, countryRank: 2)
         expect(rank_333(canadian, ranks_type)).to include(worldRank: 3, continentRank: 2, countryRank: 1)
-         # Note: this person stays 2nd in the country.
+        # Note: this person stays 2nd in the country.
         expect(rank_333(american_2, ranks_type)).to include(worldRank: 4, continentRank: 3, countryRank: 2)
       end
     end

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "AuxiliaryDataComputation" do
     let(:next_competition_2016) { FactoryGirl.create :competition, starts: Date.parse("2016-07-07") }
     let(:competition_2017) { FactoryGirl.create :competition, starts: Date.parse("2017-08-08") }
 
-    it "creates tables containing best results data for each person per even per year" do
+    it "creates tables containing best results data for each person per event per year" do
       FactoryGirl.create :result, eventId: "333", best: 700, average: 800, competition: competition_2016, person: person
       FactoryGirl.create :result, eventId: "333", best: 750, average: 850, competition: competition_2016, person: person
       FactoryGirl.create :result, eventId: "333", best: 800, average: 900, competition: competition_2017, person: person
@@ -109,7 +109,7 @@ RSpec.describe "AuxiliaryDataComputation" do
       FactoryGirl.create :result, eventId: "333", best: 900, average: 1000, person: american_2
     end
 
-    it "computes world, continental and national ranking position" do
+    it "computes world, continental, and national ranking position" do
       AuxiliaryDataComputation.compute_concise_results # Rank tables computation require concise results to be present.
       AuxiliaryDataComputation.compute_rank_tables
       %w(ranksSingle ranksAverage).each do |ranks_type|
@@ -131,7 +131,7 @@ RSpec.describe "AuxiliaryDataComputation" do
       %w(ranksSingle ranksAverage).each do |ranks_type|
         # Note: this person hasn't got any results in Europe/France yet.
         expect(rank_333(new_french, ranks_type)).to include(worldRank: 1, continentRank: 0, countryRank: 0)
-        # Note: the only change is the countryRank of new_canadian (previosly american_1).
+        # Note: the only change is the countryRank of new_canadian (previously american_1).
         # Note: the continent is still USA, so continentRank shouldn't be affected.
         expect(rank_333(new_canadian, ranks_type)).to include(worldRank: 2, continentRank: 1, countryRank: 2)
         expect(rank_333(canadian, ranks_type)).to include(worldRank: 3, continentRank: 2, countryRank: 1)

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'auxiliary_data_computation'
+
+RSpec.describe "AuxiliaryDataComputation" do
+  describe ".compute_best_of_3_in_333bf" do
+    def create_new_333bld_result(attributes = {})
+      FactoryGirl.build(:result, {
+        eventId: "333bf", formatId: "3", roundTypeId: "c",
+        value1: 3000, value2: 3000, value3: 3000, best: 3000,
+        value4: SolveTime::SKIPPED_VALUE, value5: SolveTime::SKIPPED_VALUE,
+        average: SolveTime::SKIPPED_VALUE # Average is not computed yet.
+      }.merge(attributes)).tap do |result|
+        result.save! validate: false # The average is not valid until we compute it.
+      end
+    end
+
+    it "leaves average as skipped if one of three solves is skipped" do
+      with_skipped_solve = create_new_333bld_result value3: SolveTime::SKIPPED_VALUE
+      AuxiliaryDataComputation.compute_best_of_3_in_333bf
+      expect(with_skipped_solve.reload.average).to eq SolveTime::SKIPPED_VALUE
+    end
+
+    it "sets DNF average if one of three solves is either DNF or DNS" do
+      with_dnf = create_new_333bld_result value3: SolveTime::DNF_VALUE
+      with_dns = create_new_333bld_result value3: SolveTime::DNS_VALUE
+      AuxiliaryDataComputation.compute_best_of_3_in_333bf
+      expect(with_dnf.reload.average).to eq SolveTime::DNF_VALUE
+      expect(with_dns.reload.average).to eq SolveTime::DNF_VALUE
+    end
+
+    it "sets a valid average if all three solves are completed" do
+      with_completed_solves = create_new_333bld_result
+      AuxiliaryDataComputation.compute_best_of_3_in_333bf
+      expect(with_completed_solves.reload.average).to eq 3000
+    end
+
+    it "rounds averages over 10 minutes to down to full seconds" do
+      over_10 = (10.minutes + 10.5.seconds) * 100 # In centiseconds.
+      with_completed_solves = create_new_333bld_result value1: over_10, value2: over_10, value3: over_10
+      AuxiliaryDataComputation.compute_best_of_3_in_333bf
+      expect(with_completed_solves.reload.average).to eq (10.minutes + 10.seconds) * 100
+    end
+  end
+end

--- a/webroot/results/admin/compute_auxiliary_data.php
+++ b/webroot/results/admin/compute_auxiliary_data.php
@@ -33,6 +33,8 @@ require( '../includes/_footer.php' );
 function showDescription () {
 #----------------------------------------------------------------------
 
+  echo "<p style='font-weight: bold; color: red;'>PLEASE use the new version of this script <a href='/admin/compute_auxiliary_data'>here</a>. This old version is going to be removed on the next Monday (15 May).</p>\n";
+
   echo "<p>This computes means for 3x3 bld, the auxiliary tables ConciseSingleResults, ConciseAverageResults, RanksSingle and RanksAverage and clears the caches.</p>\n";
 
   echo "<p>Do it after changes to the database data so that these things are up-to-date.</p><hr />\n";


### PR DESCRIPTION
Should fix  #1450.

Basically this ports the script as well as makes it an async job, so that the results team doesn't have to wait 3 minutes waiting for the server response.

I tested this on the staging. I paid a special attention to two things:

- Tricky ranks computation: on the staging I computed the rank tables with the old script and used `CHECKSUM TABLE`. After that I used the ruby version of the script and computed the `CHECKSUM TABLE` again. (Before this I needed to add `pesonId` to on `ORDER BY`, because those differed for people with the same times). The checksums were the same =) !
- Deferred computation in case of missing personId in the results table: I just added such a record to the records table and run the job. It was deferred as expected and after I removed the record the next run went well.

[This misses some tests of course.]