### PR TITLE
Disable changing the autonumeric on scroll.

### DIFF
--- a/WcaOnRails/app/javascript/auto-numeric/index.js
+++ b/WcaOnRails/app/javascript/auto-numeric/index.js
@@ -31,6 +31,7 @@ function applyCurrencyMask(action, $element, currencyIsoCode) {
     // decimals. For currencies with subunits we want to show decimals.
     decimalPlaces: (entry.subunitToUnit == 1) ? 0 : 2,
     showWarnings: false,
+    modifyValueOnWheel: false,
   };
 
   let autoNumericObject = $element.data("autoNumericObject");


### PR DESCRIPTION
It's way too easy to accidentally do when scrolling through the page.
Thanks to Oliver for pointing this out.