### PR TITLE
Store user's preferred locale when signing up.

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -981,4 +981,13 @@ class User < ApplicationRecord
       user.skip_confirmation!
     end
   end
+
+  # This method is called by Devise when a new user signs up.
+  # This gives us an opportunity to stash the user's preferred locale in the
+  # database, which is useful for when we send them emails in the future.
+  def self.new_with_session(params, session)
+    super.tap do |user|
+      user.preferred_locale = session[:locale]
+    end
+  end
 end

--- a/WcaOnRails/spec/features/sign_up_spec.rb
+++ b/WcaOnRails/spec/features/sign_up_spec.rb
@@ -240,4 +240,22 @@ RSpec.feature "Sign up" do
       expect(page.find("#user_dob").value).to eq ""
     end
   end
+
+  context "when signing up as a non-english speaker", js: true do
+    it "stores the user's preferred locale" do
+      page.driver.headers = { 'Accept-Language' => 'es' }
+      visit "/users/sign_up"
+
+      fill_in "user[email]", with: "jack@example.com"
+      fill_in "user[password]", with: "wca"
+      fill_in "user[password_confirmation]", with: "wca"
+      click_on "Nunca he competido en competiciones de la WCA."
+      fill_in "user[name]", with: "Jack Johnson"
+
+      click_button "Registrarse"
+
+      user = User.find_by_email!("jack@example.com")
+      expect(user.preferred_locale).to eq "es"
+    end
+  end
 end


### PR DESCRIPTION
Previously, when signing up, a user would see the website in their
preferred language (because their browser sends us the
`Accept-Lanaguage` header). Their `preferred_locale` would remain NULL
in the database. Then, when they sign back into the website, they'd
still see the website in their preferred language (because they don't
have a `preferred_locale` set, we'd fall back to their `Accept-Language`
header. So far, so good. However, when we'd go on to email the user, we
don't have any HTTP headers to look at to determine their preferred
language, so we'd email them in English, which is pretty silly, because
we should have known that they prefer a different language.

This change stores the locale we derive from a users's
`Accept-Lanaguage` header in their `preferred_locale` column, so emails
should end up in their preferred language.

One quirk of this change is that a user whose language is *not*
supported by the website will end up getting their `preferred_locale`
set to `en`. I don't think this is a problem, but may be a little suprising.