### PR TITLE
Extract the IndividualResultsValidator

### DIFF
--- a/WcaOnRails/app/models/inbox_result.rb
+++ b/WcaOnRails/app/models/inbox_result.rb
@@ -4,4 +4,10 @@ class InboxResult < ApplicationRecord
   include Resultable
 
   self.table_name = "InboxResults"
+
+  # NOTE: don't use this too often, as it triggers one person load per call!
+  # If you need names for a batch of InboxResult, consider joining the InboxPerson table.
+  def personName # rubocop:disable Naming/MethodName
+    InboxPerson.find_by(id: personId)&.name || "<personId=#{personId}>"
+  end
 end

--- a/WcaOnRails/lib/competition_results_validator.rb
+++ b/WcaOnRails/lib/competition_results_validator.rb
@@ -128,9 +128,6 @@ class CompetitionResultsValidator
 
       check_competitor_limit
 
-      # Note: the "long term" plan is to have an array of validators to apply
-      # on the results, and the line below would turn into:
-      # merge(validator_classes.map { |v| v.new.validate(results: @results) })
       validator_classes = [ResultsValidators::PositionsValidator, ResultsValidators::IndividualResultsValidator]
       merge(validator_classes.map { |v| v.new.validate(results: @results) })
     end

--- a/WcaOnRails/lib/result_methods.rb
+++ b/WcaOnRails/lib/result_methods.rb
@@ -67,7 +67,7 @@ module ResultMethods
   end
 
   # When someone changes an attribute, clear our cached values.
-  def write_attribute(attr, value)
+  def _write_attribute(attr, value)
     @sorted_solves_with_index = nil
     @solve_times = nil
     @counting = nil

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -34,17 +34,5 @@ module ResultsValidators
       @errors = []
       @warnings = []
     end
-
-    protected
-
-    # FIXME: this is kind of a helper that will be needed in several validators as well as in specs.
-    # Where does it belong?
-    def name_from_result(result)
-      if result.respond_to?(:personName)
-        result.personName
-      else
-        InboxPerson.find_by(id: result.personId)&.name || "<personId=#{result.personId}>"
-      end
-    end
   end
 end

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -34,5 +34,17 @@ module ResultsValidators
       @errors = []
       @warnings = []
     end
