### PR TITLE
Partial refunds now supported - fixes #1951

### DIFF
--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -40,7 +40,8 @@
           <%= wca_local_time(payment.created_at) %>
           <%= format_money payment.amount %>
           <% if payment.amount_available_for_refund > 0 %>
-            <%= form_tag registration_payment_refund_path(@registration, payment), method: :post do %>
+            <%= horizontal_simple_form_for :payment, url: registration_payment_refund_path(@registration, payment), html: { id: :form_refund } do |f| %>
+              <%= f.input :refund_amount, as: :money_amount, currency: payment.amount.currency.iso_code, value: payment.amount_available_for_refund, label: t('registrations.refund_form.labels.refund_amount'), hint: t('registrations.refund_form.hints.refund_amount') %>
               <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>
             <% end %>
           <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -794,6 +794,11 @@ en:
     entry_fees_fully_paid: "You have paid %{paid}, which fully covers the entry fees."
     will_pay_here: "You will pay them here after submitting your registration"
     wont_pay_here: "Please check competition's information for instruction about how to pay"
+    refund_form:
+      hints:
+        refund_amount: "The amount to refund to the competitor, can be any value up to the amount already paid."
+      labels:
+        refund_amount: "Refund Amount"
     #context: on the payment form, when registering to a competition
     payment_form:
       title: "Registration fees"


### PR DESCRIPTION
For each payment that has not been fully refunded, a form will appear allowing the administrator to specify a refund amount:

![partial-refunds](https://user-images.githubusercontent.com/4403168/34507419-c3f83618-f089-11e7-9154-a4c6ca5c123f.png)

Note that if a partial refund is given, then the user's registration page will once again show an amount to be paid that brings their total paid back to the amount due.