### PR TITLE
Use full English championship name

### DIFF
--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -7,14 +7,16 @@ class CompetitionsMailer < ApplicationMailer
   helper :markdown
 
   def notify_board_of_confirmed_competition(confirmer, competition)
-    @competition = competition
-    @confirmer = confirmer
-    mail(
-      to: "board@worldcubeassociation.org",
-      cc: competition.delegates.flat_map { |d| [d.email, d.senior_delegate&.email] }.compact.uniq + [Team.wqac.email],
-      reply_to: confirmer.email,
-      subject: "#{confirmer.name} just confirmed #{competition.name}",
-    )
+    I18n.with_locale :en do
+      @competition = competition
+      @confirmer = confirmer
+      mail(
+        to: "board@worldcubeassociation.org",
+        cc: competition.delegates.flat_map { |d| [d.email, d.senior_delegate&.email] }.compact.uniq + [Team.wqac.email],
+        reply_to: confirmer.email,
+        subject: "#{confirmer.name} just confirmed #{competition.name}",
+      )
+    end
   end
 
   def notify_organizers_of_confirmed_competition(confirmer, competition)

--- a/WcaOnRails/app/models/championship.rb
+++ b/WcaOnRails/app/models/championship.rb
@@ -24,5 +24,7 @@ class Championship < ApplicationRecord
 
     country = Country.find_by_iso2(championship_type)
     return "National Championship for #{country.name}" if country
+
+    "Championship for #{championship_type}"
   end
 end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -8,10 +8,13 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     let(:delegate) { FactoryBot.create :delegate, senior_delegate: senior_delegate }
     let(:second_delegate) { FactoryBot.create :delegate, senior_delegate: senior_delegate }
     let(:third_delegate) { FactoryBot.create :delegate }
-    let(:competition) { FactoryBot.create :competition, :with_competitor_limit, championship_types: %w(world greater_china), delegates: [delegate, second_delegate, third_delegate], registration_requirements: "Some requirements" }
-    let(:mail) { CompetitionsMailer.notify_board_of_confirmed_competition(delegate, competition) }
+    let(:competition) { FactoryBot.create :competition, :with_competitor_limit, championship_types: %w(world PL), delegates: [delegate, second_delegate, third_delegate], registration_requirements: "Some requirements" }
+    let(:mail) do
+      I18n.locale = :pl
+      CompetitionsMailer.notify_board_of_confirmed_competition(delegate, competition)
+    end
 
-    it "renders" do
+    it "renders in English" do
       expect(mail.to).to eq(["board@worldcubeassociation.org"])
       expect(mail.cc).to match_array(competition.delegates.pluck(:email) + [senior_delegate.email, third_delegate.senior_delegate.email, Team.wqac.email])
       expect(mail.from).to eq(["notifications@worldcubeassociation.org"])
@@ -19,7 +22,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
       expect(mail.subject).to eq("#{delegate.name} just confirmed #{competition.name}")
       expect(mail.body.encoded).to match("#{competition.name} is confirmed")
-      expect(mail.body.encoded).to match("This competition is marked as Greater China Championship and World Championship")
+      expect(mail.body.encoded).to match("This competition is marked as National Championship for Poland and World Championship")
       expect(mail.body.encoded).to match("There is a competitor limit of 100 because \"The hall only fits 100 competitors.\"")
       expect(mail.body.encoded).to match(admin_edit_competition_url(competition))
     end


### PR DESCRIPTION
Currently, if a Delegate confirming a competition uses other language than English, then championship name (included in the confirmation email) is partially localized. E.g. `This competition is marked as National Championship for Polska` (`Polska` instead of `Poland`)