### PR TITLE
Set up supervisor before running the default recipe

### DIFF
--- a/chef/roles/wca.json
+++ b/chef/roles/wca.json
@@ -31,12 +31,12 @@
     "recipe[openssh]",
     "recipe[timezone_lwrp]",
     "recipe[wca::base]",
+    "recipe[wca::supervisor]",
     "recipe[wca]",
     "recipe[wca::regulations]",
     "recipe[wca::email]",
     "recipe[wca::cronjobs]",
     "recipe[wca::newrelic]",
-    "recipe[wca::supervisor]",
     "recipe[wca::backup]"
   ],
   "env_run_lists": {


### PR DESCRIPTION
This fixes a bug introduced by #1876, which made the default recipe indirectly depend on supervisorctl existing. Here's how:

- The default recipe calls `startall`.
- Thanks to #1876, `startall` now uses `deploy.sh`
- `deploy.sh` calls `supervisorctl`