### PR TITLE
Implement adding registrations via form

### DIFF
--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -58,3 +58,13 @@ function compareHtmlContent(a, b) {
   var second = $('<p>' + b + '</p>').text().trim();
   return first.localeCompare(second);
 }
+
+onPage('registrations#add, registrations#do_add', function() {
+  // Bind all/clear cubing event buttons
+  $('#clear-all-events').on('click', function() {
+    $('#events input[type="checkbox"]').prop('checked', false);
+  });
+  $('#select-all-events').on('click', function() {
+    $('#events input[type="checkbox"]').prop('checked', true);
+  });
+});

--- a/WcaOnRails/app/views/registrations/add.html.erb
+++ b/WcaOnRails/app/views/registrations/add.html.erb
@@ -1,0 +1,52 @@
+<% provide(:title, t('registrations.add.title', comp: @competition.name)) %>
+
+<%= render layout: "nav" do %>
+  <% if @competition.registration_full? %>
+    <%= alert :warning, t('registrations.mailer.deleted.causes.registrations_full'), note: true %>
+  <% else %>
+    <%= alert :info, t('registrations.add.info'), note: true %>
+    <%= simple_form_for :registration_data, url: competition_registrations_do_add_path(@competition) do |f| %>
+      <%= f.input :name, input_html: { value: params.dig(:registration_data, :name) },
+                         label: t('activerecord.attributes.user.name') %>
+      <%= f.input :country, selected: params.dig(:registration_data, :country),
+                            include_blank: true,
+                            collection: Country.real,
+                            value_method: lambda { |c| c.id },
+                            label_method: lambda { |c| c.name },
+                            label: t('activerecord.attributes.user.country_iso2') %>
+      <%= f.input :birth_date, as: :date_picker,
+                               input_html: { value: params.dig(:registration_data, :birth_date) },
+                               label: t('activerecord.attributes.user.dob') %>
+      <%= f.input :gender, selected: params.dig(:registration_data, :gender), #
+                           include_blank: true,
+                           collection: User::ALLOWABLE_GENDERS,
+                           label_method: User::GENDER_LABEL_METHOD,
+                           label: t('activerecord.attributes.user.gender') %>
+      <%= f.input :email, input_html: { value: params.dig(:registration_data, :email) },
+                          label: t('activerecord.attributes.user.email') %>
+      <%= f.input :wca_id, as: :wca_id,
+                           input_html: { value: params.dig(:registration_data, :wca_id) },
+                           label: t('activerecord.attributes.user.wca_id') %>
+
+      <div class="form-group">
+        <%= label_tag "events" do %>
+          <%= t 'competitions.competition_form.events' %>
+          <button type="button" id="select-all-events" class="btn btn-primary btn-xs"><%= t 'competitions.index.all_events' %></button>
+          <button type="button" id="clear-all-events" class="btn btn-default btn-xs"><%= t 'competitions.index.clear' %></button>
+        <% end %>
+        <div id="events">
+          <% @competition.events.each do |event| %>
+          <span class="event-checkbox">
+            <%= label_tag "checkbox-#{event.id}" do %>
+              <%= check_box_tag "registration_data[event_ids][]", event.id, params.dig(:registration_data, :event_ids)&.include?(event.id), id: "checkbox-#{event.id}" %>
+              <%= cubing_icon event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name %>
+            <% end %>
+          </span>
+          <% end %>
+        </div>
+      </div>
+
+      <%= f.submit t('registrations.add.add'), class: "btn btn-primary" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1016,6 +1016,10 @@ en:
       registrations_file_label: "Registrations file"
       registrations_file_hint: "CSV file with columns: Status, Name, Country, WCA ID, Birth Date, Gender, Email, and one column for each event."
       import: "Import"
+    add:
+      title: "Add registration for %{comp}"
+      info: "This will create an approved registration. Use this form to add walk-ins during the competition."
+      add: "Add registration"
   #context: Key used when managing competitions
   competitions:
     #context: generic message

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
     post 'registrations/export' => 'registrations#export', as: :registrations_export
     get 'registrations/import' => 'registrations#import', as: :registrations_import
     post 'registrations/import' => 'registrations#do_import', as: :registrations_do_import
