### PR TITLE
Change delegate search test from creating a delegate to creating a senior delegate.

### DIFF
--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Api::V0::ApiController do
     end
 
     it 'can only find delegates' do
-      delegate = FactoryBot.create(:delegate, name: "Jeremy")
+      delegate = FactoryBot.create(:senior_delegate, name: "Jeremy")
       get :users_search, params: { q: "erem", only_delegates: true }
       expect(response.status).to eq 200
       json = JSON.parse(response.body)


### PR DESCRIPTION
The problem with creating a delegate is that we now always create a
senior delegate for that delegate, and *sometimes* that senior
delegate's name is "Dr. Jeremiah Leannon", which matches the delegate
only search for "erem" we're doing in this test.

This fixes the test failure in
https://travis-ci.org/thewca/worldcubeassociation.org/builds/405002864#L3925-L3941.