### PR TITLE
Automatically tag competition announcement posts with "competitions" and competition results posts with "results".

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -183,7 +183,7 @@ class CompetitionsController < ApplicationController
       unless comp.website.blank?
         body += " Check out the [#{comp.name} website](#{comp.website}) for more information and registration."
       end
-      create_post_and_redirect(title: title, body: body, author: current_user, world_readable: true)
+      create_post_and_redirect(title: title, body: body, author: current_user, tags: "competitions,new", world_readable: true)
 
       comp.update!(announced_at: Time.now)
     end
@@ -308,7 +308,7 @@ class CompetitionsController < ApplicationController
       comp.update!(results_posted_at: Time.now)
       comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
       comp.registrations.accepted.each { |registration| registration.user.notify_of_id_claim_possibility(comp) }
-      create_post_and_redirect(title: title, body: body, author: current_user, world_readable: true)
+      create_post_and_redirect(title: title, body: body, author: current_user, tags: "results", world_readable: true)
     end
   end
 

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -545,6 +545,7 @@ RSpec.describe CompetitionsController do
         post = assigns(:post)
         expect(post.title).to eq "#{competition.name} on December 4 - 5, 2011 in #{competition.cityName}, #{competition.countryId}"
         expect(post.body).to match(/in #{competition.cityName}, #{competition.countryId}\./)
+        expect(post.tags_array).to match_array %w(competitions new)
       end
 
       it 'handles nil start date' do
@@ -676,6 +677,7 @@ RSpec.describe CompetitionsController do
             expect(post.body).to eq "[Jeremy](#{person_url('2006YOYO01')}) won the [#{competition.name}](#{competition_url(competition)}) with a single solve of 1:00.00 in the 3x3x3 Blindfolded event. " \
               "[Dan](#{person_url('2006YOYO02')}) finished second (1:00.00) and " \
               "[Steven](#{person_url('2006YOYO03')}) finished third (1:00.00).\n\n"
+            expect(post.tags_array).to match_array %w(results)
           end
         end
 


### PR DESCRIPTION
**This is just a proposal for now, I've started an email thread with the Board and the WRT to discuss this.**

I think it would be a good goal to have every single post in our database be tagged with something. This would be a step towards that.

Some info on the posts in our database:

All posts:
```
> select count(*) from posts
7312
```

Competition announcements:
```
> select count(*) from posts where posts.body LIKE '% will take place on %'
3707
```

Competition results (competitions with 3x3x3):
```
> select count(*) from posts where posts.body LIKE '% with an average of %'
3473
```

Old competition results:
```
> select count(*) from posts where posts.body LIKE '% with an average in the final of %'
40
```

Manualy generated results for FMC comps:
```
> select count(*) from posts where posts.body LIKE '% with a mean of %'
16
```

Competition results (competitions without 3x3x3):
```
> select count(*) from posts where posts.body LIKE 'Results of the % are now available.%'
66
```

This leaves some posts unaccounted for, but it's a small enough number that I think we should just go through them by hand.

Unaccounted for posts:
```
> select CONCAT("https://www.worldcubeassociation.org/posts/", id) from posts
where (posts.body NOT LIKE '% will take place on %')
AND (posts.body NOT LIKE '% with an average of %') 
AND (posts.body NOT LIKE '% with an average in the final of %')
AND (posts.body NOT LIKE '% with a mean of %')
AND (posts.body NOT LIKE 'Results of the % are now available.%')
LIMIT 0, 250
Rows: 50
```

https://www.worldcubeassociation.org/posts/1
https://www.worldcubeassociation.org/posts/3
https://www.worldcubeassociation.org/posts/4
https://www.worldcubeassociation.org/posts/5
https://www.worldcubeassociation.org/posts/6
https://www.worldcubeassociation.org/posts/8
https://www.worldcubeassociation.org/posts/35
https://www.worldcubeassociation.org/posts/134
https://www.worldcubeassociation.org/posts/139
https://www.worldcubeassociation.org/posts/271
https://www.worldcubeassociation.org/posts/354
https://www.worldcubeassociation.org/posts/638
https://www.worldcubeassociation.org/posts/776
https://www.worldcubeassociation.org/posts/783
https://www.worldcubeassociation.org/posts/840
https://www.worldcubeassociation.org/posts/859
https://www.worldcubeassociation.org/posts/905
https://www.worldcubeassociation.org/posts/1113
https://www.worldcubeassociation.org/posts/2083
https://www.worldcubeassociation.org/posts/2128
https://www.worldcubeassociation.org/posts/2354
https://www.worldcubeassociation.org/posts/2371
https://www.worldcubeassociation.org/posts/2400
https://www.worldcubeassociation.org/posts/2615
https://www.worldcubeassociation.org/posts/2616
https://www.worldcubeassociation.org/posts/2753
https://www.worldcubeassociation.org/posts/2860
https://www.worldcubeassociation.org/posts/3012
https://www.worldcubeassociation.org/posts/3062
https://www.worldcubeassociation.org/posts/3095
https://www.worldcubeassociation.org/posts/3133
https://www.worldcubeassociation.org/posts/3171
https://www.worldcubeassociation.org/posts/3319
https://www.worldcubeassociation.org/posts/4297
https://www.worldcubeassociation.org/posts/4562
https://www.worldcubeassociation.org/posts/4593
https://www.worldcubeassociation.org/posts/4601
https://www.worldcubeassociation.org/posts/4734
https://www.worldcubeassociation.org/posts/4873
https://www.worldcubeassociation.org/posts/5256
https://www.worldcubeassociation.org/posts/5421
https://www.worldcubeassociation.org/posts/5586
https://www.worldcubeassociation.org/posts/5620
https://www.worldcubeassociation.org/posts/5945
https://www.worldcubeassociation.org/posts/6205
https://www.worldcubeassociation.org/posts/6340
https://www.worldcubeassociation.org/posts/6342
https://www.worldcubeassociation.org/posts/6569
https://www.worldcubeassociation.org/posts/6913
https://www.worldcubeassociation.org/posts/7251