### PR TITLE
Fix parser version

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     openssl (2.1.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     pluginator (1.5.0)


### PR DESCRIPTION
Apparently version 2.5.0.4 was removed: https://rubygems.org/gems/parser/versions/2.5.0.4