### PR TITLE
Add WRT to can_see_admin_competitions

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -573,15 +573,15 @@ class User < ApplicationRecord
   end
 
   def can_view_crash_course?
-    can_view_delegate_matters? || communication_team? || competition_announcement_team?
+    can_view_delegate_matters? || communication_team?
   end
 
   def can_create_posts?
-    admin? || board_member? || results_team? || wdc_team? || wrc_team? || communication_team? || can_announce_competitions?
+    wdc_team? || wrc_team? || communication_team? || can_announce_competitions?
   end
 
   def can_update_crash_course?
-    admin? || board_member? || results_team? || quality_assurance_committee? || competition_announcement_team?
+    can_admin_competitions? || quality_assurance_committee?
   end
 
   def can_admin_competitions?

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -657,7 +657,7 @@ class User < ApplicationRecord
   end
 
   def can_see_admin_competitions?
-    board_member? || senior_delegate? || admin? || quality_assurance_committee? || competition_announcement_team?
+    can_admin_competitions? || senior_delegate? || quality_assurance_committee?
   end
 
   def can_approve_media?


### PR DESCRIPTION
I believe this requires Board approval to change the permissions of a team. I'll reach out and ask for them to look at this.

Changes:
1. Line 660 is where I add can_see_admin_competitions to the WRT permissions. This would allow WRT members to have the History Button on admin/delegates and view this:
![image](https://user-images.githubusercontent.com/11577241/56174692-b1556000-5fc1-11e9-8581-491e0a31ee32.png)
This is helpful for evaluating delegates in the background checks and is information that WRT can acquire via the database already.

2. I condensed some of the permissions.
 - competition_announcement_team is already a part of can_view_delegate_matters
 - admin, board_member, results_team, and competition_announcement_team are a part of can_announce_competitions / can_admin_competitions

If 2. was separated out for some reason, please let me know and I'll revert that change.