### PR TITLE
Missing avatar thumb url fix

### DIFF
--- a/WcaOnRails/app/uploaders/avatar_uploader_base.rb
+++ b/WcaOnRails/app/uploaders/avatar_uploader_base.rb
@@ -3,7 +3,9 @@
 class AvatarUploaderBase < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  DEFAULT_URL = ActionController::Base.helpers.asset_url("missing_avatar_thumb.png", host: ENVied.ROOT_URL).freeze
+  def self.missing_avatar_thumb_url
+    @@missing_avatar_thumb_url ||= ActionController::Base.helpers.asset_url("missing_avatar_thumb.png", host: ENVied.ROOT_URL).freeze
+  end
 
   # Choose what kind of storage to use for this uploader:
   storage :file
@@ -31,7 +33,7 @@ class AvatarUploaderBase < CarrierWave::Uploader::Base
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url
-    DEFAULT_URL
+    AvatarUploaderBase.missing_avatar_thumb_url
   end
 
   # Create different versions of your uploaded files:

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe Api::V0::ApiController do
         expect(json["result"].length).to eq 1
         expect(json["result"][0]["id"]).to eq userless_person.wca_id
         expect(json["result"][0]["wca_id"]).to eq userless_person.wca_id
-        expect(json['result'][0]['avatar']['url']).to eq AvatarUploaderBase::DEFAULT_URL
-        expect(json['result'][0]['avatar']['thumb_url']).to eq AvatarUploaderBase::DEFAULT_URL
+        expect(json['result'][0]['avatar']['url']).to eq AvatarUploaderBase.missing_avatar_thumb_url
+        expect(json['result'][0]['avatar']['thumb_url']).to eq AvatarUploaderBase.missing_avatar_thumb_url
         expect(json['result'][0]['avatar']['is_default']).to eq true
       end
 
@@ -435,8 +435,8 @@ RSpec.describe Api::V0::ApiController do
         expect(json['me']['wca_id']).to eq(user.wca_id)
         expect(json['me']['name']).to eq(user.name)
         expect(json['me']['email']).to eq(user.email)
-        expect(json['me']['avatar']['url']).to eq AvatarUploaderBase::DEFAULT_URL
-        expect(json['me']['avatar']['thumb_url']).to eq AvatarUploaderBase::DEFAULT_URL
+        expect(json['me']['avatar']['url']).to eq AvatarUploaderBase.missing_avatar_thumb_url
+        expect(json['me']['avatar']['thumb_url']).to eq AvatarUploaderBase.missing_avatar_thumb_url
         expect(json['me']['avatar']['is_default']).to eq true
 
         expect(json['me']['country_iso2']).to eq "US"
@@ -462,8 +462,8 @@ RSpec.describe Api::V0::ApiController do
         expect(json['me']['wca_id']).to eq(user.wca_id)
         expect(json['me']['name']).to eq(user.name)
         expect(json['me']['email']).to eq(user.email)
-        expect(json['me']['avatar']['url']).to eq AvatarUploaderBase::DEFAULT_URL
-        expect(json['me']['avatar']['thumb_url']).to eq AvatarUploaderBase::DEFAULT_URL
+        expect(json['me']['avatar']['url']).to eq AvatarUploaderBase.missing_avatar_thumb_url
+        expect(json['me']['avatar']['thumb_url']).to eq AvatarUploaderBase.missing_avatar_thumb_url
         expect(json['me']['avatar']['is_default']).to eq true
 
         expect(json['me']['country_iso2']).to eq "US"


### PR DESCRIPTION
Use static method instead of a constant to make sure that it's loaded when all the configuration is already done.