### PR TITLE
Organizer notifications emails for competition confirmation/announcement

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -149,6 +149,9 @@ class CompetitionsController < ApplicationController
 
     if @competition.save
       flash[:success] = t('competitions.messages.create_success')
+      @competition.organizers.each do |organizer|
+        CompetitionsMailer.notify_organizer_of_addition_to_competition(current_user, @competition, organizer).deliver_later
+      end
       redirect_to edit_competition_path(@competition)
     else
       # Show id errors under name, since we don't actually show an
@@ -167,6 +170,7 @@ class CompetitionsController < ApplicationController
     else
       render 'posts/new'
     end
+    @post
   end
 
   private def editable_post_fields
@@ -185,7 +189,9 @@ class CompetitionsController < ApplicationController
       unless comp.website.blank?
         body += " Check out the [#{comp.name} website](#{comp.website}) for more information and registration."
       end
-      create_post_and_redirect(title: title, body: body, author: current_user, tags: "competitions,new", world_readable: true)
+      @full_post = create_post_and_redirect(title: title, body: body, author: current_user, tags: "competitions,new", world_readable: true)
+      @competition = competition_from_params
+      CompetitionsMailer.notify_organizer_of_announced_competition(@competition, @full_post).deliver_later
 
       comp.update!(announced_at: Time.now)
     end
@@ -463,6 +469,9 @@ class CompetitionsController < ApplicationController
 
     comp_params_minus_id = competition_params
     new_id = comp_params_minus_id.delete(:id)
+
+    old_organizers = @competition.organizers.to_a
+
     if params[:commit] == "Delete"
       cannot_delete_competition_reason = current_user.get_cannot_delete_competition_reason(@competition)
       if cannot_delete_competition_reason
@@ -474,6 +483,16 @@ class CompetitionsController < ApplicationController
         redirect_to root_url
       end
     elsif @competition.update_attributes(comp_params_minus_id)
+      new_organizers = @competition.organizers - old_organizers
+      removed_organizers = old_organizers - @competition.organizers
+
+      new_organizers.each do |new_organizer|
+        CompetitionsMailer.notify_organizer_of_addition_to_competition(current_user, @competition, new_organizer).deliver_later
+      end
+
+      removed_organizers.each do |removed_organizer|
+        CompetitionsMailer.notify_organizer_of_removal_from_competition(current_user, @competition, removed_organizer).deliver_later
+      end
 
       if new_id && !@competition.update_attributes(id: new_id)
         # Changing the competition id breaks all our associations, and our view
@@ -486,6 +505,7 @@ class CompetitionsController < ApplicationController
 
       if params[:commit] == "Confirm"
         CompetitionsMailer.notify_board_of_confirmed_competition(current_user, @competition).deliver_later
+        CompetitionsMailer.notify_organizer_of_confirmed_competition(current_user, @competition).deliver_later
         flash[:success] = t('.confirm_success')
       else
         flash[:success] = t('.save_success')

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 
 class CompetitionsMailer < ApplicationMailer
+  include MailersHelper
   helper :markdown
 
   def notify_board_of_confirmed_competition(confirmer, competition)
@@ -14,6 +15,46 @@ class CompetitionsMailer < ApplicationMailer
       reply_to: confirmer.email,
       subject: "#{confirmer.name} just confirmed #{competition.name}",
     )
+  end
+
+  def notify_organizer_of_confirmed_competition(confirmer, competition)
+    @competition = competition
+    @confirmer = confirmer
+    localized_mail I18n.locale,
+                   -> { I18n.t('users.mailer.competition_submission_email.header', delegate_name: confirmer.name, competition: competition.name) },
+                   to: competition.organizers.pluck(:email),
+                   reply_to: competition.delegates.pluck(:email)
+  end
+
+  def notify_organizer_of_announced_competition(competition, post)
+    @competition = competition
+    @post = post
+    localized_mail I18n.locale,
+                   -> { I18n.t('users.mailer.competition_announcement_email.header', competition: competition.name) },
+                   to: competition.organizers.pluck(:email),
+                   reply_to: competition.delegates.pluck(:email)
+  end
+
+  def notify_organizer_of_addition_to_competition(confirmer, competition, organizer)
+    @competition = competition
+    @confirmer = confirmer
+    @organizer = organizer
+
+    localized_mail I18n.locale,
+                   -> { I18n.t('users.mailer.organizer_addition_email.header', competition: competition.name) },
+                   to: organizer.email,
+                   reply_to: competition.delegates.pluck(:email)
+  end
+
+  def notify_organizer_of_removal_from_competition(remover, competition, organizer)
+    @competition = competition
+    @remover = remover
+    @organizer = organizer
+
+    localized_mail I18n.locale,
+                   -> { I18n.t('users.mailer.organizer_removal_email.header', competition: competition.name) },
+                   to: organizer.email,
+                   reply_to: competition.delegates.pluck(:email)
   end
 
   def notify_users_of_results_presence(user, competition)

