### PR TITLE
Add credit section to `/regulations/countries`

### DIFF
--- a/WcaOnRails/app/views/regulations/countries/index.html.erb
+++ b/WcaOnRails/app/views/regulations/countries/index.html.erb
@@ -3,6 +3,7 @@
 <% version_hash = Country::WCA_STATES["version_hash"] %>
 <% preamble = Country::WCA_STATES["text"] %>
 <% states_lists = Country::WCA_STATES["states_lists"] %>
+<% credit = Country::WCA_STATES["credit"] %>
 <% provide(:title, title) %>
 <div class="container">
   <h1><%= title %></h1>
@@ -23,4 +24,5 @@
       <% end %>
     </ul>
   <% end %>
+  <p><%=md credit %></p>
 </div>


### PR DESCRIPTION
Goes together with https://github.com/thewca/wca-regulations/pull/762.

I know that for this change to be visible `wca-states.json` must be re-generated, but as there are other changes on that file (see https://github.com/thewca/wca-regulations/pull/747) and @lgarron is planning to do that I prefer for him to do it :slightly_smiling_face: 