### PR TITLE
CompetitionResultsValidator: add a link to fix wrong position on the fly

### DIFF
--- a/WcaOnRails/app/views/admin/check_results.html.erb
+++ b/WcaOnRails/app/views/admin/check_results.html.erb
@@ -7,5 +7,7 @@
 
   <%= render "results_submission/check_results_panel", results_validator: @results_validator %>
 
+  <%= render "results_submission/automatic_fixes_panel", results_validator: @results_validator if @results_validator.suggest_fixes.values.any? %>
+
   <%= render "results_submission/results_preview_panel", results_validator: @results_validator %>
 <% end %>

--- a/WcaOnRails/app/views/results_submission/_automatic_fixes_panel.html.erb
+++ b/WcaOnRails/app/views/results_submission/_automatic_fixes_panel.html.erb
@@ -1,0 +1,13 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Fix results errors</h3>
+  </div>
+  <div class="panel-body">
+    The following automatic fixes are available for some of the results errors:
+    <ul>
+      <% results_validator.suggest_fixes.select { |_, value| value }.keys.each do |key| %>
+        <li><%= link_to "Fix #{key}", competition_admin_fix_results_errors_path(fix: key), method: :post %></li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
     get '/admin' => "admin#actions_index_for_competition", as: :admin_index
     get '/admin/upload-results' => "admin#new_results", as: :admin_upload_results_edit
     get '/admin/check-existing-results' => "admin#check_results", as: :admin_check_existing_results
+    post '/admin/fix-results-errors' => "admin#fix_errors", as: :admin_fix_results_errors
     post '/admin/upload-json' => "admin#create_results", as: :admin_upload_results
     post '/admin/clear-submission' => "admin#clear_results_submission", as: :clear_results_submission
   end


### PR DESCRIPTION
@SAuroux (but really I'd do a @thewca/results-team if it existed)

This will basically be needed for #2107, and was among the fixes suggested by `check_results`.
So first of all it applies only to **existing** results.
Then if the `CompetitionResultsValidator` detects some wrong position, the "check results" view will include a list of the possible automatic fixes (which is not displayed if everything is fine):
![fix-position](https://user-images.githubusercontent.com/1007485/57081173-83c42280-6cf4-11e9-8f52-26834b42218d.png)
Clicking the button will start again the validator which will fix errors on the fly and render the check results view.

Nothing fancy in the design, but it does the job.

I plan to extend this with the "fix roundTypeId" which exists in `check_rounds`!
(and I plan to start writing unit tests for that big validator afterwards...)
