### PR TITLE
Add support for tagging posts

### DIFF
--- a/WcaOnRails/app/controllers/posts_controller.rb
+++ b/WcaOnRails/app/controllers/posts_controller.rb
@@ -58,7 +58,7 @@ class PostsController < ApplicationController
   end
 
   private def editable_post_fields
-    [:title, :body, :sticky]
+    [:title, :body, :sticky, :tags]
   end
   helper_method :editable_post_fields
 

--- a/WcaOnRails/app/controllers/posts_controller.rb
+++ b/WcaOnRails/app/controllers/posts_controller.rb
@@ -5,7 +5,13 @@ class PostsController < ApplicationController
   before_action -> { redirect_to_root_unless_user(:can_create_posts?) }, except: [:index, :rss, :show]
 
   def index
-    @posts = Post.where(world_readable: true).order(sticky: :desc, created_at: :desc).includes(:author).page(params[:page])
+    tag = params[:tag]
+    if tag
+      @posts = Post.joins(:post_tags).where('post_tags.tag = ?', tag)
+    else
+      @posts = Post.joins("LEFT JOIN post_tags ON post_tags.post_id = posts.id").group("posts.id").having("IFNULL(SUM(tag = 'wdc'), 0) = 0")
+    end
+    @posts = @posts.where(world_readable: true).order(sticky: :desc, created_at: :desc).includes(:author).page(params[:page])
   end
 
   def rss

--- a/WcaOnRails/app/controllers/posts_controller.rb
+++ b/WcaOnRails/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
     if tag
       @posts = Post.joins(:post_tags).where('post_tags.tag = ?', tag)
     else
-      @posts = Post.joins("LEFT JOIN post_tags ON post_tags.post_id = posts.id").group("posts.id").having("IFNULL(SUM(tag = 'wdc'), 0) = 0")
+      @posts = Post.where(show_on_homepage: true)
     end
     @posts = @posts.where(world_readable: true).order(sticky: :desc, created_at: :desc).includes(:author).page(params[:page])
   end
@@ -64,7 +64,7 @@ class PostsController < ApplicationController
   end
 
   private def editable_post_fields
-    [:title, :body, :sticky, :tags]
+    [:title, :body, :sticky, :tags, :show_on_homepage]
   end
   helper_method :editable_post_fields
 

--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -54,6 +54,8 @@ class Post < ApplicationRecord
     Post.find_or_create_by!(slug: CRASH_COURSE_POST_SLUG) do |post|
       post.title = "Delegate crash course"
       post.body = "Nothing here yet"
+      post.show_on_homepage = false
+      post.world_readable = false
     end
   end
 

--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -2,10 +2,31 @@
 
 class Post < ApplicationRecord
   belongs_to :author, class_name: "User"
+  has_many :post_tags, autosave: true, dependent: :destroy
 
   validates :title, presence: true, uniqueness: true
   validates :body, presence: true
   validates :slug, presence: true, uniqueness: true
+
+  attr_writer :tags
+
+  def tags
+    @tags ||= post_tags.pluck(:tag).join(",")
+  end
+
+  def tags_array
+    tags.split(",")
+  end
+
+  before_validation do
+    tags_array.each do |tag|
+      post_tags.find_or_initialize_by(tag: tag)
+    end
+
+    post_tags.each do |post_tag|
+      post_tag.mark_for_destruction unless tags_array.include?(post_tag.tag)
+    end
+  end
 
   BREAK_TAG_RE = /<!--\s*break\s*-->/
 

--- a/WcaOnRails/app/models/post_tag.rb
+++ b/WcaOnRails/app/models/post_tag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PostTag < ApplicationRecord
+  belongs_to :post
+
+  before_validation { self.tag = self.tag.strip }
+
+  validates :tag, format: { with: /\A[a-zA-Z0-9]+\z/, message: "only allows English letters and numbers" }
+end

