### PR TITLE
Add new registration email for new users.

### DIFF
--- a/WcaOnRails/app/mailers/new_registration_mailer.rb
+++ b/WcaOnRails/app/mailers/new_registration_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class NewRegistrationMailer < ApplicationMailer
+  include MailersHelper
+
+  def send_registration_mail(user)
+    @user = user
+    localized_mail @user.locale,
+                   -> { I18n.t('users.mailer.create_new_account.header') },
+                   to: user.email,
+                   reply_to: "notifications@worldcubeassociation.org"
+  end
+end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -331,6 +331,12 @@ class User < ApplicationRecord
     end
   end
 
+  # This method was copied and overridden from https://github.com/plataformatec/devise/blob/master/lib/devise/models/confirmable.rb#L182
+  # to enable separate emails for sign-up and email reconfirmation
+  def send_on_create_confirmation_instructions
+    NewRegistrationMailer.send_registration_mail(self).deliver_now
+  end
+
   # After the user confirms their account, if they claimed a WCA ID, now is the
   # time to notify their delegate!
   def after_confirmation

--- a/WcaOnRails/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/WcaOnRails/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,6 +1,15 @@
-<p><%= t('.greeting', :recipient => @resource.email, :default => "Welcome #{@resource.email}!") %></p>
+<p>
+  <%= t 'users.mailer.reconfirmation_mail.welcome', user_email: @user.name %>
+</p>
 
-<p><%= t('.instruction', :default => "You can confirm your account email through the link below:") %></p>
+<p>
+  <%= t 'users.mailer.reconfirmation_mail.confirm' %> 
+</p>
 
-<p><%= link_to t('.action', :default => "Confirm my account"),
-         confirmation_url(@resource, :confirmation_token => @token, locale: I18n.locale) %></p>
+<p>
+  <%= link_to t('users.mailer.reconfirmation_mail.confirmation_link'), confirmation_url(@user, confirmation_token: @user.confirmation_token, locale: I18n.locale) %>
+</p>
+
+<p>
+  <%= t 'users.mailer.create_new_account.questions', contact_link: 'contact@worldcubeassociation.org' %>
+</p>

--- a/WcaOnRails/app/views/new_registration_mailer/send_registration_mail.html.erb
+++ b/WcaOnRails/app/views/new_registration_mailer/send_registration_mail.html.erb
@@ -1,0 +1,25 @@
+<p>
+  <%= t 'users.mailer.create_new_account.welcome', user_email: @user.email %>
+</p>
+
+<p>
+  <%= t 'users.mailer.create_new_account.confirm' %>
+</p>
+
+<p>
+  <%= link_to t('users.mailer.create_new_account.confirmation_link'), confirmation_url(@user, confirmation_token: @user.confirmation_token, locale: I18n.locale) %>
+</p>
+
+<p>
+  <%= t 'users.mailer.create_new_account.activate' %>
+
+  <%= link_to('login form', new_user_registration_url) %>
+</p>
+
+<p>
+  <%= t 'users.mailer.create_new_account.addendum' %>
+</p>
+
+<p>
+  <%= t 'users.mailer.create_new_account.questions', contact_link: 'contact@worldcubeassociation.org' %>
+</p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -602,6 +602,22 @@ en:
       success: "Updated locale."
       failure: "Unable to update your profile."
       unavailable: "Requested locale is not available."
+    #context: user receiving mails
+    mailer:
+      #context: user creating new account and receiving confirmation mail
+      create_new_account:
+        header: "Confirmation instructions"
+        welcome: "Welcome %{user_email}!"
+        confirm: "Your account is created and must be activated before you can use it. Please confirm your account through the link below: "
+        confirmation_link: "Confirm my account."
+        activate: "After activation you may log in to the website of the World Cube Association: "
+        addendum: "This email is generated automatically. If you didn't register an account on the website of the World Cube Association and received this message by mistake, please ignore and delete it."
+        questions: "Do you have more questions? We will be happy to answer them! Feel free to send a mail to %{contact_link}."
+      #context: user changing mail address and receiving reconfirmation mail
+      reconfirmation_mail:
+        welcome: "Hello %{user_email}!"
+        confirm: "You can confirm your new account email address through the link below:"
+        confirmation_link: "Confirm mail address."
     #context: related to claiming a WCA ID
     claim_wca_id:
       title: "Claim WCA ID"

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -20,9 +20,11 @@ FactoryBot.define do
       end
     end
 
