### PR TITLE
Fix some JSON Schema types

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -180,7 +180,7 @@ class Registration < ApplicationRecord
 
   def self.wcif_json_schema
     {
-      "type" => "object",
+      "type" => ["object", "null"], # Note: for now there may be WCIF persons without registration.
       "properties" => {
         "wcaRegistrationId" => { "type" => "integer" },
         "eventIds" => { "type" => "array", "items" => { "type" => "string", "enum" => Event.pluck(:id) } },

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -889,10 +889,10 @@ class User < ApplicationRecord
     {
       "type" => "object",
       "properties" => {
-        "registrantId" => { "type" => "integer" },
+        "registrantId" => { "type" => ["integer", "null"] }, # Note: for now registrantId may be null if the person doesn't compete.
         "name" => { "type" => "string" },
         "wcaUserId" => { "type" => "integer" },
-        "wcaId" => { "type" => "string" },
+        "wcaId" => { "type" => ["string", "null"] },
         "countryIso2" => { "type" => "string" },
         "gender" => { "type" => "string", "enum" => %w(m f o) },
         "birthdate" => { "type" => "string" },


### PR DESCRIPTION
This fixes some validation errors that prevent valid WCIFs from being saved.
WCA ID is always `null` for newcomers, so I updated the WCIF spec as well. The other fields are subjects to change, so I just left a comment explaining why we need to allow `null`.