### PR TITLE
Removing 'Changing your email will require confirming the new email' hint from signup page.

### DIFF
--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -146,7 +146,7 @@
       <div class="tab-pane active" id="email">
         <%= simple_form_for @user do |f| %>
           <%= hidden_field_tag "section", "email" %>
-          <%= f.input :email, disabled: !editable_fields.include?(:email) %>
+          <%= f.input :email, disabled: !editable_fields.include?(:email), hint: t('.confirm_new_email') %>
 
           <%= f.input :current_password %>
 

--- a/WcaOnRails/config/locales/cs.yml
+++ b/WcaOnRails/config/locales/cs.yml
@@ -612,8 +612,6 @@ cs:
           Trávníček</strong>. Ne nedbale jako <strong>b
           travnicek</strong>.<br/>Prostřední jména (celá i iniciály) jsou
           nepovinná.
-        #original_hash: c03b949
-        email: Pro změnu e-mailu je nutné nový e-mail potvrdit.
         #original_hash: 8a91e53
         pending_avatar: >-
           Po nahrání nového avataru budete muset počkat na schválení od WCA
@@ -673,7 +671,7 @@ cs:
         #original_hash: bb470cc
         information: >-
           Důležité informace, které by soutěžící měli vědět. Zobrazí se na
-          hlavní stránce soutěže. <br/>Prosíme, napište to <b>v angličtině</b> 
+          hlavní stránce soutěže. <br/>Prosíme, napište to <b>v angličtině</b>
           a v jakémkoli dalším jazyce, kterým vaši soutěžící mluví.
         #original_hash: b4d020f
         delegate_ids: Delegáti WCA pro tuto soutěž.
@@ -1278,6 +1276,7 @@ cs:
       approve: Schválit
       #original_hash: 85de4b8
       unconfirmed_email: 'E-mailová adresa tohoto účtu (%{email}) není potvrzena.'
+      confirm_new_email: Pro změnu e-mailu je nutné nový e-mail potvrdit.
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Tento účet čeká na potvrzení nové e-mailové adresy %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/da.yml
+++ b/WcaOnRails/config/locales/da.yml
@@ -606,8 +606,6 @@ da:
           Skriv dit fulde navn korrekt, for eksempel <strong>Stefan
           Pochmann</strong>. Ikke sjusket som <strong>s pochman</strong>.
           <br/>Mellem navne (enten fulde eller som initialer) er valgfrie.
-        #original_hash: c03b949
-        email: At skifte din email kræver at du bekræfter den nye email.
         #original_hash: 8a91e53
         pending_avatar: >-
           Efter at du har uploaded en ny avatar, bliver du nød til at vente på
@@ -1274,6 +1272,7 @@ da:
       approve: Godkende
       #original_hash: 85de4b8
       unconfirmed_email: 'Denne kontos email adresse (%{email}) er ikke bekræftet.'
+      confirm_new_email: 'At skifte din email kræver at du bekræfter den nye email.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Denne konto venter bekræftelse af den nye email adresse %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/de.yml
+++ b/WcaOnRails/config/locales/de.yml
@@ -607,10 +607,6 @@ de:
           Pochmann</strong>. Nicht unachtsam wie etwa <strong>s
           pochman</strong>. Zweite Vornamen (entweder ganz oder als Initial)
           sind optional.
-        #original_hash: c03b949
-        email: >-
-          Wenn Du deine E-Mail änderst, musst Du die neue Adresse erneut
-          bestätigen
         #original_hash: 8a91e53
         pending_avatar: >-
           Nachdem Du ein neues Profilbild hochgeladen hast, muss dieses erst vom
@@ -1281,6 +1277,7 @@ de:
       approve: Zustimmen
       #original_hash: 85de4b8
       unconfirmed_email: 'Die E-Mail-Adresse dieses Benutzerkontos (%{email}) ist nicht bestätigt.'
+      confirm_new_email: 'Wenn Du deine E-Mail änderst, musst Du die neue Adresse erneut bestätigen'
       #original_hash: 8a770cf
       pending_mail_confirmation: >-
         Die Bestätigung der neuen E-Mail-Adresse %{email} für diesen Acccount

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -385,7 +385,7 @@ en:
       user:
         dob: "Enter your date of birth in the format YYYY-MM-DD."
         name: "Enter your full name correctly, for example <strong>Stefan Pochmann</strong>. Not sloppily like <strong>s pochman</strong>.<br/>Middle names (either full or as initials) are optional."
