### PR TITLE
Restart ssh after making changes to its config so they actually take effect.

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -172,6 +172,9 @@ server_name = { "production" => "www.worldcubeassociation.org", "staging" => "st
 unless File.symlink?("/etc/ssh")
   FileUtils.mv "/etc/ssh", "/etc/ssh-backup"
   FileUtils.ln_s "#{repo_root}/secrets/etc_ssh-#{server_name}", "/etc/ssh"
+  service "ssh" do
+    action :restart
+  end
 end
 
 #### Let's Encrypt with acme.sh


### PR DESCRIPTION
(I broke this in #1875)

Thanks to @jonatanklosko for noticing that our production server did not have password ssh enabled.

I ran `sudo service ssh restart` on production and the problem went away, so I'm adding an explicit call to service restart in chef so we don't run into this problem again. After merging this PR up, I'll spin up a new server to see if things are working.