### PR TITLE
Update website of Russian organization

### DIFF
--- a/WcaOnRails/app/views/static_pages/organizations.html.erb
+++ b/WcaOnRails/app/views/static_pages/organizations.html.erb
@@ -120,7 +120,7 @@
        {
          country: "Russia",
          name: "Speedcubing.ru",
-         url: "http://www.speedcubing.ru",
+         url: "https://speedcubing.ru",
          logo: "speedcubing.ru.png",
        },
        {


### PR DESCRIPTION
Remove "www." and replace "http" with "https". Otherwise Chrome doesn't open this site, as the certificate issued only for "speedcubing.ru".