### PR TITLE
Add Regulations page and Organizer guidelines

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -64,8 +64,10 @@
             <%= icon('book') %> <span class="hidden-sm"><%= t '.regulations' %></span> <span class="caret"></span>
           </a>
           <ul class="dropdown-menu" role="menu">
+            <li><a href="/regulations/about"><%= icon('info-circle') %> <%= t '.about_regulations' %></a></li>
+            <li class="divider"></li>
             <li><a href="/regulations/"><%= icon('book') %> <%= t '.regulations' %></a></li>
-            <li><a href="/regulations/guidelines.html"><%= icon('question-circle') %> <%= t '.guidelines' %></a></li>
+            <li><a href="/regulations/guidelines.html"><%= icon('sticky-note') %> <%= t '.guidelines' %></a></li>
             <li><a href="/regulations/scrambles/"><%= icon('random') %> <%= t '.scrambles' %></a></li>
             <li class="divider"></li>
             <li><a href="/regulations/history/"><%= icon('history') %> <%= t '.history' %></a></li>

--- a/WcaOnRails/app/views/regulations/about/index.html.erb
+++ b/WcaOnRails/app/views/regulations/about/index.html.erb
@@ -1,6 +1,6 @@
-<% provide(:title, 'About the WCA Regulations') %>
+<% provide(:title, t('about_regulations.title')) %>
 <div class="container">
-  <h1><%= t('about_regulations.title') %></h1>
+  <h1><%= yield(:title) %></h1>
 
   <div class="panel panel-default">
     <div class="panel-heading">

--- a/WcaOnRails/app/views/regulations/about/index.html.erb
+++ b/WcaOnRails/app/views/regulations/about/index.html.erb
@@ -1,0 +1,43 @@
+<% provide(:title, 'About the WCA Regulations') %>
+<div class="container">
+  <h1><%= t('about_regulations.title') %></h1>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= t('about_regulations.panel1.title') %></h3>
+    </div>
+    <div class="panel-body">
+      <%= t('about_regulations.panel1.content1_html') %>
+      <%= t('about_regulations.panel1.content2_html') %>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= t('about_regulations.panel2.title') %></h3>
+    </div>
+    <div class="panel-body">      
+      <%= t('about_regulations.panel2.content1_html') %><br/>
+      <%= t('about_regulations.panel2.content2_html') %>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= t('about_regulations.panel3.title') %></h3>
+    </div>
+    <div class="panel-body">
+        <%= t('about_regulations.panel3.content1_html') %>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= t('about_regulations.panel4.title') %></h3>
+    </div>
+    <div class="panel-body">
+       <%= t('about_regulations.panel4.content1_html') %><br />
+       <%= t('about_regulations.panel4.content2_html') %>
+    </div>
+  </div>
+</div>

