### PR TITLE
Update Instagram icon to point to real account

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -5,7 +5,7 @@
       <span>
         <a href="<%= root_path %>">World Cube Association</a>
         <br>
-        <%= link_to(icon("instagram"), "https://www.instagram.com/worldcubeassociation/", target: "_blank", class: "hide-new-window-icon") %>
+        <%= link_to(icon("instagram"), "https://www.instagram.com/thewcaofficial/", target: "_blank", class: "hide-new-window-icon") %>
         <%= link_to(icon("facebook-official"), "https://www.facebook.com/WorldCubeAssociation/", target: "_blank", class: "hide-new-window-icon") %>
         <%= link_to(icon("twitter"), "https://www.twitter.com/theWCAofficial/", target: "_blank", class: "hide-new-window-icon") %>
         <%= link_to(icon("reddit"), "https://www.reddit.com/r/TheWCAOfficial/", target: "_blank", class: "hide-new-window-icon") %>


### PR DESCRIPTION
The Instagram icon currently points to a fake account- the WCA's official Instagram is at https://www.instagram.com/thewcaofficial/