### PR TITLE
Remove an `'s` from Disclaimer.

### DIFF
--- a/WcaOnRails/app/views/static_pages/disclaimer.html.erb
+++ b/WcaOnRails/app/views/static_pages/disclaimer.html.erb
@@ -5,7 +5,7 @@
 
   <ul>
     <li>The World Cube Association (WCA) works to verify that appropriate WCA Regulations are followed for the competition portion of WCA Competitions.</li>
-    <li>However, all other aspects of competitions, including (but not limited to) financial matters and competition websites, are solely the responsibility of the competition organizers and not the WCA's.</li>
+    <li>However, all other aspects of competitions, including (but not limited to) financial matters and competition websites, are solely the responsibility of the competition organizers and not the WCA.</li>
     <li>Unless otherwise noted, sponsorship and partnership agreements are arranged with individual competition organizers and not with the WCA.</li>
     <li>Since the WCA itself does not organize competitions, the WCA is not responsible for damage or injury incurred at WCA Competitions.</li>
     <li>It is not permitted to use the WCA's non-profit status determination letter without explicit permission from the WCA Board of Directors.</li>


### PR DESCRIPTION
See https://github.com/thewca/worldcubeassociation.org/pull/3835#discussion_r249297680 for reference.