### PR TITLE
Enable to filter search based on announcement

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -836,6 +836,14 @@ class Competition < ApplicationRecord
       competitions = competitions.where("end_date <= ?", end_date)
     end
 
+    if params[:announced_after].present?
+      announced_date = Date.safe_parse(params[:announced_after])
+      if !announced_date
+        raise WcaExceptions::BadApiParameter.new("Invalid announced date: '#{params[:announced_after]}'")
+      end
+      competitions = competitions.where("announced_at > ?", announced_date)
+    end
+
     query&.split&.each do |part|
       like_query = %w(id name cellName cityName countryId).map { |column| column + " LIKE :part" }.join(" OR ")
       competitions = competitions.where(like_query, part: "%#{part}%")
@@ -918,6 +926,7 @@ class Competition < ApplicationRecord
       city: cityName,
       country_iso2: country&.iso2,
       start_date: start_date,
+      announced_at: announced_at,
       end_date: end_date,
       delegates: delegates,
       organizers: organizers,

--- a/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
@@ -164,6 +164,15 @@ RSpec.describe Api::V0::CompetitionsController do
       expect(json.map { |c| c["id"] }).to eq [last_feb_comp.id]
     end
 
+    it 'can query by announced_after' do
+      FactoryBot.create(:competition, :confirmed, :visible, name: "Old comp 2018", announced_at: 3.days.ago)
+      FactoryBot.create(:competition, :confirmed, :visible, name: "New comp 2018", announced_at: Time.now)
+      get :index, params: { announced_after: 2.days.ago }
+      expect(response.status).to eq 200
+      json = JSON.parse(response.body)
+      expect(json.map { |c| c["name"] }).to eq ["New comp 2018"]
+    end
+
     it 'paginates' do
       7.times do
         FactoryBot.create :competition, :confirmed, :visible


### PR DESCRIPTION
Competition's search can now be filtered based on the announced_at date, and announced_at date is included in the serialized hash.

@EvilAngel00 (Rui Reis) told me the WCT would need that to be able to automatically do some weekly thing with newly announced competitions.
