### PR TITLE
Remove unused code

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -38,7 +38,7 @@ class CompetitionsController < ApplicationController
     end
   end
 
-  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :edit_schedule, :update_events, :update_events_from_wcif, :payment_setup]
+  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :edit_schedule, :payment_setup]
 
   before_action -> { redirect_to_root_unless_user(:can_create_competitions?) }, only: [:new, :create]
 
@@ -367,16 +367,6 @@ class CompetitionsController < ApplicationController
 
   def edit_schedule
     @competition = competition_from_params(includes: [competition_events: { rounds: { competition_event: [:event] } }, competition_venues: { venue_rooms: { schedule_activities: [:child_activities] } }])
-  end
-
-  def update_events
-    @competition = competition_from_params(includes: CHECK_SCHEDULE_ASSOCIATIONS)
-    if @competition.update_attributes(competition_params)
-      flash[:success] = t('.update_success')
-      redirect_to edit_events_path(@competition)
-    else
-      render :edit_events
-    end
   end
 
   def get_nearby_competitions(competition)

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1140,8 +1140,6 @@ en:
     new:
       create_competition: "Create competition"
       note_clone: "To clone an existing competition visit the information page for that competition and click the \"Clone\" link in the menu."
-    update_events:
-      update_success: "Successfully updated the competition events."
     update:
       save_success: "Successfully saved competition."
       confirm_success: "Successfully confirmed competition. Check your email, and wait for the WCAT to announce it!"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -73,7 +73,6 @@ Rails.application.routes.draw do
   get 'stripe-connect' => 'competitions#stripe_connect', as: :competitions_stripe_connect
   get 'competitions/:id/events/edit' => 'competitions#edit_events', as: :edit_events
   get 'competitions/:id/schedule/edit' => 'competitions#edit_schedule', as: :edit_schedule
-  patch 'competitions/:id/events' => 'competitions#update_events', as: :update_events
   get 'competitions/edit/nearby_competitions' => 'competitions#nearby_competitions', as: :nearby_competitions
   get 'competitions/edit/time_until_competition' => 'competitions#time_until_competition', as: :time_until_competition
   get 'competitions/:id/edit/clone_competition' => 'competitions#clone_competition', as: :clone_competition

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -1151,36 +1151,6 @@ RSpec.describe CompetitionsController do
     end
   end
 
-  describe 'POST #update_events' do
-    context 'when not signed in' do
-      sign_out
-
-      it 'redirects to the sign in page' do
-        patch :update_events, params: { id: competition, competition: { name: competition.name } }
-        expect(response).to redirect_to new_user_session_path
-      end
-    end
-
-    context 'when signed in as an admin' do
-      sign_in { FactoryBot.create :admin }
-
-      it 'updates the competition events' do
-        patch :update_events, params: { id: competition, competition: { name: competition.name } }
-        expect(response).to redirect_to edit_events_path(competition)
-      end
-    end
-
-    context 'when signed in as a regular user' do
-      sign_in { FactoryBot.create :user }
-
-      it 'does not allow access' do
-        expect {
-          patch :update_events, params: { id: competition, competition: { name: competition.name } }
-        }.to raise_error(ActionController::RoutingError)
-      end
-    end
-  end
-
   describe 'GET #payment_setup' do
     context 'when not signed in' do
       sign_out


### PR DESCRIPTION
I noticed these while working on #4102.

Since we edit events only through WCIF, these endpoints are not used anymore!
(or at least I think so, and the fact that `update_events_path` was used only in tests seems to confirm it)