### PR TITLE
Update avatar guidelines to include all staff members

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -406,6 +406,7 @@ class User < ApplicationRecord
   def quality_assurance_committee?
     team_member?(Team.wqac)
   end
+
   def competition_announcement_team?
     team_member?(Team.wcat)
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -406,9 +406,22 @@ class User < ApplicationRecord
   def quality_assurance_committee?
     team_member?(Team.wqac)
   end
-
   def competition_announcement_team?
     team_member?(Team.wcat)
+  end
+
+  # See https://www.worldcubeassociation.org/documents/motions/02.2018.1%20-%20Definitions.pdf
+  def internal_staff?
+    full_delegate? || senior_delegate? || leader_of_any_team? || board_member?
+  end
+
+  # See https://www.worldcubeassociation.org/documents/motions/02.2018.1%20-%20Definitions.pdf
+  def external_staff?
+    candidate_delegate? || member_of_any_team?
+  end
+
+  def any_kind_of_staff?
+    internal_staff? || external_staff?
   end
 
   def team_member?(team)
@@ -419,6 +432,14 @@ class User < ApplicationRecord
     self.current_team_members.select { |t| t.team_id == team.id && t.team_leader }.count > 0
   end
 
+  def member_of_any_team?
+    !self.current_team_members.empty?
+  end
+
+  def leader_of_any_team?
+    !self.teams_where_is_leader.empty?
+  end
+
   def teams_where_is_leader
     self.current_team_members.select(&:team_leader).map(&:team).uniq
   end
@@ -427,12 +448,12 @@ class User < ApplicationRecord
     software_team?
   end
 
-  def any_kind_of_staff?
-    any_kind_of_delegate? || current_team_members.count > 0
-  end
-
   def any_kind_of_delegate?
     delegate_status.present?
+  end
+
+  def full_delegate?
+    delegate_status == "delegate"
   end
 
   def senior_delegate?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -427,6 +427,10 @@ class User < ApplicationRecord
     software_team?
   end
 
+  def any_kind_of_staff?
+    any_kind_of_delegate? || current_team_members.count > 0
+  end
+
   def any_kind_of_delegate?
     delegate_status.present?
   end

--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -15,11 +15,11 @@
         <li>If the correct orientation of the picture is clear (portrait or landscape) the picture must be submitted in that correct orientation.</li>
         <li>The avatar must not contain offensive content (e.g. offensive gestures).</li>
       </ul>
-      <h4>Additional guidelines for Delegates</h4>
+      <h4>Additional guidelines for Staff and External Staff</h4>
       <ul>
-        <li>The avatar must be of the Delegate's current self, depicted in the same fashion as how they would appear at a competition as the WCA Delegate.</li>
-        <li>The avatar must be framed, cropped, angled, and lit, so that any competitor or spectator at a competition can use it to unambiguously identify the Delegate at a competition venue.</li>
-        <li>The thumbnail of the avatar is only a section of the avatar, and it will be used to represent the full avatar. The thumbnail must be adjusted, so the Delegate can be recognized from it alone, and it must contain their face.</li>
+        <li>The avatar must be of the Staff Member's current self, depicted in the same fashion as how they would appear at a competition.</li>
+        <li>The avatar must be framed, cropped, angled, and lit, so that any competitor or spectator at a competition can use it to unambiguously identify them at a competition venue.</li>
+        <li>The thumbnail of the avatar is only a section of the avatar, and it will be used to represent the full avatar. The thumbnail must be adjusted, so the Staff Member can be recognized from it alone, and it must contain their face.</li>
       </ul>
     </div>
 
@@ -29,8 +29,8 @@
           <div class="panel-heading">
             <h3 class="panel-title">
               <%= link_to user.name, edit_user_path(user) %>
-              <% if user.any_kind_of_delegate? %>
-                (<strong>Delegate</strong> - see guidelines above)
+              <% if user.any_kind_of_staff? %>
+                (<strong>Staff/External Staff</strong> - see guidelines above)
               <% end %>
             </h3>
           </div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -193,7 +193,7 @@
                     <li><%= guideline %></li>
                   <% end %>
                 </ul>
-                <% if @user.any_kind_of_delegate? %>
+                <% if @user.any_kind_of_staff? %>
                   <br /><strong><%= t('.delegate_avatar_guidelines.title') %></strong>
                   <ul>
                     <% t('.delegate_avatar_guidelines.paragraphs').values.each do |guideline| %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -744,9 +744,9 @@ en:
         '6': "The avatar must be submitted in correct orientation."
         '7': "The avatar must not contain offensive content (e.g. offensive gestures)."
       delegate_avatar_guidelines:
-        title: "Additional guidelines for Delegates:"
+        title: "Additional guidelines for Staff and External Staff:"
         paragraphs:
-          '1': "The avatar must be of your current self, depicted in the same fashion as how you would appear at a competition as the WCA Delegate."
+          '1': "The avatar must be of your current self, depicted in the same fashion as how you would appear at a competition."
           '2': "The avatar must be framed, cropped, angled, and lit, so that any competitor or spectator at a competition can use it to unambiguously identify you at a competition venue."
           '3': "The thumbnail of the avatar is only a section of the avatar, and it will be used to represent your full avatar. The thumbnail must be adjusted, so you can be recognized from it alone, and it must contain your face."
 


### PR DESCRIPTION
It was brought up in #3661 that due to the upcoming redesign of the Teams and Committees page, we should require all Staff and External Staff to upload an avatar that complies with the guidelines that the WQAC created for Delegates. This updates the wording to make the guidelines applicable to all Staff.