### PR TITLE
Fix N+1 queries in "My competitions"

### DIFF
--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -22,7 +22,7 @@
       </thead>
       <tbody>
         <% competitions.each do |competition| %>
-          <% registration = competition.registrations.find_by_user_id(current_user.id) %>
+          <% registration = registrations_by_competition_id[competition.id] %>
           <tr class="<%=[ competition.confirmed? ? "confirmed" : "not-confirmed",
                           competition.showAtAll? ? "visible" : "not-visible",
                           past ? "past" : "not-past" ].join(' ') %>"

--- a/WcaOnRails/app/views/competitions/my_competitions.html.erb
+++ b/WcaOnRails/app/views/competitions/my_competitions.html.erb
@@ -5,7 +5,7 @@
 
   <%= t '.disclaimer' %>
 
-  <%= render "my_competitions_table", competitions: @not_past_competitions, past: false %>
+  <%= render "my_competitions_table", competitions: @not_past_competitions, registrations_by_competition_id: @registered_for_by_competition_id, past: false %>
 
   <div class="panel panel-default">
     <div class="panel-heading">
@@ -19,7 +19,7 @@
 
     <div id="past-competitions" class="panel-collapse collapse">
       <div class="panel-body">
-        <%= render "my_competitions_table", competitions: @past_competitions, past: true %>
+        <%= render "my_competitions_table", competitions: @past_competitions, registrations_by_competition_id: @registered_for_by_competition_id, past: true %>
       </div>
     </div>
   </div>

--- a/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "competitions/my_competitions" do
     allow(view).to receive(:current_user) { registration.user }
     assign(:not_past_competitions, [competition])
     assign(:past_competitions, [])
+    assign(:registered_for_by_competition_id, competition.id => registration)
   end
 
   it "shows upcoming competitions" do


### PR DESCRIPTION
Currently the "My competitions" triggers one "registration" load and one
"delegate report" load per competition.
I reworked the way we build the competitions list, and first gather all
competition IDs we need to do one single `Competition` load with eager
loading of delegate reports.
I also added a `@registered_for_by_competition_id`, which avoid firing
the registration load for each competition.