### PR TITLE
Update check_rounds to also update the Scrambles table

### DIFF
--- a/webroot/results/admin/check_rounds_ACTION.php
+++ b/webroot/results/admin/check_rounds_ACTION.php
@@ -74,8 +74,17 @@ function showUpdateSQL () {
           // We can replace a roundTypeId with another one if the new one will not be replaced again
           if( ! in_array( $roundTypeIdNew, array_keys( $roundTypeIds ))){ 
 
-            // Replace
+            // Replace in Results table
             $command = "UPDATE Results
+                        SET roundTypeId='$roundTypeIdNew'
+                        WHERE competitionId='$competitionId'
+                          AND eventId='$eventId'
+                          AND roundTypeId='$roundTypeIdOld'";
+            echo "$command\n";
+            dbCommand( $command );
+
+            // Replace in Scrambles table (will do nothing if scrambles for a competition are not available)
+            $command = "UPDATE Scrambles
                         SET roundTypeId='$roundTypeIdNew'
                         WHERE competitionId='$competitionId'
                           AND eventId='$eventId'


### PR DESCRIPTION
So far the check_rounds_ACTION.php script only updated the Results table, causing inconsistency between Results ans Scrambles. 

Unfortunately, I have no testing environment of the website running, but this should be a very straight-forward fix.