### PR TITLE
Change competitions order

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -82,7 +82,7 @@ class CompetitionsController < ApplicationController
     else
       @competitions = Competition
     end
-    @competitions = @competitions.includes(:country).where(showAtAll: true).order(:start_date)
+    @competitions = @competitions.includes(:country).where(showAtAll: true).order_by_date
 
     if @present_selected
       @competitions = @competitions.not_over

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -58,6 +58,7 @@ class Competition < ApplicationRecord
         user_id: user_id,
       ).group(:id)
   }
+  scope :order_by_date, -> { order(:start_date, :end_date) }
 
   CLONEABLE_ATTRIBUTES = %w(
     cityName

--- a/WcaOnRails/app/views/delegates/stats.html.erb
+++ b/WcaOnRails/app/views/delegates/stats.html.erb
@@ -19,7 +19,7 @@
     </thead>
     <tbody>
       <% @delegates.each do |delegate| %>
-        <% competitions = delegate.delegated_competitions.order(:start_date).select(&:is_probably_over?) %>
+        <% competitions = delegate.delegated_competitions.order_by_date.select(&:is_probably_over?) %>
         <tr class="<%= delegate.delegate_status %>">
           <td class="delegate" data-toggle="tooltip" data-placement="top" data-container="body" title="<%= delegate.notes %>">
             <%= delegate.name %>


### PR DESCRIPTION
This make the competitions with the exact same start_date and end_date be together. See below screenshots.

Before:
![wx20171023-154041](https://user-images.githubusercontent.com/2390434/31877419-07105380-b79c-11e7-9fca-6ac5dca9f495.png)

After:
![wx20171023-153947](https://user-images.githubusercontent.com/2390434/31877427-0d5f6c26-b79c-11e7-8f66-2133534c9538.png)
