### PR TITLE
Cron job to renew HTTPS certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ regulations/
 !WcaOnRails/app/views/regulations/history/*.erb
 WcaOnRails/app/views/regulations-todelete/
 
+# acme.sh stuff
+WcaOnRails/public/.well-known/
+
 # byebug stuff
 .byebug_history
 

--- a/chef/site-cookbooks/wca/recipes/cronjobs.rb
+++ b/chef/site-cookbooks/wca/recipes/cronjobs.rb
@@ -60,6 +60,19 @@ unless node.chef_environment.start_with?("development")
   end
 end
 
+unless node.chef_environment.start_with?("development")
+  cron "update https certificate via acme.sh" do
+    minute '19'
+    hour '0'
+    weekday '*'
+
+    path path
+    mailto admin_email
+    user username
+    command '"/home/cubing/.acme.sh"/acme.sh --cron --home "/home/cubing/.acme.sh" > /dev/null'
+  end
+end
+
 # Run init-php-results on our first provisioning, but not on subsequent provisions.
 lockfile = '/tmp/php-results-initialized'
 init_php_commands.each do |cmd|

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -165,6 +165,17 @@ end
 
 # Use HTTPS in non development mode
 https = !node.chef_environment.start_with?("development")
+server_name = { "production" => "www.worldcubeassociation.org", "staging" => "staging.worldcubeassociation.org", "development" => "" }[node.chef_environment]
+
+#### Let's Encrypt with acme.sh
+if https
+  home_dir = "#{repo_root}/.."
+  acme_sh_dir = "#{home_dir}/.acme.sh"
+  link acme_sh_dir do
+    to "#{repo_root}/secrets/https/acme.sh-#{server_name}"
+    owner username
+  end
+end
 
 #### Nginx
 # Unfortunately, we have to compile nginx from source to get the auth request module
@@ -233,7 +244,6 @@ logrotate_app 'nginx-wca' do
   postrotate "[ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`"
 end
 
-server_name = { "production" => "www.worldcubeassociation.org", "staging" => "staging.worldcubeassociation.org", "development" => "" }[node.chef_environment]
 template "/etc/nginx/conf.d/worldcubeassociation.org.conf" do
   source "worldcubeassociation.org.conf.erb"
   mode 0644

--- a/chef/site-cookbooks/wca/templates/bashrc.erb
+++ b/chef/site-cookbooks/wca/templates/bashrc.erb
@@ -10,3 +10,5 @@ fi
 MY_BODY="\[$green$bold\]\w\[$reset\] @\h"
 END=">"
 export PS1="${MY_BODY}${END} "
+
+. "/home/cubing/.acme.sh/acme.sh.env"

--- a/chef/site-cookbooks/wca/templates/wca_https.conf.erb
+++ b/chef/site-cookbooks/wca/templates/wca_https.conf.erb
@@ -7,15 +7,15 @@
 ssl on;
 
 # Private key (should be generated locally and not by our CA)
-ssl_certificate_key <%= @repo_root %>/secrets/<%= @server_name %>.key;
+ssl_certificate_key <%= @repo_root %>/secrets/https/<%= @server_name %>.key;
 
 # Signed certificate + intermediates certificates
-ssl_certificate <%= @repo_root %>/secrets/<%= @server_name %>.chained.crt;
+ssl_certificate <%= @repo_root %>/secrets/https/<%= @server_name %>.chained.crt;
 
 # Strong DH parameters
 # The DH file is generated using the above command (takes about 20 minutes)
 # root@wca# openssl dhparam -out dh4096.pem -outform PEM -2 4096
-ssl_dhparam <%= @repo_root %>/secrets/dh4096.pem;
+ssl_dhparam <%= @repo_root %>/secrets/https/dh4096.pem;
 
 # Recommended security settings from https://wiki.mozilla.org/Security/Server_Side_TLS
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
This fixes #1838.

# TODO

- [x] ~~Update `CERTIFICATE_PATH` in WcaOnRails/app/controllers/server_status_controller.rb. See @viroulep's PR here: https://github.com/thewca/worldcubeassociation.org/pull/1839/files#diff-f34f3aa3ca06c033e53505e2c51e0d26R5~~ fix in https://github.com/thewca/worldcubeassociation.org/commit/63d6953fd5549b8fce3ff7fe8a9c629ac3cdc47c

I was trying to come up with a solution that would work for both production and staging, and I think this will. The way I did it is a bit strange with some manual setup, but now that everything is in the secrets directory on staging and production, we should not have to ever run these commands manually again:

## Stuff I've already done on production that is not reflected by this diff

I also ran the analogous commands on staging (changing them as appropriate).

1. `curl https://get.acme.sh | sh` - Install acme.sh.
2. `mv ~/.acme.sh /home/cubing/worldcubeassociation.org/secrets/https/acme.sh-www.worldcubeassociation.org && ln -s /home/cubing/worldcubeassociation.org/secrets/https/acme.sh-www.worldcubeassociation.org ~/.acme.sh` - Move the acme.sh installation and configuration into the secrets directory. Set up a symlink so acme.sh still works.
3. `acme.sh --issue -d www.worldcubeassociation.org -d worldcubeassociation.org -w /home/cubing/worldcubeassociation.org/WcaOnRails/public` - Request a certificate
4. `acme.sh --install-cert -d www.worldcubeassociation.org --key-file /home/cubing/worldcubeassociation.org/secrets/https/www.worldcubeassociation.org.key --fullchain-file /home/cubing/worldcubeassociation.org/secrets/https/www.worldcubeassociation.org.chained.crt --reloadcmd "sudo nginx -s reload"` - Teach acme.sh where to copy the certificate files after requesting them, and how to restart nginx whenever certificates are renewed in the future.

A side effect of 2) was to create a cron job and to update .bashrc to set up a `acme.sh` alias. These changes will be lost when we spin up new servers, so I updated our chef configuration to include these two changes.

**Note: I have not actually tested out if autorenew works, because I'm not entirely sure how to. Perhaps there's some way to trick acme.sh into thinking a certificate needs renewal even when it doesn't? If it isn't easy to trigger this, I suppose we can wait 2 months and see if it works.**
