### PR TITLE
Results form adjustments

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -485,7 +485,9 @@ class User < ApplicationRecord
   end
 
   def can_submit_competition_results?(competition)
-    can_admin_results? || competition.delegates.include?(self)
+    appropriate_role = can_admin_results? || competition.delegates.include?(self)
+    appropriate_time = competition.in_progress? || competition.is_probably_over?
+    appropriate_role && appropriate_time && !competition.results_posted?
   end
 
   def can_create_poll?

--- a/WcaOnRails/app/views/results_submission/edit.html.erb
+++ b/WcaOnRails/app/views/results_submission/edit.html.erb
@@ -14,7 +14,7 @@
   <%= form_tag({action: :submit}, multipart: true) do %>
     <%= text_area_tag :message, params[:message], placeholder: "Email body here", class: "markdown-editor" %><br>
     Results file<br>
-    <%= file_field_tag 'results' %><br>
+    <%= file_field_tag 'results', accept: 'application/json' %><br>
     <input type="submit" class="btn btn-primary" />
   <% end %>
 


### PR DESCRIPTION
Requests from Luis:
- Filtering JSON files in system file browser
- No access nor nav link to the form if the competition is upcoming or results have already been posted (I intentionally allow this for ongoing comps as the results can be submitted the same day the competition is held)