### PR TITLE
Get rid of the ALL_SORTED_BY_LOCALE class variable.

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -148,7 +148,7 @@ module ApplicationHelper
 
   def region_option_tags(selected_id: nil, real_only: false)
     regions = {
-      t('common.continent') => Continent::ALL_SORTED_BY_LOCALE[I18n.locale].map { |continent| [continent.name, continent.id] },
+      t('common.continent') => Continent.all_sorted_by(I18n.locale, real: real_only).map { |continent| [continent.name, continent.id] },
       t('common.country') => Country.all_sorted_by(I18n.locale, real: real_only).map { |country| [country.name, country.id] },
     }
 

--- a/WcaOnRails/app/models/concerns/localized_sortable.rb
+++ b/WcaOnRails/app/models/concerns/localized_sortable.rb
@@ -21,11 +21,6 @@ module LocalizedSortable
 
   included do
     scope :uncached_real, -> { where.not(id: fictive_ids) }
-
-    self::ALL_SORTED_BY_LOCALE = Hash[I18n.available_locales.map do |locale|
-      objects = I18nUtils.localized_sort_by!(locale, self.c_all_by_id.values) { |object| object.name_in(locale) }
-      [locale, objects]
-    end].freeze
   end
 
   class_methods do
@@ -38,7 +33,11 @@ module LocalizedSortable
     end
 
     def all_sorted_by(locale, real: false)
-      real ? self::ALL_SORTED_BY_LOCALE[locale].select(&:real?) : self::ALL_SORTED_BY_LOCALE[locale]
+      @all_sorted_by_locale ||= Hash[I18n.available_locales.map do |available_locale|
+        objects = I18nUtils.localized_sort_by!(available_locale, self.c_all_by_id.values) { |object| object.name_in(available_locale) }
+        [available_locale, objects]
+      end].freeze
+      real ? @all_sorted_by_locale[locale].select(&:real?) : @all_sorted_by_locale[locale]
     end
   end
 end


### PR DESCRIPTION
Crazy as it may seem, something like this change is necessary for me to run
many kinds of tests locally. Before this change, I'd reliably run into test
failures like this:

```
➜  ~/gitting/worldcubeassociation.org/WcaOnRails git:(caching-cleanup) ✗ bin/rspec spec/features/edit_user_spec.rb
...
Failures:

  1) Edit user entering wca id
     Failure/Error: person { FactoryBot.create(:person, name: name, countryId: Country.find_by_iso2(country_iso2).id, gender: gender, dob: dob.strftime("%F")) }

     NoMethodError:
       undefined method `id' for nil:NilClass
     # ./spec/factories/users.rb:77:in `block (5 levels) in <top (required)>'
     # ./spec/factories/users.rb:87:in `block (3 levels) in <top (required)>'
     # ./spec/features/edit_user_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/features/edit_user_spec.rb:24:in `block (2 levels) in <top (required)>'
     # -e:1:in `<main>'

Finished in 10.14 seconds (files took 0.31995 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/features/edit_user_spec.rb:19 # Edit user entering wca id

Randomized with seed 748
```

I tracked this weird behavior down to `database_cleaner.rb`:

Before each test suite, we do `DatabaseCleaner.clean_with :truncation`
followed by `TestDbManager.fill_tables`. This call to `fill_tables`
results in loading `db/seeds/countries.seeds.rb`, which calls
`Country::ALL_STATES.each(&:save!)`. This causes the `Country` class to
get loaded into memory, and we immediately generate a cached view of the
freshly emptied `Countries` table in the database*.

(* Note: You may be surprised to hear that simply loading the `Country`
class causes us to read and cache the whole database table. This was not
always the case.
https://github.com/thewca/worldcubeassociation.org/pull/3181/ refactored
`Country` a bit so that it includes the `LocalizedSortable` concern.
`LocalizedSortable` immediately generates `self::ALL_SORTED_BY_LOCALE`,
which involves calling `self.c_all_by_id`, which causes us to read and
cache the entire table from the database.)

This diff changes the `LocalizedSortable` class a bit so that it no
longer immediately invokes `self.c_all_by_id`. Instead, it only calls
that method when needed when someone calls the `all_sorted_by` method.

Now you're probably thinking "ok Jeremy, that sounds reasonble, by why
haven't we been seeing problems in Travis?" Good question! It turns out
that `bin/rspec` wasn't running into this problem. That's because
`bin/rspec` starts by loading every single spec file into memory, and we
have a number of spec files that indirectly reference the `Country`
class. For example, `spec/models/championship_spec.rb` has the following
line of code in it:

```ruby
RSpec.describe Championship do
```

This loads the `Championship` class into memory, and the `Championship`
class causes the `Country` class to get loaded, which would then cache
our not yet emptied `Countries` table in the database, so all our tests
would be happy.