### PR TITLE
Quick hack to fix the navbar image overflowing issue.

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/navbar-static-top.scss
+++ b/WcaOnRails/app/assets/stylesheets/navbar-static-top.scss
@@ -20,8 +20,7 @@
   .navbar-brand {
     padding: 0;
     padding-top: 16px;
-    height: 110px;
-    margin-bottom: -50px;
+    margin-bottom: 10px;
     margin-top: 10px;
 
     span {
@@ -81,6 +80,8 @@
 @media (min-width: $screen-sm-min) {
   .navbar-static-top {
     .navbar-brand {
+      height: 110px;
+      margin-bottom: -50px;
       img {
         height: 100px;
         margin-top: -15px;

--- a/webroot/results/style/navbar-static-top.css
+++ b/webroot/results/style/navbar-static-top.css
@@ -9,8 +9,7 @@ html, body {
 div.navbar-brand {
   padding: 0;
   padding-top: 16px;
-  height: 110px;
-  margin-bottom: -50px;
+  margin-bottom: 10px;
   margin-top: 10px;
 }
 
@@ -53,6 +52,10 @@ div.navbar-collapse {
     padding-left: 15px; /* make space for the border-top-left-radius */
   }
 
+  .navbar-brand {
+    height: 110px;
+    margin-bottom: -50px;
+  }
   .navbar-brand img {
     height: 100px;
     margin-top: -15px;


### PR DESCRIPTION
This fixes #2180, but we should seriously considering modernizing the
CSS techniques used here. I suspect that by using flexbox or even css grids, we could
simplify this a whole lot.

![image](https://user-images.githubusercontent.com/277474/40321382-ae3a5d08-5ce3-11e8-83df-7d7072388c7f.png)

![image](https://user-images.githubusercontent.com/277474/40321387-b36f4446-5ce3-11e8-9fdd-db9967f2de15.png)
