### PR TITLE
Streamline the post registration page a bit

### DIFF
--- a/WcaOnRails/app/helpers/registrations_helper.rb
+++ b/WcaOnRails/app/helpers/registrations_helper.rb
@@ -13,8 +13,12 @@ module RegistrationsHelper
     end
   end
 
-  def notify_of_preferred_events(preferred_events)
-    if preferred_events.empty?
+  def notify_of_preferred_events(registration)
+    if registration.persisted?
+      # If they already registered, don't bother telling them about the
+      # preferred events feature.
+      ""
+    elsif registration.user.preferred_events.empty?
       t('registrations.preferred_events_prompt_html', link: link_to(t('common.here'), profile_edit_path(section: :preferences)))
     else
       t('registrations.preferred_events_populated_html', link: link_to(t('common.here'), profile_edit_path(section: :preferences)))

--- a/WcaOnRails/app/views/registrations/_register_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_register_form.html.erb
@@ -3,7 +3,7 @@
                                    : registration_path(@registration) %>
 <%= horizontal_simple_form_for @registration, url: url, html: { class: 'are-you-sure no-submit-on-enter' } do |f| %>
   <%= render "shared/associated_events_picker", form_builder: f, disabled: disabled,
-              events_association_name: :registration_competition_events, allowed_events: @competition.events, selected_events: @selected_events, hint: notify_of_preferred_events(current_user.preferred_events) %>
+              events_association_name: :registration_competition_events, allowed_events: @competition.events, selected_events: @selected_events, hint: notify_of_preferred_events(@registration) %>
 
   <% if @competition.guests_enabled? %>
     <%= f.input :guests, disabled: disabled %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -23,9 +23,12 @@ Note: form_builder.object is the object having associated events.
 
 <div class="form-group <%= "has-error" unless errors.empty? %>">
   <%= label_tag events_association_name, class: "associated-events-label" do %>
-    <%= label %> (<span class="events-selected-count"></span>) <br />
-    <button type="button" class="btn btn-primary btn-xs select-all-events"><%= t 'competitions.index.all_events' %></button>
-    <button type="button" class="btn btn-default btn-xs clear-all-events"><%= t 'competitions.index.clear' %></button>
+    <%= label %> (<span class="events-selected-count"></span>)
+    <% unless disabled %>
+      <br />
+      <button type="button" class="btn btn-primary btn-xs select-all-events"><%= t 'competitions.index.all_events' %></button>
+      <button type="button" class="btn btn-default btn-xs clear-all-events"><%= t 'competitions.index.clear' %></button>
+    <% end %>
   <% end %>
   <div id="<%= events_association_name %>" class="associated-events">
     <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>


### PR DESCRIPTION
This fixes #1623:

- Do not show "all"/"clear" buttons when the associated events picker is disabled.
- Don't notify people of the preferred events feature if they're already registered for the competition.