### PR TITLE
Remove pointless condition that doesn't work

### DIFF
--- a/WcaOnRails/config/initializers/translations.rb
+++ b/WcaOnRails/config/initializers/translations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if defined?(Rails::Server) # See: https://stackoverflow.com/a/44441168
+if Rails.env.production?
   Rails.configuration.after_initialize do
     modification_timestamp = Timestamp.find_or_create_by!(name: 'en_translation_modification')
     latest_modification_date = DateTime.parse(`git log -1 --format='%ai' #{Rails.root.to_s}/config/locales/en.yml`)


### PR DESCRIPTION
This doesn't really make sense, because even though the `Rails::Server` trick works locally, it doesn't work on production (I guess it's due to unicorn). Also it's kinda pointless, because as soon as we deploy the server is restarted and this initializer runs, updating the timestamp if necessary, so before any `rails c` or `rake db:migrate` calls an email is already sent if necessary.

This was intentionally to stop Travis from failing, so I used `Rails.env.production?`.