### PR TITLE
Fix updating by sub id.

### DIFF
--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -87,6 +87,7 @@ class Person < ApplicationRecord
 
   # Update the person attributes and save the old state as a new Person with greater subId.
   def update_using_sub_id(attributes)
+    attributes = attributes.to_h
     @updating_using_sub_id = true
     if attributes.slice(:name, :countryId).all? { |k, v| v.nil? || v == self.send(k) }
       errors[:base] << "The name or the country must be different to update the person."


### PR DESCRIPTION
This stopped to work saying `NoMethodError (undefined method 'all?' for #<ActionController::Parameters:0x0000000abf8ec0>)`.

`attributes` are person params passed from a controller, so I suspect they do no longer behave exactly like a hash and thus using `#all?` fails.

Straightforward, deploying as soon as Travis passes, so that WRT can use it.