### PR TITLE
Correct Polish Speedcubing Association name

### DIFF
--- a/WcaOnRails/app/views/static_pages/organizations.html.erb
+++ b/WcaOnRails/app/views/static_pages/organizations.html.erb
@@ -120,7 +120,7 @@
        },
        {
          country: "Poland",
-         name: "Polish Speedcubing Federation",
+         name: "Polish Speedcubing Association",
          url: "http://www.speedcubing.pl",
          logo: "pss.jpg",
        },


### PR DESCRIPTION
Requested by Grzegorz Łuczyna. This is an obvious fix, so I'm gonna deploy it as soon as Travis passes.