### PR TITLE
Explicitly call .html_safe as necessary when using I18n.t

### DIFF
--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -107,10 +107,10 @@ class Person < ApplicationRecord
   def cannot_be_assigned_to_user_reasons
     dob_form_path = Rails.application.routes.url_helpers.contact_dob_path
     [].tap do |reasons|
-      reasons << I18n.t('users.errors.wca_id_no_name_html') if name.blank?
-      reasons << I18n.t('users.errors.wca_id_no_gender_html') if gender.blank?
-      reasons << I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path) if dob.blank?
-      reasons << I18n.t('users.errors.wca_id_no_citizenship_html') if country_iso2.blank?
+      reasons << I18n.t('users.errors.wca_id_no_name_html').html_safe if name.blank?
+      reasons << I18n.t('users.errors.wca_id_no_gender_html').html_safe if gender.blank?
+      reasons << I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path).html_safe if dob.blank?
+      reasons << I18n.t('users.errors.wca_id_no_citizenship_html').html_safe if country_iso2.blank?
     end
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -195,7 +195,7 @@ class User < ApplicationRecord
     if p
       cannot_be_assigned_reasons = p.cannot_be_assigned_to_user_reasons
       unless cannot_be_assigned_reasons.empty?
-        errors.add(:wca_id, cannot_be_assigned_reasons.to_sentence)
+        errors.add(:wca_id, cannot_be_assigned_reasons.xss_aware_to_sentence)
       end
     end
   end


### PR DESCRIPTION
This is quite annoying: the `translate` view helper will automatically
mark translation strings as html safe (by creating SafeBuffer-s) when
keys match certain rules (such as ending with _html). However, I18n.t
will not perform this check for us (see the yellow warning here:
http://guides.rubyonrails.org/i18n.html#using-safe-html-translations).

![image](https://user-images.githubusercontent.com/277474/36990315-3386abf0-2059-11e8-8101-48deef05258c.png)


I quickly fixed this by changing all
our occurrences of I18n.t with a _html key to explicitly call
.html_safe. I searched for this with the following grep command:

```
git grep "I18n.t.*_html" | grep -v "\.html_safe"
```

(Note: this won't necessarily handle I18n.t calls that have been split across
multiple lines)

A better future solution might be to instead make the `translate` view helper
available inside of our controllers so we can call it directly.

This fixes #2649.