### PR TITLE
Sort competitions by date before generating notifications for them.

### DIFF
--- a/WcaOnRails/app/helpers/notifications_helper.rb
+++ b/WcaOnRails/app/helpers/notifications_helper.rb
@@ -67,7 +67,7 @@ module NotificationsHelper
       }
     end
 
-    user.delegated_competitions.visible.over
+    user.delegated_competitions.visible.over.order_by_date
         .includes(:delegate_report).where(delegate_reports: { posted_at: nil })
         .each do |competition|
           notifications << {
@@ -76,7 +76,7 @@ module NotificationsHelper
           }
         end
 
-    user.delegated_competitions.visible.over
+    user.delegated_competitions.visible.over.order_by_date
         .each do |competition|
           if !competition.results_posted?
             notifications << {


### PR DESCRIPTION
Sometimes our tests expect the notifications in a different order than
our code actually produces them, and this results in flaky tests. This
fixes the most recent intermittent test failure on #897 (see https://github.com/thewca/worldcubeassociation.org/issues/897#issuecomment-400656115)