--- a/WcaOnRails/app/views/posts/_post_form.html.erb
+++ b/WcaOnRails/app/views/posts/_post_form.html.erb
@@ -2,6 +2,7 @@
 <%= simple_form_for @post, url: url, html: { class: 'form-horizontal' } do |f| %>
   <%= f.input :title, disabled: !editable_post_fields.include?(:title), autofocus: true %>
   <%= f.input :body, input_html: { class: 'markdown-editor' } if editable_post_fields.include? :body %>
+  <%= f.input :tags if editable_post_fields.include? :tags %>
   <%= f.input :sticky if editable_post_fields.include? :sticky %>
   <%= f.button :submit %>
 

--- a/WcaOnRails/app/views/posts/_post_form.html.erb
+++ b/WcaOnRails/app/views/posts/_post_form.html.erb
@@ -4,6 +4,7 @@
   <%= f.input :body, input_html: { class: 'markdown-editor' } if editable_post_fields.include? :body %>
   <%= f.input :tags if editable_post_fields.include? :tags %>
   <%= f.input :sticky if editable_post_fields.include? :sticky %>
+  <%= f.input :show_on_homepage if editable_post_fields.include? :show_on_homepage %>
   <%= f.button :submit %>
 
   <% if @post.deletable %>

--- a/WcaOnRails/app/views/posts/_post_form.html.erb
+++ b/WcaOnRails/app/views/posts/_post_form.html.erb
@@ -2,7 +2,25 @@
 <%= simple_form_for @post, url: url, html: { class: 'form-horizontal' } do |f| %>
   <%= f.input :title, disabled: !editable_post_fields.include?(:title), autofocus: true %>
   <%= f.input :body, input_html: { class: 'markdown-editor' } if editable_post_fields.include? :body %>
-  <%= f.input :tags if editable_post_fields.include? :tags %>
+
+  <% if editable_post_fields.include? :tags %>
+    <%= f.input :tags %>
+    <script>
+      $('input#post_tags').selectize({
+        plugins: ['remove_button'],
+        delimiter: ',',
+        persist: false,
+        options: <%= PostTag.distinct.pluck(:tag).map { |tag| { value: tag, text: tag } }.to_json.html_safe %>,
+        create: function(input) {
+          return {
+            value: input,
+            text: input
+          };
+        },
+      });
+    </script>
+  <% end %>
+
   <%= f.input :sticky if editable_post_fields.include? :sticky %>
   <%= f.input :show_on_homepage if editable_post_fields.include? :show_on_homepage %>
   <%= f.button :submit %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -349,7 +349,7 @@ en:
         body: "Use the &lt;!-- break --&gt; tag to show a preview on the home page. Any post on the home page will show all text before this divider. The actual post will display the full body."
         sticky: ""
         title: ""
-        tags: "Enter a comma separated list of tags for this post."
+        tags: ""
         show_on_homepage: "Careful! This is not secure for private data. This is only to prevent cluttering the homepage. Posts that are not shown on the homepage are still accessible to the public via permalink or through tags."
       #context: for a delegate report
       delegate_report:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -263,6 +263,7 @@ en:
         body: "Body"
         sticky: "Sticky"
         tags: "Tags"
+        show_on_homepage: "Show on homepage"
       #context: a team
       team:
         name: "Name"
@@ -349,6 +350,7 @@ en:
         sticky: ""
         title: ""
         tags: "Enter a comma separated list of tags for this post."
+        show_on_homepage: "Careful! This is not secure for private data. This is only to prevent cluttering the homepage. Posts that are not shown on the homepage are still accessible to the public via permalink or through tags."
       #context: for a delegate report
       delegate_report:
         schedule_url: "Full link to the published schedule (e.g., https://www.cubingusa.com/usnationals2016/schedule.php)"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -262,6 +262,7 @@ en:
         title: "Title"
         body: "Body"
         sticky: "Sticky"
+        tags: "Tags"
       #context: a team
       team:
         name: "Name"
@@ -347,6 +348,7 @@ en:
         body: "Use the &lt;!-- break --&gt; tag to show a preview on the home page. Any post on the home page will show all text before this divider. The actual post will display the full body."
         sticky: ""
         title: ""