-        email: "Changing your email will require confirming the new email."
+        email: ""
         pending_avatar: "After uploading a new avatar, you will have to wait for the WCA Results Team to approve it."
         country_iso2: ""
         current_password: ""
@@ -718,6 +718,7 @@ en:
       profile: "Profile"
       approve: "Approve"
       unconfirmed_email: "This account's email address (%{email}) is not confirmed."
+      confirm_new_email: "Changing your email will require confirming the new email."
       pending_mail_confirmation: "This account is pending confirmation of new email address %{email}."
       pending_avatar_confirmation: "This account is pending confirmation of a new avatar."
       pending_claim_confirmation_html: "This account is waiting for %{delegate} to confirm their claimed WCA ID %{wca_id}."

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -611,10 +611,6 @@ es:
         name: >-
           Introduce tu nombre completo y con corrección, por ejemplo
           <strong>Darío Méndez</strong> y no <strong>D Mendez</strong>.
-        #original_hash: c03b949
-        email: >-
-          Esta dirección tendrá que ser validada siguiendo las instrucciones en
-          un correo que te enviaremos.
         #original_hash: 8a91e53
         pending_avatar: >-
           Después de subir un nuevo avatar, tendrás que esperar que el Equipo de
@@ -1287,6 +1283,7 @@ es:
       approve: Aprobar
       #original_hash: 85de4b8
       unconfirmed_email: 'El correo electrónico de esta cuenta (%{email}) no está confirmado.'
+      confirm_new_email: 'Esta dirección tendrá que ser validada siguiendo las instrucciones en un correo que te enviaremos.'
       #original_hash: 8a770cf
       pending_mail_confirmation: >-
         Esta cuenta tiene pendiente confirmar una nueva dirección de correo

--- a/WcaOnRails/config/locales/fi.yml
+++ b/WcaOnRails/config/locales/fi.yml
@@ -584,8 +584,6 @@ fi:
           Pochmann</strong>. Ei huolimattomasti, kuten <strong>s
           pochman</strong>. Muut (toinen, kolmas jne.) etunimet (joko kokonaan
           tai pelkkänä alkukirjaimena) ovat vapaaehtoisia.
-        #original_hash: c03b949
-        email: Sähköpostiosoitteen vaihtaminen vaatii uuden osoitteen vahvistamista.
         #original_hash: 8a91e53
         pending_avatar: >-
           Uuden profiilikuvan lataamisen jälkeen sinun täytyy odottaa, että WCA
@@ -1229,6 +1227,7 @@ fi:
       approve: Hyväksy
       #original_hash: 85de4b8
       unconfirmed_email: 'Tämän tilin sähköpostiosoitetta (%{email}) ei ole vahvistettu.'
+      confirm_new_email: 'Sähköpostiosoitteen vaihtaminen vaatii uuden osoitteen vahvistamista.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Tämä tili odottaa uuden sähköpostiosoitteen (%{email}) vahvistamista.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -611,8 +611,6 @@ fr:
           Entrez votre nom complet correctement, par exemple <strong>Stefan
           Pochmann</strong>. Pas négligemment comme <strong>s pochman</strong>
           ou <strong>Stefan POCHMAN</strong>.
-        #original_hash: c03b949
-        email: 'Si vous changez votre adresse email, vous devrez la confirmer.'
         #original_hash: 8a91e53
         pending_avatar: >-
           Après avoir chargé une nouvelle photo de profil, vous devrez attendre
@@ -1297,6 +1295,7 @@ fr:
       approve: Approuver
       #original_hash: 85de4b8
       unconfirmed_email: 'L''adresse email (%{email}) de ce compte n''est pas confirmée.'
+      confirm_new_email: 'Si vous changez votre adresse email, vous devrez la confirmer.'
       #original_hash: 8a770cf
       pending_mail_confirmation: >-
         Ce compte est en attente de confirmation de la nouvelle adresse email

--- a/WcaOnRails/config/locales/hr.yml
+++ b/WcaOnRails/config/locales/hr.yml
@@ -608,8 +608,6 @@ hr:
           Unesite svoje puno ime točno, primjerice <strong>Pero Perić</strong>.
           Nemoje unijeti loše kao <strong>p perić</strong>. <br/> Srednje ime
           ili inicijali su neobavezni.
