### PR TITLE
Bring back the Facebook icon.

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -6,7 +6,7 @@
         <a href="<%= root_path %>">World Cube Association</a>
         <br>
         <%= link_to(icon("fab", "instagram"), "https://www.instagram.com/thewcaofficial/", target: "_blank", class: "hide-new-window-icon") %>
-        <%= link_to(icon("fab", "facebook-official"), "https://www.facebook.com/WorldCubeAssociation/", target: "_blank", class: "hide-new-window-icon") %>
+        <%= link_to(icon("fab", "facebook-square"), "https://www.facebook.com/WorldCubeAssociation/", target: "_blank", class: "hide-new-window-icon") %>
         <%= link_to(icon("fab", "twitter"), "https://www.twitter.com/theWCAofficial/", target: "_blank", class: "hide-new-window-icon") %>
         <%= link_to(icon("fab", "reddit"), "https://www.reddit.com/r/TheWCAOfficial/", target: "_blank", class: "hide-new-window-icon") %>
         <%= link_to(icon("fab", "twitch"), "https://www.twitch.tv/worldcubeassociation/", target: "_blank", class: "hide-new-window-icon") %>


### PR DESCRIPTION
The icon changed its name in Font Awesome 5, which was updated from Font Awesome 4 on #4381.

I'm merging this as soon as tests pass!