### PR TITLE
Markdown editor improvements

### DIFF
--- a/WcaOnRails/app/controllers/upload_controller.rb
+++ b/WcaOnRails/app/controllers/upload_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class UploadController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { redirect_to_root_unless_user(:can_upload_images?) }
+
+  def image
+    # Unfortunately, there doesn't seem to be any good way to add validations
+    # on file type/content type/etc. See
+    # https://github.com/thewca/worldcubeassociation.org/issues/4380 for more
+    # information.
+    blob = ActiveStorage::Blob.create_after_upload!(
+      io: params[:image],
+      filename: params[:image].original_filename,
+      content_type: params[:image].content_type,
+    )
+
+    render json: { filePath: url_for(blob) }
+  end
+end

--- a/WcaOnRails/app/javascript/leaflet-wca/wcaProvider.js.erb
+++ b/WcaOnRails/app/javascript/leaflet-wca/wcaProvider.js.erb
@@ -1,5 +1,5 @@
 import { GoogleProvider } from 'leaflet-geosearch';
-import { getAuthenticityToken } from 'wca/wcif-utils';
+import fetchWithAuthenticityToken from 'wca/fetchWithAuthenticityToken';
 
 export class WCAProvider extends GoogleProvider {
   endpoint({ query } = {}) {
@@ -12,12 +12,7 @@ export class WCAProvider extends GoogleProvider {
   // This overrides Provider's search method, to be able to include the CSRF token.
   async search({ query }) {
     const url = this.endpoint({ query });
-    let fetchOptions = {
-      headers: {
-        "X-CSRF-Token": getAuthenticityToken(),
-      },
-    };
-    const request = await fetch(url, fetchOptions);
+    const request = await fetchWithAuthenticityToken(url);
     const json = await request.json();
     return this.parse({ data: json });
   }

--- a/WcaOnRails/app/javascript/markdown-editor/index.js
+++ b/WcaOnRails/app/javascript/markdown-editor/index.js
@@ -1,10 +1,10 @@
-import SimpleMDE from 'simplemde';
+import EasyMDE from "easymde";
 // For some reason, the SimpleMDE css file in the src directory does not seem to work,
-// fortunately, the one in the debug directory *does*.
-// See https://github.com/NextStepWebs/simplemde-markdown-editor/issues/578.
-//import 'simplemde/src/css/simplemde.css';
-import 'simplemde/debug/simplemde.css';
-import './style.scss';
+// fortunately, the one in the dist directory *does*.
+// See https://github.com/Ionaru/easy-markdown-editor/issues/108
+// import "easymde/src/css/easymde.css";
+import "easymde/dist/easymde.min.css";
+import "./style.scss";
 
 $(function() {
   function insertText(editor, markup, promptText) {
@@ -32,7 +32,7 @@ $(function() {
   }
 
   $('.markdown-editor').each(function() {
-    var editor = new SimpleMDE({
+    var editor = new EasyMDE({
       element: this,
       spellChecker: false,
       promptURLs: true,
@@ -92,7 +92,7 @@ $(function() {
     });
 
     // Trick to fix tab and shift+tab focus from:
-    //  https://github.com/NextStepWebs/simplemde-markdown-editor/issues/122#issuecomment-176329907
+    //  https://github.com/sparksuite/simplemde-markdown-editor/issues/122#issuecomment-176329907
     editor.codemirror.options.extraKeys.Tab = false;
     editor.codemirror.options.extraKeys['Shift-Tab'] = false;
   });

--- a/WcaOnRails/app/javascript/markdown-editor/index.js
+++ b/WcaOnRails/app/javascript/markdown-editor/index.js
@@ -75,7 +75,6 @@ $(function() {
         '|', 'guide',
       ],
 
-      // Status bar isn't quite working. See https://github.com/NextStepWebs/simplemde-markdown-editor/issues/334
       status: false,
       previewRender: function(plainText, preview) {
         if(this.markdownReqest) {

--- a/WcaOnRails/app/javascript/wca/fetchWithAuthenticityToken.js
+++ b/WcaOnRails/app/javascript/wca/fetchWithAuthenticityToken.js
@@ -1,0 +1,16 @@
+function fetchWithAuthenticityToken(url, fetchOptions) {
+  if(!fetchOptions) {
+    fetchOptions = {};
+  }
+  if(!fetchOptions.headers) {
+    fetchOptions.headers = {};
+  }
+  fetchOptions.headers["X-CSRF-Token"] = getAuthenticityToken();
+  return fetch(url, fetchOptions);
+}
+
+function getAuthenticityToken() {
+  return document.querySelector('meta[name=csrf-token]').content;
+}
+
+export default fetchWithAuthenticityToken;

--- a/WcaOnRails/app/javascript/wca/wcif-utils.js
+++ b/WcaOnRails/app/javascript/wca/wcif-utils.js
@@ -1,18 +1,18 @@
-import events from './events.js.erb'
+import events from './events.js.erb';
+import fetchWithAuthenticityToken from './fetchWithAuthenticityToken';
 
 function promiseSaveWcif(competitionId, data) {
   let url = `/api/v0/competitions/${competitionId}/wcif`;
   let fetchOptions = {
     headers: {
       "Content-Type": "application/json",
-      "X-CSRF-Token": getAuthenticityToken(),
     },
     credentials: 'include',
     method: "PATCH",
     body: JSON.stringify(data),
   };
 
-  return fetch(url, fetchOptions);
+  return fetchWithAuthenticityToken(url, fetchOptions);
 }
 
 export function getAuthenticityToken() {

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -592,6 +592,15 @@ class User < ApplicationRecord
     wdc_team? || wrc_team? || communication_team? || can_announce_competitions?
   end
 
+  def can_upload_images?
+    (
+      can_create_posts? ||
+      can_update_delegate_crash_course? ||
+      any_kind_of_delegate? || # Delegates are allowed to upload photos when writing a delegate report.
+      can_manage_any_not_over_competitions? # Competition managers may want to upload photos to their competition tabs.
+    )
+  end
+
   def can_update_delegate_crash_course?
     can_admin_competitions? || quality_assurance_committee?
   end
@@ -604,6 +613,10 @@ class User < ApplicationRecord
 
   def can_manage_competition?(competition)
     can_admin_competitions? || competition.organizers.include?(self) || competition.delegates.include?(self) || wrc_team? || competition.delegates.map(&:senior_delegate).compact.include?(self) || ethics_committee?
+  end
+
+  def can_manage_any_not_over_competitions?
+    delegated_competitions.not_over.present? || organized_competitions.not_over.present?
   end
 
   def can_view_hidden_competitions?

--- a/WcaOnRails/app/views/competition_tabs/_competition_tab_form.html.erb
+++ b/WcaOnRails/app/views/competition_tabs/_competition_tab_form.html.erb
@@ -1,7 +1,7 @@
 <% provide(:include_markdown_editor, true) %>
 <%= simple_form_for @competition_tab, url: submit_url, html: { class: "competition-tab-form" } do |f| %>
   <%= f.input :name %>
-  <%= f.input :content, input_html: { class: "markdown-editor" } %>
+  <%= f.input :content, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
 
   <div class="buttons">
     <div class="buttons-left">

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -14,11 +14,11 @@
     <% @competition.delegate_report.schedule_url = link_to_competition_schedule_tab(@competition) if @competition.has_schedule? %>
     <%= f.input :schedule_url, readonly: @competition.has_schedule? %>
 
-    <%= f.input :equipment, input_html: { class: "markdown-editor" } %>
-    <%= f.input :venue, input_html: { class: "markdown-editor" } %>
-    <%= f.input :organization, input_html: { class: "markdown-editor" } %>
-    <%= f.input :incidents, input_html: { class: "markdown-editor" } %>
-    <%= f.input :remarks, input_html: { class: "markdown-editor" } %>
+    <%= f.input :equipment, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
+    <%= f.input :venue, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
+    <%= f.input :organization, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
+    <%= f.input :incidents, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
+    <%= f.input :remarks, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
 
     <%= f.button :submit, class: "btn-primary" %>
     <% is_actually_posted = DelegateReport.find(@delegate_report.id).posted? %>

--- a/WcaOnRails/app/views/posts/_post_form.html.erb
+++ b/WcaOnRails/app/views/posts/_post_form.html.erb
@@ -2,7 +2,7 @@
 <% url = @post.new_record? ? posts_path : @post.update_path %>
 <%= simple_form_for @post, url: url, html: { class: 'form-horizontal' } do |f| %>
   <%= f.input :title, disabled: !editable_post_fields.include?(:title), autofocus: true %>
-  <%= f.input :body, input_html: { class: 'markdown-editor' } if editable_post_fields.include? :body %>
+  <%= f.input :body, input_html: { class: 'markdown-editor markdown-editor-image-upload' } if editable_post_fields.include? :body %>
 
   <% if editable_post_fields.include? :tags %>
     <%= f.input :tags %>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -108,6 +108,8 @@ Rails.application.routes.draw do
   resources :posts
   get 'rss' => 'posts#rss'
 
+  post 'upload/image', to: 'upload#image'
+
   get 'admin/delegates' => 'delegates#stats', as: :delegates_stats
 
   get 'robots' => 'static_pages#robots'

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -43,7 +43,7 @@
     "react-leaflet": "^2.4.0",
     "resolve-url-loader": "^3.1.0",
     "sass-loader": "^7.1.0",
-    "simplemde": "^1.11.2",
+    "easymde": "^2.7.0",
     "style-loader": "^0.23.1",
     "webpack": "^4.38.0",
     "webpack-manifest-plugin": "^2.0.4",

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -43,7 +43,7 @@
     "react-leaflet": "^2.4.0",
     "resolve-url-loader": "^3.1.0",
     "sass-loader": "^7.1.0",
-    "easymde": "^2.7.0",
+    "easymde": "^2.7.1-202.0",
     "style-loader": "^0.23.1",
     "webpack": "^4.38.0",
     "webpack-manifest-plugin": "^2.0.4",

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -682,4 +682,19 @@ RSpec.describe User, type: :model do
       expect(User.delegate_reports_receivers_emails).to eq ["seniors@worldcubeassociation.org", "quality@worldcubeassociation.org", "regulations@worldcubeassociation.org", staff_member1.email]
     end
   end
+
+  describe "#can_manage_any_not_over_competitions?" do
+    let!(:manager_upcoming_and_past) { FactoryBot.create :user }
+    let!(:manager_past_only) { FactoryBot.create :user }
+    let!(:upcoming_competition) { FactoryBot.create :competition, starts: 1.month.from_now, organizers: [manager_upcoming_and_past] }
+    let!(:past_competition) { FactoryBot.create :competition, starts: 1.month.ago, organizers: [manager_past_only, manager_upcoming_and_past] }
+
+    it "knows if you are managing upcoming competitions" do
+      expect(manager_upcoming_and_past.can_manage_any_not_over_competitions?).to be true
+    end
+
+    it "knows if you only managed past competitions" do
+      expect(manager_past_only.can_manage_any_not_over_competitions?).to be false
+    end
+  end
 end

--- a/WcaOnRails/spec/requests/upload_spec.rb
+++ b/WcaOnRails/spec/requests/upload_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResultsSubmissionController, type: :request do
+  let(:image) { Rack::Test::UploadedFile.new('spec/support/logo.png', 'image/png') }
+
+  context "not signed in" do
+    sign_out
+
+    it "redirects when attempting to upload an image" do
+      post upload_image_path, params: { image: image }
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  context "signed in as delegate" do
+    sign_in { FactoryBot.create :delegate }
+
+    it "can upload an image" do
+      post upload_image_path, params: { image: image }
+      json = JSON.parse(response.body)
+      expect(json['filePath']).not_to be_nil
+    end
+  end
+end

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -2909,10 +2909,10 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-easymde@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.7.0.tgz#42e52010b5611892d61bcaf29f595c8f40e43002"
-  integrity sha512-ir+RC4y72HuOqwy5ZCeyfMSzgh4ZBRwYT/gjuBhBzXc6tYFhFSVQD87nEpdZehvhLSa2DshZLsPAFSGxs4ZI5A==
+easymde@^2.7.1-202.0:
+  version "2.7.1-202.0"
+  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.7.1-202.0.tgz#98487a95299390737b5360fc07818c833f80d72f"
+  integrity sha512-oZ+bqsbW6OkTagdevf1//nqBIS1KwAeSGBH6eYxl2WCARmMl0gSJK16wK3grWJseFv9fHom5SSvyd1lDcZ3Ydw==
   dependencies:
     codemirror "^5.48.0"
     codemirror-spell-checker "1.1.2"

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -2081,17 +2081,17 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror-spell-checker@*:
+codemirror-spell-checker@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz#1c660f9089483ccb5113b9ba9ca19c3f4993371e"
   integrity sha1-HGYPkIlIPMtRE7m6nKGcP0mTNx4=
   dependencies:
     typo-js "*"
 
-codemirror@*:
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.31.0.tgz#ecf3d057eb74174147066bfc7c5f37b4c4e07df2"
-  integrity sha512-LKbMZKoAz7pMmWuSEl253G6yyloSulj1kXfvYv+3n3I8wMiI7QwnCHwKM3Zw5S9ItNV28Layq0/ihQXWmn9T9w==
+codemirror@^5.48.0:
+  version "5.48.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.48.2.tgz#a9dd3d426dea4cd59efd59cd98e20a9152a30922"
+  integrity sha512-i9VsmC8AfA5ji6EDIZ+aoSe4vt9FcwPLdHB1k1ItFbVyuOFRrcfvnoKqwZlC7EVA2UmTRiNEypE4Uo7YvzVY8Q==
 
 collapse-white-space@^1.0.2:
   version "1.0.5"
@@ -2908,6 +2908,15 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+easymde@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.7.0.tgz#42e52010b5611892d61bcaf29f595c8f40e43002"
+  integrity sha512-ir+RC4y72HuOqwy5ZCeyfMSzgh4ZBRwYT/gjuBhBzXc6tYFhFSVQD87nEpdZehvhLSa2DshZLsPAFSGxs4ZI5A==
+  dependencies:
+    codemirror "^5.48.0"
+    codemirror-spell-checker "1.1.2"
+    marked "^0.7.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -4973,10 +4982,10 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-marked@*:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.1.tgz#062f43b88b02ee80901e8e8d8e6a620ddb3aa752"
-  integrity sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw==
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 mathml-tag-names@^2.1.0:
   version "2.1.1"
@@ -7843,15 +7852,6 @@ simple-swizzle@^0.2.2:
   integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
   dependencies:
     is-arrayish "^0.3.1"
-
-simplemde@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/simplemde/-/simplemde-1.11.2.tgz#a23a35d978d2c40ef07dec008c92f070d8e080e3"
-  integrity sha1-ojo12XjSxA7wfewAjJLwcNjggOM=
-  dependencies:
-    codemirror "*"
-    codemirror-spell-checker "*"
-    marked "*"
 
 slash@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Move from the abandoned SimpleMDE to EasyMDE.

Experiment with uploading images directly to the WCA website for use in markdown posts + delegate reports (this should help out with #4309).

NOTE: We should not merge this up until
Ionaru/easy-markdown-editor#109 is merged and
released. Then we should update this diff to pull in latest version of
EasyMDE with these fixes.