### PR TITLE
WCIF udpate endpoint

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -38,13 +38,14 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def update_wcif
-    competition = competition_from_params({
+    includes_associations = [{
       competition_venues: {
         venue_rooms: {
           schedule_activities: [{ child_activities: [:holder] }, :holder],
         },
       },
-    })
+    }]
+    competition = competition_from_params(includes_associations)
     require_can_manage!(competition)
     wcif = params.permit!.to_h
     wcif = wcif["_json"] || wcif

--- a/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
+++ b/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
@@ -17,7 +17,7 @@ export default class EditEvents extends React.Component {
     let onSuccess = () => this.setState({ savedWcifEvents: _.cloneDeep(wcifEvents), saving: false });
     let onFailure = () => this.setState({ saving: false });
 
-    saveWcifPart(competitionId, '/events', wcifEvents, onSuccess, onFailure);
+    saveWcifPart(competitionId, 'events', wcifEvents, onSuccess, onFailure);
   }
 
   unsavedChanges() {

--- a/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
+++ b/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
@@ -6,7 +6,7 @@ import events from 'wca/events.js.erb'
 import formats from 'wca/formats.js.erb'
 import { rootRender } from 'edit-events'
 import { pluralize } from 'edit-events/modals/utils'
-import { buildActivityCode, saveWcifPart, roundIdToString } from 'wca/wcif-utils'
+import { buildActivityCode, saveWcif, roundIdToString } from 'wca/wcif-utils'
 import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton } from 'edit-events/modals'
 
 export default class EditEvents extends React.Component {
@@ -17,7 +17,7 @@ export default class EditEvents extends React.Component {
     let onSuccess = () => this.setState({ savedWcifEvents: _.cloneDeep(wcifEvents), saving: false });
     let onFailure = () => this.setState({ saving: false });
 
-    saveWcifPart(competitionId, 'events', wcifEvents, onSuccess, onFailure);
+    saveWcif(competitionId, { events: wcifEvents }, onSuccess, onFailure);
   }
 
   unsavedChanges() {

--- a/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
+++ b/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
@@ -14,7 +14,7 @@ import { rootRender } from 'edit-schedule'
 import { EditVenue } from './EditVenue'
 import { SchedulesEditor } from './SchedulesEditor'
 import { initElementsIds, newVenueId } from './utils'
-import { saveWcifPart } from 'wca/wcif-utils'
+import { saveWcif } from 'wca/wcif-utils'
 
 export const schedulesEditPanelSelector = "#schedules-edit-panel";
 
@@ -31,7 +31,7 @@ export default class EditSchedule extends React.Component {
     let onSuccess = () => this.setState({ savedScheduleWcif: _.cloneDeep(competitionInfo.scheduleWcif), saving: false });
     let onFailure = () => this.setState({ saving: false });
 
-    saveWcifPart(competitionInfo.id, 'schedule', competitionInfo.scheduleWcif, onSuccess, onFailure);
+    saveWcif(competitionInfo.id, { schedule: competitionInfo.scheduleWcif }, onSuccess, onFailure);
   }
 
 

--- a/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
+++ b/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
@@ -31,7 +31,7 @@ export default class EditSchedule extends React.Component {
     let onSuccess = () => this.setState({ savedScheduleWcif: _.cloneDeep(competitionInfo.scheduleWcif), saving: false });
     let onFailure = () => this.setState({ saving: false });
 
-    saveWcifPart(competitionInfo.id, '/schedule', competitionInfo.scheduleWcif, onSuccess, onFailure);
+    saveWcifPart(competitionInfo.id, 'schedule', competitionInfo.scheduleWcif, onSuccess, onFailure);
   }
 
 

--- a/WcaOnRails/app/javascript/wca/wcif-utils.js
+++ b/WcaOnRails/app/javascript/wca/wcif-utils.js
@@ -19,8 +19,8 @@ function promiseSaveWcif(competitionId, data) {
   return fetch(url, fetchOptions);
 }
 
-export function saveWcifPart(competitionId, partName, data, onSuccess, onFailure) {
-  promiseSaveWcif(competitionId, { [partName]: data }).then(response => {
+export function saveWcif(competitionId, data, onSuccess, onFailure) {
+  promiseSaveWcif(competitionId, data).then(response => {
     return Promise.all([response, response.json()]);
   }).then(([response, json]) => {
     if(!response.ok) {

--- a/WcaOnRails/app/javascript/wca/wcif-utils.js
+++ b/WcaOnRails/app/javascript/wca/wcif-utils.js
@@ -4,8 +4,8 @@ function getAuthenticityToken() {
   return document.querySelector('meta[name=csrf-token]').content;
 }
 
-function promiseSaveWcif(competitionId, wcifPath, data) {
-  let url = `/api/v0/competitions/${competitionId}/wcif${wcifPath}`;
+function promiseSaveWcif(competitionId, data) {
+  let url = `/api/v0/competitions/${competitionId}/wcif`;
   let fetchOptions = {
     headers: {
       "Content-Type": "application/json",
@@ -19,8 +19,8 @@ function promiseSaveWcif(competitionId, wcifPath, data) {
   return fetch(url, fetchOptions);
 }
 
-export function saveWcifPart(competitionId, wcifPath, data, onSuccess, onFailure) {
-  promiseSaveWcif(competitionId, wcifPath, data).then(response => {
+export function saveWcifPart(competitionId, partName, data, onSuccess, onFailure) {
+  promiseSaveWcif(competitionId, { [partName]: data }).then(response => {
     return Promise.all([response, response.json()]);
   }).then(([response, json]) => {
     if(!response.ok) {

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1279,7 +1279,7 @@ class Competition < ApplicationRecord
             "numberOfDays" => { "type" => "integer" },
           },
         },
-      }
+      },
     }
   end
 

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1181,7 +1181,7 @@ class Competition < ApplicationRecord
     end
   end
 
-  private def set_wcif_events!(wcif_events, current_user)
+  def set_wcif_events!(wcif_events, current_user)
     # Remove extra events.
     self.competition_events.each do |competition_event|
       wcif_event = wcif_events.find { |e| e["id"] == competition_event.event.id }
@@ -1214,7 +1214,7 @@ class Competition < ApplicationRecord
   end
 
   # Takes an array of partial Person WCIF and updates the fields that are not immutable.
-  private def update_persons_wcif!(wcif_persons, current_user)
+  def update_persons_wcif!(wcif_persons, current_user)
     wcif_persons.each do |wcif_person|
       registration = registrations.find_by(user_id: wcif_person["wcaUserId"])
       # Note: person doesn't necessarily have corresponding registration (e.g. registratinless organizer/delegate).
@@ -1243,7 +1243,7 @@ class Competition < ApplicationRecord
     end
   end
 
-  private def set_wcif_schedule!(wcif_schedule, current_user)
+  def set_wcif_schedule!(wcif_schedule, current_user)
     if wcif_schedule["startDate"] != start_date.strftime("%F")
       raise WcaExceptions::BadApiParameter.new("Wrong start date for competition")
     elsif wcif_schedule["numberOfDays"] != number_of_days

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -185,9 +185,7 @@ Rails.application.routes.draw do
       get '/persons/:wca_id' => "persons#show", as: :person
       resources :competitions, only: [:index, :show] do
         get '/wcif' => 'competitions#show_wcif'
-        patch '/wcif/events' => 'competitions#update_events_from_wcif', as: :update_events_from_wcif
-        patch '/wcif/persons' => 'competitions#update_persons_from_wcif', as: :update_persons_from_wcif
-        patch '/wcif/schedule' => 'competitions#update_schedule_from_wcif', as: :update_schedule_from_wcif
+        patch '/wcif' => 'competitions#update_wcif', as: :update_wcif
       end
       get '/records' => "api#records"
     end

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -657,7 +657,6 @@ RSpec.describe "Competition WCIF" do
         room = competition.competition_venues.first.venue_rooms.find_by(wcif_id: 44)
         expect(room.name).to eq "Hippolyte's backyard"
       end
-
     end
   end
 

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -490,15 +490,6 @@ RSpec.describe "Competition WCIF" do
         expect(child_activity.end_time).to eq new_activity["childActivities"][0]["endTime"]
       end
 
-      it "Doesn't update invalid activity" do
-        %w(id name childActivities activityCode startTime endTime).each do |attr|
-          save_attr = schedule_wcif["venues"][0]["rooms"][0]["activities"][0][attr]
-          schedule_wcif["venues"][0]["rooms"][0]["activities"][0][attr] = nil
-          expect { competition.set_wcif_schedule!(schedule_wcif, delegate) }.to raise_error(JSON::Schema::ValidationError)
-          schedule_wcif["venues"][0]["rooms"][0]["activities"][0][attr] = save_attr
-        end
-      end
-
       it "Doesn't update with an invalid activity code" do
         # Try updating an activity with an invalid activity code
         activity = schedule_wcif["venues"][0]["rooms"][0]["activities"][0]
@@ -626,15 +617,6 @@ RSpec.describe "Competition WCIF" do
         expect(venue.longitude_microdegrees).to eq 456
         expect(venue.timezone_id).to eq "Europe/London"
       end
-
-      it "Doesn't update invalid venue" do
-        %w(id name latitudeMicrodegrees longitudeMicrodegrees timezone rooms).each do |attr|
-          save_attr = schedule_wcif["venues"][0][attr]
-          schedule_wcif["venues"][0][attr] = nil
-          expect { competition.set_wcif_schedule!(schedule_wcif, delegate) }.to raise_error(JSON::Schema::ValidationError)
-          schedule_wcif["venues"][0][attr] = save_attr
-        end
-      end
     end
 
     context "rooms" do
@@ -676,12 +658,37 @@ RSpec.describe "Competition WCIF" do
         expect(room.name).to eq "Hippolyte's backyard"
       end
 
+    end
+  end
+
+  describe "#set_wcif!" do
+    let(:wcif) { competition.to_wcif }
+
+    context "validates the given data with JSON Schema definition" do
+      it "Doesn't update invalid venue" do
+        %w(id name latitudeMicrodegrees longitudeMicrodegrees timezone rooms).each do |attr|
+          save_attr = wcif["schedule"]["venues"][0][attr]
+          wcif["schedule"]["venues"][0][attr] = nil
+          expect { competition.set_wcif!(wcif, delegate) }.to raise_error(JSON::Schema::ValidationError)
+          wcif["schedule"]["venues"][0][attr] = save_attr
+        end
+      end
+
+      it "Doesn't update invalid activity" do
+        %w(id name childActivities activityCode startTime endTime).each do |attr|
+          save_attr = wcif["schedule"]["venues"][0]["rooms"][0]["activities"][0][attr]
+          wcif["schedule"]["venues"][0]["rooms"][0]["activities"][0][attr] = nil
+          expect { competition.set_wcif!(wcif, delegate) }.to raise_error(JSON::Schema::ValidationError)
+          wcif["schedule"]["venues"][0]["rooms"][0]["activities"][0][attr] = save_attr
+        end
+      end
+
       it "Doesn't update invalid room" do
         %w(id name activities).each do |attr|
-          save_attr = schedule_wcif["venues"][0]["rooms"][0][attr]
-          schedule_wcif["venues"][0]["rooms"][0][attr] = nil
-          expect { competition.set_wcif_schedule!(schedule_wcif, delegate) }.to raise_error(JSON::Schema::ValidationError)
-          schedule_wcif["venues"][0]["rooms"][0][attr] = save_attr
+          save_attr = wcif["schedule"]["venues"][0]["rooms"][0][attr]
+          wcif["schedule"]["venues"][0]["rooms"][0][attr] = nil
+          expect { competition.set_wcif!(wcif, delegate) }.to raise_error(JSON::Schema::ValidationError)
+          wcif["schedule"]["venues"][0]["rooms"][0][attr] = save_attr
         end
       end
     end

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -387,6 +387,6 @@ def create_wcif_with_events(event_ids)
           },
         ],
       }
-    end
+    end,
   }
 end

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -5,26 +5,38 @@ require "rails_helper"
 RSpec.describe "API Competitions" do
   let(:headers) { { "CONTENT_TYPE" => "application/json" } }
 
-  describe "PATCH #update_events_from_wcif" do
-    let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
+  describe "PATCH #update_wcif" do
+    context "when not signed in" do
+      let(:competition) { FactoryBot.create(:competition, :visible) }
 
-    describe "website user (cookies based)" do
-      context "when not signed in" do
-        sign_out
-
-        it "does not allow access" do
-          patch api_v0_competition_update_events_from_wcif_path(competition)
-          expect(response).to have_http_status(401)
-          response_json = JSON.parse(response.body)
-          expect(response_json["error"]).to eq "Not logged in"
-        end
+      it "does not allow access" do
+        patch api_v0_competition_update_wcif_path(competition)
+        expect(response).to have_http_status(401)
+        response_json = JSON.parse(response.body)
+        expect(response_json["error"]).to eq "Not logged in"
       end
+    end
+
+    context "when signed in as not a competition manager" do
+      let(:competition) { FactoryBot.create(:competition, :visible) }
+      sign_in { FactoryBot.create :user }
+
+      it "does not allow access" do
+        patch api_v0_competition_update_wcif_path(competition)
+        expect(response).to have_http_status(403)
+        response_json = JSON.parse(response.body)
+        expect(response_json["error"]).to eq "Not authorized to manage competition"
+      end
+    end
+
+    describe "events" do
+      let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
 
       context "when signed in as a board member" do
         sign_in { FactoryBot.create :user, :board_member }
 
         it "updates the competition events of an unconfirmed competition" do
-          patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333)).to_json, headers: headers
+          patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(333)).to_json, headers: headers
           expect(response).to be_successful
           expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 1
         end
@@ -36,12 +48,12 @@ RSpec.describe "API Competitions" do
 
           ce = competition.competition_events.find_by_event_id("333")
           expect(ce.rounds.length).to eq 2
-          competition_events = create_wcif_events(%w(333))
-          competition_events[0][:rounds][0][:format] = "invalidformat"
-          patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
+          wcif = create_wcif_with_events(%w(333))
+          wcif[:events][0][:rounds][0][:format] = "invalidformat"
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
           expect(response).to have_http_status(400)
           response_json = JSON.parse(response.body)
-          expect(response_json["error"]).to eq "The property '#/0/rounds/0/format' value \"invalidformat\" did not match one of the following values: 1, 2, 3, a, m"
+          expect(response_json["error"]).to eq "The property '#/events/0/rounds/0/format' value \"invalidformat\" did not match one of the following values: 1, 2, 3, a, m"
           expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 2
         end
 
@@ -49,49 +61,42 @@ RSpec.describe "API Competitions" do
           let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :confirmed, event_ids: %w(222 333)) }
 
           it "can add events" do
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333 333oh 222)).to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(333 333oh 222)).to_json, headers: headers
             expect(response).to have_http_status(200)
-            competition.reload
-            expect(competition.events.map(&:id)).to match_array %w(222 333 333oh)
+            expect(competition.reload.events.map(&:id)).to match_array %w(222 333 333oh)
           end
 
           it "can remove events" do
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333)).to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(333)).to_json, headers: headers
             expect(response).to have_http_status(200)
