### PR TITLE
Disable autofill on our date(time) pickers

### DIFF
--- a/WcaOnRails/app/inputs/date_picker_input.rb
+++ b/WcaOnRails/app/inputs/date_picker_input.rb
@@ -51,6 +51,7 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
 
   def set_html_options
     input_html_options[:type] = 'text'
+    input_html_options[:autocomplete] = 'off'
     input_html_options[:data] ||= {}
     input_html_options[:data][:date_options] = date_options
     input_html_options[:placeholder] = input_placeholder


### PR DESCRIPTION
There is an annoying behavior reported by @jambrose777:

![image](https://user-images.githubusercontent.com/1007485/47641401-38269580-db66-11e8-85a5-0183733d6f89.png)

It seems adding `autocomplete="off"` on the inputs does the trick (thanks @moralsh)!