### PR TITLE
Use devise-i18n for translating devise views

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -28,7 +28,10 @@ gem 'recaptcha', require: 'recaptcha/rails'
 gem 'kaminari'
 gem 'kaminari-i18n'
 gem 'devise'
+# Note: we put devise-i18n after devise-bootstrap-views intentionally.
+# See https://github.com/thewca/worldcubeassociation.org/pull/2663 for more details.
 gem 'devise-bootstrap-views'
+gem 'devise-i18n'
 gem 'doorkeeper'
 gem 'doorkeeper-i18n'
 gem 'strip_attributes'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
       responders
       warden (~> 1.2.3)
     devise-bootstrap-views (0.0.11)
+    devise-i18n (1.6.1)
+      devise (>= 4.4)
     diff-lcs (1.3)
     docile (1.1.5)
     doorkeeper (4.2.6)
@@ -538,6 +540,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise
   devise-bootstrap-views
+  devise-i18n
   doorkeeper
   doorkeeper-i18n
   dotenv-rails

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -501,6 +501,12 @@ en:
       size_too_big: "is too big (should be at most %{file_size})"
   #context: Overriden key for sign in
   devise:
+    sessions:
+      new:
+        sign_in: "Sign in"
+    shared:
+      links:
+        sign_in: "Sign in"
     failure:
       invalid: "Invalid email, WCA ID, or password."
       not_found_in_database: "Invalid email, WCA ID, or password."


### PR DESCRIPTION
Recently, Christine has wanted to apply some changes to the Czech translation and I found out that they were related to the `devise` gem. Naturally I thought it's the [devise-i18n](https://github.com/tigrish/devise-i18n) what we need to update and that's what we did. The new version has been released and I was about to update the version used on our side when I realised that we don't actually use the library directly. Confusingly enough, phrases really seemed to come from this gem. Looking at other `devise` related gems we use, I stumbled upon [devise-bootstrap-views](https://github.com/hisea/devise-bootstrap-views), and [as you can see](https://github.com/hisea/devise-bootstrap-views/tree/master/locales) it includes it's own set of locale files that come from `devise-i18n`, except they are not updated over time...

TL;DR

To have up-to-date translations from `devise-i18n` and keep using `devise-bootstrap-views` without including a bunch of files in our repo, I added the former as a dependency and intentionally placed it after `devise-bootstrap-views`. Given that Bundler loads gems as they appear in the Gemfile, this order makes `devise-i18n` phrases take precedence.