### PR TITLE
Request spectator info in information section

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -315,7 +315,7 @@ en:
         name: "The full name of the competition including the year at the end (e.g., Danish Open 2016). Be sure to capitalize. The name must contain only alphanumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )."
         cellName: "A short name for displaying. If the name of the competition is already short, you can re-use the name (e.g., Europe 2006)."
         cityName: "Name of the city and state (if applicable) where the competition takes place. Do not include country (e.g., Paris OR San Francisco, California)."
-        information: "Some information text about the competition (e.g., Euro 2006 is open to citizens of the European countries and Israel)."
+        information: "Information about the competitor limit, entry fees for competitors and spectators, and other details particularly relevant for people interested in competing or spectating."
         delegate_ids: "WCA delegates for the competition."
         organizer_ids: "Competition organizers (they need an account to be listed here)."
         external_website: "The website of the competition. Must be a valid http(s) url."


### PR DESCRIPTION
The WCT receives a lot of emails asking for spectator information about competitions. I think this would be a good reminder for organizers/delegates to put that in the information section.