-        #original_hash: c03b949
-        email: Promjena Vaše e-mail adrese će zahtijevati potvrdu nove e-mail adrese.
         #original_hash: 8a91e53
         pending_avatar: >-
           Nakon prijenosa novog avatara, morate čekati potvrdu WCA Tima za
@@ -1281,6 +1279,7 @@ hr:
       approve: Prihvatite
       #original_hash: 85de4b8
       unconfirmed_email: 'E-mail adresa (%{email}) ovog korisničkog računa nije potvrđena.'
+      confirm_new_email: 'Promjena Vaše e-mail adrese će zahtijevati potvrdu nove e-mail adrese.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Ovaj korisnički račun čeka odobrenje nove e-mail adrese %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/hu.yml
+++ b/WcaOnRails/config/locales/hu.yml
@@ -598,10 +598,6 @@ hu:
           például: <strong>Péter Példa</strong>. Nem pedig hanyagul, mint
           <strong>pelda peter</strong>.<br/>A második keresztnevedet, ha nem
           használod, akkor kihagyhatod.
-        #original_hash: c03b949
-        email: >-
-          Az e-mail címed megváltoztatásához szükséges az új e-mail címed
-          megerősítése.
         #original_hash: 8a91e53
         pending_avatar: >-
           Miután feltöltötted az új profilképedet, várnod kell amíg a WCA
@@ -1268,6 +1264,7 @@ hu:
       approve: Jóváhagyás
       #original_hash: 85de4b8
       unconfirmed_email: 'A felhasználóhoz tartozó e-mail cím (%{email}) nem megerősített.'
+      confirm_new_email: 'Az e-mail címed megváltoztatásához szükséges az új e-mail címed megerősítése.'
       #original_hash: 8a770cf
       pending_mail_confirmation: >-
         Ehhez a felhasználóhoz függőben van egy új e-mail cím (%{email})

--- a/WcaOnRails/config/locales/id.yml
+++ b/WcaOnRails/config/locales/id.yml
@@ -600,8 +600,6 @@ id:
           Pochmann</strong>. Tidak sembarangan seperti <strong>s
           pochman</strong>.<br/>Nama tengah (lengkap atau disingkat) tidak
           diharuskan.
-        #original_hash: c03b949
-        email: Mengganti email Anda akan membutuhkan konfirmasi untuk email baru.
         #original_hash: 8a91e53
         pending_avatar: >-
           Setelah mengunggah avatar baru, Anda harus menunggu WCA Results Team
@@ -1276,6 +1274,7 @@ id:
       approve: Setujui
       #original_hash: 85de4b8
       unconfirmed_email: 'Alamat email akun ini (%{email}) belum terkonfirmasi.'
+      confirm_new_email: 'Mengganti email Anda akan membutuhkan konfirmasi untuk email baru.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Akun ini menunggu konfirmasi alamat email baru %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/it.yml
+++ b/WcaOnRails/config/locales/it.yml
@@ -534,8 +534,6 @@ it:
           Vigani Poli</strong>. Non inserire abbreviazioni come <strong> l
           vigani</strong>.<br/>I secondi nomi (sia completi o anche solo le
           iniziali) sono opzionali.
-        #original_hash: c03b949
-        email: Per cambiare la tua email è necessario confermare il nuovo indirizzo.
         #original_hash: 8a91e53
         pending_avatar: >-
           Dopo aver caricato il nuovo avatar, dovrai aspettare che il WCA
@@ -1075,6 +1073,7 @@ it:
       approve: Approva
       #original_hash: 85de4b8
       unconfirmed_email: 'L''indirizzo email (%{email}) di questo account non è confermato.'
+      confirm_new_email: 'Per cambiare la tua email è necessario confermare il nuovo indirizzo.'
       #original_hash: 8a770cf
       pending_mail_confirmation: >-
         Questo account è in attesa di conferma del nuovo indirizzo email

--- a/WcaOnRails/config/locales/ja.yml
+++ b/WcaOnRails/config/locales/ja.yml
@@ -584,8 +584,6 @@ ja:
           氏名を「ローマ字名姓 (漢字名)」の形で記入してください。ローマ字名・漢字名ともにご記入ください
           (ある場合)。スペースなど、記入方法にご注意ください。例: 中島 悠 の場合: <strong>Yu Nakajima
           (中島悠)</strong>
-        #original_hash: c03b949
-        email: メールアドレスを変更する場合は、確認メールによる認証が必要となります。
         #original_hash: 8a91e53
         pending_avatar: プロフィール画像の変更は、 WCA 競技結果チームの承認後に反映されます。
         #original_hash: da39a3e
