### PR TITLE
Add query parameter to the /persons API endpoint

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/persons_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/persons_controller.rb
@@ -2,7 +2,12 @@
 
 class Api::V0::PersonsController < Api::V0::ApiController
   def index
-    persons = Person.current.includes(:user, :ranksSingle, :ranksAverage)
+    if params[:q].present?
+      persons = Person.search(params[:q])
+    else
+      persons = Person.current.includes(:user)
+    end
+    persons = persons.includes(:ranksSingle, :ranksAverage)
     if params[:wca_ids].present?
       persons = persons.where(wca_id: params[:wca_ids].split(','))
     end

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -259,6 +259,14 @@ class Person < ApplicationRecord
     %w(m f).include? gender
   end
 
+  def self.search(query)
+    persons = Person.current.includes(:user)
+    query.split.each do |part|
+      persons = persons.where("name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
+    end
+    persons.order(:name)
+  end
+
   def serializable_hash(options = nil)
     json = {
       class: self.class.to_s.downcase,

--- a/WcaOnRails/spec/requests/api_persons_spec.rb
+++ b/WcaOnRails/spec/requests/api_persons_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe "API Persons" do
         expect(json.map { |element| element["person"]["wca_id"] }).to match_array other_people.map(&:wca_id)
       end
     end
+
+    context "when a query is given" do
+      it "renders only people matching the query parameter" do
+        get api_v0_persons_path, params: { q: "#{person.wca_id.first(4)} #{person.name[1..-1]}" }
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json.length).to eq 1
+        expect(json.map { |element| element["person"]["wca_id"] }).to match_array [person.wca_id]
+      end
+    end
   end
 
   describe "GET #show" do


### PR DESCRIPTION
Currently the only way to search for people is hitting `/api/v0/search/users` with `persons_table=true`. This is tricky, especially when explaining to third party developers. Also that endpoint's output is not consistent with what `/api/v0/persons` renders. I think the most reasonable solution is just add a query parameter to `/api/v0/persons` the same way we have it for `api/v0/competitions`.