--- a/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_addition_to_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_addition_to_competition.html.erb
@@ -1,0 +1,13 @@
+<p>
+  <%= t 'users.mailer.organizer_addition_email.intro', name: @organizer.name %>
+</p>
+
+<p>
+  <%= t 'users.mailer.organizer_addition_email.information', confirmer: @confirmer.name, competition: @competition.name %>
+  <%= link_to 'Competition edit page', edit_competition_url(@competition) %>
+</p>
+
+<p>
+  <%= t 'users.mailer.competition_submission_email.contact' %>
+  <%= @competition.delegates.pluck(:email).join(" ") %>
+</p>

--- a/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_announced_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_announced_competition.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <%= t 'users.mailer.competition_submission_email.organizers', competition: @competition.name %>
+</p>
+
+<p>
+  <%= t 'users.mailer.competition_announcement_email.announced' %>
+</p>
+
+<p>
+  <%= t 'users.mailer.competition_announcement_email.link' %>
+  <%= link_to @competition.name + " announcement", post_url(@post.slug) %>
+</p>

--- a/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_confirmed_competition.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <%= t 'users.mailer.competition_submission_email.organizers', competition: @competition.name %>
+</p>
+
+<p>
+  <%= t 'users.mailer.competition_submission_email.confirmed', delegate_name: @confirmer.name, competition: @competition.name %>
+</p>
+
+<p>
+  <%= t 'users.mailer.competition_submission_email.contact' %>
+  <%= @competition.delegates.pluck(:email).join(" ") %>
+</p>

--- a/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_removal_from_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_removal_from_competition.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <%= t 'users.mailer.organizer_addition_email.intro', name: @organizer.name %>
+</p>
+
+<p>
+  <%= t 'users.mailer.organizer_removal_email.information', remover: @remover.name, competition: @competition.name %>
+</p>
+
+<p>
+  <%= t 'users.mailer.competition_submission_email.contact' %>
+  <%= @competition.delegates.pluck(:email).join(" ") %>
+</p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -625,6 +625,25 @@ en:
         welcome: "Hello %{user_email}!"
         confirm: "You can confirm your new account email address through the link below:"
         confirmation_link: "Confirm mail address."
+      #context: notification to organizer that delegate submitted competition to the WCA Board
+      competition_submission_email:
+        header: "%{delegate_name} confirmed %{competition}"
+        organizers: "Dear organizers of %{competition},"
+        confirmed: "Your competition Delegate %{delegate_name} confirmed %{competition} and sent the submission to the WCA Board. As soon as the WCA Board announces this competition to the public, you will receive another notification."
+        contact: "If you have more questions, please get in contact with the competition Delegate(s) via email: "
+      #context: notification to organizers after the WCA Board announced their competition
+      competition_announcement_email:
+        header: "The WCA Board announced %{competition}"
+        announced: "The WCA Board approved your competition and officially announced it to the public."
+        link: "Please follow the link to get to the competition announcement: "
+      #context: notification to users after they were added to a competition as organizers
+      organizer_addition_email:
+        header: "You were added to %{competition} as an organizer"
+        intro: "Hello %{name},"
+        information: "%{confirmer} added you to %{competition} as an organizer. You can edit this competition here:"
+      organizer_removal_email:
+        header: "You were removed from %{competition} as an organizer"
+        information: "%{remover} removed you from %{competition} as an organizer."
     #context: related to claiming a WCA ID
     claim_wca_id:
       title: "Claim WCA ID"

--- a/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/WcaOnRails/spec/mailers/previews/competitions_mailer_preview.rb
@@ -7,6 +7,27 @@ class CompetitionsMailerPreview < ActionMailer::Preview
     CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)
   end
 
+  def notify_organizer_of_confirmed_competition
+    c = CompetitionDelegate.last.competition
+    CompetitionsMailer.notify_organizer_of_confirmed_competition(c.delegates[0], c)
+  end
+
+  def notify_organizer_of_announced_competition
+    c = CompetitionDelegate.last.competition
+    p = "dummy_link"
+    CompetitionsMailer.notify_organizer_of_announced_competition(c, p)
+  end
+
+  def notify_organizer_of_addition_to_competition
+    c = CompetitionDelegate.last.competition
+    CompetitionsMailer.notify_organizer_of_addition_to_competition(c.delegates[0], c, c.organizers[0])
+  end
+
+  def notify_organizer_of_removal_from_competition
+    c = CompetitionDelegate.last.competition
+    CompetitionsMailer.notify_organizer_of_removal_from_competition(c.delegates[0], c, c.organizers[0])
+  end
+
   def notify_board_of_confirmed_championship_competition
     c = Competition.find("WC2013")
     CompetitionsMailer.notify_board_of_confirmed_competition(c.delegates[0], c)


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/3011 and a missing test for https://github.com/thewca/worldcubeassociation.org/blob/b69ef804ffbaf3b589b7b3f30d060778a2725ed7/WcaOnRails/app/mailers/competitions_mailer.rb#L8

Some screenshots:
Notification to organizers about addition to competition:
![addition_mail](https://user-images.githubusercontent.com/18479675/42697383-48a715c4-86bb-11e8-97e0-6c7447837989.png)
Notification about confirmation of competition
![confirmation_mail](https://user-images.githubusercontent.com/18479675/42697385-48eb1e2c-86bb-11e8-8912-b522a8d3ea4c.png)
Notification about official announcement:
![announcement_mail](https://user-images.githubusercontent.com/18479675/42697384-48cb7c48-86bb-11e8-9e96-c576c57c4e64.png)