### PR TITLE
Remove duplicate event names in winners table

### DIFF
--- a/WcaOnRails/app/views/competitions/_results_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_results_table.html.erb
@@ -41,7 +41,7 @@
       <tr class="sort-by-<%= result.format.sort_by.to_s %> <%= result.muted ? "text-muted" : "" %>">
         <% if !hide_event %>
           <td class="event">
-            <% if !result.muted %>
+            <% if !result.muted && result.eventId != results[i - 1].eventId %>
               <%= link_to competition_results_all_path(@competition, anchor: "e#{result.event.id}") do %>
                 <%= cubing_icon result.event.id %>
                 <%= result.event.name %>


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/1652. Is this still a thing?

Basically straight forward, let me know if I used any no-gos and I'll try to fix them!
I've decided to stay with the alternating row colors instead of adding all winners into one (as shown by jfly in https://github.com/thewca/worldcubeassociation.org/issues/1652) to stay consistent with all other ranking tables on the website (rankings, records etc.)