### PR TITLE
Unfocus person select once the data is loaded in the edit person form

### DIFF
--- a/WcaOnRails/app/assets/javascripts/admin.js
+++ b/WcaOnRails/app/assets/javascripts/admin.js
@@ -26,6 +26,8 @@ onPage('admin#edit_person, admin#update_person', function() {
               $('#person_dob').data("DateTimePicker").date(value);
             }
           });
+          /* Unfocus person select once the data is loaded, so the autocomplete doesn't show up on browser tab change. */
+          $('.person_wca_id .selectize-control input').blur();
         }
       });
     }


### PR DESCRIPTION
Steps to reproduce:

1. Go to the [edit person form](https://www.worldcubeassociation.org/admin/edit_person).
2. Select a person using the autocomplete. Don't unfocus it.
3. Switch window/tab back and forth.

The autocomplete list appears again, even though we already selected a person. That's quite annoying for the WRT because they often switch tabs to copy-paste a new name of the given person, while the name field is hidden below the autocomplete list.