### PR TITLE
FactoryBot: static to dynamic attributes

### DIFF
--- a/WcaOnRails/spec/factories/competition_media.rb
+++ b/WcaOnRails/spec/factories/competition_media.rb
@@ -3,22 +3,22 @@
 FactoryBot.define do
   factory :competition_medium do
     competition { FactoryBot.create(:competition) }
-    type "article"
-    text "I am an article"
-    uri "https://www.example.com/article-42"
+    type { "article" }
+    text { "I am an article" }
+    uri { "https://www.example.com/article-42" }
     submitterName { Faker::Name.name }
-    submitterComment "This is a comment"
+    submitterComment { "This is a comment" }
     submitterEmail { Faker::Internet.email }
     timestampSubmitted { 2.days.ago }
-    timestampDecided nil
-    status "pending"
+    timestampDecided { nil }
+    status { "pending" }
 
     trait :accepted do
-      status "accepted"
+      status { "accepted" }
     end
 
     trait :pending do
-      status "pending"
+      status { "pending" }
     end
   end
 end

--- a/WcaOnRails/spec/factories/competition_tabs.rb
+++ b/WcaOnRails/spec/factories/competition_tabs.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :competition_tab do
     competition
     sequence(:name) { |n| "Info tab #{n}" }
-    content "Some additional informations."
+    content { "Some additional informations." }
   end
 end

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -4,16 +4,16 @@ FactoryBot.define do
   factory :competition do
     sequence(:name) { |n| "Foo Comp #{n} 2015" }
 
-    cityName "San Francisco"
-    countryId "USA"
-    currency_code "USD"
-    base_entry_fee_lowest_denomination 1000
-    information "Information!"
+    cityName { "San Francisco" }
+    countryId { "USA" }
+    currency_code { "USD" }
+    base_entry_fee_lowest_denomination { 1000 }
+    information { "Information!" }
     latitude { rand(-90_000_000..90_000_000) }
     longitude { rand(-180_000_000..180_000_000) }
 
     transient do
-      starts 1.year.ago
+      starts { 1.year.ago }
       ends { starts }
       event_ids { %w(333 333oh) }
     end
@@ -22,39 +22,39 @@ FactoryBot.define do
     end_date { ends.nil? ? nil : ends.strftime("%F") }
 
     trait :future do
-      starts 1.week.from_now
+      starts { 1.week.from_now }
     end
 
     trait :ongoing do
-      starts Time.now
+      starts { Time.now }
     end
 
     trait :past do
-      starts 1.week.ago
+      starts { 1.week.ago }
     end
 
     trait :results_posted do
-      results_posted_at Time.now
+      results_posted_at { Time.now }
     end
 
     trait :with_competitor_limit do
-      competitor_limit_enabled true
-      competitor_limit 100
-      competitor_limit_reason "The hall only fits 100 competitors."
+      competitor_limit_enabled { true }
+      competitor_limit { 100 }
+      competitor_limit_reason { "The hall only fits 100 competitors." }
     end
 
     events { Event.where(id: event_ids) }
 
-    venue "My backyard"
-    venueAddress "My backyard street"
-    external_website "https://www.worldcubeassociation.org"
-    showAtAll false
-    isConfirmed false
+    venue { "My backyard" }
+    venueAddress { "My backyard street" }
+    external_website { "https://www.worldcubeassociation.org" }
+    showAtAll { false }
+    isConfirmed { false }
 
-    guests_enabled true
-    on_the_spot_registration false
-    refund_policy_percent 0
-    guests_entry_fee_lowest_denomination 0
+    guests_enabled { true }
+    on_the_spot_registration { false }
+    refund_policy_percent { 0 }
+    guests_entry_fee_lowest_denomination { 0 }
 
     trait :with_delegate do
       delegates { [FactoryBot.create(:delegate)] }
@@ -82,28 +82,28 @@ FactoryBot.define do
       end
     end
 
-    use_wca_registration false
-    registration_open 2.weeks.ago.change(usec: 0)
-    registration_close 1.week.ago.change(usec: 0)
+    use_wca_registration { false }
+    registration_open { 2.weeks.ago.change(usec: 0) }
+    registration_close { 1.week.ago.change(usec: 0) }
 
     trait :registration_open do
