### PR TITLE
Regs import fixes

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -193,8 +193,19 @@ class RegistrationsController < ApplicationController
           [user, false] # Use this account.
         end
       else
-        # Create a locked account with confirmed WCA ID.
-        [create_locked_account!(registration_row), true]
+        email_user = User.find_by(email: registration_row[:email])
+        if email_user
+          if email_user.unconfirmed_wca_id.present? && email_user.unconfirmed_wca_id != registration_row[:wca_id]
+            raise "There is already a user with email #{registration_row[:email]}"\
+                  ", but it has unconfirmed WCA ID of #{email_user.unconfirmed_wca_id} instead of #{registration_row[:wca_id]}."
+          else
+            email_user.update!(wca_id: registration_row[:wca_id])
+            [email_user, false]
+          end
+        else
+          # Create a locked account with confirmed WCA ID.
+          [create_locked_account!(registration_row), true]
+        end
       end
     else
       email_user = User.find_by(email: registration_row[:email])

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -166,6 +166,8 @@ class RegistrationsController < ApplicationController
   end
 
   private def user_for_registration!(registration_row)
+    registration_row[:wca_id]&.upcase!
+    registration_row[:email]&.downcase!
     if registration_row[:wca_id].present?
       unless Person.exists?(wca_id: registration_row[:wca_id])
         raise "Non-existent WCA ID given #{registration_row[:wca_id]}."


### PR DESCRIPTION
Apparently in #3726 I missed a case when no user exists with registrant's WCA ID, but a user exists with registrant's email (now we attempt to create a new account right away, and it fails due to duplicated email).
I wrote test cases for all the scenarios, hopefully not everything is covered. I updated the flowchart in #3726 and [here](https://www.diffchecker.com/Aws8BFFH)'s the diff for the reference.