### PR TITLE
Remove remainings of teams creation

### DIFF
--- a/WcaOnRails/app/views/teams/index.html.erb
+++ b/WcaOnRails/app/views/teams/index.html.erb
@@ -29,8 +29,4 @@
       </table>
     </div>
   <% end %>
-
-  <% if current_user.can_manage_teams? %>
-    <%= link_to icon("plus", "New team"), new_team_path, class: "btn btn-primary" %>
-  <% end %>
 </div>

--- a/WcaOnRails/spec/views/teams/index.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/teams/index.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "teams/index.html.erb" do
+  describe "when signed in as an admin" do
+    let!(:user) { FactoryGirl.create :admin }
+    let!(:teams) { Team.all }
+    let!(:team_member) { FactoryGirl.create :team_member, user_id: user.id, team_id: teams.first.id }
+
+    before do
+      allow(view).to receive(:current_user) { user }
+      assign(:teams, teams)
+      render
+    end
+
+    it "lists teams" do
+      teams.each do |team|
+        expect(rendered).to match team.name
+      end
+    end
+
+    it "shows members of a team" do
+      expect(rendered).to match user.name
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1728.

Output of the test before the fix:

```
jonatanklosko@mockingjay:~/projects/worldcubeassociation.org/WcaOnRails (issue-1728) $ bundle exec rspec spec/views/teams/index.html.erb_spec.rb 
warning: parser/current is loading parser/ruby24, which recognizes
warning: 2.4.0-compliant syntax, but you are running 2.4.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

Randomized with seed 41596

teams/index.html.erb
  when signed in as an admin
    shows members of a team (FAILED - 1)
    lists teams (FAILED - 2)

TestDbManager
  CONSTANT_TABLES includes all tables filled in the files inside /db/seeds/ directory

Failures:

  1) teams/index.html.erb when signed in as an admin shows members of a team
     Failure/Error: <%= link_to icon("plus", "New team"), new_team_path, class: "btn btn-primary" %>
     
     ActionView::Template::Error:
       undefined local variable or method `new_team_path' for #<#<Class:0x00559197030b50>:0x005591980706c8>
       Did you mean?  new_post_path
                      new_poll_path
     # ./app/views/teams/index.html.erb:34:in `_app_views_teams_index_html_erb___568480149289662128_47041905833020'
     # ./spec/views/teams/index.html.erb_spec.rb:14:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # NameError:
     #   undefined local variable or method `new_team_path' for #<#<Class:0x00559197030b50>:0x005591980706c8>
     #   Did you mean?  new_post_path
     #                  new_poll_path
     #   ./app/views/teams/index.html.erb:34:in `_app_views_teams_index_html_erb___568480149289662128_47041905833020'

  2) teams/index.html.erb when signed in as an admin lists teams
     Failure/Error: <%= link_to icon("plus", "New team"), new_team_path, class: "btn btn-primary" %>
     
     ActionView::Template::Error:
       undefined local variable or method `new_team_path' for #<#<Class:0x00559197030b50>:0x005591967400e0>
       Did you mean?  new_post_path
                      new_poll_path
     # ./app/views/teams/index.html.erb:34:in `_app_views_teams_index_html_erb___568480149289662128_47041905833020'
     # ./spec/views/teams/index.html.erb_spec.rb:14:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # NameError:
     #   undefined local variable or method `new_team_path' for #<#<Class:0x00559197030b50>:0x005591967400e0>
     #   Did you mean?  new_post_path
     #                  new_poll_path
     #   ./app/views/teams/index.html.erb:34:in `_app_views_teams_index_html_erb___568480149289662128_47041905833020'

Finished in 28.71 seconds (files took 5.13 seconds to load)
3 examples, 2 failures

Failed examples:

rspec ./spec/views/teams/index.html.erb_spec.rb:23 # teams/index.html.erb when signed in as an admin shows members of a team
rspec ./spec/views/teams/index.html.erb_spec.rb:17 # teams/index.html.erb when signed in as an admin lists teams
```