-      use_wca_registration true
-      registration_open 2.weeks.ago.change(usec: 0)
-      registration_close 2.weeks.from_now.change(usec: 0)
+      use_wca_registration { true }
+      registration_open { 2.weeks.ago.change(usec: 0) }
+      registration_close { 2.weeks.from_now.change(usec: 0) }
     end
 
     trait :confirmed do
       with_delegate
-      isConfirmed true
+      isConfirmed { true }
     end
 
     trait :not_visible do
-      showAtAll false
+      showAtAll { false }
     end
 
     trait :visible do
       with_delegate
-      showAtAll true
+      showAtAll { true }
     end
 
     trait :stripe_connected do
@@ -111,12 +111,12 @@ FactoryBot.define do
       # for testing Stripe payments, and is connected
       # to the WCA Stripe account. For more information, see
       # https://github.com/thewca/worldcubeassociation.org/wiki/Payments-with-Stripe
-      connected_stripe_account_id "acct_19ZQVmE2qoiROdto"
+      connected_stripe_account_id { "acct_19ZQVmE2qoiROdto" }
     end
 
     transient do
-      championship_types []
-      with_schedule false
+      championship_types { [] }
+      with_schedule { false }
     end
 
     after(:create) do |competition, evaluator|

--- a/WcaOnRails/spec/factories/contacts.rb
+++ b/WcaOnRails/spec/factories/contacts.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :contact_form do |f|
-    f.name "Jeremy"
-    f.your_email "jeremy@example.com"
-    f.to_email "to@example.com"
-    f.subject "Subject"
+    f.name { "Jeremy" }
+    f.your_email { "jeremy@example.com" }
+    f.to_email { "to@example.com" }
+    f.subject { "Subject" }
   end
 end

--- a/WcaOnRails/spec/factories/delegate_report.rb
+++ b/WcaOnRails/spec/factories/delegate_report.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     competition { FactoryBot.create :competition }
 
     trait :posted do
-      schedule_url "http://example.com"
+      schedule_url { "http://example.com" }
       posted_at { Time.now }
       posted_by_user { FactoryBot.create(:user) }
     end

--- a/WcaOnRails/spec/factories/incidents.rb
+++ b/WcaOnRails/spec/factories/incidents.rb
@@ -2,14 +2,14 @@
 
 FactoryBot.define do
   factory :incident do
-    title "Incident title"
-    private_description "Some private description"
-    private_wrc_decision "Some private decision"
-    public_summary "The incident public summary"
+    title { "Incident title" }
+    private_description { "Some private description" }
+    private_wrc_decision { "Some private decision" }
+    public_summary { "The incident public summary" }
 
     transient do
-      tags ["DefaultTag"]
-      comps []
+      tags { ["DefaultTag"] }
+      comps { [] }
     end
 
     incident_competitions_attributes do
@@ -19,11 +19,11 @@ FactoryBot.define do
     end
 
     trait :resolved do
-      resolved_at 1.week.ago
+      resolved_at { 1.week.ago }
     end
 
     trait :digest_worthy do
-      digest_worthy 1
+      digest_worthy { 1 }
     end
 
     trait :with_comp do
@@ -36,7 +36,7 @@ FactoryBot.define do
     factory :sent_incident do
       resolved
       digest_worthy
-      digest_sent_at 2.days.ago
+      digest_sent_at { 2.days.ago }
     end
 
     after(:create) do |incident, evaluator|

--- a/WcaOnRails/spec/factories/oauth_applications.rb
+++ b/WcaOnRails/spec/factories/oauth_applications.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :oauth_application, class: Doorkeeper::Application do |f|
-    f.name "samurai app"
-    f.uid "9ad911ea379bd6f49c4f923644dbea3f44aeab5625a25f468210026a862b0c3d"
-    f.secret "3b787d2f6c9e51d1f8c4f758e569517b37d281978812ffea304b965c9bd59720"
-    f.redirect_uri "urn:ietf:wg:oauth:2.0:oob"
-    f.scopes "public dob email"
+    f.name { "samurai app" }
+    f.uid { "9ad911ea379bd6f49c4f923644dbea3f44aeab5625a25f468210026a862b0c3d" }
+    f.secret { "3b787d2f6c9e51d1f8c4f758e569517b37d281978812ffea304b965c9bd59720" }
+    f.redirect_uri { "urn:ietf:wg:oauth:2.0:oob" }
+    f.scopes { "public dob email" }
   end
 end

