### PR TITLE
WCIF: allow results to have null ranking

### DIFF
--- a/WcaOnRails/lib/round_results.rb
+++ b/WcaOnRails/lib/round_results.rb
@@ -48,7 +48,7 @@ class RoundResult
       "type" => ["object", "null"],
       "properties" => {
         "personId" => { "type" => "integer" },
-        "ranking" => { "type" => "integer" },
+        "ranking" => { "type" => ["integer", "null"] },
         "attempts" => { "type" => "array", "items" => Attempt.wcif_json_schema },
       },
     }


### PR DESCRIPTION
Context: we want to allow saving empty WCIF results to the WCA website (and `null` is a reasonable `ranking` for an empty result).