### PR TITLE
Rename scramble_group_count to scramble_set_count.

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/edit_events.scss
+++ b/WcaOnRails/app/assets/stylesheets/edit_events.scss
@@ -46,7 +46,7 @@
       width: 100%;
     }
 
-    input[name="scrambleGroupCount"] {
+    input[name="scrambleSetCount"] {
       display: inline-block;
       width: 50px;
     }

--- a/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
+++ b/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
@@ -87,7 +87,7 @@ function RoundsTable({ wcifEvents, wcifEvent }) {
           <tr>
             <th>#</th>
             <th className="text-center">Format</th>
-            <th className="text-center">Scramble Groups</th>
+            <th className="text-center">Scramble Sets</th>
             {event.canChangeTimeLimit && <th className="text-center">Time Limit</th>}
             <th className="text-center">Cutoff</th>
             <th className="text-center">To Advance</th>
@@ -104,9 +104,9 @@ function RoundsTable({ wcifEvents, wcifEvent }) {
               rootRender();
             };
 
-            let scrambleGroupCountChanged = e => {
-              let newScrambleGroupCount = parseInt(e.target.value);
-              wcifRound.scrambleGroupCount = newScrambleGroupCount;
+            let scrambleSetCountChanged = e => {
+              let newScrambleSetCount = parseInt(e.target.value);
+              wcifRound.scrambleSetCount = newScrambleSetCount;
               rootRender();
             };
 
@@ -124,7 +124,7 @@ function RoundsTable({ wcifEvents, wcifEvent }) {
                 </td>
 
                 <td className="text-center">
-                  <input name="scrambleGroupCount" className="form-control input-xs" type="number" min={1} value={wcifRound.scrambleGroupCount} onChange={scrambleGroupCountChanged} />
+                  <input name="scrambleSetCount" className="form-control input-xs" type="number" min={1} value={wcifRound.scrambleSetCount} onChange={scrambleSetCountChanged} />
                 </td>
 
                 {event.canChangeTimeLimit && (
@@ -261,6 +261,6 @@ function addRoundToEvent(wcifEvent) {
     advancementCondition: null,
     results: [],
     groups: [],
-    scrambleGroupCount: 1,
+    scrambleSetCount: 1,
   });
 }

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -79,7 +79,7 @@ class Round < ApplicationRecord
       time_limit: TimeLimit.load(wcif["timeLimit"]),
       cutoff: Cutoff.load(wcif["cutoff"]),
       advancement_condition: AdvancementCondition.load(wcif["advancementCondition"]),
-      scramble_group_count: wcif["scrambleGroupCount"],
+      scramble_set_count: wcif["scrambleSetCount"],
       round_results: RoundResults.load(wcif["roundResults"]),
     }
   end
@@ -95,7 +95,14 @@ class Round < ApplicationRecord
       "timeLimit" => event.can_change_time_limit? ? time_limit&.to_wcif : nil,
       "cutoff" => cutoff&.to_wcif,
       "advancementCondition" => advancement_condition&.to_wcif,
-      "scrambleGroupCount" => self.scramble_group_count,
+
+      # TODO: This is here for backwards compatibility with TNoodle 0.13.4,
+      # which looks at scrambleGroupCount. We can remove this once a new
+      # version of TNoodle is released which looks at a different field.
+      # See https://github.com/thewca/worldcubeassociation.org/issues/3059.
+      "scrambleGroupCount" => self.scramble_set_count,
+
+      "scrambleSetCount" => self.scramble_set_count,
       "roundResults" => round_results.map(&:to_wcif),
     }
   end
@@ -111,7 +118,7 @@ class Round < ApplicationRecord
         "advancementCondition" => AdvancementCondition.wcif_json_schema,
         "roundResults" => { "type" => "array", "items" => { "type" => RoundResult.wcif_json_schema } },
         "groups" => { "type" => "array" }, # TODO: expand on this
-        "scrambleGroupCount" => { "type" => "integer" },
+        "scrambleSetCount" => { "type" => "integer" },
       },
     }
   end

--- a/WcaOnRails/db/migrate/20180705231137_rename_scramble_group_to_scramble_set.rb
+++ b/WcaOnRails/db/migrate/20180705231137_rename_scramble_group_to_scramble_set.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameScrambleGroupToScrambleSet < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :rounds, :scramble_group_count, :scramble_set_count
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1018,7 +1018,7 @@ CREATE TABLE `rounds` (
   `time_limit` text COLLATE utf8mb4_unicode_ci,
   `cutoff` text COLLATE utf8mb4_unicode_ci,
   `advancement_condition` text COLLATE utf8mb4_unicode_ci,
-  `scramble_group_count` int(11) NOT NULL DEFAULT '1',
+  `scramble_set_count` int(11) NOT NULL DEFAULT '1',
   `round_results` mediumtext COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
@@ -1388,4 +1388,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180528130810'),
 ('20180621093155'),
 ('20180629112054'),
-('20180703172949');
+('20180703172949'),
+('20180705231137');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -266,7 +266,7 @@ module DatabaseDumper
           time_limit
           cutoff
           advancement_condition
-          scramble_group_count
+          scramble_set_count
           round_results
           created_at
           updated_at

--- a/WcaOnRails/spec/features/competition_events_spec.rb
+++ b/WcaOnRails/spec/features/competition_events_spec.rb
@@ -66,9 +66,9 @@ RSpec.feature "Competition events management" do
       end
 
       scenario "change scramble group count to 42", js: true do
-        within_round("333", 1) { fill_in("scrambleGroupCount", with: 42) }
+        within_round("333", 1) { fill_in("scrambleSetCount", with: 42) }
         save
-        expect(round_333_1.reload.scramble_group_count).to eq 42
+        expect(round_333_1.reload.scramble_set_count).to eq 42
       end
 
       scenario "change time limit to 5 minutes", js: true do

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Competition WCIF" do
   let(:delegate) { competition.delegates.first }
   let(:sixty_second_2_attempt_cutoff) { Cutoff.new(number_of_attempts: 2, attempt_result: 1.minute.in_centiseconds) }
   let(:top_16_advance) { RankingCondition.new(16) }
-  let!(:round333_1) { FactoryBot.create(:round, competition: competition, event_id: "333", number: 1, cutoff: sixty_second_2_attempt_cutoff, advancement_condition: top_16_advance, scramble_group_count: 16) }
+  let!(:round333_1) { FactoryBot.create(:round, competition: competition, event_id: "333", number: 1, cutoff: sixty_second_2_attempt_cutoff, advancement_condition: top_16_advance, scramble_set_count: 16) }
   let!(:round333_2) { FactoryBot.create(:round, competition: competition, event_id: "333", number: 2) }
   let!(:round444_1) { FactoryBot.create(:round, competition: competition, event_id: "444", number: 1) }
   let!(:round333fm_1) { FactoryBot.create(:round, competition: competition, event_id: "333fm", number: 1, format_id: "m") }
@@ -58,7 +58,8 @@ RSpec.describe "Competition WCIF" do
                   "type" => "ranking",
                   "level" => 16,
                 },
