### PR TITLE
Some cleanup of hidden teams.

### DIFF
--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TeamMember < ApplicationRecord
-  belongs_to :team
+  belongs_to :team, -> { with_hidden }
   belongs_to :user
 
   scope :current, -> { where("end_date IS NULL OR end_date > ?", Date.today) }

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -447,11 +447,13 @@ class User < ApplicationRecord
   end
 
   def staff?
-    any_kind_of_delegate? || member_of_any_team?
+    any_kind_of_delegate? || member_of_any_official_team? || board_member?
   end
 
   def staff_with_voting_rights?
-    full_delegate? || senior_delegate? || senior_member_of_any_team? || leader_of_any_team? || board_member?
+    # See "Member with Voting Rights" in:
+    #  https://www.worldcubeassociation.org/documents/motions/02.2019.1%20-%20Definitions.pdf
+    full_delegate? || senior_delegate? || senior_member_of_any_official_team? || leader_of_any_official_team? || board_member?
   end
 
   def team_member?(team)
@@ -466,16 +468,16 @@ class User < ApplicationRecord
     self.current_team_members.select { |t| t.team_id == team.id && t.team_leader }.count > 0
   end
 
-  def member_of_any_team?
-    !self.current_team_members.empty?
+  def member_of_any_official_team?
+    self.current_teams.official.any?
   end
 
-  def senior_member_of_any_team?
-    !self.teams_where_is_senior_member.empty?
+  def senior_member_of_any_official_team?
+    self.teams_where_is_senior_member.official.any?
   end
 
-  def leader_of_any_team?
-    !self.teams_where_is_leader.empty?
+  def leader_of_any_official_team?
+    self.teams_where_is_leader.official.any?
   end
 
   def teams_where_is_senior_member

--- a/WcaOnRails/app/views/static_pages/about.html.erb
+++ b/WcaOnRails/app/views/static_pages/about.html.erb
@@ -22,8 +22,7 @@
 
   <p><%= t('about.structure.committees') %>
   <ul>
-    <% Team.all_ordered_by_english_name.each do |team| %>
-      <% next if team == Team.board %>
+    <% Team.all_official.each do |team| %>
       <li>
         <strong><%= team.name %> (<%= team.acronym %>)</strong>: <%= format_team_members(team) %> <br />
         <%= t("about.structure.#{team.friendly_id}.description") %>

--- a/WcaOnRails/app/views/static_pages/contact.html.erb
+++ b/WcaOnRails/app/views/static_pages/contact.html.erb
@@ -19,8 +19,7 @@
     <%= t('contact.members') %>: <%= Team.board.current_members.includes(:user).map { |team_member| team_member.user.name }.sort.join(", ") %>
   </p>
 
-  <% Team.all_ordered_by_english_name.each do |team| %>
-    <% next if team == Team.board %>
+  <% Team.all_official.each do |team| %>
     <p>
       <strong><%= team.name %> (<%= team.acronym %>)</strong> - <%= mail_to team.email %><br />
       <%= t("contact.#{team.friendly_id}.info_html") %><br />

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -524,7 +524,7 @@ module DatabaseDumper
     }.freeze,
     "schema_migrations" => :skip_all_rows, # This is populated when loading our schema dump
     "team_members" => {
-      where_clause: "",
+      where_clause: "JOIN teams ON teams.id=team_id WHERE NOT teams.hidden",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -540,7 +540,7 @@ module DatabaseDumper
       ),
     }.freeze,
     "teams" => {
-      where_clause: "WHERE NOT hidden",
+      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -62,6 +62,18 @@ FactoryBot.define do
       end
     end
 
+    trait :wdc_leader do
+      after(:create) do |user|
+        FactoryBot.create(:team_member, team_id: Team.wdc.id, user_id: user.id, team_leader: true)
+      end
+    end
+
+    trait :banned do
+      after(:create) do |user|
+        FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id)
+      end
+    end
+
     trait :wrc_member do
       after(:create) do |user, options|
         FactoryBot.create(:team_member, team_id: Team.wrc.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)

--- a/WcaOnRails/spec/views/teams/index.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/teams/index.html.erb_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "teams/index.html.erb" do
   describe "when signed in as an admin" do
     let!(:user) { FactoryBot.create :admin }
-    let!(:teams) { Team.all }
+    let!(:teams) { Team.all_official }
     let!(:team_member) { FactoryBot.create :team_member, user_id: user.id, team_id: teams.first.id }
 
     before do


### PR DESCRIPTION
(I'm pulling out the first commit from #3492 into this PR so I can get it merged up, without having it get stuck behind a discussion about what exactly the WDC page should look like.)

- The association between TeamMember -> Team wasn't working because of
the default scope on Team which would prevent finding the team for
banned team members.
- A similar issue would prevent `Team.banned` from finding the cached
team, because we were doing a `Team.all` instead of a `Team.unscoped`.
- When dumping the developer database export, we actually *do* want to
include hidden teams, we just don't want to include the members of those
teams. Previously, we were excluding the teams, but not the team
members, which means that members of the banned team would actually end
up in the developer export! Fortunately, we haven't started using the
banned competitors team yet, so we haven't leaked any sensitive
information. Also, it's better to actually include the banned team in
the export because any code that does a `Team.banned` will break if the
banned competitors team does not exist.