### PR TITLE
Update Password confirmation label to Re-enter password

### DIFF
--- a/WcaOnRails/app/views/devise/passwords/edit.html.erb
+++ b/WcaOnRails/app/views/devise/passwords/edit.html.erb
@@ -7,7 +7,7 @@
       <%= simple_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put, role: "form" }) do |f| %>
         <%= f.hidden_field :reset_password_token %>
         <%= f.input :password, label: t('.new_password'), autofocus: true  %>
-        <%= f.input :password_confirmation, label: t('new_password_confirmation')  %>
+        <%= f.input :password_confirmation, label: t('.new_password_confirmation')  %>
 
         <%= f.submit t('.change_my_password'), class: "btn btn-primary" %>
       <% end %>

--- a/WcaOnRails/app/views/devise/passwords/edit.html.erb
+++ b/WcaOnRails/app/views/devise/passwords/edit.html.erb
@@ -6,9 +6,8 @@
     <div class="panel-body">
       <%= simple_form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put, role: "form" }) do |f| %>
         <%= f.hidden_field :reset_password_token %>
-
-        <%= f.input :password, autofocus: true  %>
-        <%= f.input :password_confirmation  %>
+        <%= f.input :password, label: t('.new_password'), autofocus: true  %>
+        <%= f.input :password_confirmation, label: t('new_password_confirmation')  %>
 
         <%= f.submit t('.change_my_password'), class: "btn btn-primary" %>
       <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -191,6 +191,8 @@ en:
         password: "Password"
         current_password: "Current password"
         password_confirmation: "Re-enter password"
+        new_password: 'New password'
+        new_password_confirmation: 'Re-enter new password'
         remember_me: "Remember me"
         pending_avatar: "Upload new avatar"
         remove_avatar: "Remove avatar"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -190,7 +190,7 @@ en:
         email: "Email"
         password: "Password"
         current_password: "Current password"
-        password_confirmation: "Password confirmation"
+        password_confirmation: "Re-enter password"
         remember_me: "Remember me"
         pending_avatar: "Upload new avatar"
         remove_avatar: "Remove avatar"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -191,8 +191,6 @@ en:
         password: "Password"
         current_password: "Current password"
         password_confirmation: "Re-enter password"
-        new_password: 'New password'
-        new_password_confirmation: 'Re-enter new password'
         remember_me: "Remember me"
         pending_avatar: "Upload new avatar"
         remove_avatar: "Remove avatar"
@@ -503,6 +501,10 @@ en:
       size_too_big: "is too big (should be at most %{file_size})"
   #context: Overriden key for sign in
   devise:
+    passwords:
+      edit:
+        new_password_confirmation: 'Re-enter new password'
+
     sessions:
       new:
         sign_in: "Sign in"


### PR DESCRIPTION
Based on issue: https://github.com/thewca/worldcubeassociation.org/issues/2914

Changes effect on pages:

**1. Sign up Page**
<img width="1153" alt="screen shot 2018-06-12 at 20 25 39" src="https://user-images.githubusercontent.com/6135761/41309776-ef5abef6-6e7f-11e8-8a89-28be5271c5d2.png">


**2. Password Change page**
<img width="1162" alt="screen shot 2018-06-12 at 20 25 27" src="https://user-images.githubusercontent.com/6135761/41309781-f1f23a86-6e7f-11e8-846d-6dc2d184dfac.png">
