### PR TITLE
Restrict championship type to real countries

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -106,7 +106,7 @@ module CompetitionsHelper
   def championship_option_tags(selected: nil)
     grouped_championship_types = {
       "Planetary Championship" => [["World", "world"]],
-      "Continental Championship" => Continent::ALL_SORTED_BY_LOCALE[I18n.locale].map { |continent| [continent.name, continent.id] },
+      "Continental Championship" => Continent.all_sorted_by(I18n.locale, real: true).map { |continent| [continent.name, continent.id] },
       "Multi-country Championship" => EligibleCountryIso2ForChampionship.championship_types.map { |championship_type| [championship_type.titleize, championship_type] },
       "National Championship" => Country.all_sorted_by(I18n.locale, real: true).map { |country| [country.name, country.iso2] },
     }

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -108,7 +108,7 @@ module CompetitionsHelper
       "Planetary Championship" => [["World", "world"]],
       "Continental Championship" => Continent::ALL_SORTED_BY_LOCALE[I18n.locale].map { |continent| [continent.name, continent.id] },
       "Multi-country Championship" => EligibleCountryIso2ForChampionship.championship_types.map { |championship_type| [championship_type.titleize, championship_type] },
-      "National Championship" => Country.all_sorted_by(I18n.locale).map { |country| [country.name, country.iso2] },
+      "National Championship" => Country.all_sorted_by(I18n.locale, real: true).map { |country| [country.name, country.iso2] },
     }
     grouped_options_for_select(grouped_championship_types, selected)
   end

--- a/WcaOnRails/app/models/championship.rb
+++ b/WcaOnRails/app/models/championship.rb
@@ -3,7 +3,7 @@
 class Championship < ApplicationRecord
   CHAMPIONSHIP_TYPES = [
     "world",
-    *Continent.c_all_by_id.keys,
+    *Continent.real.map(&:id),
     *Country.real.map(&:iso2),
     *EligibleCountryIso2ForChampionship.championship_types,
   ].freeze

--- a/WcaOnRails/app/models/championship.rb
+++ b/WcaOnRails/app/models/championship.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 class Championship < ApplicationRecord
+  CHAMPIONSHIP_TYPES = [
+    "world",
+    *Continent.c_all_by_id.keys,
+    *Country.real.map(&:iso2),
+    *EligibleCountryIso2ForChampionship.championship_types,
+  ].freeze
+
   belongs_to :competition
   has_many :eligible_country_iso2s_for_championship, class_name: "EligibleCountryIso2ForChampionship", foreign_key: :championship_type, primary_key: :championship_type
   validates_presence_of :competition
   validates :championship_type, uniqueness: { scope: :competition_id },
-                                inclusion: { in: ["world", *Continent.all.map(&:id), *Country.all.map(&:iso2), *EligibleCountryIso2ForChampionship.championship_types] }
+                                inclusion: { in: CHAMPIONSHIP_TYPES }
 
   def name
     return "World Championship" if championship_type == "world"

--- a/WcaOnRails/app/models/concerns/localized_sortable.rb
+++ b/WcaOnRails/app/models/concerns/localized_sortable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Appends a bunch of methods to *Cachable* classes to expose
+# a collection of sorted objects based on the user's locale.
+require 'active_support/concern'
+
+module LocalizedSortable
+  extend ActiveSupport::Concern
+
+  def name
+    I18n.t(read_attribute(self.class::NAME_LOOKUP_ATTRIBUTE), scope: self.class.name.underscore.pluralize)
+  end
+
+  def name_in(locale)
+    I18n.t(read_attribute(self.class::NAME_LOOKUP_ATTRIBUTE), scope: self.class.name.underscore.pluralize, locale: locale)
+  end
+
+  def real?
+    !self.class::FICTIVE_IDS.include?(id)
+  end
+
+  included do
+    scope :uncached_real, -> { where.not(id: fictive_ids) }
+
+    self::ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
+      objects = I18nUtils.localized_sort_by!(locale, self.c_all_by_id.values) { |object| object.name_in(locale) }
+      [locale, objects]
+    end].freeze
+  end
+
+  class_methods do
+    def fictive_ids
+      self::FICTIVE_IDS
+    end
+
+    def real
+      @real_objects ||= self.uncached_real
+    end
+
+    def all_sorted_by(locale, real: false)
+      real ? self::ALL_SORTED_BY_LOCALE[locale].select(&:real?) : self::ALL_SORTED_BY_LOCALE[locale]
+    end
+  end
+end

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -1,25 +1,16 @@
 # frozen_string_literal: true
 
 class Continent < ApplicationRecord
-  include Cachable
   self.table_name = "Continents"
