### PR TITLE
Remove weird use of registration's attributes

### DIFF
--- a/WcaOnRails/app/views/registrations/_register_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_register_form.html.erb
@@ -24,6 +24,7 @@
         <% if @registration.new_or_deleted? %>
           <%= f.submit t('registrations.register'), class: "btn btn-success" %>
         <% else %>
+          <%= f.hidden_field :status, value: @registration.checked_status %>
           <%= link_to t('registrations.delete'), registration_path(@registration, user_is_deleting_theirself: true), method: :delete, class: "btn btn-danger", data: { confirm: t('registrations.delete_confirm'), toggle: "tooltip" }, title: t('registrations.delete_registration') %>
           <%= f.submit t('registrations.update'), class: "btn btn-success" %>
         <% end %>

--- a/WcaOnRails/spec/features/register_for_competition_spec.rb
+++ b/WcaOnRails/spec/features/register_for_competition_spec.rb
@@ -82,6 +82,7 @@ RSpec.feature "Registering for a competition" do
 
   context "signed in as delegate" do
     let(:registration) { FactoryBot.create(:registration, user: user, competition: competition) }
+    let(:delegate_registration) { FactoryBot.create(:registration, :accepted, user: delegate, competition: competition) }
     before :each do
       sign_in delegate
     end
@@ -91,6 +92,19 @@ RSpec.feature "Registering for a competition" do
       fill_in "Guests", with: 1
       click_button "Update Registration"
       expect(registration.reload.guests).to eq 1
+    end
+
+    scenario "updating his own registration" do
+      expect(delegate_registration.guests).to eq 10
+
+      visit competition_register_path(competition)
+
+      expect(page).to have_text("Your registration has been accepted!")
+      fill_in "Guests", with: "2"
+      click_button "Update Registration"
+
+      expect(page).to have_text("Your registration has been accepted!")
+      expect(delegate_registration.reload.guests).to eq 2
     end
 
     scenario "deleting registration" do


### PR DESCRIPTION
These attributes are only set a few lines below this, and are never given through a form, so there is no reason why we need to permit them or set them to nil for every user.

Additionally, this creates a bug when an admin for a comp updates their own registration: the nullified `accepted_at` make the controller consider this registration as a "new" registration instead of an update of an accepted one.