### PR TITLE
Override several country names of Japanese

### DIFF
--- a/WcaOnRails/config/locales/country_overrides.ja.yml
+++ b/WcaOnRails/config/locales/country_overrides.ja.yml
@@ -1,0 +1,7 @@
+# Country overrides until https://github.com/onomojo/i18n-country-translations/pull/53 gets merged
+ja:
+  countries:
+    GE: ジョージア
+    KN: セントクリストファー・ネービス
+    MK: 北マケドニア
+    SZ: エスワティニ


### PR DESCRIPTION
Recently, Japanese government officially changed some country names. I'm thankful that @speedsolve has noticed it and told me. I just created a PR for changing them in https://github.com/onomojo/i18n-country-translations/pull/53 , but I want to make an immediate update for WCA as in https://github.com/thewca/worldcubeassociation.org/pull/4385 .

Could someone review and merge this?