### PR TITLE
Port media approval page to Rails

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -55,3 +55,4 @@
 @import "server_status";
 @import "relations";
 @import "edit_events";
+@import "media";

--- a/WcaOnRails/app/assets/stylesheets/media.scss
+++ b/WcaOnRails/app/assets/stylesheets/media.scss
@@ -1,0 +1,9 @@
+td {
+  form {
+    display: inline;
+
+    .btn {
+      padding: 0;
+    }
+  }
+}

--- a/WcaOnRails/app/assets/stylesheets/media.scss
+++ b/WcaOnRails/app/assets/stylesheets/media.scss
@@ -1,9 +1,18 @@
-td {
+table.validate-media tbody tr td {
+  $button-size: 20px;
+
+  vertical-align: middle;
+
+  a i {
+    font-size: $button-size;
+  }
+
   form {
     display: inline;
 
     .btn {
       padding: 0;
+      font-size: $button-size;
     }
   }
 }

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -9,7 +9,7 @@ class AdminController < ApplicationController
   before_action :compute_navbar_data
   def compute_navbar_data
     @pending_avatars_count = User.where.not(pending_avatar: nil).count
-    @pending_media_count = CompetitionsMedia.where(status: 'pending').count
+    @pending_media_count = CompetitionMedium.where(status: 'pending').count
   end
 
   def index

--- a/WcaOnRails/app/controllers/media_controller.rb
+++ b/WcaOnRails/app/controllers/media_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class MediaController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { redirect_to_root_unless_user(:can_approve_media?) }
+
+  def validate
+    @status = params["status"]
+    @status = "pending" unless CompetitionMedium.statuses.include?(@status)
+    @media = CompetitionMedium.includes(:competition).where(status: @status).order(timestampSubmitted: :desc)
+
+    I18n.with_locale(:en) { render :validate }
+  end
+
+  def edit
+    @medium = find_medium
+    I18n.with_locale(:en) { render :edit }
+  end
+
+  def update
+    @medium = find_medium
+    if @medium.update_attributes(medium_params)
+      flash[:success] = "Updated medium"
+      redirect_to edit_medium_path(@medium)
+    else
+      I18n.with_locale(:en) { render :edit }
+    end
+  end
+
+  def destroy
+    @medium = find_medium
+    if @medium.destroy
+      flash[:success] = "Deleted medium"
+      redirect_to media_validate_path
+    else
+      I18n.with_locale(:en) { render :edit }
+    end
+  end
+
+  private def medium_params
+    params.require(:competition_medium).permit(
+      :competitionId,
+      :type,
+      :text,
+      :uri,
+      :submitterName,
+      :submitterEmail,
+      :submitterComment,
+      :status,
+    )
+  end
+
+  private def find_medium
+    CompetitionMedium.find(params[:id])
+  end
+end

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -85,7 +85,7 @@ module ApplicationHelper
 
   def wca_table(responsive: true, hover: true, striped: true, floatThead: true, table_class: "", data: {})
     data[:locale] = I18n.locale
-    table_classes = "table wca-results table-condensed table-greedy-last-column #{table_class}"
+    table_classes = "table table-condensed table-greedy-last-column #{table_class}"
     if floatThead
       table_classes += " floatThead"
     end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -179,6 +179,10 @@ class Competition < ApplicationRecord
     self.isConfirmed || self.showAtAll
   end
 
+  def country
+    Country.c_find(self.countryId)
+  end
+
   # Enforce that the users marked as delegates for this competition are
   # actually delegates. Note: just because someone (legally) delegated a
   # competition in the past does not mean that they are still a delegate,

--- a/WcaOnRails/app/models/competition_medium.rb
+++ b/WcaOnRails/app/models/competition_medium.rb
@@ -7,7 +7,25 @@ class CompetitionMedium < ApplicationRecord
   self.inheritance_column = :_type_disabled
 
   belongs_to :competition, foreign_key: "competitionId"
+  validates :competition, presence: true
 
   enum status: { accepted: "accepted", pending: "pending" }
+  validates :status, presence: true
+  # TODO: This is a port of the useful *_i18n method from
+  # https://github.com/zmbacker/enum_help.
+  # https://github.com/thewca/worldcubeassociation.org/issues/2070
+  # tracks adding this gem to our codebase.
+  def self.statuses_i18n
+    self.statuses.keys.map { |k| [k, k.titleize] }.to_h
+  end
+
   enum type: { report: "report", article: "article", multimedia: "multimedia" }
+  validates :type, presence: true
+  # TODO: This is a port of the useful *_i18n method from
+  # https://github.com/zmbacker/enum_help.
+  # https://github.com/thewca/worldcubeassociation.org/issues/2070
+  # tracks adding this gem to our codebase.
+  def self.types_i18n
+    self.types.keys.map { |k| [k, k.titleize] }.to_h
+  end
 end

--- a/WcaOnRails/app/models/competitions_media.rb
+++ b/WcaOnRails/app/models/competitions_media.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class CompetitionsMedia < ApplicationRecord
-  self.table_name = "CompetitionsMedia"
-end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -488,6 +488,10 @@ class User < ApplicationRecord
     board_member? || senior_delegate? || admin?
   end
 
+  def can_approve_media?
+    admin? || communication_team?
+  end
+
   def get_cannot_delete_competition_reason(competition)
     # Only allow results admins and competition delegates to delete competitions.
     if !can_manage_competition?(competition)

--- a/WcaOnRails/app/views/media/edit.html.erb
+++ b/WcaOnRails/app/views/media/edit.html.erb
@@ -1,0 +1,23 @@
+<% provide(:title, "Edit Medium") %>
+
+<div class="container">
+  <%= link_to "Back to all media", media_validate_path %>
+
+  <h2><%= yield(:title) %></h2>
+
+  <%= horizontal_simple_form_for @medium, url: medium_path(@medium), html: { class: 'are-you-sure' } do |f| %>
+    <%= f.input :competitionId, as: :competition_id, only_one: true %>
+    <%= f.input :type, collection: CompetitionMedium::types_i18n.invert, include_blank: false %>
+    <%= f.input :text %>
+    <%= f.input :uri %>
+    <%= f.input :submitterName %>
+    <%= f.input :submitterEmail %>
+    <%= f.input :submitterComment %>
+    <%= f.input :status, collection: CompetitionMedium::statuses_i18n.invert, include_blank: false %>
+
+    <%= f.button :submit %>
+    <%= link_to medium_path(@medium), method: :delete, class: "btn btn-danger", data: { confirm: "Are you sure you want to delete this medium?" } do %>
+      Delete <%= icon("trash") %>
+    <% end %>
+  <% end %>
+</div>

--- a/WcaOnRails/app/views/media/validate.html.erb
+++ b/WcaOnRails/app/views/media/validate.html.erb
@@ -27,7 +27,7 @@
   <%= wca_table table_class: "validate-media", data: { toggle: "table", sort_name: "submission-date", sort_order: "desc" } do %>
     <thead>
       <tr>
-        <th data-sortable="true" data-field="submission-date">Submission Date</th>
+        <th data-sortable="true" data-field="submission-date" data-sort-name="_submission-date_data" data-sorter="sortBySorter">Submission Date</th>
         <th data-sortable="true" data-field="competition-date" data-sort-name="_competition-date_data" data-sorter="sortBySorter">Competition Date</th>
         <th>Competition</th>
         <th>Country, City</th>
@@ -44,7 +44,7 @@
       <% @media.each do |medium| %>
         <% competition = medium.competition %>
         <tr data-medium-id="<%= medium.id %>">
-          <td><%= medium.timestampSubmitted.iso8601 %></td>
+          <td data-sort-by="<%= medium.timestampSubmitted.to_i %>"><%= medium.timestampSubmitted.to_formatted_s(:long_utc) %></td>
           <td data-sort-by="<%= competition.start_date.to_time.to_i %>">
             <%= wca_date_range(competition.start_date, competition.end_date) %>
           </td>

--- a/WcaOnRails/app/views/media/validate.html.erb
+++ b/WcaOnRails/app/views/media/validate.html.erb
@@ -24,16 +24,16 @@
     </div>
   </form>
 
-  <%= wca_table data: { toggle: "table", sort_name: "submission-date", sort_order: "desc" } do %>
+  <%= wca_table table_class: "validate-media", data: { toggle: "table", sort_name: "submission-date", sort_order: "desc" } do %>
     <thead>
       <tr>
-        <th></th>
         <th data-sortable="true" data-field="submission-date">Submission Date</th>
         <th data-sortable="true" data-field="competition-date" data-sort-name="_competition-date_data" data-sorter="sortBySorter">Competition Date</th>
         <th>Competition</th>
         <th>Country, City</th>
         <th>Type</th>
         <th>Link</th>
+        <th></th>
 
         <!-- Extra column for .table-greedy-last-column -->
         <th></th>
@@ -44,6 +44,14 @@
       <% @media.each do |medium| %>
         <% competition = medium.competition %>
         <tr data-medium-id="<%= medium.id %>">
+          <td><%= medium.timestampSubmitted.iso8601 %></td>
+          <td data-sort-by="<%= competition.start_date.to_time.to_i %>">
+            <%= wca_date_range(competition.start_date, competition.end_date) %>
+          </td>
+          <td><%= link_to competition.name, competition_path(competition) %></td>
+          <td><strong><%= competition.country.name %></strong>, <%= competition.cityName %></td>
+          <td><%= medium.type %></td>
+          <td><%= link_to medium.text, medium.uri %></td>
           <td>
             <% if medium.pending? %>
               <%= button_to medium_path(medium),
@@ -66,14 +74,6 @@
               <%= icon("trash") %>
             <% end %>
           </td>
-          <td><%= medium.timestampSubmitted.iso8601 %></td>
-          <td data-sort-by="<%= competition.start_date.to_time.to_i %>">
-            <%= wca_date_range(competition.start_date, competition.end_date) %>
-          </td>
-          <td><%= link_to competition.name, competition_path(competition) %></td>
-          <td><strong><%= competition.country.name %></strong>, <%= competition.cityName %></td>
-          <td><%= medium.type %></td>
-          <td><%= link_to medium.text, medium.uri %></td>
           <td></td>
       <% end %>
     </tbody>

--- a/WcaOnRails/app/views/media/validate.html.erb
+++ b/WcaOnRails/app/views/media/validate.html.erb
@@ -1,0 +1,81 @@
+<% provide(:title, "Validate Media") %>
+
+<script>
+  function sortBySorter(a, b) {
+    return b['sort-by'] - a['sort-by'];
+  }
+</script>
+<div class="container-fluid">
+  <h2><%= yield(:title) %></h2>
+
+  <form action="" method="get" class="form-inline">
+    <div class="form-group">
+      <label for="status-selector">Status</label>
+      <div class="input-group">
+        <%= select_tag "status",
+                       options_for_select(CompetitionMedium.statuses_i18n.invert, @status),
+                       id: "status-selector",
+                       class: "form-control"
+        %>
+        <span class="input-group-btn">
+          <input type="submit" class="btn btn-default" value="Filter" />
+        </span>
+      </div>
+    </div>
+  </form>
+
+  <%= wca_table data: { toggle: "table", sort_name: "submission-date", sort_order: "desc" } do %>
+    <thead>
+      <tr>
+        <th></th>
+        <th data-sortable="true" data-field="submission-date">Submission Date</th>
+        <th data-sortable="true" data-field="competition-date" data-sort-name="_competition-date_data" data-sorter="sortBySorter">Competition Date</th>
+        <th>Competition</th>
+        <th>Country, City</th>
+        <th>Type</th>
+        <th>Link</th>
+
+        <!-- Extra column for .table-greedy-last-column -->
+        <th></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @media.each do |medium| %>
+        <% competition = medium.competition %>
+        <tr data-medium-id="<%= medium.id %>">
+          <td>
+            <% if medium.pending? %>
+              <%= button_to medium_path(medium),
+                            title: "Accept",
+                            class: "btn btn-link",
+                            method: :patch,
+                            params: { "competition_medium[status]" => "accepted" },
+                            data: { confirm: "Are you sure you want to accept this medium?" } do
+              %>
+                <%= icon("check") %>
+              <% end %>
+            <% end %>
+            <%= link_to icon("pencil"), edit_medium_path(medium), title: "Edit" %>
+            <%= button_to medium_path(medium),
+                          title: "Delete",
+                          class: "btn btn-link",
+                          method: :delete,
+                          data: { confirm: "Are you sure you want to delete this medium?" } do
+            %>
+              <%= icon("trash") %>
+            <% end %>
+          </td>
+          <td><%= medium.timestampSubmitted.iso8601 %></td>
+          <td data-sort-by="<%= competition.start_date.to_time.to_i %>">
+            <%= wca_date_range(competition.start_date, competition.end_date) %>
+          </td>
+          <td><%= link_to competition.name, competition_path(competition) %></td>
+          <td><strong><%= competition.country.name %></strong>, <%= competition.cityName %></td>
+          <td><%= medium.type %></td>
+          <td><%= link_to medium.text, medium.uri %></td>
+          <td></td>
+      <% end %>
+    </tbody>
+  <% end %>
+</div>

--- a/WcaOnRails/config/initializers/datetime_formats.rb
+++ b/WcaOnRails/config/initializers/datetime_formats.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# See http://gavinmorrice.com/posts/3-keeping-your-dates-and-times-dry-with-to_formatted_s
+[Time, Date].map do |klass|
+  klass::DATE_FORMATS[:long_utc] = lambda { |t| t.strftime("#{t.to_s(:long)} %Z") }
+end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -282,6 +282,15 @@ en:
       #context: a vote
       vote:
         comment: "Comment"
+      competition_medium:
+        competitionId: "Competition"
+        type: "Type"
+        text: "Text"
+        uri: "Link"
+        submitterName: "Submitter name"
+        submitterEmail: "Submitter email"
+        submitterComment: "Submitter comment"
+        status: "Status"
   #context: This key is an element of a form on the website
   simple_form:
     "yes": "Yes"
@@ -400,6 +409,15 @@ en:
         friendly_id: ""
       vote:
         comment: ""
+      competition_medium:
+        competitionId: ""
+        type: ""
+        text: ""
+        uri: ""
+        submitterName: ""
+        submitterEmail: ""
+        submitterComment: ""
+        status: ""
     #context: and a label for an option
     options:
       #context: about registration

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -64,6 +64,9 @@ Rails.application.routes.draw do
   get 'competitions/edit/time_until_competition' => 'competitions#time_until_competition', as: :time_until_competition
   get 'competitions/:id/edit/clone_competition' => 'competitions#clone_competition', as: :clone_competition
 
+  get "media/validate" => 'media#validate', as: :media_validate
+  resources :media, only: [:edit, :update, :destroy]
+
   resources :persons, only: [:index, :show]
 
   resources :polls, only: [:edit, :new, :vote, :create, :update, :index, :destroy]

--- a/WcaOnRails/lib/custom_i18n_scanner.rb
+++ b/WcaOnRails/lib/custom_i18n_scanner.rb
@@ -21,6 +21,7 @@ unless Rails.env.production?
       when "devise" then "user"
       when "admin" then "person"
       when "oauth" then "doorkeeper/application"
+      when "medium" then "competition_medium"
       when "contact"
         # ContactsController uses WebsiteContact or DobContact (which are much like extended models).
         # We need to determine which one does the key refer to.

--- a/WcaOnRails/spec/factories/competition_media.rb
+++ b/WcaOnRails/spec/factories/competition_media.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :competition_medium do
+    competition { FactoryGirl.create(:competition) }
+    type "article"
+    text "I am an article"
+    uri "https://www.example.com/article-42"
+    submitterName { Faker::Name.name }
+    submitterComment "This is a comment"
+    submitterEmail { Faker::Internet.email }
+    timestampSubmitted { 2.days.ago }
+    timestampDecided nil
+    status "pending"
+
+    trait :accepted do
+      status "accepted"
+    end
+  end
+end

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -55,6 +55,13 @@ FactoryGirl.define do
       end
     end
 
+    trait :wct_member do
+      after(:create) do |user|
+        wrc_team = Team.find_by_friendly_id('wct')
+        FactoryGirl.create(:team_member, team_id: wrc_team.id, user_id: user.id)
+      end
+    end
+
     trait :wca_id do
       transient do
         person { FactoryGirl.create(:person, name: name, countryId: Country.find_by_iso2(country_iso2).id, gender: gender, dob: dob.strftime("%F")) }

--- a/WcaOnRails/spec/features/media_spec.rb
+++ b/WcaOnRails/spec/features/media_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Media" do
+  let!(:medium1) { FactoryGirl.create(:competition_medium, text: "Article 1") }
+  let!(:medium2) { FactoryGirl.create(:competition_medium, text: "Article 2") }
+
+  context "when signed in as WCT member" do
+    before :each do
+      sign_in FactoryGirl.create :user, :wct_member
+    end
+
+    context "validate media list" do
+      scenario "accept media" do
+        visit "/media/validate"
+
+        within_medium_row(medium2) do
+          click_button "Accept"
+        end
+
+        expect(medium2.reload.status).to eq "accepted"
+      end
+
+      scenario "delete media" do
+        visit "/media/validate"
+
+        within_medium_row(medium2) do
+          click_button "Delete"
+        end
+
+        expect(CompetitionMedium.find_by_id(medium2.id)).to be_nil
+      end
+    end
+
+    context "edit media" do
+      before :each do
+        visit "/media/validate"
+        within_medium_row(medium2) do
+          click_link "Edit"
+        end
+      end
+
+      scenario "delete it" do
+        click_link "Delete"
+        expect(CompetitionMedium.find_by_id(medium2.id)).to be_nil
+      end
+
+      scenario "accept it" do
+        select "Accepted", from: "Status"
+        click_button "Update Competition medium"
+        expect(medium2.reload.status).to eq "accepted"
+      end
+
+      scenario "change text" do
+        expect(medium2.text).to eq "Article 2"
+        fill_in "Text", with: "New text"
+        click_button "Update Competition medium"
+        expect(medium2.reload.text).to eq "New text"
+      end
+    end
+  end
+end
+
+def within_medium_row(medium, &blk)
+  within("tr[data-medium-id='#{medium.id}']", &blk)
+end

--- a/WcaOnRails/spec/models/competition_medium_spec.rb
+++ b/WcaOnRails/spec/models/competition_medium_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CompetitionMedium do
+  it "defines a valid medium" do
+    medium = FactoryGirl.build :competition_medium
+    expect(medium).to be_valid
+  end
+
+  it "validates competitionId" do
+    medium = FactoryGirl.build :competition_medium, competitionId: "foo"
+    expect(medium).to be_invalid_with_errors(competition: ["can't be blank"])
+  end
+
+  it "validates type" do
+    medium = FactoryGirl.build :competition_medium, type: ""
+    expect(medium).to be_invalid_with_errors(type: ["can't be blank"])
+  end
+
+  it "validates status" do
+    medium = FactoryGirl.build :competition_medium, status: ""
+    expect(medium).to be_invalid_with_errors(status: ["can't be blank"])
+  end
+end

--- a/WcaOnRails/spec/requests/media_spec.rb
+++ b/WcaOnRails/spec/requests/media_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "only WCT" do |action, expect_success|
+  context "when not signed in" do
+    it "redirects to sign in page" do
+      self.instance_exec(&action)
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  context "when signed in as regular user" do
+    sign_in { FactoryGirl.create :user }
+
+    it "redirects to home page" do
+      self.instance_exec(&action)
+      expect(response).to redirect_to root_url
+    end
+  end
+
+  context "when signed in as a WCT member" do
+    before :each do
+      sign_in FactoryGirl.create :user, :wct_member
+    end
+
+    it 'can perform action' do
+      self.instance_exec(&action)
+      self.instance_exec(&expect_success)
+    end
+  end
+end
+
+RSpec.describe "media" do
+  let(:competition) { FactoryGirl.create(:competition, :with_delegate, :visible) }
+  let!(:medium) { FactoryGirl.create(:competition_medium, text: "i am pending") }
+  let!(:accepted_medium) { FactoryGirl.create(:competition_medium, :accepted, text: "i am accepted") }
+
+  describe 'GET #validate' do
+    it_should_behave_like 'only WCT',
+                          lambda { get media_validate_path },
+                          lambda { expect(response).to be_success }
+
+    context "signed in as WCT member" do
+      before :each do
+        sign_in FactoryGirl.create :user, :wct_member
+      end
+
+      it "shows only pending media by default" do
+        get media_validate_path
+        expect(response.body).to include "i am pending"
+        expect(response.body).not_to include "i am accepted"
+      end
+
+      it "can show accepted media" do
+        get media_validate_path, params: { status: "accepted" }
+        expect(response.body).not_to include "i am pending"
+        expect(response.body).to include "i am accepted"
+      end
+    end
+  end
+
+  describe "GET #edit" do
+    it_should_behave_like 'only WCT',
+                          lambda { get edit_medium_path(medium) },
+                          lambda { expect(response).to be_success }
+  end
+
+  describe "PATCH #update" do
+    let(:patch_medium) do
+      lambda do |attributes|
+        patch medium_path(medium), params: (attributes.map do |key, value|
+          ["competition_medium[#{key}]", value]
+        end.to_h)
+      end
+    end
+
+    it_should_behave_like 'only WCT',
+                          lambda { patch_medium.call(text: 'new text') },
+                          lambda { expect(response).to redirect_to edit_medium_path(medium) }
+
+    context "signed in as WCT member" do
+      before :each do
+        sign_in FactoryGirl.create :user, :wct_member
+      end
+
+      it "can accept medium" do
+        expect(medium.status).to eq "pending"
+        patch_medium.call(status: 'accepted')
+        expect(medium.reload.status).to eq "accepted"
+      end
+
+      it "can edit medium" do
+        competition = FactoryGirl.create :competition
+        expect(medium.type).to eq 'article'
+
+        patch_medium.call(
+          competitionId: competition.id,
+          type: 'multimedia',
+          text: 'this is some new text',
+          uri: 'http://newexample.com',
+          submitterName: 'New Jeremy',
+          submitterEmail: 'New@Jeremy',
+          submitterComment: 'this is a new comment',
+        )
+
+        medium.reload
+        expect(medium.competition).to eq competition
+        expect(medium.type).to eq "multimedia"
+        expect(medium.text).to eq "this is some new text"
+        expect(medium.uri).to eq "http://newexample.com"
+        expect(medium.submitterName).to eq "New Jeremy"
+        expect(medium.submitterEmail).to eq "New@Jeremy"
+        expect(medium.submitterComment).to eq "this is a new comment"
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:destroy_medium) { lambda { delete medium_path(medium) } }
+
+    it_should_behave_like 'only WCT',
+                          lambda { destroy_medium.call },
+                          lambda {
+                            expect(response).to redirect_to media_validate_path
+                            expect(CompetitionMedium.find_by_id(medium.id)).to be_nil
+                          }
+  end
+end


### PR DESCRIPTION
This has list, edit, delete, and approve functionality for media.
**NOTE**: The media submission form is still in PHP.
This is part of #296.

- Check out the new page here: https://staging.worldcubeassociation.org/media/validate
- The current PHP page here: https://staging.worldcubeassociation.org/results/admin/validate_media.php
- You can always submit more media here: https://staging.worldcubeassociation.org/results/media_insertion.php

## TODO (I'll address these in a later PR)
- [ ] Delete old PHP approval page code 
- [ ] Add a link (where?) for the WCT to actually get to this page
- [ ] Port the media submission page to RoR as well