### PR TITLE
Update wca_i18n to the latest version.

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -509,7 +509,7 @@ GEM
       mail (>= 2.6.1)
     warden (1.2.7)
       rack (>= 1.0)
-    wca_i18n (0.4.2)
+    wca_i18n (0.4.3)
       colorize (~> 0.8)
     web-console (3.6.2)
       actionview (>= 5.0)


### PR DESCRIPTION
This pulls in https://github.com/thewca/wca_i18n/pull/2, which hopefully
will fix the timeouts on our /translations page.