### PR TITLE
Fix InboxResult's personName

### DIFF
--- a/WcaOnRails/app/models/inbox_result.rb
+++ b/WcaOnRails/app/models/inbox_result.rb
@@ -8,6 +8,6 @@ class InboxResult < ApplicationRecord
   # NOTE: don't use this too often, as it triggers one person load per call!
   # If you need names for a batch of InboxResult, consider joining the InboxPerson table.
   def personName # rubocop:disable Naming/MethodName
-    InboxPerson.find_by(id: personId)&.name || "<personId=#{personId}>"
+    InboxPerson.find_by(id: personId, competitionId: competitionId)&.name || "<personId=#{personId}>"
   end
 end

--- a/WcaOnRails/spec/models/inbox_result_spec.rb
+++ b/WcaOnRails/spec/models/inbox_result_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InboxResult do
+  it "returns the correct person name" do
+    c1 = FactoryBot.create(:competition)
+    c2 = FactoryBot.create(:competition)
+    FactoryBot.create(:inbox_person, competitionId: c1.id, id: "1")
+    p2 = FactoryBot.create(:inbox_person, competitionId: c2.id, id: "1")
+    result = FactoryBot.create(:inbox_result, person: p2, competition: c2)
+    expect(result.personName).to eq p2.name
+  end
+end


### PR DESCRIPTION
`InboxPerson`'s id is not unique, the tuple `competitionId,id` is!
This gave the WRT a weird bug with some names during one of the last submissions.
(note: the test does fail without the fix :))

Merging asap to avoid more confusing situations.