### PR TITLE
Do not email people who have not yet confirmed their email address.

### DIFF
--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -484,7 +484,14 @@ RSpec.describe User, type: :model do
       end
 
       it "notifies the user via email" do
+        unconfirmed_user = FactoryBot.create(:user, :unconfirmed,
+                                             unconfirmed_wca_id: person.wca_id,
+                                             delegate_id_to_handle_wca_id_claim: delegate.id,
+                                             claiming_wca_id: true,
+                                             dob_verification: "1990-01-2")
+
         expect(WcaIdClaimMailer).to receive(:notify_user_of_delegate_demotion).with(user, delegate, senior_delegate).and_call_original
+        expect(WcaIdClaimMailer).not_to receive(:notify_user_of_delegate_demotion).with(unconfirmed_user, delegate, senior_delegate).and_call_original
         delegate.update!(delegate_status: nil, senior_delegate_id: nil)
       end
     end


### PR DESCRIPTION
Production is currently stuck in a loop of `Net::SMTPSyntaxError: 501 Invalid RCPT TO address provided` when trying to email this user: https://www.worldcubeassociation.org/users/48864/edit, who has not confirmed their (clearly invalid) email address.

This change ensures that we won't try to send email to users who have not confirmed their email address. This has a hypothetical downside of meaning we won't send notifications to users who *do* have a valid email address, but simply have not confirmed it yet. That said, I think this is a fine trade-off to make.

This won't fix the issue currently raging in production, so I'm going to simply delete that job manually.