### PR TITLE
Change on the spot registrations input component from a checkbox to a select.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -3,8 +3,8 @@ onPage('competitions#edit, competitions#update, competitions#admin_edit, competi
     $('.wca-registration-options').toggle(this.checked);
   }).trigger('change');
 
-  $('input[name="competition[on_the_spot_registration]"]').on('change', function() {
-    $('.wca-on-the-spot-registration-options').toggle(this.checked);
+  $('select[name="competition[on_the_spot_registration]"]').on('change', function() {
+    $('.wca-on-the-spot-registration-options').toggle(this.value === "true");
   }).trigger('change');
 
   $('input[name="competition[competitor_limit_enabled]"]').on('change', function() {

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -263,7 +263,7 @@
       <%= f.input :refund_policy_percent %>
       <%= f.input :refund_policy_limit_date, as: :datetime_picker %>
 
-      <%= f.input :on_the_spot_registration %>
+      <%= f.input :on_the_spot_registration, collection: [ :true, :false ] %>
       <div class="wca-on-the-spot-registration-options">
         <%= f.input :on_the_spot_entry_fee_lowest_denomination, as: :money_amount, currency: @competition.currency_code, currency_selector: "#competition_currency_code" %>
       </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -252,7 +252,7 @@ en:
         enable_donations: "I want to enable donations additionally to collecting the registration fees"
         championship_type: "Championship type"
         extra_registration_requirements: "Extra registration requirements"
-        on_the_spot_registration: "I want to accept on the spot registrations"
+        on_the_spot_registration: "On the spot registrations"
         on_the_spot_entry_fee_lowest_denomination: "On the spot entry fee"
         refund_policy_percent: "Percent to be refunded"
         refund_policy_limit_date: "Limit date for refunds"
@@ -506,6 +506,9 @@ en:
         guests_enabled:
           "true": "Ask about guests"
           "false": "Do NOT ask about guests"
+        on_the_spot_registration:
+          "true": "On the spot registrations will be accepted"
+          "false": "On the spot registrations WILL NOT be accepted"
   mail_form:
     #context: This key is used as a label for contact form attributes
     attributes:

--- a/WcaOnRails/lib/custom_i18n_scanner.rb
+++ b/WcaOnRails/lib/custom_i18n_scanner.rb
@@ -71,8 +71,8 @@ unless Rails.env.production?
         end
       end
 
-      # Then scan for possible radio choices
-      text.scan(/^\s*<%= f.input :(\w+), as: :radio_buttons, collection: \[(.*)\](.*)%>/) do |attribute, collection|
+      # Then scan for collection options.
+      text.scan(/^\s*<%= f.input :(\w+).* collection: \[(.*)\](.*)%>/) do |attribute, collection|
         abskey = absolute_key(".#{attribute}", path)
         occurrence = occurrence_from_position(path, text, Regexp.last_match.offset(0).first)
         model = extract_model_name(abskey)


### PR DESCRIPTION
This is a workaround for #3257, where updating an old competition would
automatically change its value for `on_the_spot_registration` from
NULL to FALSE.

Sorry for the messy screenshot, I need to figure out a better way to capture a screenshot of a select dropdown open:

![image](https://user-images.githubusercontent.com/277474/44634637-27348a80-a951-11e8-8151-a36124904971.png)

@AlbertoPdRF, what do you think?