### PR TITLE
Validate presence of `schedule_url` and `discussion_url` on reports.

### DIFF
--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -23,8 +23,14 @@ Gen 2 Display: 0
 Gen 3 Display: 0"
   end
 
+  validates :schedule_url, presence: true, if: :schedule_and_disussion_urls_required?
   validates :schedule_url, url: true
+  validates :discussion_url, presence: true, if: :schedule_and_disussion_urls_required?
   validates :discussion_url, url: true
+
+  def schedule_and_disussion_urls_required?
+    posted? && created_at > Date.new(2019, 7, 21)
+  end
 
   def posted?
     !!posted_at

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -11,8 +11,8 @@
     <% if @delegate_report.posted? %>
       <%= f.input :discussion_url %>
     <% end %>
-    <% default_schedule_url = @competition.has_schedule? ? link_to_competition_schedule_tab(@competition) : '' %>
-    <%= f.input :schedule_url, input_html: { value: default_schedule_url }, readonly: default_schedule_url.present? %>
+    <% @competition.delegate_report.schedule_url = link_to_competition_schedule_tab(@competition) if @competition.has_schedule? %>
+    <%= f.input :schedule_url, readonly: @competition.has_schedule? %>
 
     <%= f.input :equipment, input_html: { class: "markdown-editor" } %>
     <%= f.input :venue, input_html: { class: "markdown-editor" } %>

--- a/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe DelegateReportsController do
   let(:delegate) { FactoryBot.create :delegate }
   let(:comp) { FactoryBot.create(:competition, delegates: [delegate], starts: 2.days.ago) }
+  let!(:delegate_report1) { FactoryBot.create :delegate_report, competition: comp, schedule_url: "http://example.com" }
   let(:pre_delegate_reports_form_comp) { FactoryBot.create(:competition, delegates: [delegate], starts: Date.new(2015, 1, 1)) }
+  let!(:delegate_report2) { FactoryBot.create :delegate_report, competition: pre_delegate_reports_form_comp, schedule_url: "http://example.com" }
 
   context "not logged in" do
     it "redirects to sign in" do
@@ -76,7 +78,7 @@ RSpec.describe DelegateReportsController do
     it "can post report and cannot edit report if it's posted" do
       # Update the remarks *and* set posted to true for next test.
       expect(CompetitionsMailer).to receive(:notify_of_delegate_report_submission).with(comp).and_call_original
-      post :update, params: { competition_id: comp.id, delegate_report: { remarks: "My newer remarks", schedule_url: "http://example.com", posted: true } }
+      post :update, params: { competition_id: comp.id, delegate_report: { remarks: "My newer remarks", posted: true } }
       expect(response).to redirect_to(delegate_report_path(comp))
       assert_enqueued_jobs 1
       expect(flash[:info]).to eq "Your report has been posted and emailed!"
@@ -93,7 +95,7 @@ RSpec.describe DelegateReportsController do
 
     it "posting report for an ancient competition doesn't send email notification" do
       # Update the remarks *and* set posted to true for next test.
-      post :update, params: { competition_id: pre_delegate_reports_form_comp.id, delegate_report: { remarks: "My newer remarks", schedule_url: "http://example.com", posted: true } }
+      post :update, params: { competition_id: pre_delegate_reports_form_comp.id, delegate_report: { remarks: "My newer remarks", posted: true } }
       expect(response).to redirect_to(delegate_report_path(pre_delegate_reports_form_comp))
       expect(flash[:info]).to eq "Your report has been posted but not emailed because it is for a pre June 2016 competition."
       assert_enqueued_jobs 0

--- a/WcaOnRails/spec/features/delegate_report_spec.rb
+++ b/WcaOnRails/spec/features/delegate_report_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.feature "Registration management" do
   let(:delegate) { FactoryBot.create :delegate, name: "Jeremy on Bart" }
   let(:competition) { FactoryBot.create :competition, :registration_open, delegates: [delegate], name: "Submit Report 2017" }
+  let!(:delegate_report) { FactoryBot.create :delegate_report, competition: competition, schedule_url: "http://example.com" }
 
   context "when signed in as competition delegate" do
     before :each do

--- a/WcaOnRails/spec/models/delegate_report_spec.rb
+++ b/WcaOnRails/spec/models/delegate_report_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe DelegateReport do
     expect(dr).to be_invalid_with_errors discussion_url: ["must be a valid url starting with http:// or https://"]
   end
 
-  it "schedule_url is not required when posted" do
+  it "schedule_url is required when posted" do
     dr = FactoryBot.build :delegate_report, schedule_url: nil
     expect(dr).to be_valid
 
     dr.posted = true
-    expect(dr).to be_valid
+    expect(dr).to be_invalid_with_errors schedule_url: ["can't be blank"]
 
-    dr.schedule_url = "http://www.google.com"
+    dr.schedule_url = "http://example.com"
     expect(dr).to be_valid
   end
 


### PR DESCRIPTION
This is coming from point 3. in 
https://github.com/thewca/worldcubeassociation.org/pull/4282#issuecomment-511441446.