### PR TITLE
Remove unused `Performance/RedundantMatch` rule.

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -97,9 +97,6 @@ Metrics/ModuleLength:
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
-Performance/RedundantMatch:
-  Enabled: false
-
 Style/AccessModifierDeclarations:
   Enabled: false
 


### PR DESCRIPTION
When running rubocop, I was getting the following warning:

```
Warning: unrecognized cop Performance/RedundantMatch found in .rubocop.yml
```

It looks like Rubocop extracted support for performance cops into a
separate library. See
https://github.com/rubocop-hq/rubocop/commit/98c30a60fb5133e0f31d5b23587ab9c1baf5118f
and https://github.com/rubocop-hq/rubocop-performance.