### PR TITLE
Add a section for SSL certificate in server status

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -40,6 +40,7 @@ gem 'money-rails'
 gem 'octokit'
 gem 'stripe'
 gem 'oauth2'
+gem 'openssl'
 
 # Pointing to jfly/selectize-rails which has a workaround for
 #  https://github.com/selectize/selectize.js/issues/953

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -307,6 +307,7 @@ GEM
     oga (2.10)
       ast
       ruby-ll (~> 2.1)
+    openssl (2.0.3)
     orm_adapter (0.5.0)
     parallel (1.11.2)
     parser (2.4.0.0)
@@ -551,6 +552,7 @@ DEPENDENCIES
   oauth2
   octokit
   oga
+  openssl
   phantomjs
   poltergeist
   pre-commit

--- a/WcaOnRails/app/controllers/server_status_controller.rb
+++ b/WcaOnRails/app/controllers/server_status_controller.rb
@@ -2,6 +2,9 @@
 
 class ServerStatusController < ApplicationController
   MINUTES_IN_WHICH_A_JOB_SHOULD_HAVE_STARTED_RUNNING = 5
+  CERTIFICATE_PATH = "#{Rails.root}/../secrets/#{URI.parse(ENVied.ROOT_URL).host}"
+  # We want to be warned 10 days before certificate's renewal
+  CERTIFICATE_RENEW_DELAY = 10
 
   def index
     @everything_good = true
@@ -12,6 +15,21 @@ class ServerStatusController < ApplicationController
 
     @regulations_load_error = Regulation.regulations_load_error
     @everything_good &&= @regulations_load_error.blank?
+
+    # We set @expires_in the following way:
+    #  - if nil then no certificate was found
+    #  - a positive integer indicates we have this number of days before expiration
+    #  - a negative integer indicates it's expired by this number of days
+    begin
+      raw = File.read(CERTIFICATE_PATH)
+      certificate = OpenSSL::X509::Certificate.new(raw)
+      @expires_in = (certificate.not_after.to_date - Time.now.to_date).to_i
+    rescue
+      @expires_in = nil
+    end
+    # If we're in test or development, we don't want to go red on the SSL certificate.
+    @certificate_good = Rails.env.test? || Rails.env.development? || (@expires_in || 0) > ServerStatusController::CERTIFICATE_RENEW_DELAY
+    @everything_good &&= @certificate_good
 
     @locale_stats = ApplicationController.locale_counts.sort_by { |locale, count| count }.reverse
 

--- a/WcaOnRails/app/views/server_status/index.html.erb
+++ b/WcaOnRails/app/views/server_status/index.html.erb
@@ -58,6 +58,22 @@
     </div>
   </div>
 
+  <% kind_class = @certificate_good ? "success" : "danger" %>
+  <div class="panel panel-<%= kind_class %>">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        <span class="label label-<%= kind_class %>">SSL Certificate</span>
+        <% if @expires_in.nil? %>
+          No certificate to check! (Certificate path was "<%= ServerStatusController::CERTIFICATE_PATH %>")
+        <% elsif @expires_in < 0 %>
+          Has expired <%= -@expires_in %> days ago!
+        <% else %>
+          Expires in <%= @expires_in %> days.
+        <% end %>
+      </h3>
+    </div>
+  </div>
+
   <%= alert :info do
     sha1 = `git rev-parse HEAD`
     {


### PR DESCRIPTION
Fixes #1837.

Since staging and production use different ssl certificate names I had to edit some chef file.
The crazy part of me makes me think it's gonna be all fine to deploy this to production, but it's probably safer to run the chef thing first on staging.
