### PR TITLE
Add &lrm; character to maintain directionality when printing names.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -304,7 +304,7 @@ class CompetitionsController < ApplicationController
                 end
                 record_strs
               end.flatten
-              "#{uniqueName} #{record_strs.join(", ")}"
+              "#{uniqueName}&lrm; #{record_strs.join(", ")}"
             end
           end
           body += "#{record_strs.join(", ")}.  \n" # Trailing spaces for markdown give us a <br>

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -843,10 +843,10 @@ RSpec.describe CompetitionsController do
         expect(competition.results_posted_at).to be nil
         get :post_results, params: { id: competition }
         post = assigns(:post)
-        expect(post.body).to include "World records: Jeremy Fleischman 3x3x3 One-Handed 50.00 (average), " \
-          "Vincent Sheu (2006SHEU01) 3x3x3 Fewest Moves 25 (single), 3x3x3 Fewest Moves 26.00 (average), " \
-          "Vincent Sheu (2006SHEU02) 2x2x2 Cube 10.00 (single)"
-        expect(post.body).to include "North American records: Jeremy Fleischman 3x3x3 One-Handed 41.00 (single), 3x3x3 One-Handed 40.00 (single)"
+        expect(post.body).to include "World records: Jeremy Fleischman&lrm; 3x3x3 One-Handed 50.00 (average), " \
+          "Vincent Sheu (2006SHEU01)&lrm; 3x3x3 Fewest Moves 25 (single), 3x3x3 Fewest Moves 26.00 (average), " \
+          "Vincent Sheu (2006SHEU02)&lrm; 2x2x2 Cube 10.00 (single)"
+        expect(post.body).to include "North American records: Jeremy Fleischman&lrm; 3x3x3 One-Handed 41.00 (single), 3x3x3 One-Handed 40.00 (single)"
         expect(post.title).to include "in #{competition.cityName}, #{competition.country.name_in(:en)}"
         competition.reload
         expect(competition.results_posted_at.to_f).to be < Time.now.to_f


### PR DESCRIPTION
See https://github.com/thewca/worldcubeassociation.org/issues/1116 for a
discussion of different approaches to this same problem.