### PR TITLE
Don't update registration status timestamps when the status doesn't change

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -148,9 +148,14 @@ class RegistrationsController < ApplicationController
       render :edit
       return
     end
+    registration_attributes = registration_params
+    # Don't change status columns if the status is the same.
+    if @registration.checked_status.to_s == params[:registration][:status]
+      registration_attributes = registration_attributes.except(:accepted_at, :accepted_by, :deleted_at, :deleted_by)
+    end
     was_accepted = @registration.accepted?
     was_deleted = @registration.deleted?
-    if current_user.can_edit_registration?(@registration) && @registration.update_attributes(registration_params)
+    if current_user.can_edit_registration?(@registration) && @registration.update_attributes(registration_attributes)
       if !was_accepted && @registration.accepted?
         mailer = RegistrationsMailer.notify_registrant_of_accepted_registration(@registration)
         mailer.deliver_later

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe RegistrationsController do
         patch :update, params: { id: registration.id, registration: { status: 'accepted' } }
       end.to change { enqueued_jobs.size }.by(1)
       expect(registration.reload.accepted?).to be true
+      expect(registration.accepted_user).to eq organizer
     end
 
     it "changes an accepted registration to pending" do
@@ -66,6 +67,13 @@ RSpec.describe RegistrationsController do
       end.to change { enqueued_jobs.size }.by(1)
       expect(registration.reload.pending?).to be true
       expect(response).to redirect_to edit_registration_path(registration)
+    end
+
+    it "doesn't update accepted_at when status doesn't change" do
+      registration.update!(accepted_at: Time.now)
+      expect do
+        patch :update, params: { id: registration.id, registration: { comments: "A new comment.", status: "accepted" } }
+      end.to_not change { registration.reload.accepted_at }
     end
 
     it "can delete registration" do


### PR DESCRIPTION
Fixes #3639.
I'm not entirely happy with the solution, but that's the best I came up with given how we set the timestamps based on the `status` param.