### PR TITLE
Do not require entry fees for competitions in multiple countries.

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -150,7 +150,7 @@ class Competition < ApplicationRecord
   validates_numericality_of :refund_policy_percent, greater_than_or_equal_to: 0, less_than_or_equal_to: 100, if: :refund_policy_percent_required?
   validates :refund_policy_limit_date, presence: true, if: :refund_policy_percent?
   validates_inclusion_of :on_the_spot_registration, in: [true, false], if: :on_the_spot_registration_required?
-  validates_numericality_of :on_the_spot_entry_fee_lowest_denomination, greater_than_or_equal_to: 0, if: :on_the_spot_registration?
+  validates_numericality_of :on_the_spot_entry_fee_lowest_denomination, greater_than_or_equal_to: 0, if: :on_the_spot_entry_fee_required?
   monetize :on_the_spot_entry_fee_lowest_denomination,
            as: "on_the_spot_base_entry_fee",
            allow_nil: true,
@@ -645,7 +645,13 @@ class Competition < ApplicationRecord
   end
 
   def entry_fee_required?
-    confirmed? && created_at.present? && created_at > Date.new(2018, 7, 17)
+    (
+      confirmed? && created_at.present? && created_at > Date.new(2018, 7, 17) &&
+
+      # The different venues may have different entry fees. It's better for
+      # people to leave this blank than to set an incorrect value here.
+      country.present? && !country.multiple_countries?
+    )
   end
 
   def competitor_limit_enabled?
@@ -660,12 +666,34 @@ class Competition < ApplicationRecord
     confirmed? && created_at.present? && created_at > Date.new(2018, 8, 22)
   end
 
+  def on_the_spot_entry_fee_required?
+    (
+      on_the_spot_registration? &&
+
+      # The different venues may have different entry fees. It's better for
+      # people to leave this blank than to set an incorrect value here.
+      country.present? && !country.multiple_countries?
+    )
+  end
+
   def refund_policy_percent_required?
-    confirmed? && created_at.present? && created_at > Date.new(2018, 8, 22)
+    (
+      confirmed? && created_at.present? && created_at > Date.new(2018, 8, 22) &&
+
+      # The different venues may have different entry fees. It's better for
+      # people to leave this blank than to set an incorrect value here.
+      country.present? && !country.multiple_countries?
+    )
   end
 
   def guests_entry_fee_required?
-    confirmed? && created_at.present? && created_at > Date.new(2018, 8, 22)
+    (
+      confirmed? && created_at.present? && created_at > Date.new(2018, 8, 22) &&
+
+      # The different venues may have different entry fees. It's better for
+      # people to leave this blank than to set an incorrect value here.
+      country.present? && !country.multiple_countries?
+    )
   end
 
   def registration_period_required?

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -53,4 +53,8 @@ class Country < ApplicationRecord
   def self.find_by_iso2(iso2)
     c_all_by_id.values.select { |c| c.iso2 == iso2 }.first
   end
+
+  def multiple_countries?
+    MULTIPLE_COUNTRIES.any? { |c| c[:id] == self.id }
+  end
 end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -51,6 +51,26 @@ RSpec.describe Competition do
     end
   end
 
+  it "requires entry fees" do
+    competition = FactoryBot.create :competition
+    competition.confirmed = true
+
+    # Required for non-multi venue competitions.
+    competition.countryId = "USA"
+    expect(competition.entry_fee_required?).to be true
+    expect(competition.guests_entry_fee_required?).to be true
+
+    # Not required for competitions in multiple countries
+    competition.countryId = "XA"
+    expect(competition.entry_fee_required?).to be false
+    expect(competition.guests_entry_fee_required?).to be false
+
+    # Not required for with no country
+    competition.countryId = nil
+    expect(competition.entry_fee_required?).to be false
+    expect(competition.guests_entry_fee_required?).to be false
+  end
+
   context "when competition has a competitor limit" do
     it "requires competitor limit to be a number" do
       competition = FactoryBot.build :competition, competitor_limit_enabled: true


### PR DESCRIPTION
This just came up for FMC Europe, a competition which has different
registration requirements per venue. Rather than requiring the user to
specify an inaccurate number, we'd rather have these values be NULL
(unknown) in our database.

Note: This does not detect competitions in multiple venues within the
same country (such as FMC USA). We can add support for that later if we
decide we want to.