### PR TITLE
Add back the ensure trailing slash code.

### DIFF
--- a/WcaOnRails/app/controllers/regulations_controller.rb
+++ b/WcaOnRails/app/controllers/regulations_controller.rb
@@ -3,8 +3,25 @@
 class RegulationsController < ApplicationController
   include HighVoltage::StaticPage
 
+  before_action :ensure_trailing_slash
+
   private def page_finder_factory
     IndexPageFinder
+  end
+
+  private def ensure_trailing_slash
+    desired_url = url_for(params.permit!.merge(trailing_slash: true))
+    # url_for doesn't always add a trailing slash (it won't add a slash to
+    # a url like example.com/index.html, for instance).
+    # Only attempt to redirect if the current url does not match the one
+    # url_for would want.
+    if trailing_slash?(request.env['REQUEST_URI']) != trailing_slash?(desired_url)
+      redirect_to desired_url, status: 301
+    end
+  end
+
+  def trailing_slash?(url)
+    url.match(/[^\?]+/).to_s.last == '/'
   end
 end
 

--- a/WcaOnRails/spec/requests/regulations_spec.rb
+++ b/WcaOnRails/spec/requests/regulations_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "regulations" do
+  context 'redirects missing trailing slash' do
+    context "without parameters" do
+      it 'to trailing slash' do
+        get '/regulations/scrambles'
+        expect(response).to redirect_to '/regulations/scrambles/'
+
+        follow_redirect!
+        expect(response).to be_success
+      end
+    end
+
+    context "with parameters" do
+      it 'to trailing slash' do
+        get '/regulations/scrambles?foo=3'
+        expect(response).to redirect_to '/regulations/scrambles/?foo=3'
+
+        follow_redirect!
+        expect(response).to be_success
+      end
+    end
+  end
+end


### PR DESCRIPTION
This code was removed in #1346 because it broke under rails 5.
This fixes #1380.