### PR TITLE
Change key name to avoid issues in translations

### DIFF
--- a/WcaOnRails/app/views/static_pages/about.html.erb
+++ b/WcaOnRails/app/views/static_pages/about.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <blockquote class="blockquote">
-    <p class="mb-0"><%= t('about.mission') %></p>
+    <p class="mb-0"><%= t('about.mission_statement') %></p>
     <footer class="blockquote-footer"><%= t('about.mission_footer') %></footer>
   </blockquote>
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1467,7 +1467,7 @@ en:
   #context: About the WCA
   about:
     title: "About the WCA"
-    mission: Our mission is to have more competitions in more countries with more people and more fun, under fair and equal conditions.
+    mission_statement: Our mission is to have more competitions in more countries with more people and more fun, under fair and equal conditions.
     mission_footer: WCA Mission Statement
     who_we_are_title: Who we are
     who_we_are_content_html: <p>The World Cube Association governs competitions for mechanical puzzles that are operated by twisting groups of pieces, commonly known as 'twisty puzzles'. The most famous of these puzzles is the Rubik's Cube, invented by professor Rubik from Hungary. A selection of these puzzles are chosen as official events of the WCA.</p>


### PR DESCRIPTION
I don't think it can get uglier:
![i18n](https://user-images.githubusercontent.com/1007485/60492104-8d451900-9caa-11e9-9531-a7b8e89c5682.png)

:p  

I'll merge this as soon as possible, as in basically every translation this is messed up :(
(and none has been updated yet)