### PR TITLE
Add SyncMailingListsJob to the schedule work task.

### DIFF
--- a/WcaOnRails/lib/tasks/work.rake
+++ b/WcaOnRails/lib/tasks/work.rake
@@ -7,5 +7,6 @@ namespace :work do
     SubmitReportNagJob.perform_later
     ComputeLinkings.perform_later
     DumpDeveloperDatabase.perform_later
+    SyncMailingListsJob.perform_later
   end
 end


### PR DESCRIPTION
This means it will run once an hour. We should probably also schedule
the job whenever something changes that would cause mailing list
membership to change, but I think it would still be good to periodically
run the job once an hour just in case we forget to schedule the job.