### PR TITLE
Wrap announcing competition in a database transaction.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -192,11 +192,12 @@ class CompetitionsController < ApplicationController
       unless comp.website.blank?
         body += " Check out the [#{comp.name} website](#{comp.website}) for more information and registration."
       end
-      @full_post = create_post_and_redirect(title: title, body: body, author: current_user, tags: "competitions,new", world_readable: true)
-      @competition = competition_from_params
-      CompetitionsMailer.notify_organizers_of_announced_competition(@competition, @full_post).deliver_later
-
-      comp.update!(announced_at: Time.now)
+      full_post = nil
+      ActiveRecord::Base.transaction do
+        full_post = create_post_and_redirect(title: title, body: body, author: current_user, tags: "competitions,new", world_readable: true)
+        comp.update!(announced_at: Time.now)
+      end
+      CompetitionsMailer.notify_organizers_of_announced_competition(comp, full_post).deliver_later
     end
   end
 


### PR DESCRIPTION
Jacob noticed that two competitions in our database were announced, but
their `announced_at` columns were NULL. This must have been because we
crashed somewhere inbetween the call to `create_post_and_redirect` and
the call to `comp.update!`. Maybe the competition failed validations for
some reason? It's hard to tell what happened, because our server logs don't go
back that far. If we had had this code wrapped in a transaction
previously, then announcing the competition would have failed, and we
would have known to investigate it.

Note, I also moved the sending of the email to happen outside of the
database transaction. This feels more correct to me, as we don't want to
email people unless we actually *did* announce the competition (by
creating a post and updating the `announced_at` column).