### PR TITLE
Add roles to Person WCIF and set up /wcif/persons endpoint

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -56,6 +56,21 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     }
   end
 
+  def update_persons_from_wcif
+    competition = competition_from_params
+    require_can_manage!(competition)
+    wcif_persons = params["_json"].map { |wcif_person| wcif_person.permit!.to_h }
+    competition.update_persons_wcif!(wcif_persons)
+    render json: {
+      status: "Successfully saved WCIF perons",
+    }
+  rescue ActiveRecord::RecordInvalid => e
+    render status: 400, json: {
+      status: "Error while saving WCIF persons",
+      error: e,
+    }
+  end
+
   private def competition_from_params(associations = {})
     id = params[:competition_id] || params[:id]
     base_model = associations.any? ? Competition.includes(associations) : Competition

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -921,7 +921,7 @@ class Competition < ApplicationRecord
   end
 
   # Takes an array of partial Person WCIF and updates the fields that are not immutable.
-  def update_persons_wcif!(wcif_persons)
+  def update_persons_wcif!(wcif_persons, current_user)
     persons_schema = { "type" => "array", "items" => User.wcif_json_schema }
     puts persons_schema.inspect
     JSON::Validator.validate!(persons_schema, wcif_persons)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -922,6 +922,10 @@ class Competition < ApplicationRecord
 
   # Takes an array of partial Person WCIF and updates the fields that are not immutable.
   def update_persons_wcif!(wcif_persons)
+    persons_schema = { "type" => "array", "items" => User.wcif_json_schema }
+    puts persons_schema.inspect
+    JSON::Validator.validate!(persons_schema, wcif_persons)
+
     ActiveRecord::Base.transaction do
       wcif_persons.each do |wcif_person|
         # registration = registrations.joins(:user).where("users.id = ?", wcif_person["wcaUserId"]).first

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -863,7 +863,7 @@ class Competition < ApplicationRecord
     ]
     persons_wcif = registrations.order(:id).includes(includes_associations).map.with_index(1) do |r, registrant_id|
       managers.delete(r.user)
-      r.user.to_wcif(self, r.to_wcif, registrant_id)
+      r.user.to_wcif(self, r, registrant_id)
     end
     # Note: unregistered managers may generate N+1 queries on their personal bests,
     # but that's fine because there are very few of them!

--- a/WcaOnRails/app/models/concerns/personal_best.rb
+++ b/WcaOnRails/app/models/concerns/personal_best.rb
@@ -25,7 +25,7 @@ module PersonalBest
         "worldRanking" => { "type" => "integer" },
         "continentalRanking" => { "type" => "integer" },
         "nationalRanking" => { "type" => "integer" },
-        "type" => { "type" => "string", "enum" => %w(single average) }
+        "type" => { "type" => "string", "enum" => %w(single average) },
       },
     }
   end

--- a/WcaOnRails/app/models/concerns/personal_best.rb
+++ b/WcaOnRails/app/models/concerns/personal_best.rb
@@ -15,4 +15,18 @@ module PersonalBest
       "type": type,
     }
   end
+
+  def self.wcif_json_schema
+    {
+      "type" => "object",
+      "properties" => {
+        "eventId" => { "type" => "string", "enum" => Event.pluck(:id) },
+        "best" => { "type" => "integer" },
+        "worldRanking" => { "type" => "integer" },
+        "continentalRanking" => { "type" => "integer" },
+        "nationalRanking" => { "type" => "integer" },
+        "type" => { "type" => "string", "enum" => %w(single average) }
+      },
+    }
+  end
 end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -15,6 +15,8 @@ class Registration < ApplicationRecord
   has_many :competition_events, through: :registration_competition_events
   has_many :events, through: :competition_events
 
+  serialize :roles, Array
+
   accepts_nested_attributes_for :registration_competition_events, allow_destroy: true
 
   validates :user, presence: true, on: [:create]

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -189,6 +189,19 @@ class Registration < ApplicationRecord
     }
   end
 
+  def self.wcif_json_schema
+    {
+      "type" => "object",
+      "properties" => {
+        "wcaRegistrationId" => { "type" => "integer" },
+        "eventIds" => { "type" => "array", "items" => { "type" => "string", "enum" => Event.pluck(:id) } },
+        "status" => { "type" => "string", "enum" => %w(accepted deleted pending) },
+        "guests" => { "type" => "integer" },
+        "comments" => { "type" => "string" },
+      },
+    }
+  end
+
   validate :user_can_register_for_competition
   private def user_can_register_for_competition
     if user&.cannot_register_for_competition_reasons.present?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -727,24 +727,26 @@ class User < ApplicationRecord
 
   def to_wcif(competition, registration = nil, registrant_id = nil)
     person_pb = [person&.ranksAverage, person&.ranksSingle].compact.flatten
