### PR TITLE
Add support for Committee/Team Senior Members.

### DIFF
--- a/WcaOnRails/app/controllers/teams_controller.rb
+++ b/WcaOnRails/app/controllers/teams_controller.rb
@@ -24,7 +24,7 @@ class TeamsController < ApplicationController
   end
 
   private def team_params
-    team_params = params.require(:team).permit(team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :_destroy]).to_h
+    team_params = params.require(:team).permit(team_members_attributes: [:id, :team_id, :user_id, :start_date, :end_date, :team_leader, :team_senior_member, :_destroy]).to_h
     if team_params[:team_members_attributes]
       team_params[:team_members_attributes].each do |member|
         member.second.merge!(current_user: current_user.id)

--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -25,7 +25,7 @@
         { text: "Delegates", path: delegates_stats_path, fa_icon: "sitemap" },
         { text: "Server status", path: server_status_path, fa_icon: "info" },
         { text: "WCA All Voting Members", path: eligible_voters_path, fa_icon: "download" },
-        { text: "WCA Leader/Senior Members", path: leader_senior_voters_path, fa_icon: "download" },
+        { text: "WCA Leaders and Seniors", path: leader_senior_voters_path, fa_icon: "download" },
       ].each do |nav_item| %>
         <%= link_to nav_item[:path], class: "list-group-item" + (current_page?(nav_item[:path]) ? ' active' : '') do %>
           <i class="fa fa-fw fa-<%= nav_item[:fa_icon] %>"></i> <%= nav_item[:text] %>

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -184,7 +184,7 @@
               <% if current_user.can_see_eligible_voters? && !current_user.can_admin_results? %>
                 <li class="divider"></li>
                 <li><%= link_to "WCA Voting Members", eligible_voters_path %></li>
-                <li><%= link_to "WCA Leader/Senior Members", leader_senior_voters_path %></li>
+                <li><%= link_to "WCA Leaders and Seniors", leader_senior_voters_path %></li>
               <% end %>
 
               <li class="divider"></li>

--- a/WcaOnRails/app/views/teams/_team_member_fields.html.erb
+++ b/WcaOnRails/app/views/teams/_team_member_fields.html.erb
@@ -3,5 +3,6 @@
   <td><%= f.input :start_date, as: :date_picker, required: true, label: false %></td>
   <td><%= f.input :end_date, as: :date_picker, label: false %></td>
   <td class="team-leader"><%= f.input :team_leader, label: false %></td>
+  <td class="team-senior-member"><%= f.input :team_senior_member, label: false %></td>
   <td></td> <!-- Extra column for .table-greedy-last-column -->
 </tr>

--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, "Editing team #{@team.friendly_id} members") %>
+<% provide(:title, "Editing #{@team.name} members") %>
 
 <div class="container">
   <h3><%= yield(:title) %></h3>
@@ -11,7 +11,8 @@
             <th>User</th>
             <th>Start date</th>
             <th>End date</th>
-            <th>Team leader</th>
+            <th>Leader</th>
+            <th>Senior Member</th>
             <th></th> <!-- Extra column for .table-greedy-last-column -->
           </tr>
         </thead>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -134,7 +134,7 @@
           </div>
         <% end %>
 
-        <% if @user.any_kind_of_staff? %>
+        <% if @user.staff? %>
           <%= f.input :receive_delegate_reports %>
         <% end %>
 

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -40,75 +40,73 @@ FactoryBot.define do
       team_leader { false }
     end
 
+    transient do
+      team_senior_member { false }
+    end
+
     trait :board_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.board.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.board.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wrt_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wrt.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wrt.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wdc_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wdc.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wdc.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wrc_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wrc.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wrc.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wct_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wct.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wct.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wqac_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wqac.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wqac.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wcat_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wcat.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wcat.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wec_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wec.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wec.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wfc_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wfc.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wfc.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wmt_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wmt.id, user_id: user.id, team_leader: options.team_leader)
+        FactoryBot.create(:team_member, team_id: Team.wmt.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 
     trait :wst_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wst.id, user_id: user.id, team_leader: options.team_leader)
-      end
-    end
-
-    trait :wcat_member do
-      after(:create) do |user|
-        FactoryBot.create(:team_member, team_id: Team.wcat.id, user_id: user.id)
+        FactoryBot.create(:team_member, team_id: Team.wst.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
       end
     end
 

--- a/WcaOnRails/spec/features/eligible_voters_spec.rb
+++ b/WcaOnRails/spec/features/eligible_voters_spec.rb
@@ -11,24 +11,17 @@ RSpec.feature "Eligible voters csv" do
 
   let!(:user) { FactoryBot.create(:user) }
   let!(:former_team_leader) {
-    FactoryBot.create(:user, :wrc_member).tap do |user|
-      user.team_members.find_by_team_id(wrc_team_id).update!(team_leader: true, end_date: 1.day.ago)
+    FactoryBot.create(:user, :wrc_member, team_leader: true).tap do |user|
+      user.team_members.find_by_team_id(wrc_team_id).update!(end_date: 1.day.ago)
     end
   }
-  let!(:team_leader) {
-    FactoryBot.create(:user, :wrc_member).tap do |user|
-      user.team_members.find_by_team_id(wrc_team_id).update!(team_leader: true)
-    end
-  }
+  let!(:team_leader) { FactoryBot.create(:user, :wrc_member, team_leader: true) }
+  let!(:team_senior_member) { FactoryBot.create(:user, :wrc_member, team_senior_member: true) }
   let!(:team_member) { FactoryBot.create(:user, :wrc_member) }
   let!(:senior_delegate) { FactoryBot.create(:senior_delegate) }
   let!(:candidate_delegate) { FactoryBot.create(:candidate_delegate, senior_delegate: senior_delegate) }
   let!(:delegate) { FactoryBot.create(:delegate, senior_delegate: senior_delegate) }
-  let!(:delegate_who_is_also_team_leader) {
-    FactoryBot.create(:delegate, :wrc_member, senior_delegate: senior_delegate).tap do |user|
-      user.team_members.find_by_team_id(wrc_team_id).update!(team_leader: true)
-    end
-  }
+  let!(:delegate_who_is_also_team_leader) { FactoryBot.create(:delegate, :wrc_member, team_leader: true, senior_delegate: senior_delegate) }
   let!(:board_member) { FactoryBot.create(:user, :board_member) }
 
   before :each do
@@ -42,6 +35,7 @@ RSpec.feature "Eligible voters csv" do
       expect(page.response_headers['Content-Disposition']).to eq 'attachment; filename="all-wca-voters-2016-05-05T10:05:03Z.csv"'
       expect(CSV.parse(page.body)).to match_array [
         [team_leader.id.to_s, team_leader.email, team_leader.name],
+        [team_senior_member.id.to_s, team_senior_member.email, team_senior_member.name],
         [delegate.id.to_s, delegate.email, delegate.name],
         [delegate_who_is_also_team_leader.id.to_s, delegate_who_is_also_team_leader.email, delegate_who_is_also_team_leader.name],
         [senior_delegate.id.to_s, senior_delegate.email, senior_delegate.name],


### PR DESCRIPTION
This is the continuation of #3747. I didn't add anything in this PR to show publicly who are Senior Members as I'm not quite sure how to do that with the current design of our [/about page](https://www.worldcubeassociation.org/about). Maybe it's better to handle this in #3662? If we decide to do that, I'll add this information to the commit message.

I've also updated the helper methods introduced with 3462f62c11fb0c953e7a9b1241cea1f16483972e.

:warning: Final implementation of this feature depends on approval of https://github.com/thewca/wca-documents/pull/34 by WCA Staff and External Staff.