### PR TITLE
Remove unless from #2999.

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -96,31 +96,30 @@
     <% end %>
 
   </div>
-  <% unless competition.registration_requirements.blank? %>
-    <div class="col-md-12">
-      <dl class="dl-horizontal">
-        <% if competition.use_wca_registration? %>
-          <dt><%= t '.registration_period.label' %></dt>
-          <dd>
-            <p>
-              <% if competition.registration_not_yet_opened? %>
-                <%= t(".registration_period.range_future_html",
-                    start_date_and_time: wca_local_time(competition.registration_open),
-                    end_date_and_time: wca_local_time(competition.registration_close)) %>
-              <% elsif competition.registration_past? %>
-                <%= t(".registration_period.range_past_html",
-                    start_date_and_time: wca_local_time(competition.registration_open),
-                    end_date_and_time: wca_local_time(competition.registration_close)) %>
-              <% else %>
-                <%= t(".registration_period.range_ongoing_html",
-                    start_date_and_time: wca_local_time(competition.registration_open),
-                    end_date_and_time: wca_local_time(competition.registration_close)) %>
-              <% end %>
-            </p>
-          </dd>
-        <% end %>
-        <dt><%= t '.registration_requirements' %></dt>
+  <div class="col-md-12">
+    <dl class="dl-horizontal">
+      <% if competition.use_wca_registration? %>
+        <dt><%= t '.registration_period.label' %></dt>
         <dd>
+          <p>
+            <% if competition.registration_not_yet_opened? %>
+              <%= t(".registration_period.range_future_html",
+                  start_date_and_time: wca_local_time(competition.registration_open),
+                  end_date_and_time: wca_local_time(competition.registration_close)) %>
+            <% elsif competition.registration_past? %>
+              <%= t(".registration_period.range_past_html",
+                  start_date_and_time: wca_local_time(competition.registration_open),
+                  end_date_and_time: wca_local_time(competition.registration_close)) %>
+            <% else %>
+              <%= t(".registration_period.range_ongoing_html",
+                  start_date_and_time: wca_local_time(competition.registration_open),
+                  end_date_and_time: wca_local_time(competition.registration_close)) %>
+            <% end %>
+          </p>
+        </dd>
+      <% end %>
+      <dt><%= t '.registration_requirements' %></dt>
+      <dd>
         <% collapse = @competition.is_probably_over? %>
         <% if collapse %>
           <div id="show_registration_requirements">
@@ -132,11 +131,12 @@
         <% end %>
         <div class="<%= collapse ? "collapse" : "" %>" id="registration_requirements_text">
           <%= render "registration_requirements" %>
-        </dd>
-      </dl>
-    </div>
-  <% end %>
+        </div>
+      </dd>
+    </dl>
+  </div>
 </div>
+
 <% if collapse %>
   <script>
     $(function () {


### PR DESCRIPTION
The automated registration requirements didn't render on the info page unless there were extra registration requirements because I forgot to remove an `unless` -- this PR addresses that.