+  NAME_LOOKUP_ATTRIBUTE = :name
+  FICTIVE_IDS = ["_Multiple Continents"].freeze
+
+  include Cachable
+  include LocalizedSortable
 
   has_many :countries, foreign_key: :continentId
 
   def self.country_ids(continent_id)
     c_all_by_id[continent_id]&.countries&.map(&:id)
   end
-
-  def name
-    I18n.t(read_attribute(:name), scope: :continents)
-  end
-
-  def name_in(locale)
-    I18n.t(read_attribute(:name), scope: :continents, locale: locale)
-  end
-
-  ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    continents = I18nUtils.localized_sort_by!(locale, Continent.c_all_by_id.values) { |continent| continent.name_in(locale) }
-    [locale, continents]
-  end].freeze
 end

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -19,7 +19,7 @@ class Continent < ApplicationRecord
   end
 
   ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    continents = I18nUtils.localized_sort_by!(locale, Continent.all.to_a) { |continent| continent.name_in(locale) }
+    continents = I18nUtils.localized_sort_by!(locale, Continent.c_all_by_id.values) { |continent| continent.name_in(locale) }
     [locale, continents]
   end].freeze
 end

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -30,7 +30,9 @@ class Country < ApplicationRecord
     { id: 'XM', name: 'Multiple Countries (Americas)', continentId: '_Multiple Continents', iso2: 'XM' },
   ].freeze
 
-  MULTIPLE_COUNTRIES_IDS = MULTIPLE_COUNTRIES.map { |c| c[:id] }.freeze
+  FICTIVE_IDS = MULTIPLE_COUNTRIES.map { |c| c[:id] }.freeze
+  NAME_LOOKUP_ATTRIBUTE = :iso2
+  include LocalizedSortable
 
   WCA_STATES = JSON.parse(File.read(WCA_STATES_JSON_PATH)).freeze
 
@@ -48,34 +50,7 @@ class Country < ApplicationRecord
   belongs_to :continent, foreign_key: :continentId
   has_many :competitions, foreign_key: :countryId
 
-  scope :uncached_real, -> { where.not(id: MULTIPLE_COUNTRIES_IDS) }
-
-  def name
-    I18n.t(iso2, scope: :countries)
-  end
-
-  def name_in(locale)
-    I18n.t(iso2, scope: :countries, locale: locale)
-  end
-
-  def self.real
-    @real_countries ||= Country.uncached_real
-  end
-
-  def real?
-    !MULTIPLE_COUNTRIES_IDS.include?(id)
-  end
-
   def self.find_by_iso2(iso2)
     c_all_by_id.values.select { |c| c.iso2 == iso2 }.first
-  end
-
-  ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-    countries = I18nUtils.localized_sort_by!(locale, ALL_STATES.dup) { |country| country.name_in(locale) }
-    [locale, countries]
-  end].freeze
-
-  def self.all_sorted_by(locale, real: false)
-    real ? ALL_SORTED_BY_LOCALE[locale].select(&:real?) : ALL_SORTED_BY_LOCALE[locale]
   end
 end

--- a/WcaOnRails/spec/models/championship_spec.rb
+++ b/WcaOnRails/spec/models/championship_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Championship do
       championship = competition.championships.build championship_type: "XE"
       expect(championship).to be_invalid_with_errors(championship_type: ["is not included in the list"])
     end
+
+    it "cannot create a championship for a fictive continent" do
+      championship = competition.championships.build championship_type: "_Multiple Continents"
+      expect(championship).to be_invalid_with_errors(championship_type: ["is not included in the list"])
+    end
   end
 
   describe "name" do

--- a/WcaOnRails/spec/models/championship_spec.rb
+++ b/WcaOnRails/spec/models/championship_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Championship do
       championship = competition.championships.build championship_type: "mars"
       expect(championship).to be_invalid_with_errors(championship_type: ["is not included in the list"])
     end
+
+    it "cannot create a championship for a fictive country" do
+      championship = competition.championships.build championship_type: "XE"
+      expect(championship).to be_invalid_with_errors(championship_type: ["is not included in the list"])
+    end
   end
 
   describe "name" do


### PR DESCRIPTION
I noticed this when investigating a big set of `select * from Continents;` sql queries.

The big set of queries is due to our way of building the `Continent::ALL_SORTED_BY_LOCALE` variable, so it happens only once per server restart, but there is still an easy fix that I included.

But the main issue here is that I believe we don't want to be able to select our "Multiple Countries (Europe)" and such when declaring a championship type.

But I'd definitely like feedback from the Board before merging this!
(@AlbertoPdRF, @cubizh, what do you think ?)

