### PR TITLE
Grant WQAC more premissions

### DIFF
--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -10,7 +10,7 @@ class CompetitionsMailer < ApplicationMailer
     @confirmer = confirmer
     mail(
       to: "board@worldcubeassociation.org",
-      cc: competition.delegates.pluck(:email) + competition.delegates.map { |d| d.senior_delegate&.email }.compact.uniq,
+      cc: competition.delegates.flat_map { |d| [d.email, d.senior_delegate&.email] }.compact.uniq + [Team.wqac.email],
       reply_to: confirmer.email,
       subject: "#{confirmer.name} just confirmed #{competition.name}",
     )

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -466,7 +466,7 @@ class User < ApplicationRecord
   end
 
   def can_manage_competition?(competition)
-    can_admin_results? || competition.organizers.include?(self) || competition.delegates.include?(self) || wrc_team? || competition.delegates.map(&:senior_delegate).compact.include?(self)
+    can_admin_results? || competition.organizers.include?(self) || competition.delegates.include?(self) || wrc_team? || quality_assurance_committee? || competition.delegates.map(&:senior_delegate).compact.include?(self)
   end
 
   def can_view_hidden_competitions?

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
     it "renders" do
       expect(mail.to).to eq(["board@worldcubeassociation.org"])
-      expect(mail.cc).to match_array(competition.delegates.pluck(:email) + [senior_delegate.email] + [third_delegate.senior_delegate.email])
+      expect(mail.cc).to match_array(competition.delegates.pluck(:email) + [senior_delegate.email, third_delegate.senior_delegate.email, Team.wqac.email])
       expect(mail.from).to eq(["notifications@worldcubeassociation.org"])
       expect(mail.reply_to).to eq([delegate.email])
 


### PR DESCRIPTION
From Bob Burton:

> Dear WST,
> 
> The WCA Board would like to request the following two changes:
> 1) Please give the WQAC all relevant permissions required in order to announce and modify competitions.
> 2) Please add the WQAC in cc to the automatically generated emails created when a competition is confirmed.
> 
> Thank you.