### PR TITLE
PoC for composable Results validators

### DIFF
--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -19,8 +19,8 @@ module Resultable
     validates :format, presence: true
 
     # Order by event, then roundTypeId, then average if exists, then best if exists
-    scope :sorted_for_competition,
-          ->(competition_id) { includes(:format).where(competitionId: competition_id).order(:eventId, :roundTypeId).order(Arel.sql("if(formatId in ('a','m') and average>0, average, 2147483647), if(best>0, best, 2147483647)")) }
+    scope :sorted_for_competitions,
+          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).order(:competitionId, :eventId, :roundTypeId).order(Arel.sql("if(formatId in ('a','m') and average>0, average, 2147483647), if(best>0, best, 2147483647)")) }
 
     # Define cached stuff with the same name as the associations for validation
     def round_type

--- a/WcaOnRails/app/models/upload_json.rb
+++ b/WcaOnRails/app/models/upload_json.rb
@@ -13,7 +13,7 @@ class UploadJson
     else
       begin
         # Parse the json first
-        JSON::Validator.validate!(CompetitionResultsValidator::RESULT_JSON_SCHEMA, parsed_json)
+        JSON::Validator.validate!(ResultsValidators::JSONSchemas::RESULT_JSON_SCHEMA, parsed_json)
         if parsed_json["competitionId"] != competition_id
           errors.add(:results_file, "is not for this competition but for #{parsed_json["competitionId"]}!")
         end