-            competition.reload
-            expect(competition.events.map(&:id)).to match_array %w(333)
+            expect(competition.reload.events.map(&:id)).to match_array %w(333)
           end
         end
       end
 
       context "when signed in as competition delegate" do
-        let(:comp_delegate) { competition.delegates.first }
-
-        before :each do
-          sign_in comp_delegate
-          competition.events = [Event.find("333"), Event.find("222")]
-        end
+        before { sign_in competition.delegates.first }
 
         context "confirmed competition" do
-          let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :confirmed, event_ids: %w(222)) }
+          let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :confirmed, event_ids: %w(222 333)) }
 
           it "allows adding rounds to an event" do
-            competition_events = create_wcif_events(%w(222 333))
-            expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 0
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
+            competition.competition_events.find_by_event_id("333").rounds.delete_all
+            expect(competition.competition_events.find_by_event_id("333").rounds.length).to eq 0
+            patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(222 333)).to_json, headers: headers
             expect(response).to be_successful
-            expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 1
+            expect(competition.competition_events.find_by_event_id("333").rounds.length).to eq 1
           end
 
           it "does not allow adding events" do
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333 333oh 222)).to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(333 333oh 222)).to_json, headers: headers
             expect(response).to have_http_status(422)
             response_json = JSON.parse(response.body)
             expect(response_json["error"]).to eq "Cannot add events to a confirmed competition"
           end
 
           it "does not allow removing events" do
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333)).to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(333)).to_json, headers: headers
             expect(response).to have_http_status(422)
             response_json = JSON.parse(response.body)
             expect(response_json["error"]).to eq "Cannot remove events from a confirmed competition"
