### PR TITLE
Add a "clear results submission" button for WRT

### DIFF
--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -47,6 +47,20 @@ class AdminController < ApplicationController
     @results_validator = CompetitionResultsValidator.new(@competition.id, true)
   end
 
+  def clear_results_submission
+    # Just clear the "results_submitted_at" field to let the Delegate submit
+    # the results again. We don't actually want to clear InboxResult and InboxPerson.
+    @competition = competition_from_params
+
+    if @competition.results_submitted? && !@competition.results_posted?
+      @competition.update_attributes(results_submitted_at: nil)
+      flash[:success] = "Results submission cleared."
+    else
+      flash[:danger] = "Could not clear the results submission. Maybe results are alredy posted, or there is no submission."
+    end
+    redirect_to competition_admin_upload_results_edit_path
+  end
+
   def create_results
     @competition = competition_from_params
 

--- a/WcaOnRails/app/views/admin/new_results.html.erb
+++ b/WcaOnRails/app/views/admin/new_results.html.erb
@@ -1,6 +1,15 @@
 <% provide(:title, "Upload results") %>
 <%= render layout: 'competitions/nav' do %>
   <h1><%= yield(:title) %></h1>
+  <% if @competition.results_submitted? && !@competition.results_posted? %>
+    <%= alert :info, note: true do %>
+      It looks like the results have been submitted by the Delegate but not posted yet.
+      If you want to let the Delegate submit the results again you can
+      <%= link_to("clear the results submission",
+                  competition_clear_results_submission_path(@competition),
+                  method: :post, class: "btn btn-primary") %>
+    <% end %>
+  <% end %>
   <p>
     Import the results JSON for this competition.
     The server will check for any error compared to the declared rounds, cutoffs, and time limits.

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
     get '/admin/upload-results' => "admin#new_results", as: :admin_upload_results_edit
     get '/admin/check-existing-results' => "admin#check_results", as: :admin_check_existing_results
     post '/admin/upload-json' => "admin#create_results", as: :admin_upload_results
+    post '/admin/clear-submission' => "admin#clear_results_submission", as: :clear_results_submission
   end
 
   get 'competitions/:competition_id/report/edit' => 'delegate_reports#edit', as: :delegate_report_edit


### PR DESCRIPTION
@SAuroux thinks it could be useful in some rare cases.

I've added the button on the "upload and check results" admin page:
![clear-submission](https://user-images.githubusercontent.com/1007485/56868194-85899f80-69ef-11e9-8d6a-1b9465f4f1e3.png)

The button (and associated action) works iff the results are not posted and they have been submitted.