### PR TITLE
Fix compute_correct_average to do float division and rounding instead of integer division.

### DIFF
--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -127,7 +127,7 @@ class Result < ApplicationRecord
         100 * sum_moves / counting_solve_times.length
       else
         sum_centis = counting_solve_times.sum(&:time_centiseconds)
-        sum_centis / counting_solve_times.length
+        (sum_centis.to_f / counting_solve_times.length).round
       end
     end
   end

--- a/WcaOnRails/spec/models/result_spec.rb
+++ b/WcaOnRails/spec/models/result_spec.rb
@@ -167,6 +167,15 @@ RSpec.describe Result do
               expect(result).to be_invalid_with_errors(average: ["should be 43"])
             end
 
+            it "rounds instead of truncates" do
+              result = build_result(value1: 4, value2: 4, value3: 3, value4: 0, value5: 0, best: 3, average: 4)
+              expect(result).to be_valid
+
+              result.average = 33
+              expect(result.compute_correct_average).to eq 4
+              expect(result).to be_invalid_with_errors(average: ["should be 4"])
+            end
+
             it "missing solves" do
               result = build_result(value1: 42, value2: 0, value3: 0, value4: 0, value5: 0, best: 42, average: 0)
               expect(result.average_is_not_computable_reason).to be_truthy


### PR DESCRIPTION
@viroulep noticed this bug in
https://github.com/thewca/worldcubeassociation.org/issues/2984#issuecomment-403248522.

This was my bad. As @viroulep correctly noticed, we don't actually use these validations anywhere yet. I'm looking forward to that changing!