### PR TITLE
Enhance results sorting for competitions with the same start_date

### DIFF
--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -33,7 +33,7 @@ class PersonsController < ApplicationController
     @ranks_average = @person.ranksAverage
     @medals = @person.medals
     @records = @person.records
-    @results = @person.results.includes(:competition, :event, :format, :round_type).order("Events.rank, Competitions.start_date DESC, RoundTypes.rank DESC")
+    @results = @person.results.includes(:competition, :event, :format, :round_type).order("Events.rank, Competitions.start_date DESC, Competitions.id, RoundTypes.rank DESC")
     @championship_podiums = @person.championship_podiums
     params[:event] ||= @results.first.event.id
   end


### PR DESCRIPTION
At the moment if someones goes to two competitions with the same date, and participates in the same events during both then we are not consistent about ordering the results.