### PR TITLE
Add a table of contents to delegate crash course

### DIFF
--- a/WcaOnRails/app/helpers/markdown_helper.rb
+++ b/WcaOnRails/app/helpers/markdown_helper.rb
@@ -28,7 +28,7 @@ module MarkdownHelper
     end
   end
 
-  def md(content, target_blank: false)
+  def md(content, target_blank: false, toc: false)
     if content.nil?
       return ""
     end
@@ -47,6 +47,13 @@ module MarkdownHelper
       options[:link_attributes] = { target: "_blank" }
     end
 
-    Redcarpet::Markdown.new(WcaMarkdownRenderer.new(options), extensions).render(content).html_safe
+    output = "".html_safe
+
+    if toc
+      options[:with_toc_data] = true
+      output += Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC.new(options), extensions).render(content).html_safe
+    end
+
+    output += Redcarpet::Markdown.new(WcaMarkdownRenderer.new(options), extensions).render(content).html_safe
   end
 end

--- a/WcaOnRails/app/views/posts/_post.html.erb
+++ b/WcaOnRails/app/views/posts/_post.html.erb
@@ -27,7 +27,6 @@
       <% end %>
     </div>
 
-    <%= md post.body_full, toc: true if render_toc %>
-    <%= md render_teaser ? post.body_teaser : post.body_full %>
+    <%= md render_teaser ? post.body_teaser : post.body_full, toc: render_toc %>
   </div>
 </div>

--- a/WcaOnRails/app/views/posts/_post.html.erb
+++ b/WcaOnRails/app/views/posts/_post.html.erb
@@ -26,6 +26,8 @@
         <em><%= t 'posts.announcement_info_html', author_name: post.author.name, date_time: wca_local_time(post.created_at) %></em>
       <% end %>
     </div>
-    <%=md render_teaser ? post.body_teaser : post.body_full %>
+
+    <%= md post.body_full, toc: true if render_toc %>
+    <%= md render_teaser ? post.body_teaser : post.body_full %>
   </div>
 </div>

--- a/WcaOnRails/app/views/posts/index.html.erb
+++ b/WcaOnRails/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
 <div class="container">
-  <%= render @posts, render_permalink: true, render_teaser: true %>
+  <%= render @posts, render_permalink: true, render_teaser: true, render_toc: false %>
   <%= paginate @posts %>
 </div>

--- a/WcaOnRails/app/views/posts/show.html.erb
+++ b/WcaOnRails/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, @post.title) %>
 
 <div class="container">
-  <%= render @post, render_permalink: false, render_teaser: false %>
+  <%= render @post, render_permalink: false, render_teaser: false, render_toc: true %>
 </div>

--- a/WcaOnRails/spec/helpers/markdown_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/markdown_helper_spec.rb
@@ -9,5 +9,15 @@ RSpec.describe MarkdownHelper do
         "<iframe width='640' height='390' frameborder='0' src='https://www.youtube.com/embed/VIDEO'></iframe>",
       )
     end
+
+    it "with table of contents, generates links to every header" do
+      expect(helper.md("# Foo Bar", toc: true)).to eq '<ul>
+<li>
+<a href="#foo-bar">Foo Bar</a>
+</li>
+</ul>
+<h1><span id=\'foo-bar\' class=\'anchorable\'><a href=\'#foo-bar\'><span class=\'glyphicon glyphicon-link\'></span></a> Foo Bar</span></h1>
+'
+    end
   end
 end


### PR DESCRIPTION
This fixes #2221.

I've just deployed the code to staging, @pedrosino, can you give it a shot? I uploaded our readme to the delegate crash course, so you should be able to play around with it here: https://staging.worldcubeassociation.org/delegate/crash-course.