### PR TITLE
Fix attribute name for Results submission

### DIFF
--- a/WcaOnRails/app/views/results_submission/new.html.erb
+++ b/WcaOnRails/app/views/results_submission/new.html.erb
@@ -14,7 +14,7 @@
   <%= simple_form_for @results_submission, url: submit_results_path do |f| %>
     <%= f.input :schedule_url %>
     <%= f.input :message, as: :text, input_html: { class: "markdown-editor" } %>
-    <%= f.input :results, as: :file, input_html: { accept: 'application/json' } %>
+    <%= f.input :results_file, as: :file, input_html: { accept: 'application/json' } %>
     <%= f.submit "Submit", class: "btn btn-primary" %>
   <% end %>
 <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -465,7 +465,7 @@ en:
         status: ""
       results_submission:
         schedule_url: ""
-        results: ""
+        results_file: ""
         message: ""
     #context: and a label for an option
     options:


### PR DESCRIPTION
It was changed to `results_file` [here](342c62c941976d67a5b9e2d7ec39902f70745928), but somehow the view didn't get updated.

@jfly I'll merge this asap!