### PR TITLE
Various improvements to the incidents log

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/incidents.scss
+++ b/WcaOnRails/app/assets/stylesheets/incidents.scss
@@ -45,11 +45,7 @@
     .selectize-input > input {
       min-width: 100px;
     }
-    .tags-cell,
-    .comps-cell {
-      width: 25%;
-    }
-    .status-cell {
+    .status-cell, .digest-cell {
       width: 10%;
     }
   }

--- a/WcaOnRails/app/assets/stylesheets/incidents.scss
+++ b/WcaOnRails/app/assets/stylesheets/incidents.scss
@@ -45,7 +45,8 @@
     .selectize-input > input {
       min-width: 100px;
     }
-    .status-cell, .digest-cell {
+    .status-cell,
+    .digest-cell {
       width: 10%;
     }
   }

--- a/WcaOnRails/app/controllers/incidents_controller.rb
+++ b/WcaOnRails/app/controllers/incidents_controller.rb
@@ -11,12 +11,13 @@ class IncidentsController < ApplicationController
   ]
 
   def index
-    base_model = Incident.includes(:competitions, :incident_tags).order(created_at: :desc)
+    base_model = Incident.includes(:competitions, :incident_tags)
     if current_user&.can_view_delegate_matters?
       @incidents = base_model.all
     else
       @incidents = base_model.resolved
     end
+    @incidents = @incidents.sort_by(&:last_happened_date).reverse
   end
 
   def show

--- a/WcaOnRails/app/helpers/incidents_helper.rb
+++ b/WcaOnRails/app/helpers/incidents_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module IncidentsHelper
+  def class_and_text_for_status(incident)
+    if incident.resolved_at
+      ["success", "Resolved"]
+    else
+      ["warning", "Pending"]
+    end
+  end
+
+  def class_and_text_for_digest(incident)
+    if incident.digest_worthy
+      if incident.digest_sent_at
+        ["success", "Sent"]
+      else
+        ["warning", "Pending"]
+      end
+    else
+      ["success", "Not needed"]
+    end
+  end
+end

--- a/WcaOnRails/app/helpers/incidents_helper.rb
+++ b/WcaOnRails/app/helpers/incidents_helper.rb
@@ -17,7 +17,7 @@ module IncidentsHelper
         ["warning", "Pending"]
       end
     else
-      ["success", "Not needed"]
+      ["success", ""]
     end
   end
 end

--- a/WcaOnRails/app/javascript/incidents-log/index.js
+++ b/WcaOnRails/app/javascript/incidents-log/index.js
@@ -50,6 +50,10 @@ function customIncidentsSearch(text) {
   });
 }
 
