### PR TITLE
Add dummy_account column to users

### DIFF
--- a/WcaOnRails/db/migrate/20181222224850_add_dummy_account_marker_to_users.rb
+++ b/WcaOnRails/db/migrate/20181222224850_add_dummy_account_marker_to_users.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddDummyAccountMarkerToUsers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :dummy_account, :boolean, null: false, default: false
+    User.where("wca_id != '' AND encrypted_password = '' AND email LIKE '%@worldcubeassociation.org'")
+        .update_all("dummy_account = 1, email = CONCAT(wca_id, '@dummy.worldcubeassociation.org')")
+  end
+
+  def down
+    remove_column :users, :dummy_account
+    User.where("wca_id != '' AND encrypted_password = '' AND email = ''")
+        .update_all("email = CONCAT(wca_id, '@worldcubeassociation.org')")
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1165,6 +1165,7 @@ CREATE TABLE `users` (
   `preferred_locale` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `competition_notifications_enabled` tinyint(1) DEFAULT NULL,
   `receive_delegate_reports` tinyint(1) NOT NULL DEFAULT '0',
+  `dummy_account` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
@@ -1422,4 +1423,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181020004209'),
 ('20181022031135'),
 ('20181208145408'),
-('20181209171137');
+('20181209171137'),
+('20181222224850');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -591,6 +591,7 @@ module DatabaseDumper
           updated_at
           wca_id
           receive_delegate_reports
+          dummy_account
         ),
         db_default: %w(
           confirmation_sent_at

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -144,9 +144,7 @@ FactoryBot.define do
 
     factory :dummy_user, traits: [:wca_id] do
       encrypted_password { "" }
-      after(:create) do |user|
-        user.update_column(:email, "#{user.wca_id}@worldcubeassociation.org")
-      end
+      dummy_account { true }
     end
   end
 end


### PR DESCRIPTION
So far we've been determining whether a user is dummy by checking his `wca_id`, `encrypted_password` and `email`. I believe this way of handling that is a bit more complex than it could be, so this PR adds a new column that clearly indicates whether the user is dummy or not. Also I think that dummy accounts should have an empty email address instead of the fake `{wca_id}@worldcubeassociation.org` (and it was easy to skip the validation by overriding one of devise methods).

Another reason for introducing this column is simplification of the definition of locked accounts, which would come down to "non-dummy account with blank encrypted_password".