+
+    protected
+
+    # FIXME: this is kind of a helper that will be needed in several validators as well as in specs.
+    # Where does it belong?
+    def name_from_result(result)
+      if result.respond_to?(:personName)
+        result.personName
+      else
+        InboxPerson.find_by(id: result.personId)&.name || "<personId=#{result.personId}>"
+      end
+    end
   end
 end

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class IndividualResultsValidator < GenericValidator
+    MBF_RESULT_OVER_TIME_LIMIT_WARNING = "[%{round_id}] Result '%{result}' for %{person_name} is over the time limit. Please make sure it is the consequence of +2 penalties before sending the results, or fix the result to DNF."
+
+    DNS_AFTER_RESULT_WARNING = "[%{round_id}] %{person_name} has at least one DNS results followed by a valid result. Please make sure it is indeed a DNS and not a DNF."
+    SIMILAR_RESULTS_WARNING = "[%{round_id}] Results for %{person_name} are similar to the results for %{similar_person_name}."
+
+    MET_CUTOFF_MISSING_RESULTS_ERROR = "[%{round_id}] %{person_name} has met the cutoff but is missing results for the second phase. Cutoff is %{cutoff}."
+    DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR = "[%{round_id}] %{person_name} has at least one result for the second phase but didn't meet the cutoff. Cutoff is %{cutoff}."
+    MISMATCHED_RESULT_FORMAT_ERROR = "[%{round_id}] Results for %{person_name} are in the wrong format: expected %{expected_format}, but got %{format}."
+    RESULT_OVER_TIME_LIMIT_ERROR = "[%{round_id}] At least one result for %{person_name} is over the time limit which is %{time_limit} for one solve. All solves over the time limit must be changed to DNF."
+    RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR = "[%{round_ids}] The sum of results for %{person_name} is over the cumulative time limit which is %{time_limit}."
+    NO_ROUND_INFORMATION_WARNING = "[%{round_id}] Could not find information about cutoff and timelimit for this round, these validations have been skipped."
+    SUSPICIOUS_DNF_WARNING = "[%{round_ids}] The round has a cumulative time limit and %{person_name} has at least one suspicious DNF solve given their results."
+
+    # Miscelaneous errors
+    MISSING_CUMULATIVE_ROUND_ID_ERROR = "[%{original_round_id}] Unable to find the round \"%{wcif_id}\" for the cumulative time limit specified in the WCIF."\
+    " Please go to the manage events page and remove %{wcif_id} from the cumulative time limit for %{original_round_id}. WST knows about this bug (GitHub issue #3254)."
+
+    @@desc = "This validator checks that all results respect the format, time limit, and cutoff information if available. It also looks for similar results within the round."
+
+    def validate(competition_ids: [], model: Result, results: nil)
+      reset_state
+      # Get all results if not provided
+      results ||= model.sorted_for_competitions(competition_ids)
+      results_by_round_id_by_competition_id = Hash[
+        results.group_by(&:competitionId).map do |competition_id, results_for_comp|
+          [competition_id, results_for_comp.group_by { |r| "#{r.eventId}-#{r.roundTypeId}" }]
+        end
+      ]
+
+      associations = {
+        events: [],
+        competition_events: {
+          rounds: {
+            # That's a weird association, but that's needed for cumulative rounds...
+            competition: { rounds: [:competition_event] },
+            competition_event: [],
+          },
+        },
+      }
+
+      competitions = Competition.includes(associations).where(id: results_by_round_id_by_competition_id.keys)
+      rounds_info_by_round_id_by_competition_id = Hash[
+        competitions.map do |c|
+          [c.id, Hash[c.competition_events.flat_map(&:rounds).map { |r| ["#{r.event.id}-#{r.round_type_id}", r] }]]
+        end
+      ]
+      results_by_round_id_by_competition_id.each do |competition_id, results_by_round_id|
+        rounds_info_by_round_id = rounds_info_by_round_id_by_competition_id[competition_id]
+        results_by_round_id.each do |round_id, results_for_round|
+          # get cutoff and timelimit
+          round_info = get_round_info(rounds_info_by_round_id, round_id)
+
+          unless round_info
+            # This situation may happen with "old" competitions
+            @warnings << ValidationWarning.new(:results, competition_id,
+                                               NO_ROUND_INFORMATION_WARNING,
+                                               round_id: round_id)
+            # These results are for an undeclared round, skip them as an error has
+            # already been registered
+            next
+          end
+
+          time_limit_for_round = round_info.time_limit
+          cutoff_for_round = round_info.cutoff
+
+          results_for_round.each_with_index do |result, index|
+            person_name = self.name_from_result(result)
+            context = [competition_id, person_name, round_id, round_info]
+            all_solve_times = result.solve_times
+
+            # Check for possible similar results
+            check_similar_results(context, result, index, results_for_round)
+
+            # Check that the result's format matches the expected one
+            check_format_matches(context, result)
+
+            # Checks for cutoff
+            check_results_for_cutoff(context, cutoff_for_round, result) if cutoff_for_round
+
+            completed_solves = all_solve_times.select(&:complete?)
+
+            # Checks for time limits if it can be user-specified
+            if !["333mbf", "333fm"].include?(result.eventId)
+              cumulative_wcif_round_ids = time_limit_for_round.cumulative_round_ids
+              # Now let's try to find a DNF/DNS result followed by a non-DNF/DNS result
+              # Do the same for DNS.
+              has_result_after = { SolveTime::DNF => false, SolveTime::DNS => false }
+              has_result_after.keys.each do |not_complete|
+                first_index = all_solve_times.find_index(not_complete)
+                if first_index
+                  # Just use '5' here to get all of them
+                  solves_after = all_solve_times[first_index, 5]
+                  has_result_after[not_complete] = solves_after.select(&:complete?).any?
+                end
+              end
+
+              # Always output the warning about DNS followed by result
+              if has_result_after[SolveTime::DNS]
+                @warnings << ValidationWarning.new(:results, competition_id,
+                                                   DNS_AFTER_RESULT_WARNING,
+                                                   round_id: round_id,
+                                                   person_name: person_name)
+              end
+
+              case cumulative_wcif_round_ids.length
+              when 0
+                # easy case: each completed result (not DNS, DNF, or SKIPPED) must be below the time limit.
+                results_over_time_limit = completed_solves.select { |t| t.time_centiseconds > time_limit_for_round.centiseconds }
+                if results_over_time_limit&.any?
+                  @errors << ValidationError.new(:results, competition_id,
+                                                 RESULT_OVER_TIME_LIMIT_ERROR,
+                                                 round_id: round_id,
+                                                 person_name: person_name,
+                                                 time_limit: time_limit_for_round.to_s(round_info))
+                end
+              else
+                check_cumulative_across_rounds(context, result.personId,
+                                               rounds_info_by_round_id,
+                                               results_by_round_id)
+              end
+            end
+
+            check_multi_time_limit(competition_id, round_id, completed_solves, person_name) if result.eventId == "333mbf"
+          end
+        end
+      end
+
+      # Cleanup possible duplicate errors and warnings from cumulative time limits
+      @errors.uniq!
+      @warnings.uniq!
+      self
+    end
+
+    private
+
+    def check_multi_time_limit(competition_id, round_id, completed_solves, person_name)
+      completed_solves.each do |solve_time|
+        time_limit_seconds = [3600, solve_time.attempted * 600].min
+        if solve_time.time_seconds > time_limit_seconds
+          @warnings << ValidationWarning.new(:results, competition_id,
+                                             MBF_RESULT_OVER_TIME_LIMIT_WARNING,
+                                             round_id: round_id,
+                                             result: solve_time.clock_format,
+                                             person_name: person_name)
+        end
+      end
+    end
+
+    def check_similar_results(context, result, index, results_for_round)
+      competition_id, person_name, round_id, = context
+      similar = results_similar_to(result, index, results_for_round)
+      similar.each do |r|
+        @warnings << ValidationWarning.new(:results, competition_id,
+                                           SIMILAR_RESULTS_WARNING,
+                                           round_id: round_id,
+                                           person_name: person_name,
+                                           similar_person_name: self.name_from_result(r))
+      end
+    end
+
+    def check_format_matches(context, result)
+      competition_id, person_name, round_id, round_info = context
+      # FIXME: maybe that can be part of the separate
+      # "check consistency of roundTypeIds and formatIds" across a given round
+      # Check that the result's format matches the round format
+      unless round_info.format.id == result.formatId
+        @errors << ValidationError.new(:results, competition_id,
+                                       MISMATCHED_RESULT_FORMAT_ERROR,
+                                       round_id: round_id,
+                                       person_name: person_name,
+                                       expected_format: round_info.format.name,
+                                       format: Format.c_find(result.formatId).name)
+      end
+    end
+
+    def check_results_for_cutoff(context, cutoff, result)
+      competition_id, person_name, round_id, round = context
+      number_of_attempts = cutoff.number_of_attempts
+      cutoff_result = SolveTime.new(round.event.id, :single, cutoff.attempt_result)
+      solve_times = result.solve_times
+      # Compare through SolveTime so we don't need to care about DNF/DNS
+      maybe_qualifying_results = solve_times[0, number_of_attempts]
+      # Get the remaining attempt according to the expected solve count given the format
+      other_results = solve_times[number_of_attempts, round.format.expected_solve_count - number_of_attempts]
+      qualifying_results = maybe_qualifying_results.select { |solve_time| solve_time < cutoff_result }
+      skipped, unskipped = other_results.partition(&:skipped?)
+      if qualifying_results.any?
+        # Meets the cutoff, no result should be SKIPPED
+        if skipped.any?
+          @errors << ValidationError.new(:results, competition_id,
+                                         MET_CUTOFF_MISSING_RESULTS_ERROR,
+                                         round_id: round_id,
+                                         person_name: person_name,
+                                         cutoff: cutoff.to_s(round))
+        end
+      else
+        # Doesn't meet the cutoff, all results should be SKIPPED
+        if unskipped.any?
+          @errors << ValidationError.new(:results, competition_id,
+                                         DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR,
+                                         round_id: round_id,
+                                         person_name: person_name,
+                                         cutoff: cutoff.to_s(round))
+        end
+      end
+    end
+
+    def check_cumulative_across_rounds(context, person_id, rounds_by_ids, results_by_round_id)
+      competition_id, person_name, round_id, round_info = context
+      time_limit_for_round = round_info.time_limit
+      cumulative_wcif_round_ids = time_limit_for_round.cumulative_round_ids
+      # Handle both cumulative for a single round or multiple round by doing the following:
+      #  - gather all solve times for all the rounds (necessitate to map round's WCIF id to "our" round ids)
+      #  - check the sum is below the limit
+      #  - check for any suspicious DNF result
+
+      # Match wcif round ids to "our" ids
+      cumulative_round_ids = cumulative_wcif_round_ids.map do |wcif_id|
+        parsed_wcif_id = Round.parse_wcif_id(wcif_id)
+        # Get the actual round_id from our expected rounds by id
+
+        actual_round_id = rounds_by_ids.select do |id, round|
+          round.event.id == parsed_wcif_id[:event_id] && round.number == parsed_wcif_id[:round_number]
+        end.first
+        unless actual_round_id
+          # FIXME: this needs to be removed when https://github.com/thewca/worldcubeassociation.org/issues/3254 is fixed.
+          @errors << ValidationError.new(:results, competition_id,
+                                         MISSING_CUMULATIVE_ROUND_ID_ERROR,
+                                         wcif_id: wcif_id, original_round_id: round_id)
+        end
+        actual_round_id&.at(0)
+      end.compact
+
+      # Get all solve times for all cumulative rounds for the current person
+      all_results_for_cumulative_rounds = cumulative_round_ids.map do |id|
+        # NOTE: since we proceed with all checks even if some expected rounds
+        # do not exist, we may have *expected* cumulative rounds that may
+        # not exist in results.
+        results_by_round_id[id]&.find { |r| r.personId == person_id }
+      end.compact.map(&:solve_times).flatten
+      completed_solves_for_rounds = all_results_for_cumulative_rounds.select(&:complete?)
+      number_of_dnf_solves = all_results_for_cumulative_rounds.select(&:dnf?).size
+      sum_of_times_for_rounds = completed_solves_for_rounds.sum(&:time_centiseconds)
+
+      # Check the sum is below the limit
+      if sum_of_times_for_rounds > time_limit_for_round.centiseconds
+        @errors << ValidationError.new(:results, competition_id,
+                                       RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR,
+                                       round_ids: cumulative_round_ids.join(","),
+                                       person_name: person_name,
+                                       time_limit: time_limit_for_round.to_s(round_info))
+      end
+
+      # Check for any suspicious DNF
+      # Compute avg time per solve for the competitor
+      avg_per_solve = sum_of_times_for_rounds.to_f / completed_solves_for_rounds.size
+      # We want to issue a warning if the estimated time for all solves + DNFs goes roughly over the cumulative time limit by at least 10% (to reduce false positive).
+      if (number_of_dnf_solves + completed_solves_for_rounds.size) * avg_per_solve >= 1.1 * time_limit_for_round.centiseconds
+        @warnings << ValidationWarning.new(:results, competition_id,
+                                           SUSPICIOUS_DNF_WARNING,
+                                           round_ids: cumulative_round_ids.join(","),
+                                           person_name: person_name)
+      end
+    end
+
+    def results_similar_to(reference, reference_index, results)
+      # We do this programatically, but the original check_results.php used to do a big SQL query:
+      # https://github.com/thewca/worldcubeassociation.org/blob/b1ee87b318ff6e4f8658a711c19fd23a3ae51b9c/webroot/results/admin/check_results.php#L321-L353
+
+      similar_results = []
+      # Note that we don't want to treat a particular result as looking
+      # similar to itself, so we don't allow for results with matching ids.
+      # Further more, if a result A is similar to a result B, we don't want to
+      # return both (A, B) and (B, A) as matching pairs, it's sufficient to just
+      # return (A, B), which is why we require Result.id < h.resultId.
+      results.each_with_index do |r, index|
+        next if index >= reference_index
+        reference_solve_times = reference.solve_times
+        # We attribute 1 point for each similar solve_time, we then just have to count the points.
+        score = r.solve_times.each_with_index.count do |solve_time, solve_time_index|
+          solve_time.complete? && solve_time == reference_solve_times[solve_time_index]
+        end
+        # We have at least 3 matching values, consider this similar
+        if score > 2
+          similar_results << r
+        end
+      end
+      similar_results
+    end
+
+    def get_round_info(competition_rounds, round_id)
+      # This tries to get the round information from all the rounds in the competition.
+      round_info = competition_rounds[round_id]
+      unless round_info
+        # There is a legitimate situation where a round_id may be missing in the
+        # competition rounds: if it was a combined round and everyone made the cutoff!
+        event_id, round_type_id = round_id.split("-")
+        equivalent_round_id = "#{event_id}-#{RoundType.toggle_cutoff(round_type_id)}"
+        equivalent_round = competition_rounds[equivalent_round_id]
+        # Check that we indeed detected a "regular" round in the results that
+        # was a combined round before.
+        if equivalent_round&.round_type&.combined?
+          round_info = equivalent_round
+        end
+      end
+      round_info
+    end
+  end
+end

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -92,7 +92,7 @@ module ResultsValidators
               case cumulative_wcif_round_ids.length
               when 0
                 # easy case: each completed result (not DNS, DNF, or SKIPPED) must be below the time limit.
