### PR TITLE
Make sure refounds do not happen accidentally by adding a confirmation

### DIFF
--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -41,7 +41,7 @@
           <%= humanized_money_with_symbol payment.amount %>
           <% if payment.amount_available_for_refund > 0 %>
             <%= form_tag registration_payment_refund_path(@registration, payment), method: :post do %>
-              <%= submit_tag t('registrations.refund'), class: "btn btn-warning" %>
+              <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>
             <% end %>
           <% end %>
         </p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -724,6 +724,7 @@ en:
     panel_title: "Registration details"
     register: "Register!"
     refund: "Refund Payment"
+    refund_confirmation: "Are you sure you want to refund this payment?"
     update: "Update Registration"
     delete: "Delete"
     delete_confirm: "Are you sure you want to delete your registration?"


### PR DESCRIPTION
Implements @KitClement's idea, see [this comment](https://github.com/thewca/worldcubeassociation.org/issues/1819#issuecomment-322934664).

A straightforward change, gonna deploy as soon as Travis passes!