### PR TITLE
Add a `confirmed_at` column to Competitions and remove the `isConfirmed` column.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -361,7 +361,7 @@ class CompetitionsController < ApplicationController
 
   def get_nearby_competitions(competition)
     nearby_competitions = competition.nearby_competitions(Competition::NEARBY_DAYS_WARNING, Competition::NEARBY_DISTANCE_KM_WARNING)[0, 10]
-    nearby_competitions.select!(&:isConfirmed?) unless current_user.can_view_hidden_competitions?
+    nearby_competitions.select!(&:confirmed?) unless current_user.can_view_hidden_competitions?
     nearby_competitions
   end
 
@@ -575,7 +575,7 @@ class CompetitionsController < ApplicationController
       ]
     end
 
-    if @competition&.isConfirmed? && !current_user.can_admin_competitions?
+    if @competition&.confirmed? && !current_user.can_admin_competitions?
       # If the competition is confirmed, non admins are not allowed to change anything.
     else
       permitted_competition_params += [
@@ -612,7 +612,7 @@ class CompetitionsController < ApplicationController
       ]
       if current_user.can_admin_competitions?
         permitted_competition_params += [
-          :isConfirmed,
+          :confirmed,
           :showAtAll,
         ]
       end
@@ -620,7 +620,7 @@ class CompetitionsController < ApplicationController
 
     params.require(:competition).permit(*permitted_competition_params).tap do |competition_params|
       if params[:commit] == "Confirm" && current_user.can_confirm_competition?(@competition)
-        competition_params[:isConfirmed] = true
+        competition_params[:confirmed] = true
       end
       competition_params[:editing_user_id] = current_user.id
     end

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -8,7 +8,7 @@ module CompetitionsHelper
       messages << (registration.accepted? ? t('competitions.messages.tooltip_registered') : t('competitions.messages.tooltip_waiting_list'))
     end
     visible = competition.showAtAll?
-    messages << if competition.isConfirmed?
+    messages << if competition.confirmed?
                   visible ? t('competitions.messages.confirmed_visible') : t('competitions.messages.confirmed_not_visible')
                 else
                   visible ? t('competitions.messages.not_confirmed_visible') : t('competitions.messages.not_confirmed_not_visible')

--- a/WcaOnRails/app/helpers/notifications_helper.rb
+++ b/WcaOnRails/app/helpers/notifications_helper.rb
@@ -4,7 +4,7 @@ module NotificationsHelper
   def notifications_for_user(user)
     notifications = []
     # Be careful to not show a competition twice if we're both organizing and delegating it.
