### PR TITLE
Sync translators@ Google Group.

### DIFF
--- a/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
+++ b/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
@@ -19,5 +19,7 @@ class SyncMailingListsJob < ApplicationJob
     GsuiteMailingLists.sync_group("regulations@worldcubeassociation.org", Team.wrc.current_members.includes(:user).map(&:user))
     GsuiteMailingLists.sync_group("results@worldcubeassociation.org", Team.wrt.current_members.includes(:user).map(&:user))
     GsuiteMailingLists.sync_group("software@worldcubeassociation.org", Team.wst.current_members.includes(:user).map(&:user))
+    translators = User.where(id: TranslationsController::VERIFIED_TRANSLATORS_BY_LOCALE.values.flatten)
+    GsuiteMailingLists.sync_group("translators@worldcubeassociation.org", translators)
   end
 end

--- a/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe SyncMailingListsJob, type: :job do
       a_collection_containing_exactly(wst_member),
     )
 
+    stub_const "TranslationsController::VERIFIED_TRANSLATORS_BY_LOCALE", ({
+      "es" => [wst_member.id],
+      "fr" => [wrc_member.id, wrt_leader.id],
+    })
+    # translators@ mailing list
+    expect(GsuiteMailingLists).to receive(:sync_group).with(
+      "translators@worldcubeassociation.org",
+      a_collection_containing_exactly(wst_member, wrc_member, wrt_leader),
+    )
+
     SyncMailingListsJob.perform_now
   end
 end


### PR DESCRIPTION
Following #3605, this automates the `translators@` mailing list.