### PR TITLE
Add Board panel and pending WCA ID claims to Senior panel

### DIFF
--- a/WcaOnRails/app/controllers/delegates_panel_controller.rb
+++ b/WcaOnRails/app/controllers/delegates_panel_controller.rb
@@ -4,6 +4,8 @@ class DelegatesPanelController < ApplicationController
   before_action :authenticate_user!
   before_action -> { redirect_to_root_unless_user(:can_view_crash_course?) }
   before_action -> { redirect_to_root_unless_user(:can_update_crash_course?) }, only: [:edit_crash_course, :update_crash_course]
+  before_action -> { redirect_to_root_unless_user(:can_view_senior_delegate_material?) }, only: [:pending_claims_for_subordinate_delegates]
+  before_action -> { redirect_to_root_unless_user(:board_member?) }, only: [:seniors]
 
   def index
   end
@@ -26,6 +28,16 @@ class DelegatesPanelController < ApplicationController
     else
       render 'edit'
     end
+  end
+
+  def pending_claims_for_subordinate_delegates
+    # Show pending claims for a given user, or the current user, if they can see them
+    @user = User.includes(subordinate_delegates: [:users_claiming_wca_id]).find_by_id(params[:user_id] || current_user.id)
+  end
+
+  def seniors
+    # Show the list of seniors and actions available
+    @seniors = User.where(delegate_status: "senior_delegate").order(:name)
   end
 
   private def editable_post_fields

--- a/WcaOnRails/app/views/delegates_panel/index.html.erb
+++ b/WcaOnRails/app/views/delegates_panel/index.html.erb
@@ -18,6 +18,23 @@
   <% if current_user&.can_view_senior_delegate_material? %>
     <h1>Senior Delegates panel</h2>
 
-    <%= link_to "Senior Delegate forms", "https://docs.google.com/document/d/12oyMQTC6hBhiil8CFvYuIT-iZfLO48urap4yq0w4xkg/" %>
+    <ul>
+      <li>
+        <%= link_to "Senior Delegate forms", "https://docs.google.com/document/d/12oyMQTC6hBhiil8CFvYuIT-iZfLO48urap4yq0w4xkg/" %>
+      </li>
+      <li>
+        <%= link_to "Pending claims for your subordinate Delegates", pending_claims_path %>
+      </li>
+    </ul>
+  <% end %>
+
+  <% if current_user&.board_member? %>
+    <h1>Board panel</h2>
+
+    <ul>
+      <li>
+        <%= link_to "List of Senior Delegates", delegate_seniors_path %>
+      </li>
+    </ul>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/delegates_panel/pending_claims_for_subordinate_delegates.html.erb
+++ b/WcaOnRails/app/views/delegates_panel/pending_claims_for_subordinate_delegates.html.erb
@@ -1,0 +1,33 @@
+<% provide(:title, 'Pending claims for subordinate Delegates') %>
+
+<div class="container">
+  <h2>Pending WCA ID claims for Delegates managed by <%= @user.name %></h2>
+
+  <% if @user.subordinate_delegates.empty? %>
+    <div class="well">No subordinate Delegates to display</div>
+  <% else %>
+    <div class="panel-group">
+      <% @user.subordinate_delegates.sort_by { |u| u.users_claiming_wca_id.size }.reverse_each do |delegate| %>
+        <div class="panel panel-default">
+          <div class="panel-heading heading-as-link" data-toggle="collapse" data-target="#panel-<%= delegate.id %>">
+            <%= delegate.name %>
+            <span class="badge"><%= delegate.users_claiming_wca_id.size %></span>
+          </div>
+          <div id="panel-<%= delegate.id %>" class="collapse panel-collapse">
+            <ul class="list-group">
+              <% if delegate.users_claiming_wca_id.empty? %>
+                <li class="list-group-item">No pending claims.</li>
+              <% else %>
+                <% delegate.users_claiming_wca_id.each do |u| %>
+                  <%= link_to(edit_user_path(u.id, anchor: "wca_id"), class: "list-group-item") do %>
+                    <%= u.name %> has claimed WCA ID <%= u.unconfirmed_wca_id %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/WcaOnRails/app/views/delegates_panel/seniors.html.erb
+++ b/WcaOnRails/app/views/delegates_panel/seniors.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, 'List of Senior Delegates') %>
+
+<div class="container">
+  <h2>List of Senior Delegates</h2>
+  <p>Below is the list of all Senior Delegates and the actions available for them:</p>
+  <% @seniors.each do |s| %>
+    <h4><%= s.name %></h4>
+    <ul>
+      <li><%= link_to("List of subordinate pending WCA ID claims", pending_claims_path(s.id)) %></li>
+    </ul>
+  <% end %>
+</div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -89,6 +89,8 @@ Rails.application.routes.draw do
   get 'delegate/crash-course' => 'delegates_panel#crash_course'
   get 'delegate/crash-course/edit' => 'delegates_panel#edit_crash_course'
   patch 'delegate/crash-course' => 'delegates_panel#update_crash_course'
+  get 'delegate/pending-claims(/:user_id)' => 'delegates_panel#pending_claims_for_subordinate_delegates', as: 'pending_claims'
+  get 'delegate/seniors' => 'delegates_panel#seniors'
   resources :notifications, only: [:index]
 
   root 'posts#index'


### PR DESCRIPTION
Step towards #728.

Kind of an alternative suggestion to #3227, as we need more than just notifications.
It does not implement anything on the users search though!

This introduces:
  - a separate page (linked by the Senior Delegate panel) which list all subordinate Delegates of a given user, and their pending WCA ID claims.
  - a "Board panel" to list all the Senior Delegates and easily access their list of subordinate Delegates and their pending WCA ID claims (this was suggested to me by @AlbertoPdRF).

Some screenshots:

the "pending WCA ID claims" page:
![pending-claims-list](https://user-images.githubusercontent.com/1007485/47294506-8ccd8c00-d60d-11e8-8529-8d5b6c2daa39.png)

the "Board panel":
![board-panel](https://user-images.githubusercontent.com/1007485/47294513-9820b780-d60d-11e8-9315-0ede4a09eea3.png)

the "Senior Delegates" list:
![seniors-list](https://user-images.githubusercontent.com/1007485/47294525-9f47c580-d60d-11e8-951c-08927c140050.png)

@Laura-O, @TimMcMahon, @cubewhiz, @KitClement, @Baiqiang please let me know if you have a better idea for displaying the outstanding WCA ID claims!