### PR TITLE
Export competition information to pdf

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -88,6 +88,7 @@ gem 'google-api-client'
 gem 'activestorage-validator'
 gem 'image_processing'
 gem 'rest-client'
+gem 'wicked_pdf'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-autosize'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -617,6 +617,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    wicked_pdf (1.2.2)
+      activesupport
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -721,6 +723,7 @@ DEPENDENCIES
   wca_i18n
   web-console
   webpacker
+  wicked_pdf
 
 BUNDLED WITH
    2.0.1

--- a/WcaOnRails/app/assets/stylesheets/pdf.scss
+++ b/WcaOnRails/app/assets/stylesheets/pdf.scss
@@ -22,8 +22,6 @@ header {
   .pdf-title {
     font-size: 40px;
   }
-  .comp-date {
-  }
   .separator {
     display: inline-block;
     width: 50px;
@@ -58,8 +56,6 @@ table {
     padding: 5px 0;
   }
 }
-
-//td, th { border: 1px solid orange; }
 
 .main_content {
   width: 100%;

--- a/WcaOnRails/app/assets/stylesheets/pdf.scss
+++ b/WcaOnRails/app/assets/stylesheets/pdf.scss
@@ -2,7 +2,6 @@
  * This scss file is specifically used in the pdf rendered page (eg: the competition info and schedule page).
  */
 
-@import "variables";
 @import "cubing-icons";
 
 a {
@@ -145,15 +144,12 @@ table {
             height: 46px;
             width: 46px;
             .cubing-icon {
-              //border: 1px solid purple;
               &::before {
-                //border: 1px solid green;
                 font-size: 40px;
               }
             }
           }
           &.event-data {
-            //border: 1px solid green;
             border-left: 0;
             .activity-name {
               font-size: 18px;

--- a/WcaOnRails/app/assets/stylesheets/pdf.scss
+++ b/WcaOnRails/app/assets/stylesheets/pdf.scss
@@ -1,0 +1,192 @@
+/*
+ * This scss file is specifically used in the pdf rendered page (eg: the competition info and schedule page).
+ */
+
+@import "variables";
+@import "cubing-icons";
+
+a {
+  color: black;
+}
+
+header {
+  height: 120px;
+  width: 100%;
+  display: block;
+  .wca_logo {
+    width: 120px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+  .pdf_title {
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 30px;
+  }
+}
+
+.nobreak {
+  page-break-inside: avoid;
+  &::before {
+    clear: both;
+  }
+}
+
+.break-before {
+  page-break-before: always;
+}
+
+.break-after {
+  page-break-after: always;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  word-break: break-word;
+  th {
+    padding: 5px 0;
+  }
+}
+
+//td, th { border: 1px solid orange; }
+
+.main_content {
+  width: 100%;
+  table {
+    &.general_information {
+      td {
+        padding-bottom: 5px;
+        &:nth-child(odd) {
+          font-weight: bold;
+          width: 25%;
+          vertical-align: top;
+        }
+        &:nth-child(even) {
+          width: 75%;
+        }
+        p {
+          margin: 0;
+          padding: 0;
+        }
+      }
+    }
+    &.show-events-table {
+      text-align: center;
+      a {
+        text-decoration: none;
+      }
+      thead {
+        th {
+          border-bottom: 2px solid black;
+        }
+        // Due to the nested table, the percentage are not relative to the
+        // same parent and are a bit tricky to get right.
+        .event-name {
+          width: 13%;
+        }
+        .round-name {
+          width: 22%;
+        }
+        .round-format {
+          width: 13%;
+        }
+        .round-proceed {
+          width: 15%;
+        }
+      }
+      tbody {
+        tr.event-info {
+          > td {
+            border-bottom: 2px solid black;
+            &.event-name {
+              width: 13%;
+              .cubing-icon {
+                &::before {
+                  font-size: 40px;
+                  padding: 10px;
+                }
+              }
+            }
+            &.rounds-info {
+              table {
+                td {
+                  padding: 3px 0;
+                  &.round-name {
+                    width: 25%;
+                  }
+                  &.round-format {
+                    width: 15%;
+                  }
+                  &.round-proceed {
+                    width: 17%;
+                  }
+                }
+                :not(.last-round) > td {
+                  border-bottom: 1px solid black;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    &.show-schedule-table {
+      text-align: center;
+      thead {
+        th {
+          border-bottom: 2px solid black;
+        }
+      }
+      tbody {
+        td {
+          border: 1px solid black;
+          padding: 3px;
+          p {
+            padding: 0;
+            margin: 0;
+          }
+          &.event-icon {
+            border-right: 0;
+            height: 46px;
+            width: 46px;
+            .cubing-icon {
+              //border: 1px solid purple;
+              &::before {
+                //border: 1px solid green;
+                font-size: 40px;
+              }
+            }
+          }
+          &.event-data {
+            //border: 1px solid green;
+            border-left: 0;
+            .activity-name {
+              font-size: 18px;
+              font-weight: bold;
+            }
+            .room-name {
+              font-size: 14px;
+              font-style: italic;
+            }
+          }
+          &.activity-start,
+          &.activity-end {
+            min-width: 60px;
+            max-width: 80px;
+            font-weight: bold;
+          }
+          &.round-time-limit {
+            max-width: 100px;
+          }
+          &.round-proceed {
+            min-width: 70px;
+          }
+          &.round-format {
+            min-width: 60px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/WcaOnRails/app/assets/stylesheets/pdf.scss
+++ b/WcaOnRails/app/assets/stylesheets/pdf.scss
@@ -10,18 +10,29 @@ a {
 }
 
 header {
-  height: 120px;
   width: 100%;
   display: block;
-  .wca_logo {
-    width: 120px;
-    display: inline-block;
-    vertical-align: middle;
+  text-align: center;
+  font-size: 30px;
+  .pdf-logo {
+    width: 100%;
+    img {
+      width: 200px;
+    }
   }
-  .pdf_title {
+  .pdf-title {
+    font-size: 40px;
+  }
+  .comp-date {
+  }
+  .separator {
     display: inline-block;
-    vertical-align: middle;
-    font-size: 30px;
+    width: 50px;
+    border-top: 3px solid black;
+  }
+  p {
+    margin: 0;
+    padding: 0;
   }
 }
 
@@ -54,23 +65,6 @@ table {
 .main_content {
   width: 100%;
   table {
-    &.general_information {
-      td {
-        padding-bottom: 5px;
-        &:nth-child(odd) {
-          font-weight: bold;
-          width: 25%;
-          vertical-align: top;
-        }
-        &:nth-child(even) {
-          width: 75%;
-        }
-        p {
-          margin: 0;
-          padding: 0;
-        }
-      }
-    }
     &.show-events-table {
       text-align: center;
       a {
@@ -173,11 +167,11 @@ table {
           &.activity-start,
           &.activity-end {
             min-width: 60px;
-            max-width: 80px;
+            max-width: 100px;
             font-weight: bold;
           }
           &.round-time-limit {
-            max-width: 100px;
+            max-width: 200px;
           }
           &.round-proceed {
             min-width: 70px;

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -482,6 +482,7 @@ class CompetitionsController < ApplicationController
     respond_to do |format|
       format.html
       format.pdf do
+        @colored_schedule = params.key?(:with_colors)
         render pdf: "#{@competition.name}_Information", orientation: 'Landscape'
       end
     end

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -479,6 +479,12 @@ class CompetitionsController < ApplicationController
       },
     }
     @competition = competition_from_params(includes: associations)
+    respond_to do |format|
+      format.html
+      format.pdf do
+        render pdf: "#{@competition.name}_Information"
+      end
+    end
   end
 
   def show_podiums

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -482,7 +482,7 @@ class CompetitionsController < ApplicationController
     respond_to do |format|
       format.html
       format.pdf do
-        render pdf: "#{@competition.name}_Information"
+        render pdf: "#{@competition.name}_Information", orientation: 'Landscape'
       end
     end
   end

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -133,4 +133,20 @@ module CompetitionsHelper
                 end
     [first_time, last_time]
   end
+
+  def create_pdfs_directory
+    FileUtils.mkdir_p(CleanupPdfs::CACHE_DIRECTORY) unless File.directory?(CleanupPdfs::CACHE_DIRECTORY)
+  end
+
+  def path_to_cached_pdf(competition, colors)
+    CleanupPdfs::CACHE_DIRECTORY.join("#{cached_pdf_name(competition, colors)}.pdf")
+  end
+
+  def pdf_name(competition)
+    "#{competition.id}_#{I18n.locale}"
+  end
+
+  def cached_pdf_name(competition, colors)
+    "#{pdf_name(competition)}_#{competition.updated_at.iso8601}_#{colors}"
+  end
 end

--- a/WcaOnRails/app/jobs/cleanup_pdfs.rb
+++ b/WcaOnRails/app/jobs/cleanup_pdfs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CleanupPdfs < SingletonApplicationJob
+  CACHE_DIRECTORY = Rails.root.join("tmp/cache/pdfs").freeze
+  RM_DELAY = 1.week
+  queue_as :default
+
+  def perform
+    Dir["*.pdf", base: CACHE_DIRECTORY].each do |f|
+      file = CACHE_DIRECTORY.join(f)
+      File.delete(file) if File.mtime(file) < RM_DELAY.ago
+    end
+  end
+end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1225,6 +1225,7 @@ class Competition < ApplicationRecord
       update_persons_wcif!(wcif["persons"], current_user) if wcif["persons"]
       WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     end
+    update_column(:updated_at, Time.now)
   end
 
   def set_wcif_events!(wcif_events, current_user)

--- a/WcaOnRails/app/models/competition_venue.rb
+++ b/WcaOnRails/app/models/competition_venue.rb
@@ -37,7 +37,7 @@ class CompetitionVenue < ApplicationRecord
   end
 
   def top_level_activities
-    venue_rooms.flat_map(&:schedule_activities).sort_by(&:start_time)
+    venue_rooms.flat_map(&:schedule_activities)
   end
 
   def to_wcif

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -96,12 +96,12 @@ class Round < ApplicationRecord
     time_limit.to_s(self)
   end
 
-  def cutoff_to_s
-    cutoff ? cutoff.to_s(self) : ""
+  def cutoff_to_s(short: false)
+    cutoff ? cutoff.to_s(self, short: short) : ""
   end
 
-  def advancement_condition_to_s
-    advancement_condition ? advancement_condition.to_s(self) : ""
+  def advancement_condition_to_s(short: false)
+    advancement_condition ? advancement_condition.to_s(self, short: short) : ""
   end
 
   def self.parse_wcif_id(wcif_id)
@@ -127,16 +127,16 @@ class Round < ApplicationRecord
     "#{event.id}-r#{self.number}"
   end
 
-  def to_string_map
+  def to_string_map(short: false)
     {
       wcif_id: wcif_id,
       name: name,
       event_id: event.id,
       cumulative_round_ids: time_limit.cumulative_round_ids,
-      format_name: full_format_name,
+      format_name: full_format_name(with_short_names: true),
       time_limit: time_limit_to_s,
-      cutoff: cutoff_to_s,
-      advancement: advancement_condition_to_s,
+      cutoff: cutoff_to_s(short: short),
+      advancement: advancement_condition_to_s(short: short),
     }
   end
 

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -63,11 +63,15 @@ class Round < ApplicationRecord
     end
   end
 
+  def formats_used
+    cutoff_format = Format.c_find!(cutoff.number_of_attempts.to_s) if cutoff
+    [cutoff_format, format].compact
+  end
+
   def full_format_name(with_short_names: false, with_tooltips: false)
     # 'with_tooltips' implies that short names are used for display, and long
     # names are used in the tooltip.
-    cutoff_format = Format.c_find!(cutoff.number_of_attempts.to_s) if cutoff
-    phase_formats = [cutoff_format, format].compact
+    phase_formats = formats_used
     phase_formats.map! do |f|
       if with_tooltips
         content_tag(:span, f.short_name, data: { toggle: "tooltip" }, title: f.name)

--- a/WcaOnRails/app/models/schedule_activity.rb
+++ b/WcaOnRails/app/models/schedule_activity.rb
@@ -106,6 +106,7 @@ class ScheduleActivity < ApplicationRecord
       title: localized_name(rounds_by_wcif_id),
       roomId: holder.id,
       roomName: holder.name,
+      venueName: holder.competition_venue.name,
       color: color,
       activityDetails: ScheduleActivity.parse_activity_code(activity_code),
       start: start_time.in_time_zone(holder.competition_venue.timezone_id),

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -44,6 +44,15 @@
         <% end %>
       </dd>
     </dl>
+    <dl class="dl-horizontal">
+      <dt><%= icon("print") %></dt>
+      <dd>
+        <%= t("competitions.competition_info.pdf.download_html",
+              here: link_to(t("common.here"),
+                            competition_path(competition, format: :pdf),
+                            target: :_blank, class: "hide-new-window-icon")) %>
+      </dd>
+    </dl>
   </div>
 
   <div class="col-md-6">

--- a/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
@@ -9,7 +9,7 @@
 <div class="tab-content" id="schedule-tab">
   <% competition.competition_venues.each_with_index do |venue, index| %>
     <%
-      activities = venue.top_level_activities
+      activities = venue.top_level_activities.sort_by(&:start_time)
       min_time, max_time = first_and_last_time_from_activities(activities, venue.timezone_id)
       activities.map!{ |a| a.to_event(rounds_by_wcif_id) }
     %>

--- a/WcaOnRails/app/views/competitions/_pdf_events_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_events_table.html.erb
@@ -1,11 +1,12 @@
+<%# NOTE: Assumes local variable 'formats_list' to be passed! %>
 <table class="show-events-table">
   <thead>
     <tr>
-      <th class="event-name"><%= t("competitions.results_table.event") %></th>
-      <th class="round-name"><%= t("competitions.results_table.round") %></th>
-      <th class="round-format"><%= t("competitions.events.format") %></th>
-      <th class="round-time-limit"><%= t("competitions.events.time_limit") %></th>
-      <th class="round-proceed"><%= t("competitions.events.proceed") %></th>
+      <th class="event-name"><%= t "competitions.results_table.event" %></th>
+      <th class="round-name"><%= t "competitions.results_table.round" %></th>
+      <th class="round-format"><%= t "competitions.events.format" %></th>
+      <th class="round-time-limit"><%= t "competitions.events.time_limit" %></th>
+      <th class="round-proceed"><%= t "competitions.events.proceed" %></th>
     </tr>
   </thead>
   <tbody>
@@ -18,24 +19,15 @@
           <%# Nested table trick to avoid page breaks within events %>
           <table>
             <% competition_event.rounds.each do |round| %>
+              <%# While this is unused in this partial, the filled container is used by the including view. %>
+              <% formats_list << round.formats_used.map(&:id) %>
               <tr class="<%= round.final_round? ? "last-round" : "" %>">
                 <td class="round-name"><%= round.round_type.name %></td>
                 <td class="round-format">
                   <%= round.full_format_name(with_short_names: true) %><br/>
-                  <%# TODO: i18n %>
-                  <%= "#{t("competitions.events.cutoff")}: #{round.cutoff_to_s(short: true)}" if round.cutoff %>
+                  <%= t "competitions.competition_info.pdf.cutoff", short_cutoff: round.cutoff_to_s(short: true) if round.cutoff  %>
                 </td>
-                <td class="round-time-limit">
-                  <%= round.time_limit_to_s %>
-                  <% if competition_event.event.can_change_time_limit? %>
-                    <% if round.time_limit.cumulative_round_ids.length == 1 %>
-                      <%# TODO: FOOTNOTE %>
-                      <%= link_to "*", "#cumulative-time-limit" %>
-                    <% elsif round.time_limit.cumulative_round_ids.length > 1 %>
-                      <%= link_to "**", "#cumulative-across-rounds-time-limit" %>
-                    <% end %>
-                  <% end %>
-                </td>
+                <td class="round-time-limit"><%= round.time_limit_to_s %></td>
                 <td class="round-proceed"><%= round.advancement_condition_to_s(short: true) %></td>
               </tr>
             <% end %>

--- a/WcaOnRails/app/views/competitions/_pdf_events_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_events_table.html.erb
@@ -1,0 +1,47 @@
+<table class="show-events-table">
+  <thead>
+    <tr>
+      <th class="event-name"><%= t("competitions.results_table.event") %></th>
+      <th class="round-name"><%= t("competitions.results_table.round") %></th>
+      <th class="round-format"><%= t("competitions.events.format") %></th>
+      <th class="round-time-limit"><%= t("competitions.events.time_limit") %></th>
+      <th class="round-proceed"><%= t("competitions.events.proceed") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @competition.competition_events.sort_by { |ce| ce.event.rank }.each do |competition_event| %>
+      <tr class="nobreak event-info">
+        <td class="event-name">
+          <%= cubing_icon competition_event.event.id %>
+        </td>
+        <td colspan="4" class="rounds-info">
+          <%# Nested table trick to avoid page breaks within events %>
+          <table>
+            <% competition_event.rounds.each do |round| %>
+              <tr class="<%= round.final_round? ? "last-round" : "" %>">
+                <td class="round-name"><%= round.round_type.name %></td>
+                <td class="round-format">
+                  <%= round.full_format_name(with_short_names: true) %><br/>
+                  <%# TODO: i18n %>
+                  <%= "#{t("competitions.events.cutoff")}: #{round.cutoff_to_s(short: true)}" if round.cutoff %>
+                </td>
+                <td class="round-time-limit">
+                  <%= round.time_limit_to_s %>
+                  <% if competition_event.event.can_change_time_limit? %>
+                    <% if round.time_limit.cumulative_round_ids.length == 1 %>
+                      <%# TODO: FOOTNOTE %>
+                      <%= link_to "*", "#cumulative-time-limit" %>
+                    <% elsif round.time_limit.cumulative_round_ids.length > 1 %>
+                      <%= link_to "**", "#cumulative-across-rounds-time-limit" %>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td class="round-proceed"><%= round.advancement_condition_to_s(short: true) %></td>
+              </tr>
+            <% end %>
+          </table>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/WcaOnRails/app/views/competitions/_pdf_events_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_events_table.html.erb
@@ -1,4 +1,3 @@
-<%# NOTE: Assumes local variable 'formats_list' to be passed! %>
 <table class="show-events-table">
   <thead>
     <tr>
@@ -19,8 +18,6 @@
           <%# Nested table trick to avoid page breaks within events %>
           <table>
             <% competition_event.rounds.each do |round| %>
-              <%# While this is unused in this partial, the filled container is used by the including view. %>
-              <% formats_list << round.formats_used.map(&:id) %>
               <tr class="<%= round.final_round? ? "last-round" : "" %>">
                 <td class="round-name"><%= round.round_type.name %></td>
                 <td class="round-format">

--- a/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
@@ -15,7 +15,7 @@
           <th><%= t("competitions.schedule.start") %></th>
           <th><%= t("competitions.schedule.end") %></th>
           <th colspan="2"><%= t("competitions.schedule.activity") %></th>
-          <th><%= t("competitions.schedule.format") %></th>
+          <th><%= t("competitions.events.format") %></th>
           <th><%= t("competitions.events.time_limit") %></th>
           <th><%= t("competitions.events.proceed") %></th>
         </tr>

--- a/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
@@ -8,7 +8,7 @@
 <% @competition.start_date.upto(@competition.end_date) do |date| %>
   <% activities_for_day = activities_by_day[date.to_s] %>
   <% if activities_for_day&.any? %>
-    <h3><%= t("competitions.schedule.schedule_for_date", day_name: l(date, format: '%A'), full_date: l(date, format: :long)) %></h3>
+    <h1 class="break-before"><%= t("competitions.schedule.schedule_for_date", day_name: l(date, format: '%A'), full_date: l(date, format: :long)) %></h1>
     <table class="show-schedule-table break-after">
       <thead>
         <tr>
@@ -26,7 +26,6 @@
           <% round_data = rounds_by_wcif_id[activity_code_without_attempt] || {} %>
           <tr class="nobreak" style="<%= "background-color:#{a[:color]};" if @colored_schedule %>">
             <td class="activity-start"><%= l(a[:start], format: time_format_for_current_locale) %></td>
-            <%# TODO: ask Germans about that, it's pretty ugly in that locale %>
             <td class="activity-end"><%= l(a[:end], format: time_format_for_current_locale) %></td>
             <td class="event-icon <%= "no-event" if round_data.empty? %>">
               <%= cubing_icon(round_data[:event_id]) unless round_data.empty? %>
@@ -35,11 +34,11 @@
               <p class="activity-name"><%= a[:title] %></p>
               <% if output_room_name %>
                 <p class="room-name">
-                <% if output_venue_name %>
-                  <%= t("competitions.schedule.room_in_venue", room: a[:roomName], venue: a[:venueName]) %>
-                <% else %>
-                  <%= a[:roomName] %>
-                <% end %>
+                  <% if output_venue_name %>
+                    <%= t("competitions.schedule.room_in_venue", room: a[:roomName], venue: a[:venueName]) %>
+                  <% else %>
+                    <%= a[:roomName] %>
+                  <% end %>
                 </p>
               <% end %>
             </td>

--- a/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
@@ -1,0 +1,59 @@
+<% rounds_by_wcif_id = Hash[@competition.rounds.map { |r| [r.wcif_id, r.to_string_map(short: true)] }] %>
+<% activities = @competition.competition_venues.flat_map(&:top_level_activities).sort_by(&:start_time) %>
+<% activities.map!{ |a| a.to_event(rounds_by_wcif_id) } %>
+<% activities_by_day = activities.group_by { |a| a[:start].strftime("%Y-%m-%d") } %>
+<% output_venue_name = @competition.competition_venues.size > 1 %>
+<% output_room_name = @competition.competition_venues.map(&:venue_rooms).flatten.size > 1 %>
+
+<%# TODO: optionally enhance with room color! %>
+
+<% @competition.start_date.upto(@competition.end_date) do |date| %>
+  <% activities_for_day = activities_by_day[date.to_s] %>
+  <% if activities_for_day&.any? %>
+    <h3><%= t("competitions.schedule.schedule_for_date", day_name: l(date, format: '%A'), full_date: l(date, format: :long)) %></h3>
+    <table class="show-schedule-table break-after">
+      <thead>
+        <tr>
+          <th><%= t("competitions.schedule.start") %></th>
+          <th><%= t("competitions.schedule.end") %></th>
+          <th colspan="2"><%= t("competitions.schedule.activity") %></th>
+          <th><%= t("competitions.schedule.format") %></th>
+          <th><%= t("competitions.events.time_limit") %></th>
+          <th><%= t("competitions.events.proceed") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% activities_for_day.each do |a| %>
+          <% activity_code_without_attempt = "#{a[:activityDetails][:event_id]}-r#{a[:activityDetails][:round_number]}" %>
+          <% round_data = rounds_by_wcif_id[activity_code_without_attempt] || {} %>
+          <tr class="nobreak">
+            <td class="activity-start"><%= l(a[:start], format: time_format_for_current_locale) %></td>
+            <%# TODO: ask Germans about that, it's pretty ugly in that locale %>
+            <td class="activity-end"><%= l(a[:end], format: time_format_for_current_locale) %></td>
+            <td class="event-icon <%= "no-event" if round_data.empty? %>">
+              <%= cubing_icon(round_data[:event_id]) unless round_data.empty? %>
+            </td>
+            <td class="event-data">
+              <p class="activity-name"><%= a[:title] %></p>
+              <% if output_room_name %>
+                <p class="room-name">
+                <% if output_venue_name %>
+                  <%= t("competitions.schedule.room_in_venue", room: a[:roomName], venue: a[:venueName]) %>
+                <% else %>
+                  <%= a[:roomName] %>
+                <% end %>
+                </p>
+              <% end %>
+            </td>
+            <td class="round-format">
+              <%= round_data[:format_name] %><br/>
+              <%= "#{t("competitions.events.cutoff")}: #{round_data[:cutoff]}" unless round_data[:cutoff].blank? %>
+            </td>
+            <td class="round-time-limit"><%= round_data[:time_limit] %></td>
+            <td class="round-proceed"><%= round_data[:advancement] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+<% end %>

--- a/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
@@ -3,7 +3,7 @@
 <% activities.map!{ |a| a.to_event(rounds_by_wcif_id) } %>
 <% activities_by_day = activities.group_by { |a| a[:start].strftime("%Y-%m-%d") } %>
 <% output_venue_name = @competition.competition_venues.size > 1 %>
-<% output_room_name = @competition.competition_venues.map(&:venue_rooms).flatten.size > 1 %>
+<% output_room_name = @competition.competition_venues.flat_map(&:venue_rooms).size > 1 %>
 
 <% @competition.start_date.upto(@competition.end_date) do |date| %>
   <% activities_for_day = activities_by_day[date.to_s] %>

--- a/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_pdf_schedule_table.html.erb
@@ -5,8 +5,6 @@
 <% output_venue_name = @competition.competition_venues.size > 1 %>
 <% output_room_name = @competition.competition_venues.map(&:venue_rooms).flatten.size > 1 %>
 
-<%# TODO: optionally enhance with room color! %>
-
 <% @competition.start_date.upto(@competition.end_date) do |date| %>
   <% activities_for_day = activities_by_day[date.to_s] %>
   <% if activities_for_day&.any? %>
@@ -26,7 +24,7 @@
         <% activities_for_day.each do |a| %>
           <% activity_code_without_attempt = "#{a[:activityDetails][:event_id]}-r#{a[:activityDetails][:round_number]}" %>
           <% round_data = rounds_by_wcif_id[activity_code_without_attempt] || {} %>
-          <tr class="nobreak">
+          <tr class="nobreak" style="<%= "background-color:#{a[:color]};" if @colored_schedule %>">
             <td class="activity-start"><%= l(a[:start], format: time_format_for_current_locale) %></td>
             <%# TODO: ask Germans about that, it's pretty ugly in that locale %>
             <td class="activity-end"><%= l(a[:end], format: time_format_for_current_locale) %></td>
@@ -47,7 +45,7 @@
             </td>
             <td class="round-format">
               <%= round_data[:format_name] %><br/>
-              <%= "#{t("competitions.events.cutoff")}: #{round_data[:cutoff]}" unless round_data[:cutoff].blank? %>
+              <%= t "competitions.competition_info.pdf.cutoff", short_cutoff: round_data[:cutoff] unless round_data[:cutoff].blank?  %>
             </td>
             <td class="round-time-limit"><%= round_data[:time_limit] %></td>
             <td class="round-proceed"><%= round_data[:advancement] %></td>

--- a/WcaOnRails/app/views/competitions/show.pdf.erb
+++ b/WcaOnRails/app/views/competitions/show.pdf.erb
@@ -1,37 +1,31 @@
 <!doctype html>
 <html>
   <head>
-    <style>
-    </style>
+    <%= wicked_pdf_stylesheet_link_tag "pdf" -%>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   </head>
   <body>
     <header>
-      <%= wicked_pdf_stylesheet_link_tag "pdf" -%>
-      <%= wicked_pdf_image_tag "wca_logo.svg", class: "wca_logo" %>
-      <div class="pdf_title"><%= t 'competitions.competition_info.pdf_title', comp_name: @competition.name %></div>
+      <div class="pdf-logo">
+        <%= wicked_pdf_image_tag "wca_logo.svg" %>
+      </div>
+      <div class="pdf-title"><%= t 'competitions.competition_info.pdf_title', comp_name: @competition.name %></div>
+      <div class="comp-date">
+        <%= wca_date_range(@competition.start_date, @competition.end_date) %>
+      </div>
+      <div class="separator"></div>
+      <div>
+        <%= md @competition.venue %>
+        <p>
+          <%= @competition.venueAddress %>
+        </p>
+        (<%= link_to_google_maps_place "#{@competition.latitude_degrees}, #{@competition.longitude_degrees}", @competition.latitude_degrees, @competition.longitude_degrees %>)
+      </div>
+      <div class="separator"></div>
+      <div><%= @competition.city_and_country %></div>
     </header>
     <div class="main_content">
-      <h1><%= t 'competitions.show.general_info' %></h1>
-      <table class="general_information">
-        <tr>
-          <td><%= t 'competitions.competition_info.date' %></td>
-          <td><%= wca_date_range(@competition.start_date, @competition.end_date) %></td>
-        </tr>
-        <tr>
-          <td><%= t 'competitions.competition_info.city' %></td>
-          <td><%= @competition.city_and_country %></td>
-        </tr>
-        <tr>
-          <td><%= t 'competitions.competition_info.venue' %></td>
-          <td><%= md @competition.venue %><p><%= @competition.venueAddress %></p></td>
-        </tr>
-        <tr>
-          <td><%= t 'competitions.competition_info.gps' %></td>
-          <td><%= link_to_google_maps_place "#{@competition.latitude_degrees}, #{@competition.longitude_degrees}", @competition.latitude_degrees, @competition.longitude_degrees %></td>
-        </tr>
-      </table>
-      <h1><%=t 'competitions.show.events' %></h1>
+      <h1 class="break-before"><%=t 'competitions.show.events' %></h1>
       <%= render "pdf_events_table.html.erb" %>
       <h1 class="break-before"><%=t 'competitions.show.schedule' %></h1>
       <%= render "pdf_schedule_table.html.erb" %>

--- a/WcaOnRails/app/views/competitions/show.pdf.erb
+++ b/WcaOnRails/app/views/competitions/show.pdf.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <%= wicked_pdf_stylesheet_link_tag "pdf" -%>
+    <%= wicked_pdf_stylesheet_link_tag "pdf" %>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   </head>
   <body>
@@ -25,15 +25,14 @@
       <div><%= @competition.city_and_country %></div>
     </header>
     <div class="main_content">
-      <% formats_list = [] %>
       <h1 class="break-before"><%=t 'competitions.show.events' %></h1>
-      <%= render "pdf_events_table.html.erb", formats_list: formats_list %>
+      <%= render "pdf_events_table.html.erb" %>
       <%= render "pdf_schedule_table.html.erb" %>
       <h1><%= t 'competitions.competition_info.pdf.terms_and_abbr' %></h1>
       <%= render "time_limit_cutoff_format_info.html.erb", competition: @competition %>
       <h4><%= t 'competitions.competition_info.pdf.formats_abbr' %></h4>
       <ul>
-        <% formats_list.flatten.uniq.sort.each do |format_id| %>
+        <% @competition.rounds.flat_map(&:formats_used).map(&:id).uniq.sort.each do |format_id| %>
           <li>
             <%= t "competitions.competition_info.pdf.abbr_description",
               short_name: t("formats.short.#{format_id}"),

--- a/WcaOnRails/app/views/competitions/show.pdf.erb
+++ b/WcaOnRails/app/views/competitions/show.pdf.erb
@@ -9,7 +9,7 @@
       <div class="pdf-logo">
         <%= wicked_pdf_image_tag "wca_logo.svg" %>
       </div>
-      <div class="pdf-title"><%= t 'competitions.competition_info.pdf.title', comp_name: @competition.name %></div>
+      <div class="pdf-title"><%= @competition.name %></div>
       <div class="comp-date">
         <%= wca_date_range(@competition.start_date, @competition.end_date) %>
       </div>
@@ -28,7 +28,6 @@
       <% formats_list = [] %>
       <h1 class="break-before"><%=t 'competitions.show.events' %></h1>
       <%= render "pdf_events_table.html.erb", formats_list: formats_list %>
-      <h1 class="break-before"><%=t 'competitions.show.schedule' %></h1>
       <%= render "pdf_schedule_table.html.erb" %>
       <h1><%= t 'competitions.competition_info.pdf.terms_and_abbr' %></h1>
       <%= render "time_limit_cutoff_format_info.html.erb", competition: @competition %>

--- a/WcaOnRails/app/views/competitions/show.pdf.erb
+++ b/WcaOnRails/app/views/competitions/show.pdf.erb
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+  <head>
+    <style>
+    </style>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  </head>
+  <body>
+    <header>
+      <%= wicked_pdf_stylesheet_link_tag "pdf" -%>
+      <%= wicked_pdf_image_tag "wca_logo.svg", class: "wca_logo" %>
+      <div class="pdf_title"><%= t 'competitions.competition_info.pdf_title', comp_name: @competition.name %></div>
+    </header>
+    <div class="main_content">
+      <h1><%= t 'competitions.show.general_info' %></h1>
+      <table class="general_information">
+        <tr>
+          <td><%= t 'competitions.competition_info.date' %></td>
+          <td><%= wca_date_range(@competition.start_date, @competition.end_date) %></td>
+        </tr>
+        <tr>
+          <td><%= t 'competitions.competition_info.city' %></td>
+          <td><%= @competition.city_and_country %></td>
+        </tr>
+        <tr>
+          <td><%= t 'competitions.competition_info.venue' %></td>
+          <td><%= md @competition.venue %><p><%= @competition.venueAddress %></p></td>
+        </tr>
+        <tr>
+          <td><%= t 'competitions.competition_info.gps' %></td>
+          <td><%= link_to_google_maps_place "#{@competition.latitude_degrees}, #{@competition.longitude_degrees}", @competition.latitude_degrees, @competition.longitude_degrees %></td>
+        </tr>
+      </table>
+      <h1><%=t 'competitions.show.events' %></h1>
+      <%= render "pdf_events_table.html.erb" %>
+      <h1 class="break-before"><%=t 'competitions.show.schedule' %></h1>
+      <%= render "pdf_schedule_table.html.erb" %>
+      <h1>Glossary</h1>
+      time limit, cutoff, format abbrv etc
+    </div>
+  </body>
+</html>

--- a/WcaOnRails/app/views/competitions/show.pdf.erb
+++ b/WcaOnRails/app/views/competitions/show.pdf.erb
@@ -9,7 +9,7 @@
       <div class="pdf-logo">
         <%= wicked_pdf_image_tag "wca_logo.svg" %>
       </div>
-      <div class="pdf-title"><%= t 'competitions.competition_info.pdf_title', comp_name: @competition.name %></div>
+      <div class="pdf-title"><%= t 'competitions.competition_info.pdf.title', comp_name: @competition.name %></div>
       <div class="comp-date">
         <%= wca_date_range(@competition.start_date, @competition.end_date) %>
       </div>
@@ -25,12 +25,23 @@
       <div><%= @competition.city_and_country %></div>
     </header>
     <div class="main_content">
+      <% formats_list = [] %>
       <h1 class="break-before"><%=t 'competitions.show.events' %></h1>
-      <%= render "pdf_events_table.html.erb" %>
+      <%= render "pdf_events_table.html.erb", formats_list: formats_list %>
       <h1 class="break-before"><%=t 'competitions.show.schedule' %></h1>
       <%= render "pdf_schedule_table.html.erb" %>
-      <h1>Glossary</h1>
-      time limit, cutoff, format abbrv etc
+      <h1><%= t 'competitions.competition_info.pdf.terms_and_abbr' %></h1>
+      <%= render "time_limit_cutoff_format_info.html.erb", competition: @competition %>
+      <h4><%= t 'competitions.competition_info.pdf.formats_abbr' %></h4>
+      <ul>
+        <% formats_list.flatten.uniq.sort.each do |format_id| %>
+          <li>
+            <%= t "competitions.competition_info.pdf.abbr_description",
+              short_name: t("formats.short.#{format_id}"),
+              long_name: t("formats.#{format_id}") %>
+          </li>
+        <% end %>
+      </ul>
     </div>
   </body>
 </html>

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -122,6 +122,8 @@ ignore_unused:
   - 'media.new.media_guidelines.*'
 # - 'simple_form.{placeholders,hints,labels}.*'
   - 'devise.mailer.*'
+  # These are keys dynamically built in lib/advancement_condition.rb
+  - 'advancement_condition.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/WcaOnRails/config/initializers/mime_types.rb
+++ b/WcaOnRails/config/initializers/mime_types.rb
@@ -5,3 +5,5 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 Mime::Type.register 'text/plain', :txt
+# FIXME: check if it's actually needed
+Mime::Type.register 'application/pdf', :pdf

--- a/WcaOnRails/config/initializers/mime_types.rb
+++ b/WcaOnRails/config/initializers/mime_types.rb
@@ -5,5 +5,3 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 Mime::Type.register 'text/plain', :txt
-# FIXME: check if it's actually needed
-Mime::Type.register 'application/pdf', :pdf

--- a/WcaOnRails/config/initializers/wicked_pdf.rb
+++ b/WcaOnRails/config/initializers/wicked_pdf.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# WickedPDF Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `render :pdf` call.
+#
+# To learn more, check out the README:
+#
+# https://github.com/mileszs/wicked_pdf/blob/master/README.md
+
+WickedPdf.config = {
+  # Path to the wkhtmltopdf executable: This usually isn't needed if using
+  # one of the wkhtmltopdf-binary family of gems.
+  exe_path: '/usr/local/bin/wkhtmltopdf',
+  #   or
+  # exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
+
+  # Layout file to be used for all PDFs
+  # (but can be overridden in `render :pdf` calls)
+  # layout: 'pdf.html',
+}

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -126,9 +126,9 @@ en:
       ranking: "Top %{ranking}"
       percent: "Top %{percent}%"
       attempt_result:
-        time: "Result < %{time}"
-        moves: "Result < %{moves}"
-        points: "Result > %{points}"
+        time: "Best result < %{time}"
+        moves: "Best result < %{moves}"
+        points: "Best result > %{points}"
     ranking: "Top %{ranking} advance to next round"
     percent: "Top %{percent}% advance to next round"
     attempt_result:
@@ -1044,7 +1044,6 @@ en:
     competition_info:
       #context: used on the pdf export
       pdf:
-        title: "Information for %{comp_name}"
         terms_and_abbr: "Technical terms and abbreviations"
         formats_abbr: "Abbreviations for formats:"
         abbr_description: "%{short_name}: %{long_name}"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1042,8 +1042,14 @@ en:
       past_competitions: "Past competitions"
     #context: on the competition's information page
     competition_info:
-      pdf_title: "Information for %{comp_name}"
-      gps: "GPS coordinates"
+      #context: used on the pdf export
+      pdf:
+        title: "Information for %{comp_name}"
+        terms_and_abbr: "Technical terms and abbreviations"
+        formats_abbr: "Abbreviations for formats:"
+        abbr_description: "%{short_name}: %{long_name}"
+        #context: the "short" version of cutoff, which appear below the format (eg: Bo2/Ao5)
+        cutoff: "Cutoff: %{short_cutoff}"
       date: "Date"
       city: "City"
       venue: "Venue"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -122,6 +122,13 @@ en:
     name: "%{event_name} %{round_name}"
   #context: Words used to describe the requirement to advance to the next round
   advancement_condition:
+    short:
+      ranking: "Top %{ranking}"
+      percent: "Top %{ranking}%"
+      attempt_result:
+        time: "Result < %{time}"
+        moves: "Result < %{moves}"
+        points: "Result > %{points}"
     ranking: "Top %{ranking} advance to next round"
     percent: "Top %{percent}% advance to next round"
     attempt_result:
@@ -1035,6 +1042,8 @@ en:
       past_competitions: "Past competitions"
     #context: on the competition's information page
     competition_info:
+      pdf_title: "Information for %{comp_name}"
+      gps: "GPS coordinates"
       date: "Date"
       city: "City"
       venue: "Venue"
@@ -1254,6 +1263,8 @@ en:
       end: "End"
       activity: "Activity"
       room: "Room"
+      #context: when displaying the room on the general schedule, we may also display the venue if there are multiple venues
+      room_in_venue: "%{room} in %{venue}"
       venue_information_html: "You are viewing the schedule for the venue %{venue_name}."
       timezone_message: "The schedule is displayed in the timezone %{timezone}."
       multiple_venues_available: "This competition has multiple venues, make sure to check out the schedule for the other venues as well!"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -124,7 +124,7 @@ en:
   advancement_condition:
     short:
       ranking: "Top %{ranking}"
-      percent: "Top %{ranking}%"
+      percent: "Top %{percent}%"
       attempt_result:
         time: "Result < %{time}"
         moves: "Result < %{moves}"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1049,6 +1049,7 @@ en:
         abbr_description: "%{short_name}: %{long_name}"
         #context: the "short" version of cutoff, which appear below the format (eg: Bo2/Ao5)
         cutoff: "Cutoff: %{short_cutoff}"
+        download_html: "Download all the competition's details as PDF %{here}."
       date: "Date"
       city: "City"
       venue: "Venue"

--- a/WcaOnRails/lib/advancement_condition.rb
+++ b/WcaOnRails/lib/advancement_condition.rb
@@ -58,8 +58,8 @@ class RankingCondition < AdvancementCondition
     "ranking"
   end
 
-  def to_s(round)
-    I18n.t("advancement_condition.ranking", ranking: ranking)
+  def to_s(round, short: false)
+    I18n.t("advancement_condition#{".short" if short}.ranking", ranking: ranking)
   end
 end
 
@@ -70,8 +70,8 @@ class PercentCondition < AdvancementCondition
     "percent"
   end
 
-  def to_s(round)
-    I18n.t("advancement_condition.percent", percent: percent)
+  def to_s(round, short: false)
+    I18n.t("advancement_condition#{".short" if short}.percent", percent: percent)
   end
 end
 
@@ -82,13 +82,13 @@ class AttemptResultCondition < AdvancementCondition
     "attemptResult"
   end
 
-  def to_s(round)
+  def to_s(round, short: false)
     if round.event.timed_event?
-      I18n.t("advancement_condition.attempt_result.time", time: SolveTime.centiseconds_to_clock_format(attempt_result))
+      I18n.t("advancement_condition#{".short" if short}.attempt_result.time", time: SolveTime.centiseconds_to_clock_format(attempt_result))
     elsif round.event.fewest_moves?
-      I18n.t("advancement_condition.attempt_result.moves", moves: attempt_result)
+      I18n.t("advancement_condition#{".short" if short}.attempt_result.moves", moves: attempt_result)
     elsif round.event.multiple_blindfolded?
-      I18n.t("advancement_condition.attempt_result.points", points: SolveTime.multibld_attempt_to_points(attempt_result))
+      I18n.t("advancement_condition#{".short" if short}.attempt_result.points", points: SolveTime.multibld_attempt_to_points(attempt_result))
     end
   end
 end

--- a/WcaOnRails/lib/cutoff.rb
+++ b/WcaOnRails/lib/cutoff.rb
@@ -51,16 +51,16 @@ class Cutoff
     }
   end
 
-  def to_s(round)
+  def to_s(round, short: false)
     if round.event.timed_event?
-      centiseconds = self.attempt_result
-      I18n.t("cutoff.time", count: self.number_of_attempts, time: SolveTime.centiseconds_to_clock_format(centiseconds))
+      time = SolveTime.centiseconds_to_clock_format(self.attempt_result)
+      short ? time : I18n.t("cutoff.time", count: self.number_of_attempts, time: time)
     elsif round.event.fewest_moves?
       moves = self.attempt_result
-      I18n.t("cutoff.moves", count: self.number_of_attempts, moves: moves)
+      short ? moves : I18n.t("cutoff.moves", count: self.number_of_attempts, moves: moves)
     elsif round.event.multiple_blindfolded?
       points = SolveTime.multibld_attempt_to_points(self.attempt_result)
-      I18n.t("cutoff.points", count: self.number_of_attempts, points: points)
+      short ? points : I18n.t("cutoff.points", count: self.number_of_attempts, points: points)
     else
       raise "Unrecognized event: #{round.event.id}"
     end

--- a/WcaOnRails/lib/tasks/work.rake
+++ b/WcaOnRails/lib/tasks/work.rake
@@ -3,6 +3,7 @@
 namespace :work do
   desc 'Schedule work to be done'
   task schedule: :environment do
+    CleanupPdfs.perform_later
     SubmitResultsNagJob.perform_later
     SubmitReportNagJob.perform_later
     ComputeLinkings.perform_later


### PR DESCRIPTION
Currently printing the competition information (or events, or schedule) gives an extremely ugly results.
Workarounds include manually removing some DOM elements before printing, but still it's not great.

I think we should have a print-friendly version of the competition information; there are two approach for this, I think:
  - having some css for the 'print' media
  - having a dedicated pdf export

I was afraid just changing the css would be a bit painful to get everything right, so I went ahead and created an "export pdf" endpoint.

I had to make some choices (both visually and in the implementation), so there may be some stuff to discuss and adjust; but this is definitely way better than nothing!
I'll contact the WQAC/WRC very soon to have their opinion on the pdf content.
I also plan on sending this beta version to Seniors/Board to filter out big changes needed before reaching all staff with the feature.

Example pdfs:
  - en, single room, single venue (typical example of the local competition): 
[Elsass Open 2019_Information_en.pdf](https://github.com/thewca/worldcubeassociation.org/files/3131234/Elsass.Open.2019_Information_en.pdf)
  - de, the same comp: 
[Elsass Open 2019_Information_de.pdf](https://github.com/thewca/worldcubeassociation.org/files/3131235/Elsass.Open.2019_Information_de.pdf) (obviously some new keys are not translated)
  - en, single venue, multiple rooms competition (WC2019): 
[WCA World Championship 2019_Information_bw.pdf](https://github.com/thewca/worldcubeassociation.org/files/3131239/WCA.World.Championship.2019_Information_bw.pdf)
  - en, the same in colors: 
[WCA World Championship 2019_Information_colors.pdf](https://github.com/thewca/worldcubeassociation.org/files/3131242/WCA.World.Championship.2019_Information_colors.pdf)
  - en, multiple venues, multiple rooms competition (there are very few!): 
[Idéale Nabeul Open 2019_Information.pdf](https://github.com/thewca/worldcubeassociation.org/files/3131284/Ideale.Nabeul.Open.2019_Information.pdf)




## "High" level discussion

### Information

The pdf should contain printer friendly information about the competition: general details, events and rounds details, full schedule.
It should also be possible to print these information separately, even though there are in the same pdf.

### Portrait vs Landscape

I gave a try at the portrait orientation, and it just looks way better in landscape, mainly because we can fit more information in one line.
There is still a "space available" vs "details displayed", so I made some choice regarding that: the displayed formats, proceed conditions, and cutoff have been shortened significantly to save space in both the events and schedule tables (take a look at the attached examples).
To make sure these shortened versions are understood, the last page includes all the definition and abbreviations.

### Handling multiple venues and rooms

We definitely want to print out a schedule including all venues, just like we would like to avoid repeating the room/venue name if there is only one of them.
I - arbitrarily - chose to not display the room name if there is only one room, and to not display the venue name if there is only one (see the examples attached).

### Extra stuff

Some people want to print this in B&W, whereas other would like the room color to be used, so I made this an option.

### Nitpick

I played a bit with various locales to see how it would render, and I noticed something visually odd in German, so this section is mostly for feedback from German people (@Laura-O, @SAuroux, @suushiemaniac).
The time format used in the schedule looks pretty big for the space available (see the attached examples).
Do you think it's fine?
Should we switch to a different time format (eg: 24h, or a custom one)?

## Implementation details

### Page breaks

This was without a doubt the most tricky part to get right: tables may span across pages, and we'd definitely like:
  - to repeat the table header at the beginning of each page
  - to not break within an event row (which may be pretty big if there are multiple rounds)

In addition to the `page-break-inside` I had to use nested tables to avoid ugly breaks, but I've commented about that in the code.

### New partial vs re-using the existing event table

I wrote a new partial for the events table.
I tried to re-use the existing one but it quickly turned out to be a bad idea for two reasons:
  - getting page breaks right
  - we should get rid of the events table on the regular tab anyway, for a more responsive layout!

### Pdf rendering

It's made through `wkhtmltopdf`, which is conveniently already installed on the server because it's used to build the Regulations pdf.
It's for sure an additional load on the server, I'm not yet sure of how costly it is, and if we should restrict this feature somehow (eg: to logged in users, to registered competitors/organizers/delegates).

I have little knowledge about using cache for such file (AFAIK it depends on the user's locale and the last time the events/schedule has been modified), any input about this would be appreciated.

### TODO

I did not yet made the "export to pdf [with colors]" buttons, if you want to test this locally just add `.pdf` at the end of the competition homepage.
