### PR TITLE
Fix translations comparision bug

### DIFF
--- a/WcaOnRails/app/models/locale.rb
+++ b/WcaOnRails/app/models/locale.rb
@@ -31,10 +31,7 @@ class Locale < SimpleDelegator
   # Adapted from https://github.com/jonatanklosko/internationalize/blob/7090c90d4d8e4571025c3be4484b5f668cbb6501/client/app/services/translation-utils.service.js#L195-L221
   def decorate_with_hashes(text, node, prefix)
     node.each do |key, value|
-      if value.nil?
-        node.delete(key)
-        next
-      elsif leaf?(value)
+      if leaf?(value)
         # We want leaves to have at least "_translated", and maybe later "_hash"
         node[key] = { "_translated" => value }
       else
@@ -90,7 +87,7 @@ class Locale < SimpleDelegator
     missing_keys = []
     outdated_keys = []
     base.each do |key, value|
-      unless translation.key?(key)
+      if !translation.key?(key) || (leaf?(value) && translation[key]["_translated"].nil?)
         if leaf?(value)
           missing_keys << fully_qualified_name(context, key)
         else


### PR DESCRIPTION
So far, while processing (restructuring) parsed YAML data (a Ruby Hash equivalent of the given YAML), we used to remove a key from translation data whenever its value was null. In #2319 thought, there is a `null`y key and the exact same key appears later on (specifically `about_regulations`). What may happen is that for the `null`y key we just move forward without touching the YAML text (i.e. without removing the comment and the key). This leads to weird behaviour for the second occurrence of the `about_regulations` key.

I just changed it so that it's more clean what we want to achieve, and it works well indeed (I made sure that it shows what it did previously and it doesn't fail for the latest Russian update). So instead of removing the key, we keep it with its value of `null`. Then we consider a key to be missing if it doesn't exist **or if it's `null`** (when it exists but hasn't been translated yet).