### PR TITLE
Wording updates for the events tab

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -454,7 +454,12 @@ class CompetitionsController < ApplicationController
         # NOTE: we hit this association through competition.has_fees?, which then calls 'has_fee?' on each competition_event, which then use the competition to get the currency.
         competition: [],
         event: [],
-        rounds: [:competition_event, :format],
+        # NOTE: we eventually hit the rounds->competition->competition_event in the TimeLimit 'to_s' method when having cumulative limit across rounds
+        rounds: {
+          competition: { rounds: [:competition_event] },
+          competition_event: [],
+          format: [],
+        },
       },
     }
     @competition = competition_from_params(includes: associations)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -697,8 +697,7 @@ class Competition < ApplicationRecord
   end
 
   def uses_cutoff?
-    cutoff = competition_events.find { |ce| ce.rounds.find { |r| r.cutoff } }
-    !cutoff.nil?
+    competition_events.any? { |ce| ce.rounds.any?(&:cutoff) }
   end
 
   # The name `is_probably_over` is meant to be surprising.

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -3,7 +3,7 @@
 class Competition < ApplicationRecord
   self.table_name = "Competitions"
 
-  has_many :competition_events, -> { order(:event_id) }, dependent: :destroy
+  has_many :competition_events, dependent: :destroy
   has_many :events, through: :competition_events
   has_many :rounds, through: :competition_events
   has_many :registrations, dependent: :destroy

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -696,6 +696,11 @@ class Competition < ApplicationRecord
     !results_posted? && (start_date..end_date).cover?(Date.today)
   end
 
+  def uses_cutoff?
+    cutoff = competition_events.find { |ce| ce.rounds.find { |r| r.cutoff } }
+    !cutoff.nil?
+  end
+
   # The name `is_probably_over` is meant to be surprising.
   # We don't actually know when competitions are over, because we don't know their schedules, nor
   # do we know their timezones.

--- a/WcaOnRails/app/models/format.rb
+++ b/WcaOnRails/app/models/format.rb
@@ -13,6 +13,10 @@ class Format < ApplicationRecord
     I18n.t("formats.#{id}", default: self[:name])
   end
 
