### PR TITLE
Add a download CSV link for eligible voters for the WCA.

### DIFF
--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 class AdminController < ApplicationController
   before_action :authenticate_user!
   before_action -> { redirect_to_root_unless_user(:can_admin_results?) }
@@ -83,5 +85,16 @@ class AdminController < ApplicationController
   def do_compute_auxiliary_data
     ComputeAuxiliaryData.perform_later unless ComputeAuxiliaryData.in_progress?
     redirect_to admin_compute_auxiliary_data_path
+  end
+
+  def voters
+    csv = CSV.generate do |line|
+      line << ["name", "email"]
+
+      User.eligible_voters.each do |user|
+        line << [user.name, user.email]
+      end
+    end
+    send_data csv, filename: "wca-voters.csv", type: :csv
   end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -22,6 +22,12 @@ class User < ApplicationRecord
   has_many :user_preferred_events, dependent: :destroy
   has_many :preferred_events, through: :user_preferred_events, source: :event
 
+  def self.eligible_voters
+    team_leaders = TeamMember.current.where(team_leader: true).map(&:user)
+    eligible_delegates = User.where(delegate_status: %w(delegate senior_delegate board_member))
+    (team_leaders + eligible_delegates).uniq
+  end
+
   accepts_nested_attributes_for :user_preferred_events, allow_destroy: true
 
   strip_attributes only: [:wca_id, :country_iso2]

--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -22,8 +22,9 @@
         { text: "Update statistics", path: "/results/statistics.php?update8392=1", fa_icon: "area-chart" },
         { text: "Export public", path: "/results/admin/export_public.php", fa_icon: "cloud-upload" },
         { text: "Edit teams", path: teams_path, fa_icon: "users" },
-        { text: "Delegates", path: delegates_stats_path, fa_icon: "sitemap"},
-        { text: "Server status", path: server_status_path, fa_icon: "info"}
+        { text: "Delegates", path: delegates_stats_path, fa_icon: "sitemap" },
+        { text: "Server status", path: server_status_path, fa_icon: "info" },
+        { text: "WCA Voting Members CSV", path: eligible_voters_path, fa_icon: "download" },
       ].each do |nav_item| %>
         <%= link_to nav_item[:path], class: "list-group-item" + (current_page?(nav_item[:path]) ? ' active' : '') do %>
           <i class="fa fa-fw fa-<%= nav_item[:fa_icon] %>"></i> <%= nav_item[:text] %>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
   get '/regulations/*id' => 'regulations#show'
 
   get '/admin' => 'admin#index'
+  get '/admin/voters' => 'admin#voters', as: :eligible_voters
   get '/admin/merge_people' => 'admin#merge_people'
   post '/admin/merge_people' => 'admin#do_merge_people'
   get '/admin/edit_person' => 'admin#edit_person'

--- a/WcaOnRails/spec/features/eligible_voters_spec.rb
+++ b/WcaOnRails/spec/features/eligible_voters_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.feature "Eligible voters csv" do
+  let!(:wrc_team_id) { Team.find_by_friendly_id("wrc") }
+
+  let!(:user) { FactoryGirl.create(:user) }
+  let!(:former_team_leader) {
+    FactoryGirl.create(:user, :wrc_member).tap do |user|
+      user.team_members.find_by_team_id(wrc_team_id).update!(team_leader: true, end_date: 1.day.ago)
+    end
+  }
+  let!(:team_leader) {
+    FactoryGirl.create(:user, :wrc_member).tap do |user|
+      user.team_members.find_by_team_id(wrc_team_id).update!(team_leader: true)
+    end
+  }
+  let!(:team_member) { FactoryGirl.create(:user, :wrc_member) }
+  let!(:candidate_delegate) { FactoryGirl.create(:candidate_delegate) }
+  let!(:delegate) { FactoryGirl.create(:delegate) }
+  let!(:delegate_who_is_also_team_leader) {
+    FactoryGirl.create(:delegate, :wrc_member).tap do |user|
+      user.team_members.find_by_team_id(wrc_team_id).update!(team_leader: true)
+    end
+  }
+  let!(:senior_delegate) { FactoryGirl.create(:senior_delegate) }
+  let!(:board_member) { FactoryGirl.create(:board_member) }
+
+  before :each do
+    sign_in board_member
+  end
+
+  it 'includes all voters' do
+    visit "/admin/voters.csv"
+    csv = CSV.parse(page.body)
+    expect(csv).to match_array [
+      ["name", "email"],
+      [team_leader.name, team_leader.email],
+      [delegate.name, delegate.email],
+      [delegate_who_is_also_team_leader.name, delegate_who_is_also_team_leader.email],
+      [senior_delegate.name, senior_delegate.email],
+      [board_member.name, board_member.email],
+    ]
+  end
+end


### PR DESCRIPTION
Pretty straightforward. Here's what it looks like:

![image](https://user-images.githubusercontent.com/277474/28033091-b9c23cf6-6561-11e7-95a9-31c727836a38.png)

Clicking that link generates a CSV file with the following format:

```csv
name,email
Jeremy,jeremy@example.com
Ron,ron@cube.org
...
```

I've also deployed this to staging. Try it out here: https://staging.worldcubeassociation.org/admin/.