### PR TITLE
Allow non-Delegate WRT Member(s) to edit Delegate Avatars.

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -639,7 +639,7 @@ class User < ApplicationRecord
         avatar avatar_cache
       )
     end
-    if user == self || admin? || any_kind_of_delegate?
+    if user == self || admin? || any_kind_of_delegate? || results_team?
       cannot_edit_data = !!cannot_edit_data_reason_html(user)
       if !cannot_edit_data
         fields += %i(name dob gender country_iso2)


### PR DESCRIPTION
This fixes #3261, although I don't know if it's the correct way to do it.