### PR TITLE
Remove TNoodle 0.13.3 from permitted versions. Closes #3016.

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -33,7 +33,6 @@ class Api::V0::ApiController < ApplicationController
         "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.13.4.jar",
       },
       "allowed" => [
-        "TNoodle-WCA-0.13.3",
         "TNoodle-WCA-0.13.4",
       ],
       "history" => [


### PR DESCRIPTION
Never mind, #3070 already handles this.