### PR TITLE
Allow unautheticated users to see the show_events route

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -10,6 +10,7 @@ class CompetitionsController < ApplicationController
     :show_podiums,
     :show_all_results,
     :show_results_by_person,
+    :show_events,
   ]
   before_action -> { redirect_to_root_unless_user(:can_admin_competitions?) }, only: [
     :post_announcement,


### PR DESCRIPTION
I was talking with @hildrethj about this page over the weekend and he didn't know it existed. We discovered that only authenticated users could access this page but I think it would make sense to allow unauthenticated users to also see this page.