### PR TITLE
Request WRC & WDC feedback within delegate reports

### DIFF
--- a/WcaOnRails/app/controllers/delegate_reports_controller.rb
+++ b/WcaOnRails/app/controllers/delegate_reports_controller.rb
@@ -64,6 +64,8 @@ class DelegateReportsController < ApplicationController
       :posted,
       :wrc_feedback_requested,
       :wrc_incidents,
+      :wdc_feedback_requested,
+      :wdc_incidents,
     )
   end
 end

--- a/WcaOnRails/app/controllers/delegate_reports_controller.rb
+++ b/WcaOnRails/app/controllers/delegate_reports_controller.rb
@@ -62,6 +62,8 @@ class DelegateReportsController < ApplicationController
       :incidents,
       :remarks,
       :posted,
+      :wrc_feedback_requested,
+      :wrc_incidents,
     )
   end
 end

--- a/WcaOnRails/app/javascript/markdown-editor/index.js
+++ b/WcaOnRails/app/javascript/markdown-editor/index.js
@@ -39,6 +39,12 @@ $(function() {
     $('input#delegate_report_wrc_incidents').prop('disabled', !feedback_requested);
   }).trigger('change');
 
+  $('input[name="delegate_report[wdc_feedback_requested]"]').on('change', function() {
+    var feedback_requested = this.checked;
+    $('div.delegate_report_wdc_incidents').toggle(feedback_requested);
+    $('input#delegate_report_wdc_incidents').prop('disabled', !feedback_requested);
+  }).trigger('change');
+
   $('.markdown-editor').each(function() {
     let textFormattings = ['bold', 'italic', 'heading'];
     let textStructures = ['quote', 'unordered-list', 'ordered-list', 'table'];

--- a/WcaOnRails/app/javascript/markdown-editor/index.js
+++ b/WcaOnRails/app/javascript/markdown-editor/index.js
@@ -33,6 +33,12 @@ $(function() {
     cm.focus();
   }
 
+  $('input[name="delegate_report[wrc_feedback_requested]"]').on('change', function() {
+    var feedback_requested = this.checked;
+    $('div.delegate_report_wrc_incidents').toggle(feedback_requested);
+    $('input#delegate_report_wrc_incidents').prop('disabled', !feedback_requested);
+  }).trigger('change');
+
   $('.markdown-editor').each(function() {
     let textFormattings = ['bold', 'italic', 'heading'];
     let textStructures = ['quote', 'unordered-list', 'ordered-list', 'table'];

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -91,7 +91,9 @@ class CompetitionsMailer < ApplicationMailer
       @competition = competition
       mail(
         to: "reports@worldcubeassociation.org",
-        cc: competition.delegates.pluck(:email) + (competition.delegate_report.wrc_feedback_requested ? ["regulations@worldcubeassociation.org"] : []),
+        cc: competition.delegates.pluck(:email) +
+          (competition.delegate_report.wrc_feedback_requested ? ["regulations@worldcubeassociation.org"] : []) +
+          (competition.delegate_report.wdc_feedback_requested ? ["disciplinary@worldcubeassociation.org"] : []),
         reply_to: competition.delegates.pluck(:email),
         subject: "[wca-report] [#{competition.continent.name}] #{competition.name}",
       )

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -91,7 +91,7 @@ class CompetitionsMailer < ApplicationMailer
       @competition = competition
       mail(
         to: "reports@worldcubeassociation.org",
-        cc: competition.delegates.pluck(:email),
+        cc: competition.delegates.pluck(:email) + (competition.delegate_report.wrc_feedback_requested ? ["regulations@worldcubeassociation.org"] : []),
         reply_to: competition.delegates.pluck(:email),
         subject: "[wca-report] [#{competition.continent.name}] #{competition.name}",
       )

--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -28,6 +28,7 @@ Gen 3 Display: 0"
   validates :discussion_url, presence: true, if: :schedule_and_disussion_urls_required?
   validates :discussion_url, url: true
   validates :wrc_incidents, presence: true, if: :wrc_feedback_requested
+  validates :wdc_incidents, presence: true, if: :wdc_feedback_requested
 
   def schedule_and_disussion_urls_required?
     posted? && created_at > Date.new(2019, 7, 21)

--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -27,6 +27,7 @@ Gen 3 Display: 0"
   validates :schedule_url, url: true
   validates :discussion_url, presence: true, if: :schedule_and_disussion_urls_required?
   validates :discussion_url, url: true
+  validates :wrc_incidents, presence: true, if: :wrc_feedback_requested
 
   def schedule_and_disussion_urls_required?
     posted? && created_at > Date.new(2019, 7, 21)

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -2,10 +2,14 @@
 
 <div class="delegate-report">
   <% if delegate_report.wrc_feedback_requested %>
-    <font color="red">
-      <strong>@WRC: Feedback requested on incidents: <%= delegate_report.wrc_incidents %></strong>
-    </font>
-    <br><br>
+    <p style="color: red; font-weight: bold">
+      @WRC: Feedback requested on incidents: <%= delegate_report.wrc_incidents %>
+    </p>
+  <% end %>
+  <% if delegate_report.wdc_feedback_requested %>
+    <p style="color: red; font-weight: bold">
+      @WDC: Feedback requested on incidents: <%= delegate_report.wdc_incidents %>
+    </p>
   <% end %>
 
   <div>

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -1,6 +1,13 @@
 <% competition = delegate_report.competition %>
 
 <div class="delegate-report">
+  <% if delegate_report.wrc_feedback_requested %>
+    <font color="red">
+      <strong>@WRC: Feedback requested on incidents: <%= delegate_report.wrc_incidents %></strong>
+    </font>
+    <br><br>
+  <% end %>
+
   <div>
     <strong>Date</strong>
     <%= wca_date_range(competition.start_date, competition.end_date, locale: :en) %>

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -20,6 +20,8 @@
     <%= f.input :incidents, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
     <%= f.input :wrc_feedback_requested, as: :boolean %>
     <%= f.input :wrc_incidents %>
+    <%= f.input :wdc_feedback_requested, as: :boolean %>
+    <%= f.input :wdc_incidents %>
     <%= f.input :remarks, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
 
     <%= f.button :submit, class: "btn-primary" %>

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -18,6 +18,8 @@
     <%= f.input :venue, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
     <%= f.input :organization, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
     <%= f.input :incidents, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
+    <%= f.input :wrc_feedback_requested, as: :boolean %>
+    <%= f.input :wrc_incidents %>
     <%= f.input :remarks, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
 
     <%= f.button :submit, class: "btn-primary" %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -304,7 +304,9 @@ en:
         organization: "Organization"
         incidents: "Incidents"
         wrc_feedback_requested: "I would like feedback from the WRC on some of the incidents above."
-        wrc_incidents: "Incidents Needing Feedback"
+        wrc_incidents: "Incidents Needing WRC Feedback"
+        wdc_feedback_requested: "I would like feedback from the WDC on some of the incidents above."
+        wdc_incidents: "Incidents Needing WDC Feedback"
         remarks: "Remarks"
       #context: a person
       person:
@@ -507,6 +509,8 @@ en:
         incidents: "Report any incidents that you consider worth mentioning. Number the incidents starting from 1., so that other Delegates can comment referring to them by their numbers. Please make sure to mention only concrete cases, not generic events (e.g., regular +2 and DNF). Feel free to ask for Delegates' or WRC's  feedback on any of them. If you'd like to have the WDC involved in some of them, make sure to state this request clearly."
         wrc_feedback_requested: ""
         wrc_incidents: "List of numbers referencing any incidents that you would like the WRC's feedback on."
+        wdc_feedback_requested: ""
+        wdc_incidents: "List of numbers referencing any incidents that you would like the WDC's feedback on."
         remarks: "Talk about any other detail that you'd like to share (e.g., improvement/regression within the community, future plans for this region). If for the sake of conciseness you left something unsaid in the previous sections, feel free to comment them here."
         discussion_url: ""
       #context: for a competition tab

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -303,6 +303,8 @@ en:
         venue: "Venue"
         organization: "Organization"
         incidents: "Incidents"
+        wrc_feedback_requested: "I would like feedback from the WRC on some of the incidents above."
+        wrc_incidents: "Incidents Needing Feedback"
         remarks: "Remarks"
       #context: a person
       person:
@@ -503,6 +505,8 @@ en:
         venue: "Talk about rooms, light, public access, distribution of the zones (solving, scrambling, waiting, score-taking), if you set up different solving stages, problems that arose (for example, noise) and how you solved them... Please, be concise and do not report irrelevant details."
         organization: "Talk about the organization team and how they worked out the competition, if you got involved on it, their previous experience and if you noticed progress on their work, if they were professional and active the competition days, problems that arose (e.g., getting behind schedule) and how they solved them... Please, be concise and do not report irrelevant details."
         incidents: "Report any incidents that you consider worth mentioning. Number the incidents starting from 1., so that other Delegates can comment referring to them by their numbers. Please make sure to mention only concrete cases, not generic events (e.g., regular +2 and DNF). Feel free to ask for Delegates' or WRC's  feedback on any of them. If you'd like to have the WDC involved in some of them, make sure to state this request clearly."
+        wrc_feedback_requested: ""
+        wrc_incidents: "List of numbers referencing any incidents that you would like the WRC's feedback on."
         remarks: "Talk about any other detail that you'd like to share (e.g., improvement/regression within the community, future plans for this region). If for the sake of conciseness you left something unsaid in the previous sections, feel free to comment them here."
         discussion_url: ""
       #context: for a competition tab

--- a/WcaOnRails/db/migrate/20190728084145_add_wrc_and_wdc_fields_to_delegate_reports.rb
+++ b/WcaOnRails/db/migrate/20190728084145_add_wrc_and_wdc_fields_to_delegate_reports.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddWrcAndWdcFieldsToDelegateReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :delegate_reports, :wrc_feedback_requested, :boolean, null: false, default: false
+    add_column :delegate_reports, :wrc_incidents, :string, default: nil
+    add_column :delegate_reports, :wdc_feedback_requested, :boolean, null: false, default: false
+    add_column :delegate_reports, :wdc_incidents, :string, default: nil
+  end
+end

--- a/WcaOnRails/db/migrate/20190728084145_add_wrc_fields_to_delegate_reports.rb
+++ b/WcaOnRails/db/migrate/20190728084145_add_wrc_fields_to_delegate_reports.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class AddWrcFieldsToDelegateReports < ActiveRecord::Migration[5.2]
-  def change
-    add_column :delegate_reports, :wrc_feedback_requested, :boolean, null: false, default: false
-    add_column :delegate_reports, :wrc_incidents, :string, default: nil
-  end
-end

--- a/WcaOnRails/db/migrate/20190728084145_add_wrc_fields_to_delegate_reports.rb
+++ b/WcaOnRails/db/migrate/20190728084145_add_wrc_fields_to_delegate_reports.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddWrcFieldsToDelegateReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :delegate_reports, :wrc_feedback_requested, :boolean, null: false, default: false
+    add_column :delegate_reports, :wrc_incidents, :string, default: nil
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -797,6 +797,8 @@ CREATE TABLE `delegate_reports` (
   `nag_sent_at` datetime DEFAULT NULL,
   `wrc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
   `wrc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wdc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
+  `wdc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -795,6 +795,8 @@ CREATE TABLE `delegate_reports` (
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `nag_sent_at` datetime DEFAULT NULL,
+  `wrc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
+  `wrc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1560,4 +1562,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190601105825'),
 ('20190601231550'),
 ('20190622173635'),
-('20190716065618');
+('20190716065618'),
+('20190728084145');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -443,6 +443,8 @@ module DatabaseDumper
           nag_sent_at
           wrc_feedback_requested
           wrc_incidents
+          wdc_feedback_requested
+          wdc_incidents
         ),
       ),
     }.freeze,

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -441,6 +441,8 @@ module DatabaseDumper
           posted_by_user_id
           posted_at
           nag_sent_at
+          wrc_feedback_requested
+          wrc_incidents
         ),
       ),
     }.freeze,

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -186,6 +186,46 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       CompetitionsMailer.notify_of_delegate_report_submission(competition)
     end
 
+    context "wrc & wdc feedback requested" do
+      before(:each) do
+        competition.delegate_report.update_attributes!(wrc_feedback_requested: true, wrc_incidents: "1, 2, 3", wdc_feedback_requested: true, wdc_incidents: "4, 5, 6")
+      end
+
+      it "renders the headers" do
+        expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
+        expect(mail.to).to eq ["reports@worldcubeassociation.org"]
+        expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["regulations@worldcubeassociation.org"] + ["disciplinary@worldcubeassociation.org"]
+        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
+      end
+
+      it "renders the body" do
+        expect(mail.body.encoded).to match(/@WRC: Feedback requested on incidents: 1, 2, 3/)
+        expect(mail.body.encoded).to match(/@WDC: Feedback requested on incidents: 4, 5, 6/)
+        expect(mail.body.encoded).to match(/This was a great competition/)
+      end
+    end
+
+    context "wdc feedback requested" do
+      before(:each) do
+        competition.delegate_report.update_attributes!(wdc_feedback_requested: true, wdc_incidents: "4, 5, 6")
+      end
+
+      it "renders the headers" do
+        expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
+        expect(mail.to).to eq ["reports@worldcubeassociation.org"]
+        expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["disciplinary@worldcubeassociation.org"]
+        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
+      end
+
+      it "renders the body" do
+        expect(mail.body.encoded).not_to match(/@WRC/)
+        expect(mail.body.encoded).to match(/@WDC: Feedback requested on incidents: 4, 5, 6/)
+        expect(mail.body.encoded).to match(/This was a great competition/)
+      end
+    end
+
     context "wrc feedback requested" do
       before(:each) do
         competition.delegate_report.update_attributes!(wrc_feedback_requested: true, wrc_incidents: "1, 2, 3")
@@ -201,11 +241,12 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
       it "renders the body" do
         expect(mail.body.encoded).to match(/@WRC: Feedback requested on incidents: 1, 2, 3/)
+        expect(mail.body.encoded).not_to match(/@WDC/)
         expect(mail.body.encoded).to match(/This was a great competition/)
       end
     end
 
-    context "no wrc feedback" do
+    context "no wrc nor wdc feedback" do
       it "renders the headers" do
         expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
         expect(mail.to).to eq ["reports@worldcubeassociation.org"]
@@ -216,6 +257,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
       it "renders the body" do
         expect(mail.body.encoded).not_to match(/@WRC/)
+        expect(mail.body.encoded).not_to match(/@WDC/)
         expect(mail.body.encoded).to match(/This was a great competition/)
       end
     end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -186,16 +186,38 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       CompetitionsMailer.notify_of_delegate_report_submission(competition)
     end
 
-    it "renders the headers" do
-      expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
-      expect(mail.to).to eq ["reports@worldcubeassociation.org"]
-      expect(mail.cc).to match_array competition.delegates.pluck(:email)
-      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
-      expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
+    context "wrc feedback requested" do
+      before(:each) do
+        competition.delegate_report.update_attributes!(wrc_feedback_requested: true, wrc_incidents: "1, 2, 3")
+      end
+
+      it "renders the headers" do
+        expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
+        expect(mail.to).to eq ["reports@worldcubeassociation.org"]
+        expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["regulations@worldcubeassociation.org"]
+        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
+      end
+
+      it "renders the body" do
+        expect(mail.body.encoded).to match(/@WRC: Feedback requested on incidents: 1, 2, 3/)
+        expect(mail.body.encoded).to match(/This was a great competition/)
+      end
     end
 
-    it "renders the body" do
-      expect(mail.body.encoded).to match(/This was a great competition/)
+    context "no wrc feedback" do
+      it "renders the headers" do
+        expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
+        expect(mail.to).to eq ["reports@worldcubeassociation.org"]
+        expect(mail.cc).to match_array competition.delegates.pluck(:email)
+        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
+      end
+
+      it "renders the body" do
+        expect(mail.body.encoded).not_to match(/@WRC/)
+        expect(mail.body.encoded).to match(/This was a great competition/)
+      end
     end
 
     it "is sent in English" do

--- a/WcaOnRails/spec/models/delegate_report_spec.rb
+++ b/WcaOnRails/spec/models/delegate_report_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe DelegateReport do
     expect(dr).to be_valid
   end
 
+  it "wdc_feedback_requested is set false on creation" do
+    dr = FactoryBot.create :delegate_report
+    expect(dr.wdc_feedback_requested).to eq false
+  end
+
+  it "wdc_incidents is required when wdc_feedback_requested is true" do
+    dr = FactoryBot.build :delegate_report
+    expect(dr).to be_valid
+
+    dr.wdc_feedback_requested = true
+    expect(dr).to be_invalid_with_errors wdc_incidents: ["can't be blank"]
+
+    dr.wdc_incidents = "4, 5, 6"
+    expect(dr).to be_valid
+  end
+
   context "can_view_delegate_report?" do
     let(:other_delegate) { FactoryBot.create :delegate }
     let(:board_member) { FactoryBot.create :user, :board_member }

--- a/WcaOnRails/spec/models/delegate_report_spec.rb
+++ b/WcaOnRails/spec/models/delegate_report_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe DelegateReport do
     expect(dr.discussion_url).to eq "https://groups.google.com/a/worldcubeassociation.org/forum/#!topicsearchin/reports/" + URI.encode_www_form_component(dr.competition.name)
   end
 
+  it "wrc_feedback_requested is set false on creation" do
+    dr = FactoryBot.create :delegate_report
+    expect(dr.wrc_feedback_requested).to eq false
+  end
+
+  it "wrc_incidents is required when wrc_feedback_requested is true" do
+    dr = FactoryBot.build :delegate_report
+    expect(dr).to be_valid
+
+    dr.wrc_feedback_requested = true
+    expect(dr).to be_invalid_with_errors wrc_incidents: ["can't be blank"]
+
+    dr.wrc_incidents = "1, 2, 3"
+    expect(dr).to be_valid
+  end
+
   context "can_view_delegate_report?" do
     let(:other_delegate) { FactoryBot.create :delegate }
     let(:board_member) { FactoryBot.create :user, :board_member }


### PR DESCRIPTION
Within a delegate report, there is now a checkbox indicating whether feedback from the WRC is requested:

<img width="832" alt="Screen Shot 2019-07-28 at 1 00 31 PM" src="https://user-images.githubusercontent.com/24919355/62012281-1a0fb500-b139-11e9-921b-f0b98ab01683.png">

When checked, posting the report will automatically CC `wrc@worldcubeassociation.org` and add a `@WRC: Feedback requested on incidents: x, y, z` to the top of the delegate report email:

<img width="720" alt="Screen Shot 2019-07-28 at 1 03 19 PM" src="https://user-images.githubusercontent.com/24919355/62012292-3e6b9180-b139-11e9-9f58-6e562236434b.png">

EDIT: Same functionality also applies to the WDC; see comments below.

Fixes #4267 

Testing:
Automated tests, but would love feedback on whether these tests are sufficient.