### PR TITLE
Install poppler-utils package required by ActiveStorage built-in PDF previewer

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -139,6 +139,7 @@ package 'libsqlite3-dev'
 package 'g++'
 package 'libmysqlclient-dev'
 package 'imagemagick'
+package 'poppler-utils' # Required by ActiveStorage built-in PDF previewer.
 
 ruby_version = File.read("#{repo_root}/.ruby-version").match(/\d+\.\d+/)[0]
 node.default['brightbox-ruby']['version'] = ruby_version


### PR DESCRIPTION
Fixes issue described in [this comment](https://github.com/thewca/worldcubeassociation.org/pull/4242#issuecomment-504743335).

The `ActiveStorage` PDF previewer requires native packages, specifically it looks for the `pdftoppm` command that comes from the `poppler-utils` ubuntu package.

I run chef on the staging and everything worked as expected!