### PR TITLE
Fix competition serialization to not break for missing country

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -910,7 +910,7 @@ class Competition < ApplicationRecord
       website: website,
       short_name: cellName,
       city: cityName,
-      country_iso2: country.iso2,
+      country_iso2: country&.iso2,
       start_date: start_date,
       end_date: end_date,
       delegates: delegates,


### PR DESCRIPTION
Competitions don't necessarily have country assigned (it's possible until they are confirmed/visible) and this breaks the `serializable_hash` method used for APIs.