### PR TITLE
Add columns to nearby_competitions_table

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -100,7 +100,7 @@ $venue-map-wrapper-height: 400px;
 
 .modal-wide {
   overflow-y: auto;
-  width: 800px;
+  width: 90%;
 }
 
 .competitions-table {

--- a/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
@@ -5,6 +5,8 @@
     <td><%= t 'competitions.nearby_competitions.date' %></td>
     <td><%= t 'competitions.nearby_competitions.location' %></td>
     <td><%= t 'competitions.nearby_competitions.distance' %></td>
+    <td><%= t 'competitions.nearby_competitions.limit' %></td>
+    <td><%= t 'competitions.nearby_competitions.competitors' %></td>
   </tr>
   <% nearby_competitions.each do |c| %>
     <tr class="<%= @competition.dangerously_close_to?(c) ? "danger" : "warning" %>">
@@ -27,6 +29,8 @@
       <td class="text-nowrap text-right">
         <%= link_to_google_maps_dir "#{@competition.kilometers_to(c).round(2)} km", c.latitude_degrees, c.longitude_degrees, @competition.latitude_degrees, @competition.longitude_degrees %>
       </td>
+      <td><%= c.competitor_limit_enabled ? c.competitor_limit : "---" %></td>
+      <td style="text-align: center;"><%= c.competitors.count if c.is_probably_over? %></td>
     </tr>
   <% end %>
 </table>

--- a/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
@@ -29,8 +29,8 @@
       <td class="text-nowrap text-right">
         <%= link_to_google_maps_dir "#{@competition.kilometers_to(c).round(2)} km", c.latitude_degrees, c.longitude_degrees, @competition.latitude_degrees, @competition.longitude_degrees %>
       </td>
-      <td><%= c.competitor_limit_enabled ? c.competitor_limit : "---" %></td>
-      <td style="text-align: center;"><%= c.competitors.count if c.is_probably_over? %></td>
+      <td class="text-center"><%= c.competitor_limit if c.competitor_limit_enabled %></td>
+      <td class="text-center"><%= c.competitors.count if c.is_probably_over? %></td>
     </tr>
   <% end %>
 </table>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -985,6 +985,8 @@ en:
       distance: "Distance"
       before: "before"
       after: "after"
+      limit: "Limit"
+      competitors: "Competitors"
     announcements: "Announcements"
     upload_results: "Upload results"
     post_announcement: "Post competition announcement"


### PR DESCRIPTION
Fixes #2482 

@Luis-J-Ianez I added "---" in case the competition has no limit assigned. Let me know if you prefer just empty, or if you prefer that I add something to the Competitors column if the competition is not over yet.

Also, I aligned the competitor count to the center, since it looked a little off when aligned to the left (see below).

center aligned
![image](https://user-images.githubusercontent.com/1881933/35651485-0048a0aa-06c7-11e8-9875-eef17a29fcf2.png)

left aligned
![image](https://user-images.githubusercontent.com/1881933/35651503-13daed58-06c7-11e8-8e61-18769f5c9079.png)


EDIT

Another screenshot, this time from the competitions withn 365 days
![image](https://user-images.githubusercontent.com/1881933/35651572-5c528276-06c7-11e8-9eb1-f0486ee7d0f7.png)
