### PR TITLE
Remove TNoodle 0.14 from allowed version, remove 1c3a reference.

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -32,9 +32,7 @@ class Api::V0::ApiController < ApplicationController
         "information" => "#{root_url}regulations/scrambles/",
         "download" => "#{root_url}regulations/scrambles/tnoodle/TNoodle-WCA-0.15.0.jar",
       },
-      "allowed" => [
-        "TNoodle-WCA-0.14.0", "TNoodle-WCA-0.15.0"
-      ],
+      "allowed" => ["TNoodle-WCA-0.15.0"],
       "history" => [
         "TNoodle-0.7.4",
         "TNoodle-0.7.5",

--- a/WcaOnRails/app/views/regulations/scrambles/index.html.erb
+++ b/WcaOnRails/app/views/regulations/scrambles/index.html.erb
@@ -16,7 +16,7 @@
   <ul>
     <li>Official competitions must always use a current version of the official scramble program (see <%= link_to "Regulation 4f", "../#4f" %>).</li>
     <li>Delegates should download TNoodle to run it on a computer. They should not use TNoodle running on a public server (for security reasons).</li>
-    <li>Delegates must save all scramble sequences generated for an official competition, and send them with the results (see <%= link_to "Regulation 1c3a", "../#1c3a" %>).</li>
+    <li>Delegates must save all scramble sequences generated for an official competition, and send them with the results (see the <a href="https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf">WCA Competition Requirements Policy</a>).</li>
   </ul>
   <h3 id="scramble-secrecy">Scramble Secrecy</h3>
     <ul>


### PR DESCRIPTION
In the spirit of https://github.com/thewca/tnoodle/issues/418, we should set a date to accepting this PR and warn delegates about this. My suggestion is 07/29th since TNoodle announcement was not made early in the week.