### PR TITLE
Add explicit link to Delegate forms.

### DIFF
--- a/WcaOnRails/app/views/delegates_panel/index.html.erb
+++ b/WcaOnRails/app/views/delegates_panel/index.html.erb
@@ -19,11 +19,17 @@
   </ul>
 
   <% if current_user&.can_view_senior_delegate_material? %>
-    <h1>Senior Delegates panel</h2>
+    <h1>Senior Delegates panel</h1>
 
     <ul>
       <li>
-        <%= link_to "Senior Delegate forms", "https://docs.google.com/document/d/12oyMQTC6hBhiil8CFvYuIT-iZfLO48urap4yq0w4xkg/" %>
+        <%= link_to "WCA Candidate Delegate Nomination form", "https://docs.google.com/forms/d/e/1FAIpQLSfji_fOKEKcqS1Fb9fpu3qsBx-O8LiSJu_fG0TU7DJnR9Yj8g/viewform" %>
+      </li>
+      <li>
+        <%= link_to "WCA Candidate Delegate Promotion form", "https://docs.google.com/forms/d/e/1FAIpQLScq0JIOq1-2PHJoty5IE_uln_1Uq26Isp4mr3bqpfXKELQoqQ/viewform" %>
+      </li>
+      <li>
+        <%= link_to "WCA Delegate Demotion form", "https://docs.google.com/forms/d/e/1FAIpQLSf5BnccDL656ZPD3zl72Xgz7LmzLjFeTtjXKqvupo9Tn_VIRg/viewform" %>
       </li>
       <li>
         <%= link_to "Pending claims for your subordinate Delegates", pending_claims_path %>
@@ -35,7 +41,7 @@
   <% end %>
 
   <% if current_user&.board_member? %>
-    <h1>Board panel</h2>
+    <h1>Board panel</h1>
 
     <ul>
       <li>


### PR DESCRIPTION
This is related to #3863.

The @thewca/board also thinks a panel for Committee/Team Leaders is needed, with the link to the Committee/Team Member Promotion form and maybe more things, but should be a brand new panel instead of keeping amending the Delegates' one?