### PR TITLE
Add timestamps columns to competitions.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -103,6 +103,8 @@ class Competition < ApplicationRecord
     results_posted_at
     results_nag_sent_at
     announced_at
+    created_at
+    updated_at
     connected_stripe_account_id
   ).freeze
   VALID_NAME_RE = /\A([-&.:' [:alnum:]]+) (\d{4})\z/

--- a/WcaOnRails/db/migrate/20180709220826_add_timestamps_columns_to_competitions.rb
+++ b/WcaOnRails/db/migrate/20180709220826_add_timestamps_columns_to_competitions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimestampsColumnsToCompetitions < ActiveRecord::Migration[5.2]
+  def change
+    add_timestamps :Competitions, null: true
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -53,6 +53,8 @@ CREATE TABLE `Competitions` (
   `competitor_limit` int(11) DEFAULT NULL,
   `competitor_limit_reason` text COLLATE utf8mb4_unicode_ci,
   `registration_requirements` text COLLATE utf8mb4_unicode_ci,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
@@ -1389,4 +1391,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180621093155'),
 ('20180629112054'),
 ('20180703172949'),
-('20180705231137');
+('20180705231137'),
+('20180709220826');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -66,6 +66,8 @@ module DatabaseDumper
           base_entry_fee_lowest_denomination
           currency_code
           registration_requirements
+          created_at
+          updated_at
         ),
         db_default: %w(
           connected_stripe_account_id


### PR DESCRIPTION
This is necessary for #2999. Another related PR will come soon.