### PR TITLE
Add social media icons to footer

### DIFF
--- a/WcaOnRails/app/views/layouts/_footer.html.erb
+++ b/WcaOnRails/app/views/layouts/_footer.html.erb
@@ -9,6 +9,18 @@
       |
       <%= link_to "Disclaimer", disclaimer_path %>
       |
+      <a href="https://www.facebook.com/WorldCubeAssociation/" target="_blank" class="hide-new-window-icon">
+        <i class="fa fa-facebook"></i>
+      </a>
+      |
+      <a href="https://www.instagram.com/thewcaofficial/" target="_blank" class="hide-new-window-icon">
+        <i class="fa fa-instagram"></i>
+      </a>
+      |
+      <a href="https://reddit.com/u/thewca" target="_blank" class="hide-new-window-icon">
+        <i class="fa fa-reddit"></i>
+      </a>
+      |
       <a href="https://github.com/thewca/worldcubeassociation.org" target="_blank" class="hide-new-window-icon">
         <i class="fa fa-github"></i>
       </a>


### PR DESCRIPTION
Add links to Facebook, Instagram, and Reddit in the footer to promote the WCA's social media presence.