### PR TITLE
Increase Capybara wait time for the problematic selector

### DIFF
--- a/WcaOnRails/spec/features/competition_events_spec.rb
+++ b/WcaOnRails/spec/features/competition_events_spec.rb
@@ -181,7 +181,7 @@ end
 def save
   # Wait for the modal to be hidden.
   expect(page).to have_no_css(".modal-open")
-  first(:button, "save your changes!", visible: true).click
+  first(:button, "save your changes!", visible: true, wait: 3).click
   # Wait for ajax to complete.
   expect(page).to have_no_content("You have unsaved changes")
 end


### PR DESCRIPTION
An attempt of fixing intermittent test failure pointed out [here](https://github.com/thewca/worldcubeassociation.org/issues/897#issuecomment-416981708), as it happens frustratingly often. I run the spec locally in a loop until it failed, but I couldn't reproduce this exact failure. The proposed solution is to wait a little bit more for the selector to be found (3s instead of the default 2s), so it's less likely to suffer from modal hidding slowly (a wild guess).