### PR TITLE
Bumping TNoodle to 0.15.0

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -28,12 +28,12 @@ class Api::V0::ApiController < ApplicationController
   def scramble_program
     render json: {
       "current" => {
-        "name" => "TNoodle-WCA-0.14.0",
+        "name" => "TNoodle-WCA-0.15.0",
         "information" => "#{root_url}regulations/scrambles/",
-        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.14.0.jar",
+        "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.15.0.jar",
       },
       "allowed" => [
-        "TNoodle-WCA-0.14.0",
+        "TNoodle-WCA-0.14.0", "TNoodle-WCA-0.15.0"
       ],
       "history" => [
         "TNoodle-0.7.4",
@@ -56,6 +56,7 @@ class Api::V0::ApiController < ApplicationController
         "TNoodle-WCA-0.13.4",
         "TNoodle-WCA-0.13.5",
         "TNoodle-WCA-0.14.0",
+        "TNoodle-WCA-0.15.0",
       ],
     }
   end

--- a/WcaOnRails/app/views/regulations/scrambles/index.html.erb
+++ b/WcaOnRails/app/views/regulations/scrambles/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, 'WCA Scrambles') %>
 <div class="container">
   <h1>WCA Scrambles</h1>
-  <% latest_version = "TNoodle-WCA-0.14.0" %>
+  <% latest_version = "TNoodle-WCA-0.15.0" %>
   <% latest_jarfilename = "#{latest_version}.jar" %>
   <p>The current official scramble programs is <em><%= latest_version %></em>. It generates high-quality scramble sequences for all the events of a competition at once.</p>
   <center>
@@ -10,7 +10,7 @@
       <strong><%= link_to latest_jarfilename, "./tnoodle/#{latest_jarfilename}" %></strong>
     </span>
     <br/>
-    Last official change: December 3, 2018
+    Last official change: July 14th, 2019
   </center>
   <h2>Important Notes for Delegates</h2>
   <ul>
@@ -69,6 +69,7 @@
     <li><%= link_to "TNoodle-WCA-0.13.3", "./tnoodle/old/TNoodle-WCA-0.13.3.jar" %> (2018-02-05)</li>
     <li><%= link_to "TNoodle-WCA-0.13.4", "./tnoodle/old/TNoodle-WCA-0.13.4.jar" %> (2018-07-02)</li>
     <li><%= link_to "TNoodle-WCA-0.13.5", "./tnoodle/old/TNoodle-WCA-0.13.5.jar" %> (2018-10-08)</li>
-    <li><%= link_to "TNoodle-WCA-0.14.0", "./tnoodle/TNoodle-WCA-0.13.5.jar" %> (2018-12-03)</li>
+    <li><%= link_to "TNoodle-WCA-0.14.0", "./tnoodle/TNoodle-WCA-0.14.0.jar" %> (2018-12-03)</li>
+    <li><%= link_to "TNoodle-WCA-0.15.0", "./tnoodle/TNoodle-WCA-0.15.0.jar" %> (2019-07-14)</li>
   </ul>
 </div>

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe Api::V0::ApiController do
       get :scramble_program
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.14.0"
+      expect(json["current"]["name"]).to eq "TNoodle-WCA-0.15.0"
     end
   end
 


### PR DESCRIPTION
We are keeping TNoodle 0.14 allowed for the new future (as discussed between @lgarron and @jfly on Slack).