### PR TITLE
Removing keys for which variables have changed

### DIFF
--- a/WcaOnRails/config/locales/cs.yml
+++ b/WcaOnRails/config/locales/cs.yml
@@ -128,9 +128,6 @@ cs:
       name: Kombinovaná kvalifikace
       #original_hash: 4c66ad0
       cellName: Kombinovaná kvalifikace
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Kolo %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/da.yml
+++ b/WcaOnRails/config/locales/da.yml
@@ -128,9 +128,6 @@ da:
       name: Kombineret kvalifikation
       #original_hash: 4c66ad0
       cellName: Kombineret kvalifikation
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Runde %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/de.yml
+++ b/WcaOnRails/config/locales/de.yml
@@ -128,9 +128,6 @@ de:
       name: Combined Qualifikation
       #original_hash: 4c66ad0
       cellName: Combined Qualifikation
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Runde %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/fi.yml
+++ b/WcaOnRails/config/locales/fi.yml
@@ -128,9 +128,6 @@ fi:
       name: Yhdistetty karsintakierros
       #original_hash: 4c66ad0
       cellName: Yhdistetty karsintakierros
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Kierros %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/hr.yml
+++ b/WcaOnRails/config/locales/hr.yml
@@ -128,9 +128,6 @@ hr:
       name: Kombinirane kvalifikacije
       #original_hash: 4c66ad0
       cellName: Kombinirane kvalifikacije
-  round:
-    #original_hash: 66e902f
-    name: 'Original:  %{event} Runda %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/hu.yml
+++ b/WcaOnRails/config/locales/hu.yml
@@ -128,9 +128,6 @@ hu:
       name: Kombinált kvalifikáció
       #original_hash: 4c66ad0
       cellName: Kombinált kvalifikáció
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Forduló %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/it.yml
+++ b/WcaOnRails/config/locales/it.yml
@@ -128,9 +128,6 @@ it:
       name: Qualificazione combinata
       #original_hash: 4c66ad0
       cellName: Qualificazione combinata
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Round %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/ja.yml
+++ b/WcaOnRails/config/locales/ja.yml
@@ -128,9 +128,6 @@ ja:
       name: 複合予選
       #original_hash: 4c66ad0
       cellName: 複合予選
-  round:
-    #original_hash: 66e902f
-    name: '%{event} %{number} 回戦'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/ko.yml
+++ b/WcaOnRails/config/locales/ko.yml
@@ -128,9 +128,6 @@ ko:
       name: 혼합 예선
       #original_hash: 4c66ad0
       cellName: 혼합 예선
-  round:
-    #original_hash: 66e902f
-    name: '%{event} 라운드 %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/nl.yml
+++ b/WcaOnRails/config/locales/nl.yml
@@ -128,9 +128,6 @@ nl:
       name: Gecombineerde kwalificatie
       #original_hash: 4c66ad0
       cellName: Gecombineerde kwalificatie
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Ronde %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/ro.yml
+++ b/WcaOnRails/config/locales/ro.yml
@@ -128,9 +128,6 @@ ro:
       name: Calificare combinată
       #original_hash: 4c66ad0
       cellName: Calificare combinată
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Runda %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/sk.yml
+++ b/WcaOnRails/config/locales/sk.yml
@@ -128,9 +128,6 @@ sk:
       name: Kombinovaná kvalifikácia
       #original_hash: 4c66ad0
       cellName: Kombinovaná kvalifikácia
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Kolo %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/sl.yml
+++ b/WcaOnRails/config/locales/sl.yml
@@ -128,9 +128,6 @@ sl:
       name: Kombinirane kvalifikacije
       #original_hash: 4c66ad0
       cellName: Kombinirane kvalifikacije
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Runda %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/vi.yml
+++ b/WcaOnRails/config/locales/vi.yml
@@ -128,9 +128,6 @@ vi:
       name: Vòng loại gộp
       #original_hash: 4c66ad0
       cellName: Vòng loại gộp
-  round:
-    #original_hash: 66e902f
-    name: '%{event} Vòng %{number}'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/zh-CN.yml
+++ b/WcaOnRails/config/locales/zh-CN.yml
@@ -128,9 +128,6 @@ zh-CN:
       name: 组合制资格赛
       #original_hash: 4c66ad0
       cellName: 组合制资格赛
-  round:
-    #original_hash: 66e902f
-    name: '%{event}第%{number}轮'
   cutoff:
     #original_hash: cf458e7
     time:

--- a/WcaOnRails/config/locales/zh-TW.yml
+++ b/WcaOnRails/config/locales/zh-TW.yml
@@ -128,9 +128,6 @@ zh-TW:
       name: 門檻制資格賽
       #original_hash: 4c66ad0
       cellName: 門檻制資格賽
-  round:
-    #original_hash: 66e902f
-    name: '%{event}第%{number}輪'
   cutoff:
     #original_hash: cf458e7
     time:


### PR DESCRIPTION
The key for round name uses new variables, and we need to remove outdated keys to avoid the big "MISSING INTERPOLATION ..." message.

Merging this when tests pass, as it's currently pretty ugly for outdated translations (see [here](https://www.worldcubeassociation.org/competitions/GermanNationals2018#competition-events) in German for example).
Thanks @LinusFresz.