### PR TITLE
Add a friendly link to the Devise missing email confirmation alert

### DIFF
--- a/WcaOnRails/app/views/devise/sessions/new.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,7 @@
 <div class="container">
   <% # i18n-tasks-use t('devise.failure.invalid') %>
   <% # i18n-tasks-use t('devise.failure.not_found_in_database') %>
+  <% # i18n-tasks-use t('devise.failure.unconfirmed') %>
   <%= render layout: "devise/conversion_message", locals: { user: resource } do %>
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -485,6 +485,7 @@ en:
     failure:
       invalid: "Invalid email, WCA ID, or password."
       not_found_in_database: "Invalid email, WCA ID, or password."
+      unconfirmed: "You have to confirm your email address before continuing. Didn't receive a confirmation email? Go to https://www.worldcubeassociation.org/users/confirmation/new to request a new one."
   #context: Key used in external code that the WCA use
   wca:
     # These are locales used in WCA's app relevant to external gems, but which are not present in the gem's default locale file.


### PR DESCRIPTION
Fixes  #2148.

I don't think we can do much better at the moment (i.e. use HTML link), because this is controlled by the Devise gem and the key doesn't have the `_html` success.

The message seems to come from [this line](https://github.com/plataformatec/devise/blob/88e9a85d6a796a41f4dcf2528ed6d5f48916b5fd/lib/devise/hooks/activatable.rb#L8).
The `inactive_message` method is defined [here](https://github.com/plataformatec/devise/blob/ee01bac8b0b828b3da0d79c46115ba65c433d6c8/lib/devise/models/confirmable.rb#L146-L149). But it's used for generating another i18n key [here](https://github.com/plataformatec/devise/blob/88e9a85d6a796a41f4dcf2528ed6d5f48916b5fd/app/controllers/devise/registrations_controller.rb#L25), thus redefining it to return `:unconfirmed_html` would make things messy.