### PR TITLE
Optionally include user upcoming competitions in API response

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -99,7 +99,15 @@ class Api::V0::ApiController < ApplicationController
 
   def show_user(user)
     if user
-      render status: :ok, json: { user: user }
+      json = { user: user }
+      if params[:upcoming_competitions]
+        json[:upcoming_competitions] = user.registrations
+                                           .accepted
+                                           .includes(competition: [:delegates, :organizers, :events])
+                                           .map(&:competition)
+                                           .select(&:upcoming?)
+      end
+      render status: :ok, json: json
     else
       render status: :not_found, json: { user: nil }
     end

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -181,8 +181,9 @@ RSpec.describe Api::V0::ApiController do
   end
 
   describe 'show_user_*' do
+    let!(:user) { FactoryBot.create(:user_with_wca_id, name: "Jeremy") }
+
     it 'can query by id' do
-      user = FactoryBot.create(:user, name: "Jeremy")
       get :show_user_by_id, params: { id: user.id }
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
@@ -191,11 +192,10 @@ RSpec.describe Api::V0::ApiController do
     end
 
     it 'can query by wca id' do
-      user = FactoryBot.create(:user_with_wca_id)
       get :show_user_by_wca_id, params: { wca_id: user.wca_id }
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["user"]["name"]).to eq user.name
+      expect(json["user"]["name"]).to eq "Jeremy"
       expect(json["user"]["wca_id"]).to eq user.wca_id
     end
 
@@ -204,6 +204,25 @@ RSpec.describe Api::V0::ApiController do
       expect(response.status).to eq 404
       json = JSON.parse(response.body)
       expect(json["user"]).to be nil
+    end
+
+    describe 'upcoming_competitions' do
+      let!(:upcoming_comp) { FactoryBot.create(:competition, :confirmed, :visible, starts: 2.weeks.from_now) }
+      let!(:registration) { FactoryBot.create(:registration, :accepted, user: user, competition: upcoming_comp) }
+
+      it 'does not render upcoming competitions by default' do
+        get :show_user_by_id, params: { id: user.id }
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json.keys).not_to include "upcoming_competitions"
+      end
+
+      it 'renders upcoming competitions when upcoming_competitions param is set' do
+        get :show_user_by_id, params: { id: user.id, upcoming_competitions: true }
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json["upcoming_competitions"].size).to eq 1
+      end
     end
   end
 


### PR DESCRIPTION
We got a request for getting upcoming competitions for a user. The idea I got is adding it to the normal `/api/v0/users/:id` response when `?upcoming_competitions=true` is set. This way we don't render it by default unnecessarily.