@@ -1141,6 +1139,7 @@ ja:
       approve: 承認
       #original_hash: 85de4b8
       unconfirmed_email: 'メールアドレス (%{email}) が確認できません。'
+      confirm_new_email: 'メールアドレスを変更する場合は、確認メールによる認証が必要となります。'
       #original_hash: 8a770cf
       pending_mail_confirmation: '新しいメールアドレス %{email} の確認を待っています'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/ko.yml
+++ b/WcaOnRails/config/locales/ko.yml
@@ -579,8 +579,6 @@ ko:
         name: >-
           성명을 입력하세요. 예를 들어 <strong>Ilkyoo Choi</strong>. <strong>I
           Choi</strong>의 형식은 안됩니다. <br/>
-        #original_hash: c03b949
-        email: '이메일 변경시, 새로운 이메일을 검증 받으셔야 합니다.'
         #original_hash: 8a91e53
         pending_avatar: '새로운 아바타를 업로드 할 시, WCA 결과팀이 승인하기를 기다리셔야 합니다.'
         #original_hash: da39a3e
@@ -1029,6 +1027,7 @@ ko:
       approve: 승인
       #original_hash: 85de4b8
       unconfirmed_email: '이 계정의 이메일 주소 (%{email})이 검증되지 않았습니다.'
+      confirm_new_email: '이메일 변경시, 새로운 이메일을 검증 받으셔야 합니다.'
       #original_hash: 8a770cf
       pending_mail_confirmation: '이 계정은 새로운 이메일 주소 %{email}의 검증을 기다리고 있습니다.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/nl.yml
+++ b/WcaOnRails/config/locales/nl.yml
@@ -601,10 +601,6 @@ nl:
           Voer je naam volledig en juist in, bijvoorbeeld <strong>Stefan
           Pochmann</strong>. Niet: <strong>s pochmann</strong>. Tussennamen
           (volledige of als initialen) zijn optioneel.
-        #original_hash: c03b949
-        email: >-
-          Veranderen van je e-mailadres vereist bevestiging van het nieuwe
-          e-mailadres.
         #original_hash: 8a91e53
         pending_avatar: >-
           Na het uploaden van je profielfoto, is het wachten tot het
@@ -1257,6 +1253,7 @@ nl:
       approve: Goedkeuren
       #original_hash: 85de4b8
       unconfirmed_email: 'Het e-mailadres van deze account (%{email}) is nog niet bevestigd.'
+      confirm_new_email: 'Veranderen van je e-mailadres vereist bevestiging van het nieuwe e-mailadres.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Dit account wacht op bevestiging van het nieuwe e-mailadres %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/pl.yml
+++ b/WcaOnRails/config/locales/pl.yml
@@ -619,10 +619,6 @@ pl:
         name: >-
           Wprowadź swoje pełne imię poprawnie, na przykład <strong>Jan
           Kowalski</strong>. Nie zdrobniale jak <strong>j kowalski</strong>.
-        #original_hash: c03b949
-        email: >-
-          Zmiana twojego adresu email będzie wymagać potwierdzenia nowego
-          adresu.
         #original_hash: 8a91e53
         pending_avatar: >-
           Po przesłaniu nowego zdjęcia profilowego, będziesz musiał zaczekać, aż
@@ -1296,6 +1292,7 @@ pl:
       approve: Zatwierdź
       #original_hash: 85de4b8
       unconfirmed_email: 'Adres email należący do tego konta (%{email}) nie został potwierdzony.'
+      confirm_new_email: 'Zmiana twojego adresu email będzie wymagać potwierdzenia nowego adresu.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'To konto oczekuje potwierdzenia nowego adresu email %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/pt-BR.yml
+++ b/WcaOnRails/config/locales/pt-BR.yml
@@ -610,10 +610,6 @@ pt-BR:
           Informe seu nome completo corretamente, por exemplo <strong>Ayrton
           Senna da Silva</strong>, não desleixadamente como <strong>ayrton
           s</strong>.
-        #original_hash: c03b949
-        email: >-
-          Será necessário confirmar o novo email se você alterar seu email
-          cadastrado.
         #original_hash: 8a91e53
         pending_avatar: >-
           Após enviar um novo avatar, será necessário esperar a Equipe de
@@ -1284,6 +1280,7 @@ pt-BR:
       approve: Aprovar
       #original_hash: 85de4b8
       unconfirmed_email: 'O endereço de email desta conta (%{email}) não foi confirmado.'
