### PR TITLE
Revert "Disable ie8 support for Uglifier."

### DIFF
--- a/WcaOnRails/config/environments/production.rb
+++ b/WcaOnRails/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(ie8: false) # TODO: This is a workaround for https://github.com/thewca/worldcubeassociation.org/issues/3047.
+  config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
This reverts commit 9720cae8dbddd0e3e94a5c3eae51060acbd2dc42.

This is safe to do because we upgraded uglifier in
71204b654d9f57795a23211034692d4387e1af22 to 4.1.17, which brings along
uglifyjs 3.4.6, which includes a fix for
https://github.com/mishoo/UglifyJS2/issues/3215.

This fixes #3047.