### PR TITLE
Add /wdc page

### DIFF
--- a/WcaOnRails/app/controllers/wdc_controller.rb
+++ b/WcaOnRails/app/controllers/wdc_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class WdcController < ApplicationController
+  def root
+    @posts = Post.joins(:post_tags).where('post_tags.tag = ?', "wdc")
+    @posts = @posts.order(sticky: :desc, created_at: :desc).includes(:author).page(params[:page])
+  end
+end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -551,7 +551,13 @@ class User < ApplicationRecord
 
   # Returns true if the user can edit the given team.
   def can_edit_team?(team)
-    can_manage_teams? || team_leader?(team)
+    (
+      can_manage_teams? ||
+      team_leader?(team) ||
+
+      # The leader of the WDC can edit the banned competitors list
+      (team == Team.banned && team_leader?(Team.wdc))
+    )
   end
 
   def can_create_competitions?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -551,13 +551,15 @@ class User < ApplicationRecord
 
   # Returns true if the user can edit the given team.
   def can_edit_team?(team)
-    (
-      can_manage_teams? ||
+    can_manage_teams? ||
       team_leader?(team) ||
 
       # The leader of the WDC can edit the banned competitors list
       (team == Team.banned && team_leader?(Team.wdc))
-    )
+  end
+
+  def can_view_banned_competitors?
+    admin? || staff?
   end
 
   def can_create_competitions?

--- a/WcaOnRails/app/views/wdc/root.html.erb
+++ b/WcaOnRails/app/views/wdc/root.html.erb
@@ -1,0 +1,27 @@
+<% provide(:title, 'Disciplinary Committee') %>
+
+<div class="container">
+  <h1><%= yield(:title) %></h1>
+
+  <% if current_user&.can_view_banned_competitors? %>
+    <h2>Banned competitors</h2>
+
+    <% if current_user.can_edit_team?(Team.banned) %>
+      <%= link_to "Edit banned competitors", edit_team_path(Team.banned) %>
+    <% end %>
+
+    <%= alert :info, "This list is not publicly visible." %>
+    <ul>
+      <% Team.banned.current_members.includes(:user).order("users.name asc").map do |team_member| %>
+        <li>
+          <%= team_member.user.name %>
+          <%= link_to team_member.user.wca_id, person_path(team_member.user.wca_id) if team_member.user.wca_id %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <h2>Posts</h2>
+  <%= render @posts, render_permalink: true, render_teaser: true, render_toc: false %>
+  <%= paginate @posts %>
+</div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -126,6 +126,8 @@ Rails.application.routes.draw do
   get 'organizer-guidelines' => 'static_pages#organizer_guidelines'
   get 'tutorial' => redirect('/files/WCA_Competition_Tutorial.pdf', status: 302)
 
+  get 'disciplinary' => 'wdc#root'
+
   get 'contact/website' => 'contacts#website'
   post 'contact/website' => 'contacts#website_create'
   get 'contact/dob' => 'contacts#dob'

--- a/WcaOnRails/spec/requests/wdc_spec.rb
+++ b/WcaOnRails/spec/requests/wdc_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+def assert_can_see(**kwargs)
+  banned, edit_banned, posts = kwargs.values_at(:banned, :edit_banned, :posts)
+  description = kwargs.map do |item, can_see|
+    "#{(can_see ? "can" : "cannot")} see #{item}"
+  end.join(", ")
+
+  it description do
+    get disciplinary_path
+    expect(response).to be_successful
+
+    if banned
+      expect(response.body).to include "Banned"
+    else
+      expect(response.body).not_to include "Banned"
+    end
+
+    if posts
+      expect(response.body).to include "Posts"
+    else
+      expect(response.body).not_to include "Posts"
+    end
+
+    if edit_banned
+      expect(response.body).to include "Edit banned competitors"
+    else
+      expect(response.body).not_to include "Edit banned competitors"
+    end
+  end
+end
+
+RSpec.describe "wdc" do
+  describe "GET /disciplinary" do
+    context "when not signed in" do
+      sign_out
+
+      assert_can_see(
+        banned: false,
+        posts: true,
+      )
+    end
+
+    context "when signed in as regular user" do
+      sign_in { FactoryBot.create :user }
+
+      assert_can_see(
+        banned: false,
+        posts: true,
+      )
+    end
+
+    context "when signed in as a delegate" do
+      sign_in { FactoryBot.create :delegate }
+
+      assert_can_see(
+        banned: true,
+        posts: true,
+      )
+    end
+
+    context "when signed in as wdc member" do
+      sign_in { FactoryBot.create :user, :wdc_member }
+
+      assert_can_see(
+        banned: true,
+        posts: true,
+      )
+    end
+
+    context "when signed in as wdc leader" do
+      sign_in { FactoryBot.create :user, :wdc_leader }
+
+      assert_can_see(
+        banned: true,
+        edit_banned: true,
+        posts: true,
+      )
+    end
+
+    context "posts" do
+      it "shows wdc posts, but not non-wdc posts" do
+        FactoryBot.create :post, body: "This is an important WDC announcement", tags: 'wdc'
+        FactoryBot.create :post, body: "Foobar"
+
+        get disciplinary_path
+        expect(response).to be_successful
+        expect(response.body).to include "This is an important WDC announcement"
+        expect(response.body).not_to include "Foobar"
+      end
+    end
+
+    context "banned competitors" do
+      sign_in { FactoryBot.create :delegate }
+
+      it "shows banned competitors" do
+        FactoryBot.create :user, :banned, name: "Joe Cheater"
+
+        get disciplinary_path
+        expect(response).to be_successful
+        expect(response.body).to include "Joe Cheater"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes https://github.com/thewca/worldcubeassociation.org/issues/3052.

There are a few commits in this PR, I highly recommend reading them separately.

@jonatanklosko, could you take a look at the commits I did regarding hidden teams? There were some issues with the scoping you added.

Here's what the new page looks like for the leader of the WDC:

![image](https://user-images.githubusercontent.com/277474/47260765-63c6c300-d476-11e8-8e3a-90fc9983da35.png)