### PR TITLE
Add a CityValidator for validating city names.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -171,6 +171,8 @@ class Competition < ApplicationRecord
   # https://www.worldcubeassociation.org/regulations/guidelines.html#8a4++
   SHOULD_BE_ANNOUNCED_GTE_THIS_MANY_DAYS = 29
 
+  validates :cityName, city: true
+
   # We have stricter validations for confirming a competition
   validates :cityName, :countryId, :venue, :venueAddress, :latitude, :longitude, presence: true, if: :confirmed_or_visible?
   validates :external_website, presence: true, if: -> { confirmed_or_visible? && !generate_website }

--- a/WcaOnRails/lib/city_validator.rb
+++ b/WcaOnRails/lib/city_validator.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class CityValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if record.country.nil? || value.blank?
+
+    if value == "Multiple cities"
+      # This is a very special city name used for simultaneous FMC competitions
+      # such as FMC USA. See https://github.com/thewca/worldcubeassociation.org/issues/3355.
+      return
+    end
+
+    city_validator = self.class.get_validator_for_country(record.country.iso2)
+    if city_validator
+      reason_why_invalid = city_validator.reason_why_invalid(value)
+      record.errors.add(attribute, reason_why_invalid) if reason_why_invalid
+    end
+  end
+
+  @validators_by_country_iso2 = {}
+
+  def self.add_validator_for_country(country_iso2, validator)
+    @validators_by_country_iso2[country_iso2] = validator
+  end
+
+  def self.get_validator_for_country(country_iso2)
+    @validators_by_country_iso2[country_iso2]
+  end
+end
+
+class CountryCityValidator
+  # A CountryCityValidator has this one method: `reason_why_invalid` that takes
+  # in a city name, and returns a string reason why that name is not valid, or
+  # nil if the name is valid.
+  def reason_why_invalid(city)
+    raise NotImplementedError
+  end
+end
+
+class CityCommaRegionValidator < CountryCityValidator
+  def initialize(type_of_region:, valid_regions:)
+    @type_of_region = type_of_region
+    @valid_regions = valid_regions
+  end
+
+  def reason_why_invalid(city)
+    _city, region = city.split(", ")
+    if region.nil?
+      "is not of the form 'city, #{@type_of_region}'"
+    elsif !@valid_regions.include?(region)
+      "#{region} is not a valid #{@type_of_region}"
+    else
+      nil
+    end
+  end
+end
+
+# Load all the country city validators.
+Dir[File.join(__dir__, 'country_city_validators', '*.rb')].each { |file| require file }

--- a/WcaOnRails/lib/country_city_validators/ca_city_validator.rb
+++ b/WcaOnRails/lib/country_city_validators/ca_city_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+CA_PROVINCES = %w(
+  Alberta
+  British\ Columbia
+  Manitoba
+  New\ Brunswick
+  Newfoundland\ and\ Labrador
+  Nova\ Scotia
+  Ontario
+  Prince\ Edward\ Island
+  Quebec
+  Saskatchewan
+).to_set
+
+CityValidator.add_validator_for_country "CA", CityCommaRegionValidator.new(type_of_region: "province", valid_regions: CA_PROVINCES)

--- a/WcaOnRails/lib/country_city_validators/us_city_validator.rb
+++ b/WcaOnRails/lib/country_city_validators/us_city_validator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+US_STATES = %w(
+  Alabama
+  Alaska
+  Arizona
+  Arkansas
+  California
+  Colorado
+  Connecticut
+  Delaware
+  Florida
+  Georgia
+  Hawaii
+  Idaho
+  Illinois
+  Indiana
+  Iowa
+  Kansas
+  Kentucky
+  Louisiana
+  Maine
+  Maryland
+  Massachusetts
+  Michigan
+  Minnesota
+  Mississippi
+  Missouri
+  Montana
+  Nebraska
+  Nevada
+  New\ Hampshire
+  New\ Jersey
+  New\ Mexico
+  New\ York
+  North\ Carolina
+  North\ Dakota
+  Ohio
+  Oklahoma
+  Oregon
+  Pennsylvania
+  Rhode\ Island
+  South\ Carolina
+  South\ Dakota
+  Tennessee
+  Texas
+  Utah
+  Vermont
+  Virginia
+  Washington
+  West\ Virginia
+  Wisconsin
+  Wyoming
+).to_set
+
+CityValidator.add_validator_for_country "US", CityCommaRegionValidator.new(type_of_region: "state", valid_regions: US_STATES)

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :competition do
     sequence(:name) { |n| "Foo Comp #{n} 2015" }
 
