### PR TITLE
Stricter date parsing.

### DIFF
--- a/WcaOnRails/config/initializers/monkey_patches.rb
+++ b/WcaOnRails/config/initializers/monkey_patches.rb
@@ -3,13 +3,10 @@
 # Hook into rails auto reload mechanism.
 #  http://stackoverflow.com/a/7670266/1739415
 Rails.configuration.to_prepare do
-  # Date.safe_parse
-  # http://stackoverflow.com/a/21034652/1739415
   Date.class_eval do
     def self.safe_parse(value, default = nil)
-      Date.strptime(value.to_s, '%Y-%m-%d')
-    rescue ArgumentError
-      default
+      m = /\A(\d{4})-(\d{2})-(\d{2})\z/.match(value.to_s)
+      m ? Date.new(m[1].to_i, m[2].to_i, m[3].to_i) : default
     end
   end
 

--- a/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_competitions_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Api::V0::CompetitionsController do
     it 'can query by announced_after' do
       FactoryBot.create(:competition, :confirmed, :visible, name: "Old comp 2018", announced_at: 3.days.ago)
       FactoryBot.create(:competition, :confirmed, :visible, name: "New comp 2018", announced_at: Time.now)
-      get :index, params: { announced_after: 2.days.ago }
+      get :index, params: { announced_after: 2.days.ago.to_date }
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
       expect(json.map { |c| c["name"] }).to eq ["New comp 2018"]

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe CompetitionsController do
 
       context "when custom is selected" do
         before do
-          get :index, params: { state: :custom, from_date: 1.day.from_now, to_date: 2.weeks.from_now }
+          get :index, params: { state: :custom, from_date: 1.day.from_now.to_date, to_date: 2.weeks.from_now.to_date }
         end
 
         it "shows competitions overlapping the given date range" do

--- a/WcaOnRails/spec/initializers/monkey_patches_spec.rb
+++ b/WcaOnRails/spec/initializers/monkey_patches_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe "monkey patches" do
+  context "Date#safe_parse" do
+    it "parses valid dates" do
+      expect(Date.safe_parse("2018-04-03")).to eq Date.new(2018, 4, 3)
+    end
+
+    it "returns nil for invalid dates" do
+      expect(Date.safe_parse("this is not a date")).to eq nil
+      expect(Date.safe_parse("2018-1-3")).to eq nil
+    end
+
+    it "matches entire string" do
+      expect(Date.safe_parse("before 2018-01-03 after")).to eq nil
+    end
+  end
+end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe User, type: :model do
       FactoryBot.create(:user, unconfirmed_wca_id: person.wca_id,
                                delegate_id_to_handle_wca_id_claim: delegate.id,
                                claiming_wca_id: true,
-                               dob_verification: "1990-01-2")
+                               dob_verification: "1990-01-02")
     end
 
     let!(:person_without_dob) { FactoryBot.create :person, year: 0, month: 0, day: 0 }
@@ -502,7 +502,7 @@ RSpec.describe User, type: :model do
                                              unconfirmed_wca_id: person.wca_id,
                                              delegate_id_to_handle_wca_id_claim: delegate.id,
                                              claiming_wca_id: true,
-                                             dob_verification: "1990-01-2")
+                                             dob_verification: "1990-01-02")
         expect(WcaIdClaimMailer).to receive(:notify_user_of_delegate_demotion).with(user, delegate, senior_delegate).and_call_original
         expect(WcaIdClaimMailer).not_to receive(:notify_user_of_delegate_demotion).with(unconfirmed_user, delegate, senior_delegate).and_call_original
         delegate.update!(delegate_status: nil, senior_delegate_id: nil)


### PR DESCRIPTION
Our UI should only send dates of the form YYYY-MM-DD, so it would be
nice for our backend to complain if dates do not match that format.
The previous implementation would happily parse dates like `2018-1-3`,
which I think is better to not allow.

The Results Team just notified us of a dob change request with a date of
the form YYYY-M-DD, which means something must have gone wrong with our
datepicker. This doesn't fix that issue, but maybe changes things so
it's more likely people will contact us if they have issues with the
datepicker, and we can track that down.