### PR TITLE
Whoops, grep please don't kill our build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - initctl list
   - initctl status mysql-5.6
   - date
-  - dmesg | grep -i -C 100 mysql
+  - dmesg | grep -i -C 100 mysql || true
 
   - ps -efw | grep -i mysql
   - /usr/sbin/mysql-5.6-wait-ready


### PR DESCRIPTION
Grrr, grep returns a nonzero error code when it fails to find something. See https://travis-ci.org/thewca/worldcubeassociation.org/builds/235905229#L546.