### PR TITLE
Add privacy statement to the website.

### DIFF
--- a/WcaOnRails/app/views/layouts/_footer.html.erb
+++ b/WcaOnRails/app/views/layouts/_footer.html.erb
@@ -5,6 +5,8 @@
       |
       <%= link_to "Contact", contact_path %>
       |
+      <%= link_to "Privacy", privacy_path %>
+      |
       <a href="https://github.com/thewca/worldcubeassociation.org" target="_blank" class="hide-new-window-icon">
         <i class="fa fa-github"></i>
       </a>

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -26,6 +26,7 @@
             <li class="divider"></li>
             <li><a href="<%= faq_path %>"><%= icon('question-circle') %> <%= t '.faq' %></a></li>
             <li><a href="<%= contact_path %>"><%= icon('envelope') %> <%= t '.contact' %></a></li>
+            <li><a href="<%= privacy_path %>"><%= icon('user-secret') %> Privacy</a></li>
             <li class="divider"></li>
             <li><a href="<%= score_tools_path %>"><%= icon('wrench') %> <%= t '.tools' %></a></li>
             <li><a href="<%= logo_path %>"><%= image_tag('wca_logo.svg', width: '16px', class: 'fa') %> <%= t '.logo' %></a></li>

--- a/WcaOnRails/app/views/static_pages/privacy.html.erb
+++ b/WcaOnRails/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,145 @@
+<% provide(:title, "WCA Privacy Statement") %>
+
+<%#
+  This was manually exported from
+  https://docs.google.com/document/d/1u9zQMQQfR-PBGTyy5_SqUZWMUUT1XbDKjnub9ZOgXdI
+  by Jeremy. I followed File > Download as > Web Page (.html, zipped).
+  I then pretty printed the html, removed all css, removed empty <a> tags,
+  footnotes, class attributes, id attributes, span tags, and html
+  entities (such as &nbsp;).
+  I then made each of our <h2> tags "anchorable", so users can link directly to them.
+  To clean up the table, I first removed any colspan and rowspan attributes,
+  and then added bootstrap table classes (.table and .table-bordered).
+  Lastly, I manually fixed sublists, because  Google Docs exports a sublist as
+  just a new list with a special style, but we want to semantically represent
+  it as *inside* of the relevant bullet point.
+%>
+
+<div class="container">
+  <h1><%= yield(:title) %></h1>
+
+  <p>In this privacy statement we explain how we collect and use your personal data. The statement applies to all the personal data that we use for the services that we provide.</p>
+  <h2><%= anchorable "Who is the WCA?" %></h2>
+  <p>We are the World Cube Association. We govern competitions for mechanical puzzles that are operated by twisting groups of pieces, commonly known as 'twisty puzzles'.</p>
+  <p>We work together with Regional Organizations and local organizers to organize twisty puzzle competitions worldwide.</p>
+  <p>We are a non-profit organization, based in California, USA.</p>
+  <table class="table table-bordered">
+    <tbody>
+      <tr>
+        <td>
+          <p>Website</p>
+        </td>
+        <td>
+          <p><a href="https://www.worldcubeassociation.org">https://www.worldcubeassociation.org</a></p>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <p>Mailing Address</p>
+        </td>
+        <td>
+          <p>World Cube Association<br>5042 Wilshire Blvd #43206<br>Los Angeles, CA 90036</p>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <p>Email Address</p>
+        </td>
+        <td>
+          <p><a href="mailto:communication@worldcubeassociation.org">communication@worldcubeassociation.org</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h2><%= anchorable "Which personal data do we process?" %></h2>
+  <p>We register data from you that is relevant for the services that we provide, and no other data.</p>
+  <ul>
+    <li>Identifying data, contact data, and account data:<br>When you create an account on the WCA website or participate in a WCA Competition, we may collect the following personal data:<br>Your name, nationality, date-of-birth, gender, personal WCA ID (provided by us), email address, password (hashed), profile picture (managed by you).</li>
+    <li>Data related to your registration for WCA Competitions:<br>When you register for a WCA Competition, we may collect the following personal data:<br>Your name, nationality, date-of-birth, gender, personal WCA ID, email address, account name, selected events for participation, number/names of guests, specific additional registration information per competition, comments made in registration form, payment data (we never store your bank or card details).</li>
+    <li>Results and rankings for WCA Competitions:<br>When you compete in a WCA Competition we register all your results for all events.<br>After the competition we include your results in the rankings of the WCA.<br>Your competition results are not considered personal data.</li>
+    <li>Communication with the WCA:<br>When you communicate with us via email, chat, our website, social media, or other media, we register your communication with us.</li>
+    <li>Incidents and disciplinary information:<br>When you are involved in incidents at WCA Competitions or in disciplinary processes of the WCA, we register the relevant information regarding these incidents and disciplinary processes.</li>
+    <li>Usage of WCA website:<br>When you visit the WCA website, we register your use of the WCA website in our databases. This registration may include your IP address, browser type, operating system, and referring website.<br>We are using an external web analytics tool (Google Analytics). When you visit the WCA website, Google sets some standard Google Analytics cookies that help us to evaluate how our sites are used.</li>
+  </ul>
+  <h2><%= anchorable "How do we collect your data?" %></h2>
+  <p>We collect your data in the following ways:</p>
+  <ul>
+    <li>When you make an account on the WCA website, you provide us your data online, and you explicitly consent that we use it.</li>
+    <li>When you register online for a competition on the WCA website, you provide us your data online and you explicitly consent that we use it.</li>
+    <li>When you register online for a competition on an external competition website, you provide your data online to the organizers of the competition. You explicitly consent that the WCA can use your data. After the competition the WCA Delegate will send your data to the WCA.</li>
+    <li>When you register on-site for a competition, you provide your data in person to the organizers of the competition. You explicitly consent that the WCA can use your data. After the competition the WCA Delegate will send your data to the WCA.</li>
+    <li>During WCA Competitions we register your competition results and information on incidents that you are involved in. After the competition the WCA Delegate will send your data to the WCA.</li>
+    <li>In case of disciplinary processes we collect data from you and other involved parties.</li>
+    <li>When you browse through our website we collect information on your usage of our website.</li>
+    <li>When you communicate with us via email, chat, our website, social media, or other media, we may register your communication with us.</li>
+  </ul>
+  <p>We explicitly do not buy and/or use information on you from other parties, like social media, web trackers, or marketing companies.</p>
+  <h2><%= anchorable "What is your data used for?" %></h2>
+  <p>We use your data to provide services to you, to the Registered Speedcubers, to other users of our services, and for internal use of the WCA. For each service we only use relevant data. We use this data in compliance with the GDPR policy and applicable other legislations and regulations.</p>
+  <ul>
+    <li>
+      Participate at WCA Competitions:<br>In order to participate at WCA competitions we collect data from you during the registration process and during the competition.<br>With this information we:
+      <ul>
+        <li>Reserve your place for participation at the competition.</li>
+        <li>Communicate with you regarding information related to the competition.</li>
+        <li>Identify you during the competition.</li>
+        <li>Register your results for the competition.</li>
+        <li>Determine the complete competition results and competition rankings.</li>
+        <li>Determine honors and prizes for the competition.</li>
+      </ul>
+    </li>
+  </ul>
+  <ul>
+    <li>
+      Link your competition results to your profile:<br>After a WCA Competition that you participated in, we will upload your results to the WCA database and link your results to your profile.<br>With this information you and other users of the WCA services can:
+      <ul>
+        <li>Get an overview of all your competition results.</li>
+        <li>Follow your personal developments in WCA Competitions.</li>
+        <li>You can: create a user account, link this user account to your profile, and upload a profile picture to your account that is displayed on your profile.</li>
+      </ul>
+    </li>
+  </ul>
+  <ul>
+    <li>
+      Provide national, continental, and world rankings:<br>As the world governing organization for twisty puzzle competitions we register, maintain, and publish official records and rankings for all official events:
+      <ul>
+        <li>World records, continental records, national records, and personal records.</li>
+        <li>World rankings, continental rankings, and national rankings.</li>
+        <li>Statistical rankings.</li>
+      </ul>
+    </li>
+  </ul>
+  <ul>
+    <li>Communicate with you:<br>We use your contact details to communicate with you in relation to our services, to answer your questions, or to handle your complaints.</li>
+    <li>Manage disciplinary processes:<br>As the world governing organization for twisty puzzle competitions we have disciplinary processes to take action in case of alleged violations of our Mission, Spirit, Bylaws, Motions, Ethical code, or Regulations.</li>
+    <li>Improve our services:<br>We use the data that we collect to improve our services: for example we may improve our Regulations and training of staff based on incidents during WCA Competitions.</li>
+  </ul>
+  <h2><%= anchorable "Do we disclose your data to other parties?" %></h2>
+  <p>We do not disclose your data to other parties without your explicit consent.</p>
+  <ul>
+    <li>Competition Organization teams:<br>When you register online for a competition on the WCA website, you provide us your data and you consent that we use it for the competition.<br>The organization team of the competition may involve individuals who are not WCA Staff or External Staff. These individuals may get access to data that is relevant for your participation at the competition.<br>With Competition Organization teams we have service agreements on the use of personal data. We will enforce these agreements to protect your personal data.</li>
+    <li>Export of the WCA Competition results:<br>On our website we provide a function which enables individuals to download an export of the WCA database. This export includes the WCA ID, name, nationality, gender, and competition results of all Registered Speedcubers. The export does not include your date-of-birth and account information.<br>This export needs to be used according to our service agreement, see <a href="https://www.worldcubeassociation.org/results/misc/export.html">https://www.worldcubeassociation.org/results/misc/export.html</a></li>
+  </ul>
+  <h2><%= anchorable "How secure is your data at the WCA?" %></h2>
+  <p>The WCA will handle your personal data with care and attention. Only persons with the need to have access to your data have access to your data, only access to the relevant data, and only for the period that this access is necessary.</p>
+  <ul>
+    <li>The WCA will take appropriate technical and organizational measures to protect your personal data against loss or unlawful use.</li>
+    <li>Your personal data will be retained for as long as required for the services described in this privacy statement.</li>
+  </ul>
+  <h2><%= anchorable "How is your data used internationally?" %></h2>
+  <p>The WCA is based in the United States of America. But since the WCA is a worldwide organization, your data may also be processed by the WCA in other countries.</p>
+  <ul>
+    <li>The WCA may transfer your personal data from one country to another country<br>to provide the services of the WCA. In all cases we will follow the GDPR policy and applicable local legislation and regulations.</li>
+  </ul>
+  <h2><%= anchorable "What are your rights?" %></h2>
+  <p>The WCA has a Data Protection Officer that will monitor if the WCA is following the data protection laws. and take action where necessary. You may contact our Data Protection Officer to exercise any of the rights you are granted under applicable data protection laws. Some of your rights you may directly exercise on our website through functions available in your account.</p>
+  <ul>
+    <li>Right to access:<br>You may ask us whether or not we process any of your personal data and, if so, receive access to that data in the form of a copy.</li>
+    <li>Right to rectification:<br>You have the right to have your data rectified in case of inaccuracy or incompleteness.</li>
+    <li>Right to be forgotten:<br>You have the right to have your personal data (or parts of it) to be removed. If you exercise your right, we will remove your data within the WCA and order parties with copies of your data to remove your data as well. There are cases in which we cannot or will not remove (parts of) your data, for example if you have pending dues or if you are a party in a disciplinary process or measure. Your rights in such cases are described in article 17 of the GDPR.</li>
+    <li>Right to restriction of processing:<br>You have the right to obtain the restriction of the processing of your personal data, which means that we suspend the processing of your data for a certain period of time. </li>
+    <li>Right to data portability:<br>You have the right to request us to provide you with your personal data in a structured, commonly used, and machine-readable format.</li>
+    <li>Right to object:<br>You have the right to object to the processing of your personal data, which means you may request us to no longer process your personal data. We will follow the GDPR and applicable legislation and regulations in such cases.</li>
+    <li>Withdrawal of your consent:<br>You may withdraw your consent to use your personal data at any time.</li>
+  </ul>
+</div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
   get 'delegates' => 'static_pages#delegates'
   get 'organizations' => 'static_pages#organizations'
   get 'contact' => 'static_pages#contact'
+  get 'privacy' => 'static_pages#privacy'
   get 'faq' => 'static_pages#faq'
   get 'score-tools' => 'static_pages#score_tools'
   get 'logo' => 'static_pages#logo'


### PR DESCRIPTION
This was a fairly manual process that started with downloading a Google
Doc as html, and then manually cleaning it up. I documented all the
steps I took in a comment at the top of privacy.html.erb.

This is now live at https://staging.worldcubeassociation.org/privacy.