### PR TITLE
Update pre-commit gem

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -311,7 +311,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     phantomjs (2.1.1.0)
-    pluginator (1.3.0)
+    pluginator (1.4.0)
     poltergeist (1.14.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)


### PR DESCRIPTION
Travis started to fail running `pre-commit` and I have like no idea what's going on, especially that things work locally. Anyway I just decided to run update and one of the dependency gems (that was present in the error stack trace) has been updated. Let's see if Travis is happy now...