### PR TITLE
Form for submitting competition results - #2113

### DIFF
--- a/WcaOnRails/app/controllers/results_submission_controller.rb
+++ b/WcaOnRails/app/controllers/results_submission_controller.rb
@@ -16,6 +16,9 @@ class ResultsSubmissionController < ApplicationController
     if params[:results].blank? || params[:message].blank?
       flash.now[:danger] = "Please make sure to fill in the message and attach the results file."
       render :edit
+    elsif File.extname(params[:results].original_filename) != ".json"
+      flash.now[:danger] = "Please attach the JSON file from the Workbook Assistant"
+      render :edit
     else
       CompetitionsMailer.results_submitted(@competition, params[:message], current_user.name, params[:results].read).deliver_now
 

--- a/WcaOnRails/app/controllers/results_submission_controller.rb
+++ b/WcaOnRails/app/controllers/results_submission_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+class ResultsSubmissionController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { redirect_to_root_unless_user(:can_submit_competition_results?, competition_from_params) }
+
+  def edit
+    @competition = competition_from_params
+  end
+
+  def submit
+    @competition = competition_from_params
+
+    if params[:results].blank? || params[:message].blank?
+      flash.now[:danger] = "Please make sure to fill in the message and attach the results file."
+      render :edit
+    else
+      CompetitionsMailer.results_submitted(@competition, params[:message], current_user.name, params[:results].read).deliver_now
+
+      flash[:success] = "Thank you for submitting the results!"
+      redirect_to competition_path(@competition)
+    end
+  end
+
+  private def competition_from_params
+    Competition.find(params[:competition_id])
+  end
+end

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 class CompetitionsMailer < ApplicationMailer
   helper :markdown
 
@@ -62,6 +64,20 @@ class CompetitionsMailer < ApplicationMailer
       cc: ["board@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
       reply_to: "board@worldcubeassociation.org",
       subject: "#{competition.name} Delegate Report",
+    )
+  end
+
+  def results_submitted(competition, message, sender_name, file_contents)
+    @competition = competition
+    @message = message
+    @sender_name = sender_name
+    file_name = "Results_#{competition.id}_#{Time.now.utc.iso8601}.json"
+    attachments[file_name] = file_contents
+    mail(
+      to: "results@worldcubeassociation.org",
+      cc: competition.delegates.pluck(:email),
+      reply_to: competition.delegates.pluck(:email),
+      subject: "Results for #{competition.name}",
     )
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -484,6 +484,10 @@ class User < ApplicationRecord
     can_admin_results? || (can_manage_competition?(competition) && !competition.isConfirmed?)
   end
 
+  def can_submit_competition_results?(competition)
+    can_admin_results? || competition.delegates.include?(self)
+  end
+
   def can_create_poll?
     admin? || board_member? || wrc_team? || wdc_team? || quality_assurance_committee?
   end

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -64,6 +64,13 @@
           fa_icon: "clone",
         }
       end
