### PR TITLE
enable strikethrough in redcarpet

### DIFF
--- a/WcaOnRails/app/helpers/markdown_helper.rb
+++ b/WcaOnRails/app/helpers/markdown_helper.rb
@@ -60,6 +60,7 @@ module MarkdownHelper
     extensions = {
       tables: true,
       autolink: true,
+      strikethrough: true,
     }
 
     if target_blank


### PR DESCRIPTION
In SimpleMDE it is enabled by default, so in the editor users can see the text being strikethrough-ed, but our render library on the ruby side (Redcarpet) needs to have it enabled.

I've enabled it for consistencies.

(again it's a trivial fix, so merging it asap)

Thanks @SimoneCantarelli for the report.