+function activatePopover() {
+  $('[data-toggle="popover"]').popover();
+}
+
 wca.initIncidentsLogTable = function(selectizeOptions, $table, $searchInput, $tagsInput) {
   $incidentsTagsInput = $tagsInput;
   $incidentsSearchInput = $searchInput;
@@ -57,8 +61,11 @@ wca.initIncidentsLogTable = function(selectizeOptions, $table, $searchInput, $ta
 
   $table.on('search.bs.table', function() {
     // Yep, when it's filtered we need to reactivate popovers :(
-    $('[data-toggle="popover"]').popover();
+    activatePopover();
     updateUrlParams($searchInput, $tagsInput);
+  });
+  $table.on('page-change.bs.table', function() {
+    activatePopover();
   });
 
   // It's a search filter input, so there is no point to allow user to create tags

--- a/WcaOnRails/app/models/incident.rb
+++ b/WcaOnRails/app/models/incident.rb
@@ -3,7 +3,7 @@
 class Incident < ApplicationRecord
   has_many :incident_tags, autosave: true, dependent: :destroy
   has_many :incident_competitions, dependent: :destroy
-  has_many :competitions, through: :incident_competitions
+  has_many :competitions, -> { order("Competitions.start_date asc") }, through: :incident_competitions
 
   accepts_nested_attributes_for :incident_competitions, allow_destroy: true
 
@@ -13,6 +13,10 @@ class Incident < ApplicationRecord
   validates_presence_of :title
 
   include Taggable
+
+  def last_happened_date
+    competitions.last&.start_date || created_at.to_date
+  end
 
   def digest_missing?
     digest_worthy && !digest_sent_at

--- a/WcaOnRails/app/views/incidents/index.html.erb
+++ b/WcaOnRails/app/views/incidents/index.html.erb
@@ -12,8 +12,11 @@
         <tr>
           <th>Title</th>
           <th class="tags-cell">Tags</th>
-          <th class="comps-cell">Happened during</th>
+          <th class="comps-cell" data-field="happened" data-sortable="true" data-sorter="incidentsSorter">Happened during</th>
           <th class="status-cell">Status</th>
+          <% if current_user&.can_view_delegate_matters? %>
+            <th class="digest-cell" data-field="digest-sent" data-sortable="true">Sent in digest</th>
+          <% end %>
         </tr>
       </thead>
 
@@ -27,14 +30,17 @@
               <% end %>
             </td>
             <td data-competitions="<%= incident.competitions %>">
-              <% incident.incident_competitions.each do |incident_competition| %>
-                <%= render "competition_tag", incident_competition: incident_competition %>
-              <% end %>
+              <div data-last-happened="<%= incident.last_happened_date %>">
+                <% incident.incident_competitions.each do |incident_competition| %>
+                  <%= render "competition_tag", incident_competition: incident_competition %>
+                <% end %>
+              </div>
             </td>
-            <% if incident.resolved_at %>
-              <td class="text-success">Resolved</td>
-            <% else %>
-              <td class="text-warning">Pending</td>
+            <% status_class, status_text = class_and_text_for_status(incident) %>
+            <td class="text-<%= status_class %>"><%= status_text %></td>
+            <% if current_user&.can_view_delegate_matters? %>
+              <% digest_class, digest_text = class_and_text_for_digest(incident) %>
+              <td class="text-<%= digest_class %>"><%= digest_text %></td>
             <% end %>
           </tr>
         <% end %>
@@ -43,6 +49,17 @@
   </div>
 
   <script>
+    function incidentsSorter(a, b) {
+      dateA = $(a).data("last-happened");
+      dateB = $(b).data("last-happened");
+      if (dateA < dateB) {
+        return -1;
+      } else if (dateA > dateB) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
     $(function() {
       var opts = wca.defaultSelectizeOptions(<%= all_to_options(IncidentTag) %>);
       wca.initIncidentsLogTable(opts, $('.incidents-log-table'), $('.search input'), $('input#incident-tags'));

--- a/WcaOnRails/app/views/incidents/show.html.erb
+++ b/WcaOnRails/app/views/incidents/show.html.erb
@@ -71,8 +71,11 @@
     <%= link_to 'Destroy', incident_path(@incident), class: "btn btn-danger", method: :delete, data: { confirm: "Are you sure you want to delete this incident?" } %>
   <% end %>
 
+  <hr/>
+  <div>
+    This incident was created on <%= wca_local_time(@incident.created_at) %>.
+  </div>
   <% if @incident.digest_sent? %>
-    <hr/>
     <div>
       This incident was marked as sent to Delegates in a WRC digest on <%= wca_local_time(@incident.digest_sent_at) %>.
     </div>

--- a/WcaOnRails/spec/features/incident_management_spec.rb
+++ b/WcaOnRails/spec/features/incident_management_spec.rb
@@ -44,6 +44,15 @@ RSpec.feature "Incident Management" do
         expect(page).to have_content("Custom title")
         expect(page).to have_no_content("Second incident")
       end
+
+      scenario "shows regulation text" do
+        visit "/incidents"
+        page.find(:xpath, "//*[text()[contains(.,'1a')]]").click
+        # Unfortunately we don't have access to the Regulations json within travis,
+        # so here we check for the most unlikely to change Regulation:
+        # that a competition must include a WCA Delegate.
+        page.find(".popover").has_content?("must include a WCA Delegate")
+      end
     end
 
     feature "create an incident" do
@@ -54,7 +63,7 @@ RSpec.feature "Incident Management" do
       end
     end
 
-    feature "show an incident", js: true do
+    feature "show an incident" do
       scenario "shows all information" do
         visit incident_path(incident1)
         expect(page).to have_content("First incident")
@@ -63,16 +72,6 @@ RSpec.feature "Incident Management" do
         expect(page).to have_content(incident1.public_summary)
         expect(page).to have_content(incident1.private_description)
         expect(page).to have_content(incident1.private_wrc_decision)
-      end
-
-      scenario "shows regulation text" do
-        visit incident_path(incident2)
-        expect(page).to have_content("Second incident")
-        page.find(:xpath, "//*[text()[contains(.,'1a')]]").click
-        # Unfortunately we don't have access to the Regulations json within travis,
-        # so here we check for the most unlikely to change Regulation:
-        # that a competition must include a WCA Delegate.
-        page.find(".popover").has_content?("must include a WCA Delegate")
       end
     end
   end


### PR DESCRIPTION
Part of #2538.

List of changes:
  - sort incidents by the last competition's date where they happened (if no competition, take `created_at`)
  - display the "digest" status: not needed, pending, or sent
  - js sort per date or digest status
  - show creation date on the show incident page
