### PR TITLE
Style reports submitted by non competition delegate differently

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -24,15 +24,17 @@ module CompetitionsHelper
     date ? (date.to_date - competition.end_date).to_i : nil
   end
 
+  private def days_announced_before_competition(competition)
+    days_before_competition(competition.announced_at, competition)
+  end
+
   def announced_content(competition)
-    days_announced = days_before_competition(competition.announced_at, competition)
-    days_announced ? "#{pluralize(days_announced, "day")} before" : ""
+    competition.announced_at ? "#{pluralize(days_announced_before_competition(competition), "day")} before" : ""
   end
 
   def announced_class(competition)
-    days_announced = days_before_competition(competition.announced_at, competition)
-    if days_announced
-      level = [Competition::ANNOUNCED_DAYS_WARNING, Competition::ANNOUNCED_DAYS_DANGER].select { |d| days_announced > d }.count
+    if competition.announced_at
+      level = [Competition::ANNOUNCED_DAYS_WARNING, Competition::ANNOUNCED_DAYS_DANGER].select { |d| days_announced_before_competition(competition) > d }.count
       ["alert-danger", "alert-orange", "alert-green"][level]
     else
       ""
@@ -48,7 +50,7 @@ module CompetitionsHelper
     days_report = days_after_competition(competition.delegate_report.posted_at, competition)
     if days_report
       submitted_by_competition_delegate = competition.delegates.include?(competition.delegate_report.posted_by_user)
-      submitted_by_competition_delegate ? "#{pluralize(days_report, "day")} after" : "submitted by else"
+      submitted_by_competition_delegate ? "#{pluralize(days_report, "day")} after" : "submitted by other"
     else
       competition.is_probably_over? ? "pending" : ""
     end
@@ -59,7 +61,7 @@ module CompetitionsHelper
     if days_report
       report_and_results_days_to_class(days_report)
     elsif competition.is_probably_over?
-      days_report = (Date.today - competition.end_date).to_i
+      days_report = days_after_competition(Date.today, competition)
       report_and_results_days_to_class(days_report)
     else
       ""

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -47,7 +47,8 @@ module CompetitionsHelper
   def report_content(competition)
     days_report = days_after_competition(competition.delegate_report.posted_at, competition)
     if days_report
-      "#{pluralize(days_report, "day")} after"
+      submitted_by_competition_delegate = competition.delegates.include?(competition.delegate_report.posted_by_user)
+      submitted_by_competition_delegate ? "#{pluralize(days_report, "day")} after" : "submitted by else"
     else
       competition.is_probably_over? ? "pending" : ""
     end

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -16,14 +16,69 @@ module CompetitionsHelper
     messages.join(' ')
   end
 
-  def announced_class(days_announced)
-    level = [Competition::ANNOUNCED_DAYS_WARNING, Competition::ANNOUNCED_DAYS_DANGER].select { |d| days_announced > d }.count
-    ["alert-danger", "alert-orange", "alert-green"][level]
+  private def days_before_competition(date, competition)
+    date ? (competition.start_date - date.to_date).to_i : nil
   end
 
-  def report_and_results_class(days)
+  private def days_after_competition(date, competition)
+    date ? (date.to_date - competition.end_date).to_i : nil
+  end
+
+  def announced_content(competition)
+    days_announced = days_before_competition(competition.announced_at, competition)
+    days_announced ? "#{pluralize(days_announced, "day")} before" : ""
+  end
+
+  def announced_class(competition)
+    days_announced = days_before_competition(competition.announced_at, competition)
+    if days_announced
+      level = [Competition::ANNOUNCED_DAYS_WARNING, Competition::ANNOUNCED_DAYS_DANGER].select { |d| days_announced > d }.count
+      ["alert-danger", "alert-orange", "alert-green"][level]
+    else
+      ""
+    end
+  end
+
+  private def report_and_results_days_to_class(days)
     level = [Competition::REPORT_AND_RESULTS_DAYS_OK, Competition::REPORT_AND_RESULTS_DAYS_WARNING, Competition::REPORT_AND_RESULTS_DAYS_DANGER].select { |d| days > d }.count
     ["alert-green", "alert-success", "alert-orange", "alert-danger"][level]