@@ -100,34 +105,182 @@ RSpec.describe "API Competitions" do
 
         context "unconfirmed competition" do
           it "allows adding events" do
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333 333oh 222)).to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(333 333oh 222)).to_json, headers: headers
             expect(response).to have_http_status(200)
-            competition.reload
-            expect(competition.events.map(&:id)).to match_array %w(222 333 333oh)
+            expect(competition.reload.events.map(&:id)).to match_array %w(222 333 333oh)
           end
 
           it "allows removing events" do
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: create_wcif_events(%w(333)).to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: create_wcif_with_events(%w(333)).to_json, headers: headers
             expect(response).to have_http_status(200)
-            competition.reload
-            expect(competition.events.map(&:id)).to match_array %w(333)
+            expect(competition.reload.events.map(&:id)).to match_array %w(333)
           end
         end
       end
+    end
 
-      context "when signed in as a regular user" do
-        sign_in { FactoryBot.create :user }
+    describe "persons" do
+      let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :registration_open, with_schedule: true) }
+      let!(:registration) { FactoryBot.create(:registration, competition: competition) }
+      let!(:organizer_registration) { FactoryBot.create(:registration, competition: competition, user: competition.organizers.first) }
 
-        it "does not allow access" do
-          patch api_v0_competition_update_events_from_wcif_path(competition)
-          expect(response).to have_http_status(403)
-          response_json = JSON.parse(response.body)
-          expect(response_json["error"]).to eq "Not authorized to manage competition"
+      context "when signed in as a competition manager" do
+        before { sign_in competition.organizers.first }
+
+        it "can change roles for a person" do
+          persons = [{ wcaUserId: registration.user.id, roles: ["scrambler", "dataentry"] }]
+          patch api_v0_competition_update_wcif_path(competition), params: { persons: persons }.to_json, headers: headers
+          expect(registration.reload.roles).to eq ["scrambler", "dataentry"]
+        end
+
+        it "cannot override organizer role" do
+          persons = [{ wcaUserId: organizer_registration.user.id, roles: ["scrambler"] }]
+          patch api_v0_competition_update_wcif_path(competition), params: { persons: persons }.to_json, headers: headers
+          expect(organizer_registration.reload.roles).to eq ["scrambler"]
+          person_wcif = competition.reload.to_wcif["persons"].find { |person| person["wcaUserId"] == organizer_registration.user.id }
+          expect(person_wcif["roles"]).to match_array ["scrambler", "organizer"]
+        end
+
+        it "can change assignments for a person" do
+          registration.assignments.create!(
+            schedule_activity: ScheduleActivity.first, assignment_code: "staff-runner",
+          )
+          assignments = [
+            { "activityId" => 1, "assignmentCode" => "competitor", "stationNumber" => nil },
+            { "activityId" => 2, "assignmentCode" => "staff-judge", "stationNumber" => 3 },
+          ]
+          persons = [{ wcaUserId: registration.user.id, assignments: assignments }]
+          patch api_v0_competition_update_wcif_path(competition), params: { persons: persons }.to_json, headers: headers
+          expect(registration.reload.assignments.map(&:to_wcif)).to match_array assignments
+        end
+
+        it "cannot change person immutable data" do
+          persons = [{
+            wcaUserId: registration.user.id,
+            name: "New Name",
+            wcaId: "2018NEWW01",
+            registrantId: 123,
+            countryIso2: "NEW",
+            gender: "f",
+            email: "new@email.com",
+            avatar: nil,
+            personalBests: [],
+          }]
+          expect {
+            patch api_v0_competition_update_wcif_path(competition), params: { persons: persons }.to_json, headers: headers
+          }.to_not change { competition.reload.to_wcif["persons"] }
+        end
+      end
+    end
+
+    describe "schedule" do
+      let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :registration_open, with_schedule: true) }
+      let!(:wcif) { competition.to_wcif.slice("schedule") }
+
+      context "when signed in as a competition manager" do
+        before { sign_in competition.organizers.first }
+
+        it "can set venues, rooms and activities" do
+          expect {
+            # Destroy everything
+            competition.competition_venues.destroy_all
+            # Reconstruct everything from the saved WCIF
+            patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
+          }.to_not change { competition.reload.to_wcif["schedule"] }
+        end
+
+        it "can update venues and rooms" do
+          venue = competition.competition_venues.find_by(wcif_id: 2)
+          room = venue.venue_rooms.find_by(wcif_id: 2)
+          new_venue_attributes = {
+            # keep the WCIF id to update the venue
+            id: 2,
+            name: "new name",
+            latitudeMicrodegrees: 0,
+            longitudeMicrodegrees: 0,
+            timezone: "Europe/Paris",
+            rooms: [{
+              id: 2,
+              name: "my new third room",
+              activities: [],
+              extensions: [{
+                id: "com.third.party.room",
+                specUrl: "https://example.com/room.json",
+                data: {
+                  capacity: 100,
+                },
+              }],
+            }],
+          }
+          wcif["schedule"]["venues"][1] = new_venue_attributes
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
+          # We expect these objects to change!
+          expect(venue.reload.name).to eq "new name"
+          expect(room.reload.name).to eq "my new third room"
+          expect(room.wcif_extensions.first.extension_id).to eq "com.third.party.room"
+          # but we still want the first one to be untouched
+          first_venue = competition.reload.competition_venues.find_by(wcif_id: 1)
+          expect(first_venue.name).to eq "Venue 1"
+        end
+
+        it "can delete venues and rooms" do
+          venue = competition.competition_venues.find_by(wcif_id: 2)
+          wcif["schedule"]["venues"][1]["rooms"] = []
+          wcif["schedule"]["venues"].delete_at(0)
+
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
+          # We expect this object to change!
+          expect(venue.reload.venue_rooms.size).to eq 0
+          expect(competition.reload.competition_venues.size).to eq 1
+          # We expect the rooms belonging to the deleted venue to be deleted too, so no more room should be there
+          expect(VenueRoom.all.size).to eq 0
+        end
+
+        it "can update activities and nested activities" do
+          room = competition.competition_venues.first.venue_rooms.first
+          activity_with_child = room.schedule_activities.find_by(wcif_id: 2)
+          wcif_room = wcif["schedule"]["venues"][0]["rooms"][0]
+          wcif_room["activities"][1]["name"] = "new name"
+          wcif_room["activities"][1]["childActivities"][0]["name"] = "foo"
+          wcif_room["activities"][1]["childActivities"][1]["name"] = "bar"
+
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
+
+          expect(activity_with_child.reload.name).to eq "new name"
+          expect(activity_with_child.child_activities.find_by(wcif_id: 3).name).to eq "foo"
+          expect(activity_with_child.child_activities.find_by(wcif_id: 4).name).to eq "bar"
+        end
+
+        it "can delete activities and nested activities" do
+          room = competition.competition_venues.first.venue_rooms.first
+          activity_with_child = room.schedule_activities.find_by(wcif_id: 2)
+          # Remove the nested activity with a child activity
+          wcif_room = wcif["schedule"]["venues"][0]["rooms"][0]
+          wcif_room["activities"][1]["childActivities"].delete_at(1)
+          # Remove an activity
+          wcif_room["activities"].delete_at(0)
+
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
+
+          expect(room.reload.schedule_activities.size).to eq 1
+          expect(activity_with_child.reload.child_activities.size).to eq 1
+          # We expect the nested-nested activity to be destroyed with its parent
+          expect(ScheduleActivity.all.size).to eq 2
+        end
+
+        it "doesn't change anything when submitting an invalid WCIF" do
+          wcif["schedule"]["venues"] = []
+          wcif["schedule"]["startDate"] = nil
+          expect {
+            patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
+          }.to_not change { competition.reload.competition_venues.size }
         end
       end
     end
 
     describe "OAuth user" do