+    get 'registrations/add' => 'registrations#add', as: :registrations_add
+    post 'registrations/add' => 'registrations#do_add', as: :registrations_do_add
     get 'registrations/psych-sheet' => 'registrations#psych_sheet', as: :psych_sheet
     get 'registrations/psych-sheet/:event_id' => 'registrations#psych_sheet_event', as: :psych_sheet_event
     resources :registrations, only: [:index, :update, :create, :edit, :destroy], shallow: true

--- a/WcaOnRails/spec/requests/registrations_spec.rb
+++ b/WcaOnRails/spec/requests/registrations_spec.rb
@@ -7,87 +7,193 @@ RSpec.describe "registrations" do
   let!(:competition) { FactoryBot.create(:competition, :with_delegate, :visible, event_ids: %w(333 444)) }
 
   describe "POST #do_import" do
-    before do
-      sign_in competition.delegates.first
+    context "when signed in as a normal user" do
+      it "doesn't allow access" do
+        sign_in FactoryBot.create(:user)
+        post competition_registrations_do_import_path(competition)
+        expect(response).to redirect_to root_url
+      end
     end
 
-    it "redirects when WCA registration is used" do
-      competition.update!(use_wca_registration: true)
-      post competition_registrations_do_import_path(competition)
-      expect(response).to redirect_to competition_path(competition)
-    end
+    context "when signed in as competition manager" do
+      before do
+        sign_in competition.delegates.first
+      end
 
-    it "renders an error when there are missing columns" do
-      file = csv_file [
-        ["Status", "Name", "WCA ID", "Birth date", "Gender", "Email", "444"],
-      ]
-      post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-      follow_redirect!
-      expect(response.body).to include "Missing columns: country and 333."
-    end
+      it "redirects when WCA registration is used" do
+        competition.update!(use_wca_registration: true)
+        post competition_registrations_do_import_path(competition)
+        expect(response).to redirect_to competition_path(competition)
+      end
 
-    it "renders an error when the number of accepted registrations exceeds competitor limit" do
-      competition.update!(competitor_limit: 1, competitor_limit_enabled: true, competitor_limit_reason: "Testing!")
-      file = csv_file [
-        ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-        ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
-        ["a", "John Watson", "United Kingdom", "", "2000-01-01", "m", "watson@example.com", "1", "1"],
-      ]
-      expect {
+      it "renders an error when there are missing columns" do
+        file = csv_file [
+          ["Status", "Name", "WCA ID", "Birth date", "Gender", "Email", "444"],
+        ]
         post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-      }.to_not change { competition.registrations.count }
-      follow_redirect!
-      expect(response.body).to include "The given file includes 2 accepted registrations, which is more than the competitor limit of 1."
-    end
+        follow_redirect!
+        expect(response.body).to include "Missing columns: country and 333."
+      end
 
