### PR TITLE
Display correct fee based on selected events - Fixes #1674

### DIFF
--- a/WcaOnRails/app/assets/javascripts/associated-events-picker.js
+++ b/WcaOnRails/app/assets/javascripts/associated-events-picker.js
@@ -3,20 +3,36 @@ $(function() {
     return function() {
       var $eventsFormGroup = $(this).closest('.form-group');
       $eventsFormGroup.find('.event-checkbox input[type="checkbox"]').prop('checked', value);
-      updateEventsSelectedCount($eventsFormGroup);
+      updateEventsInformation($eventsFormGroup);
     };
   }
 
   $('.select-all-events').on('click', checkboxesSetter(true));
   $('.clear-all-events').on('click', checkboxesSetter(false));
 
-  function updateEventsSelectedCount($eventsFormGroup) {
-    var count = $eventsFormGroup.find('input[type="checkbox"]:checked').size();
+  function updateEventsInformation($eventsFormGroup) {
+    var checkedEvents = $eventsFormGroup.find('input[type="checkbox"]:checked');
+    var count = checkedEvents.size();
     var $eventsSelectedCount = $eventsFormGroup.find('.associated-events-label .events-selected-count');
     $eventsSelectedCount.text(count);
+
+    var eventIds = [];
+    for (var i = 0; i < count; i++) {
+      eventIds.push(checkedEvents[i].dataset.event);
+    }
+
+    wca.cancelPendingAjaxAndAjax('render_entry_fee_for_selected_events', {
+      url: 'registrations/event_fee_for_selected_events',
+      data: {
+        'eventIds': eventIds,
+      },
+      success: function(data) {
+        $('.dynamic-entry-fee').html(data.html);
+      }
+    });
   }
 
   $('.associated-events').on('change', function(e) {
-    updateEventsSelectedCount($(this).closest('.form-group'));
+    updateEventsInformation($(this).closest('.form-group'));
   }).trigger('change');
 });

