### PR TITLE
Further WCIF fixes

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -50,10 +50,9 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     }
   end
 
-  private def competition_from_params(associations = {})
+  private def competition_from_params
     id = params[:competition_id] || params[:id]
-    base_model = associations.any? ? Competition.includes(associations) : Competition
-    competition = base_model.find_by_id(id)
+    competition = Competition.find_by_id(id)
 
     # If this competition exists, but is not publicly visible, then only show it
     # to the user if they are able to manage the competition.

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -23,29 +23,14 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def show_wcif
-    # This is all the associations we may need for the competition WCIF!
-    # Since registrations are ordered later, associations inclusion for them is done later
-    includes_associations = [
-      :delegates,
-      :organizers,
-      { competition_events: [rounds: :competition_event] },
-      { competition_venues: { venue_rooms: [schedule_activities: :child_activities] } },
-    ]
-    competition = competition_from_params(includes_associations)
+    competition = competition_from_params
     require_can_manage!(competition)
 
     render json: competition.to_wcif
   end
 
   def update_wcif
-    includes_associations = [{
-      competition_venues: {
-        venue_rooms: {
-          schedule_activities: [{ child_activities: [:holder] }, :holder],
-        },
-      },
-    }]
-    competition = competition_from_params(includes_associations)
+    competition = competition_from_params
     require_can_manage!(competition)
     wcif = params.permit!.to_h
     wcif = wcif["_json"] || wcif

--- a/WcaOnRails/app/models/assignment.rb
+++ b/WcaOnRails/app/models/assignment.rb
@@ -15,6 +15,10 @@ class Assignment < ApplicationRecord
     end
   end
 
+  def wcif_equal?(other_wcif)
+    to_wcif.all? { |key, value| value == other_wcif[key] }
+  end
+
   def to_wcif
     {
       "activityId" => schedule_activity.wcif_id,

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1178,9 +1178,9 @@ class Competition < ApplicationRecord
   def set_wcif!(wcif, current_user)
     JSON::Validator.validate!(Competition.wcif_json_schema, wcif)
     ActiveRecord::Base.transaction do
-      update_persons_wcif!(wcif["persons"], current_user) if wcif["persons"]
       set_wcif_events!(wcif["events"], current_user) if wcif["events"]
       set_wcif_schedule!(wcif["schedule"], current_user) if wcif["schedule"]
+      update_persons_wcif!(wcif["persons"], current_user) if wcif["persons"]
       WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     end
   end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -14,7 +14,7 @@ class Registration < ApplicationRecord
   has_many :registration_payments
   has_many :competition_events, through: :registration_competition_events
   has_many :events, through: :competition_events
-  has_many :assignments
+  has_many :assignments, dependent: :delete_all
 
   serialize :roles, Array
 

--- a/WcaOnRails/app/models/schedule_activity.rb
+++ b/WcaOnRails/app/models/schedule_activity.rb
@@ -7,7 +7,7 @@ class ScheduleActivity < ApplicationRecord
   belongs_to :holder, polymorphic: true
   has_many :child_activities, class_name: "ScheduleActivity", as: :holder, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
-  has_many :assignments
+  has_many :assignments, dependent: :delete_all
 
   validates_presence_of :name
   validates_numericality_of :wcif_id, only_integer: true

--- a/WcaOnRails/db/migrate/20190117112257_change_wcif_extensions_extendable_id_to_string.rb
+++ b/WcaOnRails/db/migrate/20190117112257_change_wcif_extensions_extendable_id_to_string.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# One of the extendable models is Competition, with id type of string.
+# To support that we need the wcif_extensions.extendable_id to also be a string.
+# For models with normal numeric ids they will be automatically converted to strings, so that's fine.
+
+class ChangeWcifExtensionsExtendableIdToString < ActiveRecord::Migration[5.2]
+  def change
+    change_column :wcif_extensions, :extendable_id, :string
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1249,7 +1249,7 @@ DROP TABLE IF EXISTS `wcif_extensions`;
 CREATE TABLE `wcif_extensions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `extendable_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `extendable_id` bigint(20) DEFAULT NULL,
+  `extendable_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `extension_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `spec_url` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `data` text COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1475,4 +1475,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181222224850'),
 ('20181226115357'),
 ('20190105215446'),
-('20190112130723');
+('20190112130723'),
+('20190117112257');

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -698,5 +698,24 @@ RSpec.describe "Competition WCIF" do
         end
       end
     end
+
+    it "allows adding assignments for newly added activities" do
+      registration = FactoryBot.create(:registration, competition: competition)
+      activities = wcif["schedule"]["venues"][0]["rooms"][0]["activities"]
+      activities << {
+        "id" => 1000,
+        "name" => "Some stuff going on",
+        "activityCode" => "other-misc-stuff",
+        "startTime" => activities.last["startTime"],
+        "endTime" => activities.last["endTime"],
+        "childActivities" => [],
+        "extensions" => [],
+      }
+      wcif["persons"].find { |person| person["wcaUserId"] == registration.user.id }["assignments"] << {
+        "activityId" => 1000,
+        "assignmentCode" => "competitor",
+      }
+      expect { competition.set_wcif!(wcif, delegate) }.to change { registration.assignments.count }.by(1)
+    end
   end
 end

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -237,6 +237,12 @@ RSpec.describe "Competition WCIF" do
         "extensions" => [],
       )
     end
+
+    it "rendered WCIF matches JSON Schema definition" do
+      expect {
+        JSON::Validator.validate!(Competition.wcif_json_schema, competition.to_wcif)
+      }.to_not raise_error
+    end
   end
 
   describe "#set_wcif_events!" do


### PR DESCRIPTION
- Changes `wcif_extensions.extendable_id` type from `integer` to `string` (we need this because `Competition.id` is `string`; happily this works with other models having `integer` `id`s, automatic conversion takes places)
- Improves performance of rendering/updating WCIF
- Adds a spec ensuring that the output of `Competition.to_wcif` is valid according to the WCIF Schema definition (as mentioned [here](https://github.com/thewca/worldcubeassociation.org/pull/3771#issuecomment-452626107))
- Fixes a bug that prevented from creating activities and assignments for them at the same time (by simply changing the order of `schedule` and `persons` update)

When fixing performance I moved relation inclusions from controller to model, I think it's better for two reasons:
- specific WCIF methods (e.g. `wcif_events`, `wcif_schedule`) include relevant associations no matter where are they called
-  `set_wcif!` doesn't necessarily call all the sub-methods (e.g. when only `events` are given), so including all the associations would be a bit wasteful.