### PR TITLE
Add warnings to old scrambling programs

### DIFF
--- a/regulations/build/regulations/history/files/scrambles/scramble_clock.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_clock.htm
@@ -1,10 +1,14 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<title>Rubik's Clock scramble</title>
+<title>Legacy Rubik's Clock scramble</title>
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
 </head>
 <body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 <table width="100%">
 <tbody>
 <tr>

--- a/regulations/build/regulations/history/files/scrambles/scramble_cube.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_cube.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"> 
 <html> 
-<head><title>WCA Official Cube scrambler</title> 
+<head><title>Legacy WCA Official Cube scrambler</title> 
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252"> 
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--
@@ -425,6 +425,10 @@ function setForm(){
 </head> 
  
 <body bgcolor="white" onload="setForm();"> 
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
  
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--

--- a/regulations/build/regulations/history/files/scrambles/scramble_cube_222.html
+++ b/regulations/build/regulations/history/files/scrambles/scramble_cube_222.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html><head> 
  
-<title>WCA Random Position 2x2x2 Cube scrambler</title> 
+<title>Legacy WCA Random Position 2x2x2 Cube scrambler</title> 
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252"> 
 <script language="JavaScript" type="text/javascript"> 
 <!--
@@ -571,7 +571,11 @@ function setForm(){
 //--> 
 </script> 
  
-</head><body onload="setForm();" bgcolor="white"> 
+</head><body onload="setForm();" bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
  
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--

--- a/regulations/build/regulations/history/files/scrambles/scramble_cube_222old.html
+++ b/regulations/build/regulations/history/files/scrambles/scramble_cube_222old.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html><head> 
  
-<title>WCA Random Position 2x2x2 Cube scrambler</title> 
+<title>Legacy WCA Random Position 2x2x2 Cube scrambler</title> 
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252"> 
 <script language="JavaScript" type="text/javascript"> 
 <!--
@@ -572,7 +572,11 @@ function setForm(){
 </script> 
  
 </head><body onload="setForm();" bgcolor="white"> 
- 
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
+
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--
 document.writeln("\

--- a/regulations/build/regulations/history/files/scrambles/scramble_megaminx.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_megaminx.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-<head><title>Megaminx scrambler</title>
+<head><title>Legacy Megaminx scrambler</title>
 
 <script language="JavaScript1.1" type="text/javascript">
 <!--
@@ -86,6 +86,10 @@ function scramblestring(n){
 </head>
 
 <body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 
 <form name="frm">
 <table border=1 cellpadding=0 cellspacing=0 width="100%"><tr>

--- a/regulations/build/regulations/history/files/scrambles/scramble_megaminx2008.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_megaminx2008.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-<head><title>Megaminx scrambler</title>
+<head><title>Legacy Megaminx scrambler</title>
 
 <script language="JavaScript1.1" type="text/javascript">
 <!--
@@ -66,6 +66,10 @@ function scramblestring(n){
 </head>
 
 <body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 
 <form name="frm">
 <table border=1 cellpadding=0 cellspacing=0 width='100%'><tr>
@@ -99,7 +103,7 @@ R means all layers right from the L face together in one move.<br>
 ++ means 2/5 move clockwise (144 degrees), -- means 2/5 move counterclockwise (-144 degrees).<br>
 U is the regular move of the U face, according to standard cube notation.<br>
 <br>
-Program by Clément Gallet, based on earlier work by Jaap Scherphuis. Idea by Stefan Pochmann.
+Program by ClÃ©ment Gallet, based on earlier work by Jaap Scherphuis. Idea by Stefan Pochmann.
 
 </body>
 </html>

--- a/regulations/build/regulations/history/files/scrambles/scramble_pyraminx.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_pyraminx.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-<head><title>Pyraminx scrambler</title>
+<head><title>Legacy Pyraminx scrambler</title>
 
 <script language="JavaScript1.1" type="text/javascript">
 <!--
@@ -251,6 +251,10 @@ function imagetable(n)
 </head>
 
 <body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 
 <form name="frm">
 <table border=1 cellpadding=0 cellspacing=0 width="100%"><tr>

--- a/regulations/build/regulations/history/files/scrambles/scramble_pyraminx2009.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_pyraminx2009.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-<head><title>Pyraminx scrambler (Uniform Random-State)</title>
+<head><title>Legacy Pyraminx scrambler (Uniform Random-State)</title>
 
 <script language="JavaScript1.1" type="text/javascript">
 <!--
@@ -250,6 +250,10 @@ function imagetable(n)
 </head>
 
 <body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 
 <form name="frm">
 <table border=1 cellpadding=0 cellspacing=0 width="100%"><tr>

--- a/regulations/build/regulations/history/files/scrambles/scramble_pyraminx2009old.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_pyraminx2009old.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-<head><title>Pyraminx scrambler (Uniform Random-State)</title>
+<head><title>Legacy Pyraminx scrambler (Uniform Random-State)</title>
 
 <script language="JavaScript1.1" type="text/javascript">
 <!--
@@ -241,6 +241,10 @@ function imagetable(n)
 </head>
 
 <body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 
 <form name="frm">
 <table border=1 cellpadding=0 cellspacing=0 width="100%"><tr>

--- a/regulations/build/regulations/history/files/scrambles/scramble_pyraminx2010.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_pyraminx2010.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"> 
 <html> 
-<head><title>Pyraminx scrambler (Uniform Random-State)</title> 
+<head><title>Legacy Pyraminx scrambler (Uniform Random-State)</title> 
  
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--
@@ -511,7 +511,11 @@ function imagetable(n)
 </script> 
 </head> 
  
-<body bgcolor="white"> 
+<body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
  
 <form name="frm"> 
 <table border=1 cellpadding=0 cellspacing=0 width="100%"><tr> 

--- a/regulations/build/regulations/history/files/scrambles/scramble_square1.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_square1.htm
@@ -1,7 +1,7 @@
 <!-- saved from url=(0022)http://internet.e-mail -->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-<head><title>Square-1 scrambler</title>
+<head><title>Legacy Square-1 scrambler</title>
 
 <script language="JavaScript1.1" type="text/javascript">
 <!--
@@ -128,6 +128,10 @@ function domove(m){
 </head>
 
 <body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 
 <form name="frm">
 <table border=1 cellpadding=0 cellspacing=0 width="100%">

--- a/regulations/build/regulations/history/files/scrambles/scramble_square1_2010.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_square1_2010.htm
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"> 
 <html><head> 
 <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1"> 
-<title>Square-1 scrambler</title> 
+<title>Legacy Square-1 scrambler</title> 
 <script type="text/javascript" src="wz_jsgraphics.js"></script> 
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--
@@ -269,7 +269,11 @@ function drawSq(stickers, shapes, canvas) {
 //-->
 </script> 
 </head> 
-<body bgcolor="white"> 
+<body bgcolor="white">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
  
 <form name="frm"> 
 <table border=1 cellpadding=0 cellspacing=0 width="100%"> 

--- a/regulations/build/regulations/history/files/scrambles/scramble_ufo.htm
+++ b/regulations/build/regulations/history/files/scrambles/scramble_ufo.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-<head><title>Rubik's Ufo scrambler</title>
+<head><title>Legacy Rubik's Ufo scrambler</title>
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
 <script language="JavaScript1.1" type="text/javascript">
 <!--
@@ -203,6 +203,10 @@ function setForm(){
 </head>
 
 <body bgcolor="white" onload="setForm();">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
 <!-- following code added by server. PLEASE REMOVE -->
 <!-- preceding code added by server. PLEASE REMOVE -->
 <script language="JavaScript1.1" type="text/javascript">

--- a/regulations/build/regulations/history/files/scrambles/test_scramble_cube.htm
+++ b/regulations/build/regulations/history/files/scrambles/test_scramble_cube.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"> 
 <html> 
-<head><title>WCA Official Cube scrambler</title> 
+<head><title>Legacy WCA Official Cube scrambler</title> 
 <meta http-equiv="Content-Type" content="text/html; charset=windows-1252"> 
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--
@@ -428,7 +428,11 @@ function setForm(){
  
 </head> 
  
-<body bgcolor="white" onload="setForm();"> 
+<body bgcolor="white" onload="setForm();">
+  <div style="color:#721c24; background-color:#f8d7da; font-size:2rem;">
+    This scrambling program is no longer used and only kept for legacy purposes.
+    The current official scrambling program can be found <a href="https://www.worldcubeassociation.org/regulations/scrambles/">here</a>.
+  </div>
  
 <script language="JavaScript1.1" type="text/javascript"> 
 <!--


### PR DESCRIPTION
Fixes #1851

Yep, inline style :scream:, but I think that's the best way to update these old files without doing a lot of fundamental changes.
The original files can still be downloaded in the zip file ([here](https://github.com/thewca/worldcubeassociation.org/blob/regulations-data/regulations/build/regulations/history/files/scrambles.zip)).

Here is a screenshot of the Rubik's Ufo scramble program:

![screenshot_2017-10-04_18-21-24](https://user-images.githubusercontent.com/362249/31187050-e025fa1e-a930-11e7-91a9-2124260c0757.png)
