### PR TITLE
Hide events tab based on competition's information

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -448,10 +448,11 @@ class CompetitionsController < ApplicationController
   end
 
   def show
-    @competition = competition_from_params
     associations = {
       # FIXME: this part is triggerred by the competition menu generator when generating the psychsheet event list, should we care?
       competition_events: {
+        # NOTE: we hit this association through competition.has_fees?, which then calls 'has_fee?' on each competition_event, which then use the competition to get the currency.
+        competition: [],
         event: [],
         rounds: [:competition_event, :format],
       },

--- a/WcaOnRails/app/views/competitions/show.html.erb
+++ b/WcaOnRails/app/views/competitions/show.html.erb
@@ -1,9 +1,12 @@
 <% provide(:title, @competition.name) %>
-
+<%# We use this to hide the 'Events' information for competition which didn't declared rounds %>
+<% competition_has_round = @competition.rounds.any? %>
 <%= render layout: 'nav' do %>
   <ul class="nav nav-tabs">
     <li><a href="#general-info" data-toggle="tab"><%=t 'competitions.show.general_info' %></a></li>
-    <li><a href="#competition-events" data-toggle="tab"><%=t 'competitions.show.events' %></a></li>
+    <% if competition_has_round %>
+      <li><a href="#competition-events" data-toggle="tab"><%=t 'competitions.show.events' %></a></li>
+    <% end %>
     <% @competition.tabs.each do |tab| %>
       <li><a href="#<%= tab.slug %>" data-toggle="tab"><%= tab.name %></a></li>
     <% end %>
@@ -15,9 +18,11 @@
         <%= render "results_table", results: @competition.winning_results, hide_pos: true, hide_round: true %>
       <% end %>
     </div>
-    <div class="tab-pane" id="competition-events">
-      <%= render "events_tab" %>
-    </div>
+    <% if competition_has_round %>
+      <div class="tab-pane" id="competition-events">
+        <%= render "events_tab" %>
+      </div>
+    <% end %>
     <% @competition.tabs.each do |tab| %>
       <div class="tab-pane" id="<%= tab.slug %>">
         <%=md tab.content %>


### PR DESCRIPTION
For past competitions having an empty (or duplicate) tab looks quite weird, a simple workaround is to display the events tab only if we have any round information.
