### PR TITLE
Fix a feature spec failing frequently

### DIFF
--- a/WcaOnRails/spec/features/competition_manage_schedule_spec.rb
+++ b/WcaOnRails/spec/features/competition_manage_schedule_spec.rb
@@ -46,7 +46,8 @@ RSpec.feature "Competition events management" do
 end
 
 def save
-  first(:button, "save your changes!", visible: true).click
+  # Trigger click directly on the element ignoring any modals.
+  first(:button, "save your changes!", visible: true).trigger('click')
   # Wait for ajax to complete.
   expect(page).to have_no_content("You have unsaved changes")
 end


### PR DESCRIPTION
When merging dependency updates, I had to rerun some of them due to test failures. Most of them were the following:
```
  1) Competition events management unconfirmed competition change round attributes change advancement condition to top 12 people
     Failure/Error: first(:button, "save your changes!", visible: true).click
     
     Capybara::Poltergeist::MouseEventFailed:
       Firing a click at co-ordinates [668, 476] failed. Poltergeist detected another element with CSS selector 'html body.modal-open div div.fade.in.modal' at this position. It may be overlapping the element you are trying to interact with. If you don't care about overlapping elements, try using node.trigger('click').
```

Hopefully following the suggestion would fix that.