### PR TITLE
The regulations need libxrender1 to build.

### DIFF
--- a/chef/site-cookbooks/wca/recipes/regulations.rb
+++ b/chef/site-cookbooks/wca/recipes/regulations.rb
@@ -7,6 +7,7 @@ package "fonts-unfonts-core"
 package "fonts-wqy-microhei"
 package "fonts-ipafont"
 package "lmodern"
+package "libxrender1"
 
 bash "install_wkhtmltopdf" do
   not_if "/usr/local/bin/wkhtmltopdf --version | grep -q 'with patched qt'"


### PR DESCRIPTION
Previously we were building the regulations after rails. Our rails setup
installs imagemagick, which installed libmagickcore5-extra, which
installed libcairo2, which installed libxrender1.

Thanks @FatBoyXPC for the help verifiying this chain of dependencies! `apt-cache redepends` is a terribly useful command:

```
~ @production> apt-cache rdepends --installed libxrender1
libxrender1
Reverse Depends:
 libcairo2
 libcairo2
~ @production> apt-cache rdepends --installed libcairo2
libcairo2
Reverse Depends:
 libmagickcore5-extra
 libpangocairo-1.0-0
 libmagickcore5-extra
 librsvg2-2
 libpangocairo-1.0-0
 libmagickcore5-extra
~ @production> apt-cache rdepends --installed libmagickcore5-extra
libmagickcore5-extra
Reverse Depends:
 imagemagick
 libmagickcore5
 libmagickcore5
 imagemagick
 libmagickcore5
 imagemagick
```