### PR TITLE
When the user simply clicks on the calendar, create an event of `defaultTimedEventDuration`.

### DIFF
--- a/WcaOnRails/app/javascript/edit-schedule/SchedulesEditor/fullcalendar.js
+++ b/WcaOnRails/app/javascript/edit-schedule/SchedulesEditor/fullcalendar.js
@@ -46,7 +46,14 @@ export function generateCalendar(eventFetcher, showModalAction, scheduleWcif, ad
     eventResizeStart: fullCalendarHandlers.onResizeStart,
     eventResizeStop: fullCalendarHandlers.onResizeStop,
     eventResize: fullCalendarHandlers.onSizeChanged,
+
+    // We need to set selectMinDistance greater than 0 to suppress `select`
+    // events when the user simply single clicks (and does not drag) on the
+    // calendar. See https://fullcalendar.io/docs/selectMinDistance.
+    // I have no idea why this isn't the default behavior.
+    selectMinDistance: 5,
     select: (start, end) => fullCalendarHandlers.onTimeframeSelected(showModalAction, start, end),
+    dayClick: (date) => fullCalendarHandlers.onTimeframeSelected(showModalAction, date, date.clone().add(moment.duration(options.defaultTimedEventDuration))),
   }
 
   _.assign(options, localOptions);


### PR DESCRIPTION
Previously, we'd create an event of `snapDuration`, which is only 5
minutes and appears very slim on the calendar. I agree with @pedrosino
that single clicking should instead create an event of more signficant
duration: https://github.com/thewca/worldcubeassociation.org/issues/3307#issuecomment-417122672

Implementing this was a bit tricky: fullcalendar provides both a `select`
and a `dayClick` callback. When you click and drag on the calendar, only
`select` is called. When you single click on the calendar, both `select`
*and* `dayClick` are called, which isn't so useful. You can suppress the
spurious `select` event by setting the `selectMinDistance` to something
greater than 0 (see https://fullcalendar.io/docs/selectMinDistance). I
have no idea why this isn't the default behavior.

![2018-09-05_02 05 58_dalinar](https://user-images.githubusercontent.com/277474/45083304-4e592d80-b0b0-11e8-815d-f5d68effe990.gif)
