### PR TITLE
Slight performance improvements

### DIFF
--- a/WcaOnRails/app/models/team.rb
+++ b/WcaOnRails/app/models/team.rb
@@ -23,40 +23,49 @@ class Team < ApplicationRecord
     end
   end
 
+  # Code duplication from Cachable concern, as we index by friendly_id and not by id :(
+  def self.c_all_by_friendly_id
+    @@teams_by_friendly_id ||= all.index_by(&:friendly_id)
+  end
+
+  def self.c_find_by_friendly_id!(friendly_id)
+    self.c_all_by_friendly_id[friendly_id] || raise("id not found #{friendly_id}")
+  end
+
   def self.board
-    Team.find_by_friendly_id!('board')
+    Team.c_find_by_friendly_id!('board')
   end
 
   def self.wct
-    Team.find_by_friendly_id!('wct')
+    Team.c_find_by_friendly_id!('wct')
   end
 
   def self.wdc
-    Team.find_by_friendly_id!('wdc')
+    Team.c_find_by_friendly_id!('wdc')
   end
 
   def self.wec
-    Team.find_by_friendly_id!('wec')
+    Team.c_find_by_friendly_id!('wec')
   end
 
   def self.wfc
-    Team.find_by_friendly_id!('wfc')
+    Team.c_find_by_friendly_id!('wfc')
   end
 
   def self.wqac
-    Team.find_by_friendly_id!('wqac')
+    Team.c_find_by_friendly_id!('wqac')
   end
 
   def self.wrc
-    Team.find_by_friendly_id!('wrc')
+    Team.c_find_by_friendly_id!('wrc')
   end
 
   def self.wrt
-    Team.find_by_friendly_id!('wrt')
+    Team.c_find_by_friendly_id!('wrt')
   end
 
   def self.wst
-    Team.find_by_friendly_id!('wst')
+    Team.c_find_by_friendly_id!('wst')
   end
 
   def acronym

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -393,15 +393,15 @@ class User < ApplicationRecord
   end
 
   def team_member?(team)
-    self.current_team_members.where(team_id: team.id).count > 0
+    self.current_team_members.select { |t| t.team_id == team.id }.count > 0
   end
 
   def team_leader?(team)
-    self.current_team_members.where(team_id: team.id, team_leader: true).count > 0
+    self.current_team_members.select { |t| t.team_id == team.id && t.team_leader }.count > 0
   end
 
   def teams_where_is_leader
-    self.current_team_members.where(team_leader: true).map(&:team).uniq
+    self.current_team_members.select(&:team_leader).map(&:team).uniq
   end
 
   def admin?


### PR DESCRIPTION
I noticed that the rails console was spammed with team_members SQL select queries for any small page request, so I investigated a bit and it resulted in two changes:

  - cache teams, as we have a few of them and we need to get information about them very *very* often!
  - includes "current_team_members" association for current_user, as it is used very *very* often (everytime we call a 'wrc_member?' or alike), and as it fires a SQL select everytime(!!).

I don't have much precise number as my local server is not the only thing running on my computer, but I saw the average request completed time for the home page drop from ~300ms to ~260ms (not counting the first few requests that load the code obviously).
It also might just be saving the time needed to create the log output, but in any case I don't see any downside to these changes.