### PR TITLE
Revert "Bump blocks from 2.8.0 to 3.0.0 in /WcaOnRails"

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -95,8 +95,9 @@ GEM
     bindex (0.5.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    blocks (3.0.0)
-      call_with_params
+    blocks (2.8.0)
+      call_with_params (~> 0.0.2)
+      hashie
       rails (>= 3.0.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)


### PR DESCRIPTION
Reverts thewca/worldcubeassociation.org#1975

The new version of blocks seems to have broken the icons along the competitions nav bar:

![image](https://user-images.githubusercontent.com/277474/30984204-87ffa248-a441-11e7-9085-c165bfade3bf.png)