+      confirm_new_email: 'Será necessário confirmar o novo email se você alterar seu email cadastrado.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Está pendente a confirmação do novo email desta conta (%{email}).'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/pt.yml
+++ b/WcaOnRails/config/locales/pt.yml
@@ -604,10 +604,6 @@ pt:
           Introduza o seu nome corretamente, por exemplo <strong>Luís Vaz de
           Camões</strong>, não desleixadamente como <strong>luis v
           camoes</strong>. Nomes do meio (completos ou iniciais) são opcionais.
-        #original_hash: c03b949
-        email: >-
-          Será necessário confirmar o novo email se alterar o seu email de
-          registo.
         #original_hash: 8a91e53
         pending_avatar: >-
           Após carregar um avatar novo, terá que aguardar a sua aprovação pela
@@ -1277,6 +1273,7 @@ pt:
       approve: Aprovar
       #original_hash: 85de4b8
       unconfirmed_email: 'O endereço de email desta conta (%{email}) não foi confirmado.'
+      confirm_new_email: 'Será necessário confirmar o novo email se alterar o seu email de registo.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Está pendente a confirmação do novo email (%{email}) para esta conta.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/ro.yml
+++ b/WcaOnRails/config/locales/ro.yml
@@ -597,8 +597,6 @@ ro:
           Pochmann</strong>, nu <strong>stefan pochmann</strong> sau <strong>S.
           Pochmann</strong>). Nu este obligatoriu să iți treci toate prenumele
           (dacă vrei, le poți scrie, întregi sau doar inițialele).
-        #original_hash: c03b949
-        email: Schimbarea adresei de e-mail necesită confiramrea noii adrese.
         #original_hash: 8a91e53
         pending_avatar: >-
           După încărcarea unui nou avatar, va trebui să aștepți ca Echipa de
@@ -1253,6 +1251,7 @@ ro:
       approve: Aprobă
       #original_hash: 85de4b8
       unconfirmed_email: 'Adresa de e-mail acestui cont (%{email}) nu este confirmată.'
+      confirm_new_email: 'Schimbarea adresei de e-mail necesită confiramrea noii adrese.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Așteptăm confirmarea noii adrese de e-mail: %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/ru.yml
+++ b/WcaOnRails/config/locales/ru.yml
@@ -617,8 +617,6 @@ ru:
           <strong>Antoshka Rostovikov</strong>, <strong>ANTON
           ROSTOVIKOV</strong>. Если у вас есть заграничный паспорт, введите имя
           в соответствии с ним.
-        #original_hash: c03b949
-        email: Изменение email-адреса потребует подтверждения нового адреса.
         #original_hash: 8a91e53
         pending_avatar: >-
           После загрузки новой аватарки вам придётся подождать, пока её одобрит
@@ -1285,6 +1283,7 @@ ru:
       approve: Подтвердить
       #original_hash: 85de4b8
       unconfirmed_email: 'Email-адрес этого аккаунта (%{email}) не подтверждён.'
+      confirm_new_email: 'Изменение email-адреса потребует подтверждения нового адреса.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Этот аккаунт ожидает подтверждения нового email-адреса %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/sk.yml
+++ b/WcaOnRails/config/locales/sk.yml
@@ -536,10 +536,6 @@ sk:
           Napíšte svoje celé meno správne, napríklad <strong>Stefan
           Pochmann</strong>. Nie nepresne ako <strong>s pochman</strong>.
           Stredné mená (buď celé alebo ako iniciálky) sú voliteľné.
-        #original_hash: c03b949
-        email: >-
-          Na vymenenie vášho emailu budeme potrebovať potvrdenie vášho nového
-          emailu.
         #original_hash: 8a91e53
         pending_avatar: >-
           Po tom, ako nahráte svojho nového Avatara, budete musieť počkať,
@@ -1039,6 +1035,7 @@ sk:
       approve: Povoliť
       #original_hash: 85de4b8
       unconfirmed_email: 'Emailová adresa tohto účtu (%{email}) nie je potvrdená.'
+      confirm_new_email: 'Na vymenenie vášho emailu budeme potrebovať potvrdenie vášho nového emailu.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Tomuto účtu chýbajú informácie novej emailovej adresy %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/sl.yml
+++ b/WcaOnRails/config/locales/sl.yml
@@ -585,10 +585,6 @@ sl:
           Novak</strong>. Izogibajte se površnemu vnašanju kot je <strong> j
           novak</strong>.<br/>Sredinsko ime (celo ali začetnice) se vnese, če
           sami tako želite.
