### PR TITLE
When upgrading doorkeeper from 4.4.0 to 4.4.1, I saw the following post install message:

### DIFF
--- a/WcaOnRails/db/migrate/20180730182509_add_confidential_to_doorkeeper_application.rb
+++ b/WcaOnRails/db/migrate/20180730182509_add_confidential_to_doorkeeper_application.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddConfidentialToDoorkeeperApplication < ActiveRecord::Migration[5.2]
+  def change
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: true # maintaining backwards compatibility: require secrets
+    )
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -865,6 +865,7 @@ CREATE TABLE `oauth_applications` (
   `owner_id` int(11) DEFAULT NULL,
   `owner_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `dangerously_allow_any_redirect_uri` tinyint(1) NOT NULL DEFAULT '0',
+  `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
@@ -1396,4 +1397,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180705231137'),
 ('20180709220826'),
 ('20180710165401'),
-('20180731204733');
+('20180731204733'),
+('20180730182509');


### PR DESCRIPTION
>   WARNING: This is a security release that addresses token revocation not working for public apps (CVE-2018-1000211)
> 
>   There is no breaking change in this release, however to take advantage of the security fix you must:
> 
>     1. Run `rails generate doorkeeper:add_client_confidentiality` for the migration
>     2. Review your OAuth apps and determine which ones exclusively use public grant flows (eg implicit)
>     3. Update their `confidential` column to `false` for those public apps
> 
>   This is a backported security release.
> 
>   For more information:
> 
>     * https://github.com/doorkeeper-gem/doorkeeper/pull/1119
>     * https://github.com/doorkeeper-gem/doorkeeper/issues/891

This adds the mentioned migration, but does not bother to set
confidential to false for public applications. As far as I can tell,
this just means that despite upgrading doorkeeper, it will still not be
possible for public applications to revoke tokens, so we're no worse off
than we were before. I believe that in doorkeeper 5, there will be a UI
that allows application developers to decide if their application is
"confidential" or not. I think it's ok for us to just wait for that day,
and leave this effort on our various 3rd party developers.