### PR TITLE
Added new update_events_from_wcif endpoint

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -22,8 +22,12 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Enabled: false
 
+Style/AccessorMethodName:
+  Enabled: false
+
 Style/Alias:
   Enabled: false
+
 Style/EmptyMethod:
   EnforcedStyle: expanded
 

--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -71,6 +71,7 @@ gem 'http_accept_language'
 gem 'twitter_cldr'
 gem 'jquery-slick-rails'
 gem 'webpacker'
+gem 'json-schema'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -234,6 +234,8 @@ GEM
     jquery-slick-rails (1.6.0.3)
       railties (>= 3.1)
     json (1.8.6)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     jwt (1.5.6)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
@@ -537,6 +539,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   jquery-slick-rails
+  json-schema
   kaminari
   kaminari-i18n
   launchy
@@ -587,4 +590,4 @@ DEPENDENCIES
   world-flags!
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -25,7 +25,7 @@ class CompetitionsController < ApplicationController
     end
   end
 
-  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :update_events, :payment_setup]
+  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :update_events, :update_events_from_wcif, :payment_setup]
 
   before_action -> { redirect_to_root_unless_user(:can_create_competitions?) }, only: [:new, :create]
 
@@ -324,6 +324,20 @@ class CompetitionsController < ApplicationController
     else
       render :edit_events
     end
+  end
+
+  def update_events_from_wcif
+    @competition = competition_from_params
+    wcif_events = params["_json"].map { |wcif_event| wcif_event.permit!.to_h } # TODO: validate that the incoming stuff is actually wcif
+    @competition.set_wcif_events!(wcif_events)
+    render json: {
+      status: "Successfully saved WCIF events",
+    }
+  rescue ActiveRecord::RecordInvalid => e
+    render status: 400, json: {
+      status: "Error while saving WCIF events",
+      error: e,
+    }
   end
 
   def get_nearby_competitions(competition)

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -328,7 +328,7 @@ class CompetitionsController < ApplicationController
 
   def update_events_from_wcif
     @competition = competition_from_params
-    wcif_events = params["_json"].map { |wcif_event| wcif_event.permit!.to_h } # TODO: validate that the incoming stuff is actually wcif
+    wcif_events = params["_json"].map { |wcif_event| wcif_event.permit!.to_h }
     @competition.set_wcif_events!(wcif_events)
     render json: {
       status: "Successfully saved WCIF events",
@@ -337,6 +337,11 @@ class CompetitionsController < ApplicationController
     render status: 400, json: {
       status: "Error while saving WCIF events",
       error: e,
+    }
+  rescue JSON::Schema::ValidationError => e
+    render status: 400, json: {
+      status: "Error while saving WCIF events",
+      error: e.message,
     }
   end
 

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -842,6 +842,25 @@ class Competition < ApplicationRecord
     }
   end
 
