### PR TITLE
Remove coffee-script.

### DIFF
--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -13,8 +13,6 @@
     "babel-preset-stage-2": "^6.24.1",
     "blueimp-load-image": "^2.17.1",
     "classnames": "^2.2.5",
-    "coffee-loader": "^0.9.0",
-    "coffee-script": "^1.12.8",
     "compression-webpack-plugin": "^1.0.1",
     "css-loader": "^0.28.4",
     "extract-text-webpack-plugin": "^3.0.2",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -1342,16 +1342,6 @@ coffee-loader@^0.8.0:
   dependencies:
     loader-utils "^1.0.2"
 
-coffee-loader@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/coffee-loader/-/coffee-loader-0.9.0.tgz#6deabd336062ddc6d773da4dfd16367fc7107bd6"
-  dependencies:
-    loader-utils "^1.0.2"
-
-coffee-script@^1.12.8:
-  version "1.12.8"
-  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.8.tgz#a1fed1fefa21fb5eee6da0248454121ee26058da"
-
 color-convert@^1.3.0, color-convert@^1.8.2, color-convert@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"


### PR DESCRIPTION
We started seeing the following error in production:

```
~/worldcubeassociation.org/WcaOnRails @production> tail -n 15 yarn-error.log
      decamelize "^1.0.0"
      window-size "0.1.0"

Trace:
  Error: https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.8.tgz: Request failed "404 Not Found"
      at Request.<anonymous> (/usr/share/yarn/lib/cli.js:59296:26)
      at emitOne (events.js:115:13)
      at Request.emit (events.js:210:7)
      at Request.module.exports.Request.onRequestResponse (/usr/share/yarn/lib/cli.js:123897:10)
      at emitOne (events.js:115:13)
      at ClientRequest.emit (events.js:210:7)
      at HTTPParser.parserOnIncomingClient (_http_client.js:549:21)
      at HTTPParser.parserOnHeadersComplete (_http_common.js:116:23)
      at TLSSocket.socketOnData (_http_client.js:438:20)
      at emitOne (events.js:115:13)
```

It turns out that CoffeeScript on NPM has moved to "coffeescript" (no
hyphen). We aren't even using coffeescript, so I figured we might as
well remove it.