### PR TITLE
Some more changes to stripe charge handling:

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -367,11 +367,9 @@ class RegistrationsController < ApplicationController
 
     flash[:success] = 'Your payment was successful.'
     redirect_to competition_register_path
-  rescue Stripe::CardError => e
+  rescue Stripe::CardError, Stripe::InvalidRequestError => e
     flash[:danger] = 'Unsuccessful payment: ' + e.message
     redirect_to competition_register_path
-  rescue Stripe::InvalidRequestError
-    flash[:danger] = 'Unsuccessful payment: ' + e.message
   end
 
   private def journaled_stripe_charge(*stripe_charge_create_args)
@@ -396,7 +394,7 @@ class RegistrationsController < ApplicationController
         status: "success",
         stripe_charge_id: charge.id,
       )
-    rescue Stripe::CardError => e
+    rescue Stripe::CardError, Stripe::InvalidRequestError => e
       stripe_charge.update!(
         status: "failure",
         error: error_to_s(e),


### PR DESCRIPTION
We want journaled_stripe_charge to *also* handle
`Stripe::InvalidRequestError` so we can mark the charge as failed.

Also DRY up the stripe exception handling one layer higher in
`process_payment`. We had forgotten to add a `redirect_to` in the
`Stripe::InvalidRequestError` case, and I think it's fine to handle them
in the same rescue block for now (someday we may want to split them up
again if we want to handle them differently).