### PR TITLE
Pass object's id instead of itself

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -19,7 +19,7 @@
     <%= f.input :remarks, input_html: { class: "markdown-editor" } %>
 
     <%= f.button :submit, class: "btn-primary" %>
-    <% is_actually_posted = DelegateReport.find(@delegate_report).posted? %>
+    <% is_actually_posted = DelegateReport.find(@delegate_report.id).posted? %>
     <% if !is_actually_posted %>
       <%= button_tag(type: 'submit',
                      name: "delegate_report[posted]",


### PR DESCRIPTION
Looks like we didn't notice a deprecation warning on `DelegateReport.find(@object)` [here](https://github.com/thewca/worldcubeassociation.org/blob/782d88bad5baf5da56ea6c02eb2fee6efc56d862/WcaOnRails/app/views/delegate_reports/edit.html.erb#L22), and it's now deprecated and throwing an error.

Merging this asap, I don't have time for writing the test now, but will do later!