### PR TITLE
Fix race condition when updating competition tabs order

### DIFF
--- a/WcaOnRails/app/models/competition_tab.rb
+++ b/WcaOnRails/app/models/competition_tab.rb
@@ -39,9 +39,11 @@ class CompetitionTab < ApplicationRecord
     other_display_order = display_order + (direction.to_s == "up" ? -1 : 1)
     other_tab = competition.tabs.find_by(display_order: other_display_order)
     if other_tab
-      update_column :display_order, nil
-      other_tab.update_column :display_order, current_display_order
-      update_column :display_order, other_display_order
+      ActiveRecord::Base.transaction do
+        update_column :display_order, nil
+        other_tab.update_column :display_order, current_display_order
+        update_column :display_order, other_display_order
+      end
     end
   end
 end


### PR DESCRIPTION
Apparently there was competition tab with `NULL` `display_order` in our database, which shouldn't be possible. Took me quite some clicking to reproduce this on the staging (as we run multiple workers there), but eventually I managed to get to that state. After analyzing SQL `UPDATE` queries log I found out this race condition:

| tab | display order |
| --- | --- |
| A | 1 (action: down) |
| B | 2 |
| C | 3 (action: up) |

If these actions happen simultaneously then tabs' desired state is `A | 2` and `B | 2`, so one of the updates must fail. The thing is that to preserve display order uniqueness an update is done in three steps, e.g.:
1. `A = NULL`
2. `B = 1`
3. `A = 2`

So if the step 3. fails, we end up with A being `NULL`.
Wrapping these 3 steps in a transaction should solve the issue.