+        tags: "Enter a comma separated list of tags for this post."
       #context: for a delegate report
       delegate_report:
         schedule_url: "Full link to the published schedule (e.g., https://www.cubingusa.com/usnationals2016/schedule.php)"

--- a/WcaOnRails/db/migrate/20170523034604_create_post_tags.rb
+++ b/WcaOnRails/db/migrate/20170523034604_create_post_tags.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreatePostTags < ActiveRecord::Migration[5.0]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false
+      t.string :tag, null: false
+    end
+    add_index :post_tags, :tag
+    add_index :post_tags, [:post_id, :tag], unique: true
+  end
+end

--- a/WcaOnRails/db/migrate/20170523185221_add_show_on_homepage_to_posts.rb
+++ b/WcaOnRails/db/migrate/20170523185221_add_show_on_homepage_to_posts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddShowOnHomepageToPosts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :posts, :show_on_homepage, :boolean, null: false, default: true
+    add_index :posts, [:show_on_homepage, :world_readable, :sticky, :created_at], name: "idx_show_wr_sticky_created_at"
+
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE posts SET show_on_homepage=FALSE WHERE id='delegate-crash-course'"
+      end
+      dir.down do
+      end
+    end
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -754,10 +754,12 @@ CREATE TABLE `posts` (
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `world_readable` tinyint(1) NOT NULL DEFAULT '0',
+  `show_on_homepage` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_posts_on_slug` (`slug`),
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`world_readable`,`sticky`,`created_at`),
-  KEY `index_posts_on_world_readable_and_created_at` (`world_readable`,`created_at`)
+  KEY `index_posts_on_world_readable_and_created_at` (`world_readable`,`created_at`),
+  KEY `idx_show_wr_sticky_created_at` (`show_on_homepage`,`world_readable`,`sticky`,`created_at`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7114 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1213,4 +1215,5 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170516002944'),
 ('20170517192919'),
 ('20170518011526'),
-('20170523034604');
+('20170523034604'),
+('20170523185221');

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -720,6 +720,24 @@ CREATE TABLE `polls` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `post_tags`
+--
+
+DROP TABLE IF EXISTS `post_tags`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `post_tags` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `post_id` int(11) NOT NULL,
+  `tag` varchar(191) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_post_tags_on_post_id_and_tag` (`post_id`,`tag`),
+  KEY `index_post_tags_on_post_id` (`post_id`),
+  KEY `index_post_tags_on_tag` (`tag`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `posts`
 --
 
@@ -1194,4 +1212,5 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170510071858'),
 ('20170516002944'),
 ('20170517192919'),
-('20170518011526');
+('20170518011526'),
+('20170523034604');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -387,6 +387,7 @@ module DatabaseDumper
           title
           updated_at
           world_readable
+          show_on_homepage
         ),
       ),
     }.freeze,

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -390,6 +390,16 @@ module DatabaseDumper
         ),
       ),
     }.freeze,