-    describe "registrations import" do
-      context "registrant has WCA ID" do
-        it "renders an error if the WCA ID doesn't exist" do
-          expect(RegistrationsMailer).to_not receive(:notify_registrant_of_locked_account_creation)
-          file = csv_file [
-            ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-            ["a", "Sherlock Holmes", "United Kingdom", "1000DARN99", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
-          ]
-          expect {
-            post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-          }.to_not change { competition.registrations.count }
-          follow_redirect!
-          expect(response.body).to include "Non-existent WCA ID given 1000DARN99."
-        end
+      it "renders an error when the number of accepted registrations exceeds competitor limit" do
+        competition.update!(competitor_limit: 1, competitor_limit_enabled: true, competitor_limit_reason: "Testing!")
+        file = csv_file [
+          ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+          ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+          ["a", "John Watson", "United Kingdom", "", "2000-01-01", "m", "watson@example.com", "1", "1"],
+        ]
+        expect {
+          post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+        }.to_not change { competition.registrations.count }
+        follow_redirect!
+        expect(response.body).to include "The given file includes 2 accepted registrations, which is more than the competitor limit of 1."
+      end
 
-        context "user exists with the given WCA ID" do
-          context "the user is a dummy account" do
-            let!(:dummy_user) { FactoryBot.create(:dummy_user) }
+      describe "registrations import" do
+        context "registrant has WCA ID" do
+          it "renders an error if the WCA ID doesn't exist" do
+            expect(RegistrationsMailer).to_not receive(:notify_registrant_of_locked_account_creation)
+            file = csv_file [
+              ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+              ["a", "Sherlock Holmes", "United Kingdom", "1000DARN99", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+            ]
+            expect {
+              post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            }.to_not change { competition.registrations.count }
+            follow_redirect!
+            expect(response.body).to include "Non-existent WCA ID given 1000DARN99."
+          end
 
-            context "user exists with registrant's email" do
-              context "the user already has WCA ID" do
-                it "renders an error" do
-                  user = FactoryBot.create(:user, :wca_id)
+          context "user exists with the given WCA ID" do
+            context "the user is a dummy account" do
+              let!(:dummy_user) { FactoryBot.create(:dummy_user) }
+
+              context "user exists with registrant's email" do
+                context "the user already has WCA ID" do
+                  it "renders an error" do
+                    user = FactoryBot.create(:user, :wca_id)
+                    file = csv_file [
+                      ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+                      ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                    ]
+                    expect {
+                      post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+                    }.to_not change { competition.registrations.count }
+                    follow_redirect!
+                    expect(response.body).to include "There is already a user with email #{user.email}, but it has WCA ID of #{user.wca_id} instead of #{dummy_user.wca_id}."
+                  end
+                end
+
+                context "the user doesn't have WCA ID" do
+                  it "merges the user with the dummy one and registers him" do
+                    user = FactoryBot.create(:user)
+                    file = csv_file [
+                      ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+                      ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                    ]
+                    expect {
+                      post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+                    }.to change { User.count }.by(-1)
+                    expect(User.exists?(dummy_user.id)).to be false
+                    user.reload
+                    expect(user.wca_id).to eq dummy_user.wca_id
+                    expect(user.registrations.first.events.map(&:id)).to eq %w(333)
+                    expect(competition.registrations.count).to eq 1
+                  end
+                end
+              end
+
+              context "no user exists with registrant's email" do
+                it "promotes the dummy user to a locked one, registers and notifies him" do
+                  expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
                   file = csv_file [
                     ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                    ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                    ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                  ]
+                  expect {
+                    post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+                  }.to_not change { User.count }
+                  user = dummy_user.reload
+                  expect(user).to_not be_dummy_account
+                  expect(user).to be_locked_account
+                  expect(user.email).to eq "sherlock@example.com"
+                  expect(user.registrations.first.events.map(&:id)).to eq %w(333)
+                  expect(competition.registrations.count).to eq 1
+                end
+              end
+            end
+
+            context "the user is not a dummy account" do
+              it "registers this user" do
+                user = FactoryBot.create(:user, :wca_id)
+                file = csv_file [
+                  ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+                  ["a", "Sherlock Holmes", "United Kingdom", user.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                ]
+                expect {
+                  post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+                }.to_not change { User.count }
+                expect(user.registrations.first.events.map(&:id)).to eq %w(333)
+                expect(competition.registrations.count).to eq 1
+              end
+            end
+          end
+
+          context "no user exists with the given WCA ID" do
+            context "user exists with registrant's email" do
+              context "the user has unconfirmed WCA ID different from the given WCA ID" do
+                it "renders an error" do
+                  person = FactoryBot.create(:person)
+                  unconfirmed_person = FactoryBot.create(:person)
+                  user = FactoryBot.create(
+                    :user,
+                    unconfirmed_wca_id: unconfirmed_person.wca_id,
+                    dob_verification: unconfirmed_person.dob,
+                    delegate_to_handle_wca_id_claim: User.delegates.first,
+                  )
+                  file = csv_file [
+                    ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+                    ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
                   }.to_not change { competition.registrations.count }
                   follow_redirect!
-                  expect(response.body).to include "There is already a user with email #{user.email}, but it has WCA ID of #{user.wca_id} instead of #{dummy_user.wca_id}."
+                  expect(response.body).to include "There is already a user with email #{user.email}, but it has unconfirmed WCA ID of #{unconfirmed_person.wca_id} instead of #{person.wca_id}."
                 end
               end
 
-              context "the user doesn't have WCA ID" do
-                it "merges the user with the dummy one and registers him" do
+              context "the user has unconfirmed WCA ID same as the given WCA ID" do
+                it "claims the WCA ID and registers the user" do
+                  person = FactoryBot.create(:person)
                   user = FactoryBot.create(:user)
                   file = csv_file [
                     ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                    ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                    ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                  }.to change { User.count }.by(-1)
-                  expect(User.exists?(dummy_user.id)).to be false
-                  user.reload
-                  expect(user.wca_id).to eq dummy_user.wca_id
+                  }.to_not change { User.count }
+                  expect(user.reload.wca_id).to eq person.wca_id
+                  expect(user.reload.unconfirmed_wca_id).to be_nil
+                  expect(user.reload.delegate_to_handle_wca_id_claim).to be_nil
+                  expect(user.registrations.first.events.map(&:id)).to eq %w(333)
+                  expect(competition.registrations.count).to eq 1
+                end
+              end
+
+              context "the user has no unconfirmed WCA ID" do
+                it "updates this user with the WCA ID and registers him" do
+                  person = FactoryBot.create(:person)
+                  user = FactoryBot.create(:user)
+                  file = csv_file [
+                    ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+                    ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                  ]
+                  expect {
+                    post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+                  }.to_not change { User.count }
+                  expect(user.reload.wca_id).to eq person.wca_id
                   expect(user.registrations.first.events.map(&:id)).to eq %w(333)
                   expect(competition.registrations.count).to eq 1
                 end
@@ -95,31 +201,31 @@ RSpec.describe "registrations" do
             end
 
             context "no user exists with registrant's email" do
-              it "promotes the dummy user to a locked one, registers and notifies him" do
+              it "creates a locked user with this WCA ID, registers and notifies him" do
                 expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
+                person = FactoryBot.create(:person)
                 file = csv_file [
                   ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                  ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                  ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
                 ]
                 expect {
                   post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                }.to_not change { User.count }
-                user = dummy_user.reload
-                expect(user).to_not be_dummy_account
+                }.to change { User.count }.by(1)
+                user = competition.registrations.first.user
+                expect(user.wca_id).to eq person.wca_id
                 expect(user).to be_locked_account
-                expect(user.email).to eq "sherlock@example.com"
-                expect(user.registrations.first.events.map(&:id)).to eq %w(333)
-                expect(competition.registrations.count).to eq 1
               end
             end
           end
+        end
 
-          context "the user is not a dummy account" do
+        context "registrant doesn't have WCA ID" do
+          context "user exists with registrant's email" do
             it "registers this user" do
-              user = FactoryBot.create(:user, :wca_id)
+              user = FactoryBot.create(:user)
               file = csv_file [
                 ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                ["a", "Sherlock Holmes", "United Kingdom", user.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", user.email, "1", "0"],
               ]
               expect {
                 post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -127,223 +233,199 @@ RSpec.describe "registrations" do
               expect(user.registrations.first.events.map(&:id)).to eq %w(333)
               expect(competition.registrations.count).to eq 1
             end
-          end
-        end
 
-        context "no user exists with the given WCA ID" do
-          context "user exists with registrant's email" do
-            context "the user has unconfirmed WCA ID different from the given WCA ID" do
-              it "renders an error" do
-                person = FactoryBot.create(:person)
-                unconfirmed_person = FactoryBot.create(:person)
-                user = FactoryBot.create(
-                  :user,
-                  unconfirmed_wca_id: unconfirmed_person.wca_id,
-                  dob_verification: unconfirmed_person.dob,
-                  delegate_to_handle_wca_id_claim: User.delegates.first,
-                )
-                file = csv_file [
-                  ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                  ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
-                ]
-                expect {
-                  post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                }.to_not change { competition.registrations.count }
-                follow_redirect!
-                expect(response.body).to include "There is already a user with email #{user.email}, but it has unconfirmed WCA ID of #{unconfirmed_person.wca_id} instead of #{person.wca_id}."
-              end
-            end
-
-            context "the user has unconfirmed WCA ID same as the given WCA ID" do
-              it "claims the WCA ID and registers the user" do
-                person = FactoryBot.create(:person)
-                user = FactoryBot.create(:user)
-                file = csv_file [
-                  ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                  ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
-                ]
-                expect {
-                  post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                }.to_not change { User.count }
-                expect(user.reload.wca_id).to eq person.wca_id
-                expect(user.reload.unconfirmed_wca_id).to be_nil
-                expect(user.reload.delegate_to_handle_wca_id_claim).to be_nil
-                expect(user.registrations.first.events.map(&:id)).to eq %w(333)
-                expect(competition.registrations.count).to eq 1
-              end
-            end
-
-            context "the user has no unconfirmed WCA ID" do
-              it "updates this user with the WCA ID and registers him" do
-                person = FactoryBot.create(:person)
-                user = FactoryBot.create(:user)
-                file = csv_file [
-                  ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                  ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
-                ]
-                expect {
-                  post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                }.to_not change { User.count }
-                expect(user.reload.wca_id).to eq person.wca_id
-                expect(user.registrations.first.events.map(&:id)).to eq %w(333)
-                expect(competition.registrations.count).to eq 1
-              end
+            it "updates user data unless it has WCA ID" do
+              user = FactoryBot.create(:user)
+              file = csv_file [
+                ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+                ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", user.email, "1", "0"],
+              ]
+              expect {
+                post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+              }.to_not change { User.count }
+              expect(user.reload.name).to eq "Sherlock Holmes"
+              expect(user.dob).to eq Date.new(2000, 1, 1)
+              expect(user.country_iso2).to eq "GB"
             end
           end
 
           context "no user exists with registrant's email" do
-            it "creates a locked user with this WCA ID, registers and notifies him" do
+            it "creates a locked user without WCA ID, registers and notifies him" do
               expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
-              person = FactoryBot.create(:person)
               file = csv_file [
                 ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
               ]
               expect {
                 post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
               }.to change { User.count }.by(1)
               user = competition.registrations.first.user
-              expect(user.wca_id).to eq person.wca_id
+              expect(user.wca_id).to be_blank
               expect(user).to be_locked_account
             end
           end
         end
       end
 
-      context "registrant doesn't have WCA ID" do
-        context "user exists with registrant's email" do
-          it "registers this user" do
-            user = FactoryBot.create(:user)
+      describe "registrations re-import" do
+        context "CSV registrant already accepted in the database" do
+          it "leaves existing registration unchanged" do
+            registration = FactoryBot.create(:registration, :accepted, competition: competition, events: %w(333))
+            user = registration.user
             file = csv_file [
               ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-              ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", user.email, "1", "0"],
+              ["a", user.name, user.country.name, "", user.dob, user.gender, user.email, "1", "0"],
             ]
             expect {
               post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-            }.to_not change { User.count }
-            expect(user.registrations.first.events.map(&:id)).to eq %w(333)
-            expect(competition.registrations.count).to eq 1
-          end
-
-          it "updates user data unless it has WCA ID" do
-            user = FactoryBot.create(:user)
-            file = csv_file [
-              ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-              ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", user.email, "1", "0"],
-            ]
-            expect {
-              post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-            }.to_not change { User.count }
-            expect(user.reload.name).to eq "Sherlock Holmes"
-            expect(user.dob).to eq Date.new(2000, 1, 1)
-            expect(user.country_iso2).to eq "GB"
+            }.to not_change { competition.registrations.count }
+              .and not_change { registration.reload.accepted_at }
           end
         end
 
-        context "no user exists with registrant's email" do
-          it "creates a locked user without WCA ID, registers and notifies him" do
-            expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
+        context "CSV registrant already accepted in the database, but with different events" do
+          it "only updates registration events" do
+            registration = FactoryBot.create(:registration, :accepted, competition: competition, events: %(333))
+            user = registration.user
+            file = csv_file [
+              ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+              ["a", user.name, user.country.name, "", user.dob, user.gender, user.email, "1", "1"],
+            ]
+            expect {
+              post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            }.to not_change { competition.registrations.count }
+              .and not_change { registration.reload.accepted_at }
+              .and change { registration.reload.events.map(&:id) }.from(%w(333)).to(%w(333 444))
+          end
+        end
+
+        context "CSV registrant already in the database, but deleted" do
+          it "acceptes the registration again" do
+            registration = FactoryBot.create(:registration, :deleted, competition: competition)
+            user = registration.user
+            file = csv_file [
+              ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+              ["a", user.name, user.country.name, "", user.dob, user.gender, user.email, "1", "0"],
+            ]
+            expect {
+              post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            }.to not_change { competition.registrations.count }
+              .and change { registration.reload.accepted_at }
+            expect(registration.reload).to be_accepted
+          end
+        end
+
+        context "registrant deleted in the database, but not in the CSV file" do
+          it "leaves the registration unchanged" do
+            registration = FactoryBot.create(:registration, :deleted, competition: competition)
+            file = csv_file [
+              ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+            ]
+            expect {
+              post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            }.to not_change { competition.registrations.count }
+              .and not_change { registration.reload.deleted_at }
+            expect(registration.reload).to be_deleted
+          end
+        end
+
+        context "registrant accepted in the database, but not in the CSV file" do
+          it "deletes the registration" do
+            registration = FactoryBot.create(:registration, :accepted, competition: competition)
+            file = csv_file [
+              ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+            ]
+            expect {
+              post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            }.to not_change { User.count }
+              .and not_change { competition.registrations.count }
+              .and change { competition.registrations.accepted.count }.by(-1)
+            expect(registration.reload).to be_deleted
+          end
+        end
+
+        context "CSV registrant not in the database" do
+          it "creates a new registration" do
             file = csv_file [
               ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
               ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
             ]
             expect {
               post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-            }.to change { User.count }.by(1)
-            user = competition.registrations.first.user
-            expect(user.wca_id).to be_blank
-            expect(user).to be_locked_account
+            }.to change { competition.registrations.count }.by(1)
           end
         end
       end
     end
+  end
 
-    describe "registrations re-import" do
-      context "CSV registrant already accepted in the database" do
-        it "leaves existing registration unchanged" do
+  # Adding a registration reuses the logic behind importing CSV registrations
+  # and that's tested thoroughly above.
+  describe "POST #do_add" do
+    context "when signed in as a normal user" do
+      it "doesn't allow access" do
+        sign_in FactoryBot.create(:user)
+        post competition_registrations_do_import_path(competition)
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context "when signed in as competition manager" do
+      before do
+        sign_in competition.delegates.first
+      end
+
+      context "when there is existing registration for the given person" do
+        it "renders an error" do
           registration = FactoryBot.create(:registration, :accepted, competition: competition, events: %w(333))
           user = registration.user
-          file = csv_file [
-            ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-            ["a", user.name, user.country.name, "", user.dob, user.gender, user.email, "1", "0"],
-          ]
           expect {
-            post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            post competition_registrations_do_add_path(competition), params: {
+              registration_data: {
+                name: user.name, country: user.country, birth_date: user.dob,
+                gender: user.gender, email: user.email, event_ids: ["444"]
+              },
+            }
           }.to not_change { competition.registrations.count }
-            .and not_change { registration.reload.accepted_at }
+          expect(response.body).to include "This person already has a registration."
         end
       end
 
-      context "CSV registrant already accepted in the database, but with different events" do
-        it "only updates registration events" do
-          registration = FactoryBot.create(:registration, :accepted, competition: competition, events: %(333))
-          user = registration.user
-          file = csv_file [
-            ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-            ["a", user.name, user.country.name, "", user.dob, user.gender, user.email, "1", "1"],
-          ]
+      context "when there is no existing registration for the given person" do
+        it "creates an accepted registration" do
           expect {
-            post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-          }.to not_change { competition.registrations.count }
-            .and not_change { registration.reload.accepted_at }
-            .and change { registration.reload.events.map(&:id) }.from(%w(333)).to(%w(333 444))
-        end
-      end
-
-      context "CSV registrant already in the database, but deleted" do
-        it "acceptes the registration again" do
-          registration = FactoryBot.create(:registration, :deleted, competition: competition)
-          user = registration.user
-          file = csv_file [
-            ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-            ["a", user.name, user.country.name, "", user.dob, user.gender, user.email, "1", "0"],
-          ]
-          expect {
-            post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-          }.to not_change { competition.registrations.count }
-            .and change { registration.reload.accepted_at }
-          expect(registration.reload).to be_accepted
-        end
-      end
-
-      context "registrant deleted in the database, but not in the CSV file" do
-        it "leaves the registration unchanged" do
-          registration = FactoryBot.create(:registration, :deleted, competition: competition)
-          file = csv_file [
-            ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-          ]
-          expect {
-            post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-          }.to not_change { competition.registrations.count }
-            .and not_change { registration.reload.deleted_at }
-          expect(registration.reload).to be_deleted
-        end
-      end
-
-      context "registrant accepted in the database, but not in the CSV file" do
-        it "deletes the registration" do
-          registration = FactoryBot.create(:registration, :accepted, competition: competition)
-          file = csv_file [
-            ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-          ]
-          expect {
-            post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-          }.to not_change { User.count }
-            .and not_change { competition.registrations.count }
-            .and change { competition.registrations.accepted.count }.by(-1)
-          expect(registration.reload).to be_deleted
-        end
-      end
-
-      context "CSV registrant not in the database" do
-        it "creates a new registration registration" do
-          file = csv_file [
-            ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-            ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
-          ]
-          expect {
-            post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+            post competition_registrations_do_add_path(competition), params: {
+              registration_data: {
+                name: "Sherlock Holmes", country: "United Kingdom", birth_date: "2000-01-01",
+                gender: "m", email: "sherlock@example.com", event_ids: ["444"]
+              },
+            }
           }.to change { competition.registrations.count }.by(1)
+          registration = competition.registrations.last
+          expect(registration.user.name).to eq "Sherlock Holmes"
+          expect(registration.events.map(&:id)).to eq ["444"]
+          expect(registration).to be_accepted
+          follow_redirect!
+          expect(response.body).to include "Successfully added registration!"
+        end
+      end
+
+      context "when competitor limit has been reached" do
+        it "redirects to competition page" do
+          FactoryBot.create(:registration, :accepted, competition: competition, events: %w(333))
+          competition.update!(
+            competitor_limit_enabled: true, competitor_limit: 1, competitor_limit_reason: "So I take all the podiums",
+          )
+          expect {
+            post competition_registrations_do_add_path(competition), params: {
+              registration_data: {
+                name: "Sherlock Holmes", country: "United Kingdom", birth_date: "2000-01-01",
+                gender: "m", email: "sherlock@example.com", event_ids: ["444"]
+              },
+            }
+          }.to_not change { competition.registrations.count }
+          follow_redirect!
+          expect(response.body).to include "The competitor limit has been reached."
         end
       end
     end


### PR DESCRIPTION
Fixes #3437.

This builds a form on top of the import CSV logic we already have in place (as it's pretty much importing a single registration). The reason behind this is adding walk-ins during a competition (so that wca-live to handle them). Some comments:

1. Make sure to view diff with indentation changes ignored.
2. The form code is quite verbose, as there's no single model we work on, and thus it's just a "plain" form.
3. We could be fancier and provide multiple ways of registering (e.g. user select if we know there's a user, person select + email, etc), but I think it's an overkill for now.
4. I'm open to a better wording than `add` if there are any ideas =)