### PR TITLE
Flatten markdown before putting into schedule

### DIFF
--- a/WcaOnRails/app/helpers/markdown_helper.rb
+++ b/WcaOnRails/app/helpers/markdown_helper.rb
@@ -47,6 +47,15 @@ module MarkdownHelper
     end
   end
 
+  class RawTextRenderer < Redcarpet::Render::HTML
+    def link(link, title, content)
+      content
+    end
+    def paragraph(text)
+      text
+    end
+  end
+
   def md(content, target_blank: false, toc: false)
     if content.nil?
       return ""
@@ -77,9 +86,8 @@ module MarkdownHelper
     output += Redcarpet::Markdown.new(WcaMarkdownRenderer.new(options), extensions).render(content).html_safe
     output
   end
-end
 
-def md_flatten(content, target_blank: false, toc: false)
-  fragment = Nokogiri::HTML(md(content, target_blank: target_blank, toc: toc))
-  fragment.text
+  def md_as_text(content)
+    Redcarpet::Markdown.new(RawTextRenderer.new(filter_html: true)).render(content)
+  end
 end

--- a/WcaOnRails/app/helpers/markdown_helper.rb
+++ b/WcaOnRails/app/helpers/markdown_helper.rb
@@ -51,6 +51,7 @@ module MarkdownHelper
     def link(link, title, content)
       content
     end
+
     def paragraph(text)
       text
     end

--- a/WcaOnRails/app/helpers/markdown_helper.rb
+++ b/WcaOnRails/app/helpers/markdown_helper.rb
@@ -78,3 +78,8 @@ module MarkdownHelper
     output
   end
 end
+
+def md_flatten(content, target_blank: false, toc: false)
+  fragment = Nokogiri::HTML(md(content, target_blank: target_blank, toc: toc))
+  fragment.text
+end

--- a/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
@@ -3,7 +3,7 @@
 <%= javascript_pack_tag 'show_schedule' %>
 <ul class="nav nav-pills nav-justified">
   <% competition.competition_venues.each_with_index do |venue, index| %>
-    <li class="<%= (index == 0) ? "active" : "" %>"><a href="#schedule-venue-<%= venue.id %>" data-toggle="pill"><%= md_flatten venue.name %></a></li>
+    <li class="<%= (index == 0) ? "active" : "" %>"><a href="#schedule-venue-<%= venue.id %>" data-toggle="pill"><%= md_as_text venue.name %></a></li>
   <% end %>
 </ul>
 <div class="tab-content" id="schedule-tab">
@@ -22,7 +22,7 @@
     </script>
     <div class="tab-pane <%= (index == 0) ? "active" : "" %>" id="schedule-venue-<%= venue.id %>" data-venue="<%= venue.id %>">
       <p>
-        <%= t("competitions.schedule.venue_information_html", venue_name: link_to_google_maps_place(md_flatten(venue.name), venue.latitude_degrees, venue.longitude_degrees)) %>
+        <%= t("competitions.schedule.venue_information_html", venue_name: link_to_google_maps_place(md_as_text(venue.name), venue.latitude_degrees, venue.longitude_degrees)) %>
         <br />
         <%= t("competitions.schedule.timezone_message", timezone: venue.timezone_id) %>
         <% if competition.competition_venues.size > 1 %>

--- a/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
@@ -3,7 +3,7 @@
 <%= javascript_pack_tag 'show_schedule' %>
 <ul class="nav nav-pills nav-justified">
   <% competition.competition_venues.each_with_index do |venue, index| %>
-    <li class="<%= (index == 0) ? "active" : "" %>"><a href="#schedule-venue-<%= venue.id %>" data-toggle="pill"><%= venue.name %></a></li>
+    <li class="<%= (index == 0) ? "active" : "" %>"><a href="#schedule-venue-<%= venue.id %>" data-toggle="pill"><%= md_flatten venue.name %></a></li>
   <% end %>
 </ul>
 <div class="tab-content" id="schedule-tab">
@@ -22,7 +22,7 @@
     </script>
     <div class="tab-pane <%= (index == 0) ? "active" : "" %>" id="schedule-venue-<%= venue.id %>" data-venue="<%= venue.id %>">
       <p>
-        <%= t("competitions.schedule.venue_information_html", venue_name: link_to_google_maps_place(venue.name, venue.latitude_degrees, venue.longitude_degrees)) %>
+        <%= t("competitions.schedule.venue_information_html", venue_name: link_to_google_maps_place(md_flatten(venue.name), venue.latitude_degrees, venue.longitude_degrees)) %>
         <br />
         <%= t("competitions.schedule.timezone_message", timezone: venue.timezone_id) %>
         <% if competition.competition_venues.size > 1 %>


### PR DESCRIPTION
Fixes #3634 by creating an new helper function to flatten markdown into plaintext before putting it into the schedule view.