### PR TITLE
Upgrade to bundler 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 before_install:
   # Workaround for https://github.com/travis-ci/travis-ci/issues/8978
   - gem update --system
+  - gem update bundler
 
   - nvm install 8
   - nvm use 8

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -665,4 +665,4 @@ DEPENDENCIES
   webpacker
 
 BUNDLED WITH
-   1.16.6
+   2.0.1


### PR DESCRIPTION
I followed the instructions on
https://bundler.io/blog/2019/01/03/announcing-bundler-2.html, which said
to run `bundle update --bundler`, which didn't seem to affect our
lockfile much.

I'm going to merge this up as soon as the build passes. Interestingly enough, the Bundler "Breaking changes" says that they changed the default behavior of the `github:` gem source to use https (which would allow us to [clean up our Gemfile a bit](https://github.com/thewca/worldcubeassociation.org/blob/a8696c95703109f864f3a77a44dfab0e32cd0587/WcaOnRails/Gemfile#L5-L9)), but it looks like that change didn't actually make it out into the 2.0 release. I filed an issue with them here: https://github.com/bundler/bundler/issues/6910.