### PR TITLE
As per discussions with the Board, we're loosening the proximity policy a bit

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -127,10 +127,10 @@ class Competition < ApplicationRecord
   validates :currency_code, inclusion: { in: Money::Currency, message: proc { I18n.t('competitions.errors.invalid_currency_code') } }
 
   NEARBY_DISTANCE_KM_WARNING = 500
-  NEARBY_DISTANCE_KM_DANGER = 200
-  NEARBY_DISTANCE_KM_INFO = 200
+  NEARBY_DISTANCE_KM_DANGER = 100
+  NEARBY_DISTANCE_KM_INFO = 100
   NEARBY_DAYS_WARNING = 90
-  NEARBY_DAYS_DANGER = 28
+  NEARBY_DAYS_DANGER = 19
   NEARBY_DAYS_INFO = 365
   NEARBY_INFO_COUNT = 8
   RECENT_DAYS = 30
@@ -633,7 +633,7 @@ class Competition < ApplicationRecord
       return false
     end
     days_until = (c.start_date - self.start_date).to_i
-    self.kilometers_to(c) <= NEARBY_DISTANCE_KM_DANGER && days_until.abs < NEARBY_DAYS_DANGER
+    self.kilometers_to(c) < NEARBY_DISTANCE_KM_DANGER && days_until.abs < NEARBY_DAYS_DANGER
   end
 
   def results_posted?

--- a/WcaOnRails/app/views/static_pages/organizer_guidelines.erb
+++ b/WcaOnRails/app/views/static_pages/organizer_guidelines.erb
@@ -1,29 +1,39 @@
 <% provide(:title, t("organizer_guidelines.title")) %>
 <div class="container">
   <h1><%= yield(:title)  %></h1>
-  <% guidelines_in_english = t("organizer_guidelines", locale: :en) %>
-  <% localized_guidelines = t("organizer_guidelines") %>
-  <% guidelines_in_english.deep_merge(localized_guidelines).each do |key, paragraph| %>
-    <% next if key == :title %>
-    <% paragraph.each do |item, content| %>
-      <% if item.to_s.start_with?("olist") %>
-        <ol>
-          <% content.each do |_, elem| %>
-            <li><%= raw(elem) %></li>
-          <% end %>
-        </ol>
-      <% elsif item.to_s.start_with?("list") %>
-        <ul>
-          <% content.each do |_, elem| %>
-            <li><%= raw(elem) %></li>
-          <% end %>
-        </ul>
-      <% elsif item.to_s.start_with?("title") %>
-        <h4><%= content %></h4>
-      <% else %>
-        <%= raw(content) %><br/>
-      <% end %>
-    <% end %>
-  <% end %>
+  <%
+    def translate_with_structure(key)
+      data_english = t(key, locale: :en)
+      data_localized = t(key)
 
+      render_item(data_english.deep_merge(data_localized))
+    end
+
+    def render_items(items)
+      items.map { |item| content_tag(:li, render_item(item)) }.xss_aware_join
+    end
+
+    def render_item(item)
+      return item.html_safe unless item.is_a? Hash
+
+      "".html_safe.tap do |result|
+        item.each do |key, content|
+          key = key.to_s
+          if key.start_with?("olist")
+            result << content_tag(:ol, render_items(content.values))
+          elsif key.start_with?("alist")
+            result << content_tag(:ol, render_items(content.values), type: "a")
+          elsif key.start_with?("list")
+            result << content_tag(:ul, render_items(content.values))
+          elsif key.start_with?("title")
+            result << content_tag(:h4, content)
+          else
+            result << render_item(content)
+          end
+        end
+      end
+    end
+  %>
+
+  <%= translate_with_structure("organizer_guidelines") %>
 </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1390,16 +1390,22 @@ en:
       of the WCA Board. It is highly recommended to inform the WCA Board of these reasons as soon as possible to avoid a later refusal of the competition."
     paragraph4:
       title: "Proximity policy"
-      content1: "As a general policy, WCA Competitions will be accepted if they are at least 200 km or 26 days away from any other competition. WCA Board should particularly review a proposed competition if there is another competition for which the distance between
-      them is less than 200 km and the time between them is less than 26 days. A delegate requesting approval for such a competition must provide further information on why the competition should still be accepted. Possible arguments that will support such
-      a competition being accepted include:"
+      content1: "WCA competitions will be accepted if they are at least 100 km or 19 days away from any other competition. The WCA Board should particularly review a proposed competition if there is another competition for which the distance between them is less than 100 km and the time between them is less than 19 days. A delegate requesting approval for such a competition must provide further information on why the competition should still be accepted. Possible arguments that support such a competition being accepted include:"
       olist1:
-        '1': "The two competitions have different events."
+        '1': "The two competitions don't have events in common."
         '2': "The two competitions take place in different countries."
-        '3': "In the last 12 months, there have been fewer than 13 competitions in the area 200 km around the competition."
-      content2: "FMC simultaneous competitions cannot be part of any other regular competition:"
+        '3': "In the last 12 months, there have been fewer than 16 competitions in the area 100 km around the competition."
+      content2: '"FMC simultaneous competitions" are WCA competitions having only the FMC event and taking place simultaneously in different locations.'
       olist2:
-        '1': "If any location of such competitions is closer than 200 km to any other regular competition, then both competitions should be at least 5 days apart, or the other competition must not have the FM event."
+        '1':
+          content1: "FMC simultaneous competitions cannot be part of any other regular competition."
+          alist1:
+            '1a': "Time frames when both are celebrated can’t overlap."
+        '2':
+          content1: "If any location of such competitions is closer than 100 km to any other regular competition, then"
+          alist1:
+            '2a': "both competitions should be at least 5 days apart, or"
+            '2b': "the other competition must not have the FM event."
     paragraph-events:
       title: "Announcing events"
       content: 'All events that are going to be held at the competition must be specified by the Delegate when requesting the competition approval. This also includes "tentative" events (i.e. events that may be held additionally depending on the competition flow). Further additions must be approved by the Board.'


### PR DESCRIPTION
From the Board:

> @Jeremy, please make the necessary provisions to change the magnitudes for the alerts in the website (from 200 km to 100 km and from 26 days to 19 days) at your earliest convenience. Alberto will be announcing the good news in a few hours. Thanks!

I'm somewhat confused here because `NEARBY_DAYS_DANGER` was actually 28 days, not 26 days. @pedrosino, could you help me out with this?

## TODO

- [x] Update proximity policy text here: https://github.com/jfly/worldcubeassociation.org/blob/e901cea819d9e5a94a32c141d92502ebadc50a1d/WcaOnRails/config/locales/en.yml#L1391-L1402