### PR TITLE
Tune permission for user edit

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -732,6 +732,9 @@ class User < ApplicationRecord
         email preferred_events results_notifications_enabled
       )
       fields << { user_preferred_events_attributes: [:id, :event_id, :_destroy] }
+      if user.staff?
+        fields += %i(receive_delegate_reports)
+      end
     end
     if admin? || board_member? || senior_delegate?
       fields += %i(delegate_status senior_delegate_id region)
@@ -765,9 +768,6 @@ class User < ApplicationRecord
     end
     if user.wca_id.blank? && organizer_for?(user)
       fields << :name
-    end
-    if user.staff?
-      fields += %i(receive_delegate_reports)
     end
     fields
   end

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -134,8 +134,8 @@
           </div>
         <% end %>
 
-        <% if @user.staff? %>
-          <%= f.input :receive_delegate_reports %>
+        <% if current_user.can_view_all_users? && @user.staff? %>
+          <%= f.input :receive_delegate_reports, disabled: !editable_fields.include?(:receive_delegate_reports) %>
         <% end %>
 
         <%= f.submit t('.save'), class: "btn btn-primary" %>


### PR DESCRIPTION
Currently I've changed `receive_delegate_reports` to be editable only if `current_user` matches the user being edited, and made sure the field is only visible to those who can see all users.

I've discussed this a bit with @DanielEgdal and implemented the change like this, but there may be alternative solutions.
More specifically we could give edit access to admin/senior/wqac to enforce a Delegate receive reports.
But since this is already enforced by automated list memberships, and that the user could still change the setting back to "off", I don't think it makes much sense to allow anyone else but the user to edit that checkbox.