### PR TITLE
Avatar urls

### DIFF
--- a/WcaOnRails/Envfile
+++ b/WcaOnRails/Envfile
@@ -20,7 +20,7 @@ variable :WCA_LIVE_SITE, :boolean, default: false
 if defined? Rails::Server
   default_root_url = "http://localhost:#{Rails::Server.new.options[:Port]}"
 elsif Rails.env.test?
-  default_root_url = "test.host"
+  default_root_url = "http://test.host"
 else
   default_root_url = ""
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -827,7 +827,7 @@ class Competition < ApplicationRecord
   def serializable_hash(options = nil)
     {
       class: self.class.to_s.downcase,
-      url: Rails.application.routes.url_helpers.competition_path(self),
+      url: Rails.application.routes.url_helpers.competition_url(self, host: ENVied.ROOT_URL),
 
       id: id,
       name: name,

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -205,7 +205,7 @@ class Person < ApplicationRecord
   def serializable_hash(options = nil)
     json = {
       class: self.class.to_s.downcase,
-      url: Rails.application.routes.url_helpers.person_path(self.wca_id),
+      url: Rails.application.routes.url_helpers.person_url(self.wca_id, host: ENVied.ROOT_URL),
 
       id: self.wca_id,
       wca_id: self.wca_id,

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -631,7 +631,7 @@ class User < ApplicationRecord
   def serializable_hash(options = nil)
     json = {
       class: self.class.to_s.downcase,
-      url: self.wca_id ? Rails.application.routes.url_helpers.person_path(self.wca_id) : "",
+      url: self.wca_id ? Rails.application.routes.url_helpers.person_url(self.wca_id, host: ENVied.ROOT_URL) : "",
 
       id: self.id,
       wca_id: self.wca_id,

--- a/WcaOnRails/app/uploaders/avatar_uploader_base.rb
+++ b/WcaOnRails/app/uploaders/avatar_uploader_base.rb
@@ -3,6 +3,8 @@
 class AvatarUploaderBase < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
+  DEFAULT_URL = ActionController::Base.helpers.asset_url("missing_avatar_thumb.png", host: ENVied.ROOT_URL).freeze
+
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog
@@ -29,7 +31,7 @@ class AvatarUploaderBase < CarrierWave::Uploader::Base
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url
-    ActionController::Base.helpers.asset_path("missing_avatar_thumb.png")
+    DEFAULT_URL
   end
 
   # Create different versions of your uploaded files:

--- a/WcaOnRails/config/initializers/carrierwave.rb
+++ b/WcaOnRails/config/initializers/carrierwave.rb
@@ -2,15 +2,9 @@
 
 CarrierWave.configure do |config|
   config.storage = :file
-  # From http://stackoverflow.com/a/32463067
-  if Rails.application.config.action_controller.asset_host
-    config.asset_host = Rails.application.config.action_controller.asset_host
-  elsif Rails.env.test?
-    # Only set asset_host for tests, which expect carrierwave to return full
-    # paths to images. In development, we want relative paths so running behind
-    # nginx inside of Vagrant will work.
-    config.asset_host = "http://example.com"
-  end
+
+  config.asset_host = ENVied.ROOT_URL
+
   if Rails.env.test? || Rails.env.cucumber?
     config.enable_processing = false
   end

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe Api::V0::ApiController do
         expect(json["result"].length).to eq 1
         expect(json["result"][0]["id"]).to eq userless_person.wca_id
         expect(json["result"][0]["wca_id"]).to eq userless_person.wca_id
-        expect(json['result'][0]['avatar']['url']).to eq ActionController::Base.helpers.asset_path("missing_avatar_thumb.png")
-        expect(json['result'][0]['avatar']['thumb_url']).to eq ActionController::Base.helpers.asset_path("missing_avatar_thumb.png")
+        expect(json['result'][0]['avatar']['url']).to eq AvatarUploaderBase::DEFAULT_URL
+        expect(json['result'][0]['avatar']['thumb_url']).to eq AvatarUploaderBase::DEFAULT_URL
         expect(json['result'][0]['avatar']['is_default']).to eq true
       end
 
@@ -435,8 +435,8 @@ RSpec.describe Api::V0::ApiController do
         expect(json['me']['wca_id']).to eq(user.wca_id)
         expect(json['me']['name']).to eq(user.name)
         expect(json['me']['email']).to eq(user.email)
-        expect(json['me']['avatar']['url']).to eq ActionController::Base.helpers.asset_path("missing_avatar_thumb.png")
-        expect(json['me']['avatar']['thumb_url']).to eq ActionController::Base.helpers.asset_path("missing_avatar_thumb.png")
+        expect(json['me']['avatar']['url']).to eq AvatarUploaderBase::DEFAULT_URL
+        expect(json['me']['avatar']['thumb_url']).to eq AvatarUploaderBase::DEFAULT_URL
         expect(json['me']['avatar']['is_default']).to eq true
 
         expect(json['me']['country_iso2']).to eq "US"
@@ -462,8 +462,8 @@ RSpec.describe Api::V0::ApiController do
         expect(json['me']['wca_id']).to eq(user.wca_id)
         expect(json['me']['name']).to eq(user.name)
         expect(json['me']['email']).to eq(user.email)
-        expect(json['me']['avatar']['url']).to eq ActionController::Base.helpers.asset_path("missing_avatar_thumb.png")
-        expect(json['me']['avatar']['thumb_url']).to eq ActionController::Base.helpers.asset_path("missing_avatar_thumb.png")
+        expect(json['me']['avatar']['url']).to eq AvatarUploaderBase::DEFAULT_URL
+        expect(json['me']['avatar']['thumb_url']).to eq AvatarUploaderBase::DEFAULT_URL
         expect(json['me']['avatar']['is_default']).to eq true
 
         expect(json['me']['country_iso2']).to eq "US"

--- a/WcaOnRails/spec/helpers/application_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/application_helper_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ApplicationHelper do
 
   describe "#wca_id_link" do
     it "links to a person's WCA profile page" do
-      expect(wca_id_link("2005FLEI01")).to eq '<span class="wca-id"><a href="http://test.host/persons/2005FLEI01">2005FLEI01</a></span>'
+      expect(wca_id_link("2005FLEI01")).to eq "<span class=\"wca-id\"><a href=\"#{person_url "2005FLEI01"}\">2005FLEI01</a></span>"
     end
   end
 end


### PR DESCRIPTION
Turns

![image](https://cloud.githubusercontent.com/assets/17034772/26375527/a406eed4-4009-11e7-90e5-eb1ecb1bb7cf.png)

Into

![image](https://cloud.githubusercontent.com/assets/17034772/26375517/9b79a48c-4009-11e7-95c7-75516afb0578.png)

`_url` should be a real URL, not a path ^^ Also that's what external apps expect I guess.