### PR TITLE
Fix pdf CSS assets in production

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/pdf.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/pdf.css.scss
@@ -2,11 +2,13 @@
  * This scss file is specifically used in the pdf rendered page (eg: the competition info and schedule page).
  */
 
-@import "cubing-icons";
-
 a {
   color: black;
 }
+
+// We need the import here, otherwise Rails' asset adds a BOM at the beginning of it,
+// and the font doesn't get recognize!
+@import "cubing-icons";
 
 header {
   width: 100%;

--- a/WcaOnRails/config/initializers/assets.rb
+++ b/WcaOnRails/config/initializers/assets.rb
@@ -12,3 +12,4 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w(oms.js)
 Rails.application.config.assets.precompile += %w(email.css)
+Rails.application.config.assets.precompile += %w(pdf.css)


### PR DESCRIPTION
That's my bad for not noticing [this part](https://github.com/mileszs/wicked_pdf/#asset-pipeline-usage) of the documentation when implementing #4102...

However, even with this I had trouble with the cubing icons font which was not properly loaded.
I struggled finding up why as the css did show up in the source, and I "accidentally" found out that there was a BOM in the file generated!
![bom](https://user-images.githubusercontent.com/1007485/60719464-0ac98d00-9f28-11e9-9e28-544dc2212772.png)

I think this has something to do with Rails' assets detection of encoding which adds that, but I must admit I'm not understanding everything that happened.

Putting the import after any other CSS just gets rid of that BOM, so that's what I did.

Will merge ASAP.
