### PR TITLE
Add a note about the trickiness involved in using the team management ui

### DIFF
--- a/WcaOnRails/app/views/teams/edit.html.erb
+++ b/WcaOnRails/app/views/teams/edit.html.erb
@@ -3,6 +3,28 @@
 <div class="container">
   <h3><%= yield(:title) %></h3>
   <%= alert(:info, "This team is hidden") if @team.hidden? %>
+
+  <p>
+    <b>Please note:</b> This UI is a bit tricky.
+    The <b>only</b> situation where you should be editing existing rows is to
+    fix mistakes, or to change someone's "End date" from unset to set. If you
+    run into a situation you don't know how to handle, do not hesitate to reach
+    out to the WCA Software Team!
+  </p>
+
+  <p>
+    We want to store historical data of team
+    membership <b>and</b> roles. Consider the situation where leadership of a
+    team is changing from Joe to Jane, and Joe is stepping down from the team.
+    It's tempting to uncheck Joe's "Leader" checkbox, and check the "Leader"
+    checkbox from Jane. However, this causes us to lost track of the fact that
+    Joe was a leader for a period of time, and it makes it look like Jane was
+    leader for her entire time on the team. Instead, you should mark both Joe's
+    leadership row and Jane's non-leadership rows as ending today, and create
+    two new rows starting tomorrow where Joe is not leader and Jane is leader.
+  </p>
+
+
   <%= horizontal_simple_form_for @team, html: { class: 'are-you-sure no-submit-on-enter' } do |f| %>
     <div class="team-members-wrapper">
       <%= wca_table table_class: "team-members", hover: false, striped: false do %>


### PR DESCRIPTION
This sort of fixes #3753. I think this is better than updating the UI
because it still gives power users the ability to fix mistakes.

@AlbertoPdRF, could you review and let me know how you feel about this?

<img width="519" alt="2019-01-14_20-54-59_dalinar" src="https://user-images.githubusercontent.com/277474/51159633-0e187180-183f-11e9-809e-0504b139619e.png">
