### PR TITLE
Generate competitorId in the WCIF

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -23,14 +23,12 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def show_wcif
-    # This is all the associations we may need for the WCIF!
+    # This is all the associations we may need for the competition WCIF!
+    # Since registrations are ordered later, associations inclusion for them is done later
     includes_associations = [
-      {
-        registrations: [{ user: { person: [:ranksSingle, :ranksAverage] } },
-                        :events],
-      },
       :delegates,
       :organizers,
+      { competition_events: [rounds: :competition_event] },
     ]
     competition = competition_from_params(includes_associations)
     require_can_manage!(competition)

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -487,8 +487,8 @@ class CompetitionsController < ApplicationController
   def my_competitions
     competitions = (current_user.delegated_competitions +
       current_user.organized_competitions +
-      current_user.registrations.accepted.map(&:competition).reject(&:results_posted?) +
-      current_user.registrations.pending.map(&:competition).select(&:upcoming?))
+      current_user.registrations.includes(:competition).accepted.map(&:competition).reject(&:results_posted?) +
+      current_user.registrations.includes(:competition).pending.map(&:competition).select(&:upcoming?))
     if current_user.person
       competitions += current_user.person.competitions
     end

--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -35,7 +35,7 @@ class CompetitionEvent < ApplicationRecord
   def to_wcif
     {
       "id" => self.event.id,
-      "rounds" => self.rounds.order(:number).map(&:to_wcif),
+      "rounds" => self.rounds.map(&:to_wcif),
     }
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -709,12 +709,13 @@ class User < ApplicationRecord
     json
   end
 
-  def to_wcif(competition, registration = nil)
+  def to_wcif(competition, registration = nil, registrant_id = nil)
     person_pb = [person&.ranksAverage, person&.ranksSingle].compact.flatten
     {
       "name" => name,
       "wcaUserId" => id,
       "wcaId" => wca_id,
+      "registrantId" => registrant_id,
       "countryIso2" => country_iso2,
       "delegatesCompetition" => competition.delegates.include?(self),
       "organizesCompetition" => competition.organizers.include?(self),

--- a/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Api::V0::CompetitionsController do
+  def get_wcif_and_compare_persons_to(id, expected)
+    get :show_wcif, params: { competition_id: id }
+    parsed_body = JSON.parse(response.body)
+    person_arrays = parsed_body["persons"].map do |p|
+      [p["wcaUserId"], p["registrantId"]]
+    end
+    expect(person_arrays).to eq expected
+  end
+
   describe 'GET #show' do
     let(:competition) {
       FactoryBot.create(
@@ -194,6 +203,7 @@ RSpec.describe Api::V0::CompetitionsController do
       FactoryBot.create(
         :competition,
         :with_delegate,
+        :registration_open,
         id: "TestComp2014",
         name: "Test Comp 2014",
         start_date: "2014-02-03",
@@ -267,6 +277,27 @@ RSpec.describe Api::V0::CompetitionsController do
         expect(response.status).to eq 200
         parsed_body = JSON.parse(response.body)
         expect(parsed_body["id"]).to eq "TestComp2014"
+      end
+
+      it 'gets wcif with consistent competitor_id' do
+        last_registration = nil
+        user_competitor_ids = []
+        comp_id = 1
+        3.times do
+          user = FactoryBot.create(:user)
+          user_competitor_ids << [user.id, comp_id]
+          comp_id += 1
+          last_registration = FactoryBot.create(:registration, :accepted, competition: competition, user: user)
+        end
+        get_wcif_and_compare_persons_to(competition.id, user_competitor_ids + [[competition.delegates.first.id, nil]])
+
+        # Move last registration to deleted
+        last_registration.touch :deleted_at
+        # Create and register one new user
+        user = FactoryBot.create(:user)
+        last_registration = FactoryBot.create(:registration, :accepted, competition: competition, user: user)
+        user_competitor_ids << [user.id, comp_id]
+        get_wcif_and_compare_persons_to(competition.id, user_competitor_ids + [[competition.delegates.first.id, nil]])
       end
     end
   end


### PR DESCRIPTION
Fixes #1568.
@coder13, @ronaldmansveld 

Generates (and renames) the Person.id field.
The person id is only here to provide a friendly id for cubecomps-like application, and is therefore only meaningful if the person actually has a registration.

Having the field named "id" would make the user think it's actually a way to identify a person when there is the "wcaUserId" for this, so as @jonatanklosko suggested it's probably best to rename it.