--- a/WcaOnRails/app/views/static_pages/organizer_guidelines.erb
+++ b/WcaOnRails/app/views/static_pages/organizer_guidelines.erb
@@ -1,0 +1,55 @@
+<% provide(:title, 'WCA Organizer Guidelines') %>
+<div class="container">
+  <h1><%= t("organizer_guidelines.title") %></h1>
+
+  <h4><%= t("organizer_guidelines.paragraph1.title") %></h4>
+  <%= t("organizer_guidelines.paragraph1.content") %>
+  
+  <h4><%= t("organizer_guidelines.paragraph2.title") %></h4>
+  <%= t("organizer_guidelines.paragraph2.content") %>
+  
+  <h4><%= t("organizer_guidelines.paragraph3.title") %></h4>
+  <%= t("organizer_guidelines.paragraph3.content") %>
+  
+  <h4><%= t("organizer_guidelines.paragraph4.title") %></h4>
+  <%= t("organizer_guidelines.paragraph4.content1") %>
+
+  <ol>
+    <li><%= t("organizer_guidelines.paragraph4.list1.1") %></li>
+    <li><%= t("organizer_guidelines.paragraph4.list1.2") %></li>
+    <li><%= t("organizer_guidelines.paragraph4.list1.3") %></li>
+  </ol>
+
+  <%= t("organizer_guidelines.paragraph4.content2") %>
+  <ol>
+    <li><%= t("organizer_guidelines.paragraph4.list2.1") %></li>
+  </ol>
+  
+  <h4><%= t("organizer_guidelines.paragraph5.title") %></h4>
+  <%= t("organizer_guidelines.paragraph5.content") %>
+  
+  <h4><%= t("organizer_guidelines.paragraph6.title") %></h4>
+  <%= t("organizer_guidelines.paragraph6.content") %>
+
+  <h4><%= t("organizer_guidelines.paragraph7.title") %></h4>
+  <%= t("organizer_guidelines.paragraph7.content1") %><br/>
+  <%= t("organizer_guidelines.paragraph7.content2") %><br/>
+  <%= t("organizer_guidelines.paragraph7.content3") %>
+
+  <h4><%= t("organizer_guidelines.paragraph8.title") %></h4>
+  <ul>
+    <li><%= t("organizer_guidelines.paragraph8.list.1") %></li>
+    <li><%= t("organizer_guidelines.paragraph8.list.2") %></li>
+  </ul>
+  
+  <h4><%= t("organizer_guidelines.paragraph9.title") %></h4>
+  <%= t("organizer_guidelines.paragraph9.content") %>
+  <ul>
+    <li><%= t("organizer_guidelines.paragraph9.list.1") %></li>
+    <li><%= t("organizer_guidelines.paragraph9.list.2") %></li>
+    <li><%= t("organizer_guidelines.paragraph9.list.3") %></li>
+    <li><%= t("organizer_guidelines.paragraph9.list.4") %></li>
+    <li><%= t("organizer_guidelines.paragraph9.list.5") %></li>
+    <li><%= t("organizer_guidelines.paragraph9.list.6") %></li>
+  </ul>
+</div>

--- a/WcaOnRails/app/views/static_pages/organizer_guidelines.erb
+++ b/WcaOnRails/app/views/static_pages/organizer_guidelines.erb
@@ -1,6 +1,6 @@
-<% provide(:title, 'WCA Organizer Guidelines') %>
+<% provide(:title, t("organizer_guidelines.title")) %>
 <div class="container">
-  <h1><%= t("organizer_guidelines.title") %></h1>
+  <h1><%= yield(:title)  %></h1>
 
   <h4><%= t("organizer_guidelines.paragraph1.title") %></h4>
   <%= t("organizer_guidelines.paragraph1.content") %>

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -67,7 +67,9 @@ search:
     - app/assets/images
     - app/assets/fonts
     # i18n-tasks fails on TNoodle jars and old non-utf8 translations...
-    - app/views/regulations
+    - app/views/regulations/history
+    - app/views/regulations/scrambles
+    - app/views/regulations/translations    
 
   ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
   ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -491,6 +491,7 @@ en:
       multimedia: "Multimedia"
       db_export: "Database Export"
       regulations: "Regulations"
+      about_regulations: "About the Regulations"
       guidelines: "Guidelines"
       scrambles: "Scrambles"
       history: "History"
@@ -1302,3 +1303,79 @@ en:
         people: "No people found for"
         posts: "No posts found for"
         regulations_and_guidelines: "No Regulations or Guidelines found for"
