### PR TITLE
Missing `isConfirmed?` -> `confirmed?`

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -622,7 +622,7 @@ class Competition < ApplicationRecord
   end
 
   def registration_period_required?
-    use_wca_registration? || (isConfirmed? && created_at.present? && created_at > Date.new(2018, 9, 13))
+    use_wca_registration? || (confirmed? && created_at.present? && created_at > Date.new(2018, 9, 13))
   end
 
   def pending_results_or_report(days)


### PR DESCRIPTION
Our tests would have caught this, but we don't require re-running tests
when rebasing (in this case,
https://github.com/thewca/worldcubeassociation.org/pull/3386 got merged
up and then https://github.com/thewca/worldcubeassociation.org/pull/3382
got rebased on top of it without running tests). This sort of thing
happens infrequently enough that I'm ok with not changing our policy yet.

I'm going to merge this up immediately, as it fixes a bug on the website.