-    unconfirmed_competitions = (user.delegated_competitions.where(isConfirmed: false) + user.organized_competitions.where(isConfirmed: false)).uniq(&:id)
+    unconfirmed_competitions = (user.delegated_competitions.not_confirmed + user.organized_competitions.not_confirmed).uniq(&:id)
     unconfirmed_competitions.each do |unconfirmed_competition|
       notifications << {
         text: "#{unconfirmed_competition.name} is not confirmed",
@@ -17,13 +17,13 @@ module NotificationsHelper
       #                                             these competitions.
       #  - Unconfirmed, but visible competitions: These competitions should be confirmed
       #                                           so people cannot change old competitions.
-      Competition.where(isConfirmed: true, showAtAll: false).each do |competition|
+      Competition.confirmed.not_visible.each do |competition|
         notifications << {
           text: "#{competition.name} is waiting to be announced",
           url: admin_edit_competition_path(competition),
         }
       end
-      Competition.where(isConfirmed: false, showAtAll: true).each do |competition|
+      Competition.not_confirmed.visible.each do |competition|
         notifications << {
           text: "#{competition.name} is visible, but unlocked",
           url: admin_edit_competition_path(competition),

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -503,7 +503,7 @@ class User < ApplicationRecord
   end
 
   def can_add_and_remove_events?(competition)
-    can_admin_competitions? || (can_manage_competition?(competition) && !competition.isConfirmed?)
+    can_admin_competitions? || (can_manage_competition?(competition) && !competition.confirmed?)
   end
 
   def can_submit_competition_results?(competition)
@@ -567,7 +567,7 @@ class User < ApplicationRecord
       I18n.t('competitions.errors.cannot_manage')
     elsif competition.showAtAll
       I18n.t('competitions.errors.cannot_delete_public')
-    elsif competition.isConfirmed && !self.can_admin_results?
+    elsif competition.confirmed? && !self.can_admin_results?
       I18n.t('competitions.errors.cannot_delete_confirmed')
     else
       nil

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -1,11 +1,11 @@
   <% provide(:include_gmaps, true) %>
-  <% is_actually_confirmed = @competition.persisted? ? Competition.find(@competition.id).isConfirmed? : false %>
+  <% is_actually_confirmed = @competition.persisted? ? Competition.find(@competition.id).confirmed? : false %>
   <%= horizontal_simple_form_for @competition, html: { class: 'are-you-sure no-submit-on-enter', id: 'competition-form' } do |f| %>
     <% if @competition.persisted? %>
       <% if @competition_admin_view %>
         <%= hidden_field_tag :competition_admin_view, "1" %>
 
-        <%= f.input :isConfirmed %>
+        <%= f.input :confirmed, as: :boolean %>
         <%= f.input :showAtAll %>
       <% else %>
         <%= if is_actually_confirmed && @competition.showAtAll?

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -23,8 +23,8 @@
       <tbody>
         <% competitions.each do |competition| %>
           <% registration = competition.registrations.find_by_user_id(current_user.id) %>
-          <tr class="<%=[ competition.isConfirmed ? "confirmed" : "not-confirmed",
-                          competition.showAtAll ? "visible" : "not-visible",
+          <tr class="<%=[ competition.confirmed? ? "confirmed" : "not-confirmed",
+                          competition.showAtAll? ? "visible" : "not-visible",
                           past ? "past" : "not-past" ].join(' ') %>"
               data-toggle="tooltip" data-placement="top" data-container="body"
               title="<%= competition_message_for_user(competition, current_user) unless past %>">

--- a/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
@@ -16,7 +16,7 @@
         else
           link_to c.name, competition_path(c.id)
         end %>
-        <% unless c.isConfirmed? %>
+        <% unless c.confirmed? %>
           <i class="fa fa-exclamation-circle" data-toggle="tooltip" data-placement="top" data-container="body" title="This competition is not confirmed yet."></i>
         <% end %>
       </td>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -224,7 +224,7 @@ en:
       #context: a competition
       competition:
         id: "ID"
-        isConfirmed: "Do not let organizers edit this competition"
+        confirmed: "Do not let organizers edit this competition"
         showAtAll: "Make competition visible to the public"
         name: "Name"
         cellName: "Competition nickname"
@@ -416,7 +416,7 @@ en:
         guests_enabled: ""
         enable_donations: ""
         id: ""
-        isConfirmed: ""
+        confirmed: ""
         receive_registration_emails: ""
         registration_close: ""
         showAtAll: ""

--- a/WcaOnRails/db/migrate/20180912042457_add_confirmed_at_to_competitions.rb
+++ b/WcaOnRails/db/migrate/20180912042457_add_confirmed_at_to_competitions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddConfirmedAtToCompetitions < ActiveRecord::Migration[5.2]
+  def up
+    add_column :Competitions, :confirmed_at, :datetime
+    execute <<-SQL
+      UPDATE Competitions
+      SET confirmed_at = announced_at
+      WHERE announced_at IS NOT NULL
+    SQL
+    execute <<-SQL
+      UPDATE Competitions
+      SET confirmed_at = NOW()
+      WHERE isConfirmed = 1 AND confirmed_at IS NULL
+    SQL
+    remove_column :Competitions, :isConfirmed
+  end
+
+  def down
+    add_column :Competitions, :isConfirmed, :boolean, default: false, null: false
+    execute <<-SQL
+      UPDATE Competitions
+      SET isConfirmed = 1
+      WHERE confirmed_at IS NOT NULL
+    SQL
+    remove_column :Competitions, :confirmed_at
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -31,7 +31,6 @@ CREATE TABLE `Competitions` (
   `showAtAll` tinyint(1) NOT NULL DEFAULT '0',
   `latitude` int(11) DEFAULT NULL,
   `longitude` int(11) DEFAULT NULL,
-  `isConfirmed` tinyint(1) NOT NULL DEFAULT '0',
   `contact` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `remarks` text COLLATE utf8mb4_unicode_ci,
   `registration_open` datetime DEFAULT NULL,
@@ -60,6 +59,7 @@ CREATE TABLE `Competitions` (
   `guests_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
+  `confirmed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
@@ -1408,4 +1408,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180731204733'),
 ('20180822165331'),
 ('20180825115701'),
-('20180831075355');
+('20180831075355'),
+('20180912042457');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -49,7 +49,7 @@ module DatabaseDumper
           showAtAll
           latitude
           longitude
-          isConfirmed
+          confirmed_at
           contact
           registration_open
           registration_close

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe CompetitionsController do
       it 'cannot see unconfirmed nearby competitions' do
         get :edit, params: { id: my_competition }
         expect(assigns(:nearby_competitions)).to eq []
-        other_competition.isConfirmed = true
+        other_competition.confirmed = true
         other_competition.save!
         get :edit, params: { id: my_competition }
         expect(assigns(:nearby_competitions)).to eq [other_competition]
@@ -246,7 +246,7 @@ RSpec.describe CompetitionsController do
 
       it 'clones a competition' do
         # Set some attributes we don't want cloned.
-        competition.update_attributes(isConfirmed: true,
+        competition.update_attributes(confirmed: true,
                                       results_posted_at: Time.now,
                                       showAtAll: true)
 
@@ -261,9 +261,9 @@ RSpec.describe CompetitionsController do
         expect(new_comp.id).to eq ""
         expect(new_comp.name).to eq ""
         # When cloning a competition, we don't want to clone its showAtAll,
-        # isConfirmed, and results_posted_at attributes.
+        # confirmed, and results_posted_at attributes.
         expect(new_comp.showAtAll).to eq false
-        expect(new_comp.isConfirmed).to eq false
+        expect(new_comp.confirmed?).to eq false
         expect(new_comp.results_posted_at).to eq nil
         # We don't want to clone its dates.
         %w(year month day endYear endMonth endDay).each do |attribute|
@@ -320,7 +320,7 @@ RSpec.describe CompetitionsController do
       it 'can confirm competition' do
         patch :update, params: { id: competition, competition: { name: competition.name }, commit: "Confirm" }
         expect(response).to redirect_to edit_competition_path(competition)
-        expect(competition.reload.isConfirmed?).to eq true
+        expect(competition.reload.confirmed?).to eq true
       end
 
       it 'saves delegate_ids' do
@@ -396,7 +396,7 @@ RSpec.describe CompetitionsController do
       it 'cannot confirm competition' do
         patch :update, params: { id: competition, competition: { name: competition.name }, commit: "Confirm" }
         expect(response.status).to redirect_to edit_competition_path(competition)
-        expect(competition.reload.isConfirmed?).to eq false
+        expect(competition.reload.confirmed?).to eq false
       end
 
       it "who is also the delegate can remove oneself as delegate" do
@@ -520,11 +520,11 @@ RSpec.describe CompetitionsController do
           patch :update, params: { id: competition, competition: { name: competition.name }, commit: "Confirm" }
         end.to change { enqueued_jobs.size }.by(2)
         expect(response).to redirect_to edit_competition_path(competition)
-        expect(competition.reload.isConfirmed?).to eq true
+        expect(competition.reload.confirmed?).to eq true
       end
 
       it "cannot delete not confirmed, but visible competition" do
-        competition.update_attributes(isConfirmed: false, showAtAll: true)
+        competition.update_attributes(confirmed: false, showAtAll: true)
         # Attempt to delete competition. This should not work, because we only allow
         # deletion of (not confirmed and not visible) competitions.
         patch :update, params: { id: competition, competition: { name: competition.name }, commit: "Delete" }
@@ -533,7 +533,7 @@ RSpec.describe CompetitionsController do
       end
 
       it "cannot delete confirmed competition" do
-        competition.update_attributes(isConfirmed: true, showAtAll: false)
+        competition.update_attributes(confirmed: true, showAtAll: false)
         # Attempt to delete competition. This should not work, because we only let
         # delegates deleting unconfirmed competitions.
         patch :update, params: { id: competition, competition: { name: competition.name }, commit: "Delete" }
@@ -542,7 +542,7 @@ RSpec.describe CompetitionsController do
       end
 
       it "can delete not confirmed and not visible competition" do
-        competition.update_attributes(isConfirmed: false, showAtAll: false)
+        competition.update_attributes(confirmed: false, showAtAll: false)
         # Attempt to delete competition. This should work, because we allow
         # deletion of (not confirmed and not visible) competitions.
         patch :update, params: { id: competition, competition: { name: competition.name }, commit: "Delete" }
@@ -551,7 +551,7 @@ RSpec.describe CompetitionsController do
       end
 
       it "can change registration open/close of locked competition" do
-        competition.update_attribute(:isConfirmed, true)
+        competition.update_attribute(:confirmed, true)
 
         new_open = 1.week.from_now.change(sec: 0)
         new_close = 2.weeks.from_now.change(sec: 0)
@@ -583,7 +583,7 @@ RSpec.describe CompetitionsController do
       end
 
       it "cannot delete competition they are not delegating" do
-        competition.update_attributes(isConfirmed: false, showAtAll: true)
+        competition.update_attributes(confirmed: false, showAtAll: true)
         # Attempt to delete competition. This should not work, because we're
         # not the delegate for this competition.
         patch :update, params: { id: competition, competition: { name: competition.name }, commit: "Delete" }

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
     venueAddress { "My backyard street" }
     external_website { "https://www.worldcubeassociation.org" }
     showAtAll { false }
-    isConfirmed { false }
+    confirmed_at { nil }
 
     competitor_limit_enabled { false }
     guests_enabled { true }
@@ -95,7 +95,7 @@ FactoryBot.define do
 
     trait :confirmed do
       with_delegate
-      isConfirmed { true }
+      confirmed_at { Time.now }
     end
 
     trait :not_visible do

--- a/WcaOnRails/spec/features/competition_management_spec.rb
+++ b/WcaOnRails/spec/features/competition_management_spec.rb
@@ -143,7 +143,7 @@ RSpec.feature "Competition management" do
       expect(new_competition.delegates).to eq [delegate, cloned_delegate]
       expect(new_competition.venue).to eq competition_to_clone.venue
       expect(new_competition.showAtAll).to eq false
-      expect(new_competition.isConfirmed).to eq false
+      expect(new_competition.confirmed?).to eq false
       expect(new_competition.cityName).to eq 'Melbourne'
     end
 

--- a/WcaOnRails/spec/helpers/notifications_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/notifications_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NotificationsHelper do
 
       context "with some unconfirmed competitions" do
         let!(:unconfirmed_competition) { FactoryBot.create :competition, delegates: [delegate] }
-        let!(:confirmed_competition) { FactoryBot.create :competition, delegates: [delegate], isConfirmed: true }
+        let!(:confirmed_competition) { FactoryBot.create :competition, :confirmed, delegates: [delegate] }
 
         it "shows unconfirmed competitions" do
           notifications = helper.notifications_for_user(delegate)

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe Competition do
     let(:competition_with_delegate) { FactoryBot.build :competition, :with_delegate, generate_website: false }
     let(:competition_without_delegate) { FactoryBot.build :competition }
 
-    [:isConfirmed, :showAtAll].each do |action|
+    [:confirmed, :showAtAll].each do |action|
       it "can set #{action}" do
         competition_with_delegate.public_send "#{action}=", true
         expect(competition_with_delegate).to be_valid
@@ -509,6 +509,36 @@ RSpec.describe Competition do
         competition_without_delegate.public_send "#{action}=", true
         expect(competition_without_delegate).not_to be_valid
       end
+    end
+
+    it "sets confirmed_at when setting confirmed true" do
+      competition = FactoryBot.create :competition, :with_delegate
+      expect(competition.confirmed_at).to be_nil
+
+      now = Time.at(Time.now.to_i)
+      Timecop.freeze(now) do
+        competition.update!(confirmed: true)
+        expect(competition.reload.confirmed_at).to eq now
+      end
+    end
+
+    it "does not update confirmed_at when confirming already confirmed competition" do
+      competition = FactoryBot.create :competition, :confirmed
+
+      confirmed_at = competition.confirmed_at
+      expect(confirmed_at).not_to be_nil
+      Timecop.freeze(confirmed_at + 10) do
+        competition.update!(confirmed: true)
+        expect(competition.reload.confirmed_at).to eq confirmed_at
+      end
+    end
+
+    it "clears confirmed_at when setting confirmed false" do
+      competition = FactoryBot.create :competition, :confirmed
+
+      expect(competition.confirmed_at).not_to be_nil
+      competition.update!(confirmed: false)
+      expect(competition.reload.confirmed_at).to be_nil
     end
   end
 

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "API Competitions" do
         context "confirmed competition" do
           before :each do
             competition.events = [Event.find("333"), Event.find("222")]
-            competition.update!(isConfirmed: true)
+            competition.update!(confirmed: true)
           end
 
           it "can add events" do
@@ -77,7 +77,7 @@ RSpec.describe "API Competitions" do
 
         context "confirmed competition" do
           before :each do
-            competition.update!(isConfirmed: true)
+            competition.update!(confirmed: true)
           end
 
           it "allows adding rounds to an event" do

--- a/WcaOnRails/spec/requests/competitions_spec.rb
+++ b/WcaOnRails/spec/requests/competitions_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe "competitions" do
         follow_redirect!
         expect(response).to be_success
 
-        expect(competition.reload.isConfirmed?).to eq true
+        expect(competition.reload.confirmed?).to eq true
       end
 
       it 'can set championship types for an unconfirmed competition' do
-        expect(competition.isConfirmed).to be false
+        expect(competition.confirmed?).to be false
 
         patch competition_path(competition), params: {
           competition: {
@@ -38,7 +38,7 @@ RSpec.describe "competitions" do
       end
 
       it 'can set championship types for a confirmed competition' do
-        competition.update!(isConfirmed: true)
+        competition.update!(confirmed: true)
 
         patch competition_path(competition), params: {
           competition: {
@@ -60,7 +60,7 @@ RSpec.describe "competitions" do
       end
 
       it 'can set championship types for an unconfirmed competition' do
-        expect(competition.isConfirmed).to be false
+        expect(competition.confirmed?).to be false
 
         patch competition_path(competition), params: {
           competition: {
@@ -76,7 +76,7 @@ RSpec.describe "competitions" do
       end
 
       it 'cannot set championship types for a confirmed competition' do
-        competition.update!(isConfirmed: true)
+        competition.update!(confirmed: true)
 
         patch competition_path(competition), params: {
           competition: {


### PR DESCRIPTION
`confirmed_at` NULL means the competition is not confirmed.
`confirmed_at` not NULL means the competition is confirmed. When
migrating old, confirmed competitions, we set `confirmed_at` to
`announced_at` if `announced_at` is set, else we set `confirmed_at` to
`NOW()`.

The WQAC wants to handle incoming competition requests in the order they
were confirmed, and currently we don't have that information anywhere in
the database. This solves that problem. See
https://github.com/thewca/worldcubeassociation.org/issues/3321 for more
information.