### PR TITLE
Add WQAC in CC to Report and Results nags.

### DIFF
--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -102,7 +102,7 @@ class CompetitionsMailer < ApplicationMailer
     @competition = competition
     mail(
       to: competition.delegates.pluck(:email),
-      cc: ["results@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
+      cc: ["results@worldcubeassociation.org", "quality@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
       reply_to: "results@worldcubeassociation.org",
       subject: "#{competition.name} Results",
     )
@@ -112,8 +112,8 @@ class CompetitionsMailer < ApplicationMailer
     @competition = competition
     mail(
       to: competition.delegates.pluck(:email),
-      cc: ["board@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
-      reply_to: "board@worldcubeassociation.org",
+      cc: ["quality@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
+      reply_to: delegates_to_senior_delegates_email(competition.delegates),
       subject: "#{competition.name} Delegate Report",
     )
   end

--- a/WcaOnRails/app/views/competitions_mailer/submit_report_nag.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/submit_report_nag.html.erb
@@ -3,16 +3,12 @@
 </p>
 
 <p>
-  This is an automated reminder on behalf of the WCA Board.
-</p>
-
-<p>
-  <%= @competition.name %> took place <%= (DateTime.now.utc.to_date - @competition.end_date).to_i %> days ago and
-  the Delegate report must have been submitted to the
-  WCA Board within one week of the end of the competition according to Regulation <a href="https://www.worldcubeassociation.org/regulations/#1c1">1c1)</a>.
+  This is an automated reminder. <%= @competition.name %> took place <%= (DateTime.now.utc.to_date - @competition.end_date).to_i %> days ago and
+  the Delegate report must have been submitted
+  within one week of the end of the competition according to Regulation <a href="https://www.worldcubeassociation.org/regulations/#1c1">1c1)</a>.
   Irrespective of if you are available to send in your report any time soon,
   <span style="text-decoration: underline; font-weight: bold; font-size: larger;">please reply to
-  this email to update us on the situation of this missing report</span>. Then submit the report as fast
+  this email to update your Senior Delegate on the situation of this missing report</span>. Then submit the report as fast
   as possible <%= link_to "here", delegate_report_url(@competition) %>.
 </p>
 
@@ -27,5 +23,5 @@
 
 <p>
   Regards,
-  The WCA Board.
+  The WCA Quality Assurance Committee.
 </p>

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq "Comp of the Future 2016 Results"
       expect(mail.to).to match_array competition.delegates.pluck(:email)
-      expect(mail.cc).to eq ["results@worldcubeassociation.org", senior.email]
+      expect(mail.cc).to eq ["results@worldcubeassociation.org", "quality@worldcubeassociation.org", senior.email]
       expect(mail.reply_to).to eq ["results@worldcubeassociation.org"]
     end
 
@@ -164,8 +164,8 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq "Peculiar Comp 2016 Delegate Report"
       expect(mail.to).to match_array competition.delegates.pluck(:email)
-      expect(mail.cc).to eq ["board@worldcubeassociation.org", senior.email]
-      expect(mail.reply_to).to eq ["board@worldcubeassociation.org"]
+      expect(mail.cc).to eq ["quality@worldcubeassociation.org", senior.email]
+      expect(mail.reply_to).to eq [senior.email]
     end
 
     it "renders the body" do


### PR DESCRIPTION
Also, the Board won't be getting those emails any longer. This has been discussed first within the Board and then with the WQAC.