### PR TITLE
Hide competitors count of 0 until results are submitted

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -64,20 +64,18 @@
     <dl class="dl-horizontal">
       <dt><%= t '.information' %></dt>
       <dd><%=md competition.information %></dd>
-    </dl>
 
-    <dl class="dl-horizontal">
       <dt><%= t '.events' %></dt>
       <dd class="competition-events-list">
         <% @competition.events.each do |event| %>
           <%= cubing_icon event.id, data: { toggle: "tooltip", placement: "top", container: "body" }, title: event.name %>
         <% end %>
       </dd>
-    </dl>
 
-    <dl class="dl-horizontal">
-      <dt><%= t 'competitions.nav.menu.competitors' %></dt>
-      <dd><%= @competition.competitors.count %></dd>
+      <% if competition.results_posted? %>
+        <dt><%= t 'competitions.nav.menu.competitors' %></dt>
+        <dd><%= @competition.competitors.count %></dd>
+      <% end %>
     </dl>
 
     <% media = competition.media.accepted %>


### PR DESCRIPTION
At the moment competitors count is 0 for upcoming comps, an example below

![image](https://user-images.githubusercontent.com/17034772/34569061-e66ff44a-f167-11e7-9a62-49ef335b6d9c.png)
