### PR TITLE
Implement WCIF Extensions

### DIFF
--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -5,6 +5,8 @@ class CompetitionEvent < ApplicationRecord
   belongs_to :event
   has_many :registration_competition_events, dependent: :destroy
   has_many :rounds, -> { order(:number) }, dependent: :destroy
+  has_many :wcif_extensions, as: :extendable, dependent: :delete_all
+
   accepts_nested_attributes_for :rounds, allow_destroy: true
 
   validates_numericality_of :fee_lowest_denomination, greater_than_or_equal_to: 0
@@ -36,6 +38,7 @@ class CompetitionEvent < ApplicationRecord
     {
       "id" => self.event.id,
       "rounds" => self.rounds.map(&:to_wcif),
+      "extensions" => wcif_extensions.map(&:to_wcif),
     }
   end
 
@@ -43,8 +46,10 @@ class CompetitionEvent < ApplicationRecord
     self.rounds.destroy_all!
     total_rounds = wcif["rounds"].size
     wcif["rounds"].each_with_index do |wcif_round, index|
-      self.rounds.create!(Round.wcif_to_round_attributes(wcif_round, index+1, total_rounds))
+      round = self.rounds.create!(Round.wcif_to_round_attributes(wcif_round, index+1, total_rounds))
+      WcifExtension.update_wcif_extensions!(round, wcif_round["extensions"])
     end
+    WcifExtension.update_wcif_extensions!(self, wcif["extensions"])
   end
 
   def self.wcif_json_schema
@@ -55,6 +60,7 @@ class CompetitionEvent < ApplicationRecord
         "rounds" => { "type" => ["array", "null"], "items" => Round.wcif_json_schema },
         "competitorLimit" => { "type" => "integer" },
         "qualification" => { "type" => "object" }, # TODO: expand on this
+        "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
     }
   end

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -20,6 +20,8 @@ class Round < ApplicationRecord
   serialize :round_results, RoundResults
   validates_associated :round_results
 
+  has_many :wcif_extensions, as: :extendable, dependent: :delete_all
+
   MAX_NUMBER = 4
   validates_numericality_of :number,
                             only_integer: true,
@@ -142,6 +144,7 @@ class Round < ApplicationRecord
       "advancementCondition" => advancement_condition&.to_wcif,
       "scrambleSetCount" => self.scramble_set_count,
       "results" => round_results.map(&:to_wcif),
+      "extensions" => wcif_extensions.map(&:to_wcif),
     }
   end
 
@@ -157,6 +160,7 @@ class Round < ApplicationRecord
         "results" => { "type" => "array", "items" => RoundResult.wcif_json_schema },
         "scrambleSets" => { "type" => "array" }, # TODO: expand on this
         "scrambleSetCount" => { "type" => "integer" },
+        "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
     }
   end

--- a/WcaOnRails/app/models/venue_room.rb
+++ b/WcaOnRails/app/models/venue_room.rb
@@ -8,6 +8,7 @@ class VenueRoom < ApplicationRecord
   delegate :start_time, to: :competition
   delegate :end_time, to: :competition
   has_many :schedule_activities, as: :holder, dependent: :destroy
+  has_many :wcif_extensions, as: :extendable, dependent: :delete_all
 
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: "Please input a valid hexadecimal color code" }
 
@@ -24,6 +25,7 @@ class VenueRoom < ApplicationRecord
       "name" => name,
       "color" => color,
       "activities" => schedule_activities.map(&:to_wcif),
+      "extensions" => wcif_extensions.map(&:to_wcif),
     }
   end
 
@@ -41,6 +43,7 @@ class VenueRoom < ApplicationRecord
         "name" => { "type" => "string" },
         "color" => { "type" => "string" },
         "activities" => { "type" => "array", "items" => ScheduleActivity.wcif_json_schema },
+        "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
       "required" => ["id", "name", "activities"],
     }
@@ -53,6 +56,7 @@ class VenueRoom < ApplicationRecord
       activity.load_wcif!(activity_wcif)
     end
     self.schedule_activities = new_activities
+    WcifExtension.update_wcif_extensions!(self, wcif["extensions"])
     self
   end
 

--- a/WcaOnRails/app/models/wcif_extension.rb
+++ b/WcaOnRails/app/models/wcif_extension.rb
@@ -1,4 +1,24 @@
 # frozen_string_literal: true
 
 class WcifExtension < ApplicationRecord
