### PR TITLE
Improve displaying the registration requirements

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -318,6 +318,10 @@ $venue-map-wrapper-height: 400px;
   .dl-horizontal dt {
     white-space: normal;
   }
+
+  #hide_registration_requirements {
+    display: none;
+  }
 }
 
 .anchor {

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -64,10 +64,6 @@
     <dl class="dl-horizontal">
       <dt><%= t '.information' %></dt>
       <dd><%=md competition.information %></dd>
-
-    <dl class="dl-horizontal">
-      <dt><%= t '.registration_requirements' %></dt>
-      <dd><%=md competition.registration_requirements %></dd>
     </dl>
 
     <dl class="dl-horizontal">
@@ -114,4 +110,45 @@
     <% end %>
 
   </div>
+  <div class="col-md-12">
+    <dl class="dl-horizontal">
+      <dt><%= t '.registration_requirements' %></dt>
+      <dd>
+        <% collapse = @competition.is_probably_over? %>
+        <% if collapse %>
+          <div id="show_registration_requirements">
+            <%= t('competitions.competition_info.click_to_display_requirements_html', link_here: link_to(t('common.here'))) %>
+          </div>
+          <div id="hide_registration_requirements">
+            <%= link_to(t('competitions.competition_info.hide_requirements')) %>
+          </div>
+        <% end %>
+        <div class="<%= collapse ? "collapse" : "" %>" id="registration_requirements_text">
+          <%=md competition.registration_requirements %>
+        </div>
+      </dd>
+    </dl>
+
+  </div>
 </div>
+<% if collapse %>
+  <script>
+    $(function () {
+      $("#registration_requirements_text").collapse({
+        toggle: false
+      });
+      $("#show_registration_requirements a").click(function (e) {
+        e.preventDefault();
+        $("#registration_requirements_text").collapse("show");
+        $("#show_registration_requirements").hide();
+        $("#hide_registration_requirements").show();
+      });
+      $("#hide_registration_requirements a").click(function (e) {
+        e.preventDefault();
+        $("#registration_requirements_text").collapse("hide");
+        $("#hide_registration_requirements").hide();
+        $("#show_registration_requirements").show();
+      });
+    });
+  </script>
+<% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -866,6 +866,9 @@ en:
       information: "Information"
       events: "Events"
       registration_requirements: "Registration requirements"
+      #context: The 'link_here' variable is replaced by a link to show the requirements, with the text "here"
+      click_to_display_requirements_html: "This competition is over, click %{link_here} to display the registration requirements it used."
+      hide_requirements: "Hide registration requirements."
     #context: on the competition's index page
     index:
       title: "Competitions"


### PR DESCRIPTION
For long text the current location for the requirements is ugly, I moved it below all information and gave it full width.
This can be annoying when results are up since the first thing you would see on the page are the very long requirements whereas you're looking for results, so when competition is probably over the field is collapsed.

Competition not over:
![not_over](https://user-images.githubusercontent.com/1007485/36213741-cd48aa60-11a7-11e8-880a-bab0c5238842.png)

Competition over and collapse:
![over_collapsed](https://user-images.githubusercontent.com/1007485/36213764-da9a0ab0-11a7-11e8-9e6e-f4094f564e0d.png)

Competition over and visible:

![over_visible](https://user-images.githubusercontent.com/1007485/36213770-e1321afc-11a7-11e8-8a3f-8978df9459ae.png)