+      let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
+
       context "as a competition manager" do
         let(:scopes) { Doorkeeper::OAuth::Scopes.new }
 
@@ -136,9 +289,9 @@ RSpec.describe "API Competitions" do
           api_sign_in_as(competition.organizers.first, scopes: scopes)
         end
 
-        it "can update events" do
-          competition_events = create_wcif_events(%w(333))
-          round333_first = competition_events[0][:rounds][0]
+        it "can update wcif" do
+          wcif = create_wcif_with_events(%w(333))
+          round333_first = wcif[:events][0][:rounds][0]
           round333_first[:scrambleSetCount] = 2
           round333_first[:results] = [
             {
@@ -147,7 +300,7 @@ RSpec.describe "API Competitions" do
               attempts: [{ result: 456 }, { result: 745 }, { result: 657 }, { result: 465 }, { result: 835 }],
             },
           ]
-          patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: { "CONTENT_TYPE" => "application/json" }
           expect(response).to be_successful
           rounds = competition.reload.competition_events.find_by_event_id("333").rounds
           expect(rounds.length).to eq 1
@@ -166,16 +319,20 @@ RSpec.describe "API Competitions" do
           api_sign_in_as(user, scopes: scopes)
         end
 
-        it "can't update events" do
-          competition_events = create_wcif_events(%w(333))
-          patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+        it "can't update wcif" do
+          wcif = create_wcif_with_events(%w(333))
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: { "CONTENT_TYPE" => "application/json" }
           expect(response.status).to eq 403