-                results_over_time_limit = completed_solves.select { |t| t.time_centiseconds > time_limit_for_round.centiseconds }
+                results_over_time_limit = completed_solves.reject { |t| t.time_centiseconds < time_limit_for_round.centiseconds }
                 if results_over_time_limit&.any?
                   @errors << ValidationError.new(:results, competition_id,
                                                  RESULT_OVER_TIME_LIMIT_ERROR,
@@ -244,7 +244,7 @@ module ResultsValidators
       sum_of_times_for_rounds = completed_solves_for_rounds.sum(&:time_centiseconds)
 
       # Check the sum is below the limit
-      if sum_of_times_for_rounds > time_limit_for_round.centiseconds
+      unless sum_of_times_for_rounds < time_limit_for_round.centiseconds
         @errors << ValidationError.new(:results, competition_id,
                                        RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR,
                                        round_ids: cumulative_round_ids.join(","),

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -42,16 +42,12 @@ module ResultsValidators
             last_result = result
 
             if expected_pos != result.pos
-              person_name = result.personName if result.respond_to?(:personName)
-              unless person_name
-                # Then we should check InboxPerson to get that name!
-                # Note: this fires one sql select per wrong position, but it should
-                # be fine since in this case we should be checking "InboxResult"
-                # and therefore the results from one single competition submission.
-                person = InboxPerson.find_by(competitionId: competition_id, id: result.personId)
-                person_name = person ? person.name : "<personId=#{result.personId}>"
-              end
-              @errors << ValidationError.new(:results, competition_id, WRONG_POSITION_IN_RESULTS_ERROR, round_id: round_id, person_name: person_name, expected_pos: expected_pos, pos: result.pos)
+              @errors << ValidationError.new(:results, competition_id,
+                                             WRONG_POSITION_IN_RESULTS_ERROR,
+                                             round_id: round_id,
+                                             person_name: self.name_from_result(result),
+                                             expected_pos: expected_pos,
+                                             pos: result.pos)
             end
           end
         end

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -45,7 +45,7 @@ module ResultsValidators
               @errors << ValidationError.new(:results, competition_id,
                                              WRONG_POSITION_IN_RESULTS_ERROR,
                                              round_id: round_id,
-                                             person_name: self.name_from_result(result),
+                                             person_name: result.personName,
                                              expected_pos: expected_pos,
                                              pos: result.pos)
             end

--- a/WcaOnRails/lib/results_validators/validation_error.rb
+++ b/WcaOnRails/lib/results_validators/validation_error.rb
@@ -15,11 +15,15 @@ module ResultsValidators
     end
 
     def ==(other)
-      other.class == self.class && other.state == state
+      other.class == self.class && other.hash == hash
     end
 
-    def state
-      [@kind, @competition_id, @message, @args]
+    def hash
+      [@kind, @competition_id, @message, @args].hash
+    end
+
+    def eql?(other)
+      self == other
     end
   end
 

--- a/WcaOnRails/lib/results_validators/validation_issue.rb
+++ b/WcaOnRails/lib/results_validators/validation_issue.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class ValidationIssue
+    attr_reader :kind, :competition_id
+    def initialize(kind, competition_id, message, **message_args)
+      @message = message
+      @kind = kind
+      @args = message_args
+      @competition_id = competition_id
+    end
+
+    def to_s
+      format(@message, @args)
+    end
+
+    def ==(other)
+      other.class == self.class && other.hash == hash
+    end
+
+    def hash
+      [@kind, @competition_id, @message, @args].hash
+    end
+
+    def eql?(other)
+      self == other
+    end
+  end
+end

--- a/WcaOnRails/lib/results_validators/validation_warning.rb
+++ b/WcaOnRails/lib/results_validators/validation_warning.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module ResultsValidators
-  class ValidationError < ValidationIssue
+  class ValidationWarning < ValidationIssue
   end
 end

--- a/WcaOnRails/spec/factories/inbox_results.rb
+++ b/WcaOnRails/spec/factories/inbox_results.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-end

--- a/WcaOnRails/spec/factories/inbox_results.rb
+++ b/WcaOnRails/spec/factories/inbox_results.rb
@@ -1,24 +1,4 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :inbox_result do
-    transient do
-      competition { FactoryBot.create(:competition, :with_rounds, event_ids: ["333oh"]) }
-      person { FactoryBot.create(:inbox_person, competitionId: competition.id) }
-    end
-
-    personId { person.id }
-    pos { 1 }
-    competitionId { competition.id }
-    eventId { "333oh" }
-    roundTypeId { "f" }
-    formatId { "a" }
-    value1 { best }
-    value2 { average }
-    value3 { average }
-    value4 { average }
-    value5 { average }
-    best { 2000 }
-    average { 5000 }
-  end
 end

--- a/WcaOnRails/spec/factories/results.rb
+++ b/WcaOnRails/spec/factories/results.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :result do
+  resultable_instance_members = ->(*args) {
     transient do
-      person { FactoryBot.create(:person) }
-      competition { FactoryBot.create(:competition) }
+      competition { FactoryBot.create(:competition, event_ids: ["333oh"]) }
     end
 
-    personId { person.wca_id }
-    personName { person.name }
-    countryId { person.countryId }
     competitionId { competition.id }
     pos { 1 }
     eventId { "333oh" }
@@ -22,12 +18,9 @@ FactoryBot.define do
     value5 { average }
     best { 3000 }
     average { 5000 }
-    regionalSingleRecord { "" }
-    regionalAverageRecord { "" }
 
-    trait :blind_mo3 do
-      eventId { "333bf" }
-      formatId { "3" }
+    trait :mo3 do
+      formatId { "m" }
       average { best }
       value1 { best }
       value2 { best }
@@ -36,15 +29,38 @@ FactoryBot.define do
       value5 { 0 }
     end
 
-    trait :blind_dnf_mo3 do
+    trait :blind_mo3 do
+      mo3
       eventId { "333bf" }
       formatId { "3" }
-      average { -1 }
-      value1 { best }
-      value2 { best }
-      value3 { -1 }
-      value4 { 0 }
-      value5 { 0 }
     end
+
+    trait :blind_dnf_mo3 do
+      blind_mo3
+      average { -1 }
+      value3 { -1 }
+    end
+  }
+
+  factory :inbox_result do
+    instance_eval(&resultable_instance_members)
+    transient do
+      person { FactoryBot.create(:inbox_person, competitionId: competition.id) }
+    end
+
+    personId { person.id }
+  end
+
+  factory :result do
+    instance_eval(&resultable_instance_members)
+    transient do
+      person { FactoryBot.create(:person) }
+    end
+
+    personId { person.wca_id }
+    personName { person.name }
+    countryId { person.countryId }
+    regionalSingleRecord { "" }
+    regionalAverageRecord { "" }
   end
 end

--- a/WcaOnRails/spec/factories/results.rb
+++ b/WcaOnRails/spec/factories/results.rb
@@ -19,6 +19,20 @@ FactoryBot.define do
     best { 3000 }
     average { 5000 }
 
+    trait :mbf do
+      eventId { "333mbf" }
+      formatId { "3" }
+      average { 0 }
+      # 9 points in 4 minutes
+      best { 900_024_000 }
+      value1 { best }
+      # 4 points in 2 minutes
+      value2 { 950_012_000 }
+      value3 { -1 }
+      value4 { 0 }
+      value5 { 0 }
+    end
+
     trait :mo3 do
       formatId { "m" }
       average { best }

--- a/WcaOnRails/spec/lib/results_validators/individual_results_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/individual_results_validator_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RV=ResultsValidators
+IRV=RV::IndividualResultsValidator
+
+RSpec.describe IRV do
+  context "on InboxResult and Result" do
+    let!(:competition1) { FactoryBot.create(:competition, :past, event_ids: ["333oh", "444", "333mbf"]) }
+    let!(:competition2) { FactoryBot.create(:competition, :past, event_ids: ["222", "555", "666", "777", "333fm"]) }
+
+    # The idea behind this variable is the following: the validator can be applied
+    # on either a particular model for given competition ids, or on a set of results.
+    # We simply want to check it has the expected behavior on all the possible cases.
+    let(:validator_args) {
+      [InboxResult, Result].flat_map { |model|
+        [
+          { competition_ids: [competition1.id, competition2.id], model: model },
+          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+        ]
+      }
+    }
+
+    # Triggers MBF_RESULT_OVER_TIME_LIMIT_WARNING
+    # Triggers RESULT_AFTER_DNS_WARNING
+    # Triggers SIMILAR_RESULTS_WARNING
+    # Triggers MISMATCHED_RESULT_FORMAT_ERROR
+    # Triggers NO_ROUND_INFORMATION_WARNING
+    # Triggers SUSPICIOUS_DNF_WARNING
+
+    it "triggers errors on cutoff and time limits" do
+      # Triggers:
+      # DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR
+      # RESULT_OVER_TIME_LIMIT_ERROR
+      # MET_CUTOFF_MISSING_RESULTS_ERROR
+      # RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR
+      # MISSING_CUMULATIVE_ROUND_ID_ERROR
+
+      cutoff = Cutoff.new(number_of_attempts: 2, attempt_result: 50*100)
+      cutoff_fm = Cutoff.new(number_of_attempts: 2, attempt_result: 35)
+      time_limit = TimeLimit.new(centiseconds: 2.minutes.in_centiseconds, cumulative_round_ids: [])
+      round44 = FactoryBot.create(:round, competition: competition1, event_id: "444", cutoff: cutoff, time_limit: time_limit)
+      round_fm = FactoryBot.create(:round, competition: competition2, event_id: "333fm", cutoff: cutoff_fm, format_id: "m")
+      cumul_valid = TimeLimit.new(centiseconds: 8.minutes.in_centiseconds, cumulative_round_ids: ["555-r1", "666-r1"])
+      round55 = FactoryBot.create(:round, competition: competition2, event_id: "555", time_limit: cumul_valid)
+      FactoryBot.create(:round, competition: competition2, event_id: "666", time_limit: cumul_valid, format_id: "m")
+
+      # This cumulative time limit is invalid as it refers to an unexisting round.
+      # It can happen at the moment see:
+      # https://github.com/thewca/worldcubeassociation.org/issues/3254
+      cumul_invalid = TimeLimit.new(centiseconds: 8.minutes.in_centiseconds, cumulative_round_ids: ["444-r1", "777-r1"])
+      FactoryBot.create(:round, competition: competition2, event_id: "777", time_limit: cumul_invalid, format_id: "m")
+
+      expected_errors = {
+        "Result": [],
+        "InboxResult": [],
+      }
+
+      # Here the positions will be messed up but this is fine, we don't run the PositionsValidator.
+      [Result, InboxResult].each do |model|
+        result_kind = model.model_name.singular.to_sym
+        errs = []
+        # Creates a result which doesn't meet the cutoff
+        create_over_cutoff(result_kind, competition1, cutoff, "444")
+
+        # Creates a result which doesn't meet the cutoff but yet has extra values
+        res_over_with_results = create_over_cutoff(result_kind, competition1, cutoff, "444")
+        res_over_with_results.update!(value3: res_over_with_results.value2,
+                                      value4: res_over_with_results.value2,
+                                      value5: res_over_with_results.value2,
+                                      average: res_over_with_results.value2)
+
+        errs << RV::ValidationError.new(:results, competition1.id,
+                                        IRV::DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR,
+                                        round_id: "444-c",
+                                        person_name: name_for_result(res_over_with_results),
+                                        cutoff: cutoff.to_s(round44))
+
+        # Create a result which meets the cutoff but has one result over the time limit
+        res_over_limit = FactoryBot.create(result_kind, competition: competition1,
+                                                        eventId: "444",
+                                                        best: 4000, average: 4200,
+                                                        roundTypeId: "c")
+        res_over_limit.update(value5: 12_001)
+
+        errs << RV::ValidationError.new(:results, competition1.id,
+                                        IRV::RESULT_OVER_TIME_LIMIT_ERROR,
+                                        round_id: "444-c",
+                                        person_name: name_for_result(res_over_limit),
+                                        time_limit: time_limit.to_s(round44))
+
+        # Create a result which meets the cutoff but doesn't have all the necessary values
+        res_fm = create_over_cutoff(result_kind, competition2, cutoff_fm, "333fm")
+        res_fm.update(value1: 30, formatId: "m")
+
+        errs << RV::ValidationError.new(:results, competition2.id,
+                                        IRV::MET_CUTOFF_MISSING_RESULTS_ERROR,
+                                        round_id: "333fm-c",
+                                        person_name: name_for_result(res_fm),
+                                        cutoff: cutoff_fm.to_s(round_fm))
+
+        res_cumul = FactoryBot.create(result_kind, :mo3, competition: competition2, eventId: "666", best: 6000)
+        FactoryBot.create(result_kind, competition: competition2, eventId: "555", best: 6000, average: 6000, person: person_for_result(res_cumul))
+
+        errs << RV::ValidationError.new(:results, competition2.id,
+                                        IRV::RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR,
+                                        round_ids: "555-f,666-f",
+                                        person_name: name_for_result(res_cumul),
+                                        time_limit: cumul_valid.to_s(round55))
+
+        FactoryBot.create(result_kind, :mo3, competition: competition2, eventId: "777")
+
+        errs << RV::ValidationError.new(:results, competition2.id,
+                                        IRV::MISSING_CUMULATIVE_ROUND_ID_ERROR,
+                                        original_round_id: "777-f",
+                                        wcif_id: "444-r1")
+
+        expected_errors[model.to_s] = errs
+      end
+      validator_args.each do |arg|
+        irv = IRV.new.validate(arg)
+        expect(irv.errors).to match_array(expected_errors[arg[:model].to_s])
+      end
+    end
+  end
+end
+
+def create_over_cutoff(kind, competition, cutoff, event_id)
+  attributes = {
+    competition: competition,
+    eventId: event_id,
+    value1: cutoff.attempt_result + 100,
+    value2: cutoff.attempt_result + 200,
+    value3: 0,
+    value4: 0,
+    value5: 0,
+    best: cutoff.attempt_result + 100,
+    average: 0,
+    roundTypeId: "c",
+  }
+  FactoryBot.create(kind, attributes)
+end
+
+def name_for_result(result)
+  result.respond_to?(:personName) ? result.personName : InboxPerson.find_by(id: result.personId).name
+end
+
+def person_for_result(result)
+  result.class == Result ? Person.find_by(wca_id: result.personId) : InboxPerson.find_by(id: result.personId)
+end

--- a/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe ResultsValidators::PositionsValidator do
         expected_errors = {}
         [InboxResult, Result].each do |model|
           table_results = results[model.to_s]
-          personName1 = name_for_result(table_results[0].first)
-          personName2 = name_for_result(table_results[1].last)
+          personName1 = table_results[0].first.personName
+          personName2 = table_results[1].last.personName
           expected_errors[model.to_s] = [
             create_result_error(competition1.id, "333oh-f", personName1, 1, 2),
             create_result_error(competition2.id, "222-f", personName2, 5, 7),
@@ -72,8 +72,8 @@ RSpec.describe ResultsValidators::PositionsValidator do
         results1 = create_incorrect_tied_results(competition1, "222")
         results2 = create_incorrect_tied_results(competition1, "222", kind: :inbox_result)
         expected_errors = {
-          "Result" => create_result_error(competition1.id, "222-f", name_for_result(results1[1]), 1, 2),
-          "InboxResult" => create_result_error(competition1.id, "222-f", name_for_result(results2[1]), 1, 2),
+          "Result" => create_result_error(competition1.id, "222-f", results1[1].personName, 1, 2),
+          "InboxResult" => create_result_error(competition1.id, "222-f", results2[1].personName, 1, 2),
         }
         validator_args.each do |arg|
           pv = ResultsValidators::PositionsValidator.new.validate(arg)
@@ -140,8 +140,4 @@ end
 
 def create_result_error(competition_id, round_id, name, expected_pos, actual_pos)
   ResultsValidators::ValidationError.new(:results, competition_id, ResultsValidators::PositionsValidator::WRONG_POSITION_IN_RESULTS_ERROR, round_id: round_id, person_name: name, expected_pos: expected_pos, pos: actual_pos)
-end
-
-def name_for_result(result)
-  result.respond_to?(:personName) ? result.personName : InboxPerson.find_by(id: result.personId).name
 end


### PR DESCRIPTION
Follow up for #4321.

List of major changes:
  - extract the validations related to individual results (time limit, cutoff, warning for similar results and so on) to a separate `IndividualResultsValidator`.
  - tests the `IndividualResultsValidator`

List of minor changes:
  - DRY and extend the `Result`/`InboxResult` factories code
  - rename `write_attribute` to `_write_attribute` [here](https://github.com/thewca/worldcubeassociation.org/blob/a61264e5e713f84985397f036f3b8cd161407ed0/WcaOnRails/lib/result_methods.rb#L70) as something must have changed in rails 5.2 (`r.value1=X` was not triggering `write_attribute` anymore).
  - fix the time limit check to be '<' and not '<=' (ie: a time of "1:00.00" is not "before" a time limit of "1:00.00" and should be considered an error)
  - separate `ValidationError`/`ValidationWarning` as I ran into some autoload errors...
  - implement `eql?` and `hash` on the aforementioned classes.


