### PR TITLE
Some infrastructure to automate membership of our new GSuite mailing lists.

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -83,6 +83,7 @@ gem 'webpacker'
 gem 'json-schema'
 gem 'translighterate'
 gem 'enum_help'
+gem 'google-api-client'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     daemons (1.2.6)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
@@ -192,6 +194,21 @@ GEM
       momentjs-rails (>= 2.9.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    google-api-client (0.25.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (>= 0.5, < 0.7.0)
+      httpclient (>= 2.8.1, < 3.0)
+      mime-types (~> 3.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+      signet (~> 0.10)
+    googleauth (0.6.7)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      memoist (~> 0.16)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (~> 0.7)
     guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -210,6 +227,7 @@ GEM
     highline (2.0.0)
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
+    httpclient (2.8.3)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     i18n-country-translations (1.3.1)
@@ -281,6 +299,7 @@ GEM
       activemodel (>= 3.2, < 6)
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
+    memoist (0.16.0)
     method_source (0.9.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -324,6 +343,7 @@ GEM
       ruby-ll (~> 2.1)
     openssl (2.1.2)
     orm_adapter (0.5.0)
+    os (1.0.0)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -397,9 +417,14 @@ GEM
     redcarpet (3.4.0)
     ref (2.0.0)
     regexp_parser (1.2.0)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    retriable (3.1.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -455,6 +480,11 @@ GEM
       rdoc (>= 5.0)
     seedbank (0.4.0)
     shellany (0.0.1)
+    signet (0.11.0)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     simple_form (4.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -500,6 +530,7 @@ GEM
       tzinfo
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    uber (0.1.0)
     uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
@@ -563,6 +594,7 @@ DEPENDENCIES
   faker
   font-awesome-sass
   fullcalendar-rails
+  google-api-client
   guard-rspec
   high_voltage
   http_accept_language
@@ -626,4 +658,4 @@ DEPENDENCIES
   webpacker
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
+++ b/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SyncMailingListsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    GsuiteMailingLists.sync_group("delegates@worldcubeassociation.org", User.delegates)
+  end
+end

--- a/WcaOnRails/lib/gsuite_mailing_lists.rb
+++ b/WcaOnRails/lib/gsuite_mailing_lists.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+ENV['GOOGLE_APPLICATION_CREDENTIALS'] = Rails.root.join("../secrets/application_default_credentials.json").to_s
+
+require 'googleauth'
+require 'googleauth/stores/file_token_store'
+require 'google/apis/admin_directory_v1'
+
+module GsuiteMailingLists
+  def self.sync_group(group, users)
+    service = get_service
+
+    desired_emails = users.map(&:email)
+    desired_emails = desired_emails.map do |email|
+      if email.include?("+")
+        old_email = email
+        email = email.gsub(/\+[^@]*/, '')
+        puts "Warning: '#{old_email}' contains a plus sign, and google groups seems to not support + signs in email addresses, so we're going to add '#{email}' instead."
+      end
+      email
+    end
+
+    members = service.fetch_all(items: :members) do |token|
+      service.list_members(group, page_token: token)
+    end
+    current_emails = members.map(&:email)
+
+    emails_to_remove = current_emails - desired_emails
+    emails_to_add = desired_emails - current_emails
+
+    # First, remove all the emails we don't want.
+    emails_to_remove.each do |email|
+      service.delete_member(group, email)
+    end
+
+    # Last, add all the emails we do want.
+    emails_to_add.each do |email|
+      new_member = Google::Apis::AdminDirectoryV1::Member.new(email: email)
+      service.insert_member(group, new_member)
+    end
+  end
+
+  def self.get_service
+    scopes = [
+      'https://www.googleapis.com/auth/admin.directory.group',
+    ]
+    authorization = Google::Auth.get_application_default(scopes)
+
+    Google::Apis::AdminDirectoryV1::DirectoryService.new.tap do |service|
+      service.authorization = authorization
+    end
+  end
+end

--- a/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SyncMailingListsJob, type: :job do
+  it "syncs delegates mailing list" do
+    delegate = FactoryBot.create :delegate
+
+    expect(GsuiteMailingLists).to receive(:sync_group).with(
+      "delegates@worldcubeassociation.org",
+      a_collection_containing_exactly(delegate, delegate.senior_delegate),
+    )
+
+    SyncMailingListsJob.perform_now
+  end
+end


### PR DESCRIPTION
I documented the setup of all of this over in
the [Automating membership of delegates@worldcubeassociation.org](https://docs.google.com/document/d/1Fb02VBYy712vD5TxUmlhJC0wzXq7YmiXRJugw9806m4/) doc.

This adds a job called `SyncMailingListsJob` that will synchronize the
jfly-testing-delegates@worldcubeassociation.org GSuite group with the
email addresses of all our delegates.

Some notes:
  - If this goes well, I plan to change
jfly-testing-delegates@worldcubeassociation.org to
delegates@worldcubeassociation.org, but I want to test this out on a non
critical mailing list first.
  - This job currently is not triggered by anything. I plan to trigger
it manually in production from the Rails console by running
`SyncMailingListsJob.perform_later`. If that goes well, I plan to add it
to our "schedule work" cron job which runs once an hour.
  - This relies upon the existence of a
application_default_credentials.json file in our secrets directory. I
generated this file locally and have already copied it to the secrets
directory on our server. Since we rsync this directory when spinning up
a new server, it should be safe to leave it there.