### PR TITLE
Make mailto link more user-friendly

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -38,7 +38,7 @@
         <% if competition.contact.present? %>
           <%=md competition.contact %>
         <% else %>
-          <%= mail_to competition.managers.map(&:email).join(","), icon("envelope"), subject: "Question about #{competition.name}", target: "_blank", class: "hide-new-window-icon" %>
+          <%= mail_to competition.managers.map(&:email).join(","), competition.managers.map(&:email).join(", "), subject: "Question about #{competition.name}", target: "_blank", class: "hide-new-window-icon" %>
         <% end %>
       </dd>
 


### PR DESCRIPTION
Replaced envelope icon with actual email addresses so that users who do not have an application associated with mailto can still easily see them. This was brought up in Issue #2153.