### PR TITLE
Make linkings wca_ids not nullable

### DIFF
--- a/WcaOnRails/db/migrate/20170830140540_fix_nullable_linkings_wca_ids.rb
+++ b/WcaOnRails/db/migrate/20170830140540_fix_nullable_linkings_wca_ids.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FixNullableLinkingsWcaIds < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :linkings, :wca_ids, false
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -731,7 +731,7 @@ DROP TABLE IF EXISTS `linkings`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `linkings` (
   `wca_id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wca_ids` mediumtext COLLATE utf8mb4_unicode_ci,
+  `wca_ids` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `index_linkings_on_wca_id` (`wca_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1238,4 +1238,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20170818164058'),
 ('20170820023104'),
 ('20170823170616'),
-('20170831170616');
+('20170831170616'),
+('20170830140540');


### PR DESCRIPTION
Fixes #1846.

@jfly going through migrations since the `linkings` table creation, I don't see a reason for this issue, some weird scenario must have happened here.