### PR TITLE
Add a new column `incorrect_wca_id_claim_count` to the Persons table.

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -763,6 +763,7 @@ en:
       must_not_be_present: "must not be present"
       senior_has_delegate: "cannot demote Senior Delegate with subordinate Delegates"
       already_have_id: "cannot claim a WCA ID because you already have WCA ID %{wca_id}"
+      too_many_wca_id_claims_html: "There have been too many incorrect claims for this WCA ID. Please contact the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
       wca_id_no_birthdate_html: "We do not have a birthdate recorded for this WCA ID. Please contact the WCA Results Team using <a href=\"%{dob_form_path}\">this dedicated form</a>."
       wca_id_no_gender_html: "We do not have a gender recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
       wca_id_no_citizenship_html: "We do not have a citizenship recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."

--- a/WcaOnRails/db/migrate/20181209171137_add_incorrect_wca_id_claim_count_to_persons.rb
+++ b/WcaOnRails/db/migrate/20181209171137_add_incorrect_wca_id_claim_count_to_persons.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddIncorrectWcaIdClaimCountToPersons < ActiveRecord::Migration[5.2]
+  def change
+    add_column :Persons, :incorrect_wca_id_claim_count, :integer, null: false, default: 0
+    execute <<-SQL
+      ALTER VIEW rails_persons
+      AS SELECT
+        rails_id AS id,
+        id AS wca_id,
+        subId,
+        name,
+        countryId,
+        gender,
+        year,
+        month,
+        day,
+        comments,
+        incorrect_wca_id_claim_count
+      FROM Persons;
+    SQL
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -227,6 +227,7 @@ CREATE TABLE `Persons` (
   `day` tinyint(4) NOT NULL DEFAULT '0',
   `comments` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rails_id` int(11) NOT NULL AUTO_INCREMENT,
+  `incorrect_wca_id_claim_count` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`rails_id`),
   UNIQUE KEY `index_Persons_on_id_and_subId` (`id`,`subId`),
   KEY `Persons_fk_country` (`countryId`),
@@ -966,7 +967,8 @@ SET character_set_client = utf8;
  1 AS `year`,
  1 AS `month`,
  1 AS `day`,
- 1 AS `comments`*/;
+ 1 AS `comments`,
+ 1 AS `incorrect_wca_id_claim_count`*/;
 SET character_set_client = @saved_cs_client;
 DROP TABLE IF EXISTS `registration_competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1212,11 +1214,11 @@ CREATE TABLE `votes` (
 /*!50001 SET @saved_cs_client          = @@character_set_client */;
 /*!50001 SET @saved_cs_results         = @@character_set_results */;
 /*!50001 SET @saved_col_connection     = @@collation_connection */;
-/*!50001 SET character_set_client      = utf8 */;
-/*!50001 SET character_set_results     = utf8 */;
-/*!50001 SET collation_connection      = utf8_unicode_ci */;
+/*!50001 SET character_set_client      = utf8mb4 */;
+/*!50001 SET character_set_results     = utf8mb4 */;
+/*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments` from `Persons` */;
+/*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments`,`Persons`.`incorrect_wca_id_claim_count` AS `incorrect_wca_id_claim_count` from `Persons` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
@@ -1417,4 +1419,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20180908195553'),
 ('20180912042457'),
 ('20181020004209'),
-('20181022031135');
+('20181022031135'),
+('20181209171137');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -205,7 +205,10 @@ module DatabaseDumper
           rails_id
           subId
         ),
-        db_default: %w(comments),
+        db_default: %w(
+          comments
+          incorrect_wca_id_claim_count
+        ),
         fake_values: {
           "year" => "1954",
           "month" => "12",

--- a/WcaOnRails/spec/features/claim_wca_id_spec.rb
+++ b/WcaOnRails/spec/features/claim_wca_id_spec.rb
@@ -39,12 +39,14 @@ RSpec.feature "Claim WCA ID" do
 
       # Make sure we inform the user of the incorrect birthdate they just
       # entered.
+      expect(person.reload.incorrect_wca_id_claim_count).to eq 1
       expect(page.find(".alert.alert-danger")).to have_content("Birthdate does not match our database.")
       # Now enter the correct birthdate and submit the form!
       fill_in "Birthdate", with: "1988-02-03"
       click_button "Claim WCA ID"
 
       user.reload
+      expect(person.reload.incorrect_wca_id_claim_count).to eq 1
       expect(user.unconfirmed_wca_id).to eq person.wca_id
       expect(user.delegate_to_handle_wca_id_claim).to eq delegate
     end
@@ -55,6 +57,40 @@ RSpec.feature "Claim WCA ID" do
       fill_in_selectize "WCA ID", with: person_without_dob.wca_id
 
       expect(page.find("#select-nearby-delegate-area")).to have_content "WCA ID #{person_without_dob.wca_id} does not have a birthdate assigned. Please contact the WCA Results Team to resolve this."
+    end
+
+    it 'tells you to contact Results team if you WCA ID has been incorrectly claimed too many times' do
+      visit "/profile/claim_wca_id"
+
+      # Fill in WCA ID.
+      fill_in_selectize "WCA ID", with: person.wca_id
+
+      # Wait for select delegate area to load via ajax, then fill it in.
+      expect(page.find("#select-nearby-delegate-area")).to have_content "In order to assign you your WCA ID"
+      # Select a delegate.
+      delegate = person.competitions.first.delegates.first
+      choose("user_delegate_id_to_handle_wca_id_claim_#{delegate.id}")
+
+      5.times do |i|
+        # First, intentionally fill in the incorrect birthdate,
+        # to test out our validations.
+        fill_in "Birthdate", with: "1900-01-01"
+        click_button "Claim WCA ID"
+
+        # Make sure we inform the user of the incorrect birthdate they just
+        # entered.
+        expect(page.find(".alert.alert-danger")).to have_content("Birthdate does not match our database.")
+        expect(person.reload.incorrect_wca_id_claim_count).to eq(i + 1)
+      end
+
+      # Now enter the correct birthdate and submit the form!
+      fill_in "Birthdate", with: "1988-02-03"
+      click_button "Claim WCA ID"
+
+      expect(page.find(".alert.alert-danger")).to have_content("There have been too many incorrect claims for this WCA ID. Please contact the WCA Results Team to resolve this.")
+      user.reload
+      expect(user.unconfirmed_wca_id).to eq nil
+      expect(user.delegate_to_handle_wca_id_claim).to eq nil
     end
   end
 end


### PR DESCRIPTION
This lets us track how many times someone has incorrectly tried to claim
a WCA ID, and lock the WCA ID after some number of incorrect attempts (I've chosen 5 here).
After 5 wrong attempts, they are directed to contact the WCA Results
Team.

This PR does not introduce a mechanism for unlocking an account. At
first, I expect the WRT to reset a WCA ID's incorrect claim count
through phpMyAdmin. Depending on how often this happens, we could
investigate building something easier for them to use.

![2018-12-09_11 17 12_dalinar](https://user-images.githubusercontent.com/277474/49701677-15938d80-fba4-11e8-86fd-1c87154cb9aa.gif)
