### PR TITLE
Add placeholder hints for date input and datetime input.

### DIFF
--- a/WcaOnRails/app/inputs/date_picker_input.rb
+++ b/WcaOnRails/app/inputs/date_picker_input.rb
@@ -52,7 +52,7 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
   def set_html_options
     input_html_options[:type] = 'text'
     input_html_options[:data] ||= {}
-    input_html_options[:data].merge!(date_options: date_options)
+    input_html_options[:data][:date_options] = date_options
     input_html_options[:placeholder] = input_placeholder
   end
 

--- a/WcaOnRails/app/inputs/date_picker_input.rb
+++ b/WcaOnRails/app/inputs/date_picker_input.rb
@@ -53,6 +53,7 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
     input_html_options[:type] = 'text'
     input_html_options[:data] ||= {}
     input_html_options[:data].merge!(date_options: date_options)
+    input_html_options[:placeholder] = input_placeholder
   end
 
   def set_value_html_option
@@ -67,5 +68,9 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
   def date_options
     custom_options = input_html_options[:data][:date_options] || {}
     self.class.date_options_base.merge!(custom_options)
+  end
+
+  def input_placeholder
+    I18n.t('common.date_placeholder')
   end
 end

--- a/WcaOnRails/app/inputs/datetime_picker_input.rb
+++ b/WcaOnRails/app/inputs/datetime_picker_input.rb
@@ -14,4 +14,8 @@ class DatetimePickerInput < DatePickerInput
   def utc_addon
     template.content_tag :span, "UTC", class: "input-group-addon"
   end
+
+  def input_placeholder
+    I18n.t('common.datetime_placeholder')
+  end
 end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -148,6 +148,8 @@ en:
       one: "this event"
       other: "these %{count} events"
     search_site: "Search site"
+    date_placeholder: "YYYY-MM-DD"
+    datetime_placeholder: "YYYY-MM-DD HH:MM"
   delegate_statuses:
     candidate_delegate: "Candidate Delegate"
     delegate: "Delegate"


### PR DESCRIPTION
This was recommended by @LinusFresz. The `YYYY-MM-DD` and the `YYYY-MM-DD HH:MM` are both translatable.

Some screenshots:

![image](https://user-images.githubusercontent.com/277474/28844259-e4c05fe2-76b8-11e7-9334-f876ee6a16f5.png)

![image](https://user-images.githubusercontent.com/277474/28844279-ef5c5d02-76b8-11e7-910c-4eedf12a9456.png)

![image](https://user-images.githubusercontent.com/277474/28844286-f43475c6-76b8-11e7-8d25-6e455d2479cd.png)