### PR TITLE
The managed_by scope did not work when a competition has no organizers

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -51,10 +51,12 @@ class Competition < ApplicationRecord
     ).where("e#{event_id}.id = :event_id", event_id: event_id)
   }
   scope :managed_by, lambda { |user_id|
-    joins(:competition_organizers, :competition_delegates).where(
-      "delegate_id = :user_id OR organizer_id = :user_id",
-      user_id: user_id,
-    ).group(:id)
+    joins("LEFT JOIN competition_organizers ON competition_organizers.competition_id = Competitions.id")
+      .joins("LEFT JOIN competition_delegates ON competition_delegates.competition_id = Competitions.id")
+      .where(
+        "delegate_id = :user_id OR organizer_id = :user_id",
+        user_id: user_id,
+      ).group(:id)
   }
 
   CLONEABLE_ATTRIBUTES = %w(

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -692,4 +692,26 @@ RSpec.describe Competition do
       expect(Competition.contains('wes').contains('blah').first).to eq nil
     end
   end
+
+  describe "#managed_by" do
+    let(:delegate1) { FactoryGirl.create(:delegate) }
+    let(:delegate2) { FactoryGirl.create(:delegate) }
+    let(:organizer1) { FactoryGirl.create(:user) }
+    let(:organizer2) { FactoryGirl.create(:user) }
+    let!(:competition) {
+      FactoryGirl.create(:competition, :confirmed, delegates: [delegate1, delegate2], organizers: [organizer1, organizer2])
+    }
+    let!(:competition_without_organizers) {
+      FactoryGirl.create(:competition, :confirmed, delegates: [delegate1, delegate2], organizers: [])
+    }
+    let!(:other_comp) { FactoryGirl.create(:competition) }
+
+    it "finds comps by delegate" do
+      expect(Competition.managed_by(delegate1.id)).to match_array [competition, competition_without_organizers]
+    end
+
+    it "finds comps by organizer" do
+      expect(Competition.managed_by(organizer1.id)).to match_array [competition]
+    end
+  end
 end


### PR DESCRIPTION
This is because it was doing an inner join, rather than an outer join.

## Previous query
With an inner join, if the join on organizers doesn't find anything, then no rows are returned.

```mysql
  Competition Load (15.2ms)  SELECT  `Competitions`.* FROM `Competitions` INNER JOIN `competition_organizers` ON `competition_organizers`.`competition_id` = `Competitions`.`id` INNER JOIN `competition_delegates` ON `competition_delegates`.`competition_id` = `Competitions`.`id` WHERE (delegate_id = 8 OR organizer_id = 8) GROUP BY `Competitions`.`id` LIMIT 11
```

## New query
With a left join, if the join on organizers doesn't find anything, then the row is still returned, but the organizer_id is NULL.

```mysql
  Competition Load (3.2ms)  SELECT  `Competitions`.* FROM `Competitions` LEFT JOIN competition_organizers ON competition_organizers.competition_id=Competitions.id LEFT JOIN competition_delegates ON competition_delegates.competition_id=Competitions.id WHERE (delegate_id = 8 OR organizer_id = 8) GROUP BY `Competitions`.`id` LIMIT 11
```