### PR TITLE
Cleanup metadata.json after building export.

### DIFF
--- a/webroot/results/admin/export_public.php
+++ b/webroot/results/admin/export_public.php
@@ -273,7 +273,7 @@ function exportPublic ( $exportFormatVersion, $sources ) {
 
   #--- Delete temporary and old stuff we don't need anymore
   echo "<p><b>Delete temporary and old stuff we don't need anymore</b></p>";
-  mySystem( "rm README.md $sqlFile *.tsv" );
+  mySystem( "rm README.md $sqlFile *.tsv metadata.json" );
   mySystem( "rm ../../misc/$oldBasenameStart*" );
 
   #------------------------------------------


### PR DESCRIPTION
I noticed this show up as an uncommitted file while poking around on
staging:

```
~/worldcubeassociation.org @staging> git status
HEAD detached at FETCH_HEAD
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        webroot/results/misc/metadata.json

nothing added to commit but untracked files present (use "git add" to track)
```