### PR TITLE
Call check_rounds for every single event, including the last one.

### DIFF
--- a/webroot/results/admin/check_rounds.php
+++ b/webroot/results/admin/check_rounds.php
@@ -241,6 +241,10 @@ function checkRounds () {
 
   }
 
+  // Hacky workaround for https://github.com/thewca/worldcubeassociation.org/issues/830
+  list( $prevCompetitionId, $prevEventId ) = explode('|', $prevEvent);
+  $wrongs += checkRoundNames ( $roundInfos, $prevCompetitionId, $prevEventId );
+
   #--- Tell the result.
   $date = wcaDate();
   noticeBox2(


### PR DESCRIPTION
This fixes #830.

I've deployed this to staging, and you can see it in action here: https://staging.worldcubeassociation.org/results/admin/check_rounds.php?competitionId=JinhuaOpen2016&show=Show.

It takes a while for check_rounds to run against every competition, so I've screenshotted the results of running it against staging:

![image](https://user-images.githubusercontent.com/277474/34818006-66d48e92-f66e-11e7-9906-c453a4897e78.png)