+  def set_wcif_events!(wcif_events)
+    # Remove extra events.
+    self.competition_events.each do |competition_event|
+      competition_event.destroy! unless wcif_events.find { |wcif_event| wcif_event["id"] == competition_event.event.id }
+    end
+
+    # Create missing events.
+    wcif_events.each do |wcif_event|
+      competition_events.find_or_create_by!(event_id: wcif_event["id"])
+    end
+
+    # Update all events.
+    wcif_events.each do |wcif_event|
+      competition_events.find_by_event_id!(wcif_event["id"]).load_wcif!(wcif_event)
+    end
+
+    reload
+  end
+
   def serializable_hash(options = nil)
     {
       class: self.class.to_s.downcase,

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -843,6 +843,9 @@ class Competition < ApplicationRecord
   end
 
   def set_wcif_events!(wcif_events)
+    events_schema = { "type" => "array", "items" => CompetitionEvent.wcif_json_schema }
+    JSON::Validator.validate!(events_schema, wcif_events)
+
     ActiveRecord::Base.transaction do
       # Remove extra events.
       self.competition_events.each do |competition_event|

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -843,19 +843,21 @@ class Competition < ApplicationRecord
   end
 
   def set_wcif_events!(wcif_events)
-    # Remove extra events.
-    self.competition_events.each do |competition_event|
-      competition_event.destroy! unless wcif_events.find { |wcif_event| wcif_event["id"] == competition_event.event.id }
-    end
+    ActiveRecord::Base.transaction do
+      # Remove extra events.
+      self.competition_events.each do |competition_event|
+        competition_event.destroy! unless wcif_events.find { |wcif_event| wcif_event["id"] == competition_event.event.id }
+      end
 
-    # Create missing events.
-    wcif_events.each do |wcif_event|
-      competition_events.find_or_create_by!(event_id: wcif_event["id"])
-    end
+      # Create missing events.
+      wcif_events.each do |wcif_event|
+        competition_events.find_or_create_by!(event_id: wcif_event["id"])
+      end
 
-    # Update all events.
-    wcif_events.each do |wcif_event|
-      competition_events.find_by_event_id!(wcif_event["id"]).load_wcif!(wcif_event)
+      # Update all events.
+      wcif_events.each do |wcif_event|
+        competition_events.find_by_event_id!(wcif_event["id"]).load_wcif!(wcif_event)
+      end
     end
 
     reload

--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -46,4 +46,16 @@ class CompetitionEvent < ApplicationRecord
       self.rounds.create!(Round.wcif_to_round_attributes(wcif_round, index+1))
     end
   end
+
+  def self.wcif_json_schema
+    {
+      "type" => "object",
+      "properties" => {
+        "id" => { "type" => "string" },
+        "rounds" => { "type" => "array", "items" => Round.wcif_json_schema },
+        "competitorLimit" => { "type" => "integer" },
+        "qualification" => { "type" => "object" }, # TODO: expand on this
+      },
+    }
+  end
 end

--- a/WcaOnRails/app/models/preferred_format.rb
+++ b/WcaOnRails/app/models/preferred_format.rb
@@ -3,4 +3,6 @@
 class PreferredFormat < ApplicationRecord
   belongs_to :event
   belongs_to :format
+
+  default_scope -> { order(:ranking) }
 end

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -53,6 +53,16 @@ class Round < ApplicationRecord
     advancement_condition ? advancement_condition.to_s(self) : ""
   end
 
+  def self.from_wcif(wcif, round_number)
+    Round.new(
+      number: round_number,
+      format_id: wcif["format"],
+      time_limit: TimeLimit.load(wcif["timeLimit"]),
+      cutoff: Cutoff.load(wcif["cutoff"]),
+      advancement_condition: AdvancementCondition.load(wcif["advancementCondition"]),
+    )
+  end
+
   def to_wcif
     {
       "id" => "#{event.id}-#{self.number}",

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -72,4 +72,19 @@ class Round < ApplicationRecord
       "advancementCondition" => advancement_condition&.to_wcif,
     }
   end
+
+  def self.wcif_json_schema
+    {
+      "type" => "object",
+      "properties" => {
+        "id" => { "type" => "string" },
+        "format" => { "type" => "string", "enum" => Format.pluck(:id) },
+        "timeLimit" => TimeLimit.wcif_json_schema,
+        "cutoff" => Cutoff.wcif_json_schema,
+        "advancementCondition" => AdvancementCondition.wcif_json_schema,
+        "roundResults" => { "type" => "array" }, # TODO: expand on this
+        "groups" => { "type" => "array" }, # TODO: expand on this
+      },
+    }
+  end
 end

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -53,14 +53,14 @@ class Round < ApplicationRecord
     advancement_condition ? advancement_condition.to_s(self) : ""
   end
 
-  def self.from_wcif(wcif, round_number)
-    Round.new(
+  def self.wcif_to_round_attributes(wcif, round_number)
+    {
       number: round_number,
       format_id: wcif["format"],
       time_limit: TimeLimit.load(wcif["timeLimit"]),
       cutoff: Cutoff.load(wcif["cutoff"]),
       advancement_condition: AdvancementCondition.load(wcif["advancementCondition"]),
-    )
+    }
   end
 
   def to_wcif

--- a/WcaOnRails/config/initializers/monkey_patches.rb
+++ b/WcaOnRails/config/initializers/monkey_patches.rb
@@ -60,4 +60,11 @@ Rails.configuration.to_prepare do
       self.in_seconds * 100
     end
   end
+
+  ActiveRecord::Associations::CollectionProxy.class_eval do
+    def destroy_all!
+      self.each(&:destroy!)
+      self.reload
+    end
+  end
 end

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
   get 'stripe-connect' => 'competitions#stripe_connect', as: :competitions_stripe_connect
   get 'competitions/:id/events/edit' => 'competitions#edit_events', as: :edit_events
   patch 'competitions/:id/events' => 'competitions#update_events', as: :update_events
+  patch 'competitions/:id/wcif/events' => 'competitions#update_events_from_wcif', as: :update_events_from_wcif
   get 'competitions/edit/nearby_competitions' => 'competitions#nearby_competitions', as: :nearby_competitions
   get 'competitions/edit/time_until_competition' => 'competitions#time_until_competition', as: :time_until_competition
   get 'competitions/:id/edit/clone_competition' => 'competitions#clone_competition', as: :clone_competition

--- a/WcaOnRails/lib/advancement_condition.rb
+++ b/WcaOnRails/lib/advancement_condition.rb
@@ -39,6 +39,16 @@ class AdvancementCondition
   def self.dump(cutoff)
     cutoff ? JSON.dump(cutoff.to_wcif) : nil
   end
+
+  def self.wcif_json_schema
+    {
+      "type" => ["object", "null"],
+      "properties" => {
+        "type" => { "type" => "string", "enum" => AdvancementCondition.subclasses.map(&:wcif_type) },
+        "level" => { "type" => "integer" },
+      },
+    }
+  end
 end
 
 class RankingCondition < AdvancementCondition

--- a/WcaOnRails/lib/cutoff.rb
+++ b/WcaOnRails/lib/cutoff.rb
@@ -41,6 +41,16 @@ class Cutoff
     cutoff ? JSON.dump(cutoff.to_wcif) : nil
   end
 
+  def self.wcif_json_schema
+    {
+      "type" => ["object", "null"],
+      "properties" => {
+        "numberOfAttempts" => { "type" => "integer" },
+        "attemptResult" => { "type" => "integer" },
+      },
+    }
+  end
+
   def to_s(round)
     if round.event.timed_event?
       centiseconds = self.attempt_result

--- a/WcaOnRails/lib/time_limit.rb
+++ b/WcaOnRails/lib/time_limit.rb
@@ -53,6 +53,16 @@ class TimeLimit
     competition_event.rounds.find_by_number!(round_number)
   end
 
+  def self.wcif_json_schema
+    {
+      "type" => ["object", "null"],
+      "properties" => {
+        "centiseconds" => { "type" => "integer" },
+        "cumulativeRoundIds" => { "type" => "array", "items" => { "type" => "string" } },
+      },
+    }
+  end
+
   def to_s(round)
     time_str = SolveTime.new(round.competition_event.event_id, :best, self.centiseconds).clock_format
     case self.cumulative_round_ids.length

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -87,8 +87,9 @@ RSpec.describe "Competition WCIF" do
   end
 
   describe "#set_wcif_events!" do
+    let(:wcif) { competition.to_wcif }
+
     it "removes competition event when wcif rounds are empty" do
-      wcif = competition.to_wcif
       wcif_444_event = wcif["events"].find { |e| e["id"] == "444" }
       wcif_444_event["rounds"] = []
 
@@ -100,7 +101,6 @@ RSpec.describe "Competition WCIF" do
     end
 
     it "removes competition event when wcif event is missing" do
-      wcif = competition.to_wcif
       wcif["events"].reject! { |e| e["id"] == "444" }
 
       competition.set_wcif_events!(wcif["events"])
@@ -110,7 +110,6 @@ RSpec.describe "Competition WCIF" do
     end
 
     it "creates competition event when adding round to previously nonexistent event" do
-      wcif = competition.to_wcif
       wcif["events"] << {
         "id" => "555",
         "rounds" => [
@@ -133,7 +132,6 @@ RSpec.describe "Competition WCIF" do
     end
 
     it "creates new round when adding round to existing event" do
-      wcif = competition.to_wcif
       wcif_444_event = wcif["events"].find { |e| e["id"] == "444" }
       wcif_444_event["rounds"][0]["advancementCondition"] = {
         "type" => "ranking",
@@ -164,7 +162,6 @@ RSpec.describe "Competition WCIF" do
     end
 
     it "can change round format to '3'" do
-      wcif = competition.to_wcif
       wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
       wcif_333_event["rounds"][0]["format"] = '3'
 

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Competition WCIF" do
+  let!(:competition) {
+    FactoryGirl.create(
+      :competition,
+      :with_delegate,
+      id: "TestComp2014",
+      name: "Test Comp 2014",
+      start_date: "2014-02-03",
+      end_date: "2014-02-05",
+      external_website: "http://example.com",
+      showAtAll: true,
+      event_ids: %w(333 444),
+    )
+  }
+  let(:delegate) { competition.delegates.first }
+  let(:sixty_second_2_attempt_cutoff) { Cutoff.new(number_of_attempts: 2, attempt_result: 1.minute.in_centiseconds) }
+  let(:top_16_advance) { RankingCondition.new(16) }
+  let!(:round333_1) { FactoryGirl.create(:round, competition: competition, event_id: "333", number: 1, cutoff: sixty_second_2_attempt_cutoff, advancement_condition: top_16_advance) }
+  let!(:round333_2) { FactoryGirl.create(:round, competition: competition, event_id: "333", number: 2) }
+  let!(:round444_1) { FactoryGirl.create(:round, competition: competition, event_id: "444", number: 1) }
+  before :each do
+    # Load all the rounds we just created.
+    competition.reload
+  end
+
+  describe "#to_wcif" do
+    it "renders a valid WCIF" do
+      expect(competition.to_wcif).to eq(
+        "formatVersion" => "1.0",
+        "id" => "TestComp2014",
+        "name" => "Test Comp 2014",
+        "persons" => [delegate.to_wcif(competition)],
+        "events" => [
+          {
+            "id" => "333",
+            "rounds" => [
+              {
+                "id" => "333-1",
+                "format" => "a",
+                "timeLimit" => {
+                  "centiseconds" => 10.minutes.in_centiseconds,
+                  "cumulativeRoundIds" => [],
+                },
+                "cutoff" => {
+                  "numberOfAttempts" => 2,
+                  "attemptResult" => 1.minute.in_centiseconds,
+                },
+                "advancementCondition" => {
+                  "type" => "ranking",
+                  "level" => 16,
+                },
+              },
+              {
+                "id" => "333-2",
+                "format" => "a",
+                "timeLimit" => {
+                  "centiseconds" => 10.minutes.in_centiseconds,
+                  "cumulativeRoundIds" => [],
+                },
+                "cutoff" => nil,
+                "advancementCondition" => nil,
+              },
+            ],
+          },
+          {
+            "id" => "444",
+            "rounds" => [
+              {
+                "id" => "444-1",
+                "format" => "a",
+                "timeLimit" => {
+                  "centiseconds" => 10.minutes.in_centiseconds,
+                  "cumulativeRoundIds" => [],
+                },
+                "cutoff" => nil,
+                "advancementCondition" => nil,
+              },
+            ],
+          },
+        ],
+      )
+    end
+  end
+
+  describe "#set_wcif_events!" do
+    it "removes competition event when wcif rounds are empty" do
+      wcif = competition.to_wcif
+      wcif_444_event = wcif["events"].find { |e| e["id"] == "444" }
+      wcif_444_event["rounds"] = []
+
+      competition.set_wcif_events!(wcif["events"])
+
+      wcif["events"].reject! { |e| e["id"] == "444" }
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+      expect(competition.events.map(&:id)).to match_array %w(333)
+    end
+
+    it "removes competition event when wcif event is missing" do
+      wcif = competition.to_wcif
+      wcif["events"].reject! { |e| e["id"] == "444" }
+
+      competition.set_wcif_events!(wcif["events"])
+
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+      expect(competition.events.map(&:id)).to match_array %w(333)
+    end
+
+    it "creates competition event when adding round to previously nonexistent event" do
+      wcif = competition.to_wcif
+      wcif["events"] << {
+        "id" => "555",
+        "rounds" => [
+          {
+            "id" => "555-1",
+            "format" => "3",
+            "timeLimit" => {
+              "centiseconds" => 3*60*100,
+              "cumulativeRoundIds" => [],
+            },
+            "cutoff" => nil,
+            "advancementCondition" => nil,
+          },
+        ],
+      }
+
+      competition.set_wcif_events!(wcif["events"])
+
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+    end
+
+    it "creates new round when adding round to existing event" do
+      wcif = competition.to_wcif
+      wcif_444_event = wcif["events"].find { |e| e["id"] == "444" }
+      wcif_444_event["rounds"][0]["advancementCondition"] = {
+        "type" => "ranking",
+        "level" => 16,
+      }
+      wcif_444_event["rounds"] << {
+        "id" => "444-2",
+        "format" => "a",
+        "timeLimit" => {
+          "centiseconds" => 10.minutes.in_centiseconds,
+          "cumulativeRoundIds" => [],
+        },
+        "cutoff" => nil,
+        "advancementCondition" => nil,
+      }
+
+      competition.set_wcif_events!(wcif["events"])
+
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+
+      # Verify that we can remove the round we just added, so long as we
+      # clear the advancementCondition on the first round.
+      wcif_444_event["rounds"][0]["advancementCondition"] = nil
+      wcif_444_event["rounds"].pop
+      competition.set_wcif_events!(wcif["events"])
+
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+    end
+
+    it "can change round format to '3'" do
+      wcif = competition.to_wcif
+      wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
+      wcif_333_event["rounds"][0]["format"] = '3'
+
+      competition.set_wcif_events!(wcif["events"])
+
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+    end
+  end
+end

--- a/WcaOnRails/spec/requests/competitions_spec.rb
+++ b/WcaOnRails/spec/requests/competitions_spec.rb
@@ -3,46 +3,103 @@
 require "rails_helper"
 
 RSpec.describe "competitions" do
-  sign_in { FactoryGirl.create :admin }
+  let(:competition) { FactoryGirl.create(:competition, :with_delegate, :visible) }
 
-  let(:competition) { FactoryGirl.create(:competition, :with_delegate) }
+  describe 'PATCH #update_competition' do
+    context "when signed in as admin" do
+      sign_in { FactoryGirl.create :admin }
 
-  it 'can confirm competition' do
-    patch competition_path(competition), params: {
-      'competition[name]' => competition.name,
-      'competition[delegate_ids]' => competition.delegate_ids,
-      'commit' => 'Confirm',
-    }
-    follow_redirect!
-    expect(response).to be_success
+      it 'can confirm competition' do
+        patch competition_path(competition), params: {
+          'competition[name]' => competition.name,
+          'competition[delegate_ids]' => competition.delegate_ids,
+          'commit' => 'Confirm',
+        }
+        follow_redirect!
+        expect(response).to be_success
 
-    expect(competition.reload.isConfirmed?).to eq true
+        expect(competition.reload.isConfirmed?).to eq true
+      end
+
+      it 'can set championship types for a competition' do
+        patch competition_path(competition), params: {
+          competition: {
+            championships_attributes: {
+              "1" => { championship_type: "world" },
+              "0" => { championship_type: "_Europe" },
+            },
+          },
+        }
+        follow_redirect!
+        expect(response).to be_success
+        expect(competition.reload.championships.count).to eq 2
+      end
+    end
   end
 
-  it 'can post results for a competition' do
-    expect(Post.count).to eq 0
+  describe 'POST #update_wcif_events' do
+    context 'when not signed in' do
+      sign_out
 
-    get competition_post_results_path(competition)
+      it 'redirects to the sign in page' do
+        patch update_events_from_wcif_path(competition)
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
 
-    expect(Post.count).to eq 1
+    context 'when signed in as an admin' do
+      sign_in { FactoryGirl.create :admin }
 
-    # Attempt to post results for a competition that already has results posted.
-    get competition_post_results_path(competition)
+      it 'updates the competition events' do
+        headers = { "CONTENT_TYPE" => "application/json" }
+        competition_events = [
+          {
+            id: "333",
+            rounds: [
+              {
+                id: "333-1",
+                format: "a",
+                timeLimit: {
+                  centiseconds: 4242,
+                  cumulativeRoundIds: [],
+                },
+                cutoff: nil,
+                advancementCondition: nil,
+              },
+            ],
+          },
+        ]
+        patch update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
+        expect(response).to be_success
+        expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 1
+      end
+    end
 
-    expect(Post.count).to eq 1
+    context 'when signed in as a regular user' do
+      sign_in { FactoryGirl.create :user }
+
+      it 'does not allow access' do
+        patch update_events_from_wcif_path(competition)
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 
-  it 'can set championship types for a competition' do
-    patch competition_path(competition), params: {
-      competition: {
-        championships_attributes: {
-          "1" => { championship_type: "world" },
-          "0" => { championship_type: "_Europe" },
-        },
-      },
-    }
-    follow_redirect!
-    expect(response).to be_success
-    expect(competition.reload.championships.count).to eq 2
+  describe "GET #post_results" do
+    context "when signed in as an admin" do
+      sign_in { FactoryGirl.create :admin }
+      it 'can post results for a competition' do
+        expect(Post.count).to eq 0
+
+        get competition_post_results_path(competition)
+
+        expect(Post.count).to eq 1
+
+        # Attempt to post results for a competition that already has results posted.
+        get competition_post_results_path(competition)
+
+        expect(Post.count).to eq 1
+      end
+    end
   end
 end

--- a/WcaOnRails/spec/requests/competitions_spec.rb
+++ b/WcaOnRails/spec/requests/competitions_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe "competitions" do
         ]
         patch update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
         expect(response).to have_http_status(400)
+        response_json = JSON.parse(response.body)
+        expect(response_json["error"]).to eq "The property '#/0/rounds/0/format' value \"invalidformat\" did not match one of the following values: 1, 2, 3, a, m"
         expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 2
       end
     end

--- a/WcaOnRails/spec/support/controller_macros.rb
+++ b/WcaOnRails/spec/support/controller_macros.rb
@@ -26,6 +26,13 @@ module RequestMacros
       follow_redirect!
     end
   end
+
+  def sign_out
+    before :each do
+      delete destroy_user_session_path
+      follow_redirect!
+    end
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Note: This PR introduces an API that is not actually used anywhere. I have other, pending work* to introduce a UI that writes to this new `update_wcif` endpoint.

*See https://github.com/jfly/worldcubeassociation.org/compare/jfly:edit-rounds-api...edit-rounds-ui for the upcoming UI changes that will take advantage of this PR. I've deployed `edit-rounds-ui` to staging so people can see what the finished product is supposed to be like. In particular, see [the edit ui](https://staging.worldcubeassociation.org/competitions/LondonOpen2017/events/edit) and [the view ui](https://staging.worldcubeassociation.org/competitions/LondonOpen2017/events/).