--- a/WcaOnRails/app/assets/javascripts/associated-events-picker.js
+++ b/WcaOnRails/app/assets/javascripts/associated-events-picker.js
@@ -16,7 +16,10 @@ $(function() {
     var $eventsSelectedCount = $eventsFormGroup.find('.associated-events-label .events-selected-count');
     $eventsSelectedCount.text(count);
 
-    var event_ids = checkedEvents.toArray().map(i => i.dataset.event)
+    var event_ids = [];
+    for (var i = 0; i < count; i++) {
+      event_ids.push(checkedEvents[i].dataset.event);
+    }
 
     wca.cancelPendingAjaxAndAjax('render_entry_fee_for_selected_events', {
       url: 'registrations/event_fee_for_selected_events',

--- a/WcaOnRails/app/assets/javascripts/associated-events-picker.js
+++ b/WcaOnRails/app/assets/javascripts/associated-events-picker.js
@@ -16,19 +16,16 @@ $(function() {
     var $eventsSelectedCount = $eventsFormGroup.find('.associated-events-label .events-selected-count');
     $eventsSelectedCount.text(count);
 
-    var eventIds = [];
-    for (var i = 0; i < count; i++) {
-      eventIds.push(checkedEvents[i].dataset.event);
-    }
+    var event_ids = checkedEvents.toArray().map(i => i.dataset.event)
 
     wca.cancelPendingAjaxAndAjax('render_entry_fee_for_selected_events', {
       url: 'registrations/event_fee_for_selected_events',
       data: {
-        'eventIds': eventIds,
+        'event_ids': event_ids,
       },
       success: function(data) {
-        $('.dynamic-entry-fee').html(data.html);
-      }
+        $('.entry-fee-total').html(data.html);
+      },
     });
   }
 

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RegistrationsController < ApplicationController
-  before_action :authenticate_user!, except: [:new, :create, :index, :psych_sheet, :psych_sheet_event, :register]
+  before_action :authenticate_user!, except: [:new, :create, :index, :psych_sheet, :psych_sheet_event, :register, :entry_fee_for_selected_events]
 
   private def competition_from_params
     competition = if params[:competition_id]
@@ -280,6 +280,19 @@ class RegistrationsController < ApplicationController
 
     flash[:success] = 'Payment was refunded'
     redirect_to edit_registration_path(registration)
+  end
+
+  def entry_fee_for_selected_events
+    competition = competition_from_params
+    eventIds = params[:eventIds] ||= {}
+
+    @entry_fee_amount = competition.base_entry_fee
+    eventIds.each do |eventId|
+      @entry_fee_amount += competition.competition_events.find_by_event_id!(eventId).fee
+    end
+    render json: {
+      html: render_to_string(partial: 'entry_fee_amount'),
+    }
   end
 
   def create

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -284,10 +284,10 @@ class RegistrationsController < ApplicationController
 
   def entry_fee_for_selected_events
     competition = competition_from_params
-    eventIds = params[:eventIds] ||= {}
+    event_ids = params[:event_ids] ||= {}
 
     @entry_fee_amount = competition.base_entry_fee
-    eventIds.each do |eventId|
+    event_ids.each do |eventId|
       @entry_fee_amount += competition.competition_events.find_by_event_id!(eventId).fee
     end
     render json: {

--- a/WcaOnRails/app/views/registrations/_entry_fee.html.erb
+++ b/WcaOnRails/app/views/registrations/_entry_fee.html.erb
@@ -11,12 +11,7 @@
     <div class="form-group">
       <label class="col-sm-2 control-label" for="entry_fees"><%= label %></label>
       <div class="col-sm-9">
-
-        <% if @registration.show_payment_form? %>
-          <p class="form-control-static payment-form"><%= format_money(money_amount) %></p>
-        <% else %>
-          <p class="form-control-static dynamic-entry-fee"><%= format_money(money_amount) %></p>
-        <% end %>
+        <p class="form-control-static <%= entry_fee_class %>"><%= format_money(money_amount) %></p>
         <% unless hint.blank? %>
           <p class="help-block"><span <%= raw(hint_context_attribute) %>><%= hint %></span></p>
         <% end %>

--- a/WcaOnRails/app/views/registrations/_entry_fee.html.erb
+++ b/WcaOnRails/app/views/registrations/_entry_fee.html.erb
@@ -11,7 +11,12 @@
     <div class="form-group">
       <label class="col-sm-2 control-label" for="entry_fees"><%= label %></label>
       <div class="col-sm-9">
-        <p class="form-control-static"><%= format_money(money_amount) %></p>
+
+        <% if @registration.show_payment_form? %>
+          <p class="form-control-static payment-form"><%= format_money(money_amount) %></p>
+        <% else %>
+          <p class="form-control-static dynamic-entry-fee"><%= format_money(money_amount) %></p>
+        <% end %>
         <% unless hint.blank? %>
           <p class="help-block"><span <%= raw(hint_context_attribute) %>><%= hint %></span></p>
         <% end %>

--- a/WcaOnRails/app/views/registrations/_entry_fee_amount.html.erb
+++ b/WcaOnRails/app/views/registrations/_entry_fee_amount.html.erb
@@ -1,0 +1,1 @@
+          <%= format_money(@entry_fee_amount) %>

--- a/WcaOnRails/app/views/registrations/_payment_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_payment_form.html.erb
@@ -1,8 +1,8 @@
 <%= horizontal_simple_form_for :payment, url: competition_process_payment_path(@competition), html: { id: :form_payment } do |f| %>
-  <%= render 'entry_fee', label: "Paid", money_amount: @registration.paid_entry_fees %>
+  <%= render 'entry_fee', label: "Paid", money_amount: @registration.paid_entry_fees, entry_fee_class: "entry-fee-paid" %>
   <%= f.input :stripe_token, as: :hidden, input_html: { id: :stripe_token } %>
   <%= f.input :total_amount, as: :hidden, input_html: { id: :total_amount } %>
-  <%= render 'entry_fee', label: "Remaining", money_amount: @registration.outstanding_entry_fees %>
+  <%= render 'entry_fee', label: "Remaining", money_amount: @registration.outstanding_entry_fees, entry_fee_class: "entry-fee-remaining" %>
   <% if @competition.enable_donations %>
     <%= f.input :donation, as: :money_amount, currency: @registration.outstanding_entry_fees.currency.iso_code, value: "0", label: t('registrations.payment_form.labels.donation'), hint: t('registrations.payment_form.hints.donation') %>
   <% end %>

--- a/WcaOnRails/app/views/registrations/_register_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_register_form.html.erb
@@ -15,7 +15,7 @@
   <%# If there are no entry fees, no need to display this information %>
   <% unless @registration.show_payment_form? || !@competition.has_fees? %>
     <% fees_hint, hint_context = fees_hint_and_context(@registration) %>
-    <%= render 'entry_fee', hint: fees_hint, hint_context: hint_context %>
+    <%= render 'entry_fee', hint: fees_hint, hint_context: hint_context, entry_fee_class: "entry-fee-total" %>
   <% end %>
 
   <% unless disabled %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -40,7 +40,7 @@ Note: form_builder.object is the object having associated events.
           <%= f.hidden_field :event_id %>
         <% end %>
         <%= label_tag "#{events_association_name}_#{event.id}" do %>
-          <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "#{events_association_name}_#{event.id}", disabled: disabled }, "0", "1" %>
+          <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "#{events_association_name}_#{event.id}", disabled: disabled, "data-event": event.id }, "0", "1" %>
           <%= content_tag(:span, "",
                           class: "cubing-icon event-#{event.id}",
                           data: { toggle: "tooltip", placement: "top" },

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     get 'results/all' => 'competitions#show_all_results'
     get 'results/by_person' => 'competitions#show_results_by_person'
 
+    get 'registrations/event_fee_for_selected_events' => 'registrations#entry_fee_for_selected_events', as: :entry_fee_for_selected_events
     patch 'registrations/selected' => 'registrations#do_actions_for_selected', as: :registrations_do_actions_for_selected
     post 'registrations/export' => 'registrations#export', as: :registrations_export
     get 'registrations/psych-sheet' => 'registrations#psych_sheet', as: :psych_sheet


### PR DESCRIPTION
The entry_fee partial is used by the register view for displaying amounts of money such as amount paid, remaining, and the entry fee. To stop the javascript updating each of these I needed to add a class to distinguish them so the javascript could update the correct one. Let me know if there's a better way to achieve this, and of course any other improvements.