### PR TITLE
Use an alias to have includes on delegate reports

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -425,9 +425,12 @@ class Competition < ApplicationRecord
     CompetitionDelegate.where(competition_id: id).where.not(delegate_id: delegates.map(&:id)).delete_all
   end
 
+  # We setup an alias here to be able to take advantage of `includes(:delegate_report)` on a competition,
+  # while still being able to use the 'with_old_id' trick.
+  alias_method :original_delegate_report, :delegate_report
   def delegate_report
     with_old_id do
-      DelegateReport.find_by_competition_id(id)
+      original_delegate_report
     end
   end
 


### PR DESCRIPTION
Currently taking advantage of `Competition.includes(:delegate_report)` is impossible because we enforce a `DelegateReport.find...` in a `delegate_report` method.
A workaround for this is to setup an alias to the original `delegate_report` method, and use it in our `with_old_id` wrapper.

It still works fine when changing competitions ids, and that fixes a n+1 query we have on the "admin" view of the competitions page.
Excerpt from the request before:
```
Processing by CompetitionsController#index as JS
  Parameters: {"utf8"=>"✓", "region"=>"all", "search"=>"", "state"=>"present", "year"=>"all years", "from_date"=>"", "to_date"=>"", "delegate"=>"", "display"=>"admin"}
   (0.6ms)  SELECT `Competitions`.`year` FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE
  Rendering competitions/index.js.erb
  TeamMember Load (0.3ms)  SELECT `team_members`.* FROM `team_members` WHERE `team_members`.`user_id` = 277 AND (end_date IS NULL OR end_date > '2018-10-24')
  Competition Exists (0.2ms)  SELECT  1 AS one FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24') LIMIT 1
  CACHE Competition Exists (0.0ms)  SELECT  1 AS one FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24') LIMIT 1
   (0.2ms)  SELECT COUNT(*) FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24')
  Competition Load (0.2ms)  SELECT `Competitions`.* FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24') ORDER BY `Competitions`.`start_date` ASC, `Competitions`.`end_date` ASC
  Country Load (0.3ms)  SELECT `Countries`.* FROM `Countries` WHERE `Countries`.`id` IN ('United Kingdom', 'Poland', 'Brazil', 'USA', 'Germany', 'Belgium', 'Sweden', 'Italy', 'Philippines', 'France', 'Peru', 'Russia', 'Netherlands', 'Denmark', 'Luxembourg', 'India')
  CompetitionDelegate Load (0.2ms)  SELECT `competition_delegates`.* FROM `competition_delegates` WHERE `competition_delegates`.`competition_id` IN ('UKC2018', 'PolishChampionship2018', 'Itapeva2018', 'AZCubingBigCubeBrawl2018', 'MunichOpen2018', 'ZonhovenAutumnOpen2018', 'NordicChampionship2018', 'ItalianChampionship2018', 'BaguioCityOpen2018', 'IdahoSpudcubing2018', 'BarbyCubeOpen2018', 'IquitosCubing2018', 'WelcometoAcademy2018', 'GermanBigCubeOpen2018', 'MeppelOpen2018', 'VivaVidaSBCOpen2018', 'LowerMorelandFall2018', 'KvisselFall2018', 'LuxembourgOpen2018', 'BCMAryaCubingChallenge2018', 'SnoCoFall2018', 'FleurdelisFall2018', 'NewJersey2018', 'BruggeOpen2018', 'AwesomeBruchsalCubing2018', 'MPEIOpen2018', 'Hawaii2018', 'WSMO2018', 'BrasiliaSpring2018', 'AZCubingOpen2018', 'UtahSnowballBash2018', 'RockyTop2018', 'SESCSantos2018', 'Skillcon2018', 'SouthAmericanChampionship2018', 'JharkhandCubeOpen2019', 'TGBBO2019', 'ManchesterOpen2019', 'ChesterOpen2019')
  User Load (0.2ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (7056, 234, 349, 1436, 1517, 341, 19111, 1312, 7685, 116, 248, 12061, 2, 870, 41, 1554, 1547, 79, 280, 281, 454, 524, 8447, 51489, 249, 11454, 1, 339, 5294, 140, 4, 269, 428, 567, 1315, 9241, 293, 337, 6516, 14631, 17776, 5569, 247, 256, 259, 705, 8184, 18, 314, 118, 283)
  DelegateReport Load (0.2ms)  SELECT `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` IN ('UKC2018', 'PolishChampionship2018', 'Itapeva2018', 'AZCubingBigCubeBrawl2018', 'MunichOpen2018', 'ZonhovenAutumnOpen2018', 'NordicChampionship2018', 'ItalianChampionship2018', 'BaguioCityOpen2018', 'IdahoSpudcubing2018', 'BarbyCubeOpen2018', 'IquitosCubing2018', 'WelcometoAcademy2018', 'GermanBigCubeOpen2018', 'MeppelOpen2018', 'VivaVidaSBCOpen2018', 'LowerMorelandFall2018', 'KvisselFall2018', 'LuxembourgOpen2018', 'BCMAryaCubingChallenge2018', 'SnoCoFall2018', 'FleurdelisFall2018', 'NewJersey2018', 'BruggeOpen2018', 'AwesomeBruchsalCubing2018', 'MPEIOpen2018', 'Hawaii2018', 'WSMO2018', 'BrasiliaSpring2018', 'AZCubingOpen2018', 'UtahSnowballBash2018', 'RockyTop2018', 'SESCSantos2018', 'Skillcon2018', 'SouthAmericanChampionship2018', 'JharkhandCubeOpen2019', 'TGBBO2019', 'ManchesterOpen2019', 'ChesterOpen2019')
  DelegateReport Load (0.2ms)  SELECT  `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` = 'UKC2018' LIMIT 1
  CACHE DelegateReport Load (0.0ms)  SELECT  `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` = 'UKC2018' LIMIT 1  [["competition_id", "UKC2018"], ["LIMIT", 1]]
  DelegateReport Load (0.5ms)  SELECT  `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` = 'PolishChampionship2018' LIMIT 1
  CACHE DelegateReport Load (0.0ms)  SELECT  `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` = 'PolishChampionship2018' LIMIT 1  [["competition_id", "PolishChampionship2018"], ["LIMIT", 1]]
 /////// ........
 /////// a whole lot of other DelegateReport loads
  DelegateReport Load (0.2ms)  SELECT  `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` = 'ChesterOpen2019' LIMIT 1
  CACHE DelegateReport Load (0.0ms)  SELECT  `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` = 'ChesterOpen2019' LIMIT 1  [["competition_id", "ChesterOpen2019"], ["LIMIT", 1]]
  Rendered competitions/_admin_index_table.html.erb (170.1ms)
  Rendered competitions/_index_competitions_list.html.erb (174.6ms)
  Rendered competitions/index.js.erb (177.9ms)
Completed 200 OK in 199ms (Views: 175.6ms | ActiveRecord: 12.3ms)
```

