### PR TITLE
Fix the discussion url for future delegate reports.

### DIFF
--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -10,7 +10,7 @@ class DelegateReport < ApplicationRecord
 
   before_create :set_discussion_url
   def set_discussion_url
-    self.discussion_url = "https://groups.google.com/forum/#!topicsearchin/wca-delegates/" + URI.encode_www_form_component(competition.name)
+    self.discussion_url = "https://groups.google.com/a/worldcubeassociation.org/forum/#!topicsearchin/reports/" + URI.encode_www_form_component(competition.name)
   end
 
   before_create :equipment_default

--- a/WcaOnRails/spec/models/delegate_report_spec.rb
+++ b/WcaOnRails/spec/models/delegate_report_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DelegateReport do
 
   it "discussion_url is set on creation" do
     dr = FactoryBot.create :delegate_report
-    expect(dr.discussion_url).to eq "https://groups.google.com/forum/#!topicsearchin/wca-delegates/" + URI.encode_www_form_component(dr.competition.name)
+    expect(dr.discussion_url).to eq "https://groups.google.com/a/worldcubeassociation.org/forum/#!topicsearchin/reports/" + URI.encode_www_form_component(dr.competition.name)
   end
 
   context "can_view_delegate_report?" do


### PR DESCRIPTION
There are a few competitions in our database with the wrong url. ~Alberto
and I will fix those manually.~ I have manually fixed all of those.