### PR TITLE
Include competition id in results API.

### DIFF
--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -17,6 +17,7 @@ class Result < ApplicationRecord
   def serializable_hash(options = nil)
     {
       id: id,
+      competition_id: competitionId,
       pos: pos,
       event_id: eventId,
       round_type_id: roundTypeId,


### PR DESCRIPTION
This makes `/api/v0/persons/:wca_id/results` include competition ids, straightforward change.