### PR TITLE
Round result allow less than 5 attempts

### DIFF
--- a/WcaOnRails/lib/round_results.rb
+++ b/WcaOnRails/lib/round_results.rb
@@ -19,7 +19,7 @@ class RoundResult
   attr_accessor :person_id, :ranking, :attempts
   validates :person_id, numericality: { only_integer: true }
   validates :ranking, numericality: { only_integer: true }, allow_nil: true
-  validates :attempts, length: { is: 5, message: "must have 5 attempts" }
+  validates :attempts, length: { maximum: 5, message: "must have at most 5 attempts" }
 
   def initialize(person_id: nil, ranking: nil, attempts: nil)
     self.person_id = person_id


### PR DESCRIPTION
This allows storing less than 5 attempts for WCIF Round results. By assuming that the rest of attempts is skipped we save data bandwidth when passing WCIF around and some database space =)