### PR TITLE
Misc improvements

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1386,4 +1386,4 @@ en:
         '3': "Calling groups and laying out score sheets"
         '4': "Score-taking and printing results"
         '5': "Looking for scramblers and judges"
-        '6': "Dealing with all organizational issues regarding the venue (e.g. keys or WiFi)"        
+        '6': "Dealing with all organizational issues regarding the venue (e.g. keys or WiFi)"

--- a/WcaOnRails/spec/lib/test_db_manager_spec.rb
+++ b/WcaOnRails/spec/lib/test_db_manager_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe TestDbManager do
+  it "CONSTANT_TABLES includes all tables filled in the files inside /db/seeds/ directory" do
+    expected_files = TestDbManager::CONSTANT_TABLES.map do |table_name|
+      "db/seeds/#{table_name.underscore}.seeds.rb"
+    end
+    expect(Dir["db/seeds/*.seeds.rb"]).to match_array expected_files
+  end
+end

--- a/WcaOnRails/spec/support/test_db_manager.rb
+++ b/WcaOnRails/spec/support/test_db_manager.rb
@@ -17,12 +17,3 @@ class TestDbManager
     Rake::Task["db:seed:common"].invoke
   end
 end
-
-RSpec.describe TestDbManager do
-  it "CONSTANT_TABLES includes all tables filled in the files inside /db/seeds/ directory" do
-    expected_files = TestDbManager::CONSTANT_TABLES.map do |table_name|
-      "db/seeds/#{table_name.underscore}.seeds.rb"
-    end
-    expect(Dir["db/seeds/*.seeds.rb"]).to match_array expected_files
-  end
-end


### PR DESCRIPTION
I moved around the TestDbManager spec so it would stopp running no matter what file you're testing.

## Before

```
~/gitting/worldcubeassociation.org/WcaOnRails @kaladin> bin/rspec spec/models/competition_tab_spec.rb 
Running via Spring preloader in process 21029

Randomized with seed 27998

TestDbManager
  CONSTANT_TABLES includes all tables filled in the files inside /db/seeds/ directory

CompetitionTab
  has a valid factory
  ensures all attributes are defined as either cloneable or uncloneable
  #reorder
    doesn't change anything when swapping first tab with its predecessor
    can swap tab with its successor
    doesn't change anything when swapping last tab with its successor
    can swap tab with its predecessor
  #display_order
    starts from 1 for each competition
    increases by one for new created tabs
    are updated correctly after a tab is deleted

Finished in 11.04 seconds (files took 0.40141 seconds to load)
10 examples, 0 failures

Randomized with seed 27998
```

## After

```
~/gitting/worldcubeassociation.org/WcaOnRails @kaladin> bin/rspec spec/models/competition_tab_spec.rb 
Running via Spring preloader in process 21437

Randomized with seed 27998

CompetitionTab
  has a valid factory
  ensures all attributes are defined as either cloneable or uncloneable
  #reorder
    doesn't change anything when swapping first tab with its predecessor
    can swap tab with its successor
    doesn't change anything when swapping last tab with its successor
    can swap tab with its predecessor
  #display_order
    starts from 1 for each competition
    increases by one for new created tabs
    are updated correctly after a tab is deleted

Finished in 13.45 seconds (files took 0.34945 seconds to load)
9 examples, 0 failures

Randomized with seed 27998
```

I plan to merge this up as soon as tests pass.