### PR TITLE
Bump fontawesome version

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -186,8 +186,8 @@ GEM
     faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
-    font-awesome-sass (4.7.0)
-      sass (>= 3.2)
+    font-awesome-sass (5.5.0.1)
+      sassc (>= 1.11)
     formatador (0.2.5)
     fullcalendar-rails (3.9.0.0)
       jquery-rails (>= 4.0.5, < 5.0.0)
@@ -462,17 +462,19 @@ GEM
       ast
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    sass (3.6.0)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+      rb-inotify (>= 0.9.7, >= 0.9)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -662,4 +664,4 @@ DEPENDENCIES
   webpacker
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
This bumps the version of Font Awesome from 4.7.0 to 5.5.0.1. This also changes the sass dependency from the soon-to-be deprecated sass to the replacement sassc.