### PR TITLE
Add support for cyrillic К and к.

### DIFF
--- a/webroot/results/admin/persons_finish_unfinished.php
+++ b/webroot/results/admin/persons_finish_unfinished.php
@@ -268,8 +268,8 @@ function showUnfinishedPersons () {
 function removeUglyAccentsAndStuff ( $ugly ) {
 #----------------------------------------------------------------------
 
-    $accent   = "ÀÁÂÃÄÅÆĂÇĆČÈÉÊËÌÍÎÏİÐĐÑÒÓÔÕÖØÙÚÛÜÝÞřßŞȘŠŚşșśšŢȚţțŻŽźżžəàáâãäåæăąắặảầấạậāằçćčèéêëęěễệếềēểğìíîïịĩіıðđķŁłļñńņňòóôõöøỗọơốờőợồộớùúûüưứữũụűūůựýýþÿỳỹ";
-    $noaccent = "aaaaaaaaccceeeeiiiiiddnoooooouuuuybrsssssssssttttzzzzzaaaaaaaaaaaaaaaaaaaccceeeeeeeeeeeegiiiiiiiiddklllnnnnoooooooooooooooouuuuuuuuuuuuuyybyyy";
+    $accent   = "ÀÁÂÃÄÅÆĂÇĆČÈÉÊËÌÍÎÏİÐĐÑÒÓÔÕÖØÙÚÛÜÝÞřßŞȘŠŚşșśšŢȚţțŻŽźżžəàáâãäåæăąắặảầấạậāằçćčèéêëęěễệếềēểğìíîïịĩіıðđķКкŁłļñńņňòóôõöøỗọơốờőợồộớùúûüưứữũụűūůựýýþÿỳỹ";
+    $noaccent = "aaaaaaaaccceeeeiiiiiddnoooooouuuuybrsssssssssttttzzzzzaaaaaaaaaaaaaaaaaaaccceeeeeeeeeeeegiiiiiiiiddkKklllnnnnoooooooooooooooouuuuuuuuuuuuuyybyyy";
 
     $nice = '';
     for( $i=0; $i<mb_strlen($ugly, 'UTF-8'); $i++ ){


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Ka_(Cyrillic). This would have
provided better handling for this WCA ID:
https://www.worldcubeassociation.org/persons/2018UREI01.