### PR TITLE
Ignore running jobs when checking for stuck jobs.

### DIFF
--- a/WcaOnRails/app/controllers/server_status_controller.rb
+++ b/WcaOnRails/app/controllers/server_status_controller.rb
@@ -9,7 +9,7 @@ class ServerStatusController < ApplicationController
   def index
     @everything_good = true
 
-    @jobs_that_should_have_run_by_now = Delayed::Job.where(attempts: 0).where('created_at < ?', MINUTES_IN_WHICH_A_JOB_SHOULD_HAVE_STARTED_RUNNING.minutes.ago)
+    @jobs_that_should_have_run_by_now = Delayed::Job.where(attempts: 0).where(locked_at: nil).where('created_at < ?', MINUTES_IN_WHICH_A_JOB_SHOULD_HAVE_STARTED_RUNNING.minutes.ago)
     @oldest_job_that_should_have_run_by_now = @jobs_that_should_have_run_by_now.order(:created_at).first
     @everything_good &&= @oldest_job_that_should_have_run_by_now.blank?
 

--- a/WcaOnRails/spec/controllers/server_status_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/server_status_controller_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe ServerStatusController, type: :controller do
 
       expect(assigns(:everything_good)).to eq true
     end
+
+    it "ignores jobs in progress" do
+      old_job = Delayed::Job.create(created_at: 10.minutes.ago, handler: "")
+      _oldest_but_running_job = Delayed::Job.create(created_at: 15.minutes.ago, handler: "", locked_at: Time.now)
+
+      get :index
+
+      oldest_job_that_should_have_run_by_now = assigns(:oldest_job_that_should_have_run_by_now)
+      expect(oldest_job_that_should_have_run_by_now).to eq old_job
+
+      expect(assigns(:everything_good)).to eq false
+    end
   end
 
   context "regulations" do


### PR DESCRIPTION
Previously, we were just looking at jobs that haven't had a completed
(succeeded OR failed) attempt yet. This included jobs that were
currently running. That means that despite us giving jobs 10 minutes of
execution time, we would start complaining about jobs after they've been
running for only 5 minutes.

Unfortunately, our compute auxiliary data script has started fairly
reliably taking > 5 minutes, so most times it runs, it results in a
warning on the server-status page that is gone by the time some one
looks into it. While we should definitely do something to improve the
speed of the compute auxiliar data script, this change causes us to
ignore ongoing jobs when checking for jobs that should have run by now.

We will notice if a running job takes more than 10 minutes, delayed job
has infrastructure to kill the ongoing job and mark it as a failure (see
Delayed::Worker.max_run_time in config/initializers/delayed_job_config.rb).