### PR TITLE
Remove phone number column from the delgate stats page.

### DIFF
--- a/WcaOnRails/app/views/delegates/stats.html.erb
+++ b/WcaOnRails/app/views/delegates/stats.html.erb
@@ -13,7 +13,6 @@
         <th class="last" data-sortable="true">Last delegated</th>
         <th class="first" data-sortable="true">First delegated</th>
         <th class="total" data-sortable="true">Total delegated</th>
-        <th class="phone">Phone number</th>
         <th class="history"></th>
       </tr>
     </thead>
@@ -33,7 +32,6 @@
           <td class="last"><%= competitions&.last&.start_date %></td>
           <td class="first"><%= competitions&.first&.start_date %></td>
           <td class="total"><%= competitions&.count %></td>
-          <td><%= delegate.phone_number %></td>
           <td>
             <% if current_user&.can_see_admin_competitions? %>
               <%= link_to "History", competitions_path(display: "admin", years: "all", delegate: delegate.id) %>


### PR DESCRIPTION
I never wanted to add this in the first place. Glad to finally get rid
of it. You can still get to the delegate's phone number by clicking on
the pencil.

![image](https://user-images.githubusercontent.com/277474/45107493-9d25b800-b0ee-11e8-801c-f4245e7db4f9.png)
