### PR TITLE
Remove TNoodle-WCA-0.13.5 from the list of allowed versions.

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -34,7 +34,6 @@ class Api::V0::ApiController < ApplicationController
       },
       "allowed" => [
         "TNoodle-WCA-0.13.5",
-        "TNoodle-WCA-0.14.0",
       ],
       "history" => [
         "TNoodle-0.7.4",


### PR DESCRIPTION
@jfly (or anyone on @thewca/software-team), could you review?