### PR TITLE
Add a test that makes sure `common.time_format` is always unset, or set to 12h or 24h.

### DIFF
--- a/WcaOnRails/config/locales/ko.yml
+++ b/WcaOnRails/config/locales/ko.yml
@@ -238,7 +238,7 @@ ko:
     #original_hash: 52249b5
     datetime_placeholder: '년-월-일 시간 (YYYY-MM-DD HH:MM)'
     #original_hash: 7136e3b
-    time_format: 12기준
+    time_format: 12h
   oauth:
     applications:
       #original_hash: 0c4ea38

--- a/WcaOnRails/spec/i18n_spec.rb
+++ b/WcaOnRails/spec/i18n_spec.rb
@@ -14,4 +14,19 @@ RSpec.describe 'I18n' do
   it 'does not have unused keys' do
     expect(unused_keys).to be_empty, "#{unused_keys.leaves.count} unused i18n keys\n#{unused_keys.inspect}\nYou can also run `i18n-tasks unused -l en' to show them"
   end
+
+  I18n.available_locales.each do |locale|
+    it "#{locale} defines time_format correctly" do
+      time_format = I18n.translate("common.time_format", locale: locale, default: nil)
+      allowed_values = [
+        "12h",
+        "24h",
+
+        # It's ok if the translation doesn't define a value for time_format, because
+        # we'll fall back to the English setting.
+        nil,
+      ]
+      expect(allowed_values).to include time_format
+    end
+  end
 end


### PR DESCRIPTION
@viroulep fixed these in
https://github.com/thewca/worldcubeassociation.org/pull/3463, but it
looks like Korean broke again since then. Added a test will make sure
this never happens again =)