### PR TITLE
Increase Delayed Job Worker timeout to 20 minutes

### DIFF
--- a/WcaOnRails/config/initializers/delayed_job_config.rb
+++ b/WcaOnRails/config/initializers/delayed_job_config.rb
@@ -3,7 +3,7 @@
 require 'delayed/plugins/save_completed_jobs'
 
 Delayed::Worker.destroy_failed_jobs = false
-Delayed::Worker.max_run_time = 15.minutes
+Delayed::Worker.max_run_time = 20.minutes
 Delayed::Worker.delay_jobs = !Rails.env.test?
 Delayed::Worker.plugins << Delayed::Plugins::SaveCompletedJobs
 Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))


### PR DESCRIPTION
Follows #4149, as 15 minutes turned out to not to be enough (although the last time I triggered it, took just 8 minutes).