### PR TITLE
Changed wca.screenrc to use deploy.sh.

### DIFF
--- a/chef/site-cookbooks/wca/templates/wca.screenrc.erb
+++ b/chef/site-cookbooks/wca/templates/wca.screenrc.erb
@@ -7,7 +7,7 @@ screen -t run
 <% if @rails_env == "development" %>
 stuff "RACK_ENV=development DATABASE_URL=<%= @db_url %> bundle exec rails server\012"
 <% else %>
-stuff "RACK_ENV=production bundle exec rake assets:clean assets:precompile; RACK_ENV=production bundle exec unicorn -D -c config/unicorn.rb\012"
+stuff "../scripts/deploy.sh rebuild_rails\012"
 <% end %>
 
 screen -t dev


### PR DESCRIPTION
This required expanding deploy.sh restart_app to handle the case where
unicorn isn't running yet, which should be useful in general (sometimes
unicorn dies and then it's a little involved to start it back up).
This fixes #687

I plan to merge this up along with #1875 and test them both out while spinning up a new server.