### PR TITLE
Add informative message for unique wca id validation error, closes #774

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -78,7 +78,9 @@ class User < ApplicationRecord
       user = User.find_by_wca_id(wca_id)
       # If there is a non dummy user with this WCA ID, fail validation.
       if user && !user.dummy_account?
-        errors.add(:wca_id, I18n.t('users.errors.unique'))
+        errors.add(:wca_id, I18n.t('users.errors.unique',
+                   used_name: user.name,
+                   used_email: user.email))
       end
     end
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -78,9 +78,12 @@ class User < ApplicationRecord
       user = User.find_by_wca_id(wca_id)
       # If there is a non dummy user with this WCA ID, fail validation.
       if user && !user.dummy_account?
-        errors.add(:wca_id, I18n.t('users.errors.unique',
-                   used_name: user.name,
-                   used_email: user.email))
+        errors.add(
+          :wca_id,
+          I18n.t('users.errors.unique',
+                 used_name: user.name,
+                 used_email: user.email),
+        )
       end
     end
   end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -625,8 +625,8 @@ en:
     errors:
       not_found: "not found"
       already_assigned: "already assigned to a different user"
-      dob_incorrect_html: "does not match our database. If you're sure you're providing the correct date in the correct format (YYYY-MM-DD) please contact the WCA Results Team using <a href=\"%{dob_form_path}\">this dedicated form</a>."
-      unique: "must be unique"
+      dob_incorrect_html: "does not match our database. If you're sure you're providing the correct date in the correct format (YYYY-MM-DD) please contact with WCA Results Team using <a href=\"%{dob_form_path}\">this dedicated form</a>."
+      unique: "is already used by \"%{used_name}\" with %{used_email}"
       dob_past: "must be in the past"
       must_be_senior: "must be a senior delegate"
       must_not_be_present: "must not be present"

--- a/WcaOnRails/spec/features/edit_user_spec.rb
+++ b/WcaOnRails/spec/features/edit_user_spec.rb
@@ -12,6 +12,10 @@ RSpec.feature "Edit user" do
     visit edit_user_path(user)
   end
 
+  def submit_form
+    find('input[type="submit"]').click
+  end
+
   scenario "entering wca id", js: true do
     sign_in admin
     navigate_to_form(new_user)
@@ -26,7 +30,7 @@ RSpec.feature "Edit user" do
 
     # Entering a valid wca id
     fill_in "WCA ID", with: new_person.wca_id
-    find('input[type="submit"]').click
+    submit_form
 
     expect(page).to have_text "Account updated"
   end

--- a/WcaOnRails/spec/features/edit_user_spec.rb
+++ b/WcaOnRails/spec/features/edit_user_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Edit user" do
 
     # Entering an existing wca id
     fill_in "WCA ID", with: existing_user.wca_id
-    find('input[type="submit"]').click
+    submit_form
 
     expect(page).to have_text I18n.t('users.errors.unique',
                                      used_name: existing_user.name,

--- a/WcaOnRails/spec/features/edit_user_spec.rb
+++ b/WcaOnRails/spec/features/edit_user_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Edit user" do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:existing_user) { FactoryBot.create(:user_with_wca_id) }
+  let(:new_person) { FactoryBot.create(:person) }
+  let(:new_user) { FactoryBot.create(:user) }
+
+  def navigate_to_form(user)
+    visit edit_user_path(user)
+  end
+
+  scenario "entering wca id", js: true do
+    sign_in admin
+    navigate_to_form(new_user)
+
+    # Entering an existing wca id
+    fill_in "WCA ID", with: existing_user.wca_id
+    find('input[type="submit"]').click
+
+    expect(page).to have_text I18n.t('users.errors.unique',
+                                     used_name: existing_user.name,
+                                     used_email: existing_user.email)
+
+    # Entering a valid wca id
+    fill_in "WCA ID", with: new_person.wca_id
+    find('input[type="submit"]').click
+
+    expect(page).to have_text "Account updated"
+  end
+end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -183,11 +183,19 @@ RSpec.describe User, type: :model do
       expect(user.wca_id).to be_nil
     end
 
-    it "verifies WCA ID unique when changing WCA ID" do
-      person2 = FactoryBot.create :person, wca_id: "2006FLEI01"
-      user2 = FactoryBot.create :user, wca_id: "2006FLEI01", name: person2.name
-      user.wca_id = user2.wca_id
-      expect(user).to be_invalid_with_errors(wca_id: ["must be unique"])
+    context "when WCA ID is not unique" do
+      let(:existing_user) { FactoryBot.create :user_with_wca_id }
+      let(:invalid_user) { FactoryBot.build :user, wca_id: existing_user.wca_id }
+
+      it "verifies WCA ID unique when changing WCA ID" do
+        expect(invalid_user.valid?).to be false
+        expect(invalid_user.errors.messages).to include :wca_id
+      end
+
+      it "shows an appropriate error message" do
+        expected_message = %(is already used by "#{existing_user.name}" with #{existing_user.email})
+        expect(invalid_user).to be_invalid_with_errors wca_id: [expected_message]
+      end
     end
 
     it "removes dummy accounts and copies name when WCA ID is assigned" do


### PR DESCRIPTION
When editing a user you would not get a sufficient error
message explaining what is actually wrong. This commit adds an
error message explaining that the WCA ID is already taken.

![image](https://user-images.githubusercontent.com/277474/32813683-1d3fb8f0-c960-11e7-978e-a6b5ef75a7f5.png)