### PR TITLE
Fix registrations' tables when full emails are not shown.

### DIFF
--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -48,9 +48,7 @@
             <% if @competition.using_stripe_payments? %>
               <th class="paid"><%= t 'activerecord.attributes.registration.paid_entry_fees' %></th>
             <% end %>
-            <% if @show_full_mail %>
-              <th class="email"><%= t 'activerecord.attributes.registration.email' %></th>
-            <% end %>
+            <th class="email"><%= t 'activerecord.attributes.registration.email' %></th>
 
             <!-- Extra column for .table-greedy-last-column -->
             <th></th>


### PR DESCRIPTION
As a result of #4041, when emails are not shown the tables have more columns than headers. This commit fixes such bug. Thanks to @LinusFresz for reporting!

I'll merge this one up right after the tests pass.