+  end
+
+  def report_content(competition)
+    days_report = days_after_competition(competition.delegate_report.posted_at, competition)
+    if days_report
+      "#{pluralize(days_report, "day")} after"
+    else
+      competition.is_probably_over? ? "pending" : ""
+    end
+  end
+
+  def report_class(competition)
+    days_report = days_after_competition(competition.delegate_report.posted_at, competition)
+    if days_report
+      report_and_results_days_to_class(days_report)
+    elsif competition.is_probably_over?
+      days_report = (Date.today - competition.end_date).to_i
+      report_and_results_days_to_class(days_report)
+    else
+      ""
+    end
+  end
+
+  def results_content(competition)
+    days_results = days_after_competition(competition.results_posted_at, competition)
+    if days_results
+      "#{pluralize(days_results, "day")} after"
+    else
+      competition.is_probably_over? ? "pending" : ""
+    end
+  end
+
+  def results_class(competition)
+    return "" unless competition.is_probably_over?
+
+    days_results = days_after_competition(competition.results_posted_at, competition)
+    report_and_results_days_to_class(days_results)
   end
 
   def year_is_a_number?(year)

--- a/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
@@ -27,9 +27,6 @@
       </thead>
       <tbody>
         <% competitions.each_with_index do |competition, index| %>
-          <% announced = competition.announced_at %>
-          <% report = competition.delegate_report.posted_at %>
-          <% results = competition.results_posted_at %>
           <tr>
             <td>
               <%= flag_icon competition.country.iso2, 16 %><%= link_to competition.cellName, competition_path(competition) %>
@@ -41,38 +38,9 @@
             <td class="admin-date">
               <%= wca_date_range(competition.start_date, competition.end_date, locale: :en) %>
             </td>
-            <% if announced
-                days_announced = (competition.start_date - announced.to_date).to_i
-                announced_class = announced_class(days_announced)
-                announced_content = "#{pluralize(days_announced, "day")} before"
-              end %>
-            <%= content_tag :td, announced_content, class: "admin-date #{announced_class}" %>
-
-            <% if report
-                days_report = (report.to_date - competition.end_date).to_i
-                report_class = report_and_results_class(days_report)
-                report_content = "#{pluralize(days_report, "day")} after"
-              else
-                if competition.is_probably_over?
-                  days_report = (Date.today - competition.end_date).to_i
-                  report_class = report_and_results_class(days_report)
-                  report_content = "pending"
-                end
-              end %>
-            <%= content_tag :td, report_content, class: "admin-date #{report_class}" %>
-
-            <% if results
-               days_results = (results.to_date - competition.end_date).to_i
-               results_class = report_and_results_class(days_results)
-               results_content = "#{pluralize(days_results, "day")} after"
-              else
-                if competition.is_probably_over?
-                  days_results = (Date.today - competition.end_date).to_i
-                  results_class = report_and_results_class(days_results)
-                  results_content = "pending"
-                end
-              end %>
-            <%= content_tag :td, results_content, class: "admin-date #{results_class}" %>
+            <%= content_tag :td, announced_content(competition), class: "admin-date #{announced_class(competition)}" %>
+            <%= content_tag :td, report_content(competition), class: "admin-date #{report_class(competition)}" %>
+            <%= content_tag :td, results_content(competition), class: "admin-date #{results_class(competition)}" %>
             <td>
               <% if current_user&.can_admin_results? %>
                 <%= link_to "Edit", admin_edit_competition_path(competition), class: "btn btn-sm btn-primary", target: "_blank" %>


### PR DESCRIPTION
# Before

![image](https://cloud.githubusercontent.com/assets/277474/26735649/a43e3022-4777-11e7-89a6-7954a484e47b.png)

# After

![image](https://cloud.githubusercontent.com/assets/277474/26745261/999e4270-479e-11e7-9826-bf29274b3e48.png)