### PR TITLE
Edit events modal fixes

### DIFF
--- a/WcaOnRails/app/javascript/edit-events/ButtonActivatedModal.jsx
+++ b/WcaOnRails/app/javascript/edit-events/ButtonActivatedModal.jsx
@@ -28,7 +28,15 @@ export default class ButtonActivatedModal extends React.Component {
         {this.props.buttonValue}
         <Modal show={this.state.showModal} onHide={this.close}>
           <form className={this.props.formClass}
-                onSubmit={e => { e.preventDefault(); this.props.onOk(); }}
+                onSubmit={e => {
+                  // Because we're rendering a modal inside of a modal, we're
+                  // actually also rendering a form inside of a form. We don't
+                  // want submitting this inner form to trigger a submit of the
+                  // outer form, so we must stop event propagation here.
+                  e.stopPropagation();
+                  e.preventDefault();
+                  this.props.onOk();
+                }}
                 onClick={e => {
                   // Prevent clicks on the modal from propagating up to the button, which
                   // would cause this modal to be marked as visible. This causes a race when

--- a/WcaOnRails/app/javascript/edit-events/modals/TimeLimit.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/TimeLimit.jsx
@@ -37,14 +37,7 @@ function objectifyArray(arr) {
 }
 
 class SelectRoundsButton extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { selectedRoundsById: objectifyArray(props.selectedRoundIds) };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({ selectedRoundsById: objectifyArray(nextProps.selectedRoundIds) });
-  }
+  state = { selectedRoundsById: objectifyArray(this.props.selectedRoundIds) };
 
   reset = () => {
     this.setState({ selectedRoundsById: objectifyArray(this.props.selectedRoundIds) });

--- a/WcaOnRails/app/javascript/edit-events/modals/TimeLimit.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/TimeLimit.jsx
@@ -101,7 +101,7 @@ class SelectRoundsButton extends React.Component {
                   let checked = !!selectedRoundsById[roundId];
                   let eventAlreadySelected = this.getSelectedRoundIds().find(roundId => parseActivityCode(roundId).eventId === eventId);
                   let disabled = !checked && eventAlreadySelected;
-                  let disabledReason = disabled && `Cannot select this round because you've already selected a round with ${event.name}`;
+                  let disabledReason = disabled ? `Cannot select this round because you've already selected a round with ${event.name}` : null;
                   return (
                     <li key={roundId}>
                       <div className="checkbox">


### PR DESCRIPTION
Some bug fixes for the edit events modal. This fixes sharing time limits with other rounds. See the commit messages for more details.

These changes are live on staging, you can try them out here: https://staging.worldcubeassociation.org/competitions/GermanNationals2018/events/edit.