+    roles = registration&.roles || []
+    roles << "delegate" if competition.delegates.include?(self)
+    roles << "organizer" if competition.organizers.include?(self)
     {
       "name" => name,
       "wcaUserId" => id,
       "wcaId" => wca_id,
       "registrantId" => registrant_id,
       "countryIso2" => country_iso2,
-      "delegatesCompetition" => competition.delegates.include?(self),
-      "organizesCompetition" => competition.organizers.include?(self),
       "gender" => gender,
       # /wcif is restricted to users who can manage the competition,
       # we can include private data
       "birthdate" => dob.to_s,
       "email" => email,
-      "registration" => registration,
+      "registration" => registration&.to_wcif,
       "avatar" => {
         "url" => avatar.url,
         "thumbUrl" => avatar.url(:thumb),
       },
+      "roles" => roles,
       "personalBests" => person_pb.map(&:to_wcif),
     }
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -751,6 +751,33 @@ class User < ApplicationRecord
     }
   end
 
+  def self.wcif_json_schema
+    {
+      "type" => "object",
+      "properties" => {
+        "registrantId" => { "type" => "integer" },
+        "name" => { "type" => "string" },
+        "wcaUserId" => { "type" => "integer" },
+        "wcaId" => { "type" => "string" },
+        "countryIso2" => { "type" => "string" },
+        "gender" => { "type" => "string", "enum" => %w(m f o) },
+        "birthdate" => { "type" => "string" },
+        "email" => { "type" => "string" },
+        "avatar" => {
+          "type" => ["object", "null"],
+          "properties" => {
+            "url" => { "type" => "string" },
+            "thumbUrl" => { "type" => "string" },
+          },
+        },
+        "roles" => { "type" => "array", "items" => { "type" => "string" } },
+        "registration" => Registration.wcif_json_schema,
+        "assignments" => { "type" => "object" }, # TODO: expand on this,
+        "personalBests" => { "type" => "array", "items" => PersonalBest.wcif_json_schema },
+      },
+    }
+  end
+
   # Devise's method overriding! (the unwanted lines are commented)
   # We have the separate form for updating password and it requires current_password to be entered.
   # So we don't want to remove the password and password_confirmation if they are in the params and are blank.

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -173,6 +173,7 @@ Rails.application.routes.draw do
       resources :competitions, only: [:index, :show] do
         get '/wcif' => 'competitions#show_wcif'
         patch '/wcif/events' => 'competitions#update_events_from_wcif', as: :update_events_from_wcif
+        patch '/wcif/persons' => 'competitions#update_persons_from_wcif', as: :update_persons_from_wcif
       end
       get '/records' => "api#records"
     end

--- a/WcaOnRails/db/migrate/20180403194359_add_roles_to_registration.rb
+++ b/WcaOnRails/db/migrate/20180403194359_add_roles_to_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRolesToRegistration < ActiveRecord::Migration[5.1]
   def change
     add_column :registrations, :roles, :text

--- a/WcaOnRails/db/migrate/20180403194359_add_roles_to_registration.rb
+++ b/WcaOnRails/db/migrate/20180403194359_add_roles_to_registration.rb
@@ -1,0 +1,5 @@
+class AddRolesToRegistration < ActiveRecord::Migration[5.1]
+  def change
+    add_column :registrations, :roles, :text
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -982,6 +982,7 @@ CREATE TABLE `registrations` (
   `accepted_by` int(11) DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `deleted_by` int(11) DEFAULT NULL,
+  `roles` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1323,4 +1324,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180107142301'),
 ('20180120132926'),
 ('20180201005000'),
-('20180206211650');
+('20180206211650'),
+('20180403194359');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -448,6 +448,7 @@ module DatabaseDumper
           guests
           updated_at
           user_id
+          roles
         ),
         db_default: %w(ip),
         fake_values: {

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -247,10 +247,9 @@ RSpec.describe "API Competitions" do
           wcaId: "2018NEWW01",
           registrantId: 123,
           countryIso2: "NEW",
-          gender: "new",
+          gender: "f",
           email: "new@email.com",
           avatar: nil,
-          registration: nil,
           personalBests: [],
         }]
         expect {


### PR DESCRIPTION
Implements another part of WCIF spec.

### Roles

I added `roles` field to `registrations` table. The user of the API can store any roles here (e.g. *scrambler*, *judge*, *dataentry*, *runner*). Two special roles (implicitly specified in the WCIF spec) being *delegate* and *organizer* are not stored in the `roles` column, they are computed on the fly instead (as they shouldn't be changed using this API).
*Drawback: there is no way to save other roles for registrationless person at the moment (e.g. a delegate that doesn't compete). Still, I think registrations is the right place and we will likely handle those cases in the future (e.g. we talked about registrations without events for such people).*

### /wcif/persons API

As discussed over Slack, the idea for this endpoint is to update people information (`roles` and `assignments` as per the current WCIF spec). The request may contain full people WCIF or partial ones (just `wcaUserId` and the updated field). There should be no way to update immutable data (like name), just the fields specified above.