### PR TITLE
Check that scramble group names match [A-Z]+

### DIFF
--- a/webroot/results/admin/upload_results.php
+++ b/webroot/results/admin/upload_results.php
@@ -205,6 +205,10 @@ if($form->submitted()) {
         foreach ($round->groups as $group) {
           $groupId = property_exists($group, 'group') ? ($group->group) : false;
 
+          if(!preg_match("/^[A-Z]+$/", $groupId)) {
+            $round_errors[] = "Invalid scramble group name: ".o($groupId);
+          }
+
           // Store normal scrambles
           if(!property_exists($group, 'scrambles')) {
             $round_errors[] = "Group has no scramble data: `".o($eventId)."`:`".o($roundTypeId)."`:`".o($groupId)."`.";


### PR DESCRIPTION
This fixes #2201.

@FatBoyXPC, could you take a look at this php code? Thanks!

Thanks to #2161, group names will no longer be silently truncated, instead we get an error message. For example, here's what happens when I try to upload results containing a scramble group named "Bad group name":

![image](https://user-images.githubusercontent.com/277474/33622053-8d23f4c8-d9a1-11e7-8f0f-56f49b5ea153.png)

Here's what happens when I try to upload results containing a scramble group named "ba1":

![image](https://user-images.githubusercontent.com/277474/33622187-f3fed55a-d9a1-11e7-803f-123eea7072f5.png)