### PR TITLE
For CompetitionTab.slug to behave the same in all locales.

### DIFF
--- a/WcaOnRails/app/models/competition_tab.rb
+++ b/WcaOnRails/app/models/competition_tab.rb
@@ -18,7 +18,10 @@ class CompetitionTab < ApplicationRecord
   ).freeze
 
   def slug
-    "#{id}-#{name.parameterize}"
+    # parameterization behaves differently under different locales. However, we
+    # want slugs to be the same across all locales, so we intentionally wrap
+    # the call to parameterize in a I18n.with_locale.
+    I18n.with_locale(:en) { "#{id}-#{name.parameterize}" }
   end
 
   after_create :set_display_order

--- a/WcaOnRails/spec/models/competition_tab_spec.rb
+++ b/WcaOnRails/spec/models/competition_tab_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe CompetitionTab, type: :model do
     expect(CompetitionTab.column_names).to match_array(CompetitionTab::CLONEABLE_ATTRIBUTES + CompetitionTab::UNCLONEABLE_ATTRIBUTES)
   end
 
+  context "#slug" do
+    it "generates the same slug under different locales" do
+      competition_tab = FactoryBot.build(:competition_tab, id: 42, name: "Schedule / Расписание")
+      expect(I18n.with_locale(:en) { competition_tab.slug }).to eq "42-schedule"
+      expect(I18n.with_locale(:ru) { competition_tab.slug }).to eq "42-schedule"
+    end
+  end
+
   context "#display_order" do
     let(:competition) { FactoryBot.create(:competition) }
     let(:other_competition) { FactoryBot.create(:competition) }


### PR DESCRIPTION
This fixes #2959.