### PR TITLE
Add support for syncing leaders@ and results@

### DIFF
--- a/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
+++ b/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
@@ -5,5 +5,7 @@ class SyncMailingListsJob < ApplicationJob
 
   def perform
     GsuiteMailingLists.sync_group("delegates@worldcubeassociation.org", User.delegates)
+    GsuiteMailingLists.sync_group("leaders@worldcubeassociation.org", TeamMember.current.where(team_leader: true).map(&:user))
+    GsuiteMailingLists.sync_group("results@worldcubeassociation.org", Team.wrt.current_members.includes(:user).map(&:user))
   end
 end

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -36,39 +36,43 @@ FactoryBot.define do
       end
     end
 
+    transient do
+      team_leader { false }
+    end
+
     trait :board_member do
-      after(:create) do |user|
-        FactoryBot.create(:team_member, team_id: Team.board.id, user_id: user.id)
+      after(:create) do |user, options|
+        FactoryBot.create(:team_member, team_id: Team.board.id, user_id: user.id, team_leader: options.team_leader)
       end
     end
 
     trait :wrt_member do
-      after(:create) do |user|
-        FactoryBot.create(:team_member, team_id: Team.wrt.id, user_id: user.id)
+      after(:create) do |user, options|
+        FactoryBot.create(:team_member, team_id: Team.wrt.id, user_id: user.id, team_leader: options.team_leader)
       end
     end
 
     trait :wdc_member do
-      after(:create) do |user|
-        FactoryBot.create(:team_member, team_id: Team.wdc.id, user_id: user.id)
+      after(:create) do |user, options|
+        FactoryBot.create(:team_member, team_id: Team.wdc.id, user_id: user.id, team_leader: options.team_leader)
       end
     end
 
     trait :wrc_member do
-      after(:create) do |user|
-        FactoryBot.create(:team_member, team_id: Team.wrc.id, user_id: user.id)
+      after(:create) do |user, options|
+        FactoryBot.create(:team_member, team_id: Team.wrc.id, user_id: user.id, team_leader: options.team_leader)
       end
     end
 
     trait :wct_member do
-      after(:create) do |user|
-        FactoryBot.create(:team_member, team_id: Team.wct.id, user_id: user.id)
+      after(:create) do |user, options|
+        FactoryBot.create(:team_member, team_id: Team.wct.id, user_id: user.id, team_leader: options.team_leader)
       end
     end
 
     trait :wqac_member do
-      after(:create) do |user|
-        FactoryBot.create(:team_member, team_id: Team.wqac.id, user_id: user.id)
+      after(:create) do |user, options|
+        FactoryBot.create(:team_member, team_id: Team.wqac.id, user_id: user.id, team_leader: options.team_leader)
       end
     end
 

--- a/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -3,12 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe SyncMailingListsJob, type: :job do
-  it "syncs delegates mailing list" do
+  it "syncs mailing lists" do
+    # delegates@ mailing list
     delegate = FactoryBot.create :delegate
-
     expect(GsuiteMailingLists).to receive(:sync_group).with(
       "delegates@worldcubeassociation.org",
       a_collection_containing_exactly(delegate, delegate.senior_delegate),
+    )
+
+    # leaders@ mailing list
+    wrt_leader = FactoryBot.create :user, :wrt_member, team_leader: true
+    wrt_member = FactoryBot.create :user, :wrt_member, team_leader: false
+    wdc_leader = FactoryBot.create :user, :wdc_member, team_leader: true
+    FactoryBot.create :user, :wdc_member, team_leader: false
+    expect(GsuiteMailingLists).to receive(:sync_group).with(
+      "leaders@worldcubeassociation.org",
+      a_collection_containing_exactly(wrt_leader, wdc_leader),
+    )
+
+    # results@ mailing list
+    expect(GsuiteMailingLists).to receive(:sync_group).with(
+      "results@worldcubeassociation.org",
+      a_collection_containing_exactly(wrt_leader, wrt_member),
     )
 
     SyncMailingListsJob.perform_now


### PR DESCRIPTION
I imagine this will go well. If it does, then it should be
straightforward to implement the rest of the forwards from
https://docs.google.com/spreadsheets/d/1I2l_ht2NhcXurG9wezludKNb6ZFjpuWS4jrF_h8DaIw/edit?ts=5bef0e17#gid=0.

I'm not sure what the nicest way to write the tests for this is. The way
I've done it is one big test, which is a bit tricky to read through
(testing leaders@ interacts with testing results@, for instance). I'd
like to have one test per mailing list, but I couldn't figure out how to
`expect` one call to `GsuiteMailingLists.sync_group` but ignore the
other calls.