### PR TITLE
Change the phrase "left to 0" to "set to 0" in a number of places.

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -406,7 +406,7 @@ en:
         countryId: ""
         end_date: ""
         generate_website: ""
-        base_entry_fee_lowest_denomination: 'The base entry fee for the competition. The entry fee will be displayed on the competition information page and the registration page if used. If this is left to 0, a sentence will be displayed saying that registrations will be accepted for free.'
+        base_entry_fee_lowest_denomination: 'The base entry fee for the competition. The entry fee will be displayed on the competition information page and the registration page if used. If this is set to 0, a sentence will be displayed saying that registrations will be accepted for free.'
         currency_code: "The currency code for entry fees."
         guests_enabled: ""
         enable_donations: ""
@@ -424,10 +424,10 @@ en:
         championship_type: ""
         extra_registration_requirements: "Please indicate here any extra registration requirements not covered above, like for example directions on how to pay. <br/>Please fill this out <b>in English</b> and whatever other languages your competitors speak; this will be displayed on the competition's information page, as well on the registration page if you are using the WCA website registrations."
         on_the_spot_registration: ""
-        on_the_spot_entry_fee_lowest_denomination: "If this is left to 0, a sentence will be displayed saying that on the spot registrations will be accepted for free."
-        refund_policy_percent: "For now this number is informational only, refunds will have to be issued manually. If this is left to 0, a sentence will be displayed saying that registration fees won't be refunded under any circumstance."
+        on_the_spot_entry_fee_lowest_denomination: "If this is set to 0, a sentence will be displayed saying that on the spot registrations will be accepted for free."
+        refund_policy_percent: "For now this number is informational only, refunds will have to be issued manually. If this is set to 0, a sentence will be displayed saying that registration fees won't be refunded under any circumstance."
         refund_policy_limit_date: "Date after which no more refunds will be issued."
-        guests_entry_fee_lowest_denomination: "For now this number is informational only, guest fees cannot be managed through this website. If this is left to 0, a sentence will be displayed saying that spectators can attend for free."
+        guests_entry_fee_lowest_denomination: "For now this number is informational only, guest fees cannot be managed through this website. If this is set to 0, a sentence will be displayed saying that spectators can attend for free."
       website_contact:
         inquiry: ""
         competition_id: ""


### PR DESCRIPTION
"left to 0" feels wrong to be, because these fields don't actually start
out as 0, they start out empty, and the user can choose to set them to 0
if they want.

@AlbertoPdRF, what do you think?