+          response_json = JSON.parse(response.body)
+          expect(response_json["error"]).to eq "Not authorized to manage competition"
           expect(competition.reload.competition_events.find_by_event_id("333").rounds.length).to eq 0
         end
       end
     end
 
     describe "CSRF" do
+      let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
+
       # CSRF protection is always disabled for tests, enable it for this these requests.
       around(:each) do |example|
         ActionController::Base.allow_forgery_protection = true
@@ -188,9 +345,9 @@ RSpec.describe "API Competitions" do
 
         it "prevents from CSRF attacks" do
           headers["ACCESS_TOKEN"] = "INVALID"
-          competition_events = create_wcif_events(%w(333))
+          wcif = create_wcif_with_events(%w(333))
           expect {
-            patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
           }.to raise_exception ActionController::InvalidAuthenticityToken
         end
       end
@@ -205,220 +362,31 @@ RSpec.describe "API Competitions" do
 
         it "does not use CSRF protection as we use oauth token" do
           headers["ACCESS_TOKEN"] = nil
-          competition_events = create_wcif_events(%w(333))
-          patch api_v0_competition_update_events_from_wcif_path(competition), params: competition_events.to_json, headers: headers
+          wcif = create_wcif_with_events(%w(333))
+          patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
           expect(response).to be_successful
         end
       end
     end
   end
