### PR TITLE
Scope the users_claiming_wca_id to confirmed users

### DIFF
--- a/WcaOnRails/app/controllers/delegates_panel_controller.rb
+++ b/WcaOnRails/app/controllers/delegates_panel_controller.rb
@@ -32,7 +32,7 @@ class DelegatesPanelController < ApplicationController
 
   def pending_claims_for_subordinate_delegates
     # Show pending claims for a given user, or the current user, if they can see them
-    @user = User.includes(subordinate_delegates: [:users_claiming_wca_id]).find_by_id(params[:user_id] || current_user.id)
+    @user = User.includes(subordinate_delegates: [:confirmed_users_claiming_wca_id]).find_by_id(params[:user_id] || current_user.id)
   end
 
   def seniors

--- a/WcaOnRails/app/helpers/notifications_helper.rb
+++ b/WcaOnRails/app/helpers/notifications_helper.rb
@@ -53,7 +53,7 @@ module NotificationsHelper
     # for an account. We don't want to bother delegates with these claims until
     # the user has confirmed their account, though, so filter out users with
     # confirmed_at=NULL.
-    user.users_claiming_wca_id.where.not(confirmed_at: nil).each do |user_claiming_wca_id|
+    user.confirmed_users_claiming_wca_id.each do |user_claiming_wca_id|
       notifications << {
         text: "#{user_claiming_wca_id.email} has claimed WCA ID #{user_claiming_wca_id.unconfirmed_wca_id}",
         url: edit_user_path(user_claiming_wca_id.id, anchor: "wca_id"),

--- a/WcaOnRails/app/views/delegates_panel/pending_claims_for_subordinate_delegates.html.erb
+++ b/WcaOnRails/app/views/delegates_panel/pending_claims_for_subordinate_delegates.html.erb
@@ -7,18 +7,19 @@
     <div class="well">No subordinate Delegates to display</div>
   <% else %>
     <div class="panel-group">
-      <% @user.subordinate_delegates.sort_by { |u| u.users_claiming_wca_id.size }.reverse_each do |delegate| %>
+      <% @user.subordinate_delegates.sort_by { |u| u.confirmed_users_claiming_wca_id.size }.reverse_each do |delegate| %>
+        <% users = delegate.confirmed_users_claiming_wca_id %>
         <div class="panel panel-default">
           <div class="panel-heading heading-as-link" data-toggle="collapse" data-target="#panel-<%= delegate.id %>">
             <%= delegate.name %>
-            <span class="badge"><%= delegate.users_claiming_wca_id.size %></span>
+            <span class="badge"><%= users.size %></span>
           </div>
           <div id="panel-<%= delegate.id %>" class="collapse panel-collapse">
             <ul class="list-group">
-              <% if delegate.users_claiming_wca_id.empty? %>
+              <% if users.empty? %>
                 <li class="list-group-item">No pending claims.</li>
               <% else %>
-                <% delegate.users_claiming_wca_id.each do |u| %>
+                <% users.each do |u| %>
                   <%= link_to(edit_user_path(u.id, anchor: "wca_id"), class: "list-group-item") do %>
                     <%= u.name %> has claimed WCA ID <%= u.unconfirmed_wca_id %>
                   <% end %>


### PR DESCRIPTION
Turns out we always manually scoped `users_claiming_wca_id` to confirmed user accounts, so we might as well just scope it in the association :)

(It also fixes an issue with #3500, as it lists *all* the pending claim, not only those for confirmed accounts)