-                "scrambleGroupCount" => 16,
+                "scrambleSetCount" => 16,
+                "scrambleGroupCount" => 16, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
                 "roundResults" => [],
               },
               {
@@ -70,7 +71,8 @@ RSpec.describe "Competition WCIF" do
                 },
                 "cutoff" => nil,
                 "advancementCondition" => nil,
-                "scrambleGroupCount" => 1,
+                "scrambleSetCount" => 1,
+                "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
                 "roundResults" => [],
               },
             ],
@@ -84,7 +86,8 @@ RSpec.describe "Competition WCIF" do
                 "timeLimit" => nil,
                 "cutoff" => nil,
                 "advancementCondition" => nil,
-                "scrambleGroupCount" => 1,
+                "scrambleSetCount" => 1,
+                "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
                 "roundResults" => [],
               },
             ],
@@ -98,7 +101,8 @@ RSpec.describe "Competition WCIF" do
                 "timeLimit" => nil,
                 "cutoff" => nil,
                 "advancementCondition" => nil,
-                "scrambleGroupCount" => 1,
+                "scrambleSetCount" => 1,
+                "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
                 "roundResults" => [],
               },
             ],
@@ -115,7 +119,8 @@ RSpec.describe "Competition WCIF" do
                 },
                 "cutoff" => nil,
                 "advancementCondition" => nil,
-                "scrambleGroupCount" => 1,
+                "scrambleSetCount" => 1,
+                "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
                 "roundResults" => [],
               },
             ],
@@ -256,7 +261,8 @@ RSpec.describe "Competition WCIF" do
             },
             "cutoff" => nil,
             "advancementCondition" => nil,
-            "scrambleGroupCount" => 1,
+            "scrambleSetCount" => 1,
+            "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
             "roundResults" => [],
           },
         ],
@@ -282,7 +288,8 @@ RSpec.describe "Competition WCIF" do
         },
         "cutoff" => nil,
         "advancementCondition" => nil,
-        "scrambleGroupCount" => 1,
+        "scrambleSetCount" => 1,
+        "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
         "roundResults" => [],
       }
 
@@ -329,12 +336,13 @@ RSpec.describe "Competition WCIF" do
       expect(competition.to_wcif["events"]).to eq(wcif["events"])
     end
 
-    it "can set scrambleGroupCount" do
+    it "can set scrambleSetCount" do
       wcif_333mbf_event = wcif["events"].find { |e| e["id"] == "333mbf" }
-      wcif_333mbf_event["rounds"][0]["scrambleGroupCount"] = 32
+      wcif_333mbf_event["rounds"][0]["scrambleSetCount"] = 32
 
       competition.set_wcif_events!(wcif["events"], delegate)
 
+      wcif_333mbf_event["rounds"][0]["scrambleGroupCount"] = 32 # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
       expect(competition.to_wcif["events"]).to eq(wcif["events"])
     end
 

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "API Competitions" do
         it "can update events" do
           competition_events = create_wcif_events(%w(333))
           round333_first = competition_events[0][:rounds][0]
-          round333_first[:scrambleGroupCount] = 2
+          round333_first[:scrambleSetCount] = 2
           round333_first[:roundResults] = [
             {
               personId: 1,
@@ -156,7 +156,7 @@ RSpec.describe "API Competitions" do
           expect(response).to be_success
           rounds = competition.reload.competition_events.find_by_event_id("333").rounds
           expect(rounds.length).to eq 1
-          expect(rounds.first.scramble_group_count).to eq 2
+          expect(rounds.first.scramble_set_count).to eq 2
           expect(rounds.first.round_results.length).to eq 1
           expect(rounds.first.round_results.first.attempts.map(&:result)).to eq [456, 745, 657, 465, 835]
         end
@@ -400,7 +400,7 @@ def create_wcif_events(event_ids)
           timeLimit: nil,
           cutoff: nil,
           advancementCondition: nil,
-          scrambleGroupCount: 1,
+          scrambleSetCount: 1,
         },
       ],
     }


### PR DESCRIPTION
This is for consistency with the rename that occurred in TNoodle 0.13.4.

@jonatanklosko, I think this will break groupifier. I've created a PR for that here: https://github.com/jonatanklosko/groupifier/pull/7