-    before(:create) { |user| user.skip_confirmation! }
-    trait :unconfirmed do
-      before(:create) { |user| user.confirmed_at = nil }
+    transient do
+      confirmed true
+    end
+    before(:create) do |user, options|
+      user.skip_confirmation! if options.confirmed
     end
 
     factory :admin do

--- a/WcaOnRails/spec/helpers/notifications_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/notifications_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe NotificationsHelper do
         user = FactoryBot.create :user
         user.update_attributes!(unconfirmed_wca_id: person.wca_id, delegate_to_handle_wca_id_claim: delegate, dob_verification: person.dob)
 
-        unconfirmed_user = FactoryBot.create :user, :unconfirmed
+        unconfirmed_user = FactoryBot.create :user, confirmed: false
         unconfirmed_user.update_attributes!(unconfirmed_wca_id: person.wca_id, delegate_to_handle_wca_id_claim: delegate, dob_verification: person.dob)
 
         notifications = helper.notifications_for_user(delegate)

--- a/WcaOnRails/spec/mailers/new_registration_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/new_registration_mailer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NewRegistrationMailer, type: :mailer do
+  describe "send registration mail to new users" do
+    user = FactoryBot.create :user
+    mail = NewRegistrationMailer.send_registration_mail(user)
+
+    it "renders the headers" do
+      expect(mail.subject).to eq "Confirmation instructions"
+      expect(mail.to).to eq [user.email]
+      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match user.email
+      expect(mail.body.encoded).to match "Your account is created and must be activated before you can use it."
+    end
+  end
+end

--- a/WcaOnRails/spec/mailers/previews/new_registration_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/new_registration_mailer_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/new_registration_mailer
+class NewRegistrationMailerPreview < ActionMailer::Preview
+  def send_registration_mail
+    user = User.where.not(confirmed_at: nil).first
+    NewRegistrationMailer.send_registration_mail(user)
+  end
+end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -353,6 +353,14 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "check if registration form sends mail to newly registered user" do
+    it "sends mail" do
+      user = FactoryBot.build(:user, confirmed: false)
+      expect(NewRegistrationMailer).to receive(:send_registration_mail).with(user).and_call_original
+      user.save!
+    end
+  end
+
   describe "unconfirmed_wca_id" do
     let!(:person) { FactoryBot.create :person, year: 1990, month: 1, day: 2 }
     let!(:senior_delegate) { FactoryBot.create :senior_delegate }
@@ -489,12 +497,12 @@ RSpec.describe User, type: :model do
       end
 
       it "notifies the user via email" do
-        unconfirmed_user = FactoryBot.create(:user, :unconfirmed,
+        unconfirmed_user = FactoryBot.create(:user,
+                                             confirmed: false,
                                              unconfirmed_wca_id: person.wca_id,
                                              delegate_id_to_handle_wca_id_claim: delegate.id,
                                              claiming_wca_id: true,
                                              dob_verification: "1990-01-2")
-
         expect(WcaIdClaimMailer).to receive(:notify_user_of_delegate_demotion).with(user, delegate, senior_delegate).and_call_original
         expect(WcaIdClaimMailer).not_to receive(:notify_user_of_delegate_demotion).with(unconfirmed_user, delegate, senior_delegate).and_call_original
         delegate.update!(delegate_status: nil, senior_delegate_id: nil)


### PR DESCRIPTION
As a follow-up to https://github.com/thewca/worldcubeassociation.org/issues/1814 I've looked into creating a new confirmation mail for newly created user accounts.

However, we can only change the reconfirmation instructions mail (which was originally requested in https://github.com/thewca/worldcubeassociation.org/issues/1814 if we overwrite `send_reconfirmation_instructions` in our User model as well. To be honest, I am not entirely sure if it's worth it to only change a few words.

I've already added tests (which are going to fail for the foreign language mails) to test the new registration mail. I used https://github.com/thewca/worldcubeassociation.org/blob/f66b258c7d8f54defc0544d912c6d521f99fc316/WcaOnRails/spec/mailers/registrations_mailer_spec.rb Lines 26 - 46 as comparison to create a test for foreign languages as well, but the test for competition registration mails obviously assumes that we have translations for the confirmation mails. How can I avoid to run into test errors for these language tests while we only have a user registration confirmation mail in english?

I am definitely open for discussions about the mail text! :)

Screenshot:
![new-registration-mail](https://user-images.githubusercontent.com/18479675/41935411-e5af5122-7989-11e8-9284-6c5dcd215cb6.png)