+  def short_name
+    I18n.t("formats.short.#{id}", default: self[:name])
+  end
+
   def allowed_first_phase_formats
     {
       "1" => [],

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -56,22 +56,21 @@ class Round < ApplicationRecord
     end
   end
 
-  def full_format_name(with_short_names = false, with_tooltips = false)
+  def full_format_name(with_short_names: false, with_tooltips: false)
     # 'with_tooltips' implies that short names are used for display, and long
     # names are used in the tooltip.
     cutoff_format = Format.c_find!(cutoff.number_of_attempts.to_s) if cutoff
-    phase_formats = [cutoff_format, format]
+    phase_formats = [cutoff_format, format].compact
     phase_formats.map! do |f|
       if with_tooltips
-        content_tag(:span, f&.short_name, data: { toggle: "tooltip" }, title: f&.name)
+        content_tag(:span, f.short_name, data: { toggle: "tooltip" }, title: f.name)
       elsif with_short_names
-        f&.short_name
+        f.short_name
       else
-        f&.name
+        f.name
       end
     end
-    # Using '+' instead of string interpolation here to avoid losing the content_tag
-    cutoff_format ? phase_formats[0] + " / " + phase_formats[1] : phase_formats[1]
+    safe_join(phase_formats, " / ")
   end
 
   def round_type

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -56,6 +56,24 @@ class Round < ApplicationRecord
     end
   end
 
+  def full_format_name(with_short_names = false, with_tooltips = false)
+    # 'with_tooltips' implies that short names are used for display, and long
+    # names are used in the tooltip.
+    cutoff_format = Format.c_find!(cutoff.number_of_attempts.to_s) if cutoff
+    phase_formats = [cutoff_format, format]
+    phase_formats.map! do |f|
+      if with_tooltips
+        content_tag(:span, f&.short_name, data: { toggle: "tooltip" }, title: f&.name)
+      elsif with_short_names
+        f&.short_name
+      else
+        f&.name
+      end
+    end
+    # Using '+' instead of string interpolation here to avoid losing the content_tag
+    cutoff_format ? phase_formats[0] + " / " + phase_formats[1] : phase_formats[1]
+  end
+
   def round_type
     RoundType.c_find(round_type_id)
   end

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -24,10 +24,9 @@
             <%= competition_event.event.name if round.number == 1 %>
           </td>
           <td><%= round.round_type.name %></td>
-          <% round_cutoff = round.cutoff %>
           <td>
-            <% if round_cutoff %>
-              <% cutoff_format = Format.c_find!(round_cutoff.number_of_attempts.to_s) %>
+            <% if round.cutoff %>
+              <% cutoff_format = Format.c_find!(round.cutoff.number_of_attempts.to_s) %>
               <span data-toggle="tooltip" title="<%= cutoff_format.name %>"><%= cutoff_format.short_name %></span> /
             <% end %>
             <span data-toggle="tooltip" title="<%= round.format.name %>"><%= round.format.short_name %></span>

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <th><%= t("competitions.results_table.event") %></th>
       <th><%= t("competitions.results_table.round") %></th>
-      <th><%= t("competitions.events.format") %></th>
+      <th><%= link_to t("competitions.events.format"), "#format" %></th>
       <th><%= link_to t("competitions.events.time_limit"), "#time-limit" %></th>
       <th><%= link_to t("competitions.events.cutoff"), "#cutoff" %></th>
       <th><%= t("competitions.events.proceed") %></th>

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -25,7 +25,7 @@
           </td>
           <td><%= round.round_type.name %></td>
           <td>
-            <%= round.full_format_name(true, true) %>
+            <%= round.full_format_name(with_short_names: true, with_tooltips: true) %>
           </td>
           <td>
             <%= round.time_limit_to_s %>

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -25,11 +25,7 @@
           </td>
           <td><%= round.round_type.name %></td>
           <td>
-            <% if round.cutoff %>
-              <% cutoff_format = Format.c_find!(round.cutoff.number_of_attempts.to_s) %>
-              <span data-toggle="tooltip" title="<%= cutoff_format.name %>"><%= cutoff_format.short_name %></span> /
-            <% end %>
-            <span data-toggle="tooltip" title="<%= round.format.name %>"><%= round.format.short_name %></span>
+            <%= round.full_format_name(true, true) %>
           </td>
           <td>
             <%= round.time_limit_to_s %>

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -11,7 +11,7 @@
   <thead>
 
   <tbody>
-    <% @competition.competition_events.each do |competition_event| %>
+    <% @competition.competition_events.sort_by { |ce| ce.event.rank }.each do |competition_event| %>
       <% competition_event.rounds.each do |round| %>
         <tr class="<%= round.final_round? ? "last-round" : "" %>">
           <td>

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -1,3 +1,7 @@
+<%
+  has_cumulative_one_round = false
+  has_cumulative_across_rounds = false
+%>
 <%= wca_table table_class: "show-events-table" do %>
   <thead>
     <tr>
@@ -5,7 +9,9 @@
       <th><%= t("competitions.results_table.round") %></th>
       <th><%= link_to t("competitions.events.format"), "#format" %></th>
       <th><%= link_to t("competitions.events.time_limit"), "#time-limit" %></th>
-      <th><%= link_to t("competitions.events.cutoff"), "#cutoff" %></th>
+      <% if @competition.uses_cutoff? %>
+        <th><%= link_to t("competitions.events.cutoff"), "#cutoff" %></th>
+      <% end %>
       <th><%= t("competitions.events.proceed") %></th>
     </tr>
   <thead>
@@ -30,17 +36,21 @@
             <%= round.time_limit_to_s %>
             <% if competition_event.event.can_change_time_limit? %>
               <% if round.time_limit.cumulative_round_ids.length == 1 %>
+                <% has_cumulative_one_round = true %>
                 <%= link_to "*", "#cumulative-time-limit" %>
               <% elsif round.time_limit.cumulative_round_ids.length > 1 %>
+                <% has_cumulative_across_rounds = true %>
                 <%= link_to "**", "#cumulative-across-rounds-time-limit" %>
               <% end %>
             <% end %>
           </td>
-          <td><%= round.cutoff_to_s %></td>
+          <% if @competition.uses_cutoff? %>
+            <td><%= round.cutoff_to_s %></td>
+          <% end %>
           <td><%= round.advancement_condition_to_s %></td>
         </tr>
       <% end %>
     <% end %>
   </tbody>
 <% end %>
-<%= render "time_limit_div" %>
+<%= render "time_limit_div", show_cumulative_one_round: has_cumulative_one_round, show_cumulative_across_rounds: has_cumulative_across_rounds, show_cutoff: @competition.uses_cutoff? %>

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -18,7 +18,14 @@
             <%= competition_event.event.name if round.number == 1 %>
           </td>
           <td><%= round.round_type.name %></td>
-          <td><%= round.format.name %></td>
+          <% round_cutoff = round.cutoff %>
+          <td>
+            <% if round_cutoff %>
+              <% cutoff_format = Format.c_find!(round_cutoff.number_of_attempts.to_s) %>
+              <span data-toggle="tooltip" title="<%= cutoff_format.name %>"><%= cutoff_format.short_name %></span> /
+            <% end %>
+            <span data-toggle="tooltip" title="<%= round.format.name %>"><%= round.format.short_name %></span>
+          </td>
           <td>
             <%= round.time_limit_to_s %>
             <% if competition_event.event.can_change_time_limit? %>

--- a/WcaOnRails/app/views/competitions/_time_limit_div.html.erb
+++ b/WcaOnRails/app/views/competitions/_time_limit_div.html.erb
@@ -1,25 +1,36 @@
+<%
+  show_cumulative_one_round ||= false
+  show_cumulative_across_rounds ||= false
+  show_cutoff ||= false
+%>
 <div class="time-limit-information">
   <h4 id="time-limit"><%= t("competitions.events.time_limit") %></h4>
   <p>
     <%= t("competitions.events.time_limit_information.time_limit_html",
           regulation_link: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "A1a4"), regulations_path + "#A1a4", target: "_blank")) %>
