### PR TITLE
Lazyload embedded maps iframes

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competition_tabs.js
+++ b/WcaOnRails/app/assets/javascripts/competition_tabs.js
@@ -11,6 +11,12 @@ onPage("competitions#show", function() {
   function showTabFromHash() {
     id = window.location.hash || '#general-info';
     $('a[href="' + id + '"]').tab('show');
+    $(id).find("iframe").each(function () {
+      $iframe = $(this);
+      if ($iframe.attr("src") === undefined) {
+        $iframe.attr("src", $iframe.data("src"));
+      }
+    });
   }
 });
 

--- a/WcaOnRails/app/helpers/markdown_helper.rb
+++ b/WcaOnRails/app/helpers/markdown_helper.rb
@@ -32,7 +32,7 @@ module MarkdownHelper
     def postprocess(full_document)
       # Support embed Open Street Map
       full_document.gsub!(/map\(([^)]*)\)/) do
-        "<iframe width='600' height='450' style='overflow: hidden' frameborder='0' style='border:0' src=\"#{embedded_map_url($1)}\"></iframe>"
+        "<iframe width='600' height='450' style='overflow: hidden' frameborder='0' style='border:0' data-src=\"#{embedded_map_url($1)}\"></iframe>"
       end
 
       # Support embed YouTube videos


### PR DESCRIPTION
Related to #3025.

While investigating our well-above-expectation google maps billing for May I realized that the embedded map iframe was loaded every time we load a competition page, even though the map is in an invisible tab!
So it triggered a useless geocoding query every time someone would load the competition page of a competition using our `map()` markdown helper in tabs...

That's pretty costly, and I'm pretty sure this will drastically decrease the amount of geocoding queries made!