### PR TITLE
Remove column names from generated csv voter files

### DIFF
--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -98,7 +98,6 @@ class AdminController < ApplicationController
 
   private def voters(users, filename)
     csv = CSV.generate do |line|
-
       users.each do |user|
         line << [user.id, user.email, user.name]
       end

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -98,7 +98,6 @@ class AdminController < ApplicationController
 
   private def voters(users, filename)
     csv = CSV.generate do |line|
-      line << ["id", "email", "name"]
 
       users.each do |user|
         line << [user.id, user.email, user.name]

--- a/WcaOnRails/spec/features/eligible_voters_spec.rb
+++ b/WcaOnRails/spec/features/eligible_voters_spec.rb
@@ -41,7 +41,6 @@ RSpec.feature "Eligible voters csv" do
 
       expect(page.response_headers['Content-Disposition']).to eq 'attachment; filename="all-wca-voters-2016-05-05T10:05:03Z.csv"'
       expect(CSV.parse(page.body)).to match_array [
-        ["id", "email", "name"],
         [team_leader.id.to_s, team_leader.email, team_leader.name],
         [delegate.id.to_s, delegate.email, delegate.name],
         [delegate_who_is_also_team_leader.id.to_s, delegate_who_is_also_team_leader.email, delegate_who_is_also_team_leader.name],
@@ -57,7 +56,6 @@ RSpec.feature "Eligible voters csv" do
 
       expect(page.response_headers['Content-Disposition']).to eq 'attachment; filename="leader-senior-wca-voters-2016-05-05T10:05:03Z.csv"'
       expect(CSV.parse(page.body)).to match_array [
-        ["id", "email", "name"],
         [team_leader.id.to_s, team_leader.email, team_leader.name],
         [delegate_who_is_also_team_leader.id.to_s, delegate_who_is_also_team_leader.email, delegate_who_is_also_team_leader.name],
         [senior_delegate.id.to_s, senior_delegate.email, senior_delegate.name],


### PR DESCRIPTION
This seemed simple enough so I gave it a shot. Let me know if I did this wrong or broke something.

From Walker via email:
I just want to make a minor change to the voting files that are generated when I click on each one.

In each file, it has the first row as a list of: Name, email, ID. Would I be able to get that row removed? 

When I try to upload the file to Helios, it tries to add that row into the data as a voter. So each time I have to take it out of the data before uploading the file. Sometimes messing around with the file also makes it so the file doesn't upload correctly in Helios.