### PR TITLE
Delegates can change championship_type of an unconfirmed competition.

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/email.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/email.css.scss
@@ -1,0 +1,3 @@
+h2.alert {
+  color: red;
+}

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -563,12 +563,12 @@ class CompetitionsController < ApplicationController
         :competitor_limit_reason,
         :remarks,
         competition_events_attributes: [:id, :event_id, :_destroy],
+        championships_attributes: [:id, :championship_type, :_destroy],
       ]
       if current_user.can_admin_results?
         permitted_competition_params += [
           :isConfirmed,
           :showAtAll,
-          { championships_attributes: [:id, :championship_type, :_destroy] },
         ]
       end
     end

--- a/WcaOnRails/app/models/championship.rb
+++ b/WcaOnRails/app/models/championship.rb
@@ -6,4 +6,15 @@ class Championship < ApplicationRecord
   validates_presence_of :competition
   validates :championship_type, uniqueness: { scope: :competition_id },
                                 inclusion: { in: ["world", *Continent.all.map(&:id), *Country.all.map(&:iso2), *EligibleCountryIso2ForChampionship.championship_types] }
+  def name
+    return "World Championship" if championship_type == "world"
+
+    return "Greater China Championship" if championship_type == "greater_china"
+
+    continent = Continent.c_find(championship_type)
+    return "Continental Championship for #{continent.name}" if continent
+
+    country = Country.find_by_iso2(championship_type)
+    return "National Championship for #{country.name}" if country
+  end
 end

--- a/WcaOnRails/app/models/championship.rb
+++ b/WcaOnRails/app/models/championship.rb
@@ -6,6 +6,7 @@ class Championship < ApplicationRecord
   validates_presence_of :competition
   validates :championship_type, uniqueness: { scope: :competition_id },
                                 inclusion: { in: ["world", *Continent.all.map(&:id), *Country.all.map(&:iso2), *EligibleCountryIso2ForChampionship.championship_types] }
+
   def name
     return "World Championship" if championship_type == "world"
 

--- a/WcaOnRails/app/views/competitions_mailer/notify_board_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_board_of_confirmed_competition.html.erb
@@ -1,5 +1,9 @@
 <h1><%= @competition.name %> is confirmed</h1>
 
+<% if @competition.championships.present? %>
+  <h2>This competition is marked as <%= @competition.championships.map(&:name).sort.to_sentence %></h2>
+<% end %>
+
 <% if @competition.remarks.present? %>
   <p>
     <%= @confirmer.name %> says: <%= @competition.remarks %>

--- a/WcaOnRails/app/views/competitions_mailer/notify_board_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_board_of_confirmed_competition.html.erb
@@ -1,8 +1,8 @@
 <h1><%= @competition.name %> is confirmed</h1>
 
 <% if @competition.championships.present? %>
-  <h2>This competition is marked as <%= @competition.championships.map(&:name).sort.to_sentence %></h2>
-<% end %>
+  <h2 class="alert">This competition is marked as <%= @competition.championships.map(&:name).sort.to_sentence %></h2>
+  <% end %>
 
 <% if @competition.remarks.present? %>
   <p>

--- a/WcaOnRails/app/views/layouts/mailer.html.erb
+++ b/WcaOnRails/app/views/layouts/mailer.html.erb
@@ -1,4 +1,7 @@
 <html>
+  <head>
+    <%= stylesheet_link_tag 'email' %>
+  </head>
   <body>
     <%= yield %>
   </body>

--- a/WcaOnRails/config/initializers/assets.rb
+++ b/WcaOnRails/config/initializers/assets.rb
@@ -11,3 +11,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w(oms.js)
+Rails.application.config.assets.precompile += %w(email.css)

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -95,7 +95,7 @@ FactoryGirl.define do
       currency_code "AUD"
       # This is an actual test stripe account set up
       # for testing Stripe payments, and is connected
-      # to the WCA Stripe account. For more inforamtion, see
+      # to the WCA Stripe account. For more information, see
       # https://github.com/thewca/worldcubeassociation.org/wiki/Payments-with-Stripe
       connected_stripe_account_id "acct_19ZQVmE2qoiROdto"
     end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     let(:delegate) { FactoryGirl.create :delegate, senior_delegate: senior_delegate }
     let(:second_delegate) { FactoryGirl.create :delegate, senior_delegate: senior_delegate }
     let(:third_delegate) { FactoryGirl.create :delegate }
-    let(:competition) { FactoryGirl.create :competition, :with_competitor_limit, delegates: [delegate, second_delegate, third_delegate] }
+    let(:competition) { FactoryGirl.create :competition, :with_competitor_limit, championship_types: %w(world greater_china), delegates: [delegate, second_delegate, third_delegate] }
     let(:mail) { CompetitionsMailer.notify_board_of_confirmed_competition(delegate, competition) }
 
     it "renders" do
