### PR TITLE
Use language_region_compatible_from instead of preferred_language_from.

### DIFF
--- a/WcaOnRails/app/controllers/application_controller.rb
+++ b/WcaOnRails/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
     # If the locale for the session is not set, we want to infer it from the following sources:
     #  - the current user preferred locale
     #  - the Accept-Language http header
-    session[:locale] ||= current_user&.preferred_locale || http_accept_language.preferred_language_from(I18n.available_locales)
+    session[:locale] ||= current_user&.preferred_locale || http_accept_language.language_region_compatible_from(I18n.available_locales)
     I18n.locale = session[:locale] || I18n.default_locale
 
     @@locale_counts ||= Hash.new(0)


### PR DESCRIPTION
`language_region_compatible_from` seems to try harder to find a locale than
`preferred_language_from`.

Before
======

```
➜  ~ curl -isH "Accept-Language: ja-jp" http://localhost:3000 | grep "rel..next"
    <a rel="next" href="/?page=2">2</a>
  <a rel="next" href="/?page=2">Next &rsaquo;</a>
```

After
=====

```
➜  ~ curl -isH "Accept-Language: ja-jp" http://localhost:3000 | grep "rel..next"
    <a rel="next" href="/?page=2">2</a>
  <a rel="next" href="/?page=2">次 &rsaquo;</a>
```