-
-  describe "PATCH #update_persons_from_wcif" do
-    let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :registration_open, :with_valid_schedule) }
-    let!(:registration) { FactoryBot.create(:registration, competition: competition) }
-    let!(:organizer_registration) { FactoryBot.create(:registration, competition: competition, user: competition.organizers.first) }
-
-    context "when not signed in" do
-      it "does not allow access" do
-        patch api_v0_competition_update_persons_from_wcif_path(competition)
-        expect(response).to have_http_status(401)
-        response_json = JSON.parse(response.body)
-        expect(response_json["error"]).to eq "Not logged in"
-      end
-    end
-
-    context "when signed in as a competition manager" do
-      before { sign_in competition.organizers.first }
-
-      it "can change roles for a person" do
-        persons = [{ wcaUserId: registration.user.id, roles: ["scrambler", "dataentry"] }]
-        patch api_v0_competition_update_persons_from_wcif_path(competition), params: persons.to_json, headers: headers
-        expect(registration.reload.roles).to eq ["scrambler", "dataentry"]
-      end
-
-      it "cannot override organizer role" do
-        persons = [{ wcaUserId: organizer_registration.user.id, roles: ["scrambler"] }]
-        patch api_v0_competition_update_persons_from_wcif_path(competition), params: persons.to_json, headers: headers
-        expect(organizer_registration.reload.roles).to eq ["scrambler"]
-        person_wcif = competition.reload.to_wcif["persons"].find { |person| person["wcaUserId"] == organizer_registration.user.id }
-        expect(person_wcif["roles"]).to match_array ["scrambler", "organizer"]
-      end
-
-      it "can change assignments for a person" do
-        registration.assignments.create!(
-          schedule_activity: ScheduleActivity.first, assignment_code: "staff-runner",
-        )
-        assignments = [
-          { "activityId" => 1, "assignmentCode" => "competitor", "stationNumber" => nil },
-          { "activityId" => 2, "assignmentCode" => "staff-judge", "stationNumber" => 3 },
-        ]
-        persons = [{ wcaUserId: registration.user.id, assignments: assignments }]
-        patch api_v0_competition_update_persons_from_wcif_path(competition), params: persons.to_json, headers: headers
-        expect(registration.reload.assignments.map(&:to_wcif)).to match_array assignments
-      end
-
-      it "cannot change person immutable data" do
-        persons = [{
-          wcaUserId: registration.user.id,
-          name: "New Name",
-          wcaId: "2018NEWW01",
-          registrantId: 123,
-          countryIso2: "NEW",
-          gender: "f",
-          email: "new@email.com",
-          avatar: nil,
-          personalBests: [],
-        }]
-        expect {
-          patch api_v0_competition_update_persons_from_wcif_path(competition), params: persons.to_json, headers: headers
-        }.to_not change { competition.reload.to_wcif["persons"] }
-      end
-    end
-  end
-
-  describe "PATCH #update_schedule_from_wcif" do
-    let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :registration_open, with_schedule: true) }
-
-    context "when not signed in" do
-      it "does not allow access" do
-        patch api_v0_competition_update_schedule_from_wcif_path(competition)
-        expect(response).to have_http_status(401)
-        response_json = JSON.parse(response.body)
-        expect(response_json["error"]).to eq "Not logged in"
-      end
-    end
-
-    context "when signed in as not a competition manager" do
-      before(:each) { sign_in FactoryBot.create(:user) }
-      it "does not allow access" do
-        patch api_v0_competition_update_schedule_from_wcif_path(competition)
-        expect(response).to have_http_status(403)
-        response_json = JSON.parse(response.body)
-        expect(response_json["error"]).to eq "Not authorized to manage competition"
-      end
-    end
-
-    context "when signed in as a competition manager" do
-      before { sign_in competition.organizers.first }
-
-      let!(:schedule) { competition.to_wcif["schedule"] }
-
-      it "can set venues, rooms and activities" do
-        expect {
-          # Destroy everything
-          competition.competition_venues.destroy_all
-          # Reconstruct everything from the saved WCIF
-          patch api_v0_competition_update_schedule_from_wcif_path(competition), params: schedule.to_json, headers: headers
-        }.to_not change { competition.reload.to_wcif["schedule"] }
-      end
-
-      it "can update venues and rooms" do
-        venue = competition.competition_venues.find_by(wcif_id: 2)
-        room = venue.venue_rooms.find_by(wcif_id: 2)
-        new_venue_attributes = {
-          # keep the WCIF id to update the venue
-          id: 2,
-          name: "new name",
-          latitudeMicrodegrees: 0,
-          longitudeMicrodegrees: 0,
-          timezone: "Europe/Paris",
-          rooms: [{
-            id: 2,
-            name: "my new third room",
-            activities: [],
-            extensions: [{
-              id: "com.third.party.room",
-              specUrl: "https://example.com/room.json",
-              data: {
-                capacity: 100,
-              },
-            }],
-          }],
-        }
-        schedule["venues"][1] = new_venue_attributes
-        patch api_v0_competition_update_schedule_from_wcif_path(competition), params: schedule.to_json, headers: headers
-        # We expect these objects to change!
-        expect(venue.reload.name).to eq "new name"
-        expect(room.reload.name).to eq "my new third room"
-        expect(room.wcif_extensions.first.extension_id).to eq "com.third.party.room"
-        # but we still want the first one to be untouched
-        first_venue = competition.reload.competition_venues.find_by(wcif_id: 1)
-        expect(first_venue.name).to eq "Venue 1"
-      end
-
-      it "can delete venues and rooms" do
-        venue = competition.competition_venues.find_by(wcif_id: 2)
-        schedule["venues"][1]["rooms"] = []
-        schedule["venues"].delete_at(0)
-
-        patch api_v0_competition_update_schedule_from_wcif_path(competition), params: schedule.to_json, headers: headers
-        # We expect this object to change!
-        expect(venue.reload.venue_rooms.size).to eq 0
-        expect(competition.reload.competition_venues.size).to eq 1
-        # We expect the rooms belonging to the deleted venue to be deleted too, so no more room should be there
-        expect(VenueRoom.all.size).to eq 0
-      end
-
-      it "can update activities and nested activities" do
-        room = competition.competition_venues.first.venue_rooms.first
-        activity_with_child = room.schedule_activities.find_by(wcif_id: 2)
-        wcif_room = schedule["venues"][0]["rooms"][0]
-        wcif_room["activities"][1]["name"] = "new name"
-        wcif_room["activities"][1]["childActivities"][0]["name"] = "foo"
-        wcif_room["activities"][1]["childActivities"][1]["name"] = "bar"
-
-        patch api_v0_competition_update_schedule_from_wcif_path(competition), params: schedule.to_json, headers: headers
-
-        activity_with_child.reload
-        expect(activity_with_child.name).to eq "new name"
-        expect(activity_with_child.child_activities.find_by(wcif_id: 3).name).to eq "foo"
-        expect(activity_with_child.child_activities.find_by(wcif_id: 4).name).to eq "bar"
-      end
-
-      it "can delete activities and nested activities" do
-        room = competition.competition_venues.first.venue_rooms.first
-        activity_with_child = room.schedule_activities.find_by(wcif_id: 2)
-        # Remove the nested activity with a child activity
-        wcif_room = schedule["venues"][0]["rooms"][0]
-        wcif_room["activities"][1]["childActivities"].delete_at(1)
-        # Remove an activity
-        wcif_room["activities"].delete_at(0)
-
-        patch api_v0_competition_update_schedule_from_wcif_path(competition), params: schedule.to_json, headers: headers
-
-        room.reload
-        activity_with_child.reload
-        expect(room.schedule_activities.size).to eq 1
-        expect(activity_with_child.child_activities.size).to eq 1
-        # We expect the nested-nested activity to be destroyed with its parent
-        expect(ScheduleActivity.all.size).to eq 2
-      end
-
-      it "doesn't change anything when submitting an invalid WCIF" do
-        schedule["venues"] = []
-        schedule["startDate"] = nil
-        expect {
-          patch api_v0_competition_update_schedule_from_wcif_path(competition), params: schedule.to_json, headers: headers
-        }.to_not change { competition.reload.competition_venues.size }
-      end
-    end
-  end
 end
 
