### PR TITLE
Update to blocks 3.0.0 and adopt API changes

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -95,9 +95,8 @@ GEM
     bindex (0.5.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    blocks (2.8.0)
-      call_with_params (~> 0.0.2)
-      hashie
+    blocks (3.0.0)
+      call_with_params
       rails (>= 3.0.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -98,9 +98,7 @@
 
       <% blocks.define :nav_list do |nav_items| %>
         <div class="list-group list-group-root">
-          <% nav_items.each do |nav_item| %>
-            <%= blocks.render :nav_list_item, nav_item %>
-          <% end %>
+          <%= blocks.render :nav_list_item, collection: nav_items %>
         </div>
       <% end %>
 
@@ -117,7 +115,7 @@
         <% if !nav_item[:hidden] %>
 
           <%= link_to nav_item[:path], class: "list-group-item" + (nav_item[:active] ? ' active' : '') do %>
-            <%= blocks.render :nav_icon, nav_item %>
+            <%= blocks.render :nav_icon, nav_item, {} %>
             <%= nav_item[:text] %>
             <% if nav_item[:notification_count] %>
               <span id="pending-registrations-count" class="pull-right label <%= nav_item[:notification_count] > 0 ? "label-danger" : "label-success" %>">
@@ -140,7 +138,7 @@
                                   placement: "top",
                                   container: "body",
                                 } do %>
-                      <%= blocks.render :nav_icon, child_nav_item %>
+                      <%= blocks.render :nav_icon, child_nav_item, {} %>
                     <% end %>
                   <% end %>
                 </span>
@@ -149,9 +147,7 @@
 
             <% if nav_item[:children] && nav_item[:children].length > 0 %>
               <div class="list-group">
-                <% nav_item[:children].each do |child_nav_item| %>
-                  <%= blocks.render :nav_list_item, child_nav_item %>
-                <% end %>
+                <%= blocks.render :nav_list_item, collection: nav_item[:children] %>
               </div>
             <% end %>
           <% end %>


### PR DESCRIPTION
Reverting #1977 after fixing incompatibilities with the new version of blocks.