and after:
```
Processing by CompetitionsController#index as JS
  Parameters: {"utf8"=>"✓", "region"=>"all", "search"=>"", "state"=>"present", "year"=>"all years", "from_date"=>"", "to_date"=>"", "delegate"=>"", "display"=>"admin"}
   (0.7ms)  SELECT `Competitions`.`year` FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE
  Rendering competitions/index.js.erb
  TeamMember Load (0.2ms)  SELECT `team_members`.* FROM `team_members` WHERE `team_members`.`user_id` = 277 AND (end_date IS NULL OR end_date > '2018-10-24')
  Competition Exists (0.2ms)  SELECT  1 AS one FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24') LIMIT 1
  CACHE Competition Exists (0.0ms)  SELECT  1 AS one FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24') LIMIT 1
   (0.5ms)  SELECT COUNT(*) FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24')
  Competition Load (0.2ms)  SELECT `Competitions`.* FROM `Competitions` WHERE `Competitions`.`showAtAll` = TRUE AND (results_posted_at IS NULL AND end_date >= '2018-10-24') ORDER BY `Competitions`.`start_date` ASC, `Competitions`.`end_date` ASC
  Country Load (0.2ms)  SELECT `Countries`.* FROM `Countries` WHERE `Countries`.`id` IN ('United Kingdom', 'Poland', 'Brazil', 'USA', 'Germany', 'Belgium', 'Sweden', 'Italy', 'Philippines', 'France', 'Peru', 'Russia', 'Netherlands', 'Denmark', 'Luxembourg', 'India')
  CompetitionDelegate Load (1.6ms)  SELECT `competition_delegates`.* FROM `competition_delegates` WHERE `competition_delegates`.`competition_id` IN ('UKC2018', 'PolishChampionship2018', 'Itapeva2018', 'AZCubingBigCubeBrawl2018', 'MunichOpen2018', 'ZonhovenAutumnOpen2018', 'NordicChampionship2018', 'ItalianChampionship2018', 'BaguioCityOpen2018', 'IdahoSpudcubing2018', 'BarbyCubeOpen2018', 'IquitosCubing2018', 'WelcometoAcademy2018', 'GermanBigCubeOpen2018', 'MeppelOpen2018', 'VivaVidaSBCOpen2018', 'LowerMorelandFall2018', 'KvisselFall2018', 'LuxembourgOpen2018', 'BCMAryaCubingChallenge2018', 'SnoCoFall2018', 'FleurdelisFall2018', 'NewJersey2018', 'BruggeOpen2018', 'AwesomeBruchsalCubing2018', 'MPEIOpen2018', 'Hawaii2018', 'WSMO2018', 'BrasiliaSpring2018', 'AZCubingOpen2018', 'UtahSnowballBash2018', 'RockyTop2018', 'SESCSantos2018', 'Skillcon2018', 'SouthAmericanChampionship2018', 'JharkhandCubeOpen2019', 'TGBBO2019', 'ManchesterOpen2019', 'ChesterOpen2019')
  User Load (0.3ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (7056, 234, 349, 1436, 1517, 341, 19111, 1312, 7685, 116, 248, 12061, 2, 870, 41, 1554, 1547, 79, 280, 281, 454, 524, 8447, 51489, 249, 11454, 1, 339, 5294, 140, 4, 269, 428, 567, 1315, 9241, 293, 337, 6516, 14631, 17776, 5569, 247, 256, 259, 705, 8184, 18, 314, 118, 283)
  DelegateReport Load (0.8ms)  SELECT `delegate_reports`.* FROM `delegate_reports` WHERE `delegate_reports`.`competition_id` IN ('UKC2018', 'PolishChampionship2018', 'Itapeva2018', 'AZCubingBigCubeBrawl2018', 'MunichOpen2018', 'ZonhovenAutumnOpen2018', 'NordicChampionship2018', 'ItalianChampionship2018', 'BaguioCityOpen2018', 'IdahoSpudcubing2018', 'BarbyCubeOpen2018', 'IquitosCubing2018', 'WelcometoAcademy2018', 'GermanBigCubeOpen2018', 'MeppelOpen2018', 'VivaVidaSBCOpen2018', 'LowerMorelandFall2018', 'KvisselFall2018', 'LuxembourgOpen2018', 'BCMAryaCubingChallenge2018', 'SnoCoFall2018', 'FleurdelisFall2018', 'NewJersey2018', 'BruggeOpen2018', 'AwesomeBruchsalCubing2018', 'MPEIOpen2018', 'Hawaii2018', 'WSMO2018', 'BrasiliaSpring2018', 'AZCubingOpen2018', 'UtahSnowballBash2018', 'RockyTop2018', 'SESCSantos2018', 'Skillcon2018', 'SouthAmericanChampionship2018', 'JharkhandCubeOpen2019', 'TGBBO2019', 'ManchesterOpen2019', 'ChesterOpen2019')
  Rendered competitions/_admin_index_table.html.erb (150.1ms)
  Rendered competitions/_index_competitions_list.html.erb (154.7ms)
  Rendered competitions/index.js.erb (157.8ms)
Completed 200 OK in 180ms (Views: 163.3ms | ActiveRecord: 5.1ms)
```