+  serialize :data, JSON
+
+  validates :extension_id, format: { with: /\A\w+(\.\w+)*\z/ }
+  validates :spec_url, url: true
+  validates :data, presence: true
+
+  def to_wcif
+    { "id" => self.extension_id, "specUrl" => self.spec_url, "data" => self.data }
+  end
+
+  def self.wcif_json_schema
+    {
+      "type" => ["object"],
+      "properties" => {
+        "id" => { "type" => "string" },
+        "specUrl" => { "type" => "string" },
+        "data" => { "type" => "object" },
+      },
+    }
+  end
 end

--- a/WcaOnRails/app/models/wcif_extension.rb
+++ b/WcaOnRails/app/models/wcif_extension.rb
@@ -5,7 +5,6 @@ class WcifExtension < ApplicationRecord
 
   validates :extension_id, format: { with: /\A\w+(\.\w+)*\z/ }
   validates :spec_url, url: true
-  validates :data, presence: true
 
   def to_wcif
     { "id" => self.extension_id, "specUrl" => self.spec_url, "data" => self.data }
@@ -20,5 +19,28 @@ class WcifExtension < ApplicationRecord
         "data" => { "type" => "object" },
       },
     }
+  end
+
+  def self.wcif_to_attributes(wcif)
+    {
+      extension_id: wcif["id"],
+      spec_url: wcif["specUrl"],
+      data: wcif["data"],
+    }
+  end
+
+  def load_wcif!(wcif)
+    update_attributes!(WcifExtension.wcif_to_attributes(wcif))
+    self
+  end
+
+  def self.update_wcif_extensions!(parent, extension_wcifs)
+    updated_extensions = (extension_wcifs || []).map do |extension_wcif|
+      extension = parent.wcif_extensions.find do |wcif_extension|
+        wcif_extension.extension_id == extension_wcif["id"]
+      end
+      (extension || parent.wcif_extensions.build).load_wcif!(extension_wcif)
+    end
+    parent.wcif_extensions = updated_extensions
   end
 end

--- a/WcaOnRails/app/models/wcif_extension.rb
+++ b/WcaOnRails/app/models/wcif_extension.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class WcifExtension < ApplicationRecord
+end

