### PR TITLE
Create a `registration_full?` helper.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -236,6 +236,10 @@ class Competition < ApplicationRecord
     self.confirmed? || self.showAtAll
   end
 
+  def registration_full?
+    self.competitor_limit_enabled? && self.registrations.accepted.count >= self.competitor_limit
+  end
+
   def country
     Country.c_find(self.countryId)
   end

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -57,7 +57,7 @@
           </ul>
         <% end %>
       <% else %>
-        <% if @competition.competitor_limit_enabled? && @competition.registrations.accepted.count >= @competition.competitor_limit %>
+        <% if @competition.registration_full? %>
           <%= alert :warning, t('registrations.registration_full', competitor_limit: @competition.competitor_limit) %>
         <% end %>
         <p>

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -780,4 +780,26 @@ RSpec.describe Competition do
       expect(competition.serializable_hash[:country_iso2]).to be_nil
     end
   end
+
+  describe "#registration_full?" do
+    let(:competition) {
+      FactoryBot.create :competition,
+                        :registration_open,
+                        competitor_limit_enabled: true,
+                        competitor_limit: 10,
+                        competitor_limit_reason: "Dude, this is my closet"
+    }
+
+    it "detects full competition" do
+      expect(competition.registration_full?).to be false
+
+      # Add 9 accepted registrations. The list should not yet be full.
+      FactoryBot.create_list :registration, 9, :accepted, competition: competition
+      expect(competition.registration_full?).to be false
+
+      # Add a 10th registration, which will fill up the registration list.
+      FactoryBot.create :registration, :accepted, competition: competition
+      expect(competition.registration_full?).to be true
+    end
+  end
 end


### PR DESCRIPTION
I created this to start working on
https://github.com/thewca/worldcubeassociation.org/issues/1692, but then
decided to stop working on it (see
https://github.com/thewca/worldcubeassociation.org/issues/1692#issuecomment-431607210).