### PR TITLE
Always use an absolute link to the documents.

### DIFF
--- a/WcaOnRails/app/helpers/static_pages_helper.rb
+++ b/WcaOnRails/app/helpers/static_pages_helper.rb
@@ -11,6 +11,6 @@ module StaticPagesHelper
     safe_join Dir.glob("#{Rails.root}/public/documents/#{directory}/*.pdf")
                  .sort
                  .map { |doc| File.basename(doc, ".pdf") }
-                 .map { |name| content_tag(:li, link_to(name, "documents/#{directory}/#{name}.pdf")) }
+                 .map { |name| content_tag(:li, link_to(name, "/documents/#{directory}/#{name}.pdf")) }
   end
 end


### PR DESCRIPTION
This fixes https://github.com/thewca/wca-documents/issues/10.