### PR TITLE
NULLify competitor_limit.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -7,8 +7,8 @@ onPage('competitions#edit, competitions#update, competitions#admin_edit, competi
     $('.wca-on-the-spot-registration-options').toggle(this.value === "true");
   }).trigger('change');
 
-  $('input[name="competition[competitor_limit_enabled]"]').on('change', function() {
-    $('.wca-competitor-limit-options').toggle(this.checked);
+  $('select[name="competition[competitor_limit_enabled]"]').on('change', function() {
+    $('.wca-competitor-limit-options').toggle(this.value === "true");
   }).trigger('change');
 
   $('input[name="competition[generate_website]"]').on('change', function() {

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -121,6 +121,7 @@ class Competition < ApplicationRecord
   MAX_ID_LENGTH = 32
   MAX_NAME_LENGTH = 50
   MAX_COMPETITOR_LIMIT = 5000
+  validates_inclusion_of :competitor_limit_enabled, in: [true, false], if: :competitor_limit_required?
   validates_numericality_of :competitor_limit, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_COMPETITOR_LIMIT, if: :competitor_limit_enabled?
   validates :competitor_limit_reason, presence: true, if: :competitor_limit_enabled?
   validates :id, presence: true, uniqueness: true, length: { maximum: MAX_ID_LENGTH },
@@ -603,6 +604,10 @@ class Competition < ApplicationRecord
 
   def competitor_limit_enabled?
     competitor_limit_enabled
+  end
+
+  def competitor_limit_required?
+    isConfirmed? && created_at.present? && created_at > Date.new(2018, 9, 1)
   end
 
   def on_the_spot_registration_required?

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -255,7 +255,7 @@
         </div>
       </div>
 
-      <%= f.input :competitor_limit_enabled %>
+      <%= f.input :competitor_limit_enabled, collection: [ :true, :false ] %>
       <div class="wca-competitor-limit-options">
         <%= f.input :competitor_limit %>
         <%= f.input :competitor_limit_reason %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -244,7 +244,7 @@ en:
         contact: "Contact"
         information: "Information"
         use_wca_registration: "I would like to use the WCA website for registration"
-        competitor_limit_enabled: "I would like to specify a limit on the number of competitors that can enter this competition."
+        competitor_limit_enabled: "Competitor limit"
         competitor_limit: "Maximum number of competitors"
         competitor_limit_reason: "The reason for the competitor limit"
         guests_enabled: "Guests"
@@ -422,8 +422,8 @@ en:
         showAtAll: ""
         start_date: ""
         use_wca_registration: ""
-        competitor_limit_enabled: "For now this number is informational only, and does not yet prevent more people from registering. We are working on adding explicit support for this to the registration flow, but it requires some other work first."
-        competitor_limit: "The number of competitors allowed in this competition."
+        competitor_limit_enabled: "Although it is not required by the Regulations to provide a competitor limit, it's highly recommended to do so."
+        competitor_limit: "The number of competitors allowed in this competition. For now this number is informational only, and does not yet prevent more people from registering. We are working on adding explicit support for this to the registration flow, but it requires some other work first."
         competitor_limit_reason: "What is the reason for the limit on competitors? Please fill this out in English!"
         venueAddress: ""
         championship_type: ""
@@ -511,6 +511,9 @@ en:
         guests_enabled:
           "true": "Ask about guests"
           "false": "Do NOT ask about guests"
+        competitor_limit_enabled:
+          "true": "I want to specify a competitor limit"
+          "false": "I DON'T WANT to specify a competitor limit"
         on_the_spot_registration:
           "true": "On the spot registrations will be accepted"
           "false": "On the spot registrations WILL NOT be accepted"

--- a/WcaOnRails/db/migrate/20180831075355_nullify_competitor_limit.rb
+++ b/WcaOnRails/db/migrate/20180831075355_nullify_competitor_limit.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class NullifyCompetitorLimit < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null(:Competitions, :competitor_limit_enabled, true)
+    change_column_default(:Competitions, :competitor_limit_enabled, from: 0, to: nil)
+    Competition.where(competitor_limit_enabled: 0).update_all(competitor_limit_enabled: nil)
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -49,7 +49,7 @@ CREATE TABLE `Competitions` (
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
-  `competitor_limit_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `competitor_limit_enabled` tinyint(1) DEFAULT NULL,
   `competitor_limit` int(11) DEFAULT NULL,
   `competitor_limit_reason` text COLLATE utf8mb4_unicode_ci,
   `extra_registration_requirements` text COLLATE utf8mb4_unicode_ci,
@@ -1407,4 +1407,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180730182509'),
 ('20180731204733'),
 ('20180822165331'),
-('20180825115701');
+('20180825115701'),
+('20180831075355');

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -51,6 +51,7 @@ FactoryBot.define do
     showAtAll { false }
     isConfirmed { false }
 
+    competitor_limit_enabled { false }
     guests_enabled { true }
     on_the_spot_registration { false }
     refund_policy_percent { 0 }


### PR DESCRIPTION
This is pretty much the same as #3086 (+ #3270), and may be required for #2472.

I haven't done anything with the `competitor_limit_reason` column, but it surprises me that it has both `NULL` and `""` values, any idea why?