### PR TITLE
Do not allow trailing commas in city names.

### DIFF
--- a/WcaOnRails/lib/city_validator.rb
+++ b/WcaOnRails/lib/city_validator.rb
@@ -44,7 +44,7 @@ class CityCommaRegionValidator < CountryCityValidator
   end
 
   def reason_why_invalid(city)
-    _city, region = city.split(", ")
+    _city, region = city.split(", ", 2)
     if region.nil?
       "is not of the form 'city, #{@type_of_region}'"
     elsif !@valid_regions.include?(region)

--- a/WcaOnRails/spec/lib/city_validator_spec.rb
+++ b/WcaOnRails/spec/lib/city_validator_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe CityValidator do
       expect(model).to be_invalid_with_errors city: ["is not of the form 'city, state'"]
     end
 
+    it "does not allow extra commas" do
+      model.city = "New York, New York, foo bar"
+      expect(model).to be_invalid_with_errors city: ["New York, foo bar is not a valid state"]
+    end
+
     it "allows multiple cities" do
       model.city = "Multiple cities"
       expect(model).to be_valid


### PR DESCRIPTION
Ruby's split method will split as many times as possible, and when
destructuring the result into 2 variables, it only pulls off the first
two pieces, and drops the rest. This is not what we want, because it
allows people to (intentionally or accidentally) add more stuff to city
names after commas and we won't realize it.

I first added a failing test that passes now that we limit the split to
producing 2 items.