### PR TITLE
Add secure flag to cookies

### DIFF
--- a/WcaOnRails/config/environments/production.rb
+++ b/WcaOnRails/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/WcaOnRails/config/environments/production.rb
+++ b/WcaOnRails/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/WcaOnRails/config/initializers/session_store.rb
+++ b/WcaOnRails/config/initializers/session_store.rb
@@ -2,5 +2,5 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session'
+Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session',
                                                       secure: Rails.env.production?

--- a/WcaOnRails/config/initializers/session_store.rb
+++ b/WcaOnRails/config/initializers/session_store.rb
@@ -2,4 +2,5 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session'
+Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session',
+                                                      secure: Rails.env.production?

--- a/WcaOnRails/config/initializers/session_store.rb
+++ b/WcaOnRails/config/initializers/session_store.rb
@@ -3,3 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session'
+                                                      secure: Rails.env.production?

--- a/WcaOnRails/config/initializers/session_store.rb
+++ b/WcaOnRails/config/initializers/session_store.rb
@@ -2,5 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session',
-                                                      secure: Rails.env.production?
+Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session'


### PR DESCRIPTION
Closes #3994 via [this Stack Overflow answer](https://stackoverflow.com/a/31255092/2558618). 

This only protects the session cookie, but that's as good as we can do unless we want to force traffic through SSL (which would need to be a bigger discussion).