--- a/WcaOnRails/db/migrate/20181122233823_create_wcif_extensions.rb
+++ b/WcaOnRails/db/migrate/20181122233823_create_wcif_extensions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateWcifExtensions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :wcif_extensions do |t|
+      t.references :extendable, polymorphic: true
+      t.string :extension_id, null: false
+      t.string :spec_url, null: false
+      t.text :data, null: false
+    end
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1214,6 +1214,20 @@ CREATE TABLE `votes` (
   KEY `index_votes_on_user_id` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `wcif_extensions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `wcif_extensions` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `extendable_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `extendable_id` bigint(20) DEFAULT NULL,
+  `extension_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `spec_url` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `data` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_wcif_extensions_on_extendable_type_and_extendable_id` (`extendable_type`,`extendable_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 /*!50001 SET @saved_cs_client          = @@character_set_client */;
 /*!50001 SET @saved_cs_results         = @@character_set_results */;
@@ -1428,4 +1442,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181208145408'),
 ('20181209171137'),
 ('20181222224850'),
-('20181226115357');
+('20181226115357'),
+('20181122233823');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -672,6 +672,7 @@ module DatabaseDumper
         ),
       ),
     }.freeze,
+    "wcif_extensions" => :skip_all_rows,
   }.freeze
 
   def self.development_dump(dump_filename)

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Competition WCIF" do
   let!(:round444_1) { FactoryBot.create(:round, competition: competition, event_id: "444", number: 1) }
   let!(:round333fm_1) { FactoryBot.create(:round, competition: competition, event_id: "333fm", number: 1, format_id: "m") }
   let!(:round333mbf_1) { FactoryBot.create(:round, competition: competition, event_id: "333mbf", number: 1, format_id: "3") }
+  let!(:round333mbf_1_extension) { round333mbf_1.wcif_extensions.create!(extension_id: "com.third.party", spec_url: "https://example.com", data: { "tables" => 5 }) }
   before :each do
     # Load all the rounds we just created.
     competition.reload
@@ -42,6 +43,7 @@ RSpec.describe "Competition WCIF" do
         "events" => [
           {
             "id" => "333",
+            "extensions" => [],
             "rounds" => [
               {
                 "id" => "333-r1",
@@ -60,6 +62,7 @@ RSpec.describe "Competition WCIF" do
                 },
                 "scrambleSetCount" => 16,
                 "results" => [],
+                "extensions" => [],
               },
               {
                 "id" => "333-r2",
@@ -72,11 +75,13 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "results" => [],
+                "extensions" => [],
               },
             ],
           },
           {
             "id" => "333fm",
+            "extensions" => [],
             "rounds" => [
               {
                 "id" => "333fm-r1",
@@ -86,11 +91,13 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "results" => [],
+                "extensions" => [],
               },
             ],
           },
           {
             "id" => "333mbf",
+            "extensions" => [],
             "rounds" => [
               {
                 "id" => "333mbf-r1",
@@ -100,11 +107,21 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "results" => [],
+                "extensions" => [
+                  {
+                    "id" => "com.third.party",
+                    "specUrl" => "https://example.com",
+                    "data" => {
+                      "tables" => 5,
+                    },
+                  },
+                ],
               },
             ],
           },
           {
             "id" => "444",
+            "extensions" => [],
             "rounds" => [
               {
                 "id" => "444-r1",
@@ -117,6 +134,7 @@ RSpec.describe "Competition WCIF" do
                 "advancementCondition" => nil,
                 "scrambleSetCount" => 1,
                 "results" => [],
+                "extensions" => [],
               },
             ],
           },
@@ -131,11 +149,13 @@ RSpec.describe "Competition WCIF" do
               "latitudeMicrodegrees" => 123_456,
               "longitudeMicrodegrees" => 123_456,
               "timezone" => "Europe/Paris",
+              "extensions" => [],
               "rooms" => [
                 {
                   "id" => 1,
                   "name" => "Room 1 for venue 1",
                   "color" => VenueRoom::DEFAULT_ROOM_COLOR,
+                  "extensions" => [],
                   "activities" => [
                     {
                       "id" => 1,
@@ -144,6 +164,7 @@ RSpec.describe "Competition WCIF" do
                       "startTime" => "2014-02-03T12:00:00Z",
                       "endTime" => "2014-02-03T13:00:00Z",
                       "childActivities" => [],
+                      "extensions" => [],
                     },
                     {
                       "id" => 2,
@@ -151,6 +172,7 @@ RSpec.describe "Competition WCIF" do
                       "activityCode" => "333fm-r1",
                       "startTime" => "2014-02-05T10:00:00Z",
                       "endTime" => "2014-02-05T11:00:00Z",
+                      "extensions" => [],
                       "childActivities" => [
                         {
                           "id" => 3,
@@ -159,6 +181,7 @@ RSpec.describe "Competition WCIF" do
                           "startTime" => "2014-02-05T10:00:00Z",
                           "endTime" => "2014-02-05T10:30:00Z",
                           "childActivities" => [],
+                          "extensions" => [],
                         },
                         {
                           "id" => 4,
@@ -166,6 +189,7 @@ RSpec.describe "Competition WCIF" do
                           "activityCode" => "333fm-r1-g2",
                           "startTime" => "2014-02-05T10:30:00Z",
                           "endTime" => "2014-02-05T11:00:00Z",
+                          "extensions" => [],
                           "childActivities" => [
                             {
                               "id" => 5,
@@ -174,6 +198,7 @@ RSpec.describe "Competition WCIF" do
                               "startTime" => "2014-02-05T10:30:00Z",
                               "endTime" => "2014-02-05T11:00:00Z",
                               "childActivities" => [],
+                              "extensions" => [],
                             },
                           ],
                         },
@@ -189,18 +214,21 @@ RSpec.describe "Competition WCIF" do
               "latitudeMicrodegrees" => 123_456,
               "longitudeMicrodegrees" => 123_456,
               "timezone" => "Europe/Paris",
+              "extensions" => [],
               "rooms" => [
                 {
                   "id" => 2,
                   "name" => "Room 1 for venue 2",
                   "color" => VenueRoom::DEFAULT_ROOM_COLOR,
                   "activities" => [],
+                  "extensions" => [],
                 },
                 {
                   "id" => 3,
                   "name" => "Room 2 for venue 2",
                   "color" => VenueRoom::DEFAULT_ROOM_COLOR,
                   "activities" => [],
+                  "extensions" => [],
                 },
               ],
             },
@@ -246,6 +274,7 @@ RSpec.describe "Competition WCIF" do
     it "creates competition event when adding round to previously nonexistent event" do
       wcif["events"] << {
         "id" => "555",
+        "extensions" => [],
         "rounds" => [
           {
             "id" => "555-r1",
@@ -258,6 +287,7 @@ RSpec.describe "Competition WCIF" do
             "advancementCondition" => nil,
             "scrambleSetCount" => 1,
             "results" => [],
+            "extensions" => [],
           },
         ],
       }
@@ -284,6 +314,7 @@ RSpec.describe "Competition WCIF" do
         "advancementCondition" => nil,
         "scrambleSetCount" => 1,
         "results" => [],
+        "extensions" => [],
       }
 
       competition.set_wcif_events!(wcif["events"], delegate)
@@ -357,6 +388,32 @@ RSpec.describe "Competition WCIF" do
 
       expect(competition.to_wcif["events"]).to eq(wcif["events"])
     end
+
+    it "can set event and round extensions" do
+      wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
+      wcif_333_event["extensions"] = [
+        {
+          "id" => "com.third.party.event",
+          "specUrl" => "https://example.com/event.json",
+          "data" => {
+            "prizes" => ['100$', '50$', '20$'],
+          },
+        },
+      ]
+      wcif_333_event["rounds"][0]["extensions"] = [
+        {
+          "id" => "com.third.party.round",
+          "specUrl" => "https://example.com/round.json",
+          "data" => {
+            "displays" => 10,
+          },
+        },
+      ]
+
+      competition.set_wcif_events!(wcif["events"], delegate)
+
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+    end
   end
 
   describe "#set_wcif_schedule!" do
@@ -410,8 +467,10 @@ RSpec.describe "Competition WCIF" do
               "startTime" => competition_start_time.change(hour: 9, min: 0, sec: 0).utc.iso8601,
               "endTime" => competition_start_time.change(hour: 9, min: 15, sec: 0).utc.iso8601,
               "childActivities" => [],
+              "extensions" => [],
             },
           ],
+          "extensions" => [],
         }
         schedule_wcif["venues"][0]["rooms"][0]["activities"] << new_activity
         competition.set_wcif_schedule!(schedule_wcif, delegate)
@@ -556,6 +615,7 @@ RSpec.describe "Competition WCIF" do
           "longitudeMicrodegrees" => 456,
           "timezone" => "Europe/London",
           "rooms" => [],
+          "extensions" => [],
         }
         competition.set_wcif_schedule!(schedule_wcif, delegate)
         expect(competition.to_wcif["schedule"]).to eq(schedule_wcif)
@@ -607,6 +667,7 @@ RSpec.describe "Competition WCIF" do
           "name" => "Hippolyte's backyard",
           "color" => VenueRoom::DEFAULT_ROOM_COLOR,
           "activities" => [],
+          "extensions" => [],
         }
         competition.set_wcif_schedule!(schedule_wcif, delegate)
         expect(competition.to_wcif["schedule"]).to eq(schedule_wcif)

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -318,6 +318,13 @@ RSpec.describe "API Competitions" do
             id: 2,
             name: "my new third room",
             activities: [],
+            extensions: [{
+              id: "com.third.party.room",
+              specUrl: "https://example.com/room.json",
+              data: {
+                capacity: 100,
+              },
+            }],
           }],
         }
         schedule["venues"][1] = new_venue_attributes
@@ -325,6 +332,7 @@ RSpec.describe "API Competitions" do
         # We expect these objects to change!
         expect(venue.reload.name).to eq "new name"
         expect(room.reload.name).to eq "my new third room"
+        expect(room.wcif_extensions.first.extension_id).to eq "com.third.party.room"
         # but we still want the first one to be untouched
         first_venue = competition.reload.competition_venues.find_by(wcif_id: 1)
         expect(first_venue.name).to eq "Venue 1"


### PR DESCRIPTION
A trial of implementing the [WCIF Extensions proposal](https://docs.google.com/document/d/1UateBFRwU159qaP9QH_PD6Q11zlcafWJoWCtBQMtvj4/edit#heading=h.7uvl0bnq1y3q).

## Approach
Supporting an `"extensions"` attribute for every WCIF Entity is unpractical (many of them are unlikely to be extended, e.g. `TimeLimit`, `Cutoff`, `Avatar`) and hard to implement (as some WCIF Entities cannot be unambiguously identified, e.g. `Assignment`). For these reasons at this point the implementation supports extensions of: `Event`, `Round`, `Venue`, `Room`, `Activity`.
Another entity worth supporting is `Person`, but for now the only way to store data for `Person` is the corresponding entry in the `registrations` table (we do this for `roles` already), whereas some people may not have a registration. This is a more general issue, and we need to solve it in the future (e.g. with event-less registrations), but for now I just ignored the `Person` entity.

## Implementation
This implementation introduces a `wcif_extensions` table responsible for storing individual extensions for any WCIF Entity. It's thus designed as a polymorphic relation. `WcifExtension` is supposed to encapsulate as much shared logic as possible, so that enabling extensions for a new WCIF Entity takes pretty much 4 lines of code in the corresponding model.

## Questions
- [ ] How should the WCIF Spec by updated? I.e. one of:
1. A general note about extensions + a list of entities supporting it.
2. Changing each entity schema to also include `"extensions": [Extension]` with a reference to an `Extension` entity.