### PR TITLE
Allow Senior Delegates to promote/demote Delegates (fixes #1046).

### DIFF
--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -89,6 +89,9 @@ class UsersController < ApplicationController
     old_confirmation_sent_at = @user.confirmation_sent_at
     dangerous_change = current_user == @user && [:password, :password_confirmation, :email].any? { |attribute| user_params.key? attribute }
     if dangerous_change ? @user.update_with_password(user_params) : @user.update_attributes(user_params)
+      if @user.saved_change_to_delegate_status
+        DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(@user, current_user).deliver_later
+      end
       if current_user == @user
         # Sign in the user, bypassing validation in case their password changed
         bypass_sign_in @user

--- a/WcaOnRails/app/mailers/delegate_status_change_mailer.rb
+++ b/WcaOnRails/app/mailers/delegate_status_change_mailer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class DelegateStatusChangeMailer < ApplicationMailer
+  def notify_board_and_wqac_of_delegate_status_change(user_whose_delegate_status_changed, user_who_made_the_change)
+    I18n.with_locale :en do
+      @user_whose_delegate_status_changed = user_whose_delegate_status_changed
+      @user_who_made_the_change = user_who_made_the_change
+      if user_whose_delegate_status_changed.delegate_status
+        if user_whose_delegate_status_changed.delegate_status == "senior_delegate"
+          @user_senior_delegate = user_whose_delegate_status_changed
+        else
+          @user_senior_delegate = user_whose_delegate_status_changed.senior_delegate
+        end
+      else
+        @user_senior_delegate = User.find_by_id!(user_whose_delegate_status_changed.senior_delegate_id_before_last_save)
+      end
+      to = ["board@worldcubeassociation.org"]
+      cc = ["quality@worldcubeassociation.org", user_who_made_the_change.email]
+      # TODO: This can get cleaned up once we require delegates to have senior delegates: https://github.com/thewca/worldcubeassociation.org/issues/2933
+      cc << @user_senior_delegate.email if @user_senior_delegate
+      mail(
+        to: to,
+        cc: cc,
+        reply_to: [user_who_made_the_change.email],
+        subject: "#{user_who_made_the_change.name} just changed the Delegate status of #{user_whose_delegate_status_changed.name}",
+      )
+    end
+  end
+end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -596,7 +596,7 @@ class User < ApplicationRecord
       )
       fields << { user_preferred_events_attributes: [:id, :event_id, :_destroy] }
     end
-    if admin? || board_member?
+    if admin? || board_member? || senior_delegate?
       fields += %i(delegate_status senior_delegate_id region)
     end
     if user.any_kind_of_delegate?

--- a/WcaOnRails/app/views/delegate_status_change_mailer/notify_board_and_wqac_of_delegate_status_change.html.erb
+++ b/WcaOnRails/app/views/delegate_status_change_mailer/notify_board_and_wqac_of_delegate_status_change.html.erb
@@ -1,0 +1,18 @@
+<h1>
+  <% old_status = User.delegate_statuses_i18n[@user_whose_delegate_status_changed.delegate_status_before_last_save] || 'Registered Speedcuber' %>
+  <% new_status = @user_whose_delegate_status_changed.delegate_status_i18n || 'Registered Speedcuber' %>
+  <%= @user_who_made_the_change.name %> has changed the Delegate status of <%= @user_whose_delegate_status_changed.name %> from <%= old_status %> to <%= new_status %>.
+</h1>
+<%# TODO: This if statement can get removed once we require delegates to have senior delegates: https://github.com/thewca/worldcubeassociation.org/issues/2933 %>
+<% if @user_senior_delegate.nil? %>
+  <h2 class="alert">
+    Warning: <%= @user_who_made_the_change.name %> forgot to assign a Senior Delegate to <%= @user_whose_delegate_status_changed.name %>.
+  </h2>
+<% elsif @user_who_made_the_change.name != @user_senior_delegate.name %>
+  <h2 class="alert">
+    Warning: <%= @user_who_made_the_change.name %> is not <%= @user_whose_delegate_status_changed.name %>'s Senior Delegate.
+  </h2>
+<% end %>
+<p>
+  You can see additional information or make changes in the <%= link_to "Edit User", edit_user_url(@user_whose_delegate_status_changed) %> page.
+</p>

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -165,6 +165,21 @@ RSpec.describe UsersController do
         expect(user.reload.name).to eq "Johnny 5"
       end
     end
