### PR TITLE
Fix sass deprecated code warnings

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/persons.scss
+++ b/WcaOnRails/app/assets/stylesheets/persons.scss
@@ -33,7 +33,7 @@
 #person {
   /* Generic table style for the person profile page. */
   table {
-    @extend table.with-solves;
+    @extend table, .with-solves;
     white-space: nowrap;
 
     .cubing-icon {

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -129,7 +129,7 @@ table.with-solves {
 }
 
 table.wca-results {
-  @extend table.with-solves;
+  @extend table, .with-solves;
 
   thead tr th {
     &.pos {
@@ -447,10 +447,10 @@ select.input-xs {
   &:hover {
     cursor: pointer;
     .panel-info > & {
-      @extend a.list-group-item-info:hover;
+      @extend a, .list-group-item-info, :hover;
     }
     .panel-warning > & {
-      @extend a.list-group-item-warning:hover;
+      @extend a, .list-group-item-warning, :hover;
     }
   }
   a {


### PR DESCRIPTION
Fixes #1928 by following the suggestions in the warnings. This appears to have no visual impact on the CSS generated.