### PR TITLE
Add max width and height on images in delegate reports.

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/email.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/email.css.scss
@@ -1,3 +1,5 @@
+@import "delegate_reports";
+
 h2.alert {
   color: red;
 }


### PR DESCRIPTION
I have only tested this with our mailer previewer, although I hope it will work in real email clients.

# Before

![image](https://user-images.githubusercontent.com/277474/47259393-e727ea80-d45d-11e8-89a2-1d531773a0c5.png)

# After

![image](https://user-images.githubusercontent.com/277474/47259394-ee4ef880-d45d-11e8-9097-d7c65bdd20ca.png)
