### PR TITLE
Pass array of persons by reference

### DIFF
--- a/webroot/results/admin/persons_check_finished.php
+++ b/webroot/results/admin/persons_check_finished.php
@@ -276,13 +276,13 @@ function checkDuplicatesInCompetition () {
 
 
 #----------------------------------------------------------------------
-function getMostSimilarPersons ( $id, $name, $countryId, $persons ) {
+function getMostSimilarPersons ( $id, $name, $countryId, &$persons ) {
 #----------------------------------------------------------------------
   return getMostSimilarPersonsMax( $id, $name, $countryId, $persons, 5 );
 }
 
 #----------------------------------------------------------------------
-function getMostSimilarPersonsMax ( $id, $name, $countryId, $persons, $max ) {
+function getMostSimilarPersonsMax ( $id, $name, $countryId, &$persons, $max ) {
 #----------------------------------------------------------------------
 
   #--- Compute similarities to all persons.


### PR DESCRIPTION
The WRT started to have issues with that script recently.
Initially I though it was because we iterated through a lot (all) persons, but it turns out it's just because php pass variables by value by default.
Array should be copy on write though, maybe the "forward" function call we make is considered as writing the data?

Anyway I did some measurements to validate this: I took the memory usage before calling `getMostSimilarPersons` and at the beginning of `getMostSimilarPersonsMax`.
When passing by reference the difference in memory usage is 624 bytes, when not passing by reference it's over 18 Mb.
(I couldn't do a before/after `getMostSimilarPersons` because the script fails in the function)

It's pretty clear to me this is an appropriate quickfix, as we do the same in there: https://github.com/thewca/worldcubeassociation.org/blob/ea9e6192b2af68a673d027a571aa42eee94c7af3/webroot/results/admin/persons_finish_unfinished.php#L285

