### PR TITLE
Add bottom-padding to /organizations page organization-box.

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/organizations.scss
+++ b/WcaOnRails/app/assets/stylesheets/organizations.scss
@@ -6,6 +6,7 @@ $organization-cell-width: 120px;
   .organization-box {
     text-align: center;
     padding-right: 20px;
+    padding-bottom: 20px;
     a {
       display: inline-block;
       position: relative;


### PR DESCRIPTION
Adding a bottom padding makes the page look less crowded and better, specially on phone.

Screenshots:

- Desktop:

![image](https://user-images.githubusercontent.com/26309166/50728708-aff8d980-112e-11e9-8b81-e11c6863a07f.png)

- Phone:

![image](https://user-images.githubusercontent.com/26309166/50728710-b71fe780-112e-11e9-8587-66e04cb4018f.png)