### PR TITLE
Speed up users search

### DIFF
--- a/WcaOnRails/app/assets/javascripts/users.js
+++ b/WcaOnRails/app/assets/javascripts/users.js
@@ -62,6 +62,7 @@ onPage('users#edit, users#update', function() {
 var usersTableAjax = {
   queryParams: function(params) {
     return $.extend(params || {}, {
+      region: $('#region').val(),
       search: $('#search').val(),
     });
   },
@@ -99,6 +100,7 @@ onPage('users#index', function() {
     $table.bootstrapTable('refresh');
   }
 
+  $('#region').on('change', reloadUsers);
   $('#search').on('input', _.debounce(reloadUsers, TEXT_INPUT_DEBOUNCE_MS));
 
   $table.on('load-success.bs.table', function(e, data) {

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -18,27 +18,25 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html {}
       format.json do
-        @users = User.joins("INNER JOIN Countries ON iso2 = country_iso2")
+        @users = User.in_region(params[:region])
         params[:search]&.split&.each do |part|
-          like_query = %w(users.name wca_id email Countries.name).map do |column|
+          like_query = %w(users.name wca_id email).map do |column|
             column + " LIKE :part"
           end.join(" OR ")
           @users = @users.where(like_query, part: "%#{part}%")
         end
-        if params[:sort] == "country"
-          @users = @users.order("Countries.name #{params[:order]}")
-        elsif params[:sort]
+        params[:sort] = params[:sort] == "country" ? :country_iso2 : params[:sort]
+        if params[:sort]
           @users = @users.order(params[:sort] => params[:order])
         end
-        users_array = @users.to_a
-        selected_rows = users_array[params[:offset].to_i, params[:limit].to_i] || []
         render json: {
-          total: users_array.size,
-          rows: selected_rows.map do |user|
+          total: @users.size,
+          rows: @users.limit(params[:limit]).offset(params[:offset]).map do |user|
             {
               wca_id: user.wca_id ? view_context.link_to(user.wca_id, person_path(user.wca_id)) : "",
               name: ERB::Util.html_escape(user.name),
-              country: user.country.id,
+              # Users don't have to provide a country upon registration
+              country: user.country&.id,
               email: ERB::Util.html_escape(user.email),
               edit: view_context.link_to("Edit", edit_user_path(user)),
             }

--- a/WcaOnRails/app/models/continent.rb
+++ b/WcaOnRails/app/models/continent.rb
@@ -13,4 +13,8 @@ class Continent < ApplicationRecord
   def self.country_ids(continent_id)
     c_all_by_id[continent_id]&.countries&.map(&:id)
   end
+
+  def self.country_iso2s(continent_id)
+    c_all_by_id[continent_id]&.countries&.map(&:iso2)
+  end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -24,6 +24,12 @@ class User < ApplicationRecord
 
   scope :confirmed_email, -> { where.not(confirmed_at: nil) }
 
+  scope :in_region, lambda { |region_id|
+    unless region_id.blank? || region_id == 'all'
+      where(country_iso2: (Continent.country_iso2s(region_id) || Country.c_find(region_id)&.iso2))
+    end
+  }
+
   def self.eligible_voters
     team_leaders = TeamMember.current.where(team_leader: true).map(&:user)
     eligible_delegates = User.where(delegate_status: %w(delegate senior_delegate))

--- a/WcaOnRails/app/views/users/index.html.erb
+++ b/WcaOnRails/app/views/users/index.html.erb
@@ -4,11 +4,14 @@
   <h2><%= yield(:title) %></h2>
 
   <div id="users-query-fields" class="form-inline bs-table-query-fields">
+    <div class="form-group">
+      <%= select_tag(:region, region_option_tags(selected_id: params[:region], real_only: true), class: "form-control") %>
+    </div>
     <div id="search-box" class="form-group">
       <div class="input-group">
         <%= content_tag :span, icon("search"), class: "input-group-addon",
                                data: { toggle: "tooltip", placement: "top" },
-                               title: "Type name, WCA ID, email, or country. Use a space to separate them." %>
+                               title: "Type name, WCA ID, or email. Use a space to separate them." %>
         <%= text_field_tag :search, params[:search], class: "form-control" %>
       </div>
     </div>


### PR DESCRIPTION
Fixes #956.

Turns out there were two performance drainers there:
  - the expensive inner join to search countries
  - @jfly's comment [there](https://github.com/thewca/worldcubeassociation.org/pull/3133#discussion_r206716029) was very true on the default page (where we select all users, then limit+offset)

I fixed the first point by using the same region filter we use for the persons search, and since the query becomes much more cheaper it's also just fine to issue the count!

The only "tricky" part was that the `Person` table has a `countryId` field, whereas `User` has a `country_iso2`.

The time to render the page is now equivalent to the persons index, and I don't even think we need a fulltext index on the `name` column.