### PR TITLE
Fix deprecation warnings for RubyMoney

### DIFF
--- a/WcaOnRails/config/initializers/ruby_money.rb
+++ b/WcaOnRails/config/initializers/ruby_money.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Money.locale_backend = :i18n


### PR DESCRIPTION
Will merge ASAP, not only because it clobbers our CI logs, but also because it's a trivial change.