### PR TITLE
Fix computation of average above 10 minutes

### DIFF
--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -141,8 +141,11 @@ module Resultable
       else
         # Cast at least one of the operands to float
         sum_centis = counting_solve_times.sum(&:time_centiseconds).to_f
-        # Round the result
-        (sum_centis / counting_solve_times.length).round
+        raw_average = sum_centis / counting_solve_times.length
+        # Round the result.
+        # If the average is above 10 minutes, round it to the nearest second as per
+        # https://www.worldcubeassociation.org/regulations/#9f2
+        raw_average > 60_000 ? raw_average.round(-2) : raw_average.round
       end
     end
   end

--- a/WcaOnRails/spec/models/result_spec.rb
+++ b/WcaOnRails/spec/models/result_spec.rb
@@ -96,13 +96,24 @@ RSpec.describe Result do
         context "uncombined round" do
           let(:roundTypeId) { "1" }
 
-          it "all solves" do
-            result = build_result(value1: 42, value2: 43, value3: 44, value4: 45, value5: 46, best: 42, average: 44)
+          it "all solves with average below 10 minutes" do
+            # This average computes to 44.0066... and should be rounded to 44.01
+            result = build_result(value1: 4200, value2: 4300, value3: 4400, value4: 4502, value5: 4600, best: 4200, average: 4401)
             expect(result).to be_valid
 
             result.average = 33
-            expect(result.compute_correct_average).to eq 44
-            expect(result).to be_invalid_with_errors(average: ["should be 44"])
+            expect(result.compute_correct_average).to eq 4401
+            expect(result).to be_invalid_with_errors(average: ["should be 4401"])
+          end
+
+          it "all solves with average above 10 minutes" do
+            # This average computes to 600.66... and should be rounded to 601
+            result = build_result(value1: 1001, value2: 60_100, value3: 60_100, value4: 60_000, value5: 70_000, best: 1001, average: 60_100)
+            expect(result).to be_valid
+
+            result.average = 33
+            expect(result.compute_correct_average).to eq 60_100
+            expect(result).to be_invalid_with_errors(average: ["should be 60100"])
           end
 
           it "DNF average" do
@@ -158,13 +169,24 @@ RSpec.describe Result do
           context "uncombined round" do
             let(:roundTypeId) { "1" }
 
-            it "all solves" do
-              result = build_result(value1: 42, value2: 43, value3: 44, value4: 0, value5: 0, best: 42, average: 43)
+            it "all solves with average below 10 minutes" do
+              # This average computes to 44.0066... and should be rounded to 44.01
+              result = build_result(value1: 4300, value2: 4502, value3: 4400, value4: 0, value5: 0, best: 4300, average: 4401)
               expect(result).to be_valid
 
               result.average = 33
-              expect(result.compute_correct_average).to eq 43
-              expect(result).to be_invalid_with_errors(average: ["should be 43"])
+              expect(result.compute_correct_average).to eq 4401
+              expect(result).to be_invalid_with_errors(average: ["should be 4401"])
+            end
+
+            it "all solves with average above 10 minutes" do
+              # This average computes to 600.66... and should be rounded to 601
+              result = build_result(value1: 60_100, value2: 60_100, value3: 60_000, value4: 0, value5: 0, best: 60_000, average: 60_100)
+              expect(result).to be_valid
+
+              result.average = 33
+              expect(result.compute_correct_average).to eq 60_100
+              expect(result).to be_invalid_with_errors(average: ["should be 60100"])
             end
 
             it "rounds instead of truncates" do


### PR DESCRIPTION
Noticed by the WRT and the competition's Delegate when posting Forgotten O'Clocks SBC 2019.
@SAuroux 

The tests I added fail without the fix but succeed with it.