### PR TITLE
Fix bugs with computing DNF averages and round formats that don't need averages (such as best of 1, 2, 3 (except for 333bf, 333ft, 333fm)).

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -196,7 +196,7 @@ class CompetitionsController < ApplicationController
     # If the format for this round was to sort by average, but this particular
     # result did not achieve an average, then switch to "best", and do not allow
     # a short format (to make it clear what happened).
-    if sort_by == "average" && !result.to_solve_time(:average).completed?
+    if sort_by == "average" && result.to_solve_time(:average).incomplete?
       sort_by = "single"
       short = false
     end

--- a/WcaOnRails/app/helpers/results_helper.rb
+++ b/WcaOnRails/app/helpers/results_helper.rb
@@ -17,11 +17,11 @@ module ResultsHelper
       pb_single = results.first.best_solve
       pb_average = results.first.average_solve
       results.each do |result|
-        if result.best_solve.completed? && result.best_solve <= pb_single
+        if result.best_solve.complete? && result.best_solve <= pb_single
           pb_single = result.best_solve
           markers[result.id][:single] = true
         end
-        if result.average_solve.completed? && result.average_solve <= pb_average
+        if result.average_solve.complete? && result.average_solve <= pb_average
           pb_average = result.average_solve
           markers[result.id][:average] = true
         end

--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -80,16 +80,47 @@ class Result < ApplicationRecord
     event ? invalid_solve_count_reason : "Event needed to compute average"
   end
 
+  def should_compute_average?
+    # Average of 5 and Mean of 3 rounds should definitely attempt to compute the average (the average
+    # may still be empty because of combined rounds).
+    # Best of 3 is weird. We actually do want to populate the average column for best of 3 with:
+    #  - 333fm was changed from allowing best of 3 (and disallowing mean of 3) to allowing mean of 3 (and disallowing best of 3).
+    #    See "Relevant regulations changes" below.
+    #    With this change in format, the Board decided to compute means for all
+    #    the old best of 3 rounds, and assign mean records to them.
+    #    However, we could not change the format of the rounds, as that would have affected rankings
+    #    in past competitions, so the rounds remain as best of 3, but with an average computed.
+    #  - 333ft has a similar story to 333fm. It also changed from allowing best of 3
+    #    (and disallowing mean of 3) to allowing mean of 3 (and disallowing best
+    #    of 3). See "Relevant regulations changes" below.
+    #  - 333bf is quite a special case. At competitions, competitors are ranked according to best of 3, but
+    #    the WCA awards records on both single and mean of 3.
+    #    See https://www.worldcubeassociation.org/regulations/#9b3b.
+
+    # Relevant regulations changes:
+    #  - August 28, 2012 (beginning of the regulations on github): https://github.com/thewca/wca-regulations/commit/0c7f3e0501970c84178d914cd41a0d488ad3fac1
+    #    - 333ft introduced with legal formats "123a".
+    #  - September 9, 2012: https://github.com/thewca/wca-regulations/commit/6e5c44f0e397b735549923ff538846d3c4387dd4
+    #    - 333ft legal formats changed from "123a" to "123m".
+    #  - December 7, 2013: https://github.com/thewca/wca-regulations/commit/dc182c84e2ef60aeba37f5af896bd67f4c459575
+    #    - 333fm legal formats changed from "123" to "123m".
+    #  - December 9, 2013: https://github.com/thewca/wca-regulations/issues/109 and https://github.com/thewca/wca-regulations/commit/80ebf04e3ed0752df8047f4428277bf186f374c2
+    #    - All events that allow "mean of 3" no longer allow "best of 3".
+    formatId == "a" || formatId == "m" || (formatId == "3" && %(333ft 333fm 333bf).include?(eventId))
+  end
+
   def compute_correct_best
     best_solve = sorted_solves.first
     best_solve ? best_solve.wca_value : 0
   end
 
   def compute_correct_average
-    if average_is_not_computable_reason || missed_combined_round_cutoff?
+    if average_is_not_computable_reason || missed_combined_round_cutoff? || !should_compute_average?
       0
     else
-      if eventId == "333fm"
+      if counting_solve_times.any?(&:incomplete?)
+        SolveTime::DNF_VALUE
+      elsif eventId == "333fm"
         sum_moves = counting_solve_times.sum(&:move_count)
         100 * sum_moves / counting_solve_times.length
       else

--- a/WcaOnRails/lib/solve_time.rb
+++ b/WcaOnRails/lib/solve_time.rb
@@ -128,8 +128,12 @@ class SolveTime
     !skipped?
   end
 
-  def completed?
+  def complete?
     !dn? && unskipped?
+  end
+
+  def incomplete?
+    !complete?
   end
 
   def time_seconds
@@ -208,7 +212,7 @@ class SolveTime
   end
 
   private def units
-    if !completed?
+    if incomplete?
       ""
     elsif @event.timed_event?
       time_minutes >= 1 ? "" : " seconds"

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -576,7 +576,7 @@ RSpec.describe CompetitionsController do
       context "winners announcement" do
         context "333" do
           def add_result(pos, name, event_id: "333", dnf: false)
-            Result.new(
+            Result.create!(
               pos: pos,
               personId: "2006YOYO#{format('%.2d', pos)}",
               personName: name,
@@ -592,7 +592,7 @@ RSpec.describe CompetitionsController do
               value5: 999,
               best: 999,
               average: dnf ? SolveTime::DNF_VALUE : 999,
-            ).save!(validate: false) # See https://github.com/thewca/worldcubeassociation.org/issues/1688
+            )
           end
 
           let!(:unrelated_podium_result) { add_result(1, "joe", event_id: "333oh") }
@@ -681,7 +681,7 @@ RSpec.describe CompetitionsController do
 
         context "333fm" do
           def add_result(pos, name, dnf: false)
-            Result.new(
+            Result.create!(
               pos: pos,
               personId: "2006YOYO#{format('%.2d', pos)}",
               personName: name,
@@ -697,7 +697,7 @@ RSpec.describe CompetitionsController do
               value5: 0,
               best: 24,
               average: dnf ? SolveTime::DNF_VALUE : 2766,
-            ).save!(validate: false) # See https://github.com/thewca/worldcubeassociation.org/issues/1688
+            )
           end
 
           it "announces top 3 in final" do
@@ -733,7 +733,7 @@ RSpec.describe CompetitionsController do
             solve_time.attempted = 9
             solve_time.solved = 8
             solve_time.time_centiseconds = (45.minutes + 32.seconds).in_centiseconds
-            Result.new(
+            Result.create!(
               pos: pos,
               personId: "2006YOYO#{format('%.2d', pos)}",
               personName: name,
@@ -749,7 +749,7 @@ RSpec.describe CompetitionsController do
               value5: 0,
               best: solve_time.wca_value,
               average: 0,
-            ).save!(validate: false) # See https://github.com/thewca/worldcubeassociation.org/issues/1688
+            )
           end
 
           it "announces top 3 in final" do


### PR DESCRIPTION
This fixes #1688. 