### PR TITLE
Change `be_success` to `be_successful`.

### DIFF
--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "API Competitions" do
 
         it "updates the competition events of an unconfirmed competition" do
           patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333)).to_json, headers: headers
-          expect(response).to be_success
+          expect(response).to be_successful
           expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 1
         end
 
@@ -84,7 +84,7 @@ RSpec.describe "API Competitions" do
             competition_events = create_wcif_events(%w(222 333))
             expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 0
             patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
-            expect(response).to be_success
+            expect(response).to be_successful
             expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 1
           end
 
@@ -153,7 +153,7 @@ RSpec.describe "API Competitions" do
             },
           ]
           patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: { "CONTENT_TYPE" => "application/json" }
-          expect(response).to be_success
+          expect(response).to be_successful
           rounds = competition.reload.competition_events.find_by_event_id("333").rounds
           expect(rounds.length).to eq 1
           expect(rounds.first.scramble_set_count).to eq 2
@@ -212,7 +212,7 @@ RSpec.describe "API Competitions" do
           headers["ACCESS_TOKEN"] = nil
           competition_events = create_wcif_events(%w(333))
           patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end

--- a/WcaOnRails/spec/requests/api_persons_spec.rb
+++ b/WcaOnRails/spec/requests/api_persons_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "API Persons" do
 
     it "renders properly" do
       get api_v0_persons_path
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json.length).to eq 4
     end
@@ -18,7 +18,7 @@ RSpec.describe "API Persons" do
     it "renders a person with multiple sub ids once" do
       person.update_using_sub_id!(name: "#{person.name} II")
       get api_v0_persons_path
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json.length).to eq 4
     end
@@ -26,7 +26,7 @@ RSpec.describe "API Persons" do
     context "when a list of WCA IDs is given" do
       it "renders only people having one of these ids" do
         get api_v0_persons_path, params: { wca_ids: other_people.map(&:wca_id).join(',') }
-        expect(response).to be_success
+        expect(response).to be_successful
         json = JSON.parse(response.body)
         expect(json.length).to eq 3
         expect(json.map { |element| element["person"]["wca_id"] }).to match_array other_people.map(&:wca_id)
@@ -37,7 +37,7 @@ RSpec.describe "API Persons" do
   describe "GET #show" do
     it "renders properly" do
       get api_v0_person_path(person.wca_id)
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json["person"]["wca_id"]).to eq person.wca_id
       expect(json["person"]["name"]).to eq person.name
@@ -47,7 +47,7 @@ RSpec.describe "API Persons" do
       FactoryBot.create :ranks_single, personId: person.wca_id, eventId: "333", best: 450
       FactoryBot.create :ranks_average, personId: person.wca_id, eventId: "333", best: 590
       get api_v0_person_path(person.wca_id)
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json["personal_records"]["333"]["single"]["best"]).to eq 450
       expect(json["personal_records"]["333"]["average"]["best"]).to eq 590

--- a/WcaOnRails/spec/requests/competitions_spec.rb
+++ b/WcaOnRails/spec/requests/competitions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "competitions" do
           'commit' => 'Confirm',
         }
         follow_redirect!
-        expect(response).to be_success
+        expect(response).to be_successful
 
         expect(competition.reload.isConfirmed?).to eq true
       end
@@ -33,7 +33,7 @@ RSpec.describe "competitions" do
           },
         }
         follow_redirect!
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(competition.reload.championships.count).to eq 2
       end
 
@@ -49,7 +49,7 @@ RSpec.describe "competitions" do
           },
         }
         follow_redirect!
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(competition.reload.championships.count).to eq 2
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe "competitions" do
           },
         }
         follow_redirect!
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(competition.reload.championships.count).to eq 2
       end
 
@@ -87,7 +87,7 @@ RSpec.describe "competitions" do
           },
         }
         follow_redirect!
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(competition.reload.championships.count).to eq 0
       end
     end

--- a/WcaOnRails/spec/requests/http_accept_spec.rb
+++ b/WcaOnRails/spec/requests/http_accept_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe "HTTP_ACCEPT" do
 
   it 'handles malformed HTTP_ACCEPT' do
     get root_url, params: { "HTTP_ACCEPT" => "*/*;" }
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it 'rss' do
     get rss_url, params: { "HTTP_ACCEPT" => "text/plain" }
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 end

