### PR TITLE
Automatically create an example OAuth application whenever importing the developer database.

### DIFF
--- a/WcaOnRails/config/initializers/monkey_patches.rb
+++ b/WcaOnRails/config/initializers/monkey_patches.rb
@@ -67,4 +67,12 @@ Rails.configuration.to_prepare do
       self.reload
     end
   end
+
+  # Copied and modified from https://github.com/doorkeeper-gem/doorkeeper/issues/210#issuecomment-15895378
+  Doorkeeper::OAuth::PreAuthorization.class_eval do
+    old_validate_redirect_uri = instance_method(:validate_redirect_uri)
+    define_method(:validate_redirect_uri) do
+      return @client.application.dangerously_allow_any_redirect_uri ? true : old_validate_redirect_uri.bind(self).call
+    end
+  end
 end

--- a/WcaOnRails/db/migrate/20171221184910_add_dangerously_allow_any_redirect_uri_to_oauth_applications.rb
+++ b/WcaOnRails/db/migrate/20171221184910_add_dangerously_allow_any_redirect_uri_to_oauth_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDangerouslyAllowAnyRedirectUriToOauthApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :oauth_applications, :dangerously_allow_any_redirect_uri, :boolean, null: false, default: false
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -786,6 +786,7 @@ CREATE TABLE `oauth_applications` (
   `updated_at` datetime DEFAULT NULL,
   `owner_id` int(11) DEFAULT NULL,
   `owner_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `dangerously_allow_any_redirect_uri` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
@@ -1247,4 +1248,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20171122220857'),
 ('20171124184454'),
 ('20171219000023'),
-('20171219204656');
+('20171219204656'),
+('20171221184910');

--- a/WcaOnRails/lib/tasks/db.rake
+++ b/WcaOnRails/lib/tasks/db.rake
@@ -86,6 +86,18 @@ namespace :db do
           LogTask.log_task "Setting all user passwords to '#{default_password}'" do
             User.update_all encrypted_password: default_encrypted_password
           end
+
+          # Create an OAuth application so people can easily play around with OAuth on staging.
+          Doorkeeper::Application.create!(
+            name: "Example Application for staging",
+            uid: "example-application-id",
+            secret: "example-secret",
+            redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
+            dangerously_allow_any_redirect_uri: true,
+            scopes: Doorkeeper.configuration.scopes.to_s,
+            owner_id: User.find_by_wca_id!("2005FLEI01").id,
+            owner_type: "User",
+          )
         end
       end
     end


### PR DESCRIPTION
This makes things easier for people testing out TNoodle. (needed for https://github.com/thewca/tnoodle/pull/236)