### PR TITLE
Update gb_city_validator.rb

### DIFF
--- a/WcaOnRails/lib/country_city_validators/gb_city_validator.rb
+++ b/WcaOnRails/lib/country_city_validators/gb_city_validator.rb
@@ -93,5 +93,19 @@ GB_COUNTIES = %w(
   Worcestershire
   Yorkshire
 ).to_set
+GB_TERRITORIES = %w(
+  Akrotiri\ and\ Dhekelia
+  Anguilla
+  Bermuda
+  British\ Virgin\ Islands
+  Cayman\ Islands
+  Falkland\ Islands
+  Gibraltar
+  Montserrat
+  Pitcairn\ Islands
+  Saint\ Helena,\ Ascension\ and\ Tristan\ da\ Cunha
+  Turks\ and\ Caicos\ Islands
+).to_set
+GB_REGIONS = GB_COUNTIES | GB_TERRITORIES
 
-CityValidator.add_validator_for_country "GB", CityCommaRegionValidator.new(type_of_region: "county", valid_regions: GB_COUNTIES)
+CityValidator.add_validator_for_country "GB", CityCommaRegionValidator.new(type_of_region: "county", valid_regions: GB_REGIONS)


### PR DESCRIPTION
Updated to include British Overseas Territories that retain a permanent population. British Antarctic Territory, British Indian Territory and South Georgia and the South Sandwich Islands excluded.