### PR TITLE
Don't try to send emails when running rake tasks.

### DIFF
--- a/WcaOnRails/config.ru
+++ b/WcaOnRails/config.ru
@@ -2,5 +2,6 @@
 
 # This file is used by Rack-based servers to start the application.
 
+ENV['RAILS_RACKING'] = '1'
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/WcaOnRails/config/initializers/translations.rb
+++ b/WcaOnRails/config/initializers/translations.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-if Rails.env.production?
+# We only want to attempt to send email when the server is starting up.
+# We don't want to send emails as a side effect of some rake script.
+# See https://github.com/thewca/worldcubeassociation.org/issues/2085.
+if Rails.env.production? && ENV['RAILS_RACKING']
   Rails.configuration.after_initialize do
     modification_timestamp = Timestamp.find_or_create_by!(name: 'en_translation_modification')
     latest_modification_date = Time.parse(`git log -1 --format='%ai' #{Rails.root.to_s}/config/locales/en.yml`)


### PR DESCRIPTION
This fixes #2085.

I tested this out on staging, and it seems to do the right thing: we go into the if statement when restarting unicorn, and we do not go into the if statement when running rake tasks.