### PR TITLE
Always export registrations in unambiguous order

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -97,7 +97,7 @@ class RegistrationsController < ApplicationController
 
   def export
     @competition = competition_from_params
-    @registrations = @competition.registrations.includes(:user, :events).find(selected_registrations_ids)
+    @registrations = @competition.registrations.order(:id).includes(:user, :events).find(selected_registrations_ids)
 
     respond_to do |format|
       format.csv do


### PR DESCRIPTION
Groupifier Next regenerates competitor ids to match the ones on Cubecomps (that's a dirty hack until wca-live is ready). It loads them from Cubecomps directly, but if the competition is not uploaded there yet, it generates ids the same way Cubecomps would do that. This relies on people order in WCIF (by registration id) being the same as registrations order in the exported CSV file (which is not clear at the moment).

Apart from the above, I think it's fine to be consistent about the order anyway.