### PR TITLE
Add subject translation for email reconfirmation.

### DIFF
--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -121,6 +121,7 @@ ignore_unused:
   - 'delegate_statuses.*'
   - 'media.new.media_guidelines.*'
 # - 'simple_form.{placeholders,hints,labels}.*'
+  - 'devise.mailer.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -506,8 +506,8 @@ en:
       wrong_size: "is the wrong size (should be %{file_size})"
       size_too_small: "is too small (should be at least %{file_size})"
       size_too_big: "is too big (should be at most %{file_size})"
-  #context: Overriden key for sign in
   devise:
+    #context: Overridden key for sign in
     passwords:
       edit:
         new_password_confirmation: 'Re-enter new password'
@@ -522,6 +522,10 @@ en:
       invalid: "Invalid email, WCA ID, or password."
       not_found_in_database: "Invalid email, WCA ID, or password."
       unconfirmed: "You have to confirm your email address before continuing. Didn't receive a confirmation email? Go to https://www.worldcubeassociation.org/users/confirmation/new to request a new one."
+    #context: Overridden key for Devise reconfirmation email subject
+    mailer:
+      confirmation_instructions:
+        subject: "Please confirm your new email address"
   #context: Key used in external code that the WCA use
   wca:
     # These are locales used in WCA's app relevant to external gems, but which are not present in the gem's default locale file.


### PR DESCRIPTION
This is a follow-up to https://github.com/thewca/worldcubeassociation.org/pull/3009.
To enable the translation of the reconfirmation email subject, I've overridden Devise's translation in our en.yml.
Background: We now use Devise's confirmation instructions for **re**confirmation instructions aber changes in the user's email address. This leads to misleading subjects for changed email reconfirmations which I want to get rid of with this PR.