+  #context: About the regulations
+  about_regulations:
+    title: "About the Regulations"
+    panel1:
+      title: "Regulations"
+      content1_html: 'All competitions must follow the <a href="/regulations/">WCA Regulations</a>. It is important for competitors to read these regulations before attending their first competition.'
+      content2_html: 'The WCA Regulations are supplemented by the <a href="/regulations/guidelines.html">WCA Guidelines</a>, which contain additional clarifications and explanations.'
+    panel2:
+      title: "Translations"
+      content1_html: 'The WCA Regulations are not only available in English, but WCA members have translated them into several languages: <a href="/regulations/translations/">Translations</a>.'
+      content2_html: '<strong>Important</strong>: Although the translations are very helpful, they are not official. In competitions, the English version of the WCA Regulations is binding.'
+    panel3:
+      title: "Regulations FAQ"
+      content1_html: 'The <a href="/faq">FAQ section</a> answers several frequently asked questions about the WCA Regulations.'
+    panel4:
+      title: "Organizer Guidelines"
+      content1_html: 'If you are interested in organizing a competition or already planning to organize one, please read our <a href="/organizer_guidelines">Organizer Guidelines</a>.'
+      content2_html: 'This document contains important information and should be read by every competition organizer.'
+  #context: Organizer Guidelines
+  organizer_guidelines:
+    title: "WCA Competition Organizer Guidelines"
+    paragraph1:
+      title: "How to organize a competition"
+      content: "All WCA competitions must be attended and overseen by a WCA Delegate. If you are interested in organizing your own competition, please contact your nearest WCA Delegate. They will be able to give you more information on the local practices and can
+      help you with finding a suitable date as they know if there are any other competitions planned in the same time frame. If there is no WCA Delegate near your area, please get in touch with the Senior Delegate for your region."
+    paragraph2:
+      title: "Expected expenses for organizing a competition"
+      content: "The expected expenses differ greatly from country to country and are determined by several factors like the size of the venue and other general conditions. Recouping all expenses with entry fees is possible. However, to keep these as low as possible,
+      it is highly recommended to search for sponsors. Although WCA Delegates are volunteers and do not receive a salary for their work, organizers should consider paying compensation for their travel expenses."
+    paragraph3:
+      title: "Deadlines for the announcement of the competition"
+      content: "The competition should be announced at least one month before the start of the competition (see Guideline 8a4++). If there are special reasons preventing this deadline to be met, competitions may be announced up to two weeks before, at the discretion
+      of the WCA Board. It is highly recommended to inform the WCA Board of these reasons as soon as possible to avoid a later refusal of the competition."
+    paragraph4:
+      title: "Proximity policy"
+      content1: "As a general policy, WCA Competitions will be accepted if they are at least 200 km or 26 days away from any other competition. WCA Board should particularly review a proposed competition if there is another competition for which the distance between
+      them is less than 200 km and the time between them is less than 27 days. A delegate requesting approval for such a competition must provide further information on why the competition should still be accepted. Possible arguments that will support such
+      a competition being accepted include:"
+      list1:
+        '1': "The two competitions have different events."
+        '2': "The two competitions take place in different countries."
+        '3': "In the last 12 months, there have been fewer than 13 competitions in the area 200 km around the competition."
+      content2: "FMC simultaneous competitions cannot be part of any other regular competition:"
+      list2:
+        '1': "If any location of such competitions is closer than 200 km to any other regular competition, then both competitions should be at least 5 days apart, or the other competition must not have the FM event."
+    paragraph5:
+      title: "Competitor limits"
+      content: "The number of competitors may be limited per event or per competition (see Regulation Z4). Like for all regulations in article Z, the delegate of the competition must get an approval of the competitor limit by the Board. Competitor limits should be
+        chosen wisely and in accordance with the expected competitor interest. The limit should not set to a lower number for minor reasons. The intended limit should already be taken into consideration when searching for a suitable venue. The competitors
+        limit must be clearly stated on the competition page on the WCA website."
+    paragraph6:
+      title: "Handling registrations"
+      content: "Registrations must be processed on a first come first served basis, which means that the earliest complete registration must be treated first. If entry fees are prepaid, a registration is considered complete when the entry fee has been paid. This
+      should be clearly stated in the paying instructions on the competition website."
+    paragraph7:
+      title: "Managing the waiting list"
+      content1: "Once the competitor limit for a competition is reached, a waiting list should be opened. When registered and approved competitors cancel their registration, they can be replaced with the next competitors on the waiting list."
+      content2: "If competition entry fees are prepaid, it is an efficient approach to offer the free spot to the next competitor on the waiting list and set a deadline until when the registration fee should be paid to complete the registration (e.g. 48 hours). In case the payment is not
+      received in time or the competitor denies, the free spot should be offered to the next person on the waiting list. This process should be continued until the free spots are filled. There are no exceptions for competitors to bypass the waiting list."
+      content3: "If competitors did not go through the regular registration process but competed, their results will be removed retroactively (assuming the competitors limit existed and was reached)."
+    paragraph8:
+      title: "Tasks before the competition"
+      list:
+        '1': "Before announcing the competition, a schedule is required to be published on the competition website. This schedule can be adjusted later."
+        '2': "Competitors should be split into groups, score sheets must be printed and should be split according to the groups' distribution. It is also recommended to plan who will scramble for every group of every event, at least for the first rounds.
+        Scramblers should be reliable."
+    paragraph9:
+      title: "Tasks during the competition"
+      content: "The tasks an organizer has to do during a competition should be discussed with the WCA Delegate. The typical tasks are (they can be delegated to other reliable people):"
+      list:
+        '1': "Managing the registration desk"
+        '2': "Making announcements"
+        '3': "Calling groups and laying out score sheets"
+        '4': "Score-taking and printing results"
+        '5': "Looking for scramblers and judges"
+        '6': "Dealing with all organizational issues regarding the venue (e.g. keys or WiFi)"        

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1319,7 +1319,7 @@ en:
       content1_html: 'The <a href="/faq">FAQ section</a> answers several frequently asked questions about the WCA Regulations.'
     panel4:
       title: "Organizer Guidelines"
