### PR TITLE
Update user data based on CSV registration if it has no WCA ID

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -211,6 +211,16 @@ class RegistrationsController < ApplicationController
       email_user = User.find_by(email: registration_row[:email])
       # Use the user if exists, otherwise create a locked account without WCA ID.
       if email_user
+        unless email_user.wca_id.present?
+          # If this is just a user account with no WCA ID, update its data.
+          # Given it's verified by organizers, it's more trustworthy/official data (if different at all).
+          email_user.update!(
+            name: registration_row[:name],
+            country_iso2: Country.c_find(registration_row[:country]).iso2,
+            gender: registration_row[:gender],
+            dob: registration_row[:birth_date],
+          )
+        end
         [email_user, false]
       else
         [create_locked_account!(registration_row), true]

--- a/WcaOnRails/spec/requests/registrations_spec.rb
+++ b/WcaOnRails/spec/requests/registrations_spec.rb
@@ -224,6 +224,20 @@ RSpec.describe "registrations" do
             expect(user.registrations.first.events.map(&:id)).to eq %w(333)
             expect(competition.registrations.count).to eq 1
           end
+
+          it "updates user data unless it has WCA ID" do
+            user = FactoryBot.create(:user)
+            file = csv_file [
+              ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+              ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", user.email, "1", "0"],
+            ]
+            expect {
+              post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            }.to_not change { User.count }
+            expect(user.reload.name).to eq "Sherlock Holmes"
+            expect(user.dob).to eq Date.new(2000, 1, 1)
+            expect(user.country_iso2).to eq "GB"
+          end
         end
 
         context "no user exists with registrant's email" do


### PR DESCRIPTION
It's sometimes the case that someone has a WCA account but the data is either not complete (e.g missing birthdate) or not accurate (instead of full name there is just first name). If such an account doesn't have WCA ID, it's a better approach to update its data when importing CSV registration (this data comes from organizers and thus is more reliable in terms of correctness).