### PR TITLE
Restore default order for competition_event

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -3,7 +3,7 @@
 class Competition < ApplicationRecord
   self.table_name = "Competitions"
 
-  has_many :competition_events, dependent: :destroy
+  has_many :competition_events, -> { order(:event_id) }, dependent: :destroy
   has_many :events, through: :competition_events
   has_many :rounds, through: :competition_events
   has_many :registrations, dependent: :destroy


### PR DESCRIPTION
I removed it in #3161 because it didn't seem used besides for showing the events information, but it turns out the spec breaks in some specific cases.

The default order for `competition_event` is by `updated_at`, which means that some specs may fail depending on the order in which they are executed.
If executed first, the `to_wcif` test fails because the factory use the default implicit "rank"-sort on Event to create the competition_event, and it tries to match it to the manually written WCIF which has "444" out of place (with regard to the event rank order).

If not executed first, some other test "touches" the 444 `competition_event`, making it exported last in the WCIF, thus matching what we expect.

This fails:
```
bin/rspec ./spec/models/competition_wcif_spec.rb --seed 2038 --order rand:3
Running via Spring preloader in process 28510
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.

Randomized with seed 3

Competition WCIF
  #to_wcif
    renders a valid WCIF (FAILED - 1)
  #set_wcif_events!
    can set scrambleSetCount
    creates competition event when adding round to previously nonexistent event
    creates new round when adding round to existing event
    does not remove competition event when wcif rounds are empty
    removes competition event when wcif event is missing
    can change round format to '3'
[...]
```

This doesn't:
```
[12:43] daisy:~/Documents/cube/wca/worldcubeassociation.org/WcaOnRails (fix-event-order-spec|…)$ bin/rspec ./spec/models/competition_wcif_spec.rb --seed 2038 --order rand:2
Running via Spring preloader in process 28286
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.

Randomized with seed 2

Competition WCIF
  #set_wcif_events!
    can set roundResults
    does not remove competition event when wcif rounds are empty
    can set scrambleSetCount
    ignores setting time limit for 333mbf and 333fm
    does remove competition event when wcif rounds are nil
    creates new round when adding round to existing event
    creates competition event when adding round to previously nonexistent event
    can change round format to '3'
    removes competition event when wcif event is missing
  #set_wcif_schedule!
    activities
[...]
  #to_wcif
    renders a valid WCIF
```

Enforcing a consistent order on `competition_events` seems appropriate, but I already tried to add a default scope joining the Events table and ordering on "Events.rank", but I ran into issues with the rounds has_many through association as it didn't seem to join the Events table.

I'm fine with restoring the previous default ordering, as we sort them by event rank where it needs to be anyway.
