### PR TITLE
Add the server's ip addresses to the bottom of server status.

### DIFF
--- a/WcaOnRails/app/views/server_status/index.html.erb
+++ b/WcaOnRails/app/views/server_status/index.html.erb
@@ -79,7 +79,8 @@
     {
         "PID": Process.pid,
         "Uptime": duration_to_s(Time.now - WcaOnRails::BOOTED_AT),
-        "Git commit": link_to(sha1.first(7), "https://github.com/thewca/worldcubeassociation.org/commit/#{sha1}")
+        "Git commit": link_to(sha1.first(7), "https://github.com/thewca/worldcubeassociation.org/commit/#{sha1}"),
+        "IP Addresses": Socket.ip_address_list.select(&:ipv4_private?).map(&:ip_address).join(","),
     }.map { |key, value| "#{key}: #{value}" }.join(" #{icon "circle"} ").html_safe
   end %>
 


### PR DESCRIPTION
This will be useful for automating spinning up new servers.