-      content1_html: 'If you are interested in organizing a competition or already planning to organize one, please read our <a href="/organizer_guidelines">Organizer Guidelines</a>.'
+      content1_html: 'If you are interested in organizing a competition or already planning to organize one, please read our <a href="/organizer-guidelines">Organizer Guidelines</a>.'
       content2_html: 'This document contains important information and should be read by every competition organizer.'
   #context: Organizer Guidelines
   organizer_guidelines:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1339,7 +1339,7 @@ en:
     paragraph4:
       title: "Proximity policy"
       content1: "As a general policy, WCA Competitions will be accepted if they are at least 200 km or 26 days away from any other competition. WCA Board should particularly review a proposed competition if there is another competition for which the distance between
-      them is less than 200 km and the time between them is less than 27 days. A delegate requesting approval for such a competition must provide further information on why the competition should still be accepted. Possible arguments that will support such
+      them is less than 200 km and the time between them is less than 26 days. A delegate requesting approval for such a competition must provide further information on why the competition should still be accepted. Possible arguments that will support such
       a competition being accepted include:"
       list1:
         '1': "The two competitions have different events."

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -852,6 +852,8 @@ fr:
       db_export: Export de la base de données
       #original_hash: 1fa73f3
       regulations: Règlement
+      #original_hash: 6bce1b5
+      about_regulations: À propos du Règlement
       #original_hash: 141d1d7
       guidelines: Recommandations
       #original_hash: c4622c3

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -108,7 +108,7 @@ Rails.application.routes.draw do
   get 'logo' => 'static_pages#logo'
   get 'wca-workbook-assistant' => 'static_pages#wca_workbook_assistant'
   get 'wca-workbook-assistant-versions' => 'static_pages#wca_workbook_assistant_versions'
-  get 'organizer_guidelines' => 'static_pages#organizer_guidelines'
+  get 'organizer-guidelines' => 'static_pages#organizer_guidelines'
 
   get 'contact/website' => 'contacts#website'
   post 'contact/website' => 'contacts#website_create'

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
   get 'logo' => 'static_pages#logo'
   get 'wca-workbook-assistant' => 'static_pages#wca_workbook_assistant'
   get 'wca-workbook-assistant-versions' => 'static_pages#wca_workbook_assistant_versions'
+  get 'organizer_guidelines' => 'static_pages#organizer_guidelines'
 
   get 'contact/website' => 'contacts#website'
   post 'contact/website' => 'contacts#website_create'


### PR DESCRIPTION
Fixes #1593 

* Page about regulations with links/explanations
* Static page with organizer guidelines
* Link to the "About the Regulations"-page in the dropdown menu
* Icons changed (guidelines are not a question mark anymore...)

Screenshots:
[About page](http://imgur.com/qvGhtqe)
[Organizer Guidelines](http://imgur.com/DHjQmqk)

I decided to make both the regulations page and the organizer guidelines translatable. That gives translators a lot of additional work, but I think that's worth it. :-)

