### PR TITLE
Fall back to Date.toString() when `Intl` is not available.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -378,9 +378,16 @@ $(function() {
   $('.wca-local-time').each(function() {
     var data = $(this).data();
     var date = new Date(data.utcTime);
-    var formatted = new Intl.DateTimeFormat(data.locale, {
-      weekday: 'long', day: 'numeric', month: 'long', year: 'numeric', hour: 'numeric', minute: 'numeric', timeZoneName: 'short'
-    }).format(date);
+    var formatted;
+    if(typeof(Intl) !== "undefined") {
+      formatted = new Intl.DateTimeFormat(data.locale, {
+        weekday: 'long', day: 'numeric', month: 'long', year: 'numeric', hour: 'numeric', minute: 'numeric', timeZoneName: 'short'
+      }).format(date);
+    } else {
+      // Workaround for https://github.com/thewca/worldcubeassociation.org/issues/3228.
+      // We can remove this once we consider Safari 9 to be "dead enough".
+      formatted = date.toString();
+    }
     $(this).text(formatted);
   });
 });


### PR DESCRIPTION
This is a workaround that fixes https://github.com/thewca/worldcubeassociation.org/issues/3228.

I deployed this to staging so I could test it out on browserstack. Things are looking ok now!

![image](https://user-images.githubusercontent.com/277474/44962175-4000eb00-aed1-11e8-836f-134d2eddc63f.png)
