### PR TITLE
Allow Board members to have a Senior Delegate.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/users.js
+++ b/WcaOnRails/app/assets/javascripts/users.js
@@ -7,7 +7,7 @@ onPage('users#edit, users#update', function() {
       candidate_delegate: true,
       delegate: true,
       senior_delegate: false,
-      board_member: false,
+      board_member: true,
     }[delegateStatus];
 
     var $seniorDelegateSelect = $('.form-group.user_senior_delegate');

--- a/WcaOnRails/app/assets/javascripts/users.js
+++ b/WcaOnRails/app/assets/javascripts/users.js
@@ -1,5 +1,8 @@
 onPage('users#edit, users#update', function() {
   // Hide/show senior delegate select based on what the user's role is.
+  // This is a copy of def self.delegate_status_allows_senior_delegate(delegate_status) in the user model
+  // https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/app/models/user.rb#L299-L308
+  // It is necessary to fix both files for changes to work
   $('select[name="user[delegate_status]"]').on("change", function(e) {
     var delegateStatus = this.value;
     var seniorDelegateRequired = {

--- a/WcaOnRails/app/assets/stylesheets/delegates.scss
+++ b/WcaOnRails/app/assets/stylesheets/delegates.scss
@@ -1,5 +1,5 @@
 tr.board-member {
-  font-weight: bold;
+  // Vestigial - to be removed once https://github.com/thewca/worldcubeassociation.org/issues/2003 is done
 }
 
 tr.senior-delegate {

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -296,6 +296,9 @@ class User < ApplicationRecord
     end
   end
 
+  # This is a copy of def self.delegate_status_allows_senior_delegate(delegate_status) in the user model
+  # https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/app/assets/javascripts/users.js#L3-L11
+  # It is necessary to fix both files for changes to work
   def self.delegate_status_allows_senior_delegate(delegate_status)
     {
       nil => false,

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -303,7 +303,7 @@ class User < ApplicationRecord
       "candidate_delegate" => true,
       "delegate" => true,
       "senior_delegate" => false,
-      "board_member" => false,
+      "board_member" => true,
     }.fetch(delegate_status)
   end
 

--- a/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
+++ b/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
@@ -18,7 +18,8 @@
       <%= render "shared/user", user: delegate %>
     <% end %>
   </td>
-  # Temporary hack - to be removed once https://github.com/thewca/worldcubeassociation.org/issues/2003 is done
-  <td><%= t "delegate_statuses.#{delegate.delegate_status == "board_member" ? "Delegate" : delegate.delegate_status}" %></td>
+  <%# Temporary hack - to be removed once https://github.com/thewca/worldcubeassociation.org/issues/2003 is done %>
+  <td><%= t "enums.user.delegate_status.#{delegate.delegate_status == "board_member" ? "delegate" : delegate.delegate_status}" %>
+  </td>
   <td><%= delegate.region %></td>
 </tr>

--- a/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
+++ b/WcaOnRails/app/views/static_pages/_delegate_row.html.erb
@@ -18,6 +18,7 @@
       <%= render "shared/user", user: delegate %>
     <% end %>
   </td>
-  <td><%= t "delegate_statuses.#{delegate.delegate_status}" %></td>
+  # Temporary hack - to be removed once https://github.com/thewca/worldcubeassociation.org/issues/2003 is done
+  <td><%= t "delegate_statuses.#{delegate.delegate_status == "board_member" ? "Delegate" : delegate.delegate_status}" %></td>
   <td><%= delegate.region %></td>
 </tr>

--- a/WcaOnRails/app/views/static_pages/delegates.html.erb
+++ b/WcaOnRails/app/views/static_pages/delegates.html.erb
@@ -5,9 +5,7 @@
   <p><%= t('about.structure.delegates_html', see_link: "") %></p>
   <p><%= t('delegates_page.acknowledges') %></p>
 
-  <% delegate_sort_order = { region: :asc, delegate_status: :desc, name: :asc } %>
-
-  <%= render partial: "delegates_in_region_table", locals: { delegates: @board_members.order(delegate_sort_order) } %>
+  <% delegate_sort_order = { region: :asc, name: :asc } %>
 
   <% @senior_delegates.order(delegate_sort_order).each do |senior_delegate| %>
     <%= render partial: "delegates_in_region_table", locals: { delegates: [senior_delegate] + senior_delegate.subordinate_delegates.order(delegate_sort_order) } %>

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe User, type: :model do
     expect(senior_delegate1).to be_invalid_with_errors(senior_delegate: ["must not be present"])
   end
 
-  it "does not allow senior delegate if board member" do
+  it "allows senior delegate if board member" do
     board_member = FactoryBot.create :user
     board_member.board_member!
 
@@ -117,7 +117,7 @@ RSpec.describe User, type: :model do
 
     expect(board_member).to be_valid
     board_member.senior_delegate = senior_delegate
-    expect(board_member).to be_invalid_with_errors(senior_delegate: ["must not be present"])
+    expect(board_member).to be_valid
   end
 
   it "does not allow senior delegate if regular user" do


### PR DESCRIPTION
Fixes #2002 

**Remember**
- [x] Board members are shown last on the list, and not on alphabetical order (they were last because of region being World (Something))
- [x] Show "Delegate" instead of "Board member" (temporary hack)
- [x] Make line not-bold 

![senior](https://user-images.githubusercontent.com/1881933/35186132-4d365cba-fdf6-11e7-80a2-18ccf8d2cac0.gif)
