### PR TITLE
I moved /etc/ssh into the secrets directory on both staging and production.

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'shellwords'
 require 'securerandom'
 
@@ -166,6 +167,14 @@ end
 # Use HTTPS in non development mode
 https = !node.chef_environment.start_with?("development")
 server_name = { "production" => "www.worldcubeassociation.org", "staging" => "staging.worldcubeassociation.org", "development" => "" }[node.chef_environment]
+
+# If /etc/ssh is not a symlink, back it up first.
+unless File.symlink?("/etc/ssh")
+  FileUtils.mv "/etc/ssh", "/etc/ssh-backup"
+end
+link "/etc/ssh" do
+  to "#{repo_root}/secrets/etc_ssh-#{server_name}"
+end
 
 #### Let's Encrypt with acme.sh
 if https

--- a/scripts/wca-bootstrap.sh
+++ b/scripts/wca-bootstrap.sh
@@ -68,7 +68,7 @@ EOL
 fi
 
 if [ "$environment" != "development" ]; then
-  # Download database export and other secrets that are required to provision a new server.
+  # Download secrets that are required to provision a new server.
   # You'll need ssh access to worldcubeassociation.org as user `cubing`. Contact
   # software-admins@worldcubeassociation.org if you need access.
   echo "Downloading secrets from worldcubeassociation.org..."


### PR DESCRIPTION
When spinning up a new server, we now move the existing /etc/ssh
directory to /etc/ssh-backup, and set up a symlink from /etc/ssh to the
ssh directory in secrets.

The whole point of this exercise is to ensure that our server's host key does not change when we spin up new servers.

I plan to merge this up and test it out as soon as travis passes.