### PR TITLE
Clarifies birthdate field in sign up page

### DIFF
--- a/WcaOnRails/app/views/users/_claim_wca_id_selector.html.erb
+++ b/WcaOnRails/app/views/users/_claim_wca_id_selector.html.erb
@@ -1,9 +1,10 @@
 <%= f.input :unconfirmed_wca_id, label: t('common.user.wca_id'), as: :user_ids, persons_table: true, only_one: true %>
+
+<%= f.input :dob_verification, as: :date_picker %>
+
 <div id="select-nearby-delegate-area">
   <%= render "users/select_nearby_delegate" %>
 </div>
-
-<%= f.input :dob_verification, as: :date_picker %>
 
 <script>
   $(function() {

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -185,7 +185,7 @@ en:
         login: "Email or WCA ID"
         country_iso2: "Citizenship"
         dob: "Birthdate"
-        dob_verification: "Birthdate"
+        dob_verification: "Your Birthdate"
         gender: "Gender"
         email: "Email"
         password: "Password"


### PR DESCRIPTION
Fixes #2453 

Reorganizes delegate field to be below birthdate field and changes text from "Birthdate" to "Your Birthdate".

![screen shot 2018-02-19 at 6 54 31 pm 1](https://user-images.githubusercontent.com/24919355/36405607-61929756-15a6-11e8-895d-525b335ff48e.png)