### PR TITLE
Don't let Delegates modify disabled fields of a confirmed competition.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -610,20 +610,9 @@ class CompetitionsController < ApplicationController
 
   private def competition_params
     permitted_competition_params = [
-      :use_wca_registration,
-      :external_registration_page,
       :receive_registration_emails,
-      :registration_open,
-      :registration_close,
-      :guests_enabled,
-      :enable_donations,
       :being_cloned_from_id,
       :clone_tabs,
-      :refund_policy_limit_date,
-      :regulation_z1,
-      :regulation_z1_reason,
-      :regulation_z3,
-      :regulation_z3_reason,
     ]
 
     if @competition.nil? || @competition.can_edit_registration_fees?
@@ -656,6 +645,12 @@ class CompetitionsController < ApplicationController
         :contact,
         :generate_website,
         :external_website,
+        :use_wca_registration,
+        :external_registration_page,
+        :enable_donations,
+        :guests_enabled,
+        :registration_open,
+        :registration_close,
         :competitor_limit_enabled,
         :competitor_limit,
         :competitor_limit_reason,
@@ -665,6 +660,10 @@ class CompetitionsController < ApplicationController
         :on_the_spot_entry_fee_lowest_denomination,
         :refund_policy_percent,
         :refund_policy_limit_date,
+        :regulation_z1,
+        :regulation_z1_reason,
+        :regulation_z3,
+        :regulation_z3_reason,
         :guests_entry_fee_lowest_denomination,
         competition_events_attributes: [:id, :event_id, :_destroy],
         championships_attributes: [:id, :championship_type, :_destroy],

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -589,14 +589,16 @@ RSpec.describe CompetitionsController do
         expect(response).to redirect_to root_url
       end
 
-      it "can change registration open/close of locked competition" do
-        competition.update_attribute(:confirmed, true)
+      it "cannot change registration open/close of locked competition" do
+        old_open = 2.days.from_now.change(sec: 0)
+        old_close = 4.weeks.from_now.change(sec: 0)
+        competition.update_attributes(confirmed: true, registration_open: old_open, registration_close: old_close)
 
         new_open = 1.week.from_now.change(sec: 0)
         new_close = 2.weeks.from_now.change(sec: 0)
         patch :update, params: { id: competition, competition: { registration_open: new_open, registration_close: new_close } }
-        expect(competition.reload.registration_open).to eq new_open
-        expect(competition.reload.registration_close).to eq new_close
+        expect(competition.reload.registration_open).to eq old_open
+        expect(competition.reload.registration_close).to eq old_close
       end
 
       it "can change extra registration requirements field before competition is confirmed" do


### PR DESCRIPTION
This is a follow up of #2999 that fixes #4201.