### PR TITLE
"My competitions" for Senior Delegates

### DIFF
--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -19,7 +19,7 @@
           <th></th>
           <th></th>
           <th></th>
-          <th></th>
+          <th><%= "Delegates" if show_delegates %></th>
           <th class="big-column"></th>
         </tr>
       </thead>
@@ -53,25 +53,22 @@
               <% end %>
             </td>
             <td>
-              <% if current_user.can_view_delegate_report?(competition.delegate_report) %>
-                <%= link_to icon('file-text-o'), delegate_report_path(competition), title: t('.report'), data: { 'toggle': 'tooltip', 'container': 'body' } %>
-              <% end %>
-              <% if current_user.can_edit_delegate_report?(competition.delegate_report) %>
-                <%= link_to icon('pencil-square-o'), delegate_report_edit_path(competition), title: t('.edit_report'), data: { 'toggle': 'tooltip', 'container': 'body' } %>
-              <% end %>
-              <% if competition.user_should_post_delegate_report?(current_user) %>
-                <%= icon('warning', title: t('.missing_report'), data: { 'toggle': 'tooltip', 'container': 'body' }) %>
+              <% if show_delegates %>
+                <%= competition.delegates.map(&:name).join(", ") %>
+              <% else %>
+                <% if current_user.can_view_delegate_report?(competition.delegate_report) %>
+                  <%= link_to icon('file-text-o'), delegate_report_path(competition), title: t('.report'), data: { 'toggle': 'tooltip', 'container': 'body' } %>
+                <% end %>
+                <% if current_user.can_edit_delegate_report?(competition.delegate_report) %>
+                  <%= link_to icon('pencil-square-o'), delegate_report_edit_path(competition), title: t('.edit_report'), data: { 'toggle': 'tooltip', 'container': 'body' } %>
+                <% end %>
+                <% if competition.user_should_post_delegate_report?(current_user) %>
+                  <%= icon('warning', title: t('.missing_report'), data: { 'toggle': 'tooltip', 'container': 'body' }) %>
+                <% end %>
               <% end %>
             </td>
             <td class="big-column"></td>
           </tr>
-          <% if show_delegates %>
-            <tr class="<%= tr_classes %>">
-              <td></td>
-              <td colspan="6"><%= competition.delegates.map(&:name).join(", ") %></td>
-              <td class="big-column"></td>
-            </tr>
-          <% end %>
         <% end %>
       </tbody>
     </table>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -1,3 +1,5 @@
+<% show_delegates ||= false %>
+<% registrations_by_competition_id ||= {} %>
 <% if competitions.length < 1 %>
   <%= alert :info do %>
     <% if !past %>
@@ -17,15 +19,17 @@
           <th></th>
           <th></th>
           <th></th>
+          <th></th>
           <th class="big-column"></th>
         </tr>
       </thead>
       <tbody>
         <% competitions.each do |competition| %>
           <% registration = registrations_by_competition_id[competition.id] %>
-          <tr class="<%=[ competition.confirmed? ? "confirmed" : "not-confirmed",
+          <% tr_classes = [ competition.confirmed? ? "confirmed" : "not-confirmed",
                           competition.showAtAll? ? "visible" : "not-visible",
-                          past ? "past" : "not-past" ].join(' ') %>"
+                          past ? "past" : "not-past" ].join(' ') %>
+          <tr class="<%= tr_classes %>"
               data-toggle="tooltip" data-placement="bottom" data-container="body"
               title="<%= competition_message_for_user(competition, current_user) unless past %>">
             <td><%= link_to competition.name, competition_path(competition) %></td>
@@ -61,6 +65,13 @@
             </td>
             <td class="big-column"></td>
           </tr>
+          <% if show_delegates %>
+            <tr class="<%= tr_classes %>">
+              <td></td>
+              <td colspan="6"><%= competition.delegates.map(&:name).join(", ") %></td>
+              <td class="big-column"></td>
+            </tr>
+          <% end %>
         <% end %>
       </tbody>
     </table>

--- a/WcaOnRails/app/views/competitions/for_senior.html.erb
+++ b/WcaOnRails/app/views/competitions/for_senior.html.erb
@@ -1,0 +1,8 @@
+<% provide(:title, "Upcoming competitions for Delegates managed by #{@user.name}") %>
+
+<div class="container">
+  <h3><%= yield(:title) %></h3>
+
+  <%= render "my_competitions_table", competitions: @competitions, past: false, show_delegates: true %>
+
+</div>

--- a/WcaOnRails/app/views/competitions/my_competitions.html.erb
+++ b/WcaOnRails/app/views/competitions/my_competitions.html.erb
@@ -34,10 +34,13 @@
     })();
   </script>
 
-  <p>
-    <% if current_user.wca_id %>
+  <% if current_user.wca_id %>
+    <p>
       <%= link_to t('layouts.navigation.my_results'), person_path(current_user.wca_id) %>
+    </p>
+    <% if current_user.senior_delegate? %>
+      <p><%= link_to "Upcoming competitions for my subordinate Delegates", competitions_for_senior_path %></p>
     <% end %>
-  </p>
+  <% end %>
 
 </div>

--- a/WcaOnRails/app/views/delegates_panel/seniors.html.erb
+++ b/WcaOnRails/app/views/delegates_panel/seniors.html.erb
@@ -7,6 +7,7 @@
     <h4><%= s.name %></h4>
     <ul>
       <li><%= link_to("List of subordinate pending WCA ID claims", pending_claims_path(s.id)) %></li>
+      <li><%= link_to("List of subordinate upcoming competitions", competitions_for_senior_path(s.id)) %></li>
     </ul>
   <% end %>
 </div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   post 'admin/avatars' => 'admin/avatars#update_all'
 
   get 'competitions/mine' => 'competitions#my_competitions', as: :my_comps
+  get 'competitions/for_senior(/:user_id)' => 'competitions#for_senior', as: :competitions_for_senior
   resources :competitions, only: [:index, :show, :edit, :update, :new, :create] do
     get 'results/podiums' => 'competitions#show_podiums'
     get 'results/all' => 'competitions#show_all_results'

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -159,6 +159,35 @@ RSpec.describe CompetitionsController do
     end
   end
 
+  describe 'GET #for_senior' do
+    context 'when not signed in' do
+      sign_out
+
+      it 'redirects to the sign in page' do
+        get :new
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'when signed in as a senior Delegate' do
+      sign_in { FactoryBot.create :senior_delegate }
+
+      it 'renders the for_senior page' do
+        get :for_senior
+        expect(response).to render_template :for_senior
+      end
+    end
+
+    context 'when signed in as a regular Delegate' do
+      sign_in { FactoryBot.create :delegate }
+
+      it 'does not allow access' do
+        get :for_senior
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
   describe 'GET #edit' do
     let(:organizer) { FactoryBot.create(:user) }
     let(:admin) { FactoryBot.create :admin }


### PR DESCRIPTION
Fixes part (1&2) of #3129.
It simply implements an equivalent of "my competitions" for Senior Delegates.

Adding the Delegates to the table is not super clean when there are a lot of Delegates, therefore I tried two options:
  - One with an additional row (which is implemented in this PR):
![two_trs](https://user-images.githubusercontent.com/1007485/48127573-58e89c80-e284-11e8-8c13-09f12b215231.png)

  - One with a column substitution (since the Delegate report links are not very useful for upcoming competitions):
![col](https://user-images.githubusercontent.com/1007485/48127621-71f14d80-e284-11e8-89cc-c7fd144c20c1.png)

