### PR TITLE
Change competitors limit reason type to text

### DIFF
--- a/WcaOnRails/db/migrate/20170629134754_change_competitor_limit_reason_type_to_text.rb
+++ b/WcaOnRails/db/migrate/20170629134754_change_competitor_limit_reason_type_to_text.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeCompetitorLimitReasonTypeToText < ActiveRecord::Migration[5.0]
+  def change
+    change_column :Competitions, :competitor_limit_reason, :text
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -61,7 +61,7 @@ CREATE TABLE `Competitions` (
   `enable_donations` tinyint(1) DEFAULT NULL,
   `competitor_limit_enabled` tinyint(1) NOT NULL DEFAULT '0',
   `competitor_limit` int(11) DEFAULT NULL,
-  `competitor_limit_reason` varchar(191) DEFAULT NULL,
+  `competitor_limit_reason` text,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
@@ -1476,4 +1476,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170523185221'),
 ('20170524221221'),
 ('20170524224533'),
-('20170624115851');
+('20170624115851'),
+('20170629134754');


### PR DESCRIPTION
Fixes #1748.
I changed the type as currently the description is forced to be quite brief. This automatically makes the field into a nice textarea =)