### PR TITLE
Competitions API updates

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -12,7 +12,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     end
 
     competitions = Competition.search(params[:q], params: params, managed_by_user: managed_by_user)
-    competitions = competitions.includes(:delegates, :organizers)
+    competitions = competitions.includes(:delegates, :organizers, :events)
 
     paginate json: competitions
   end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1136,7 +1136,8 @@ class Competition < ApplicationRecord
       competitions = competitions.where(like_query, part: "%#{part}%")
     end
 
-    competitions.includes(:delegates, :organizers).order(start_date: :desc)
+    date_order = params[:date_order] == "asc" ? :asc : :desc
+    competitions.includes(:delegates, :organizers).order(start_date: date_order)
   end
 
   def all_activities
@@ -1356,6 +1357,7 @@ class Competition < ApplicationRecord
       end_date: end_date,
       delegates: delegates,
       organizers: organizers,
+      event_ids: events.map(&:id),
     }
   end
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1136,8 +1136,20 @@ class Competition < ApplicationRecord
       competitions = competitions.where(like_query, part: "%#{part}%")
     end
 
-    date_order = params[:date_order] == "asc" ? :asc : :desc
-    competitions.includes(:delegates, :organizers).order(start_date: date_order)
+    orderable_fields = %i(name start_date end_date)
+    if params[:sort]
+      order = params[:sort].split(',')
+                           .map do |part|
+                             reverse, field = part.match(/^(-)?(\w+)$/).captures
+                             [field.to_sym, reverse ? :desc : :asc]
+                           end
+                           .select { |field, _| orderable_fields.include?(field) }
+                           .to_h
+    else
+      order = { start_date: :desc }
+    end
+
+    competitions.includes(:delegates, :organizers).order(**order)
   end
 
   def all_activities

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -6,24 +6,30 @@ RSpec.describe "API Competitions" do
   let(:headers) { { "CONTENT_TYPE" => "application/json" } }
 
   describe "GET #index" do
-    let!(:competition1) { FactoryBot.create :competition, :visible, starts: 1.week.from_now }
-    let!(:competition2) { FactoryBot.create :competition, :visible, starts: 2.weeks.from_now }
-    let!(:competition3) { FactoryBot.create :competition, :visible, starts: 3.weeks.from_now }
+    let!(:competition1) { FactoryBot.create :competition, :visible, starts: 1.week.from_now, name: "First 2019" }
+    let!(:competition2) { FactoryBot.create :competition, :visible, starts: 1.week.from_now, name: "Second 2019" }
+    let!(:competition3) { FactoryBot.create :competition, :visible, starts: 2.weeks.from_now, name: "Third 2019" }
+    let!(:competition4) { FactoryBot.create :competition, :visible, starts: 3.weeks.from_now, name: "Fourth 2019" }
 
     it "orders competitions by date descending by default" do
       get api_v0_competitions_path, params: { start: 2.week.from_now }
       expect(response).to be_successful
-      json = JSON.parse(response.body)
-      expect(json[0]["id"]).to eq competition3.id
-      expect(json[1]["id"]).to eq competition2.id
+      ids = JSON.parse(response.body).map { |c| c["id"] }
+      expect(ids).to eq [competition4, competition3].map(&:id)
     end
 
     it "allows ordering by date ascending" do
-      get api_v0_competitions_path, params: { start: 2.week.from_now, date_order: "asc" }
+      get api_v0_competitions_path, params: { start: 2.week.from_now, sort: "start_date" }
       expect(response).to be_successful
-      json = JSON.parse(response.body)
-      expect(json[0]["id"]).to eq competition2.id
-      expect(json[1]["id"]).to eq competition3.id
+      ids = JSON.parse(response.body).map { |c| c["id"] }
+      expect(ids).to eq [competition3, competition4].map(&:id)
+    end
+
+    it "allows ordering by multiple fields" do
+      get api_v0_competitions_path, params: { sort: "start_date,-name" }
+      expect(response).to be_successful
+      ids = JSON.parse(response.body).map { |c| c["id"] }
+      expect(ids).to eq [competition2, competition1, competition3, competition4].map(&:id)
     end
   end
 

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -5,6 +5,28 @@ require "rails_helper"
 RSpec.describe "API Competitions" do
   let(:headers) { { "CONTENT_TYPE" => "application/json" } }
 
+  describe "GET #index" do
+    let!(:competition1) { FactoryBot.create :competition, :visible, starts: 1.week.from_now }
+    let!(:competition2) { FactoryBot.create :competition, :visible, starts: 2.weeks.from_now }
+    let!(:competition3) { FactoryBot.create :competition, :visible, starts: 3.weeks.from_now }
+
+    it "orders competitions by date descending by default" do
+      get api_v0_competitions_path, params: { start: 2.week.from_now }
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      expect(json[0]["id"]).to eq competition3.id
+      expect(json[1]["id"]).to eq competition2.id
+    end
+
+    it "allows ordering by date ascending" do
+      get api_v0_competitions_path, params: { start: 2.week.from_now, date_order: "asc" }
+      expect(response).to be_successful
+      json = JSON.parse(response.body)
+      expect(json[0]["id"]).to eq competition2.id
+      expect(json[1]["id"]).to eq competition3.id
+    end
+  end
+
   describe "GET #results" do
     let!(:competition) { FactoryBot.create :competition, :visible }
     let!(:result) { FactoryBot.create :result, competition: competition }

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe "API Competitions" do
     end
 
     it "allows ordering by multiple fields" do
+      get api_v0_competitions_path, params: { sort: "start_date,name" }
+      expect(response).to be_successful
+      ids = JSON.parse(response.body).map { |c| c["id"] }
+      expect(ids).to eq [competition1, competition2, competition3, competition4].map(&:id)
+    end
+
+    it "allows setting descending order" do
       get api_v0_competitions_path, params: { sort: "start_date,-name" }
       expect(response).to be_successful
       ids = JSON.parse(response.body).map { |c| c["id"] }


### PR DESCRIPTION
Suggested in a mailing thread, two changes that seem useful for all API users:
- include event ids in competition objects returned by the API
- allow sorting `/api/v0/competitions` by date ascending, this allows for getting a list of upcoming competitions with ease