-    cityName { "San Francisco" }
+    cityName { "San Francisco, California" }
     countryId { "USA" }
     currency_code { "USD" }
     base_entry_fee_lowest_denomination { 1000 }

--- a/WcaOnRails/spec/features/competition_management_spec.rb
+++ b/WcaOnRails/spec/features/competition_management_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "Competition management" do
   context "when signed in as delegate" do
     let(:delegate) { FactoryBot.create(:delegate) }
     let(:cloned_delegate) { FactoryBot.create(:delegate) }
-    let(:competition_to_clone) { FactoryBot.create :competition, cityName: 'Melbourne', delegates: [cloned_delegate], showAtAll: true }
+    let(:competition_to_clone) { FactoryBot.create :competition, cityName: 'Melbourne', countryId: "Australia", delegates: [cloned_delegate], showAtAll: true }
 
     let(:threes) { Event.find("333") }
     let(:fours) { Event.find("444") }

--- a/WcaOnRails/spec/lib/city_validator_spec.rb
+++ b/WcaOnRails/spec/lib/city_validator_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'relations'
+
+RSpec.describe CityValidator do
+  context "US" do
+    let(:country) { Country.find_by_iso2!("US") }
+    let(:model) { TestModel.new(country: country) }
+
+    it "requires city, state" do
+      model.city = "New York, New York"
+      expect(model).to be_valid
+
+      model.city = "New York, NY"
+      expect(model).to be_invalid_with_errors city: ["NY is not a valid state"]
+
+      model.city = "New York"
+      expect(model).to be_invalid_with_errors city: ["is not of the form 'city, state'"]
+    end
+
+    it "allows multiple cities" do
+      model.city = "Multiple cities"
+      expect(model).to be_valid
+    end
+  end
+
+  context "CA" do
+    let(:country) { Country.find_by_iso2!("CA") }
+    let(:model) { TestModel.new(country: country) }
+
+    it "requires city, province" do
+      model.city = "Dieppe, New Brunswick"
+      expect(model).to be_valid
+
+      model.city = "Dieppe, NB"
+      expect(model).to be_invalid_with_errors city: ["NB is not a valid province"]
+
+      model.city = "Dieppe"
+      expect(model).to be_invalid_with_errors city: ["is not of the form 'city, province'"]
+    end
+  end
+
+  context "GB" do
+    let(:country) { Country.find_by_iso2!("GB") }
+    let(:model) { TestModel.new(country: country) }
+
+    it "anything goes" do
+      model.city = "Anything Goes?"
+      expect(model).to be_valid
+    end
+  end
+end
+
+class TestModel
+  include ActiveModel::Model
+
+  attr_accessor :city
+  validates :city, city: true
+
+  attr_accessor :country
+end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe Competition do
     end
   end
 
+  it "rejects invalid city names" do
+    city = "San Diego"
+    expect(FactoryBot.build(:competition, countryId: "USA", cityName: city)).to be_invalid_with_errors(
+      cityName: ["is not of the form 'city, state'"],
+    )
+
+    city = "San Diego, California"
+    expect(FactoryBot.build(:competition, countryId: "USA", cityName: city)).to be_valid
+  end
+
   context "when there is an entry fee" do
     it "correctly identifies there is a fee when there is only a base fee" do
       competition = FactoryBot.build :competition, name: "Foo: Test - 2015", base_entry_fee_lowest_denomination: 10
@@ -705,7 +715,7 @@ RSpec.describe Competition do
 
   describe "#contains" do
     let!(:delegate) { FactoryBot.create :delegate, name: 'Pedro' }
-    let!(:search_comp) { FactoryBot.create :competition, name: "Awesome Comp 2016", cityName: "Piracicaba", delegates: [delegate] }
+    let!(:search_comp) { FactoryBot.create :competition, name: "Awesome Comp 2016", cityName: "Piracicaba", countryId: "Brazil", delegates: [delegate] }
     it "searching with two words" do
       expect(Competition.contains('eso').contains('aci').first).to eq search_comp
       expect(Competition.contains('awesome').contains('comp').first).to eq search_comp


### PR DESCRIPTION
(This is part of #361.)

I had some fun with Ruby here. My thinking is that the validations we
want to enforce will be a bit different depending on the country, so I
made it possible to create a `CountryCityValidator` for each
country. These `CountryCityValidator`s know how to check if a city name
is valid or not. If there is no `CountryCityValidator` for a given
country, then we treat the city name as valid. I could see us changing
that in the future once we've added a `CountryCityValidator` for every
country we host competitions in.

![image](https://user-images.githubusercontent.com/277474/45043567-5bc7d680-b022-11e8-8ea7-c87694ed5acf.png)