### PR TITLE
Allow filtering by tag in rss feeds.

### DIFF
--- a/WcaOnRails/app/controllers/posts_controller.rb
+++ b/WcaOnRails/app/controllers/posts_controller.rb
@@ -16,7 +16,13 @@ class PostsController < ApplicationController
   end
 
   def rss
-    @posts = Post.where(world_readable: true).order(created_at: :desc).includes(:author).page(params[:page])
+    tag = params[:tag]
+    if tag
+      @posts = Post.joins(:post_tags).where('post_tags.tag = ?', tag)
+    else
+      @posts = Post
+    end
+    @posts = @posts.where(world_readable: true).order(created_at: :desc).includes(:author).page(params[:page])
 
     # Force responding with xml, regardless of the given HTTP_ACCEPT headers.
     request.format = :xml

--- a/WcaOnRails/spec/controllers/posts_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/posts_controller_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe PostsController do
         get :rss, format: :xml
         expect(assigns(:posts).to_a).to eq [post1, sticky_post, wdc_post]
       end
+
+      it "filters by tag" do
+        get :rss, format: :xml, params: { tag: "wdc" }
+        expect(assigns(:posts).to_a).to eq [wdc_post]
+      end
     end
 
     describe "GET #show" do


### PR DESCRIPTION
This fixes #2860.

This will allow filtering by new competitions with http://localhost:3000/rss.xml?tag=competitions and results with http://localhost:3000/rss.xml?tag=results.