### PR TITLE
Don't enqueue multiple scheduled jobs

### DIFF
--- a/WcaOnRails/app/jobs/compute_linkings.rb
+++ b/WcaOnRails/app/jobs/compute_linkings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ComputeLinkings < ApplicationJob
+class ComputeLinkings < SingletonApplicationJob
   queue_as :default
 
   def perform

--- a/WcaOnRails/app/jobs/dump_developer_database.rb
+++ b/WcaOnRails/app/jobs/dump_developer_database.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DumpDeveloperDatabase < ApplicationJob
+class DumpDeveloperDatabase < SingletonApplicationJob
   queue_as :default
 
   def perform

--- a/WcaOnRails/app/jobs/singleton_application_job.rb
+++ b/WcaOnRails/app/jobs/singleton_application_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SingletonApplicationJob < ApplicationJob
+  before_enqueue do |job|
+    # Abort if job of the kind is already enqueued.
+    already_enqueued = Delayed::Job.exists?(["handler LIKE ?", "%job_class: #{job.class.name}%"])
+    throw :abort if already_enqueued
+  end
+end

--- a/WcaOnRails/app/jobs/submit_report_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_report_nag_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubmitReportNagJob < ApplicationJob
+class SubmitReportNagJob < SingletonApplicationJob
   queue_as :default
 
   def nag_needed(competition)

--- a/WcaOnRails/app/jobs/submit_results_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_results_nag_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubmitResultsNagJob < ApplicationJob
+class SubmitResultsNagJob < SingletonApplicationJob
   queue_as :default
 
   def nag_needed(competition)

--- a/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
+++ b/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SyncMailingListsJob < ApplicationJob
+class SyncMailingListsJob < SingletonApplicationJob
   queue_as :default
 
   SENIOR_DELEGATES_REGIONS_INFO = [

--- a/WcaOnRails/spec/jobs/singleton_application_job_spec.rb
+++ b/WcaOnRails/spec/jobs/singleton_application_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class ExampleJob < SingletonApplicationJob
+  queue_as :default
+
+  def perform
+    puts "Doing stuff..."
+  end
+end
+
+class ExampleJob2 < SingletonApplicationJob
+  queue_as :default
+
+  def perform
+    puts "Doing other stuff..."
+  end
+end
+
+RSpec.describe SingletonApplicationJob, type: :job do
+  # Copied from spec/lib/delayed/plugins/save_completed_jobs_spec.rb
+  around(:each) do |example|
+    old_delay_jobs = Delayed::Worker.delay_jobs
+    old_queue_adapter = ActiveJob::Base.queue_adapter
+    old_test_adapter = ActiveJob::Base._test_adapter
+    Delayed::Worker.delay_jobs = true
+    ActiveJob::Base.queue_adapter = :delayed_job
+    ActiveJob::Base.disable_test_adapter
+    example.run
+    Delayed::Worker.delay_jobs = old_delay_jobs
+    ActiveJob::Base.queue_adapter = old_queue_adapter
+    ActiveJob::Base.enable_test_adapter(old_test_adapter)
+  end
+
+  it "doesn't enqueue the same job multiple times" do
+    expect { ExampleJob.perform_later }.to change { Delayed::Job.count }.by(1)
+    expect { ExampleJob.perform_later }.to change { Delayed::Job.count }.by(0)
+  end
+
+  it "allows enqueuing multiple jobs of different types at the same time" do
+    expect { ExampleJob.perform_later }.to change { Delayed::Job.count }.by(1)
+    expect { ExampleJob2.perform_later }.to change { Delayed::Job.count }.by(1)
+  end
+end


### PR DESCRIPTION
We schedule some jobs every hour, in case any of them keeps failing for an hour we definitely don't want the same job to be enqueued again. Given there's a problem making a job fail, we just end up with duplicated jobs failing over and over.
This introduces a new class that ensures only one job of the given type is enqueued at a time.