### PR TITLE
Fixes time_format in some locales

### DIFF
--- a/WcaOnRails/config/locales/da.yml
+++ b/WcaOnRails/config/locales/da.yml
@@ -243,7 +243,7 @@ da:
     #original_hash: 52249b5
     datetime_placeholder: 'ÅÅÅÅ-MM-DD TT:MM'
     #original_hash: 7136e3b
-    time_format: 12 timers ur
+    time_format: 12h
   oauth:
     applications:
       #original_hash: 0c4ea38

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -174,7 +174,7 @@ en:
     delete: Delete
     date_placeholder: "YYYY-MM-DD"
     datetime_placeholder: "YYYY-MM-DD HH:MM"
-    #context: the time format in the schedule table. Please use "12h" for am/pm time, or "24h" for 24 hours time.
+    #context: the time format in the schedule table. Please set this to *exactly* "12h" to use am/pm time, or "24h" for 24 hours time (do not translate the 'h' or anything).
     time_format: "12h"
   #context: Key used in the OAuth part of the site (checkout the /oauth/applications page for more details)
   oauth:

--- a/WcaOnRails/config/locales/ja.yml
+++ b/WcaOnRails/config/locales/ja.yml
@@ -238,7 +238,7 @@ ja:
     #original_hash: 52249b5
     datetime_placeholder: YYYY-MM-DD HH-MM (西暦-月-日 時-分)
     #original_hash: 7136e3b
-    time_format: 12時間制
+    time_format: 12h
   oauth:
     applications:
       #original_hash: 0c4ea38

--- a/WcaOnRails/config/locales/ko.yml
+++ b/WcaOnRails/config/locales/ko.yml
@@ -238,7 +238,7 @@ ko:
     #original_hash: 52249b5
     datetime_placeholder: '년-월-일 시간 (YYYY-MM-DD HH:MM)'
     #original_hash: 7136e3b
-    time_format: 12기준
+    time_format: 12h
   oauth:
     applications:
       #original_hash: 0c4ea38


### PR DESCRIPTION
"time_format" is supposed to be exactly "12h" or "24h", this fixes some
inconsistencies in existing locales.

I've also clarified the "context" message we display within internationalize.
(I'll merge this when tests pass as it is trivial)