+    "post_tags" => {
+      where_clause: "JOIN posts ON posts.id=post_tags.post_id WHERE world_readable = TRUE",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          post_id
+          tag
+        ),
+      ),
+    }.freeze,
     "preferred_formats" => {
       where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -531,7 +531,7 @@ RSpec.describe CompetitionsController do
 
   describe 'GET #post_announcement' do
     context 'when signed in as results team member' do
-      sign_in { FactoryGirl.create(:results_team) }
+      sign_in { FactoryGirl.create(:user, :wrt_member) }
 
       # Posts should always be in English, therefore we want to check using an English text,
       # even if the user posting has a different locale
@@ -558,7 +558,7 @@ RSpec.describe CompetitionsController do
 
   describe 'GET #post_results' do
     context 'when signed in as results team member' do
-      sign_in { FactoryGirl.create(:results_team) }
+      sign_in { FactoryGirl.create(:user, :wrt_member) }
 
       # Posts should always be in English, therefore we want to check using an English text,
       # even if the user posting has a different locale

--- a/WcaOnRails/spec/controllers/delegates_panel_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/delegates_panel_controller_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe DelegatesPanelController do
-  describe "signed in as results team member" do
-    let(:results_team_user) { FactoryGirl.create :results_team }
+  describe "signed in as wrt member" do
+    let(:wrt_member) { FactoryGirl.create :user, :wrt_member }
     before :each do
-      sign_in results_team_user
+      sign_in wrt_member
     end
 
     it "can edit" do

--- a/WcaOnRails/spec/controllers/posts_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/posts_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PostsController do
   let!(:post1) { FactoryGirl.create(:post, created_at: 1.hours.ago) }
   let!(:hidden_post) { FactoryGirl.create(:post, created_at: 1.hours.ago, world_readable: false) }
   let!(:sticky_post) { FactoryGirl.create(:post, sticky: true, created_at: 2.hours.ago) }
-  let!(:wdc_post) { FactoryGirl.create(:post, created_at: 3.hours.ago, tags: "wdc,othertag") }
+  let!(:wdc_post) { FactoryGirl.create(:post, created_at: 3.hours.ago, tags: "wdc,othertag", show_on_homepage: false) }
 
   context "not logged in" do
     describe "GET #index" do
@@ -48,7 +48,7 @@ RSpec.describe PostsController do
         expect(assigns(:post)).to eq post1
       end
 
-      it "cannot find not worldreadable posts" do
+      it "cannot find not world_readable posts" do
         expect { get :show, params: { id: hidden_post.slug } }.to raise_exception(ActiveRecord::RecordNotFound)
       end
     end

--- a/WcaOnRails/spec/controllers/posts_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/posts_controller_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe PostsController do
     end
   end
 
-  context "logged in as wrc team" do
-    sign_in { FactoryGirl.create :wrc_team }
+  context "logged in as wrc member" do
+    sign_in { FactoryGirl.create :user, :wrc_member }
 
     describe "GET #new" do
       it "works" do
@@ -78,6 +78,28 @@ RSpec.describe PostsController do
         p = Post.find_by_slug("Title")
         expect(p.title).to eq "Title"
         expect(p.body).to eq "body"
+        expect(p.world_readable).to eq true
+      end
+    end
+  end
+
+  context "logged in as wdc member" do
+    sign_in { FactoryGirl.create :user, :wdc_member }
+
+    describe "GET #new" do
+      it "returns 200" do
+        get :new
+        expect(response.status).to eq 200
+      end
+    end
+
+    describe "POST #create" do
+      it "creates a tagged post" do
+        post :create, params: { post: { title: "Title", body: "body", tags: "wrc, notes" } }
+        p = Post.find_by_slug("Title")
+        expect(p.title).to eq "Title"
+        expect(p.body).to eq "body"
+        expect(p.tags_array).to match_array %w(wrc notes)
         expect(p.world_readable).to eq true
       end
     end

--- a/WcaOnRails/spec/factories/posts.rb
+++ b/WcaOnRails/spec/factories/posts.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     slug { title.parameterize }
     sticky false
     world_readable true
+    show_on_homepage true
     author
 
     trait :sticky do

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -34,14 +34,21 @@ FactoryGirl.define do
       end
     end
 
-    factory :results_team do
+    trait :wrt_member do
       after(:create) do |user|
         results_team = Team.find_by_friendly_id('wrt')
         FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id)
       end
     end
 
-    factory :wrc_team do
+    trait :wdc_member do
+      after(:create) do |user|
+        wdc_team = Team.find_by_friendly_id('wdc')
+        FactoryGirl.create(:team_member, team_id: wdc_team.id, user_id: user.id)
+      end
+    end
+
+    trait :wrc_member do
       after(:create) do |user|
         wrc_team = Team.find_by_friendly_id('wrc')
         FactoryGirl.create(:team_member, team_id: wrc_team.id, user_id: user.id)

--- a/WcaOnRails/spec/models/post_spec.rb
+++ b/WcaOnRails/spec/models/post_spec.rb
@@ -28,4 +28,28 @@ RSpec.describe Post do
     expect(post.body_teaser).to eq post.body
     expect(post.body_full).to eq post.body
   end
