### PR TITLE
Run the clear cache cron job more frequently.

### DIFF
--- a/chef/site-cookbooks/wca/recipes/cronjobs.rb
+++ b/chef/site-cookbooks/wca/recipes/cronjobs.rb
@@ -77,7 +77,7 @@ unless node.chef_environment.start_with?("development")
   cron "clear rails cache" do
     minute '0'
     hour '5'
-    weekday 'TUE,FRI'
+    weekday 'MON,WED,SAT'
 
     path path
     mailto admin_email


### PR DESCRIPTION
Run the clear cache cron job more frequently.

We just ran out of space with only 3 hours to go until running the cron
job again. Increasing the cron job to 3 days a week should hopefully
give us some headroom.