### PR TITLE
Restore paragraph margin

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -303,12 +303,14 @@ $venue-map-wrapper-height: 400px;
 }
 
 .competition-info {
-  p {
-    margin: 0;
-  }
+  .compact {
+    p {
+      margin: 0;
+    }
 
-  dd p {
-    margin-bottom: 0;
+    dd p {
+      margin-bottom: 0;
+    }
   }
 
   dd.competition-events-list {

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -1,6 +1,6 @@
 <div class="row competition-info">
   <div class="col-md-6">
-    <dl class="dl-horizontal">
+    <dl class="dl-horizontal compact">
       <dt><%= t '.date' %></dt>
       <dd><%= wca_date_range(competition.start_date, competition.end_date) %></dd>
 


### PR DESCRIPTION
Fixes #2589.

If I get this correctly, this was used to have consistent spacing between all the competition's basic details, however it messes up with the paragraph spacing in both the information and requirements field, which I think we should keep.

I've introduced a `compact` scope for the information fields where we prefer have no paragraph spacing.