### PR TITLE
Move autosize to webpacker

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -90,10 +90,6 @@ gem 'image_processing'
 gem 'rest-client'
 gem 'wicked_pdf'
 
-source 'https://rails-assets.org' do
-  gem 'rails-assets-autosize'
-end
-
 group :development, :test do
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -31,7 +31,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
   specs:
     actioncable (5.2.3)
       actionpack (= 5.2.3)
@@ -417,7 +416,6 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
-    rails-assets-autosize (4.0.2)
     rails-controller-testing (1.0.4)
       actionpack (>= 5.0.1.x)
       actionview (>= 5.0.1.x)
@@ -675,7 +673,6 @@ DEPENDENCIES
   premailer-rails
   rack-cors
   rails
-  rails-assets-autosize!
   rails-controller-testing
   rails-i18n
   rake

--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -30,7 +30,6 @@
 //= require bootstrap-table
 //= require bootstrap-table-locale-all
 //= require extensions/bootstrap-table-mobile
-//= require autosize
 //= require fullcalendar
 //= require fullcalendar/lang/cs.js
 //= require fullcalendar/lang/da.js
@@ -345,11 +344,6 @@ $(function() {
     // Re-apply tooltip on each table body change
     $('[data-toggle="tooltip"]').tooltip();
   });
-});
-
-// Setting up autosize
-$(function() {
-  autosize($('textarea:not(.no-autosize)'));
 });
 
 // Helpers

--- a/WcaOnRails/app/javascript/packs/application.js
+++ b/WcaOnRails/app/javascript/packs/application.js
@@ -12,3 +12,9 @@ import 'polyfills';
 import 'flag-icon-css/css/flag-icon.css';
 import 'incidents-log';
 import 'leaflet-wca';
+import autosize from 'autosize';
+
+// Setting up autosize
+$(function() {
+  autosize($('textarea:not(.no-autosize)'));
+});

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -16,6 +16,7 @@
     "@rails/webpacker": "^4.0.7",
     "autonumeric": "^4.5.4",
     "autoprefixer": "^9.6.1",
+    "autosize": "^4.0.2",
     "babel-loader": "^8.0.6",
     "babel-plugin-lodash": "^3.3.4",
     "blueimp-load-image": "^2.22.0",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -1400,6 +1400,11 @@ autoprefixer@^9.4.9, autoprefixer@^9.6.1:
     postcss "^7.0.17"
     postcss-value-parser "^4.0.0"
 
+autosize@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-4.0.2.tgz#073cfd07c8bf45da4b9fd153437f5bafbba1e4c9"
+  integrity sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
`rails-assets.org` was down (is down?), and since we have only one dependency here we may as well move it to webpacker.

`autosize` is a jquery plugin, so this only works because we first load jquery through rails assets then include our webpacker application pack!
(but this is the case for pretty much all our `app/javascript` codebase, as long as we keep jquery in rails assets. And migrating jquery to webpacker will be a huge pain because of the amount of dependencies we have to move with it!)

Anyway, works locally, will deploy to staging just to be safe, and will merge.