+
+  context "tags" do
+    let(:post) { FactoryGirl.create(:post) }
+
+    it "can tag posts with a comma separated list" do
+      expect(post.tags_array).to match_array %w()
+
+      post.update!(tags: "wdc, test")
+      expect(Post.find(post.id).tags_array).to match_array %w(wdc test)
+
+      post.update!(tags: "wdc")
+      expect(Post.find(post.id).tags_array).to match_array %w(wdc)
+    end
+
+    it "tags must not have spaces" do
+      post.update!(tags: "wdc")
+      expect(Post.find(post.id).tags_array).to match_array %w(wdc)
+
+      expect(post.update(tags: "wdc,test tag with spaces")).to eq false
+      expect(post).to be_invalid_with_errors("post_tags.tag": ["only allows English letters and numbers"])
+
+      expect(Post.find(post.id).tags_array).to match_array %w(wdc)
+    end
+  end
 end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -481,34 +481,34 @@ RSpec.describe User, type: :model do
 
   it "#teams and #current_teams return unique team names" do
     wrc_team = Team.find_by_friendly_id('wrc')
-    results_team = Team.find_by_friendly_id('wrt')
+    wrt_team = Team.find_by_friendly_id('wrt')
     user = FactoryGirl.create(:user)
 
     FactoryGirl.create(:team_member, team_id: wrc_team.id, user_id: user.id, start_date: Date.today - 20, end_date: Date.today - 10)
-    FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id, start_date: Date.today - 5, end_date: Date.today + 5)
-    FactoryGirl.create(:team_member, team_id: results_team.id, user_id: user.id, start_date: Date.today + 6, end_date: Date.today + 10)
+    FactoryGirl.create(:team_member, team_id: wrt_team.id, user_id: user.id, start_date: Date.today - 5, end_date: Date.today + 5)
+    FactoryGirl.create(:team_member, team_id: wrt_team.id, user_id: user.id, start_date: Date.today + 6, end_date: Date.today + 10)
 
-    expect(user.teams).to match_array [wrc_team, results_team]
-    expect(user.current_teams).to match_array [results_team]
+    expect(user.teams).to match_array [wrc_team, wrt_team]
+    expect(user.current_teams).to match_array [wrt_team]
   end
 
   it 'former members of the results team are not considered current members' do
-    member = FactoryGirl.create :results_team
-    team_member = member.team_members.first
+    wrt_member = FactoryGirl.create :user, :wrt_member
+    team_member = wrt_member.team_members.first
     team_member.update_attributes!(end_date: 1.day.ago)
 
-    expect(member.reload.team_member?('wrt')).to eq false
+    expect(wrt_member.reload.team_member?('wrt')).to eq false
   end
 
   it 'former leaders of the results team are not considered current leaders' do
-    leader = FactoryGirl.create :results_team
-    team_member = leader.team_members.first
+    wrt_leader = FactoryGirl.create :user, :wrt_member
+    team_member = wrt_leader.team_members.first
     team_member.update_attributes!(team_leader: true)
     team_member.update_attributes!(end_date: 1.day.ago)
 
-    expect(leader.reload.team_leader?('wrt')).to eq false
+    expect(wrt_leader.reload.team_leader?('wrt')).to eq false
 
-    expect(leader.teams_where_is_leader.count).to eq 0
+    expect(wrt_leader.teams_where_is_leader.count).to eq 0
   end
 
   describe "#update_with_password" do


### PR DESCRIPTION
Check this out live on staging!

- https://staging.worldcubeassociation.org/posts?tag=results
- https://staging.worldcubeassociation.org/posts/3rd-guwahati-open-2017-on-june-10-11-2017-in-guwahati-assam-india/edit
- https://staging.worldcubeassociation.org/posts/new

This fixes #1666.

- Adds a text field when creating posts to let you specify a comma separated list of tags.
- Adds a `tag=` url parameter to the `/posts` page that only shows posts matching the given tag.
- When no tag is specified, then posts tagged "wrc" will not be shown.