### PR TITLE
Remove TNoodle-WCA-0.13.3 from the list of allowed versions.

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -33,7 +33,6 @@ class Api::V0::ApiController < ApplicationController
         "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.13.4.jar",
       },
       "allowed" => [
-        "TNoodle-WCA-0.13.3",
         "TNoodle-WCA-0.13.4",
       ],
       "history" => [


### PR DESCRIPTION
This fixes #3016.

@Laura-O, can you let me know when would be an ok time to merge this up? Thanks!