-def create_wcif_events(event_ids)
-  event_ids.map do |event_id|
-    {
-      id: event_id,
-      rounds: [
-        {
-          id: "#{event_id}-r1",
-          format: "a",
-          timeLimit: nil,
-          cutoff: nil,
-          advancementCondition: nil,
-          scrambleSetCount: 1,
-        },
-      ],
-    }
-  end
+def create_wcif_with_events(event_ids)
+  {
+    events: event_ids.map do |event_id|
+      {
+        id: event_id,
+        rounds: [
+          {
+            id: "#{event_id}-r1",
+            format: "a",
+            timeLimit: nil,
+            cutoff: nil,
+            advancementCondition: nil,
+            scrambleSetCount: 1,
+          },
+        ],
+      }
+    end
+  }
 end


### PR DESCRIPTION
This implements a new API endpoint for updating WCIF. The request body may include only the parts you want to update (i.e. to update schedule you can submit just `{ schedule: {...} }`), this way it combines the functionality of all the more specific endpoints we had so far, while coming with some advantages (updating WCIF becomes an atomic operation via single db transaction; also we can easily add top-level competition extensions now).

Feel free to ignore `*_spec.rb` files as there's much diff, while they barely changed content-wise. I'm think the API spec structure is way cleaner now.

Do we know of any apps using the current endpoints? (Groupifier1 does, but I will obviously take care of that).

@jfly do you have time to look at this?