### PR TITLE
Use actual class instead of base class name.

### DIFF
--- a/WcaOnRails/app/inputs/date_picker_input.rb
+++ b/WcaOnRails/app/inputs/date_picker_input.rb
@@ -18,7 +18,7 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
   def self.date_options_base
     {
       locale: I18n.locale.to_s,
-      format: DatePickerInput.picker_pattern,
+      format: self.picker_pattern,
       dayViewHeaderFormat: DatePickerInput.date_view_header_format,
     }
   end
@@ -57,7 +57,7 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
 
   def set_value_html_option
     return unless value.present?
-    input_html_options[:value] ||= value.is_a?(String) ? value : I18n.localize(value, format: DatePickerInput.display_pattern)
+    input_html_options[:value] ||= value.is_a?(String) ? value : I18n.localize(value, format: self.class.display_pattern)
   end
 
   def value
@@ -66,6 +66,6 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
 
   def date_options
     custom_options = input_html_options[:data][:date_options] || {}
-    DatePickerInput.date_options_base.merge!(custom_options)
+    self.class.date_options_base.merge!(custom_options)
   end
 end

--- a/WcaOnRails/app/inputs/datetime_picker_input.rb
+++ b/WcaOnRails/app/inputs/datetime_picker_input.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class DatetimePickerInput < DatePickerInput
-  private
-
-  def display_pattern
+  def self.display_pattern
     I18n.t('datepicker.dformat') + ' ' + I18n.t('timepicker.dformat')
   end
 
-  def picker_pattern
+  def self.picker_pattern
     I18n.t('datepicker.pformat') + ' ' + I18n.t('timepicker.pformat')
   end
+
+  private
 
   def utc_addon
     template.content_tag :span, "UTC", class: "input-group-addon"

--- a/WcaOnRails/spec/features/competition_management_spec.rb
+++ b/WcaOnRails/spec/features/competition_management_spec.rb
@@ -158,6 +158,17 @@ RSpec.feature "Competition management" do
 
         expect(comp_with_fours.reload.events).to match_array [threes]
       end
+
+      scenario 'can edit registration open datetime', js: true do
+        visit edit_competition_path(comp_with_fours)
+        check "competition_use_wca_registration"
+
+        expect(page).not_to have_selector(".bootstrap-datetimepicker-widget .datepicker")
+        expect(page).not_to have_selector(".bootstrap-datetimepicker-widget .timepicker")
+        find('#competition_registration_open').click
+        expect(page).to have_selector(".bootstrap-datetimepicker-widget .datepicker")
+        expect(page).to have_selector(".bootstrap-datetimepicker-widget .timepicker")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes the datetime picker for registrations opening/closing.