### PR TITLE
Address deprecation warning about `uglify` option being removed.

### DIFF
--- a/WcaOnRails/.babelrc
+++ b/WcaOnRails/.babelrc
@@ -5,10 +5,10 @@
       {
         "modules": false,
         "targets": {
-          "browsers": "> 1%",
-          "uglify": true
+          "browsers": "> 1%"
         },
-        "useBuiltIns": "entry"
+        "useBuiltIns": "entry",
+        "forceAllTransforms": true
       }
     ],
     "@babel/preset-react"


### PR DESCRIPTION
See https://babeljs.io/docs/en/babel-preset-env#forcealltransforms.