### PR TITLE
Add `irb` to `Gemfile`.

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -105,6 +105,11 @@ group :development, :test do
   gem 'byebug'
   gem 'i18n-tasks'
   gem 'i18n-spec'
+
+  # We may be able to remove this when a future version of bundler comes out.
+  # See https://github.com/bundler/bundler/issues/6929#issuecomment-459151506 and
+  # https://github.com/bundler/bundler/pull/6963 for more information.
+  gem 'irb', require: false
 end
 
 group :development do

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -273,6 +273,7 @@ GEM
     image_processing (1.9.0)
       mini_magick (>= 4.9.3, < 5)
       ruby-vips (>= 2.0.13, < 3)
+    irb (1.0.0)
     iso (0.2.2)
       i18n
     jaro_winkler (1.5.3)
@@ -649,6 +650,7 @@ DEPENDENCIES
   i18n-spec
   i18n-tasks
   image_processing
+  irb
   jbuilder
   jquery-rails
   jquery-slick-rails
@@ -708,4 +710,4 @@ DEPENDENCIES
   wicked_pdf
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Ever since upgrading to Ruby 2.6 (see https://github.com/thewca/worldcubeassociation.org/pull/3873), I've experienced the following crash when running `bin/rails console`:

```
$ bin/rails c
warning package.json: No license field
warning No license field
Running via Spring preloader in process 12917
Traceback (most recent call last):
	28: from -e:1:in `<main>'
	27: from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	26: from /usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	25: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `load'
	24: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	23: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `block in load'
	22: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:285:in `load'
	21: from /home/jeremy/gitting/worldcubeassociation.org/WcaOnRails/bin/rails:11:in `<top (required)>'
	20: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	19: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	18: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	17: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	16: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/commands.rb:18:in `<top (required)>'
	15: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/command.rb:44:in `invoke'
	14: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/command.rb:70:in `find_by_namespace'
	13: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/command/behavior.rb:79:in `lookup'
	12: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/command/behavior.rb:79:in `each'
	11: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/command/behavior.rb:80:in `block in lookup'
	10: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/command/behavior.rb:80:in `each'
	 9: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/command/behavior.rb:84:in `block (2 levels) in lookup'
	 8: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	 7: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	 6: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	 5: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	 4: from /home/jeremy/.gem/ruby/2.6.0/gems/railties-5.2.3/lib/rails/commands/console/console_command.rb:3:in `<top (required)>'
	 3: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	 2: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	 1: from /home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
/home/jeremy/.gem/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require': cannot load such file -- irb (LoadError)
```

Some Googling let me on the following journey:
  - https://www.reddit.com/r/rails/comments/akhmae/ruby_26_breaks_rails_console/ ->
  - https://github.com/Shopify/bootsnap/issues/223 ->
  - https://github.com/bundler/bundler/issues/6929#issuecomment-459151506

So, this appears to be due to a bundler change, and one workaround is to
explicitly add `irb` to your Gemfile. It seems like this may be fixed in
a future version of bundler: https://github.com/bundler/bundler/pull/6963.