### PR TITLE
Modified fallback case in Envfile

### DIFF
--- a/WcaOnRails/Envfile
+++ b/WcaOnRails/Envfile
@@ -29,7 +29,7 @@ elsif defined? Rails::Server
   port = Rails::Server::Options.new.parse!(ARGV)[:Port]
   default_root_url = "http://localhost:#{port}"
 else
-  default_root_url = ""
+  default_root_url = "http://test.host"
 end
 variable :ROOT_URL, :string, default: default_root_url
 


### PR DESCRIPTION
The Envfile currently does not specify a host address if `user.inspect` is not called within a request. This change fixes this, adding a host address if the method is called via the Rails console.