### PR TITLE
Extract scrambles validator

### DIFF
--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -34,5 +34,33 @@ module ResultsValidators
       @errors = []
       @warnings = []
     end
+
+    protected
+
+    def get_rounds_info_for_competition(competition, round_ids_from_results)
+      # Get rounds information from the competition, and detect a legitimate situation
+      # where a round_id may be missing in the competition rounds: if it was a
+      # combined round and everyone made the cutoff!
+      # See additional comment here: https://github.com/thewca/worldcubeassociation.org/pull/4357#discussion_r307312177
+      rounds_information = Hash[
+        competition.competition_events.flat_map(&:rounds).map do |r|
+          ["#{r.event.id}-#{r.round_type_id}", r]
+        end
+      ]
+      # Now try to "cast" a declared combined round to an existing non-combined round
+      missing_round_ids = round_ids_from_results - rounds_information.keys
+      extra_round_ids = rounds_information.keys - round_ids_from_results
+      missing_round_ids.each do |round_id|
+        event_id, round_type_id = round_id.split("-")
+        equivalent_round_id = "#{event_id}-#{RoundType.toggle_cutoff(round_type_id)}"
+        if extra_round_ids.delete(equivalent_round_id)
+          equivalent_round = rounds_information[equivalent_round_id]
+          if equivalent_round.round_type.combined?
+            rounds_information[round_id] = rounds_information.delete(equivalent_round_id)
+          end
+        end
+      end
+      rounds_information
+    end
   end
 end

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -37,7 +37,7 @@ module ResultsValidators
 
     protected
 
-    def get_rounds_info_for_competition(competition, round_ids_from_results)
+    def get_rounds_info(competition, round_ids_from_results)
       # Get rounds information from the competition, and detect a legitimate situation
       # where a round_id may be missing in the competition rounds: if it was a
       # combined round and everyone made the cutoff!

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -49,7 +49,7 @@ module ResultsValidators
         end
       ]
       results_by_round_id_by_competition_id.each do |competition_id, results_by_round_id|
-        rounds_info_by_round_id = get_rounds_info_for_competition(competitions[competition_id], results_by_round_id.keys)
+        rounds_info_by_round_id = get_rounds_info(competitions[competition_id], results_by_round_id.keys)
         results_by_round_id.each do |round_id, results_for_round|
           # get cutoff and timelimit
           round_info = rounds_info_by_round_id[round_id]

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -33,7 +33,7 @@ module ResultsValidators
 
       results_by_competition_id.each do |competition_id, results_for_comp|
         # Get actual round ids from results