-        #original_hash: c03b949
-        email: >-
-          Sprememba obstoječega E-naslova bo zahtevala potrditev novega
-          E-naslova.
         #original_hash: 8a91e53
         pending_avatar: >-
           Po prenosu novega avatarja je potrebno počakati na odobritev s strani
@@ -1203,6 +1199,7 @@ sl:
       approve: Potrdi
       #original_hash: 85de4b8
       unconfirmed_email: 'E-naslov tega uporabniškega računa (%{email}) še ni potrjen.'
+      confirm_new_email: 'Sprememba obstoječega E-naslova bo zahtevala potrditev novega E-naslova.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Uporabniški račun čaka na potrditev novega E-naslova %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/vi.yml
+++ b/WcaOnRails/config/locales/vi.yml
@@ -594,8 +594,6 @@ vi:
           Điền họ tên chính xác của bạn, có đầy đủ dấu, ví dụ <strong>Vương
           Thiện Trung</strong>. Ví dụ tên không hợp lệ: <strong>V T
           trung</strong> hoặc <strong>Vuong Thien Trung</strong>.
-        #original_hash: c03b949
-        email: Thay đổi địa chỉ email yêu cầu bạn phải xác nhận địa chỉ email mới.
         #original_hash: 8a91e53
         pending_avatar: >-
           Sau khi đăng tải hình đại diện mới, bạn phải đợi Đội ngũ Kết quả WCA
@@ -1254,6 +1252,7 @@ vi:
       approve: Chấp nhận
       #original_hash: 85de4b8
       unconfirmed_email: 'Địa chỉ email (%{email}) của tài khoản này chưa được xác nhận.'
+      confirm_new_email: 'Thay đổi địa chỉ email yêu cầu bạn phải xác nhận địa chỉ email mới.'
       #original_hash: 8a770cf
       pending_mail_confirmation: 'Tài khoản này đang chờ xác nhận từ địa chỉ email mới %{email}.'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/zh-CN.yml
+++ b/WcaOnRails/config/locales/zh-CN.yml
@@ -488,9 +488,7 @@ zh-CN:
         #original_hash: d0bb74a
         name: >-
           正确输入你的全名，比如<strong>Baiqiang Dong (董百强)</strong>。别偷懒只输入<strong>Baiqiang
-          (百强)</strong>。
-        #original_hash: c03b949
-        email: 修改邮箱需要确认新邮箱。
+          (百强)</strong>
         #original_hash: 8a91e53
         pending_avatar: 你需要等待WCA成绩组通过你上传的新头像。
         #original_hash: da39a3e
@@ -917,6 +915,7 @@ zh-CN:
       approve: 通过
       #original_hash: 85de4b8
       unconfirmed_email: '该帐号的邮件地址 (%{email})尚未确认。'
+      confirm_new_email: '修改邮箱需要确认新邮箱。'
       #original_hash: 8a770cf
       pending_mail_confirmation: '该帐号的新邮件地址%{email}正在等待确认。'
       #original_hash: 0340b0b

--- a/WcaOnRails/config/locales/zh-TW.yml
+++ b/WcaOnRails/config/locales/zh-TW.yml
@@ -581,8 +581,6 @@ zh-TW:
         name: >-
           請正確地輸入您的全名，例如<strong>Stefan Pochmann</strong>。禁止隨意輸入，例如<strong>s
           pochman</strong>。<br/>中間名（全名或字首縮寫）則可有可無。
-        #original_hash: c03b949
-        email: 您必須確認新的電子郵件才能更改您的電子郵件。
         #original_hash: 8a91e53
         pending_avatar: 上傳新的頭像之後，必須等待WCA成績組的審核。
         #original_hash: da39a3e
@@ -1133,6 +1131,7 @@ zh-TW:
       approve: 確認
       #original_hash: 85de4b8
       unconfirmed_email: '這個帳號的電子郵件(%{email})尚未確認。'
+      confirm_new_email: '您必須確認新的電子郵件才能更改您的電子郵件。'
       #original_hash: 8a770cf
       pending_mail_confirmation: '這個帳號的新電子郵件%{email}正在等待審核。'
       #original_hash: 0340b0b


### PR DESCRIPTION
Fixes:  #3665