### PR TITLE
Warn new registrant once a competitor limit is reached

### DIFF
--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -61,6 +61,9 @@
           </ul>
         <% end %>
       <% else %>
+        <% if @competition.competitor_limit_enabled? && @competition.registrations.accepted.count >= @competition.competitor_limit %>
+          <%= alert :warning, t('registrations.registration_full', competitor_limit: @competition.competitor_limit) %>
+        <% end %>
         <p>
           <%= t 'registrations.can_register', comp: @competition.name %>
         </p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -815,6 +815,7 @@ en:
     please_sign_in_html: "%{sign_in} to register for %{comp}. If you do not yet have a WCA account, you can create one %{here}."
     greeting: "Hi, %{name}!"
     please_fix_profile_html: "In order to register for this %{comp}, you must fix the following problems with your %{profile}:"
+    registration_full: "The competitor limit for this competition is %{competitor_limit} and it has already been reached. If you register, your registration will be placed on a waiting list. It may not be approved unless a spot frees up."
     can_register: "You can register for %{comp} below."
     check_registration_information: "Please check the information about registration to find out if you need to do something else, like paying a registration fee."
     have_registered: "You have submitted your registration for %{comp}. You can see your registration details below."

--- a/WcaOnRails/spec/models/incident_spec.rb
+++ b/WcaOnRails/spec/models/incident_spec.rb
@@ -32,6 +32,6 @@ RSpec.describe Incident do
     comp2 = [FactoryBot.create(:competition), "not in the report"]
     incident = FactoryBot.create(:incident, comps: [comp, comp2])
     expect(incident.competitions.size).to eq 2
-    expect(incident.incident_competitions.map(&:comments)).to eq [comp[1], comp2[1]]
+    expect(incident.incident_competitions.map(&:comments)).to match_array [comp[1], comp2[1]]
   end
 end


### PR DESCRIPTION
Fixes #2584.

Limit hasn't been reached:

![image](https://user-images.githubusercontent.com/17034772/38836532-c7bac34c-41ce-11e8-9e9a-ff6a1aaddc03.png)

Limit has been reached:

![image](https://user-images.githubusercontent.com/17034772/38836568-ea783626-41ce-11e8-9318-3df5911a4fb9.png)

@Z4chy thoughts?