### PR TITLE
Disable ie8 support for Uglifier.

### DIFF
--- a/WcaOnRails/config/environments/production.rb
+++ b/WcaOnRails/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(ie8: false) # TODO: This is a workaround for https://github.com/thewca/worldcubeassociation.org/issues/3047.
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
This is a workaround for #3047.

Before
======

```
cat /home/jeremy/gitting/worldcubeassociation.org/WcaOnRails/public/assets/application-3b86dfd1fed4fa8518ff2a8218dcf7157e4d7e2dc88af946e40f5a4612a24b2d.js | grep -oE '.{100}"test".{100}'
t&&(r.splice(t,1),a.splice(t,1))}}),f=function f(e){return new Event(e,{bubbles:!0})};try{new Event("test")}catch(h){createEvent=function createEvent(e){var t=document.createEvent("Event");return t.initEven
```

After
=====

```
➜  ~/gitting/worldcubeassociation.org/WcaOnRails git:(issue-3047) ✗ cat /home/jeremy/gitting/worldcubeassociation.org/WcaOnRails/public/assets/application-d0708bacdbf0ccbaa9d953d7e94165039436c68b7afdf0f1ab04abdefd8abfa4.js | grep -oE '.{100}"test".{100}'
1<t&&(r.splice(t,1),a.splice(t,1))}}),f=function(e){return new Event(e,{bubbles:!0})};try{new Event("test")}catch(e){f=function(e){var t=document.createEvent("Event");return t.initEvent(e,!0,!1),t}}var s=nu
```