### PR TITLE
Name reason in competition form is now required

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -191,7 +191,7 @@ class Competition < ApplicationRecord
 
   # We have stricter validations for confirming a competition
   validates :cityName, :countryId, :venue, :venueAddress, :latitude, :longitude, presence: true, if: :confirmed_or_visible?
-  validates :name_reason, presence: true, if: :name_reason_required?
+  validates :name_reason, presence: true
   validates :external_website, presence: true, if: -> { confirmed_or_visible? && !generate_website }
 
   validates :registration_open, :registration_close, presence: { message: I18n.t('simple_form.required.text') }, if: :registration_period_required?
@@ -765,10 +765,6 @@ class Competition < ApplicationRecord
 
   def registration_period_required?
     use_wca_registration? || (confirmed? && created_at.present? && created_at > Date.new(2018, 9, 13))
-  end
-
-  def name_reason_required?
-    confirmed? && created_at.present? && created_at > Date.new(2018, 10, 20)
   end
 
   def pending_results_or_report(days)

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe CompetitionsController do
       sign_in { FactoryBot.create :admin }
 
       it "creates a new competition" do
-        post :create, params: { competition: { name: "FatBoyXPC 2015", use_wca_registration: false } }
+        post :create, params: { competition: { name: "FatBoyXPC 2015", name_reason: "Boy is fat", use_wca_registration: false } }
         new_comp = assigns(:competition)
         expect(response).to redirect_to edit_competition_path("FatBoyXPC2015")
         expect(new_comp.id).to eq "FatBoyXPC2015"
@@ -250,7 +250,7 @@ RSpec.describe CompetitionsController do
       end
 
       it "creates a competition with correct website when using WCA as competition's website" do
-        post :create, params: { competition: { name: "Awesome Competition 2016", external_website: nil, generate_website: "1", use_wca_registration: false } }
+        post :create, params: { competition: { name: "Awesome Competition 2016", name_reason: "This is awesome", external_website: nil, generate_website: "1", use_wca_registration: false } }
         competition = assigns(:competition)
         expect(competition.website).to eq competition_url(competition)
       end
@@ -266,7 +266,7 @@ RSpec.describe CompetitionsController do
         organizer = FactoryBot.create :user
         expect(CompetitionsMailer).to receive(:notify_organizer_of_addition_to_competition).with(delegate, anything, organizer).and_call_original
         expect do
-          post :create, params: { competition: { name: "Test 2015", delegate_ids: delegate.id, organizer_ids: organizer.id, use_wca_registration: false } }
+          post :create, params: { competition: { name: "Test 2015", name_reason: "This is a test competition", delegate_ids: delegate.id, organizer_ids: organizer.id, use_wca_registration: false } }
         end.to change { enqueued_jobs.size }.by(1)
         expect(response).to redirect_to edit_competition_path("Test2015")
         new_comp = assigns(:competition)

--- a/WcaOnRails/spec/features/competition_management_spec.rb
+++ b/WcaOnRails/spec/features/competition_management_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature "Competition management" do
       scenario "with valid data" do
         visit "/competitions/new"
         fill_in "Name", with: "My Competition 2015"
+        fill_in "The reason for the name", with: "A competition in 2015"
         uncheck "I would like to use the WCA website for registration"
         click_button "Create Competition"
 
@@ -33,6 +34,7 @@ RSpec.feature "Competition management" do
         visit edit_competition_path(competition)
         click_link "Clone"
         fill_in "Name", with: "Pedro 2016"
+        fill_in "The reason for the name", with: "A competition in 2016"
         fill_in "Start date", with: "2016-11-30"
         fill_in "End date", with: "2016-11-30"
         click_button "Create Competition"
@@ -119,6 +121,7 @@ RSpec.feature "Competition management" do
       visit "/competitions/new"
 
       fill_in "Name", with: "New Comp 2015"
+      fill_in "The reason for the name", with: "A new competition in 2015"
       uncheck "I would like to use the WCA website for registration"
       click_button "Create Competition"
       expect(page).to have_content "Successfully created new competition!" # wait for request to complete
@@ -133,6 +136,7 @@ RSpec.feature "Competition management" do
       visit clone_competition_path(competition_to_clone)
 
       fill_in "Name", with: "New Comp 2015"
+      fill_in "The reason for the name", with: "A new competition in 2015"
 
       expect(page).to have_button('Create Competition')
       click_button "Create Competition"

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -709,6 +709,7 @@ RSpec.describe Competition do
       competition.build_clone.tap do |clone|
         clone.name = "Cloned Competition 2016"
         clone.start_date, clone.end_date = [1.month.from_now.strftime("%F")] * 2
+        clone.name_reason = "This competition is a clone"
       end
     end
     let!(:tab) { FactoryBot.create(:competition_tab, competition: competition) }


### PR DESCRIPTION
Name reason is always validated and the attribute was added in previous tests. Checks one item of the wishlist in issue #3759 