### PR TITLE
Teach people about the developer's export.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains all of the code that runs on [worldcubeassociation.org]
 - Set up mysql with a user with username "root" with an empty password.
   1. `cd WcaOnRails/`
   2. `bundle install && bin/yarn`
-  3. `bin/rake db:load:development` - Download and import a sanitized copy of our production database.
+  3. `bin/rake db:load:development` - Download and import the [developer's database export](https://github.com/thewca/worldcubeassociation.org/wiki/Developer-database-export).
   4. `bin/foreman start` - Run rails and webpack. The server will be accessible at localhost:3000
 - `bin/rspec` - Run tests. Make sure that `RAILS_ENV=test bin/webpack-dev-server` is already running.
 - [Mailcatcher](http://mailcatcher.me/) is a good tool for catching emails in development.

--- a/WcaOnRails/app/views/devise/sessions/new.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/new.html.erb
@@ -16,6 +16,16 @@
             <%= f.label :password %>
             <%= link_to t("devise.passwords.new.forgot_your_password"), new_user_password_path %><br />
             <%= f.password_field :password, autocomplete: "off", class: "form-control", tabindex: "2" %>
+            <% if Timestamp.find_by_name(DatabaseDumper::DUMP_TIMESTAMP_NAME) %>
+              <p class="help-block">
+                Hint! It looks like you are using the
+                <a href="https://github.com/thewca/worldcubeassociation.org/wiki/Developer-database-export" target="_blank">developer export</a>,
+                every user's
+                password is "wca". You can find email addresses to log in
+                with over on
+                <%= link_to "the delegates page", delegates_path %>.
+              </p>
+            <% end %>
           </div>
           <% if devise_mapping.rememberable? %>
             <div class="checkbox">

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -2,6 +2,7 @@
 
 module DatabaseDumper
   JOIN_WHERE_VISIBLE_COMP = "JOIN Competitions ON Competitions.id=competition_id WHERE showAtAll=1"
+  DUMP_TIMESTAMP_NAME = "developer_dump_exported_at"
 
   def self.actions_to_column_sanitizers(columns_by_action)
     {}.tap do |column_sanitizers|
@@ -569,6 +570,8 @@ module DatabaseDumper
         populate_table_sql = "INSERT INTO #{dump_db_name}.#{table_name} (#{column_sanitizers.keys.join(", ")}) SELECT #{column_expressions} FROM #{table_name} #{table_sanitizer[:where_clause]}"
         ActiveRecord::Base.connection.execute(populate_table_sql)
       end
+
+      ActiveRecord::Base.connection.execute("INSERT INTO #{dump_db_name}.timestamps (name, date) VALUES ('#{DUMP_TIMESTAMP_NAME}', UTC_TIMESTAMP())")
     end
 
     LogTask.log_task "Dumping '#{dump_db_name}' to '#{dump_filename}'" do


### PR DESCRIPTION
@larspetrus, you suggested this in an unrelated email thread.

I've updated the developer database export to include a timestamp of when the export was performed. If we find this timestamp in our database, then we assume we're on the developer export and we show this message.

![image](https://cloud.githubusercontent.com/assets/277474/26183990/f733c816-3b36-11e7-8954-2fbde960adad.png)