### PR TITLE
Only correct people can see Admin View page

### DIFF
--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -37,8 +37,10 @@
             { text: t('.menu.orga_view'), path: edit_competition_path(@competition), fa_icon: "lock" },
             { text: t('.menu.event_view'), path: edit_events_path(@competition), fa_icon: "cubes" },
             { text: t('.menu.payment_view'), path: competitions_payment_setup_path(@competition), fa_icon: "cc-stripe" },
+          ] +
+          (current_user.can_admin_results? ? [
             { text: t('.menu.admin_view'), path: admin_edit_competition_path(@competition), fa_icon: "lock" },
-          ]
+          ] : [])
         }
         if @competition.use_wca_registration?
           nav_items << {


### PR DESCRIPTION
Fixes #2514 

When editing a competition, removes the admin view tab for people who can't admin results.