### PR TITLE
Raname roundResults to results to comply with the WCIF#Round definition

### DIFF
--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -112,7 +112,7 @@ class Round < ApplicationRecord
       cutoff: Cutoff.load(wcif["cutoff"]),
       advancement_condition: AdvancementCondition.load(wcif["advancementCondition"]),
       scramble_set_count: wcif["scrambleSetCount"],
-      round_results: RoundResults.load(wcif["roundResults"]),
+      round_results: RoundResults.load(wcif["results"]),
     }
   end
 
@@ -148,7 +148,7 @@ class Round < ApplicationRecord
       "scrambleGroupCount" => self.scramble_set_count,
 
       "scrambleSetCount" => self.scramble_set_count,
-      "roundResults" => round_results.map(&:to_wcif),
+      "results" => round_results.map(&:to_wcif),
     }
   end
 
@@ -161,7 +161,7 @@ class Round < ApplicationRecord
         "timeLimit" => TimeLimit.wcif_json_schema,
         "cutoff" => Cutoff.wcif_json_schema,
         "advancementCondition" => AdvancementCondition.wcif_json_schema,
-        "roundResults" => { "type" => "array", "items" => { "type" => RoundResult.wcif_json_schema } },
+        "results" => { "type" => "array", "items" => { "type" => RoundResult.wcif_json_schema } },
         "groups" => { "type" => "array" }, # TODO: expand on this
         "scrambleSetCount" => { "type" => "integer" },
       },

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Competition WCIF" do
                 },
                 "scrambleSetCount" => 16,
                 "scrambleGroupCount" => 16, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
-                "roundResults" => [],
+                "results" => [],
               },
               {
                 "id" => "333-r2",
@@ -73,7 +73,7 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
-                "roundResults" => [],
+                "results" => [],
               },
             ],
           },
@@ -88,7 +88,7 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
-                "roundResults" => [],
+                "results" => [],
               },
             ],
           },
@@ -103,7 +103,7 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
-                "roundResults" => [],
+                "results" => [],
               },
             ],
           },
@@ -121,7 +121,7 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
-                "roundResults" => [],
+                "results" => [],
               },
             ],
           },
@@ -263,7 +263,7 @@ RSpec.describe "Competition WCIF" do
             "advancementCondition" => nil,
             "scrambleSetCount" => 1,
             "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
-            "roundResults" => [],
+            "results" => [],
           },
         ],
       }
@@ -290,7 +290,7 @@ RSpec.describe "Competition WCIF" do
         "advancementCondition" => nil,
         "scrambleSetCount" => 1,
         "scrambleGroupCount" => 1, # TODO: remove once TNoodle is updated to not read this. See https://github.com/thewca/worldcubeassociation.org/issues/3059.
-        "roundResults" => [],
+        "results" => [],
       }
 
       competition.set_wcif_events!(wcif["events"], delegate)
@@ -346,9 +346,9 @@ RSpec.describe "Competition WCIF" do
       expect(competition.to_wcif["events"]).to eq(wcif["events"])
     end
 
-    it "can set roundResults" do
+    it "can set round results" do
       wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
-      wcif_333_event["rounds"][0]["roundResults"] = [
+      wcif_333_event["rounds"][0]["results"] = [
         {
           "personId" => 1,
           "ranking" => 10,

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "API Competitions" do
           competition_events = create_wcif_events(%w(333))
           round333_first = competition_events[0][:rounds][0]
           round333_first[:scrambleSetCount] = 2
-          round333_first[:roundResults] = [
+          round333_first[:results] = [
             {
               personId: 1,
               ranking: 10,


### PR DESCRIPTION
Apparently `roundResults` ended up in the WCIF JSON, whereas `results` was intended.
(See [WCIF#Round](https://docs.google.com/document/d/1hnzAZizTH0XyGkSYe-PxFL5xpKVWl_cvSdTzlT_kAs8/edit#heading=h.bwp8bmejyow0) for reference)