### PR TITLE
Add pt country overrides

### DIFF
--- a/WcaOnRails/config/locales/country_overrides.pt.yml
+++ b/WcaOnRails/config/locales/country_overrides.pt.yml
@@ -1,0 +1,25 @@
+# Country overrides until https://github.com/onomojo/i18n-country-translations/pull/52 gets merged
+pt:
+  countries:
+    AM: Arménia
+    CZ: República Checa
+    EE: Estónia
+    FO: Ilhas Faroé
+    GL: Gronelândia
+    IR: Irão
+    KH: Cambodja
+    KM: Comoros
+    LV: Letónia
+    MC: Mónaco
+    MG: Madagáscar
+    MK: Macedónia
+    MU: Maurícia
+    NC: Nova Caledónia
+    PL: Polónia
+    PS: Palestina
+    QO: Oceânia Remota
+    RO: Roménia
+    SG: Singapura
+    SI: Eslovénia
+    VN: Vietname
+    YE: Iémen


### PR DESCRIPTION
It will most likely take a long time for https://github.com/onomojo/i18n-country-translations/pull/52 to be merged & published, so this adds temporary country overrides for Portuguese. Thanks @cubizh!