-        rounds_ids = results_for_comp.map { |r| "#{r.eventId}-#{r.roundTypeId}" }.uniq!
+        rounds_ids = results_for_comp.map { |r| "#{r.eventId}-#{r.roundTypeId}" }.uniq
 
         unless scrambles[competition_id]&.any?
           @errors << ValidationError.new(:scrambles, competition_id,

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class ScramblesValidator < GenericValidator
+    MISSING_SCRAMBLES_FOR_ROUND_ERROR = "[%{round_id}] Missing scrambles. Use the workbook assistant to add the correct scrambles to the round."
+    MISSING_SCRAMBLES_FOR_COMPETITION_ERROR = "Missing scrambles for the competition. Use the workbook assistant to add scrambles."
+    UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR = "[%{round_id}] Too many scrambles. Use the workbook assistant to uncheck the unused scrambles."
+    MISSING_SCRAMBLES_FOR_GROUP_ERROR = "[%{round_id}] Group %{group_id}: missing scrambles, detected only %{actual} instead of %{expected}."
+
+    @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
+
+    def validate(competition_ids: [], model: Result, results: nil)
+      reset_state
+      # Get all results if not provided
+      results ||= model.sorted_for_competitions(competition_ids)
+
+      associations = {
+        events: [],
+        competition_events: {
+          rounds: [:competition_event],
+        },
+      }
+
+      results_by_competition_id = results.group_by(&:competitionId)
+
+      scrambles = Scramble.where(competitionId: results_by_competition_id.keys).group_by(&:competitionId)
+
+      competitions = Hash[
+        Competition.includes(associations).where(id: results_by_competition_id.keys).map do |c|
+          [c.id, c]
+        end
+      ]
+
+      results_by_competition_id.each do |competition_id, results_for_comp|
+        # Get actual round ids from results
+        rounds_ids = results_for_comp.map { |r| "#{r.eventId}-#{r.roundTypeId}" }.uniq!
+
+        unless scrambles[competition_id]&.any?
+          @errors << ValidationError.new(:scrambles, competition_id,
+                                         MISSING_SCRAMBLES_FOR_COMPETITION_ERROR,
+                                         competition_id: competition_id)
+          next
+        end
+
+        # Group scramble by round_id
+        scrambles_by_round_id = scrambles[competition_id].group_by { |s| "#{s.eventId}-#{s.roundTypeId}" }
+        detected_scrambles_rounds_ids = scrambles_by_round_id.keys
+        (rounds_ids - detected_scrambles_rounds_ids).each do |round_id|
+          @errors << ValidationError.new(:scrambles, competition_id,
+                                         MISSING_SCRAMBLES_FOR_ROUND_ERROR,
+                                         round_id: round_id)
+        end
+
+        (detected_scrambles_rounds_ids - rounds_ids).each do |round_id|
+          @errors << ValidationError.new(:scrambles, competition_id,
+                                         UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR,
+                                         round_id: round_id)
+        end
+
+        rounds_info_by_ids = get_rounds_info(competitions[competition_id], rounds_ids)
+
+        # For existing rounds and scrambles matching expected rounds in the WCA website,
+        # check that the number of scrambles match at least the number of expected scrambles.
+        (detected_scrambles_rounds_ids & rounds_info_by_ids.keys).each do |round_id|
+          format = rounds_info_by_ids[round_id].format
+          expected_number_of_scrambles = format.expected_solve_count
+          scrambles_by_group_id = scrambles_by_round_id[round_id].group_by(&:groupId)
+          scrambles_by_group_id.each do |group_id, scrambles_for_group|
+            # filter out extra scrambles
+            actual_number_of_scrambles = scrambles_for_group.reject(&:isExtra).size
+            if actual_number_of_scrambles < expected_number_of_scrambles
+              @errors << ValidationError.new(:scrambles, competition_id,
+                                             MISSING_SCRAMBLES_FOR_GROUP_ERROR,
+                                             round_id: round_id, group_id: group_id,
+                                             actual: actual_number_of_scrambles,
+                                             expected: expected_number_of_scrambles)
+            end
+          end
+        end
+      end
+      self
+    end
+  end
+end

--- a/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RV = ResultsValidators
+SV = RV::ScramblesValidator
+
+RSpec.describe SV do
+  context "on InboxResult and Result" do
+    let!(:competition1) { FactoryBot.create(:competition, :past, event_ids: ["333oh"]) }
+    let!(:competition2) { FactoryBot.create(:competition, :past, event_ids: ["222", "333bf"]) }
+
+    # The idea behind this variable is the following: the validator can be applied
+    # on either a particular model for given competition ids, or on a set of results.
+    # We simply want to check it has the expected behavior on all the possible cases.
+    let(:validator_args) {
+      [InboxResult, Result].flat_map { |model|
+        [
+          { competition_ids: [competition1.id, competition2.id], model: model },
+          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+        ]
+      }
+    }
+
+    context "Scramble" do
+      # Triggers:
+      # MISSING_SCRAMBLES_FOR_ROUND_ERROR
+      # MISSING_SCRAMBLES_FOR_COMPETITION_ERROR
+      # UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR
+      # MISSING_SCRAMBLES_FOR_GROUP_ERROR
+      it "matches Result" do
+        [Result, InboxResult].each do |model|
+          result_kind = model.model_name.singular.to_sym
+          FactoryBot.create(result_kind, competition: competition1, eventId: "333oh")
+          FactoryBot.create(result_kind, competition: competition2, eventId: "222")
+          FactoryBot.create(result_kind, :blind_mo3, competition: competition2)
+        end
+
+        expected_errors = [
+          RV::ValidationError.new(:scrambles, competition1.id,
+                                  SV::UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR,
+                                  round_id: "333-f"),
+          RV::ValidationError.new(:scrambles, competition2.id,
+                                  SV::MISSING_SCRAMBLES_FOR_ROUND_ERROR,
+                                  round_id: "333bf-f"),
+        ]
+
+        # Scrambles are shared between InboxResult and Result
+        create_scramble_set(5, competitionId: competition1.id, eventId: "333oh")
+        create_scramble_set(5, competitionId: competition1.id, eventId: "333")
+        create_scramble_set(5, competitionId: competition2.id, eventId: "222")
+
+        validator_args.each do |arg|
+          sv = SV.new.validate(arg)
+          expect(sv.warnings).to be_empty
+          expect(sv.errors).to match_array(expected_errors)
+        end
+      end
+
+      it "matches the competition's data" do
+        [Result, InboxResult].each do |model|
+          result_kind = model.model_name.singular.to_sym
+          FactoryBot.create(result_kind, competition: competition1, eventId: "333oh")
+          FactoryBot.create(result_kind, competition: competition2, eventId: "333bf")
+        end
+
+        FactoryBot.create(:round, competition: competition2, event_id: "333bf", format_id: "3")
+
+        create_scramble_set(2, competitionId: competition2.id, eventId: "333bf")
+
+        expected_errors = [
+          RV::ValidationError.new(:scrambles, competition1.id,
+                                  SV::MISSING_SCRAMBLES_FOR_COMPETITION_ERROR,
+                                  competition_id: competition1.id),
+          RV::ValidationError.new(:scrambles, competition2.id,
+                                  SV::MISSING_SCRAMBLES_FOR_GROUP_ERROR,
+                                  round_id: "333bf-f", group_id: "A",
+                                  actual: 2, expected: 3),
+        ]
+
+        validator_args.each do |arg|
+          sv = SV.new.validate(arg)
+          expect(sv.warnings).to be_empty
+          expect(sv.errors).to match_array(expected_errors)
+        end
+      end
+    end
+  end
+
+  def create_scramble_set(n, **kwargs)
+    1.upto(n) do |i|
+      FactoryBot.create(:scramble, scrambleNum: i, **kwargs)
+    end
+  end
+end


### PR DESCRIPTION
Follow up for #4321.

Since getting all the rounds information (with the "combined round fix" discussed [here](https://github.com/thewca/worldcubeassociation.org/pull/4357#discussion_r307312177)) is a pretty common issue for the validators, I extracted the logic to a method in the generic class.

The remaining of the PR is just extracting the part checking scrambles from the `CompetitionResultsValidator` and implementing tests.