### PR TITLE
Prevent from page jump when clicking medal links

### DIFF
--- a/WcaOnRails/app/assets/javascripts/persons.js
+++ b/WcaOnRails/app/assets/javascripts/persons.js
@@ -100,6 +100,7 @@ onPage('persons#show', function() {
 
   /* Highlight rows when user clicks on medal count. */
   $(".highlight-medal").on('click', function(event) {
+    event.preventDefault();
     var dataPlace = $(this).data('place');
     $('.results-by-event table').toggleClass('highlight-' + dataPlace);
     return false;


### PR DESCRIPTION
Clicking on medal links introduced in #3635 may cause the browser to scroll to the top of the page, this ensures it doesn't happen.