### PR TITLE
Update exim config to use Amazon SES on production and mailcatcher on staging

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -173,7 +173,7 @@ logrotate_app 'delayed_job-wca' do
 end
 
 # Run mailcatcher in every environment except production.
-if rails_env != "production"
+if node.chef_environment != "production"
   gem_package "mailcatcher"
   execute "start mailcatcher" do
     command "mailcatcher --http-ip=0.0.0.0"

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -176,7 +176,7 @@ end
 if node.chef_environment != "production"
   gem_package "mailcatcher"
   execute "start mailcatcher" do
-    command "mailcatcher --http-ip=0.0.0.0"
+    command "mailcatcher --no-quit --http-ip=0.0.0.0"
     not_if "pgrep -f [m]ailcatcher"
   end
 end

--- a/chef/site-cookbooks/wca/recipes/email.rb
+++ b/chef/site-cookbooks/wca/recipes/email.rb
@@ -1,4 +1,30 @@
-node.default['exim4']['configtype'] = 'internet'
+secrets = WcaHelper.get_secrets(self)
+
+node.default['exim4']['configtype'] = 'smarthost'
+
+if node.chef_environment != "production"
+  # Configuration for mailcatcher
+  node.default['exim4']['smarthost_server'] = '127.0.0.1'
+  node.default['exim4']['smarthost_port'] = '1025'
+else
+  # Configuration for Amazon SES. Inspired by
+  # https://technpol.wordpress.com/2014/03/29/configuring-exim-for-amazon-mail-debian-exim4-and-aws-ses/
+  node.default['exim4']['smarthost_server'] = 'email-smtp.us-west-2.amazonaws.com'
+  node.default['exim4']['smarthost_port'] = '587'
+  # Amazon will resolve to a different server name each time (via the load
+  # balancer), so you can’t just put your smtp server name in here.
+  node.default['exim4']['smarthost_auth_server'] = '*.amazonaws.com'
+  node.default['exim4']['smarthost_login'] = secrets['SMTP_USERNAME']
+  node.default['exim4']['smarthost_pwd'] = secrets['SMTP_PASSWORD']
+end
+
+node.default['exim4']['other_hostnames'] = node['fqdn']
+node.default['exim4']['local_interfaces'] = '127.0.1.1' # make way for mailcatcher
+node.default['exim4']['relay_domains'] = ''
+node.default['exim4']['minimaldns'] = 'false'
+node.default['exim4']['relay_nets'] = ''
 node.default['exim4']['use_split_config'] = false
-node.default['exim4']['local_interfaces'] = ''
+node.default['exim4']['hide_mailname'] = false
+node.default['exim4']['localdelivery'] = 'maildir_home'
+
 include_recipe "exim4-light"

--- a/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
+++ b/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
@@ -9,6 +9,20 @@ upstream app {
 <% end %>
 }
 
+<% if node.chef_environment != "production" %>
+  # Serve mailcatcher at https://staging.worldcubeassociation.org:444
+  server {
+    server_name staging.worldcubeassociation.org;
+
+    listen 444 ssl;
+    include wca_https.conf;
+
+    location / {
+      proxy_pass http://localhost:1080;
+    }
+  }
+<% end %>
+
 server {
   server_name <%= @server_name %> localhost;
 


### PR DESCRIPTION
I decided to finally shave this yak after @viroulep ran into some pain debugging a job failure on staging. This PR changes how sendmail (which is used by cron) works on both production and staging:

- On production, sendmail now uses Amazon SES. This means that cronjob failures will no longer be treated as spam by Google Groups.
- On staging, sendmail now sends mail to localhost:1025 (mailcatcher). **This means no more cronjob emails from staging will get emailed to us, which should be a nice break on all our inboxes** I also updated chef to automatically run mailcatcher on staging, and our staging nginx config so you can access mailcatcher at https://staging.worldcubeassociation.org:444/. This will catch emails from both WcaOnRails, and anything that uses sendmail. One way to test this out by ssh-ing to staging and invoking sendmail:

```
/tmp @staging> echo "Subject: This is a test email from jeremy" | sendmail -v jeremyfleischman@gmail.com  LOG: MAIN
  <= cubing@staging.worldcubeassociation.org U=cubing P=local S=418
/tmp @staging> delivering 1eXe4q-0006HD-9E
R: smarthost for jeremyfleischman@gmail.com
T: remote_smtp_smarthost for jeremyfleischman@gmail.com
Transport port=25 replaced by host-specific port=1025
Connecting to 127.0.0.1 [127.0.0.1]:1025 ... connected
  SMTP<< 220 EventMachine SMTP Server
  SMTP>> EHLO staging.worldcubeassociation.org
  SMTP<< 250-Ok EventMachine SMTP Server
         250-NO-SOLICITING
         250 SIZE 20000000
  SMTP>> MAIL FROM:<cubing@staging.worldcubeassociation.org> SIZE=1450
  SMTP<< 250 Ok
  SMTP>> RCPT TO:<jeremyfleischman@gmail.com>
  SMTP<< 250 Ok
  SMTP>> DATA
  SMTP<< 354 Send it
  SMTP>> writing message and terminating "."
  SMTP<< 250 Message accepted
  SMTP>> QUIT
LOG: MAIN
  => jeremyfleischman@gmail.com R=smarthost T=remote_smtp_smarthost H=127.0.0.1 [127.0.0.1] C="250 Message accepted"
LOG: MAIN
  Completed
```

After the above, you can view the email at https://staging.worldcubeassociation.org:444/.