### PR TITLE
Allow anyone who can create a poll to view it.

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -632,7 +632,7 @@ class User < ApplicationRecord
   end
 
   def can_view_poll?
-    admin? || can_vote_in_poll?
+    can_create_poll? || can_vote_in_poll?
   end
 
   def can_view_delegate_matters?


### PR DESCRIPTION
In particular, this allows all WRC members to view polls, even if they're not an
admin.