+
+    context "when the delegate status of a user is changed by a senior delegate" do
+      let(:user_who_makes_the_change) { FactoryBot.create(:senior_delegate) }
+      let(:user_senior_delegate) { FactoryBot.create(:senior_delegate) }
+      let(:user_whose_delegate_status_changes) { FactoryBot.create(:delegate, delegate_status: "candidate_delegate", senior_delegate: user_senior_delegate) }
+
+      it "notifies the board and the wqac via email" do
+        sign_in user_who_makes_the_change
+        expect(DelegateStatusChangeMailer).to receive(:notify_board_and_wqac_of_delegate_status_change).with(user_whose_delegate_status_changes, user_who_makes_the_change).and_call_original
+        expect do
+          patch :update, params: { id: user_whose_delegate_status_changes.id, user: { delegate_status: "delegate" } }
+        end.to change { enqueued_jobs.size }.by(1)
+        expect(user_whose_delegate_status_changes.reload.delegate_status).to eq "delegate"
+      end
+    end
   end
 
   describe "GET #index" do

--- a/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DelegateStatusChangeMailer, type: :mailer do
+  describe "notify_board_and_wqac_of_delegate_status_change" do
+    let(:senior_delegate1) { FactoryBot.create :senior_delegate }
+    let(:senior_delegate2) { FactoryBot.create :senior_delegate }
+    let(:delegate) { FactoryBot.create :delegate, delegate_status: "candidate_delegate", senior_delegate: senior_delegate1 }
+    let(:user) { FactoryBot.create :user }
+
+    it "email headers are correct" do
+      user.update!(delegate_status: "candidate_delegate", senior_delegate: senior_delegate1)
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(user, senior_delegate1)
+
+      expect(mail.subject).to eq("#{senior_delegate1.name} just changed the Delegate status of #{user.name}")
+      expect(mail.to).to eq(["board@worldcubeassociation.org"])
+      expect(mail.cc).to eq(["quality@worldcubeassociation.org", senior_delegate1.email, senior_delegate1.email])
+      expect(mail.from).to eq(["notifications@worldcubeassociation.org"])
+      expect(mail.reply_to).to eq([senior_delegate1.email])
+    end
+
+    it "promoting a registered speedcuber to a delegate" do
+      user.update!(delegate_status: "candidate_delegate", senior_delegate: senior_delegate1)
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(user, senior_delegate1)
+
+      expect(mail.body.encoded).to match("#{senior_delegate1.name} has changed the Delegate status of #{user.name} from Registered Speedcuber to Candidate Delegate.")
+      expect(mail.body.encoded).not_to match("Warning")
+      expect(mail.body.encoded).to match(edit_user_url(user))
+    end
+
+    # TODO: This test can get removed once we require delegates to have senior delegates: https://github.com/thewca/worldcubeassociation.org/issues/2933
+    it "promoting a registered speedcuber to a delegate without setting a senior delegate" do
+      user.update!(delegate_status: "candidate_delegate")
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(user, senior_delegate1)
+
+      expect(mail.cc).to eq(["quality@worldcubeassociation.org", senior_delegate1.email])
+      expect(mail.body.encoded).to match("Warning: #{senior_delegate1.name} forgot to assign a Senior Delegate to #{user.name}")
+      expect(mail.body.encoded).to match(edit_user_url(user))
+    end
+
+    it "promoting a candidate delegate to a delegate" do
+      delegate.update!(delegate_status: "delegate")
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(delegate, senior_delegate1)
+
+      expect(mail.body.encoded).to match("#{senior_delegate1.name} has changed the Delegate status of #{delegate.name} from Candidate Delegate to Delegate.")
+      expect(mail.body.encoded).not_to match("Warning")
+      expect(mail.body.encoded).to match(edit_user_url(delegate))
+    end
+
+    it "demoting a candidate delegate to a registered speedcuber" do
+      delegate.update!(delegate_status: nil, senior_delegate: nil)
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(delegate, senior_delegate1)
+
+      expect(mail.body.encoded).to match("#{senior_delegate1.name} has changed the Delegate status of #{delegate.name} from Candidate Delegate to Registered Speedcuber.")
+      expect(mail.body.encoded).not_to match("Warning")
+      expect(mail.body.encoded).to match(edit_user_url(delegate))
+    end
+
+    it "renders a warning if someone other than their senior delegate makes the change" do
+      delegate.update!(delegate_status: "delegate")
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(delegate, senior_delegate2)
+
+      expect(mail.body.encoded).to match("Warning: #{senior_delegate2.name} is not #{delegate.name}'s Senior Delegate.")
+    end
+  end
+end