-    <br/>
-    <% cumulative_one_round = content_tag :strong, t("competitions.events.time_limit_information.cumulative_time_limit"), id: "cumulative-time-limit" %>
-    <%= t("competitions.events.time_limit_information.cumulative_one_round_html",
-          cumulative_time_limit: cumulative_one_round,
-          regulation_link: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "A1a2"), regulations_path + "#A1a2", target: "_blank")) %>
-    <br/>
-    <% cumulative_across_rounds = content_tag :strong, t("competitions.events.time_limit_information.cumulative_time_limit"), id: "cumulative-across-rounds-time-limit" %>
-    <%= t("competitions.events.time_limit_information.cumulative_across_rounds_html",
-          cumulative_time_limit: cumulative_across_rounds,
-          guideline_link: link_to(t("competitions.events.time_limit_information.guideline_link_text", number: "A1a2++"), regulations_path + "/guidelines.html#A1a2++", target: "_blank")) %>
+    <% if show_cumulative_one_round %>
+      <br/>
+      <% cumulative_one_round = content_tag :strong, t("competitions.events.time_limit_information.cumulative_time_limit"), id: "cumulative-time-limit" %>
+      <%= t("competitions.events.time_limit_information.cumulative_one_round_html",
+            cumulative_time_limit: cumulative_one_round,
+            regulation_link: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "A1a2"), regulations_path + "#A1a2", target: "_blank")) %>
+    <% end %>
+    <% if show_cumulative_across_rounds %>
+      <br/>
+      <% cumulative_across_rounds = content_tag :strong, t("competitions.events.time_limit_information.cumulative_time_limit"), id: "cumulative-across-rounds-time-limit" %>
+      <%= t("competitions.events.time_limit_information.cumulative_across_rounds_html",
+            cumulative_time_limit: cumulative_across_rounds,
+            guideline_link: link_to(t("competitions.events.time_limit_information.guideline_link_text", number: "A1a2++"), regulations_path + "/guidelines.html#A1a2++", target: "_blank")) %>
+    <% end %>
   </p>
 
