### PR TITLE
Update to our flag-icon-css fork

### DIFF
--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -23,7 +23,7 @@
     "css-loader": "^1.0.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^2.0.0",
-    "flag-icon-css": "^3.2.0",
+    "flag-icon-css": "viroulep/flag-icon-css#3.2.1-xk",
     "glob": "^7.1.3",
     "js-yaml": "^3.12.0",
     "node-sass": "^4.9.3",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -3699,10 +3699,9 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-flag-icon-css@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/flag-icon-css/-/flag-icon-css-3.2.0.tgz#a9898b92078505ce5249fe8bba071518d6ae7880"
-  integrity sha512-XwbQgswfJ19jVrYL92+MKK3HJfIG+6lC8oifaG6mOtahWaXHbDFXQ7UVbw1+I+zidM1azOD8aFC0DO+xZzK0Xg==
+flag-icon-css@viroulep/flag-icon-css#3.2.1-xk:
+  version "3.2.1"
+  resolved "https://codeload.github.com/viroulep/flag-icon-css/tar.gz/9b5f113466e9597b5b2fe8e4bc5d8414789c5175"
 
 flatten@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
The maintainer of `flag-icon-css` won't add user-assigned ISO country codes, so I forked the repository, added lipis/flag-icon-css#256 (the Kosovo flag), and rebuilt the css-s.

I've done this against the latest `flag-icon-css` (3.2.1), and will try to keep it up to date if new releases occur (I've created a tag `3.2.1-xk`).