### PR TITLE
Add trophy with tooltip to championships

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -397,3 +397,7 @@ table.admin-competitions {
     }
   }
 }
+
+.championship-trophy {
+  color: $orange;
+}

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -169,7 +169,14 @@
 
     </div>
     <div id="competition-data">
-      <h3><%= @competition.name %></h3>
+      <h3>
+        <% if @competition.championships.any? %>
+          <span class="championship-trophy" data-toggle="tooltip" data-placement="bottom" title="<%= @competition.championships.sort.map { |championship| championship.name }.join(", ") %>">
+            <%= icon('trophy') %>
+          </span>
+        <% end %>
+        <%= @competition.name %>
+      </h3>
       <hr />
 
       <% if @competition.user_should_post_delegate_report?(current_user) %>

--- a/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
@@ -1,7 +1,7 @@
 <h1><%= @competition.name %> is confirmed</h1>
 
 <% if @competition.championships.present? %>
-  <h2 class="alert">This competition is marked as <%= @competition.championships.map(&:name).sort.to_sentence %></h2>
+  <h2 class="alert">This competition is marked as <%= @competition.championships.sort.map(&:name).to_sentence %></h2>
   <% end %>
 
 <% if @competition.remarks.present? %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1097,6 +1097,12 @@ en:
       submit_delete: "Are you sure you want to delete this competition? There is no going back."
       coordinates: "Coordinates"
       add_championship: "Add Championship"
+      championship_types:
+        world: "World Championship"
+        continental: "Continental Championship: %{continent}"
+        national: "National Championship: %{country}"
+        greater_china: "Greater China Championship"
+        generic: "Championship: %{type}"
     #context: and when an error occured
     errors:
       invalid_name_message: "must end with a year and must contain only alphanumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )"

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
       expect(mail.subject).to eq("#{delegate.name} just confirmed #{competition.name}")
       expect(mail.body.encoded).to match("#{competition.name} is confirmed")
-      expect(mail.body.encoded).to match("This competition is marked as National Championship for Poland and World Championship")
+      expect(mail.body.encoded).to match("This competition is marked as World Championship and National Championship: Poland")
       expect(mail.body.encoded).to match("There is a competitor limit of 100 because \"The hall only fits 100 competitors.\"")
       expect(mail.body.encoded).to match(admin_edit_competition_url(competition))
     end

--- a/WcaOnRails/spec/models/championship_spec.rb
+++ b/WcaOnRails/spec/models/championship_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe Championship do
       expect(championship.name).to eq "World Championship"
 
       championship = Championship.new(championship_type: "_Europe")
-      expect(championship.name).to eq "Continental Championship for Europe"
+      expect(championship.name).to eq "Continental Championship: Europe"
 
       championship = Championship.new(championship_type: "greater_china")
       expect(championship.name).to eq "Greater China Championship"
 
       championship = Championship.new(championship_type: "ES")
-      expect(championship.name).to eq "National Championship for Spain"
+      expect(championship.name).to eq "National Championship: Spain"
     end
   end
 end


### PR DESCRIPTION
This is a potential fix for #1983. A potential issue with this is that it isn't super obvious that the trophy is hoverable, but I think this is a problem that much of the WCA website faces. A possible addition might be a little badge to the right of the competition name that says what kind of championship it is.

![screenshot from 2018-12-19 22-54-52](https://user-images.githubusercontent.com/3170853/50263021-dfdf7780-03e1-11e9-8b42-d4f09d0d9c6e.png)
