### PR TITLE
Remove duplicate definition of `Style/NegatedIf`.

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -100,9 +100,6 @@ Naming/MemoizedInstanceVariableName:
 Performance/RedundantMatch:
   Enabled: false
 
-Style/NegatedIf:
-  Enabled: false
-
 Style/AccessModifierDeclarations:
   Enabled: false
 


### PR DESCRIPTION
Rubocop was conviniently warning about this:

> .rubocop.yml:103: `Style/NegatedIf` is concealed by line 148