### PR TITLE
Remove TNoodle 0.13.5 from the list of allowed versions, and add 0.14.0.

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -33,7 +33,7 @@ class Api::V0::ApiController < ApplicationController
         "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.14.0.jar",
       },
       "allowed" => [
-        "TNoodle-WCA-0.13.5",
+        "TNoodle-WCA-0.14.0",
       ],
       "history" => [
         "TNoodle-0.7.4",


### PR DESCRIPTION
This was supposed to happen in
https://github.com/thewca/worldcubeassociation.org/pull/3685/, but it
was backwards!