### PR TITLE
Display delegate from params on the competitions index page

### DIFF
--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -128,8 +128,6 @@
 </div>
 
 <script>
-  $('#<%= params[:state] %>').button('toggle');
-
   $('#present').on('click', function() {
     $('#past .caption').html("<%= t('competitions.index.past') %>");
   });
@@ -155,15 +153,11 @@
     }
   });
 
-  $('#state .btn:not(#custom)').on('click', function() {
-    $('.custom-control').hide();
+  $('#state').on('change', function(event) {
+    $('.custom-control').toggle(event.target === $('#state_custom')[0]);
   });
 
-  $('#custom').on('click', function() {
-    $('.custom-control').show();
-  });
-
-  $('#state .btn.active').trigger('click');
+  $('#<%= params[:state] %>').button('toggle');
 
   $('#display-<%= @display %>').button('toggle');
 </script>

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -104,7 +104,8 @@
 
 <div id="delegate" class="form-group delegate-selector">
   <%= label_tag(t('layouts.navigation.delegate')) %>
-  <input id="delegate" name="delegate" class="wca-autocomplete wca-autocomplete-only_one wca-autocomplete-only_delegates wca-autocomplete-users_search"></input>
+  <%= text_field_tag "delegate", params[:delegate], class: "wca-autocomplete wca-autocomplete-only_one wca-autocomplete-only_delegates wca-autocomplete-users_search",
+                                 data: { data: User.where(id: params[:delegate]).to_json } %>
 </div>
 
 <div id="display" class="form-group">

--- a/WcaOnRails/spec/features/competitions_list_spec.rb
+++ b/WcaOnRails/spec/features/competitions_list_spec.rb
@@ -3,6 +3,23 @@
 require "rails_helper"
 
 RSpec.feature "Competitions list" do
+  context "list view" do
+    context "when a delegate is set in the params" do
+      let(:competition) { FactoryGirl.create :competition, :visible, :future }
+      let(:delegate) { competition.delegates.first }
+
+      before { visit "/competitions?delegate=#{delegate.id}" }
+
+      it "the delegate is selected within the form", js: true do
+        expect(page.find("#competition-query-form #delegate")).to have_text(delegate.name)
+      end
+
+      it "only competitions delegated by the given delegate are shown" do
+        expect(page).to have_selector("#competitions-list .competition-info", count: 1)
+      end
+    end
+  end
+
   context "admin view" do
     before :each do
       sign_in FactoryGirl.create(:admin)


### PR DESCRIPTION
At the moment selecting a delegate within competitions#index form and refreshing the page results in a proper list of competitions, but the delegate field doesn't show anyone.

Also [this line](https://github.com/thewca/worldcubeassociation.org/blob/3b01f03a621513a74d84a576f5f85fc4e2ed8fe1/WcaOnRails/app/views/competitions/_index_form.html.erb#L165) causes the years dropdown to appear on a page load if the past state is selected.

This PR fixes both problems.