### PR TITLE
Invoke notify_board_and_wqac_of_delegate_status_change immediately, rather than as a background job.

### DIFF
--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -90,7 +90,8 @@ class UsersController < ApplicationController
     dangerous_change = current_user == @user && [:password, :password_confirmation, :email].any? { |attribute| user_params.key? attribute }
     if dangerous_change ? @user.update_with_password(user_params) : @user.update_attributes(user_params)
       if @user.saved_change_to_delegate_status
-        DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(@user, current_user).deliver_later
+        # TODO: See https://github.com/thewca/worldcubeassociation.org/issues/2969.
+        DelegateStatusChangeMailer.notify_board_and_wqac_of_delegate_status_change(@user, current_user).deliver_now
       end
       if current_user == @user
         # Sign in the user, bypassing validation in case their password changed

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -176,7 +176,12 @@ RSpec.describe UsersController do
         expect(DelegateStatusChangeMailer).to receive(:notify_board_and_wqac_of_delegate_status_change).with(user_whose_delegate_status_changes, user_who_makes_the_change).and_call_original
         expect do
           patch :update, params: { id: user_whose_delegate_status_changes.id, user: { delegate_status: "delegate" } }
-        end.to change { enqueued_jobs.size }.by(1)
+
+          # For now, we're not sending the delegate status email in a
+          # background job. See
+          # https://github.com/thewca/worldcubeassociation.org/issues/2969.
+        end.to change { enqueued_jobs.size }.by(0)
+
         expect(user_whose_delegate_status_changes.reload.delegate_status).to eq "delegate"
       end
     end


### PR DESCRIPTION
This is a quick workaround for #2969.