### PR TITLE
Adds roundTypeId to round

### DIFF
--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -41,8 +41,9 @@ class CompetitionEvent < ApplicationRecord
 
   def load_wcif!(wcif)
     self.rounds.destroy_all!
+    total_rounds = wcif["rounds"].size
     wcif["rounds"].each_with_index do |wcif_round, index|
-      self.rounds.create!(Round.wcif_to_round_attributes(wcif_round, index+1))
+      self.rounds.create!(Round.wcif_to_round_attributes(wcif_round, index+1, total_rounds))
     end
   end
 

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -40,6 +40,24 @@ class Round < ApplicationRecord
     Event.c_find(competition_event.event_id)
   end
 
+  # Compute a round type id from round information
+  def round_type_id
+    if number == total_number_of_rounds
+      cutoff ? "c" : "f"
+    elsif number == 1
+      cutoff ? "d" : "1"
+    elsif number == 2
+      cutoff ? "e" : "2"
+    else
+      # Combined third round/Semi Final
+      cutoff ? "g" : "3"
+    end
+  end
+
+  def round_type
+    RoundType.c_find(round_type_id)
+  end
+
   def final_round?
     competition_event.rounds.last == self
   end
@@ -72,9 +90,10 @@ class Round < ApplicationRecord
     advancement_condition ? advancement_condition.to_s(self) : ""
   end
 
-  def self.wcif_to_round_attributes(wcif, round_number)
+  def self.wcif_to_round_attributes(wcif, round_number, total_rounds)
     {
       number: round_number,
+      total_number_of_rounds: total_rounds,
       format_id: wcif["format"],
       time_limit: TimeLimit.load(wcif["timeLimit"]),
       cutoff: Cutoff.load(wcif["cutoff"]),

--- a/WcaOnRails/db/migrate/20180701160042_add_total_number_of_rounds_to_round.rb
+++ b/WcaOnRails/db/migrate/20180701160042_add_total_number_of_rounds_to_round.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddTotalNumberOfRoundsToRound < ActiveRecord::Migration[5.2]
+  def up
+    add_column :rounds, :total_number_of_rounds, :integer, null: false
+
+    # Structure to gather all changes
+    updates_by_total_number_of_rounds = {
+      1 => [],
+      2 => [],
+      3 => [],
+      4 => [],
+    }
+
+    CompetitionEvent.includes(:rounds).all.reject { |ce| ce.rounds.empty? }.each do |ce|
+      total_rounds = ce.rounds.size
+      ce.rounds.each_with_index do |r, index|
+        # We do *not* update the round right away, as it would fire one SQL update by round (!)
+        # Instead we store this information to do a bulk update later
+        updates_by_total_number_of_rounds[total_rounds] << r.id
+      end
+    end
+    updates_by_total_number_of_rounds.each do |total_number_of_rounds, round_ids|
+      Round.where(id: round_ids).update_all(total_number_of_rounds: total_number_of_rounds)
+    end
+  end
+
+  def down
+    remove_column :rounds, :total_number_of_rounds
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1020,6 +1020,7 @@ CREATE TABLE `rounds` (
   `advancement_condition` text COLLATE utf8mb4_unicode_ci,
   `scramble_set_count` int(11) NOT NULL DEFAULT '1',
   `round_results` mediumtext COLLATE utf8mb4_unicode_ci,
+  `total_number_of_rounds` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1388,5 +1389,6 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180528130810'),
 ('20180621093155'),
 ('20180629112054'),
+('20180701160042'),
 ('20180703172949'),
 ('20180705231137');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -262,6 +262,7 @@ module DatabaseDumper
           id
           competition_event_id
           format_id
+          total_number_of_rounds
           number
           time_limit
           cutoff

--- a/WcaOnRails/spec/factories/rounds.rb
+++ b/WcaOnRails/spec/factories/rounds.rb
@@ -11,5 +11,6 @@ FactoryBot.define do
     format { Format.c_find(format_id) }
     competition_event { competition.competition_events.find_by_event_id!(event_id) }
     number 1
+    total_number_of_rounds 1
   end
 end

--- a/WcaOnRails/spec/models/competition_event_spec.rb
+++ b/WcaOnRails/spec/models/competition_event_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CompetitionEvent do
   end
 
   def build_rounds(round_numbers)
-    competition_event.rounds_attributes = round_numbers.map { |n| { number: n, format_id: "a" } }
+    competition_event.rounds_attributes = round_numbers.map { |n| { number: n, format_id: "a", total_number_of_rounds: round_numbers.size } }
   end
 
   def mark_rounds_for_destruction(round_numbers)


### PR DESCRIPTION
See [this discussion](https://github.com/thewca/worldcubeassociation.org/pull/3018#issuecomment-401594865) for the motivation behind this.

This introduces:
  - a way to link a round to its type id (db column)
  - a method to compute the round type id from a round and competition's attributes (round number, total number of rounds for the event, does the round have a cutoff?)
  - computation of the round type id when creating rounds (that currently occurs only through the events WCIF)
  - migration to update existing rounds (can only affect competitions after the introduction of `competition_event` in 2017)

I did not export the `roundTypeId` into the WCIF as it's not in the spec (yet?), but in any case we should always compute it ourselves.
Also I used camel case for the field, just in case some day we want to do joins with existing data.