### PR TITLE
Add transaction handling to computation of ranks

### DIFF
--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -67,53 +67,55 @@ module AuxiliaryDataComputation
       %w(best RanksSingle ConciseSingleResults),
       %w(average RanksAverage ConciseAverageResults),
     ].each do |field, table_name, concise_table_name|
-      ActiveRecord::Base.connection.execute "TRUNCATE TABLE #{table_name}"
-      current_country_by_wca_id = Person.current.pluck(:wca_id, :countryId).to_h
-      # Get all personal records (note: people that changed their country appear once for each country).
-      personal_records_with_event = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT eventId, personId, countryId, continentId, min(#{field}) value
-        FROM #{concise_table_name}
-        WHERE eventId <> '333mbo'
-        GROUP BY personId, countryId, continentId, eventId
-        ORDER BY eventId, value
-      SQL
-      personal_records_with_event.group_by(&:first).each do |event_id, personal_records|
-        personal_rank = Hash.new { |h, k| h[k] = {} }
-        ranked = Hash.new { |h, k| h[k] = {} }
-        counter = Hash.new(0)
-        current_rank = Hash.new(0)
-        previous_value = {}
-        personal_records.each do |_, person_id, country_id, continent_id, value|
-          # Update the region states (unless we have ranked this person already,
-          # e.g. 2008SEAR01 twice in North America and World because of his two countries).
-          ["World", continent_id, country_id].each do |region|
-            next if ranked[region][person_id]
-            counter[region] += 1
-            # As we ordered by value it can either be greater or tie the previous one.
-            current_rank[region] = counter[region] if previous_value[region].nil? || value > previous_value[region]
-            previous_value[region] = value
-            ranked[region][person_id] = true
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.execute "DELETE FROM #{table_name}"
+        current_country_by_wca_id = Person.current.pluck(:wca_id, :countryId).to_h
+        # Get all personal records (note: people that changed their country appear once for each country).
+        personal_records_with_event = ActiveRecord::Base.connection.execute <<-SQL
+          SELECT eventId, personId, countryId, continentId, min(#{field}) value
+          FROM #{concise_table_name}
+          WHERE eventId <> '333mbo'
+          GROUP BY personId, countryId, continentId, eventId
+          ORDER BY eventId, value
+        SQL
+        personal_records_with_event.group_by(&:first).each do |event_id, personal_records|
+          personal_rank = Hash.new { |h, k| h[k] = {} }
+          ranked = Hash.new { |h, k| h[k] = {} }
+          counter = Hash.new(0)
+          current_rank = Hash.new(0)
+          previous_value = {}
+          personal_records.each do |_, person_id, country_id, continent_id, value|
+            # Update the region states (unless we have ranked this person already,
+            # e.g. 2008SEAR01 twice in North America and World because of his two countries).
+            ["World", continent_id, country_id].each do |region|
+              next if ranked[region][person_id]
+              counter[region] += 1
+              # As we ordered by value it can either be greater or tie the previous one.
+              current_rank[region] = counter[region] if previous_value[region].nil? || value > previous_value[region]
+              previous_value[region] = value
+              ranked[region][person_id] = true
+            end
+            # Set the person's data (first time the current location is matched).
+            personal_rank[person_id][:best] ||= value
+            personal_rank[person_id][:world_rank] ||= current_rank["World"]
+            if continent_id == Country.c_find(current_country_by_wca_id[person_id]).continentId
+              personal_rank[person_id][:continent_rank] ||= current_rank[continent_id]
+            end
+            if country_id == current_country_by_wca_id[person_id]
+              personal_rank[person_id][:country_rank] ||= current_rank[country_id]
+            end
           end
-          # Set the person's data (first time the current location is matched).
-          personal_rank[person_id][:best] ||= value
-          personal_rank[person_id][:world_rank] ||= current_rank["World"]
-          if continent_id == Country.c_find(current_country_by_wca_id[person_id]).continentId
-            personal_rank[person_id][:continent_rank] ||= current_rank[continent_id]
+          values = personal_rank.map do |person_id, rank_data|
+            # Note: continent_rank and country_rank may be not present because of a country change, in such case we default to 0.
+            "('#{person_id}', '#{event_id}', #{rank_data[:best]}, #{rank_data[:world_rank]}, #{rank_data[:continent_rank] || 0}, #{rank_data[:country_rank] || 0})"
           end
-          if country_id == current_country_by_wca_id[person_id]
-            personal_rank[person_id][:country_rank] ||= current_rank[country_id]
+          # Insert 500 rows at once to avoid running into too long query.
+          values.each_slice(500) do |values_subset|
+            ActiveRecord::Base.connection.execute <<-SQL
+              INSERT INTO #{table_name} (personId, eventId, best, worldRank, continentRank, countryRank) VALUES
+              #{values_subset.join(",\n")}
+            SQL
           end
-        end
-        values = personal_rank.map do |person_id, rank_data|
-          # Note: continent_rank and country_rank may be not present because of a country change, in such case we default to 0.
-          "('#{person_id}', '#{event_id}', #{rank_data[:best]}, #{rank_data[:world_rank]}, #{rank_data[:continent_rank] || 0}, #{rank_data[:country_rank] || 0})"
-        end
-        # Insert 500 rows at once to avoid running into too long query.
-        values.each_slice(500) do |values_subset|
-          ActiveRecord::Base.connection.execute <<-SQL
-            INSERT INTO #{table_name} (personId, eventId, best, worldRank, continentRank, countryRank) VALUES
-            #{values_subset.join(",\n")}
-          SQL
         end
       end
     end


### PR DESCRIPTION
This pull request is with respect to https://github.com/thewca/worldcubeassociation.org/issues/4022

I've had a quick look at the code and it looked straightforward to wrap the computation of statistics within a transaction. Although I am not a Ruby / Rails developer and don't have a development environment in which to test the change, I'm hoping that one of the WCA software team can give it a try on my behalf.

Notes:
- The change involves the addition of [ActiveRecord::Base.transaction](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html) as can be seen elsewhere in the WcaOnRails code.
- The original code was using "TRUNCATE TABLE" which is a DDL statement and therefore cannot be wrapped in a transaction. However, RanksSingle and RanksAverage table sizes are relatively small at ~25MiB (~400,000 records) so a regular "DELETE" statement should not cause any issues with respect to the MySQL transaction log.

The change is best viewed when ignoring white space:
```
-      ActiveRecord::Base.connection.execute "TRUNCATE TABLE #{table_name}"
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.execute "DELETE FROM #{table_name}"
           ...
+      end
```