### PR TITLE
Install cron jobs only on production

### DIFF
--- a/WcaOnRails/lib/tasks/work.rake
+++ b/WcaOnRails/lib/tasks/work.rake
@@ -7,6 +7,7 @@ namespace :work do
     SubmitReportNagJob.perform_later
     ComputeLinkings.perform_later
     DumpDeveloperDatabase.perform_later
-    SyncMailingListsJob.perform_later
+    # NOTE: we want to only do this on the actual "production" server, as we need the real users' emails.
+    SyncMailingListsJob.perform_later if ENVied.WCA_LIVE_SITE
   end
 end


### PR DESCRIPTION
We've had two apocalypses, better make sure it never happens again.

I think it should be enough to make sure that cron job never touches staging.
When merging I'll remove the existing cron file and re-run chef, and then make sure the file still doesn't exist.