### PR TITLE
Try out imagemagick's auto_orient feature.

### DIFF
--- a/WcaOnRails/app/uploaders/avatar_uploader_base.rb
+++ b/WcaOnRails/app/uploaders/avatar_uploader_base.rb
@@ -3,6 +3,14 @@
 class AvatarUploaderBase < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
+  # Copied from https://makandracards.com/makandra/12323-carrierwave-auto-rotate-tagged-jpegs.
+  process :auto_orient
+  def auto_orient
+    manipulate! do |image|
+      image.tap(&:auto_orient)
+    end
+  end
+
   def self.missing_avatar_thumb_url
     @@missing_avatar_thumb_url ||= ActionController::Base.helpers.asset_url("missing_avatar_thumb.png", host: ENVied.ROOT_URL).freeze
   end


### PR DESCRIPTION
See:
 - https://www.howtogeek.com/254830/why-your-photos-dont-always-appear-correctly-rotated/
 - http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/
 - https://makandracards.com/makandra/12323-carrierwave-auto-rotate-tagged-jpegs

I've deployed this to staging. I've asked the WRT to test this out and let me know if it works better than the current code on production.