+      if current_user&.can_submit_competition_results?(@competition)
+        nav_items << {
+          text: t('.menu.submit_results'),
+          path: submit_results_edit_path(@competition),
+          fa_icon: "cloud-upload",
+        }
+      end
       if current_user&.can_view_delegate_report?(@competition.delegate_report)
         nav_items << {
           text: t('.menu.delegate_report'),

--- a/WcaOnRails/app/views/competitions_mailer/results_submitted.erb
+++ b/WcaOnRails/app/views/competitions_mailer/results_submitted.erb
@@ -1,0 +1,7 @@
+<p>Results Team,</p>
+
+<p><%= @sender_name %> has uploaded the results for <%= @competition.name %>. You can upload them <%= link_to "here", "https://www.worldcubeassociation.org/results/admin/upload_results.php?competitionId=#{@competition.id}" %>.</p>
+
+<p>Here's a message from <%= @sender_name %>:</p>
+
+<blockquote><%= md @message %></blockquote>

--- a/WcaOnRails/app/views/results_submission/_nav.html.erb
+++ b/WcaOnRails/app/views/results_submission/_nav.html.erb
@@ -1,0 +1,3 @@
+<%= render layout: "competitions/nav" do %>
+  <%= yield %>
+<% end %>

--- a/WcaOnRails/app/views/results_submission/edit.html.erb
+++ b/WcaOnRails/app/views/results_submission/edit.html.erb
@@ -1,0 +1,21 @@
+<% provide(:title, "Results submission") %>
+<%= render layout: 'nav' do %>
+  <h1><%= yield(:title) %></h1>
+
+  <p>Please enter the body of your email to the Results Team.</p>
+  <p>
+    Make sure to include a link to the competition schedule (and all time
+    limits and cutoffs) and provide any changes to the provided schedule, as
+    well as any other additional details required by the
+    <%= link_to "'Submitting competition results' section of the delegate crash course",
+                delegate_crash_course_path(anchor: "submitting-competition-results") %>.
+  </p>
+
+  <%= form_tag({action: :submit}, multipart: true) do %>
+    <%= text_area_tag :message, params[:message], placeholder: "Email body here", class: "markdown-editor" %><br>
+    Results file<br>
+    <%= file_field_tag 'results' %><br>
+    <input type="submit" class="btn btn-primary" />
+  <% end %>
+
+<% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1049,6 +1049,7 @@ en:
         payment_view: "Setup payments"
         admin_view: "Admin view"
         tabs: "Manage tabs"
+        submit_results: "Submit results"
         delegate_report: "Delegate report"
         registration: "Registration"
         register: "Register"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
     get 'tabs/:id/reorder' => "competition_tabs#reorder", as: :tab_reorder
   end
 
+  get 'competitions/:competition_id/submit-results' => 'results_submission#edit', as: :submit_results_edit
+  post 'competitions/:competition_id/submit-results' => 'results_submission#submit', as: :submit_results
+
   get 'competitions/:competition_id/report/edit' => 'delegate_reports#edit', as: :delegate_report_edit
   get 'competitions/:competition_id/report' => 'delegate_reports#show', as: :delegate_report
   patch 'competitions/:competition_id/report' => 'delegate_reports#update'

--- a/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
@@ -35,4 +35,8 @@ class CompetitionsMailerPreview < ActionMailer::Preview
     competition = report.competition
     CompetitionsMailer.notify_of_delegate_report_submission(competition)
   end
+
+  def results_submitted
+    CompetitionsMailer.results_submitted(Competition.last, "Here are the results.\nThey look good.", "John Doe", '{ "results": "good" }')
+  end
 end

--- a/WcaOnRails/spec/requests/results_submission_spec.rb
+++ b/WcaOnRails/spec/requests/results_submission_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResultsSubmissionController, type: :request do
+  let(:delegate) { FactoryBot.create :delegate }
+  let(:comp) { FactoryBot.create(:competition, delegates: [delegate]) }
+
+  context "not logged in" do
+    it "redirects to sign in" do
+      get submit_results_edit_path(comp.id)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  context "logged in as a regular user" do
+    sign_in { FactoryBot.create(:user) }
+
+    it "redirects to home page" do
+      get submit_results_edit_path(comp.id)
+      expect(response).to redirect_to(root_url)
+    end
+  end
+
+  context "logged in as a regular delegate" do
+    sign_in { FactoryBot.create(:delegate) }
+
+    it "redirects to home page" do
+      get submit_results_edit_path(comp.id)
+      expect(response).to redirect_to(root_url)
+    end
+  end
+
+  context "logged in as THE delegate" do
+    let(:user) { comp.delegates.first }
+    let(:submission_message) { "Hello, here are the results" }
+    let(:file_contents) { '{ "results": "good" }' }
+    let(:file) do
+      temp_file = Tempfile.new("sometmpfilename.tmp")
+      temp_file.write(file_contents)
+      temp_file.rewind
+      Rack::Test::UploadedFile.new(temp_file.path, "application/json")
+    end
+
+    before :each do
+      sign_in user
+    end
+
+    describe "Seeing results submission page" do
+      it "returns http success" do
+        get submit_results_edit_path(comp.id)
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    describe "Posting results" do
+      it "sends the 'results submitted' email immediately" do
+        expect(CompetitionsMailer)
+          .to receive(:results_submitted)
+          .with(comp, submission_message, user.name, file_contents)
+          .and_call_original
+        post submit_results_path(comp.id), params: { competition_id: comp.id, message: submission_message, results: file }
+
+        assert_enqueued_jobs 0
+      end
+
+      it "redirects to competition page" do
+        post submit_results_path(comp.id), params: { competition_id: comp.id, message: submission_message, results: file }
+
+        expect(flash[:success]).not_to be_empty
+        expect(response).to redirect_to(competition_path(comp))
+      end
+    end
+
+    describe "Posting results with missing message" do
+      it "flashes an error and doesn't send an email" do
+        expect {
+          post submit_results_path(comp.id), params: { competition_id: comp.id, results: file }
+        }.to_not change { ActionMailer::Base.deliveries.count }
+
+        expect(flash.now[:danger]).not_to be_empty
+      end
+    end
+
+    describe "Posting results with missing file" do
+      it "flashes an error and doesn't send an email" do
+        expect {
+          post submit_results_path(comp.id), params: { competition_id: comp.id, message: submission_message }
+        }.to_not change { ActionMailer::Base.deliveries.count }
+
+        expect(flash.now[:danger]).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the "Step 1" of #2113:

> ### Step 1: Add a page for submitting results
> * Add a new "Submit results" navigation item in the delegate view of a competition, probably just above "Delegate report"
> * It opens a simple view with a file upload, a text input, and a Submit button
> * Clicking the button sends an email:
>   * To the results team
>   * CC to the delegates of the competition
>   * With "Results for \<competition-name\>" as subject and the content of the text input as body
>   * With the uploaded file attached

I realized that I can't upload the file directly to an email if the email is buffered and sent later.
I fixed that problem by writing the file to local disk...
For now, it's not deleted, and it's very inefficient because I'm sure the results team will upload the same file again later anyway...
I'm not sure we should use this as is, but I wanted to show what the page looks like and what it does.