### PR TITLE
Comment on competition_event's default order

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -3,6 +3,7 @@
 class Competition < ApplicationRecord
   self.table_name = "Competitions"
 
+  # We need this default order, tests rely on it.
   has_many :competition_events, -> { order(:event_id) }, dependent: :destroy
   has_many :events, through: :competition_events
   has_many :rounds, through: :competition_events


### PR DESCRIPTION
As suggested by @jfly [here](https://github.com/thewca/worldcubeassociation.org/pull/3176#issuecomment-414548072).

This is a very trivial change so I'll merge it when tests pass.