### PR TITLE
Enable avatar removal for dummy accounts

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -423,7 +423,7 @@ class User < ApplicationRecord
   end
 
   def can_change_users_avatar?(user)
-    user.wca_id.present? && self.editable_fields_of_user(user).include?(:pending_avatar)
+    user.wca_id.present? && self.editable_fields_of_user(user).include?(:remove_avatar)
   end
 
   def organizer_for?(user)
@@ -580,7 +580,8 @@ class User < ApplicationRecord
   def editable_fields_of_user(user)
     fields = Set.new
     if user.dummy_account?
-      return fields
+      # That's the only field we want to be able to edit for these accounts
+      return %i(remove_avatar)
     end
     if user == self
       fields += %i(


### PR DESCRIPTION
Right now the WRT cannot remove avatars for dummy accounts, which is an issue.
Unfortunately this can't be tested locally or on staging, as dummy accounts only exist in prod.

(my approach for this would just be to deploy this and see if it works)