--- a/WcaOnRails/spec/factories/persons.rb
+++ b/WcaOnRails/spec/factories/persons.rb
@@ -8,22 +8,22 @@ FactoryBot.define do
       id = id.next while Person.exists?(wca_id: id)
       id
     end
-    subId 1
+    subId { 1 }
     name { Faker::Name.name }
     countryId { Country.real.sample.id }
-    gender "m"
-    year 1966
-    month 4
-    day 4
+    gender { "m" }
+    year { 1966 }
+    month { 4 }
+    day { 4 }
 
     trait :missing_dob do
-      year 0
-      month 0
-      day 0
+      year { 0 }
+      month { 0 }
+      day { 0 }
     end
 
     trait :missing_gender do
-      gender ""
+      gender { "" }
     end
 
     factory :person_with_multiple_sub_ids do

--- a/WcaOnRails/spec/factories/polls.rb
+++ b/WcaOnRails/spec/factories/polls.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :poll do
     question { Faker::Lorem.paragraph }
-    multiple false
+    multiple { false }
     deadline { Date.today + 15 }
 
     trait :confirmed do
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     trait :multiple do
-      multiple true
+      multiple { true }
     end
   end
 end

--- a/WcaOnRails/spec/factories/posts.rb
+++ b/WcaOnRails/spec/factories/posts.rb
@@ -5,13 +5,13 @@ FactoryBot.define do
     body { Faker::Lorem.paragraph }
     title { Faker::Hacker.say_something_smart }
     slug { title.parameterize }
-    sticky false
-    world_readable true
-    show_on_homepage true
+    sticky { false }
+    world_readable { true }
+    show_on_homepage { true }
     author
 
     trait :sticky do
-      sticky true
+      sticky { true }
     end
 
     factory :sticky_post, traits: [:sticky]

--- a/WcaOnRails/spec/factories/ranks.rb
+++ b/WcaOnRails/spec/factories/ranks.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :ranks_average do
     transient do
-      rank 1
+      rank { 1 }
     end
 
     best { rank * 100 }
@@ -14,7 +14,7 @@ FactoryBot.define do
 
   factory :ranks_single do
     transient do
-      rank 1
+      rank { 1 }
     end
 
     best { rank * 100 }

--- a/WcaOnRails/spec/factories/registration_payment.rb
+++ b/WcaOnRails/spec/factories/registration_payment.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :registration_payment do
-    amount_lowest_denomination 0
+    amount_lowest_denomination { 0 }
   end
 end

--- a/WcaOnRails/spec/factories/registrations.rb
+++ b/WcaOnRails/spec/factories/registrations.rb
@@ -4,23 +4,23 @@ FactoryBot.define do
   factory :registration do
     association :competition, factory: [:competition, :registration_open]
     association :user, factory: [:user, :wca_id]
-    guests 10
-    comments ""
+    guests { 10 }
+    comments { "" }
     transient do
       events { competition.events }
     end
     competition_events { competition.competition_events.where(event: events) }
 
     trait :accepted do
-      accepted_at Time.now
+      accepted_at { Time.now }
     end
 
     trait :deleted do
-      deleted_at Time.now
+      deleted_at { Time.now }
     end
 
     trait :pending do
-      accepted_at nil
+      accepted_at { nil }
     end
 
     trait :newcomer do

--- a/WcaOnRails/spec/factories/results.rb
+++ b/WcaOnRails/spec/factories/results.rb
@@ -11,18 +11,18 @@ FactoryBot.define do
     personName { person.name }
     countryId { person.countryId }
     competitionId { competition.id }
-    pos 1
-    eventId "333oh"
-    roundTypeId "f"
-    formatId "a"
+    pos { 1 }
+    eventId { "333oh" }
+    roundTypeId { "f" }
+    formatId { "a" }
     value1 { best }
     value2 { average }
     value3 { average }
     value4 { average }
     value5 { average }
-    best 3000
-    average 5000
-    regionalSingleRecord ""
-    regionalAverageRecord ""
+    best { 3000 }
+    average { 5000 }
+    regionalSingleRecord { "" }
+    regionalAverageRecord { "" }
   end
 end

--- a/WcaOnRails/spec/factories/results_submission.rb
+++ b/WcaOnRails/spec/factories/results_submission.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :results_submission do
-    schedule_url "https://example.com/schedule"
+    schedule_url { "https://example.com/schedule" }
 
