### PR TITLE
Fix bug with ordering WC podiums by position

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -237,7 +237,7 @@ class CompetitionsController < ApplicationController
         title = "Results of #{comp.name}, in #{comp.cityName}, #{comp.countryId} posted"
         body = "Results of the [#{comp.name}](#{competition_url(comp)}) are now available.\n\n"
       else
-        top_three = comp.results.where(event: event).podium
+        top_three = comp.results.where(event: event).podium.order(:pos)
         if top_three.empty?
           return render html: "<div class='container'><div class='alert alert-warning'>Nobody competed in event: #{event.id}</div></div>".html_safe
         else

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -660,7 +660,7 @@ class Competition < ApplicationRecord
 
   def events_with_podium_results
     light_results_from_relation(
-      results.podium,
+      results.podium.order(:pos),
     ).group_by(&:event)
       .sort_by { |event, _results| event.rank }
   end

--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -12,7 +12,7 @@ class Result < ApplicationRecord
   belongs_to :event, foreign_key: :eventId
   belongs_to :format, foreign_key: :formatId
 
-  scope :podium, -> { joins(:round_type).merge(RoundType.final_rounds).where(pos: [1..3]).where("best > 0").order(:pos) }
+  scope :podium, -> { joins(:round_type).merge(RoundType.final_rounds).where(pos: [1..3]).where("best > 0") }
   scope :winners, -> { joins(:round_type, :event).merge(RoundType.final_rounds).where("pos = 1 and best > 0").order("Events.rank") }
 
   validates :competition, presence: true

--- a/WcaOnRails/spec/models/person_spec.rb
+++ b/WcaOnRails/spec/models/person_spec.rb
@@ -111,4 +111,16 @@ RSpec.describe Person, type: :model do
       end
     end
   end
+
+  describe "#world_championship_podiums" do
+    let!(:wc2015) { FactoryGirl.create :competition, cellName: "World Championship 2015", starts: Date.new(2015, 1, 1) }
+    let!(:wc2017) { FactoryGirl.create :competition, cellName: "World Championship 2017", starts: Date.new(2017, 1, 1) }
+    let!(:result1) { FactoryGirl.create :result, person: person, competition: wc2015, pos: 2, eventId: "333" }
+    let!(:result2) { FactoryGirl.create :result, person: person, competition: wc2015, pos: 1, eventId: "333oh" }
+    let!(:result3) { FactoryGirl.create :result, person: person, competition: wc2017, pos: 3, eventId: "444" }
+
+    it "return results ordered by year and event" do
+      expect(person.world_championship_podiums.to_a).to eq [result3, result1, result2]
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1785.

Apparently it had nothing to do with the `group_by` method (actually expected), but rather a wrong query. The `podium` scope that we used, automatically added ordering by `pos` at the first place.

I decided to simply get rid of the misleading ordering and used it only when necessary.