### PR TITLE
Fix Delegate Crash Course link.

### DIFF
--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -46,7 +46,7 @@ class Post < ApplicationRecord
 
   def edit_path
     if is_delegate_crash_course_post?
-      Rails.application.routes.url_helpers.delegate_crash_course_edit_path
+      Rails.application.routes.url_helpers.panel_delegate_crash_course_edit_path
     else
       Rails.application.routes.url_helpers.edit_post_path(slug)
     end


### PR DESCRIPTION
The `edit_path` wasn't properly updated on #4084.