--- a/WcaOnRails/spec/requests/incidents_spec.rb
+++ b/WcaOnRails/spec/requests/incidents_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Incidents management", type: :request do
       sign_in { FactoryBot.create(:user) }
       it "shows a resolved incident" do
         get incident_path(incident)
-        expect(response).to be_success
+        expect(response).to be_successful
       end
       it "does not show a pending incident" do
         get incident_path(pending_incident)
@@ -43,7 +43,7 @@ RSpec.describe "Incidents management", type: :request do
       sign_in { FactoryBot.create(:delegate) }
       it "shows a pending incident" do
         get incident_path(pending_incident)
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe "Incidents management", type: :request do
       sign_in { FactoryBot.create(:user, :wdc_member) }
       it "shows a pending incident" do
         get incident_path(pending_incident)
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe "Incidents management", type: :request do
       sign_in { FactoryBot.create(:user, :wqac_member) }
       it "shows a pending incident" do
         get incident_path(pending_incident)
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe "Incidents management", type: :request do
       end
       it "shows the incident creation form" do
         get new_incident_path
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -107,7 +107,7 @@ RSpec.describe "Incidents management", type: :request do
       end
       it "renders the edit page" do
         get edit_incident_path(incident)
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -143,7 +143,7 @@ RSpec.describe "Incidents management", type: :request do
         expect {
           post incidents_path, params: { incident: invalid_attributes }
         }.to change(Incident, :count).by(0)
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -187,7 +187,7 @@ RSpec.describe "Incidents management", type: :request do
         summary = incident.public_summary
         put incident_path(incident), params: { incident: invalid_attributes }
         incident.reload
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(incident.public_summary).to eq summary
       end
     end

--- a/WcaOnRails/spec/requests/media_spec.rb
+++ b/WcaOnRails/spec/requests/media_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "media" do
   describe 'GET #new' do
     it_should_behave_like 'must sign in',
                           lambda { get new_medium_path },
-                          lambda { |current_user| expect(response).to be_success }
+                          lambda { |current_user| expect(response).to be_successful }
   end
 
   describe 'POST #create' do
@@ -142,7 +142,7 @@ RSpec.describe "media" do
   describe 'GET #validate' do
     it_should_behave_like 'only WCT',
                           lambda { get validate_media_path },
-                          lambda { expect(response).to be_success }
+                          lambda { expect(response).to be_successful }
 
     context "signed in as WCT member" do
       before :each do
@@ -167,7 +167,7 @@ RSpec.describe "media" do
   describe "GET #edit" do
     it_should_behave_like 'only WCT',
                           lambda { get edit_medium_path(medium) },
-                          lambda { expect(response).to be_success }
+                          lambda { expect(response).to be_successful }
   end
 
   describe "PATCH #update" do

--- a/WcaOnRails/spec/requests/oauth/oauth_spec.rb
+++ b/WcaOnRails/spec/requests/oauth/oauth_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "oauth api" do
 
   it 'can authenticate with grant_type password' do
     post oauth_token_path, params: { grant_type: "password", username: user.email, password: user.password, scope: "public email" }
-    expect(response).to be_success
+    expect(response).to be_successful
     json = JSON.parse(response.body)
     expect(json['error']).to eq(nil)
     access_token = json['access_token']
@@ -57,7 +57,7 @@ RSpec.describe "oauth api" do
       # We've now received an authorization_code from the user, lets request an
       # access_token.
       post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: oauth_authorization_url }
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json['error']).to eq(nil)
       access_token = json['access_token']
@@ -104,7 +104,7 @@ RSpec.describe "oauth api" do
       # We've now received an authorization_code from the user, lets request an
       # access_token.
       post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: oauth_authorization_url }
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json['error']).to eq(nil)
       access_token = json['access_token']
@@ -116,7 +116,7 @@ RSpec.describe "oauth api" do
       # Since we now have a refresh token, we should be able to get a new access
       # token.
       post oauth_token_path, params: { grant_type: "refresh_token", client_id: oauth_app.uid, client_secret: oauth_app.secret, redirect_uri: oauth_authorization_url, refresh_token: refresh_token }
