### PR TITLE
Add delegate notification for missing competition results after competition is over #2

### DIFF
--- a/WcaOnRails/app/helpers/notifications_helper.rb
+++ b/WcaOnRails/app/helpers/notifications_helper.rb
@@ -76,6 +76,16 @@ module NotificationsHelper
           }
         end
 
+    user.delegated_competitions.visible.over
+        .each do |competition|
+          if !competition.results_posted?
+            notifications << {
+              text: "The competition results for #{competition.name} have not been submitted.",
+              url: submit_results_edit_path(competition),
+            }
+          end
+        end
+
     notifications
   end
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -218,6 +218,10 @@ class Competition < ApplicationRecord
     persisted? && is_probably_over? && !delegate_report.posted? && delegates.include?(user)
   end
 
+  def user_should_post_competition_results?(user)
+    persisted? && is_probably_over? && !self.results_posted? && delegates.include?(user)
+  end
+
   def warnings_for(user)
     warnings = {}
     if !self.showAtAll

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -187,6 +187,12 @@
         <% end %>
       <% end %>
 
+      <% if @competition.user_should_post_competition_results?(current_user) %>
+        <%= alert :warning, note: true do %>
+          Please submit results for this competition! You can upload them <%= link_to "here", submit_results_edit_path(@competition) %>.
+        <% end %>
+      <% end %>
+
       <% @competition.warnings_for(current_user).each do |field, message| %>
         <%= alert :warning, message, note: true %>
       <% end %>

--- a/WcaOnRails/spec/helpers/notifications_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/notifications_helper_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe NotificationsHelper do
               text: "The delegate report for #{past_competition_missing_report.name} has not been submitted.",
               url: delegate_report_path(past_competition_missing_report),
             },
+            {
+              text: "The competition results for #{past_competition_missing_report.name} have not been submitted.",
+              url: submit_results_edit_path(past_competition_missing_report),
+            },
+            {
+              text: "The competition results for #{past_competition_having_report.name} have not been submitted.",
+              url: submit_results_edit_path(past_competition_having_report),
+            },
           ]
         end
       end


### PR DESCRIPTION
Second pull request because me -> stupid (removed the previous commits from the correct branch). 

Fixes https://github.com/thewca/worldcubeassociation.org/issues/2116 and replaces https://github.com/thewca/worldcubeassociation.org/pull/2977 which I can't seem to open again.

I have been failing to remove/squash the merge commits for some reason :/

Else this should be ready to merge. Files did not change after @jfly 's LGTM.