--- a/WcaOnRails/spec/mailers/previews/delegate_status_change_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/delegate_status_change_mailer_preview.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/delegate_status_change_mailer
+class DelegateStatusChangeMailerPreview < ActionMailer::Preview
+  def notify_board_and_wqac_of_delegate_status_change
+    mail = nil
+    ActiveRecord::Base.transaction do
+      user_whose_delegate_status_changed = User.where(delegate_status: "candidate_delegate").first
+      user_whose_delegate_status_changed.delegate_status = "delegate"
+      user_whose_delegate_status_changed.save!
+      user_who_made_the_change = User.where(delegate_status: "senior_delegate").first
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(user_whose_delegate_status_changed, user_who_made_the_change)
+      raise ActiveRecord::Rollback
+    end
+    mail
+  end
+
+  # TODO: This preview can get removed once we require delegates to have senior delegates: https://github.com/thewca/worldcubeassociation.org/issues/2933
+  def notify_board_and_wqac_of_delegate_status_change_without_senior_delegate
+    mail = nil
+    ActiveRecord::Base.transaction do
+      user_whose_delegate_status_changed = User.where(delegate_status: nil).first
+      user_whose_delegate_status_changed.delegate_status = "candidate_delegate"
+      user_whose_delegate_status_changed.save!
+      user_who_made_the_change = User.where(delegate_status: "senior_delegate").first
+      mail = DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(user_whose_delegate_status_changed, user_who_made_the_change)
+      raise ActiveRecord::Rollback
+    end
+    mail
+  end
+end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -617,5 +617,12 @@ RSpec.describe User, type: :model do
       expect(organizer.can_edit_user?(registration.user)).to eq true
       expect(organizer.editable_fields_of_user(registration.user).to_a).to eq [:name]
     end
+
+    it "allows senior delegates to assign delegate status" do
+      user = FactoryBot.create :user
+      senior_delegate = FactoryBot.create :senior_delegate
+      expect(senior_delegate.can_edit_user?(user)).to eq true
+      expect(senior_delegate.editable_fields_of_user(user).to_a).to include(:delegate_status, :senior_delegate_id, :region)
+    end
   end
 end


### PR DESCRIPTION
I need some help to finish this:

- I don't know what the .rake_tasks~ file that it says I changed is.
- Rubocop gives me two offenses that I don't know how to fix.
- Maybe I forgot to do something important.
- Maybe I didn't do things on the best place to do them.
- Maybe some tests are missing.
- The mailer preview looks stupid because I can't figure out how to find a user whose delegate status has changed:

![image](https://user-images.githubusercontent.com/26309166/40879053-93839bf8-669a-11e8-8893-a187595c7241.png)

Also, before merging and deploying this, all the affected parties must be warned. I can take care of that once this is ready to go.