-      expect(response).to be_success
+      expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json['error']).to eq(nil)
       access_token = json['access_token']
@@ -152,7 +152,7 @@ RSpec.describe "oauth api" do
         # We've now received an authorization_code from the user, lets request an
         # access_token.
         post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: different_redirect_uri }
-        expect(response).to be_success
+        expect(response).to be_successful
         json = JSON.parse(response.body)
         expect(json['error']).to eq(nil)
         access_token = json['access_token']
@@ -188,7 +188,7 @@ RSpec.describe "oauth api" do
   def verify_access_token(access_token)
     integration_session.reset! # posting to oauth_token_path littered our state
     get api_v0_me_path, headers: { "Authorization" => "Bearer #{access_token}" }
-    expect(response).to be_success
+    expect(response).to be_successful
     json = JSON.parse(response.body)
     # We just do a sanity check of the /me route here. There is a more
     # complete test in api_controller_spec.

--- a/WcaOnRails/spec/requests/persons_spec.rb
+++ b/WcaOnRails/spec/requests/persons_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "persons" do
 
     it 'renders without error' do
       get person_path(person.wca_id)
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 end

--- a/WcaOnRails/spec/requests/regulations_spec.rb
+++ b/WcaOnRails/spec/requests/regulations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "regulations" do
         expect(response).to redirect_to '/regulations/scrambles/'
 
         follow_redirect!
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe "regulations" do
         expect(response).to redirect_to '/regulations/scrambles/?foo=3'
 
         follow_redirect!
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end

--- a/WcaOnRails/spec/requests/relations_spec.rb
+++ b/WcaOnRails/spec/requests/relations_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "relations" do
         wca_id1: person1.wca_id,
         wca_id2: person2.wca_id,
       }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(flash.now[:danger]).to be_nil
     end
   end

--- a/WcaOnRails/spec/requests/users_spec.rb
+++ b/WcaOnRails/spec/requests/users_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "users" do
       'user[password_confirmation]' => user.password,
     }
     follow_redirect!
-    expect(response).to be_success
+    expect(response).to be_successful
 
     post user_confirmation_path, params: { 'user[email]' => user.email }
     follow_redirect!
-    expect(response).to be_success
+    expect(response).to be_successful
     expect(response.body).to include(I18n.t('devise.confirmations.send_instructions'))
   end
 
@@ -29,14 +29,14 @@ RSpec.describe "users" do
     # sign in
     post user_session_path, params: { 'user[login]' => user.email, 'user[password]' => user.password }
     follow_redirect!
-    expect(response).to be_success
+    expect(response).to be_successful
     get profile_edit_path
-    expect(response).to be_success
+    expect(response).to be_successful
 
     new_password = 'new_password'
     put user_path(user), params: { 'user[email]' => user.email, 'user[password]' => new_password, 'user[password_confirmation]' => new_password, 'user[current_password]' => user.password }
     follow_redirect!
-    expect(response).to be_success
+    expect(response).to be_successful
 
     # sign out
     delete destroy_user_session_path
@@ -47,7 +47,7 @@ RSpec.describe "users" do
     post user_session_path, params: { 'user[login]' => user.email, 'user[password]' => new_password }
     follow_redirect!
     get profile_edit_path
-    expect(response).to be_success
+    expect(response).to be_successful
   end
 
   it 'sign in shows conversion message for competitors missing accounts' do
@@ -55,7 +55,7 @@ RSpec.describe "users" do
 
     # attempt to sign in
     post user_session_path, params: { 'user[login]' => person.wca_id, 'user[password]' => "a password" }
-    expect(response).to be_success
+    expect(response).to be_successful
     expect(response.body).to include "It looks like you have not created a WCA website account yet"
   end
 
@@ -64,7 +64,7 @@ RSpec.describe "users" do
 
     # attempt to reset password
     post user_password_path, params: { 'user[login]' => person.wca_id, 'user[password]' => "a password" }
-    expect(response).to be_success
+    expect(response).to be_successful
     expect(response.body).to include "It looks like you have not created a WCA website account yet"
   end
 end


### PR DESCRIPTION
This addresses a deprecation warning for Rails 6. See
https://github.com/rspec/rspec-rails/issues/1857 and
https://www.neontsunami.com/posts/rails-success-predicate-deprecation.