### PR TITLE
Actually allow user to edit its fields

### DIFF
--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -134,7 +134,7 @@
           </div>
         <% end %>
 
-        <% if current_user.can_view_all_users? && @user.staff? %>
+        <% if @user.staff? && (current_user.can_view_all_users? || current_user == @user) %>
           <%= f.input :receive_delegate_reports, disabled: !editable_fields.include?(:receive_delegate_reports) %>
         <% end %>
 


### PR DESCRIPTION
Related to #4080, I forgot to actually allow a user to edit its own fields...
This is relevant for any staff who is not a Delegate/admin, as they can't see all user yet are allow to edit that field.

