### PR TITLE
Fix schedule manager to adjust child activities according to parent changes

### DIFF
--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -47,9 +47,9 @@ class CompetitionEvent < ApplicationRecord
     total_rounds = wcif["rounds"].size
     wcif["rounds"].each_with_index do |wcif_round, index|
       round = self.rounds.create!(Round.wcif_to_round_attributes(wcif_round, index+1, total_rounds))
-      WcifExtension.update_wcif_extensions!(round, wcif_round["extensions"])
+      WcifExtension.update_wcif_extensions!(round, wcif_round["extensions"]) if wcif_round["extensions"]
     end
-    WcifExtension.update_wcif_extensions!(self, wcif["extensions"])
+    WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
   end
 
   def self.wcif_json_schema

--- a/WcaOnRails/app/models/competition_venue.rb
+++ b/WcaOnRails/app/models/competition_venue.rb
@@ -20,7 +20,7 @@ class CompetitionVenue < ApplicationRecord
       room.load_wcif!(room_wcif)
     end
     self.venue_rooms = new_rooms
-    WcifExtension.update_wcif_extensions!(self, wcif["extensions"])
+    WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     self
   end
 

--- a/WcaOnRails/app/models/schedule_activity.rb
+++ b/WcaOnRails/app/models/schedule_activity.rb
@@ -120,7 +120,7 @@ class ScheduleActivity < ApplicationRecord
       activity.load_wcif!(activity_wcif)
     end
     self.child_activities = new_child_activities
-    WcifExtension.update_wcif_extensions!(self, wcif["extensions"])
+    WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     self
   end
 

--- a/WcaOnRails/app/models/venue_room.rb
+++ b/WcaOnRails/app/models/venue_room.rb
@@ -60,7 +60,7 @@ class VenueRoom < ApplicationRecord
       activity.load_wcif!(activity_wcif)
     end
     self.schedule_activities = new_activities
-    WcifExtension.update_wcif_extensions!(self, wcif["extensions"])
+    WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     self
   end
 

--- a/WcaOnRails/app/models/wcif_extension.rb
+++ b/WcaOnRails/app/models/wcif_extension.rb
@@ -35,7 +35,7 @@ class WcifExtension < ApplicationRecord
   end
 
   def self.update_wcif_extensions!(parent, extension_wcifs)
-    updated_extensions = (extension_wcifs || []).map do |extension_wcif|
+    updated_extensions = extension_wcifs.map do |extension_wcif|
       extension = parent.wcif_extensions.find do |wcif_extension|
         wcif_extension.extension_id == extension_wcif["id"]
       end


### PR DESCRIPTION
Fixes https://github.com/jonatanklosko/groupifier-next/issues/1 (the issue was submitted on that repo, but it's a bug on the WCA side).

The implementation moves child activities when the parent one is moved, and scales them by the same rate if the parent is resized. I think that's the most reasonable approach here.

Additionally I fixed extensions not to be wiped out when they are missing in an update request body.