### PR TITLE
Don't run rubocop twice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,4 @@ before_script:
   - DISABLE_SPRING=1 bundle exec rake assets:precompile
 script:
   - bundle exec overcommit --sign && bundle exec overcommit --sign pre-commit && (cd .. && BUNDLE_GEMFILE=WcaOnRails/Gemfile bundle exec overcommit --run)
-  - bundle exec rubocop
   - bundle exec rake


### PR DESCRIPTION
We already invoke rubocop as part of overcommit. There's no need to run
it twice =)

For example, we ran rubocop twice in this travis build: https://travis-ci.org/thewca/worldcubeassociation.org/builds/565803731:

![image](https://user-images.githubusercontent.com/277474/62185211-63692b80-b316-11e9-91b5-831da98d8af1.png)
