### PR TITLE
Set expiry date of credit card to 2030 for refund test - Fixes #2357

### DIFF
--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -679,7 +679,7 @@ RSpec.describe RegistrationsController do
           card: {
             number: "4242424242424242",
             exp_month: 12,
-            exp_year: 2017,
+            exp_year: Date.today.year + 1,
             cvc: "314",
           },
         ).id


### PR DESCRIPTION
Now we are in 2018, a credit card with an expiry date of 2017 is not valid.