### PR TITLE
Always set base_entry_fee_lowest_denomination in Competitions factory.

### DIFF
--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CompetitionsController do
-  let(:competition) { FactoryBot.create(:competition, :with_delegate, :entry_fee, :registration_open) }
+  let(:competition) { FactoryBot.create(:competition, :with_delegate, :registration_open) }
   let(:future_competition) { FactoryBot.create(:competition, :with_delegate, :ongoing) }
 
   describe 'GET #index' do

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -590,7 +590,7 @@ RSpec.describe RegistrationsController do
 
   describe 'POST #process_payment' do
     context 'when not signed in' do
-      let(:competition) { FactoryBot.create(:competition, :entry_fee, :visible, :registration_open, events: Event.where(id: %w(222 333))) }
+      let(:competition) { FactoryBot.create(:competition, :stripe_connected, :visible, :registration_open, events: Event.where(id: %w(222 333))) }
       sign_out
 
       it 'redirects to the sign in page' do
@@ -600,7 +600,7 @@ RSpec.describe RegistrationsController do
     end
 
     context 'when signed in' do
-      let(:competition) { FactoryBot.create(:competition, :entry_fee, :visible, :registration_open, events: Event.where(id: %w(222 333))) }
+      let(:competition) { FactoryBot.create(:competition, :stripe_connected, :visible, :registration_open, events: Event.where(id: %w(222 333))) }
       let!(:user) { FactoryBot.create(:user, :wca_id) }
       let!(:registration) { FactoryBot.create(:registration, competition: competition, user: user) }
 
@@ -656,7 +656,7 @@ RSpec.describe RegistrationsController do
 
   describe 'POST #refund_payment' do
     context 'when signed in as a competitor' do
-      let(:competition) { FactoryBot.create(:competition, :entry_fee, :visible, :registration_open, events: Event.where(id: %w(222 333))) }
+      let(:competition) { FactoryBot.create(:competition, :stripe_connected, :visible, :registration_open, events: Event.where(id: %w(222 333))) }
       let!(:user) { FactoryBot.create(:user, :wca_id) }
       let!(:registration) { FactoryBot.create(:registration, competition: competition, user: user) }
 
@@ -670,7 +670,7 @@ RSpec.describe RegistrationsController do
 
     context 'when signed in as organizer' do
       let(:organizer) { FactoryBot.create(:user) }
-      let(:competition) { FactoryBot.create(:competition, :entry_fee, :visible, :registration_open, organizers: [organizer], events: Event.where(id: %w(222 333))) }
+      let(:competition) { FactoryBot.create(:competition, :stripe_connected, :visible, :registration_open, organizers: [organizer], events: Event.where(id: %w(222 333))) }
       let!(:registration) { FactoryBot.create(:registration, competition: competition, user: organizer) }
 
       context "processes a payment" do

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     cityName "San Francisco"
     countryId "USA"
     currency_code "USD"
+    base_entry_fee_lowest_denomination 1000
     information "Information!"
     registration_requirements "Requirements"
     latitude { rand(-90_000_000..90_000_000) }
@@ -91,9 +92,7 @@ FactoryBot.define do
       showAtAll true
     end
 
-    trait :entry_fee do
-      base_entry_fee_lowest_denomination 1000
-      currency_code "AUD"
+    trait :stripe_connected do
       # This is an actual test stripe account set up
       # for testing Stripe payments, and is connected
       # to the WCA Stripe account. For more information, see

--- a/WcaOnRails/spec/views/registrations/register.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/register.html.erb_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "registrations/register" do
   end
 
   def setup(payment_status)
-    competition = FactoryBot.create(:competition, :entry_fee, :visible, :registration_open)
+    competition = FactoryBot.create(:competition, :stripe_connected, :visible, :registration_open)
     registration = FactoryBot.create(:registration, payment_status, competition: competition)
     allow(view).to receive(:current_user) { registration.user }
     assign(:competition, competition)


### PR DESCRIPTION
We recently made a change to start enforcing that new competitions are
required to set a `base_entry_fee_lowest_denomination`. This updates our
competitions factory to set this attribute.

We had a `:entry_fee` trait that we would use for two different reasons:

1. The test needs the competition to be connected to Stripe.
2. The test just needs a base entry fee set.

I created a new `:stripe_connected` trait for tests like 1).

I simply removed the `:entry_fee` trait from tests like 2), because we
now always set a base entry fee for competitions.