### PR TITLE
Yet another attempt at fixing #687

### DIFF
--- a/chef/site-cookbooks/wca/recipes/supervisor.rb
+++ b/chef/site-cookbooks/wca/recipes/supervisor.rb
@@ -7,10 +7,4 @@ template "/etc/supervisor/conf.d/workers.conf" do
   variables({
     repo_root: repo_root,
   })
-  notifies :run, 'execute[supervisor-update]', :delayed
-end
-
-execute "supervisor-update" do
-  command "supervisorctl update"
-  action :nothing
 end

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -126,6 +126,7 @@ rebuild_regs() {
 }
 
 restart_dj() {
+  sudo supervisorctl update
   sudo supervisorctl restart workers:*
 }
 


### PR DESCRIPTION
Currently, our server dies while starting up and attempting to restart the workers:

```
++ restart_dj
++ sudo supervisorctl restart 'workers:*'
error: <class 'xmlrpclib.Fault'>, <Fault 10: 'BAD_NAME: workers'>: file: /usr/lib/python2.7/xmlrpclib.py line: 794
```