### PR TITLE
Modify fix_results script

### DIFF
--- a/webroot/results/admin/fix_results.php
+++ b/webroot/results/admin/fix_results.php
@@ -56,7 +56,7 @@ if(!isset($_SESSION['anticsrf_key'])) {
 <p>After fixing your results, you must run these scripts to ensure that the changes are sound.</p>
 <ol>
     <li><a id="check-results" href="#" target="_blank">Check results</a></li>
-    <li><a id="check-rounds" href="#" target="_blank">Check rounds</a> (only needed if the round type was changed, e.g. "Final" <-> "Combined Final")</li>
+    <li><a id="check-rounds" href="#" target="_blank">Check rounds</a> (only needed if the round type was changed, e.g. "Final" &lt;-&gt; "Combined Final")</li>
     <li><a href="/admin/do_compute_auxiliary_data" target="_blank">Compute auxiliary data</a> (only needed if best or average were affected and only once in the end when fixing multiple results)</li>
 </ol>
 

--- a/webroot/results/admin/fix_results.php
+++ b/webroot/results/admin/fix_results.php
@@ -55,9 +55,9 @@ if(!isset($_SESSION['anticsrf_key'])) {
 
 <p>After fixing your results, you must run these scripts to ensure that the changes are sound.</p>
 <ol>
-    <li><a id="check-results" href="#" target="_blank">Check results</a></li>
+    <li><a id="check-results" href="#" target="_blank">Check results</a> (needed once for each round to fix rankings and to check for consistency)</li>
     <li><a id="check-rounds" href="#" target="_blank">Check rounds</a> (only needed if the round type was changed, e.g. "Final" &lt;-&gt; "Combined Final")</li>
-    <li><a href="/admin/do_compute_auxiliary_data" target="_blank">Compute auxiliary data</a> (only needed if best or average were affected and only once in the end when fixing multiple results)</li>
+    <li><a id="compute-aux-data" href="#" target="_blank">Compute auxiliary data</a> (only needed if best or average were affected and only once in the end when fixing multiple results)</li>
 </ol>
 
 <script>
@@ -321,25 +321,22 @@ function roundTypeIdChange(newRoundId)
 function somethingChanged()
 {
   if(!lastCompetitionId || !lastEventId) {
-    $('#check-results').hide();
+    $('#check-results').attr("href", "check_results.php");
+    $('#check-rounds').attr("href", "check_rounds.php");
+    $('#compute-aux-data').attr("href", "/admin/compute_auxiliary_data");
   } else {
-    $('#check-results').show();
     var params = {
       competitionId: lastCompetitionId,
       eventId: lastEventId,
       show: "Show",
     };
     $('#check-results').attr("href", "check_results.php?" + $.param(params));
-  }
-  if(!lastCompetitionId) {
-    $('#check-rounds').hide();
-  } else {
-    $('#check-rounds').show();
     var params = {
       competitionId: lastCompetitionId,
       show: "Show",
     };
     $('#check-rounds').attr("href", "check_rounds.php?" + $.param(params));
+    $('#compute-aux-data').attr("href", "/admin/do_compute_auxiliary_data");
   }
 }
 

--- a/webroot/results/admin/fix_results.php
+++ b/webroot/results/admin/fix_results.php
@@ -56,7 +56,8 @@ if(!isset($_SESSION['anticsrf_key'])) {
 <p>After fixing your results, you must run these scripts to ensure that the changes are sound.</p>
 <ol>
     <li><a id="check-results" href="#" target="_blank">Check results</a></li>
-    <li><a href="/admin/do_compute_auxiliary_data" target="_blank">Compute auxiliary data</a></li>
+    <li><a id="check-rounds" href="#" target="_blank">Check rounds</a> (only needed if the round type was changed, e.g. "Final" <-> "Combined Final")</li>
+    <li><a href="/admin/do_compute_auxiliary_data" target="_blank">Compute auxiliary data</a> (only needed if best or average were affected and only once in the end when fixing multiple results)</li>
 </ol>
 
 <script>
@@ -329,6 +330,16 @@ function somethingChanged()
       show: "Show",
     };
     $('#check-results').attr("href", "check_results.php?" + $.param(params));
+  }
+  if(!lastCompetitionId) {
+    $('#check-rounds').hide();
+  } else {
+    $('#check-rounds').show();
+    var params = {
+      competitionId: lastCompetitionId,
+      show: "Show",
+    };
+    $('#check-rounds').attr("href", "check_rounds.php?" + $.param(params));
   }
 }
 


### PR DESCRIPTION
updated fix_results script with additional link to check_rounds and additional information for users

I already deployed and tested this on staging and it works fine! 

Only minor flaw: The fact that the additional description for 2. does not appear/disappear together with the link might not be that nice, but this has no effect on operation and I consider this fine for an admin script.