### PR TITLE
Change round ids to match the updated WCIF activity code definition.

### DIFF
--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -42,7 +42,7 @@ class Round < ApplicationRecord
   end
 
   def self.parse_wcif_id(wcif_id)
-    event_id, round_number = wcif_id.split("-")
+    event_id, round_number = /^([^-]+)-r([^-]+)$/.match(wcif_id).captures
     round_number = round_number.to_i
     { event_id: event_id, round_number: round_number }
   end
@@ -80,7 +80,7 @@ class Round < ApplicationRecord
   end
 
   def wcif_id
-    "#{event.id}-#{self.number}"
+    "#{event.id}-r#{self.number}"
   end
 
   def to_wcif

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Competition WCIF" do
             "id" => "333",
             "rounds" => [
               {
-                "id" => "333-1",
+                "id" => "333-r1",
                 "format" => "a",
                 "timeLimit" => {
                   "centiseconds" => 10.minutes.in_centiseconds,
@@ -57,7 +57,7 @@ RSpec.describe "Competition WCIF" do
                 },
               },
               {
-                "id" => "333-2",
+                "id" => "333-r2",
                 "format" => "a",
                 "timeLimit" => {
                   "centiseconds" => 10.minutes.in_centiseconds,
@@ -72,7 +72,7 @@ RSpec.describe "Competition WCIF" do
             "id" => "333fm",
             "rounds" => [
               {
-                "id" => "333fm-1",
+                "id" => "333fm-r1",
                 "format" => "m",
                 "timeLimit" => nil,
                 "cutoff" => nil,
@@ -84,7 +84,7 @@ RSpec.describe "Competition WCIF" do
             "id" => "333mbf",
             "rounds" => [
               {
-                "id" => "333mbf-1",
+                "id" => "333mbf-r1",
                 "format" => "3",
                 "timeLimit" => nil,
                 "cutoff" => nil,
@@ -96,7 +96,7 @@ RSpec.describe "Competition WCIF" do
             "id" => "444",
             "rounds" => [
               {
-                "id" => "444-1",
+                "id" => "444-r1",
                 "format" => "a",
                 "timeLimit" => {
                   "centiseconds" => 10.minutes.in_centiseconds,
@@ -150,7 +150,7 @@ RSpec.describe "Competition WCIF" do
         "id" => "555",
         "rounds" => [
           {
-            "id" => "555-1",
+            "id" => "555-r1",
             "format" => "3",
             "timeLimit" => {
               "centiseconds" => 3*60*100,
@@ -174,7 +174,7 @@ RSpec.describe "Competition WCIF" do
         "level" => 16,
       }
       wcif_444_event["rounds"] << {
-        "id" => "444-2",
+        "id" => "444-r2",
         "format" => "a",
         "timeLimit" => {
           "centiseconds" => 10.minutes.in_centiseconds,

--- a/WcaOnRails/spec/models/round_spec.rb
+++ b/WcaOnRails/spec/models/round_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Round do
     end
 
     it "set to 5 minutes" do
-      round.update!(time_limit: TimeLimit.new(centiseconds: 5.minutes.in_centiseconds, cumulative_round_ids: ["333-1"]))
+      round.update!(time_limit: TimeLimit.new(centiseconds: 5.minutes.in_centiseconds, cumulative_round_ids: ["333-r1"]))
       expect(round.time_limit.centiseconds).to eq 5.minutes.in_centiseconds
       expect(round.time_limit_to_s).to eq "5:00.00 cumulative"
     end
 
     it "set to 60 minutes shared between 444bf and 555bf" do
-      four_blind_round.update!(time_limit: TimeLimit.new(centiseconds: 5.minutes.in_centiseconds, cumulative_round_ids: ["444bf-1", "555bf-1"]))
+      four_blind_round.update!(time_limit: TimeLimit.new(centiseconds: 5.minutes.in_centiseconds, cumulative_round_ids: ["444bf-r1", "555bf-r1"]))
       expect(four_blind_round.time_limit.centiseconds).to eq 5.minutes.in_centiseconds
       expect(four_blind_round.time_limit_to_s).to eq "5:00.00 total for 4x4x4 Blindfolded Round 1 and 5x5x5 Blindfolded Round 1"
     end


### PR DESCRIPTION
`333-1` should actually be `333-r1`, as per the WCIF doc: https://docs.google.com/document/d/1hnzAZizTH0XyGkSYe-PxFL5xpKVWl_cvSdTzlT_kAs8/edit#heading=h.14uuu58hnua.

@coder13, thanks for noticing this! Could you take a look at this PR?