-  <h4 id="cutoff"><%= t("competitions.events.cutoff") %></h4>
-  <p>
-    <%= t("competitions.events.time_limit_information.cutoff_html",
-          regulation_link: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9g"), regulations_path + "#9g", target: "_blank")) %>
-  </p>
+  <% if show_cutoff %>
+    <h4 id="cutoff"><%= t("competitions.events.cutoff") %></h4>
+    <p>
+      <%= t("competitions.events.time_limit_information.cutoff_html",
+            regulation_link: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9g"), regulations_path + "#9g", target: "_blank")) %>
+    </p>
+  <% end %>
   <h4 id="format"><%= t("competitions.events.format") %></h4>
   <p>
     <%= t("competitions.events.time_limit_information.format_html",

--- a/WcaOnRails/app/views/competitions/_time_limit_div.html.erb
+++ b/WcaOnRails/app/views/competitions/_time_limit_div.html.erb
@@ -20,4 +20,10 @@
     <%= t("competitions.events.time_limit_information.cutoff_html",
           regulation_link: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9g"), regulations_path + "#9g", target: "_blank")) %>
   </p>
+  <h4 id="format"><%= t("competitions.events.format") %></h4>
+  <p>
+    <%= t("competitions.events.time_limit_information.format_html",
+          link_to_9b: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9b"), regulations_path + "#9b", target: "_blank"),
+          link_to_9f: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9f"), regulations_path + "#9f", target: "_blank")) %>
+  </p>
 </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -68,6 +68,13 @@ en:
     "3": "Best of 3"
     "a": "Average of 5"
     "m": "Mean of 3"
+    #context: short name alternative
+    short:
+      "1": "Bo1"
+      "2": "Bo2"
+      "3": "Bo3"
+      "a": "Ao5"
+      "m": "Mo3"
   #context: Round name
   rounds:
     "0":
@@ -131,7 +138,7 @@ en:
       one_round: "%{time} cumulative"
       across_rounds: "%{time} total for %{rounds}"
     333fm: "1 hour"
-    333mbf: "10 minutes per cube"
+    333mbf: "10 minutes per cube, up to 60 minutes"
   #context: Common word used in multiple places on the website
   common:
     continent: "Continent"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1106,7 +1106,7 @@ en:
       events: "Events"
     #context: on the events page
     events:
-      #context: explanation of what time limit and cutoff are
+      #context: explanation of what time limit, cutoff, and format are
       time_limit_information:
         time_limit_html: "If you reach the time limit during your solve, the judge will stop you and your result will be DNF (see %{regulation_link})."
         #context: as used in "please see Regulation A1a4"
@@ -1118,6 +1118,7 @@ en:
         cumulative_one_round_html: "A %{cumulative_time_limit} may be enforced (see %{regulation_link})."
         cumulative_across_rounds_html: "A %{cumulative_time_limit} may be enforced across rounds (see %{guideline_link})."
         cutoff_html: "The result to beat to proceed to the second phase of a combined round (see %{regulation_link})."
+        format_html: "The format describes how to determine the ranking of competitors based on their results. The list of allowed formats per event is described in %{link_to_9b}. See %{link_to_9f} for a description of each format."
       format: "Format"
       time_limit: "Time limit"
       cutoff: "Cutoff"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -138,7 +138,7 @@ en:
       one_round: "%{time} cumulative"
       across_rounds: "%{time} total for %{rounds}"
     333fm: "1 hour"
-    333mbf: "10 minutes per cube, up to 60 minutes"
+    333mbf: "10:00.00 per cube, up to 60:00.00"
   #context: Common word used in multiple places on the website
   common:
     continent: "Continent"

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -180,8 +180,7 @@ fr:
       across_rounds: '%{time} au total pour les tours suivant : %{rounds}'
     #original_hash: f030c3d
     333fm: 1 heure
-    #original_hash: 2c2abd5
-    333mbf: 10 minutes par cube, au plus 60 minutes
+    333mbf: 10:00.00 par cube, au plus 60:00.00
   common:
     #original_hash: 2513cf0
     continent: Continent

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -181,7 +181,7 @@ fr:
     #original_hash: f030c3d
     333fm: 1 heure
     #original_hash: 2c2abd5
-    333mbf: 10 minutes par cube
+    333mbf: 10 minutes par cube, au plus 60 minutes
   common:
     #original_hash: 2513cf0
     continent: Continent

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -2088,6 +2088,7 @@ fr:
         cutoff_html: >-
           Le score à atteindre pour passer à la deuxième phase d'un tour combiné
           (voir la %{regulation_link}).
+        format_html: "Le format décrit la manière de déterminer le classement des compétiteurs. La liste des formats autorisés par épreuve est donnée dans la %{link_to_9b}. La description de chaque format est disponible dans la %{link_to_9f}."
       #original_hash: 041a5de
       format: Format
       #original_hash: 0d1fcc3


### PR DESCRIPTION
I've updated the mbf time limit to include the maximum allowed time, and the events format to include the format for all phases when displaying a combined round.

The format column can be a little long with combined round: I introduced a "short name" alternative for formats (with a tooltip containing the format's full name), which could be used to save some space.
Not sure how good an idea this is, so I'm gonna try to have feedback before going forward with this.