### PR TITLE
Ensure WCIF registration comments are not blank

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -175,7 +175,7 @@ class Registration < ApplicationRecord
                     'pending'
                   end,
       "guests" => guests,
-      "comments" => comments,
+      "comments" => comments || '',
     }
   end
 


### PR DESCRIPTION
WCIF schema specifies that `Registration#comments` are always a `string`, whereas our database allows it to be `NULL` https://github.com/thewca/worldcubeassociation.org/blob/ffe4c59de68cddb12c39b4a2f1abbc11df9fbb92/WcaOnRails/app/models/registration.rb#L190
The db column has the type of `text` and I got error trying to set a default value for it (apparently the `text` type could be problematic when it comes to default value). For that reason I did a simpler fix that ensures the produced WCIF matches the schema even if `comments` are nil in the db. Open to other ideas for fixing this!