### PR TITLE
Turns the rails relation into an array

### DIFF
--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -30,9 +30,11 @@ class UsersController < ApplicationController
         elsif params[:sort]
           @users = @users.order(params[:sort] => params[:order])
         end
+        users_array = @users.to_a
+        selected_rows = users_array[params[:offset].to_i, params[:limit].to_i] || []
         render json: {
-          total: @users.count,
-          rows: @users.limit(params[:limit]).offset(params[:offset]).map do |user|
+          total: users_array.size,
+          rows: selected_rows.map do |user|
             {
               wca_id: user.wca_id ? view_context.link_to(user.wca_id, person_path(user.wca_id)) : "",
               name: ERB::Util.html_escape(user.name),


### PR DESCRIPTION
Related to #956.

This user search query has LIKE statements and is very costly, and we run it twice:
  - to count rows
  - to limit + offset the result

Turning the relation into an array saves the SQL count, as getting the array size in ruby is way faster than the expensive query.

Full request before this change:
```
Processing by UsersController#index as JSON
  Parameters: {"search"=>"philippe", "sort"=>"name", "order"=>"asc", "offset"=>"0", "limit"=>"10", "user"=>{}}
  Team Load (0.2ms)  SELECT  `teams`.* FROM `teams` WHERE `teams`.`hidden` = FALSE AND `teams`.`friendly_id` = 'wst' LIMIT 1
  (0.2ms)  SELECT COUNT(*) FROM `team_members` WHERE `team_members`.`user_id` = 277 AND (end_date IS NULL OR end_date > '2018-07-26') AND `team_members`.`team_id` = 2
  (413.9ms)  SELECT COUNT(*) FROM `users` INNER JOIN Countries ON iso2 = country_iso2 WHERE (users.name LIKE '%philippe%' OR wca_id LIKE '%philippe%' OR email LIKE '%philippe%' OR Countries.name LIKE '%philippe%')
  User Load (1173.7ms)  SELECT  `users`.* FROM `users` INNER JOIN Countries ON iso2 = country_iso2 WHERE (users.name LIKE '%philippe%' OR wca_id LIKE '%philippe%' OR email LIKE '%philippe%' OR Countries.name LIKE '%philippe%') ORDER BY `users`.`name` ASC LIMIT 10 OFFSET 0
Completed 200 OK in 1601ms (Views: 1.2ms | ActiveRecord: 1587.9ms)
```

Full request after this change (*not* on "philippe" as the sql query is cached):
```
Processing by UsersController#index as JSON
  Parameters: {"search"=>"virouleau", "sort"=>"name", "order"=>"asc", "offset"=>"0", "limit"=>"10", "user"=>{}}
  Team Load (0.3ms)  SELECT  `teams`.* FROM `teams` WHERE `teams`.`hidden` = FALSE AND `teams`.`friendly_id` = 'wst' LIMIT 1
   (0.1ms)  SELECT COUNT(*) FROM `team_members` WHERE `team_members`.`user_id` = 277 AND (end_date IS NULL OR end_date > '2018-07-26') AND `team_members`.`team_id` = 2
  User Load (1294.5ms)  SELECT `users`.* FROM `users` INNER JOIN Countries ON iso2 = country_iso2 WHERE (users.name LIKE '%virouleau%' OR wca_id LIKE '%virouleau%' OR email LIKE '%virouleau%' OR Countries.name LIKE '%virouleau%') ORDER BY `users`.`name` ASC
Completed 200 OK in 1300ms (Views: 0.3ms | ActiveRecord: 1294.9ms)
```

Should be roughly a 25% performance improvement.