### PR TITLE
Allow seniors to view unnanounced competitions of "their" delegates

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -462,7 +462,7 @@ class User < ApplicationRecord
   end
 
   def can_manage_competition?(competition)
-    can_admin_results? || competition.organizers.include?(self) || competition.delegates.include?(self) || wrc_team?
+    can_admin_results? || competition.organizers.include?(self) || competition.delegates.include?(self) || wrc_team? || competition.delegates.map(&:senior_delegate).compact.include?(self)
   end
 
   def can_view_hidden_competitions?


### PR DESCRIPTION
Fixes #2604 

I tested locally and it works. Competition doesn't show up on the list but the senior can view and edit.