--- a/WcaOnRails/db/migrate/20190716065618_add_id_to_inbox_results.rb
+++ b/WcaOnRails/db/migrate/20190716065618_add_id_to_inbox_results.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIdToInboxResults < ActiveRecord::Migration[5.2]
+  def change
+    add_column :InboxResults, :id, :primary_key
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -210,6 +210,8 @@ CREATE TABLE `InboxResults` (
   `value5` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`),
   KEY `InboxResults_fk_tournament` (`competitionId`),
   KEY `InboxResults_fk_event` (`eventId`),
   KEY `InboxResults_fk_format` (`formatId`),
@@ -1557,4 +1559,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190221194112'),
 ('20190601105825'),
 ('20190601231550'),
-('20190622173635');
+('20190622173635'),
+('20190716065618');

--- a/WcaOnRails/lib/competition_results_validator.rb
+++ b/WcaOnRails/lib/competition_results_validator.rb
@@ -47,7 +47,6 @@ class CompetitionResultsValidator
   # Results-related errors and warnings
   MET_CUTOFF_MISSING_RESULTS_ERROR = "[%{round_id}] %{person_name} has met the cutoff but is missing results for the second phase. Cutoff is %{cutoff}."
   DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR = "[%{round_id}] %{person_name} has at least one result for the second phase but didn't meet the cutoff. Cutoff is %{cutoff}."
-  WRONG_POSITION_IN_RESULTS_ERROR = "[%{round_id}] Result for %{person_name} has a wrong position: expected %{expected_pos} and got %{pos}."
   MISMATCHED_RESULT_FORMAT_ERROR = "[%{round_id}] Result for %{person_name} are in the wrong format: expected %{expected_format}, but got %{format}."
   RESULT_OVER_TIME_LIMIT_ERROR = "[%{round_id}] At least one result for %{person_name} is over the time limit which is %{time_limit} for one solve. All solves over the time limit must be changed to DNF."
   RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR = "[%{round_ids}] The sum of results for %{person_name} is over the cumulative time limit which is %{time_limit}."
@@ -424,10 +423,6 @@ class CompetitionResultsValidator
     #   - for multiblind, check if we should ouput a warning (if time is over the time limit, as the 'Result' object validation allows for time up to 30s over the timelimit)
 
     results_by_round_id.each do |round_id, results_for_round|
-      expected_pos = 0
-      last_result = nil
-      # Number of tied competitors, *without* counting the first one
-      number_of_tied = 0
       results_for_round.each_with_index do |result, index|
         person_info = @persons_by_id[result.personId]
         unless person_info

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class GenericValidator
+    attr_reader :errors, :warnings
+    @@desc = "Please override that class variable with a proper description when you inherit the class."
+
+    def initialize
+      reset_state
+    end
+
+    def has_errors?
+      @errors.any?
+    end
+
+    def has_warnings?
+      @warnings.any?
+    end
+
+    # User must provide either:
+    #   - 'competition_ids' and 'model' (Result | InboxResult)
+    #   - 'results'
+    def validate(competition_ids: [], model: Result, results: nil)
+      raise NotImplementedError
+    end
+
+    def description
+      @@desc
+    end
+
+    private
+
+    def reset_state
+      @errors = []
+      @warnings = []
+    end
+  end
+end

--- a/WcaOnRails/lib/results_validators/json_schemas.rb
+++ b/WcaOnRails/lib/results_validators/json_schemas.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  module JSONSchemas
+    INDIVIDUAL_RESULT_JSON_SCHEMA = {
+      "type" => "object",
+      "properties" => {
+        "personId" => { "type" => "number" },
+        "position" => { "type" => "number" },
+        "results" => {
+          "type" => "array",
+          "items" => { "type" => "number" },
+        },
+        "best" => { "type" => "number" },
+        "average" => { "type" => "number" },
+      },
+      "required" => ["personId", "position", "results", "best", "average"],
+    }.freeze
+
+    GROUP_JSON_SCHEMA = {
+      "type" => "object",
+      "properties" => {
+        "group" => { "type" => "string" },
+        "scrambles" => {
+          "type" => "array",
+          "items" => { "type" => "string" },
+        },
+        "extraScrambles" => {
+          "type" => "array",
+          "items" => { "type" => "string" },
+        },
+      },
+      "required" => ["group", "scrambles"],
+    }.freeze
+
+    ROUND_JSON_SCHEMA = {
+      "type" => "object",
+      "properties" => {
+        "roundId" => { "type" => "string" },
+        "formatId" => { "type" => "string" },
+        "results" => {
+          "type" => "array",
+          "items" => INDIVIDUAL_RESULT_JSON_SCHEMA,
+        },
+        "groups" => {
+          "type" => "array",
+          "items" => GROUP_JSON_SCHEMA,
+        },
+      },
+      "required" => ["roundId", "formatId", "results", "groups"],
+    }.freeze
+
+    PERSON_JSON_SCHEMA = {
+      "type" => "object",
+      "properties" => {
+        "id" => { "type" => "number" },
+        "name" => { "type" => "string" },
+        # May be empty
+        "wcaId" => { "type" => "string" },
+        "countryId" => { "type" => "string" },
+        # May be empty
+        "gender" => { "type" => "string" },
+        "dob" => { "type" => "string" },
+      },
+      "required" => ["id", "name", "wcaId", "countryId", "gender", "dob"],
+    }.freeze
+
+    EVENT_JSON_SCHEMA = {
+      "type" => "object",
+      "properties" => {
+        "eventId" => { "type" => "string" },
+        "rounds" => {
+          "type" => "array",
+          "items" => ROUND_JSON_SCHEMA,
+        },
+      },
+      "required" => ["eventId", "rounds"],
+    }.freeze
+
+    RESULT_JSON_SCHEMA = {
+      "type" => "object",
+      "properties" => {
+        "formatVersion" => { "type" => "string" },
+        "competitionId" => { "type" => "string" },
+        "persons" => {
+          "type" => "array",
+          "items" => PERSON_JSON_SCHEMA,
+        },
+        "events" => {
+          "type" => "array",
+          "items" => EVENT_JSON_SCHEMA,
+        },
+      },
+      "required" => ["formatVersion", "competitionId", "persons", "events"],
+    }.freeze
+  end
+end

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -48,7 +48,7 @@ module ResultsValidators
                 # Note: this fires one sql select per wrong position, but it should
                 # be fine since in this case we should be checking "InboxResult"
                 # and therefore the results from one single competition submission.
-                person = InboxPerson.where(competitionId: competition_id, id: result.personId).first
+                person = InboxPerson.find_by(competitionId: competition_id, id: result.personId)
                 person_name = person ? person.name : "<personId=#{result.personId}>"
               end
               @errors << ValidationError.new(:results, competition_id, WRONG_POSITION_IN_RESULTS_ERROR, round_id: round_id, person_name: person_name, expected_pos: expected_pos, pos: result.pos)

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -22,7 +22,17 @@ module ResultsValidators
             # so we simply need to check that the position stored matched the expected one
 
             # Unless we find two exact same results, we increase the expected position
-            if last_result && result.average == last_result.average && result.best == last_result.best
+            tied = false
+            if last_result
+              if ["a", "m"].include?(result.formatId)
+                # If the ranking is based on average, look at both average and best.
+                tied = result.average == last_result.average && result.best == last_result.best
+              else
+                # else we just compare the bests
+                tied = result.best == last_result.best
+              end
+            end
+            if tied
               number_of_tied += 1
             else
               expected_pos += 1

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class PositionsValidator < GenericValidator
+    WRONG_POSITION_IN_RESULTS_ERROR = "[%{round_id}] Result for %{person_name} has a wrong position: expected %{expected_pos} and got %{pos}."
+
+    @@desc = "This validator checks that positions stored in results are correct with regard to the actual results."
+
+    def validate(competition_ids: [], model: Result, results: nil)
+      reset_state
+      # Get all results if not provided
+      results ||= model.sorted_for_competitions(competition_ids)
+      results.group_by(&:competitionId).each do |competition_id, results_for_comp|
+        results_for_comp.group_by { |r| "#{r.eventId}-#{r.roundTypeId}" }.each do |round_id, results_for_round|
+          expected_pos = 0
+          last_result = nil
+          # Number of tied competitors, *without* counting the first one
+          number_of_tied = 0
+          results_for_round.each_with_index do |result, index|
+            # Check for position in round
+            # The scope "InboxResult.sorted_for_competitions" already sorts by average then best,
+            # so we simply need to check that the position stored matched the expected one
+
+            # Unless we find two exact same results, we increase the expected position
+            if last_result && result.average == last_result.average && result.best == last_result.best
+              number_of_tied += 1
+            else
+              expected_pos += 1
+              expected_pos += number_of_tied
+              number_of_tied = 0
+            end
+            last_result = result
+
+            if expected_pos != result.pos
+              person_name = result.personName if result.respond_to?(:personName)
+              unless person_name
+                # Then we should check InboxPerson to get that name!
+                # Note: this fires one sql select per wrong position, but it should
+                # be fine since in this case we should be checking "InboxResult"
+                # and therefore the results from one single competition submission.
+                person = InboxPerson.where(competitionId: competition_id, id: result.personId).first
+                person_name = person ? person.name : "<personId=#{result.personId}>"
+              end
+              @errors << ValidationError.new(:results, competition_id,WRONG_POSITION_IN_RESULTS_ERROR, round_id: round_id, person_name: person_name, expected_pos: expected_pos, pos: result.pos)
+            end
+          end
+        end
+      end
+      self
+    end
+  end
+end

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -41,7 +41,7 @@ module ResultsValidators
                 person = InboxPerson.where(competitionId: competition_id, id: result.personId).first
                 person_name = person ? person.name : "<personId=#{result.personId}>"
               end
-              @errors << ValidationError.new(:results, competition_id,WRONG_POSITION_IN_RESULTS_ERROR, round_id: round_id, person_name: person_name, expected_pos: expected_pos, pos: result.pos)
+              @errors << ValidationError.new(:results, competition_id, WRONG_POSITION_IN_RESULTS_ERROR, round_id: round_id, person_name: person_name, expected_pos: expected_pos, pos: result.pos)
             end
           end
         end

--- a/WcaOnRails/lib/results_validators/validation_error.rb
+++ b/WcaOnRails/lib/results_validators/validation_error.rb
@@ -16,8 +16,8 @@ module ResultsValidators
       format(@message, @args)
     end
 
-    def ==(o)
-      o.class == self.class && o.state == state
+    def ==(other)
+      other.class == self.class && other.state == state
     end
 
     def state

--- a/WcaOnRails/lib/results_validators/validation_error.rb
+++ b/WcaOnRails/lib/results_validators/validation_error.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  ERRORS_AND_WARNING_KINDS = [:events, :persons, :results, :rounds, :scrambles].freeze
+
+  class ValidationIssue
+    attr_reader :kind, :competition_id
+    def initialize(kind, competition_id, message, **message_args)
+      @message = message
+      @kind = kind
+      @args = message_args
+      @competition_id = competition_id
+    end
+
+    def to_s
+      format(@message, @args)
+    end
+
+    def ==(o)
+      o.class == self.class && o.state == state
+    end
+
+    def state
+      [@kind, @competition_id, @message, @args]
+    end
+  end
+
+  class ValidationError < ValidationIssue
+  end
+
+  class ValidationWarning < ValidationIssue
+  end
+end

--- a/WcaOnRails/lib/results_validators/validation_error.rb
+++ b/WcaOnRails/lib/results_validators/validation_error.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module ResultsValidators
-  ERRORS_AND_WARNING_KINDS = [:events, :persons, :results, :rounds, :scrambles].freeze
-
   class ValidationIssue
     attr_reader :kind, :competition_id
     def initialize(kind, competition_id, message, **message_args)

--- a/WcaOnRails/spec/factories/inbox_persons.rb
+++ b/WcaOnRails/spec/factories/inbox_persons.rb
@@ -3,10 +3,12 @@
 FactoryBot.define do
   factory :inbox_person do
     # The InboxPerson's (competitionId, id) must be unique,
-    # and id is not the usual auto increment integer.
+    # and id is not the usual auto increment integer (it's actually a varchar!)
     # Therefore we make the simple choice of always setting the id based on
     # what is present in the db.
-    id { (InboxPerson.maximum(:id) || 0) + 1 }
+    # 'maximum(:id).to_i' always work: either it's nil and returns 0, or it just
+    # returns the appropriate number.
+    id { (InboxPerson.maximum(:id).to_i + 1) }
     wcaId { "" }
     name { Faker::Name.name }
     countryId { Country.real.sample.iso2 }

--- a/WcaOnRails/spec/factories/inbox_results.rb
+++ b/WcaOnRails/spec/factories/inbox_results.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :inbox_result do
     transient do
       competition { FactoryBot.create(:competition, :with_rounds, event_ids: ["333oh"]) }
-      person { FactoryBot.create(:inbox_person, competitionId: competition) }
+      person { FactoryBot.create(:inbox_person, competitionId: competition.id) }
     end
 
     personId { person.id }

--- a/WcaOnRails/spec/factories/results.rb
+++ b/WcaOnRails/spec/factories/results.rb
@@ -24,5 +24,27 @@ FactoryBot.define do
     average { 5000 }
     regionalSingleRecord { "" }
     regionalAverageRecord { "" }
+
+    trait :blind_mo3 do
+      eventId { "333bf" }
+      formatId { "3" }
+      average { best }
+      value1 { best }
+      value2 { best }
+      value3 { best }
+      value4 { 0 }
+      value5 { 0 }
+    end
+
+    trait :blind_dnf_mo3 do
+      eventId { "333bf" }
+      formatId { "3" }
+      average { -1 }
+      value1 { best }
+      value2 { best }
+      value3 { -1 }
+      value4 { 0 }
+      value5 { 0 }
+    end
   end
 end

--- a/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResultsValidators::PositionsValidator do
+  context "on InboxResult and Result" do
+    let!(:competition1) { FactoryBot.create(:competition, :past, event_ids: ["333oh"]) }
+    let!(:competition2) { FactoryBot.create(:competition, :past, event_ids: ["222"]) }
+
+    # The idea behind this variable is the following: the validator can be applied
+    # on either a particular model for given competition ids, or on a set of results.
+    # We simply want to check it has the expected behavior on all the possible cases.
+    let(:validator_args) {
+      [InboxResult, Result].flat_map { |model|
+        [
+          { competition_ids: [competition1.id, competition2.id], model: model },
+          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+        ]
+      }
+    }
+
+    context "basic results" do
+      let!(:results) {
+        {
+          "Result" => [
+            create_results(competition1, 5, "333oh"),
+            create_results(competition2, 5, "222"),
+          ],
+          "InboxResult" => [
+            create_results(competition1, 5, "333oh", kind: :inbox_result),
+            create_results(competition2, 5, "222", kind: :inbox_result),
+          ],
+        }
+      }
+      it "validates results correctly ordered on given competitions" do
+        validator_args.each do |arg|
+          pv = ResultsValidators::PositionsValidator.new.validate(arg)
+          expect(pv.has_errors?).to eq false
+        end
+      end
+
+      it "invalidates messed up positions in given competitions" do
+        expected_errors = {}
+        [InboxResult, Result].each do |model|
+          table_results = results[model.to_s]
+          personName1 = name_for_result(table_results[0].first)
+          personName2 = name_for_result(table_results[1].last)
+          expected_errors[model.to_s] = [
+            create_result_error(competition1.id, "333oh-f", personName1, 1, 2),
+            create_result_error(competition2.id, "222-f", personName2, 5, 7),
+          ]
+          model.where(pos: 1, eventId: "333oh").update(pos: 2)
+          model.where(pos: 5, eventId: "222").update(pos: 7)
+        end
+        validator_args.each do |arg|
+          pv = ResultsValidators::PositionsValidator.new.validate(arg)
+          expect(pv.errors).to match_array(expected_errors[arg[:model].to_s])
+        end
+      end
+    end
+    context "tied results" do
+      it "validates correctly tied results" do
+        create_correct_tied_results(competition1, "333oh")
+        create_correct_tied_results(competition1, "333oh", kind: :inbox_result)
+        validator_args.each do |arg|
+          pv = ResultsValidators::PositionsValidator.new.validate(arg)
+          expect(pv.has_errors?).to eq false
+        end
+      end
+      it "invalidates incorrectly tied results" do
+        results1 = create_incorrect_tied_results(competition1, "222")
+        results2 = create_incorrect_tied_results(competition1, "222", kind: :inbox_result)
+        expected_errors = {
+          "Result" => create_result_error(competition1.id, "222-f", name_for_result(results1[1]), 1, 2),
+          "InboxResult" => create_result_error(competition1.id, "222-f", name_for_result(results2[1]), 1, 2),
+        }
+        validator_args.each do |arg|
+          pv = ResultsValidators::PositionsValidator.new.validate(arg)
+          expect(pv.errors).to match_array(expected_errors[arg[:model].to_s])
+        end
+      end
+    end
+  end
+end
+
+def create_results(competition, number, event_id, kind: :result)
+  results = []
+  1.upto(number) do |i|
+    # By default the factory creates a predefined best/average, to have increasing
+    # time we need to provide some arbitrary times increasing with the position.
+    results << FactoryBot.create(kind, competition: competition, pos: i, best: i*1000, average: i*2000, eventId: event_id)
+  end
+  results
+end
+
+def create_correct_tied_results(competition, event_id, kind: :result)
+  [
+    FactoryBot.create(kind, competition: competition, pos: 1, best: 1000, average: 2000, eventId: event_id),
+    FactoryBot.create(kind, competition: competition, pos: 1, best: 1000, average: 2000, eventId: event_id),
+    FactoryBot.create(kind, competition: competition, pos: 3, best: 2000, average: 2000, eventId: event_id),
+  ]
+end
+
+def create_incorrect_tied_results(competition, event_id, kind: :result)
+  [
+    FactoryBot.create(kind, competition: competition, pos: 1, best: 1000, average: 2000, eventId: event_id),
+    FactoryBot.create(kind, competition: competition, pos: 2, best: 1000, average: 2000, eventId: event_id),
+    FactoryBot.create(kind, competition: competition, pos: 3, best: 2000, average: 2000, eventId: event_id),
+  ]
+end
+
+def create_result_error(competition_id, round_id, name, expected_pos, actual_pos)
+  ResultsValidators::ValidationError.new(:results, competition_id, ResultsValidators::PositionsValidator::WRONG_POSITION_IN_RESULTS_ERROR, round_id: round_id, person_name: name, expected_pos: expected_pos, pos: actual_pos)
+end
+
+def name_for_result(result)
+  result.respond_to?(:personName) ? result.personName : InboxPerson.where(id: result.personId).first.name
+end

--- a/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
@@ -143,5 +143,5 @@ def create_result_error(competition_id, round_id, name, expected_pos, actual_pos
 end
 
 def name_for_result(result)
-  result.respond_to?(:personName) ? result.personName : InboxPerson.where(id: result.personId).first.name
+  result.respond_to?(:personName) ? result.personName : InboxPerson.find_by(id: result.personId).name
 end


### PR DESCRIPTION
This is a follow up for #4112 , and a first step for #4006.

Given the discussions with the WRT and @SAuroux, they definitely need to be able to apply any kind of validation to an arbitrary set of results/competitions.
This PR aims to introduce the basic design for each results validator, as well as an application to the `PositionValidator`, and tests for it.

The idea is that all validators respond to the method `validate` and set a pre-defined set of internal variables (errors and warnings) that the user can access.
The user can provide either a set of competition ids and source from where to get the results (`InboxResult` or `Result`), or directly a set of results.
This allows to reuse preloaded results or work on a new set of results.

The first case would apply to the `CompetitionResultsValidator` which preloads all the competition results and would apply a arbitrary set of validators on it, and the second case apply on a yet-to-be-implemented page, where the WRT could select an arbitrary set of validators and competitions to be validated.

Introducing the `ResultsValidators` module also let us move elsewhere the JSON validation schema, while still being in the same namespace.

The long term plan is obviously to make the `CompetitionResultsValidator` extend from `GenericValidator` and aggregate several other validators, but for now I've just incorporated the `PositionValidator`.