@@ -19,6 +19,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
       expect(mail.subject).to eq("#{delegate.name} just confirmed #{competition.name}")
       expect(mail.body.encoded).to match("#{competition.name} is confirmed")
+      expect(mail.body.encoded).to match('This competition is marked as Greater China Championship and World Championship')
       expect(mail.body.encoded).to match("There is a competitor limit of 100 because \"The hall only fits 100 competitors.\"")
       expect(mail.body.encoded).to match(admin_edit_competition_url(competition))
     end

--- a/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
@@ -8,7 +8,7 @@ class CompetitionsMailerPreview < ActionMailer::Preview
   end
 
   def notify_board_of_confirmed_championship_competition
-    c = Championship.last.competition
+    c = Competition.find("WC2013")
     CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)
   end
 

--- a/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
@@ -7,6 +7,11 @@ class CompetitionsMailerPreview < ActionMailer::Preview
     CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)
   end
 
+  def notify_board_of_confirmed_championship_competition
+    c = Championship.last.competition
+    CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)
+  end
+
   def notify_users_of_results_presence
     competition = Competition.joins(:results).where.not(results_posted_at: nil).last
     user = competition.competitor_users.last

--- a/WcaOnRails/spec/models/championship_spec.rb
+++ b/WcaOnRails/spec/models/championship_spec.rb
@@ -17,4 +17,20 @@ RSpec.describe Championship do
       expect(championship).to be_invalid_with_errors(championship_type: ["is not included in the list"])
     end
   end
+
+  describe "name" do
+    it "returns the name associated to the championship_type" do
+      championship = Championship.new(championship_type: "world")
+      expect(championship.name).to eq "World Championship"
+
+      championship = Championship.new(championship_type: "_Europe")
+      expect(championship.name).to eq "Continental Championship for Europe"
+
+      championship = Championship.new(championship_type: "greater_china")
+      expect(championship.name).to eq "Greater China Championship"
+
+      championship = Championship.new(championship_type: "ES")
+      expect(championship.name).to eq "National Championship for Spain"
+    end
+  end
 end

--- a/WcaOnRails/spec/requests/competitions_spec.rb
+++ b/WcaOnRails/spec/requests/competitions_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe "competitions" do
         expect(competition.reload.isConfirmed?).to eq true
       end
 
-      it 'can set championship types for a competition' do
+      it 'can set championship types for an unconfirmed competition' do
+        expect(competition.isConfirmed).to be false
+
         patch competition_path(competition), params: {
           competition: {
             championships_attributes: {
@@ -33,6 +35,60 @@ RSpec.describe "competitions" do
         follow_redirect!
         expect(response).to be_success
         expect(competition.reload.championships.count).to eq 2
+      end
+
+      it 'can set championship types for a confirmed competition' do
+        competition.update!(isConfirmed: true)
+
+        patch competition_path(competition), params: {
+          competition: {
+            championships_attributes: {
+              "1" => { championship_type: "world" },
+              "0" => { championship_type: "_Europe" },
+            },
+          },
+        }
+        follow_redirect!
+        expect(response).to be_success
+        expect(competition.reload.championships.count).to eq 2
+      end
+    end
+
+    context "signed in as a delegate" do
+      before :each do
+        sign_in competition.delegates.first
+      end
+
+      it 'can set championship types for an unconfirmed competition' do
+        expect(competition.isConfirmed).to be false
+
+        patch competition_path(competition), params: {
+          competition: {
+            championships_attributes: {
+              "1" => { championship_type: "world" },
+              "0" => { championship_type: "_Europe" },
+            },
+          },
+        }
+        follow_redirect!
+        expect(response).to be_success
+        expect(competition.reload.championships.count).to eq 2
+      end
+
+      it 'cannot set championship types for a confirmed competition' do
+        competition.update!(isConfirmed: true)
+
+        patch competition_path(competition), params: {
+          competition: {
+            championships_attributes: {
+              "1" => { championship_type: "world" },
+              "0" => { championship_type: "_Europe" },
+            },
+          },
+        }
+        follow_redirect!
+        expect(response).to be_success
+        expect(competition.reload.championships.count).to eq 0
       end
     end
   end


### PR DESCRIPTION
Fixes #1982 

1. Delegates can set championship types for ONLY UNCONFIRMED competitions.
2. When a Delegate confirms a championship competition, the auto-generated e-mail to the Board shows VERY CLEARLY the championship types (see attached image).

![imagen](https://user-images.githubusercontent.com/26309166/31733809-056295c8-b43d-11e7-90ce-d418e982ec4f.png)