### PR TITLE
Added a basic feature test of submitting a delegate report.

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/show.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/show.html.erb
@@ -29,6 +29,6 @@
   <%= render @delegate_report %>
 
   <% if current_user.can_edit_delegate_report?(@competition.delegate_report) %>
-    <%= link_to icon("pencil", "Edit"), delegate_report_edit_path(@competition), class: "btn btn-default" %>
+    <%= link_to icon("pencil", "Edit Report"), delegate_report_edit_path(@competition), class: "btn btn-default" %>
   <% end %>
 <% end %>

--- a/WcaOnRails/spec/features/delegate_report_spec.rb
+++ b/WcaOnRails/spec/features/delegate_report_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Registration management" do
+  let(:delegate) { FactoryGirl.create :delegate, name: "Jeremy on Bart" }
+  let(:competition) { FactoryGirl.create :competition, :registration_open, delegates: [delegate], name: "Submit Report 2017" }
+
+  context "when signed in as competition delegate" do
+    before :each do
+      sign_in delegate
+    end
+
+    scenario "view, edit, save, submit report" do
+      # View report
+      visit "/competitions/#{competition.id}/report"
+      expect(page).to have_text("Submit Report 2017")
+      expect(page).to have_text("Your report is not posted yet")
+
+      # Edit and save report
+      click_link "Edit Report"
+      fill_in "Remarks", with: "some remarks"
+      click_button "Update Delegate report"
+      expect(page).to have_text("some remarks")
+
+      # Submit report
+      expect(competition.reload.delegate_report.posted?).to be false
+      click_button "Post the report"
+      expect(page).to have_text("Report submitted by Jeremy on Bart")
+      expect(competition.reload.delegate_report.posted?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1805.

This test failed before I pulled down @viroulep's fix in #1804:

```
Registration management
  when signed in as competition delegate
    view, edit, save, submit report (FAILED - 1)
  HTML screenshot: file:///home/jeremy/gitting/worldcubeassociation.org/WcaOnRails/tmp/capybara/screenshot_2017-08-06-12-58-53.583.html

Failures:

  1) Registration management when signed in as competition delegate view, edit, save, submit report
     Failure/Error: <% is_actually_posted = DelegateReport.find(@delegate_report).posted? %>
     
     ActionView::Template::Error:
       You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.
     # /home/jeremy/.bundle/ruby/2.4.0/gems/activerecord-5.1.2/lib/active_record/relation/finder_methods.rb:461:in `find_one'
     # /home/jeremy/.bundle/ruby/2.4.0/gems/activerecord-5.1.2/lib/active_record/relation/finder_methods.rb:450:in `find_with_ids'
     # /home/jeremy/.bundle/ruby/2.4.0/gems/activerecord-5.1.2/lib/active_record/relation/finder_methods.rb:66:in `find'
     # /home/jeremy/.bundle/ruby/2.4.0/gems/activerecord-5.1.2/lib/active_record/querying.rb:3:in `find'
     # /home/jeremy/.bundle/ruby/2.4.0/gems/activerecord-5.1.2/lib/active_record/core.rb:178:in `find'
     # ./app/views/delegate_reports/edit.html.erb:22:in `block (2 levels) in _app_views_delegate_reports_edit_html_erb___4425369187670242821_103380580'
     # /home/jeremy/.bundle/ruby/2.4.0/gems/actionview-5.1.2/lib/action_view/helpers/capture_helper.rb:39:in `block in capture'
```