### PR TITLE
Drop query parts of under for words so query isn't blocked completely

### DIFF
--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -6,8 +6,9 @@ class PersonsController < ApplicationController
       format.html
       format.js do
         persons = Person.in_region(params[:region]).order(:name)
-        params[:search]&.split&.select { |part| part.length >= 4 }.each do |part|
-          persons = persons.where("MATCH(rails_persons.name) AGAINST (:name_match IN BOOLEAN MODE) OR wca_id LIKE :wca_id_part OR ", name_match: "#{part}*", wca_id_part: "#{part}%")
+        # We're only looking at queries longer than 4 characters to avoid blocked queries because of how fulltext is currently set up. See https://github.com/thewca/worldcubeassociation.org/issues/2234
+        params[:search]&.split&.select { |part| part.length >= 4 }&.each do |part|
+          persons = persons.where("MATCH(rails_persons.name) AGAINST (:name_match IN BOOLEAN MODE) OR wca_id LIKE :wca_id_part", name_match: "#{part}*", wca_id_part: "#{part}%")
         end
 
         render json: {

--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -6,8 +6,8 @@ class PersonsController < ApplicationController
       format.html
       format.js do
         persons = Person.in_region(params[:region]).order(:name)
-        params[:search]&.split&.each do |part|
-          persons = persons.where("MATCH(rails_persons.name) AGAINST (:name_match IN BOOLEAN MODE) OR wca_id LIKE :wca_id_part", name_match: "#{part}*", wca_id_part: "#{part}%")
+        params[:search]&.split&.select { |part| part.length >= 4 }.each do |part|
+          persons = persons.where("MATCH(rails_persons.name) AGAINST (:name_match IN BOOLEAN MODE) OR wca_id LIKE :wca_id_part OR ", name_match: "#{part}*", wca_id_part: "#{part}%")
         end
 
         render json: {


### PR DESCRIPTION
The implements @timreyn's solution in #2234 of ignoring words less than four characters to avoid the query from being blocked entirely. It's not a complete fix, but I think it's better than the current situation.