### PR TITLE
Adds 'my results' and 'my competitions' under user profile

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -141,10 +141,11 @@
               </li>
               <li><%= link_to t('.edit_profile'), profile_edit_path %></li>
 
+              <li class="divider"></li>
+              <li><%= link_to t('.my_competitions'), my_comps_path %></li>
+
               <% if current_user.wca_id? %>
-                <li class="divider"></li>
-                <li><%= link_to t('.my_results'), person_path(current_user.wca_id) -%></li>
-                <li><%= link_to t('.my_competitions'), my_comps_path -%></li>
+                <li><%= link_to t('.my_results'), person_path(current_user.wca_id) %></li>
               <% end %>
 
               <% if current_user.staff? %>

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -141,6 +141,12 @@
               </li>
               <li><%= link_to t('.edit_profile'), profile_edit_path %></li>
 
+              <% if current_user.wca_id? %>
+                <li class="divider"></li>
+                <li><%= link_to t('.my_results'), person_path(current_user.wca_id) -%></li>
+                <li><%= link_to t('.my_competitions'), my_comps_path -%></li>
+              <% end %>
+
               <% if current_user.staff? %>
                 <li class="divider"></li>
                 <li><%= link_to t('.panel'), panel_path %></li>


### PR DESCRIPTION
Summary:
When the user has a WCA ID linked, "My Results" and "My Competitions" now show up under the user navigation.
<img width="242" alt="Screen Shot 2019-07-11 at 11 17 12 PM" src="https://user-images.githubusercontent.com/24919355/61106635-9e242600-a432-11e9-98ac-94940e091b5a.png">

Fixes https://github.com/thewca/worldcubeassociation.org/issues/4158

Testing:
No automated tests changed.
Tested with my own account (WCA ID linked) to verify the two links were present, and tested with an account without a WCA ID to confirm the two links were not present.

I had wanted to contribute in the past, but wasn't able to due to school. Thus, this is basically my first PR! I'm super open to feedback as well as ideas for a slightly more difficult second issue. I'm hoping to contribute a bit to the WCA site in my free time. :)