### PR TITLE
Modify readme to include using MySQL versions 5.6 or 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ This repository contains all of the code that runs on [worldcubeassociation.org]
   ```
 
 ## Run directly with Ruby (lightweight, but only runs the Rails portions of the site)
-- Set up MySQL with a user with username "root" with an empty password.
+- Install either MySQL 5.6 or 5.7, and set it up with a user with username "root" with an empty password.
   If it poses problems, try the following:
   ```shell
-  # Install MySQL if you hadn't already.
-  # Using apt that would be: sudo apt install mysql-server
+  # Install MySQL 5.6/5.7 if you haven't already.
+  # Using apt that would be: sudo apt install mysql-server-5.6
   # Then run MySQL CLI as administrator and set an empty password for the root user:
   sudo mysql -u root
   ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';


### PR DESCRIPTION
Fixes #4370 

From that ticket:

Using mysql version 8, mysqldump has a different behavior than 5.6 (used in prod). It alphabetizes the list of tables, and it changes the character sets. For my recent PR, this meant a structure.sql with a diff of about 600 lines instead of 7!

Clarifying the readme will ensure others do not experience similar issues in the future.