### PR TITLE
Added a scripts/servers.sh to spin up a new production server on AWS.

### DIFF
--- a/scripts/servers.sh
+++ b/scripts/servers.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+
+set -e
+
+PRODUCTION_SERVER_NAME="worldcubeassociation.org"
+TEMP_NEW_SERVER_NAME="temp-new-server-via-cli"
+ELASTIC_IP="34.208.140.116"
+
+test_ssh_to_production() {
+  local test_command='ssh -o PasswordAuthentication=no cubing@worldcubeassociation.org echo Successfulness'
+  local connected_str=`${test_command} || true`
+  if [ "${connected_str}" != "Successfulness" ]; then
+    echo "" >> /dev/stderr
+    echo "Unable to connect to the current production server." >> /dev/stderr
+    echo "You need to set up passwordless ssh to production locally before spinning up a new server." >> /dev/stderr
+    echo "If you do not know how to do this, look into ssh-copy-id." >> /dev/stderr
+    echo "When you think you've got things set up correctly, try running '${test_command}'." >> /dev/stderr
+    exit 1
+  fi
+}
+
+test_ssh_agent_forwarding() {
+  local ssh_command=$1
+
+  local test_command="${ssh_command} echo Successfulness"
+  local connected_str=`${test_command} || true`
+  if [ "${connected_str}" != "Successfulness" ]; then
+    echo "" >> /dev/stderr
+    echo "Unable to connect to the new server." >> /dev/stderr
+    echo "When you think you've got things set up correctly, try running '${test_command}'." >> /dev/stderr
+    exit 1
+  fi
+
+  local test_command="${ssh_command} ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no cubing@worldcubeassociation.org echo Successfulness"
+  local connected_str=`${test_command} || true`
+  if [ "${connected_str}" != "Successfulness" ]; then
+    echo "" >> /dev/stderr
+    echo "Unable to connect to the current production server through the newly created server." >> /dev/stderr
+    echo "This is indicative of a problem with your ssh agent forwarding. GitHub has some useful troubleshooting tips here: https://developer.github.com/v3/guides/using-ssh-agent-forwarding/#troubleshooting-ssh-agent-forwarding." >> /dev/stderr
+    echo "When you think you've got things set up correctly, try running '${test_command}'." >> /dev/stderr
+    exit 1
+  fi
+}
+
+get_instance_domain_name() {
+  local  __resultvar=$1
+  local instance_id=$2
+
+  local __domain_name=`aws ec2 describe-instances --instance-ids ${instance_id} | jq --raw-output ".Reservations[0].Instances[0].PublicDnsName"`
+  eval $__resultvar="'${__domain_name}'"
+}
+
+get_instance_internal_ip_address() {
+  local  __resultvar=$1
+  local instance_id=$2
+
+  local __ip_address=`aws ec2 describe-instances --instance-ids ${instance_id} | jq --raw-output ".Reservations[0].Instances[0].NetworkInterfaces[0].PrivateIpAddresses[0].PrivateIpAddress"`
+  eval $__resultvar="'${__ip_address}'"
+}
+
+new() {
+  print_command_usage_and_exit() {
+    echo "Usage: $0 new [keyname]" >> /dev/stderr
+    echo "For example: $0 new jfly-kaladin-arch" >> /dev/stderr
+
+    echo "" >> /dev/stderr
+    echo "Run 'aws ec2 describe-key-pairs' to see a list of valid key pairs." >> /dev/stderr
+    echo "If you do not have one associated with our account yet, you'll need to create one." >> /dev/stderr
+    echo "The directions here: http://docs.aws.amazon.com/cli/latest/userguide/cli-ec2-keypairs.html#creating-a-key-pair might help." >> /dev/stderr
+    exit 1
+  }
+  if [ $# -ne 1 ]; then
+    print_command_usage_and_exit
+  fi
+
+  keyname=$1
+  shift
+
+  pem_filename=~/.ssh/${keyname}.pem
+  if ! [ -e $pem_filename ]; then
+    echo "" >> /dev/stderr
+    echo "Could not find ${pem_filename}, I won't be able to connect to any EC2 servers until that file exists." >> /dev/stderr
+    exit 1
+  fi
+
+  test_ssh_to_production
+
+  # Spin up a new EC2 instance.
+  json=`aws ec2 run-instances \
+    --image-id ami-7c22b41c \
+    --count 1 \
+    --instance-type t2.medium \
+    --key-name $keyname \
+    --security-groups "allow all incoming" \
+    --block-device-mappings '[ { "DeviceName": "/dev/sda1", "Ebs": { "DeleteOnTermination": true, "VolumeSize": 32, "VolumeType": "standard" } } ]'`
+
+  instance_id=`echo $json | jq --raw-output '.Instances[0].InstanceId'`
+
+  get_instance_domain_name domain_name ${instance_id}
+
+  json=`aws ec2 create-tags --resources ${instance_id} --tags Key=Name,Value=${TEMP_NEW_SERVER_NAME}`
+  echo "Allocated new server with instance id: $instance_id and named it ${TEMP_NEW_SERVER_NAME}."
+  echo "Its public dns name is ${domain_name}."
+
+  echo -n "Waiting for ${TEMP_NEW_SERVER_NAME} to finish initializing..."
+  aws ec2 wait instance-status-ok --instance-ids ${instance_id}
+  echo " done!"
+
+  ssh_command="ssh -i ${pem_filename} -o StrictHostKeyChecking=no -A ubuntu@${domain_name}"
+
+  test_ssh_agent_forwarding "${ssh_command}"
+
+  echo "For debugging purposes, you can ssh to the server via '${ssh_command}'"
+  echo "Bootstrapping the newly created server..."
+  # See http://ubuntu-smoser.blogspot.com/2010/07/verify-ssh-keys-on-ec2-instances.html or
+  # https://alestic.com/2012/04/ec2-ssh-host-key/ for better solutions than
+  # setting StrictHostKeyChecking=no.
+  ${ssh_command} -A 'sudo wget https://raw.githubusercontent.com/thewca/worldcubeassociation.org/master/scripts/wca-bootstrap.sh -O /tmp/wca-bootstrap.sh && sudo -E bash /tmp/wca-bootstrap.sh production'
+
+  # After bootstrapping the new server, it will have a new host key. To avoid future errors like
+  #
+  #  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+  #  @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+  #  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+  #
+  # we remove the now invalid host key associated with this domain name.
+  ssh-keygen -R ${domain_name}
+}
+
+function passthetorch() {
+  print_command_usage_and_exit() {
+    echo "Usage: $0 passthetorch" >> /dev/stderr
+    echo "For example: $0 passthetorch" >> /dev/stderr
+    exit 1
+  }
+  if [ $# -ne 0 ]; then
+    print_command_usage_and_exit
+  fi
+
+  find_instance_by_name() {
+    local  __resultvar=$1
+    local instance_name=$2
+
+    local running_instances=`aws ec2 describe-instances | jq ".Reservations[] | .Instances[] | select(.State.Name == \"running\")"`
+    local instance_id=`echo "${running_instances}" | jq --raw-output "select((.Tags[] | select(.Key == \"Name\") | .Value) == \"${instance_name}\") | .InstanceId"`
+    local instances_count=`count_lines "${instance_id}"`
+    if [ "${instances_count}" != "1" ]; then
+      echo "Found ${instances_count} running instances named ${instance_name}, when I expected to find exactly 1." >> /dev/stderr
+      echo "I'm giving up now." >> /dev/stderr
+      exit 1
+    fi
+    eval $__resultvar="'$instance_id'"
+  }
+
+  find_instance_by_name production_instance_id ${PRODUCTION_SERVER_NAME}
+  echo "Found instance '${PRODUCTION_SERVER_NAME}' with id ${production_instance_id}!"
+
+  find_instance_by_name new_server_id ${TEMP_NEW_SERVER_NAME}
+  echo "Found instance '${TEMP_NEW_SERVER_NAME}' with id ${new_server_id}!"
+
+  get_instance_domain_name domain_name ${new_server_id}
+  echo "Testing out new server at ${domain_name}"
+
+  # Do a quick smoke test of the new server.
+  local ip_address=`dig +short ${domain_name}`
+  curl_cmd="curl --write-out %{http_code} --silent --resolve www.worldcubeassociation.org:443:${ip_address} https://www.worldcubeassociation.org/server-status"
+  curl_result=`${curl_cmd}`
+
+  ip_addresses=`echo "$curl_result" | grep -o "IP Addresses: [^ <]\+"`
+  get_instance_internal_ip_address expected_ip ${new_server_id}
+  if ! echo $ip_addresses | grep ${expected_ip} > /dev/null; then
+    echo "" >> /dev/stderr
+    echo "When visiting https://www.worldcubeassociation.org/server-status via server ${ip_address}, we expected to see internal IP address ${expected_ip}, but instead found ${ip_addresses}" >> /dev/stderr
+    exit 1
+  fi
+
+  server_status=`echo "$curl_result" | tail -1`
+  if [ "${server_status}" != "200" ]; then
+    echo "" >> /dev/stderr
+    echo "https://www.worldcubeassociation.org/server-status returned non 200 status code: ${server_status}" >> /dev/stderr
+    echo "You can test this out by running: ${curl_cmd}" >> /dev/stderr
+    exit 1
+  fi
+
+  echo "The new server at ${domain_name} appears to be working."
+  echo "We're ready to assign it the elastic ip address ${ELASTIC_IP}"
+
+  user_confirmation_str=""
+  confirmation_str="HOLD ONTO YOUR BUTTS"
+  while [ "${user_confirmation_str}" != "${confirmation_str}" ]; do
+    echo "Please type \"${confirmation_str}\" and press enter before proceeding."
+    echo -n "> "
+    read user_confirmation_str
+  done
+
+  aws ec2 associate-address --public-ip ${ELASTIC_IP} --instance-id ${new_server_id}
+}
+
+# Copied from https://stackoverflow.com/a/17841619
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+# Copied from https://stackoverflow.com/a/8574392
+containsElement() {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
+
+assert_eq() {
+  if [ "$1" != "$2" ]; then
+    echo "Expected '$1' to equal '$2'." >> /dev/stderr
+    exit 1
+  fi
+}
+
+# Inspired by https://stackoverflow.com/a/16533786
+count_lines() {
+  echo -n "$1" | awk 'END{print NR}'
+}
+assert_eq `count_lines ''` "0"
+assert_eq `count_lines 'foo'` "1"
+assert_eq `count_lines $'foo\n'` "1"
+assert_eq `count_lines $'foo\nbar'` "2"
+assert_eq `count_lines $'foo\nbar\n'` "2"
+
+COMMANDS=(new passthetorch)
+JOINED_COMMANDS=`join_by "|" "${COMMANDS[@]}"`
+print_usage_and_exit() {
+  echo "Usage: $0 [$JOINED_COMMANDS]" >> /dev/stderr
+  exit 1
+}
+if [ $# -eq 0 ]; then
+  print_usage_and_exit
+fi
+
+COMMAND=$1
+if ! containsElement "$COMMAND" "${COMMANDS[@]}"; then
+  echo "Unrecognized command: $COMMAND" >> /dev/stderr
+  print_usage_and_exit
+fi
+shift
+
+if [ "$COMMAND" == "new" ]; then
+  new "$@"
+elif [ "$COMMAND" == "passthetorch" ]; then
+  passthetorch "$@"
+fi


### PR DESCRIPTION
I'm testing this script out right now, and will update this description with the results of my test. There are 3 main subcommands to this script: `new`, `passthetorch`, and `reap-servers`.

## new

This is basically a port of our wiki on [Spinning up a new server part 1](https://github.com/thewca/worldcubeassociation.org/wiki/Spinning-up-a-new-server-part-1) (creating a new server named `temp-new-server-via-cli` and bootstrapping it). I had to fix a frustratingly large number of bugs with our chef scripts to get this working properly (#1887, #1886, #1885, #1882, #1881, #1880, #1878, #1876).

```
~/gitting/worldcubeassociation.org @kaladin> time scripts/servers.sh new jfly-kaladin-arch
Allocated new server with instance id: i-0a8478c4ce19aa5e8 and named it temp-new-server-via-cli.
Its public dns name is ec2-34-212-181-254.us-west-2.compute.amazonaws.com.
Waiting for temp-new-server-via-cli to finish initializing... done!
Warning: Permanently added 'ec2-34-212-181-254.us-west-2.compute.amazonaws.com,34.212.181.254' (ECDSA) to the list of known hosts.
Warning: Permanently added 'worldcubeassociation.org,34.208.140.116' (ECDSA) to the list of known hosts.
For debugging purposes, you can ssh to the server via 'ssh -i /home/jeremy/.ssh/jfly-kaladin-arch.pem -o StrictHostKeyChecking=no -A ubuntu@ec2-34-212-181-254.us-west-2.compute.amazonaws.com'
Bootstrapping the newly created server...
--2017-08-31 20:22:04--  https://raw.githubusercontent.com/thewca/worldcubeassociation.org/master/scripts/wca-bootstrap.sh
...
[2017-08-31T20:55:47+00:00] INFO: Chef Run complete in 1420.6019635 seconds
[2017-08-31T20:55:47+00:00] INFO: Skipping removal of unused files from the cache
[2017-08-31T20:55:47+00:00] INFO: Running report handlers
[2017-08-31T20:55:47+00:00] INFO: Report handlers complete
# Host ec2-34-212-181-254.us-west-2.compute.amazonaws.com found: line 122
/home/jeremy/.ssh/known_hosts updated.
Original contents retained as /home/jeremy/.ssh/known_hosts.old

Successfully spun up new server at ec2-34-212-181-254.us-west-2.compute.amazonaws.com
Run 'scripts/servers.sh passthetorch' to test out the new server and possibly switchover to it.

real	38m17.946s
user	0m3.449s
sys	0m1.790s
```

**As you can see above, creating a new server and bootstrapping it takes just under 40 minutes.**

## passthetorch

The `passthetorch` subcommand automates [Spinning up a new server part 2](https://github.com/thewca/worldcubeassociation.org/wiki/Spinning-up-a-new-server-part-2) (basically, changing our elastic ip address to point at the new server and updating server descriptions). Currently, this command is interactive: it does some smoke tests of the new server, and if everything looks good, it updates your `/etc/hosts` file and tells you to poke around a bit. Once you've confirmed that things look good, you must type "HOLD ONTO YOUR BUTTS" and press enter. After that, it will change the server descriptions so the new production server is called `www.worldcubeassociation.org`, and the old production server is called `DELETEME_old_www.worldcubeassociation.org`.

```bash
~/gitting/worldcubeassociation.org @kaladin> scripts/servers.sh passthetorch
Found instance 'www.worldcubeassociation.org' with id i-05bad8e5a0609e6ba!
Found instance 'temp-new-server-via-cli' with id i-0a8478c4ce19aa5e8!
Testing out new server at ec2-34-212-181-254.us-west-2.compute.amazonaws.com
The new server at ec2-34-212-181-254.us-west-2.compute.amazonaws.com appears to be working.
We're almost ready to assign it the elastic ip address 34.208.140.116
Found instance 'temp-new-server-via-cli' with id i-0a8478c4ce19aa5e8 at ec2-34-212-181-254.us-west-2.compute.amazonaws.com (34.212.181.254)!
Backed up /etc/hosts to /etc/hosts.old and added entry for worldcubeassociation.org.
NOTE: This server is not live yet! I just added an entry to your hostsfile (www.worldcubeassociation.org should now resolve to 34.212.181.254) so you can test it out manually before we switchover the elastic ip address.
Try visiting https://www.worldcubeassociation.org/server-status in your web browser. At the bottom, you should see ip address 172.31.5.225.
If you do not, then our attempt to edit /etc/hosts probably failed and you're still communicating with the current production server.
If everything looks good, then run 'scripts/servers.sh passthetorch' to switchover to the new server.
Please type "HOLD ONTO YOUR BUTTS" and press enter before proceeding.
> HOLD ONTO YOUR BUTTS
Backed up /etc/hosts to /etc/hosts.old and removed entry for worldcubeassociation.org.
{
    "AssociationId": "eipassoc-ad1c7f91"
}

The new server with id i-0a8478c4ce19aa5e8 is now live with the elastic ip 34.208.140.116!
Renamed server i-05bad8e5a0609e6ba to DELETEME_old_www.worldcubeassociation.org.
Renamed server i-0a8478c4ce19aa5e8 to www.worldcubeassociation.org.
Don't forget to terminate the old server named DELETEME_old_www.worldcubeassociation.org!
You can do this by running 'scripts/servers.sh reap-servers'.
```

## reap-servers

After the new server goes live, you still need to kill the old server (now named `DELETEME_old_www.worldcubeassociation.org`). This command prompts the user before actually doing anything destructive:

```
~/gitting/worldcubeassociation.org @kaladin> scripts/servers.sh reap-servers
Found instance 'DELETEME_old_www.worldcubeassociation.org' with id i-05bad8e5a0609e6ba!
I am going to terminate DELETEME_old_www.worldcubeassociation.org
Please type "HOLD ONTO YOUR BUTTS" and press enter before proceeding.
> HOLD ONTO YOUR BUTTS
{
    "TerminatingInstances": [
        {
            "InstanceId": "i-05bad8e5a0609e6ba",
            "CurrentState": {
                "Code": 32,
                "Name": "shutting-down"
            },
            "PreviousState": {
                "Code": 16,
                "Name": "running"
            }
        }
    ]
}

Successfully terminated DELETEME_old_www.worldcubeassociation.org
```

# Note

I intentionally wrote `passthetorch` and `reap-servers` in a way that requires user input. I am open to removing the user input and combining all 3 steps, but I was thinking it would make more sense to do that in a later PR. My thinking was that we should use this new script for a while and learn what sort of issues arise before we fully automate everything. This is already a huge step forward. I'm open to being convinced I'm wrong about this, however.