### PR TITLE
Render 0 seconds as "0 seconds", rather than "".

### DIFF
--- a/WcaOnRails/app/javascript/edit-events/modals/utils.js
+++ b/WcaOnRails/app/javascript/edit-events/modals/utils.js
@@ -103,7 +103,7 @@ export function centisecondsToString(centiseconds, { short } = {}) {
   }
 
   let seconds = centiseconds / SECOND_IN_CS;
-  if(seconds > 0) {
+  if(seconds > 0 || str.length === 0) {
     str += pluralize(seconds, "second", { fixed: 2, abbreviate: short }) + " ";
   }
 


### PR DESCRIPTION
This fixes #1916.

I don't want to do any interesting validations in javascript, I'd prefer for the edit events page to stay as dumb (and simple) as possible. I am ok with adding validations to our api backend, but I don't see any value in doing so right now.