-    message "Here are the results.\nThey look good."
+    message { "Here are the results.\nThey look good." }
 
-    results_json_str '{"results": "good"}'
+    results_json_str { '{"results": "good"}' }
   end
 end

--- a/WcaOnRails/spec/factories/rounds.rb
+++ b/WcaOnRails/spec/factories/rounds.rb
@@ -4,13 +4,13 @@ FactoryBot.define do
   factory :round do
     transient do
       competition { FactoryBot.create :competition, event_ids: [event_id] }
-      event_id "333"
-      format_id "a"
+      event_id { "333" }
+      format_id { "a" }
     end
 
     format { Format.c_find(format_id) }
     competition_event { competition.competition_events.find_by_event_id!(event_id) }
-    number 1
-    total_number_of_rounds 1
+    number { 1 }
+    total_number_of_rounds { 1 }
   end
 end

--- a/WcaOnRails/spec/factories/scrambles.rb
+++ b/WcaOnRails/spec/factories/scrambles.rb
@@ -2,11 +2,11 @@
 
 FactoryBot.define do
   factory :scramble do
-    eventId "333"
-    roundTypeId "f"
-    groupId "a"
-    isExtra false
-    scrambleNum 0
-    scramble "R2 D2"
+    eventId { "333" }
+    roundTypeId { "f" }
+    groupId { "a" }
+    isExtra { false }
+    scrambleNum { 0 }
+    scramble { "R2 D2" }
   end
 end

--- a/WcaOnRails/spec/factories/team_members.rb
+++ b/WcaOnRails/spec/factories/team_members.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :team_member do
-    team_id 1
-    user_id 1
-    start_date "2016-02-18"
-    end_date nil
+    team_id { 1 }
+    user_id { 1 }
+    start_date { "2016-02-18" }
+    end_date { nil }
   end
 end

--- a/WcaOnRails/spec/factories/teams.rb
+++ b/WcaOnRails/spec/factories/teams.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :team do
-    friendly_id 'foo'
+    friendly_id { 'foo' }
   end
 end

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -5,13 +5,13 @@ FactoryBot.define do
     name { Faker::Name.name }
     email { Faker::Internet.email }
     country_iso2 { Country.real.sample.iso2 }
-    gender "m"
-    dob Date.new(1980, 1, 1)
-    password "wca"
+    gender { "m" }
+    dob { Date.new(1980, 1, 1) }
+    password { "wca" }
     password_confirmation { "wca" }
 
     transient do
-      preferred_event_ids []
+      preferred_event_ids { [] }
     end
     # Using accept_nested_attributes_for
     user_preferred_events_attributes do
@@ -21,15 +21,15 @@ FactoryBot.define do
     end
 
     transient do
-      confirmed true
+      confirmed { true }
     end
     before(:create) do |user, options|
       user.skip_confirmation! if options.confirmed
     end
 
     factory :admin do
-      name "Mr. Admin"
-      email "admin@worldcubeassociation.org"
+      name { "Mr. Admin" }
+      email { "admin@worldcubeassociation.org" }
       after(:create) do |user|
         software_team = Team.wst
         FactoryBot.create(:team_member, team_id: software_team.id, user_id: user.id, team_leader: true)
@@ -90,20 +90,20 @@ FactoryBot.define do
 
     factory :delegate, traits: [:wca_id] do
       association :senior_delegate
-      delegate_status "delegate"
+      delegate_status { "delegate" }
     end
 
     factory :candidate_delegate, traits: [:wca_id] do
       association :senior_delegate
-      delegate_status "candidate_delegate"
+      delegate_status { "candidate_delegate" }
     end
 
     factory :senior_delegate, traits: [:wca_id] do
-      delegate_status "senior_delegate"
+      delegate_status { "senior_delegate" }
     end
 
     factory :dummy_user, traits: [:wca_id] do
-      encrypted_password ""
+      encrypted_password { "" }
       after(:create) do |user|
         user.update_column(:email, "#{user.wca_id}@worldcubeassociation.org")
       end


### PR DESCRIPTION
I just saw this warning when running tests:
```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

name { "Jeremy" }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct

 (called from block (2 levels) in <top (required)> at /home/fifi/dev/wca/worldcubeassociation.org/WcaOnRails/spec/factories/contacts.rb:5)
```

So I did what the message said, it fixed a lot of them but a few went undetected and I fixed them manually.