### PR TITLE
Add competitor limit fields to Competitions - Fixes #1325

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -3,6 +3,10 @@ onPage('competitions#edit, competitions#update, competitions#admin_edit, competi
     $('.wca-registration-options').toggle(this.checked);
   }).trigger('change');
 
+  $('input[name="competition[competitor_limit_enabled]"]').on('change', function() {
+    $('.wca-competitor-limit-options').toggle(this.checked);
+  }).trigger('change');
+
   $('input[name="competition[generate_website]"]').on('change', function() {
     var generateWebsite = this.checked;
     $('div.competition_external_website').toggle(!generateWebsite);

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -477,6 +477,9 @@ class CompetitionsController < ApplicationController
         :contact,
         :generate_website,
         :external_website,
+        :competitor_limit_enabled,
+        :competitor_limit,
+        :competitor_limit_reason,
         :remarks,
         competition_events_attributes: [:id, :event_id, :_destroy],
       ]

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -68,6 +68,9 @@ class Competition < ApplicationRecord
     contact
     remarks
     use_wca_registration
+    competitor_limit_enabled
+    competitor_limit
+    competitor_limit_reason
     guests_enabled
     base_entry_fee_lowest_denomination
     currency_code
@@ -99,6 +102,9 @@ class Competition < ApplicationRecord
   PATTERN_TEXT_WITH_LINKS_RE = /\A[^{}]*(#{PATTERN_LINK_RE.source}[^{}]*)*\z/
   MAX_ID_LENGTH = 32
   MAX_NAME_LENGTH = 50
+  MAX_COMPETITOR_LIMIT = 5000
+  validates_numericality_of :competitor_limit, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_COMPETITOR_LIMIT, if: :competitor_limit_enabled?
+  validates :competitor_limit_reason, presence: true, if: :competitor_limit_enabled?
   validates :id, presence: true, uniqueness: true, length: { maximum: MAX_ID_LENGTH },
                  format: { with: /\A[a-zA-Z0-9]+\Z/ }, if: :name_valid_or_updating?
   private def name_valid_or_updating?
@@ -517,6 +523,10 @@ class Competition < ApplicationRecord
 
   def has_fees?
     base_entry_fee_lowest_denomination + competition_events.sum(:fee_lowest_denomination) > 0
+  end
+
+  def competitor_limit_enabled?
+    competitor_limit_enabled
   end
 
   def pending_results_or_report(days)

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -252,6 +252,14 @@
       </div>
     </div>
 
+    <% if @competition_admin_view || !is_actually_confirmed %>
+      <%= f.input :competitor_limit_enabled %>
+      <div class="wca-competitor-limit-options">
+        <%= f.input :competitor_limit %>
+        <%= f.input :competitor_limit_reason %>
+      </div>
+    <% end %>
+
     <hr>
     <%= f.input :remarks, disabled: is_actually_confirmed %>
 

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -42,6 +42,11 @@
         <% end %>
       </dd>
 
+      <% if competition.competitor_limit_enabled? %>
+        <dt><%= t '.competitor_limit' %></dt>
+        <dd><%= competition.competitor_limit %></dd>
+      <% end %>
+
       <% if competition.has_fees? %>
         <dt><%= t '.entry_fee' %></dt>
         <dd><%= humanized_money_with_symbol competition.base_entry_fee %></dd>

--- a/WcaOnRails/app/views/competitions_mailer/notify_board_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_board_of_confirmed_competition.html.erb
@@ -6,6 +6,12 @@
   </p>
 <% end %>
 
+<% if @competition.competitor_limit_enabled? %>
+  <p>
+    There is a competitor limit of <%= @competition.competitor_limit %> because "<%= @competition.competitor_limit_reason %>"
+  </p>
+<% end %>
+
 <p>
   @Board: You can delete this competition or make it publicly visible <%= link_to "here", admin_edit_competition_url(@competition) %>.
   For a complete list of confirmed but unannounced competitions see your <%= link_to "notifications", notifications_url %>.

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -215,6 +215,9 @@ en:
         contact: "Contact"
         information: "Information"
         use_wca_registration: "I would like to use the WCA website for registration"
+        competitor_limit_enabled: "I would like to specify a limit on the number of competitors that can enter this competition."
+        competitor_limit: "Maximum number of competitors"
+        competitor_limit_reason: "The reason for the competitor limit"
         guests_enabled: "Guests"
         receive_registration_emails: "Notify me by email when someone registers for this competition"
         registration_open: "Registration open"
@@ -333,6 +336,9 @@ en:
         showAtAll: ""
         start_date: ""
         use_wca_registration: ""
+        competitor_limit_enabled: "For now this number is informational only, and does not yet prevent more people from registering. We are working on adding explicit support for this to the registration flow, but it requires some other work first."
+        competitor_limit: "The number of competitors allowed in this competition."
+        competitor_limit_reason: "What is the reason for the limit on competitors?"
         venueAddress: ""
       website_contact:
         message: ""
@@ -790,6 +796,7 @@ en:
         one: "WCA Delegate"
         other: "WCA Delegates"
       contact: "Contact"
+      competitor_limit: "Competitor Limit"
       entry_fee: "Entry Fee"
       information: "Information"
     #context: on the competition's index page

--- a/WcaOnRails/db/migrate/20170517194354_add_competitor_limit_to_competitions.rb
+++ b/WcaOnRails/db/migrate/20170517194354_add_competitor_limit_to_competitions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCompetitorLimitToCompetitions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :Competitions, :competitor_limit_enabled, :boolean, null: false, default: 0
+    add_column :Competitions, :competitor_limit, :integer
+    add_column :Competitions, :competitor_limit_reason, :string
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -59,6 +59,9 @@ CREATE TABLE `Competitions` (
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
+  `competitor_limit_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `competitor_limit` int(11) DEFAULT NULL,
+  `competitor_limit_reason` varchar(191) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
@@ -1470,4 +1473,5 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170523034604'),
 ('20170523185221'),
 ('20170524221221'),
-('20170524224533');
+('20170524224533'),
+('20170517194354');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -55,6 +55,9 @@ module DatabaseDumper
           registration_close
           enable_donations
           use_wca_registration
+          competitor_limit_enabled
+          competitor_limit
+          competitor_limit_reason
           guests_enabled
           results_posted_at
           results_nag_sent_at

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -841,7 +841,7 @@ RSpec.describe CompetitionsController do
     end
   end
 
-  describe 'POST #udpate_events' do
+  describe 'POST #update_events' do
     context 'when not signed in' do
       sign_out
 

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -36,6 +36,12 @@ FactoryGirl.define do
       results_posted_at Time.now
     end
 
+    trait :with_competitor_limit do
+      competitor_limit_enabled true
+      competitor_limit 100
+      competitor_limit_reason "The hall only fits 100 competitors."
+    end
+
     events { Event.where(id: event_ids) }
 
     venue "My backyard"

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
   describe "notify_board_of_confirmed_competition" do
     let(:delegate) { FactoryGirl.create :delegate }
     let(:second_delegate) { FactoryGirl.create :delegate }
-    let(:competition) { FactoryGirl.create :competition, delegates: [delegate, second_delegate] }
+    let(:competition) { FactoryGirl.create :competition, :with_competitor_limit, delegates: [delegate, second_delegate] }
     let(:mail) { CompetitionsMailer.notify_board_of_confirmed_competition(delegate, competition) }
 
     it "renders" do
@@ -17,6 +17,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
       expect(mail.subject).to eq("#{delegate.name} just confirmed #{competition.name}")
       expect(mail.body.encoded).to match("#{competition.name} is confirmed")
+      expect(mail.body.encoded).to match("There is a competitor limit of 100 because \"The hall only fits 100 competitors.\"")
       expect(mail.body.encoded).to match(admin_edit_competition_url(competition))
     end
   end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe Competition do
     end
   end
 
+  context "when competition has a competitor limit" do
+    it "requires competitor limit to be a number" do
+      competition = FactoryGirl.build :competition, competitor_limit_enabled: true
+      expect(competition).to be_invalid_with_errors(competitor_limit: ["is not a number"])
+    end
+
+    it "requires competitor limit to be greater than 0" do
+      competition = FactoryGirl.build :competition, competitor_limit_enabled: true, competitor_limit: 0, competitor_limit_reason: 'Because'
+      expect(competition).to be_invalid_with_errors(competitor_limit: ["must be greater than or equal to 1"])
+    end
+
+    it "requires competitor limit to be less than 5001" do
+      competition = FactoryGirl.build :competition, competitor_limit_enabled: true, competitor_limit: 5001, competitor_limit_reason: 'Because'
+      expect(competition).to be_invalid_with_errors(competitor_limit: ["must be less than or equal to 5000"])
+    end
+
+    it "requires a competitor limit reason" do
+      competition = FactoryGirl.build :competition, competitor_limit_enabled: true, competitor_limit: 100
+      expect(competition).to be_invalid_with_errors(competitor_limit_reason: ["can't be blank"])
+    end
+  end
+
   context "delegates" do
     it "delegates for future comps must be current delegates" do
       competition = FactoryGirl.build :competition, :with_delegate, :future


### PR DESCRIPTION
Competitor limits are not enforced anywhere, this is for display
purposes only at this stage.

**Competition Form**
![competitor-limit-edit](https://cloud.githubusercontent.com/assets/4403168/26181718/a50d35fc-3bb5-11e7-9264-7fbb555dc795.png)

**Competition General Info Tab**
![competitor-limit-info](https://cloud.githubusercontent.com/assets/4403168/26181725/af3c227c-3bb5-11e7-871a-36f7061a97d7.png)

Some of the competition tests were failing due to Date.today and 1.day.from_now returning the same date. It turns out that Date.today is not timezone aware but Date.current is. So I modified some Date.today to Date.current to get the tests to pass. Let me know if this is OK or if there is some other way of dealing with this.