### PR TITLE
Add structures for per event pricing - Fixes #1499

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -451,7 +451,7 @@ class Competition < ApplicationRecord
   end
 
   def using_stripe_payments?
-    connected_stripe_account_id && has_entry_fee?
+    connected_stripe_account_id && has_fees?
   end
 
   def can_edit_registration_fees?
@@ -511,8 +511,12 @@ class Competition < ApplicationRecord
     self.events.include?(event)
   end
 
-  def has_entry_fee?
+  def has_base_entry_fee?
     base_entry_fee.nonzero?
+  end
+
+  def has_fees?
+    base_entry_fee_lowest_denomination + competition_events.sum(:fee_lowest_denomination) > 0
   end
 
   def pending_results_or_report(days)

--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -7,12 +7,25 @@ class CompetitionEvent < ApplicationRecord
   has_many :rounds, -> { order(:number) }
   accepts_nested_attributes_for :rounds, allow_destroy: true
 
+  validates_numericality_of :fee_lowest_denomination, greater_than_or_equal_to: 0
+  monetize :fee_lowest_denomination,
+           as: "fee",
+           with_model_currency: :currency_code
+
   validate do
     remaining_rounds = rounds.reject(&:marked_for_destruction?)
     numbers = remaining_rounds.map(&:number).sort
     if numbers != (1..remaining_rounds.length).to_a
       errors.add(:rounds, "#{numbers} is wrong")
     end
+  end
+
+  def currency_code
+    competition&.currency_code
+  end
+
+  def has_fee?
+    fee.nonzero?
   end
 
   def to_wcif

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -105,12 +105,12 @@ class Registration < ApplicationRecord
   end
 
   def entry_fee
-    competition.base_entry_fee
+    competition.base_entry_fee + competition_events.to_a.sum(&:fee)
   end
 
   def paid_entry_fees
     Money.new(
-      registration_payments.sum(&:amount_lowest_denomination),
+      registration_payments.sum(:amount_lowest_denomination),
       competition.currency_code,
     )
   end

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -42,9 +42,15 @@
         <% end %>
       </dd>
 
-      <% if competition.has_entry_fee? %>
+      <% if competition.has_fees? %>
         <dt><%= t '.entry_fee' %></dt>
         <dd><%= humanized_money_with_symbol competition.base_entry_fee %></dd>
+        <% competition.competition_events.each do |competition_event| %>
+          <% if competition_event.has_fee? %>
+            <dt><%= competition_event.event.name %></dt>
+            <dd><%= humanized_money_with_symbol competition_event.fee %></dd>
+          <% end %>
+        <% end %>
       <% end %>
     </dl>
   </div>

--- a/WcaOnRails/app/views/registrations/_register_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_register_form.html.erb
@@ -13,7 +13,7 @@
 
   <%# If the user has to pay fee here, this information will already be in the payment form %>
   <%# If there are no entry fees, no need to display this information %>
-  <% unless @registration.show_payment_form? || !@competition.has_entry_fee? %>
+  <% unless @registration.show_payment_form? || !@competition.has_fees? %>
     <% fees_hint, hint_context = fees_hint_and_context(@registration) %>
     <%= render 'entry_fee', hint: fees_hint, hint_context: hint_context %>
   <% end %>

--- a/WcaOnRails/db/migrate/20170518011526_add_event_fees_to_competition_events.rb
+++ b/WcaOnRails/db/migrate/20170518011526_add_event_fees_to_competition_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEventFeesToCompetitionEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :competition_events, :fee_lowest_denomination, :integer, null: false, default: 0
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -449,6 +449,7 @@ CREATE TABLE `competition_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
@@ -1192,4 +1193,5 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170503205810'),
 ('20170510071858'),
 ('20170516002944'),
-('20170517192919');
+('20170517192919'),
+('20170518011526');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -314,6 +314,7 @@ module DatabaseDumper
           id
           competition_id
           event_id
+          fee_lowest_denomination
         ),
       ),
     }.freeze,

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe Competition do
     end
   end
 
+  context "when there is an entry fee" do
+    it "correctly identifies there is a fee when there is only a base fee" do
+      competition = FactoryGirl.build :competition, name: "Foo: Test - 2015", base_entry_fee_lowest_denomination: 10
+      expect(competition.has_fees?).to be true
+      expect(competition.has_base_entry_fee?).to eq competition.base_entry_fee
+    end
+
+    it "correctly identifies there is a fee when there is only event fees" do
+      competition = FactoryGirl.create :competition, name: "Foo: Test - 2015", base_entry_fee_lowest_denomination: 0
+      competition.competition_events.first.update_attribute(:fee_lowest_denomination, 100)
+      expect(competition.has_base_entry_fee?).to be nil
+      expect(competition.has_fees?).to be true
+    end
+  end
+
   context "delegates" do
     it "delegates for future comps must be current delegates" do
       competition = FactoryGirl.build :competition, :with_delegate, :future


### PR DESCRIPTION
This change adds the ability to store and calculate per event entry fees but it does not implement the UI.

I manually updated the database to show how the entry fees would show up.
![entry-fees](https://cloud.githubusercontent.com/assets/4403168/26187139/0facc700-3bda-11e7-953b-fdaf5649ee50.png)

Here's a shot after registering for one event
![fully-paid](https://cloud.githubusercontent.com/assets/4403168/26187159/30a3a32a-3bda-11e7-8572-79b25ca83c6c.png)

Then after another 2 events added to the registration
![needs-further-payment](https://cloud.githubusercontent.com/assets/4403168/26187173/44b5ea44-3bda-11e7-9beb-f0dc097390ce.png)
 



