### PR TITLE
Allow changing registration fees, even if people have already paid.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -471,7 +471,9 @@ class Competition < ApplicationRecord
   end
 
   def can_edit_registration_fees?
-    registrations.with_payments.empty?
+    # Quick workaround for https://github.com/thewca/worldcubeassociation.org/issues/2123
+    # (We used to return `registrations.with_payments.empty?` here)
+    true
   end
 
   def registration_opened?

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -419,14 +419,15 @@ RSpec.describe CompetitionsController do
         expect(competition.currency_code).to eq "EUR"
       end
 
-      it "cannot update the registration fees when there is any payment" do
+      it "can update the registration fees when there is any payment" do
+        # See https://github.com/thewca/worldcubeassociation.org/issues/2123
+
         previous_fees = competition.base_entry_fee_lowest_denomination
-        previous_currency = competition.currency_code
         FactoryBot.create(:registration, :paid, competition: competition)
         patch :update, params: { id: competition, competition: { base_entry_fee_lowest_denomination: previous_fees + 10, currency_code: "EUR" } }
         competition.reload
-        expect(competition.base_entry_fee_lowest_denomination).to eq previous_fees
-        expect(competition.currency_code).to eq previous_currency
+        expect(competition.base_entry_fee_lowest_denomination).to eq previous_fees + 10
+        expect(competition.currency_code).to eq "EUR"
       end
     end
 


### PR DESCRIPTION
This is a quick fix for #2123.

@viroulep, will anything break horribly if we merge this up? My thinking is that this will cause people to show up as not fully paid, which will be weird, but workable because their registrations will still be accepted.