### PR TITLE
Change incidents log menu icon to fa-balance-scale.

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -70,7 +70,7 @@
             <li><a href="/regulations/"><%= icon('book') %> <%= t '.regulations' %></a></li>
             <li><a href="/regulations/guidelines.html"><%= icon('sticky-note') %> <%= t '.guidelines' %></a></li>
             <li><a href="/regulations/scrambles/"><%= icon('random') %> <%= t '.scrambles' %></a></li>
-            <li><%= link_to(icon('database', "Incidents log"), incidents_path) %></li>
+            <li><%= link_to(icon('balance-scale', "Incidents log"), incidents_path) %></li>
             <li class="divider"></li>
             <li><a href="/regulations/history/"><%= icon('history') %> <%= t '.history' %></a></li>
             <li><a href="/regulations/translations/"><%= icon('language') %> <%= t '.translations' %></a></li>


### PR DESCRIPTION
@viroulep said over chat he was happy to change the icon. :-)

<img width="232" alt="screen shot 2018-03-10 at 22 08 19" src="https://user-images.githubusercontent.com/248078/37250358-931a155c-24af-11e8-944b-96abce3a4894.png">

I considered three options:
- `exclamation-circle`
- `gavel`
- `balance-scale`

The latter two represent the fact that the incidents log is essentially a log of [case law](https://en.wikipedia.org/wiki/Case_law).

I think `balance-scale` is the best combination of specific (`exclamation-circle` looks generic), recognizable (`gavel` looks a bit like a normal hammer), and visually fitting.

Screenshots for `exclamation-circle` and `gavel`, respectively:

<img width="253" alt="screen shot 2018-03-09 at 20 17 24" src="https://user-images.githubusercontent.com/248078/37250327-ee5156a2-24ae-11e8-85d0-77aa1742bc54.png">
<img width="228" alt="screen shot 2018-03-10 at 22 08 56" src="https://user-images.githubusercontent.com/248078/37250360-a6fa0eba-24af-11e8-9fc0-e1826a79451a.png">
