### PR TITLE
Enable refresh tokens for WCA OAuth.

### DIFF
--- a/WcaOnRails/config/initializers/doorkeeper.rb
+++ b/WcaOnRails/config/initializers/doorkeeper.rb
@@ -59,7 +59,7 @@ Doorkeeper.configure do
   # reuse_access_token
 
   # Issue access tokens with refresh token (disabled by default)
-  # use_refresh_token
+  use_refresh_token
 
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter confirmation: true (default false) if you want to enforce ownership of


### PR DESCRIPTION
This enables OAuth applications to read competition WCIF data automatically, without needing the delegate or organizer to log in each time.

See https://github.com/doorkeeper-gem/doorkeeper/wiki/Enable-Refresh-Token-Credentials, and #374 for more information including a motivating use case.

Fixes #374.