### PR TITLE
Prevent certain cutoffs from being selected based on round Format

### DIFF
--- a/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
@@ -70,9 +70,9 @@ export default {
               >
                 <option value={0}>No cutoff</option>
                 {solveCount > 1 ? <option disabled="disabled">────────</option> : null}
-                {solveCount > 1 ? <option value={1}>Best of 1</option> : null}
+                {solveCount > 1 && wcifRound.format !== 'a'  ? <option value={1}>Best of 1</option> : null}
                 {solveCount > 2 ? <option value={2}>Best of 2</option> : null}
-                {solveCount > 3 ? <option value={3}>Best of 3</option> : null}
+                {solveCount > 3 && wcifRound.format !== 'a' ? <option value={3}>Best of 3</option> : null}
               </select>
               <div className="input-group-addon">
                 <strong>/ {formats.byId[wcifRound.format].name}</strong>

--- a/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
@@ -37,7 +37,7 @@ export default {
   },
   Input({ value: cutoff, onChange, autoFocus, wcifEvent, roundNumber }) {
     let wcifRound = wcifEvent.rounds[roundNumber - 1];
-    let solveCount = formats.byId[wcifRound.format].expectedSolveCount;
+    let cutoffFormats = formats.byId[wcifRound.format].allowedFirstPhaseFormats;
 
     let numberOfAttemptsInput, attemptResultInput;
     let onChangeAggregator = () => {
@@ -69,10 +69,10 @@ export default {
                       ref={c => numberOfAttemptsInput = c}
               >
                 <option value={0}>No cutoff</option>
-                {solveCount > 1 ? <option disabled="disabled">────────</option> : null}
-                {solveCount > 1 && wcifRound.format !== 'a'  ? <option value={1}>Best of 1</option> : null}
-                {solveCount > 2 ? <option value={2}>Best of 2</option> : null}
-                {solveCount > 3 && wcifRound.format !== 'a' ? <option value={3}>Best of 3</option> : null}
+                {cutoffFormats.length > 0 && (<option disabled="disabled">────────</option>)}
+                {cutoffFormats.map((format, index) =>
+                  <option key={index} value={+format}>Best of {format}</option>
+                )}
               </select>
               <div className="input-group-addon">
                 <strong>/ {formats.byId[wcifRound.format].name}</strong>

--- a/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
@@ -37,6 +37,7 @@ export default {
   },
   Input({ value: cutoff, onChange, autoFocus, wcifEvent, roundNumber }) {
     let wcifRound = wcifEvent.rounds[roundNumber - 1];
+    let solveCount = formats.byId[wcifRound.format].expectedSolveCount;
 
     let numberOfAttemptsInput, attemptResultInput;
     let onChangeAggregator = () => {
@@ -57,7 +58,7 @@ export default {
     return (
       <div>
         <div className="form-group">
-          <label htmlFor="cutoff-round-format-input" className="col-sm-3 control-label">Round format</label>
+          <label htmlFor="cutoff-round-format-input" className="col-sm-3 control-label">Cutoff format</label>
           <div className="col-sm-9">
             <div className="input-group">
               <select value={cutoff ? cutoff.numberOfAttempts : 0}
@@ -68,10 +69,10 @@ export default {
                       ref={c => numberOfAttemptsInput = c}
               >
                 <option value={0}>No cutoff</option>
-                <option disabled="disabled">────────</option>
-                <option value={1}>Best of 1</option>
-                <option value={2}>Best of 2</option>
-                <option value={3}>Best of 3</option>
+                {solveCount > 1 ? <option disabled="disabled">────────</option> : null}
+                {solveCount > 1 ? <option value={1}>Best of 1</option> : null}
+                {solveCount > 2 ? <option value={2}>Best of 2</option> : null}
+                {solveCount > 3 ? <option value={3}>Best of 3</option> : null}
               </select>
               <div className="input-group-addon">
                 <strong>/ {formats.byId[wcifRound.format].name}</strong>

--- a/WcaOnRails/app/models/format.rb
+++ b/WcaOnRails/app/models/format.rb
@@ -9,6 +9,16 @@ class Format < ApplicationRecord
 
   scope :recommended, -> { where("ranking = 1") }
 
+  def allowed_first_phase_formats
+    {
+      "1" => [],
+      "2" => [ "1" ],
+      "3" => [ "1", "2" ],
+      "m" => [ "1", "2" ],
+      "a" => [ "2" ], # https://www.worldcubeassociation.org/regulations/#9b1
+    }[self.id]
+  end
+
   def serializable_hash(options = nil)
     {
       id: self.id,
@@ -18,6 +28,7 @@ class Format < ApplicationRecord
       expected_solve_count: self.expected_solve_count,
       trim_fastest_n: self.trim_fastest_n,
       trim_slowest_n: self.trim_slowest_n,
+      allowed_first_phase_formats: self.allowed_first_phase_formats,
     }
   end
 end

--- a/WcaOnRails/app/models/format.rb
+++ b/WcaOnRails/app/models/format.rb
@@ -12,10 +12,10 @@ class Format < ApplicationRecord
   def allowed_first_phase_formats
     {
       "1" => [],
-      "2" => [ "1" ],
-      "3" => [ "1", "2" ],
-      "m" => [ "1", "2" ],
-      "a" => [ "2" ], # https://www.worldcubeassociation.org/regulations/#9b1
+      "2" => ["1"],
+      "3" => ["1", "2"],
+      "m" => ["1", "2"],
+      "a" => ["2"], # https://www.worldcubeassociation.org/regulations/#9b1
     }[self.id]
   end
 

--- a/WcaOnRails/spec/features/competition_events_spec.rb
+++ b/WcaOnRails/spec/features/competition_events_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Competition events management" do
       within_round("333", 1) { find("[name=cutoff]").click }
 
       within_modal do
-        select "Best of 2", from: "Round format"
+        select "Best of 2", from: "Cutoff format"
         fill_in "minutes", with: "2"
         click_button "Ok"
       end


### PR DESCRIPTION
fixes part of #1916.
Also bundled in a change with the text in the cutoff modal saying "Round Format" changing it to "Cutoff Format" which makes more sense, should probably have been a separate change however.