### PR TITLE
Bumping to latest version of TNoodle (v0.13.4).

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -28,12 +28,13 @@ class Api::V0::ApiController < ApplicationController
   def scramble_program
     render json: {
       "current" => {
-        "name" => "TNoodle-WCA-0.13.3",
+        "name" => "TNoodle-WCA-0.13.4",
         "information" => "#{root_url}regulations/scrambles/",
-        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.13.3.jar",
+        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.13.4.jar",
       },
       "allowed" => [
         "TNoodle-WCA-0.13.3",
+        "TNoodle-WCA-0.13.4",
       ],
       "history" => [
         "TNoodle-0.7.4",
@@ -53,6 +54,7 @@ class Api::V0::ApiController < ApplicationController
         "TNoodle-WCA-0.13.1",
         "TNoodle-WCA-0.13.2",
         "TNoodle-WCA-0.13.3",
+        "TNoodle-WCA-0.13.4",
       ],
     }
   end

--- a/WcaOnRails/app/views/regulations/scrambles/index.html.erb
+++ b/WcaOnRails/app/views/regulations/scrambles/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, 'WCA Scrambles') %>
 <div class="container">
   <h1>WCA Scrambles</h1>
-  <% latest_version = "TNoodle-WCA-0.13.3" %>
+  <% latest_version = "TNoodle-WCA-0.13.4" %>
   <% latest_jarfilename = "#{latest_version}.jar" %>
   <p>The current official scramble programs is <em><%= latest_version %></em>. It generates high-quality scramble sequences for all the events of a competition at once.</p>
   <center>
@@ -10,7 +10,7 @@
       <strong><%= link_to latest_jarfilename, "./tnoodle/#{latest_jarfilename}" %></strong>
     </span>
     <br/>
-    Last official change: February 5th, 2018
+    Last official change: July 2nd, 2018
   </center>
   <h2>Important Notes for Delegates</h2>
   <ul>
@@ -55,6 +55,7 @@
     <li><%= link_to "TNoodle-WCA-0.12.0", "./tnoodle/old/TNoodle-WCA-0.12.0.jar" %> (2017-09-25)</li>
     <li><%= link_to "TNoodle-WCA-0.13.1", "./tnoodle/old/TNoodle-WCA-0.13.1.jar" %> (2018-01-29)</li>
     <li><%= link_to "TNoodle-WCA-0.13.2", "./tnoodle/old/TNoodle-WCA-0.13.2.jar" %> (2018-02-03)</li>
-    <li><%= link_to "TNoodle-WCA-0.13.3", "./tnoodle/TNoodle-WCA-0.13.3.jar" %> (2018-02-05)</li>
+    <li><%= link_to "TNoodle-WCA-0.13.3", "./tnoodle/old/TNoodle-WCA-0.13.3.jar" %> (2018-02-05)</li>
+    <li><%= link_to "TNoodle-WCA-0.13.4", "./tnoodle/TNoodle-WCA-0.13.4.jar" %> (2018-07-02)</li>
   </ul>
 </div>

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe Api::V0::ApiController do
       get :scramble_program
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.13.3"
+      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.13.4"
     end
   end
 


### PR DESCRIPTION
Please see https://github.com/thewca/worldcubeassociation.org/pull/3014.

Note that this actually still allows for TNoodle v0.13.3. I've created https://github.com/thewca/worldcubeassociation.org/issues/2992 to track actually removing TNoodle 0.13.3 as legal for competition.