### PR TITLE
 Fix outdated references

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1823,7 +1823,7 @@ en:
             '2b': "the other competition must not have the 3x3x3 Fewest Moves event."
     paragraph-events:
       title: "Announcing events"
-      content: 'All events that are going to be held at the competition must be specified by the Delegate when requesting the competition approval. This also includes "tentative" events (i.e. events that may be held additionally depending on the competition flow). Further additions must be approved by the WCAT.'
+      content: 'All events that are going to be held at the competition must be specified by the Delegate when requesting the competition approval. Further additions must be approved by the WCAT.'
     paragraph5:
       title: "Competitor limits"
       content_html: "The number of competitors may be limited per event or per competition (see <a href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>). The Delegate of the competition must get an approval of the competitor limit by the WCAT. Competitor limits should be

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1802,8 +1802,7 @@ en:
       it is highly recommended to search for sponsors. Although WCA Delegates are volunteers and do not receive a salary for their work, organizers should consider paying compensation for their travel expenses."
     paragraph3:
       title: "Deadlines for the announcement of the competition"
-      content_html: "The competition should be announced at least one month before the start of the competition (see <a href='https://www.worldcubeassociation.org/regulations/guidelines.html#8a4++'>Guideline 8a4++</a>). If there are special reasons preventing this deadline to be met, competitions may be announced up to two weeks before, at the discretion
-      of the WCAT. It is highly recommended to inform the WCAT of these reasons as soon as possible to avoid a later refusal of the competition."
+      content_html: "The competition must be announced at least 28 days before the start of the competition (see <a href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>).
     paragraph4:
       title: "Proximity policy"
       content1: "WCA competitions will be accepted if they are at least 100 km or 19 days away from any other competition. The WCAT should particularly review a proposed competition if there is another competition for which the distance between them is less than 100 km and the time between them is less than 19 days. A Delegate requesting approval for such a competition must provide further information on why the competition should still be accepted. Possible arguments that support such a competition being accepted include:"
@@ -1827,7 +1826,7 @@ en:
       content: 'All events that are going to be held at the competition must be specified by the Delegate when requesting the competition approval. This also includes "tentative" events (i.e. events that may be held additionally depending on the competition flow). Further additions must be approved by the WCAT.'
     paragraph5:
       title: "Competitor limits"
-      content_html: "The number of competitors may be limited per event or per competition (see <a href='https://www.worldcubeassociation.org/regulations/#Z4'>Regulation Z4</a>). Like for all regulations in article Z, the Delegate of the competition must get an approval of the competitor limit by the WCAT. Competitor limits should be
+      content_html: "The number of competitors may be limited per event or per competition (see <a href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>). Like for all regulations in article Z, the Delegate of the competition must get an approval of the competitor limit by the WCAT. Competitor limits should be
         chosen wisely and in accordance with the expected competitor interest. The limit should not set to a lower number for minor reasons. The intended limit should already be taken into consideration when searching for a suitable venue. The competitors
         limit must be clearly stated on the competition page on the WCA website."
     paragraph6:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1802,7 +1802,7 @@ en:
       it is highly recommended to search for sponsors. Although WCA Delegates are volunteers and do not receive a salary for their work, organizers should consider paying compensation for their travel expenses."
     paragraph3:
       title: "Deadlines for the announcement of the competition"
-      content_html: "The competition must be announced at least 28 days before the start of the competition (see <a href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>).
+      content_html: "The competition must be announced at least 28 days before the start of the competition (see <a href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>)."
     paragraph4:
       title: "Proximity policy"
       content1: "WCA competitions will be accepted if they are at least 100 km or 19 days away from any other competition. The WCAT should particularly review a proposed competition if there is another competition for which the distance between them is less than 100 km and the time between them is less than 19 days. A Delegate requesting approval for such a competition must provide further information on why the competition should still be accepted. Possible arguments that support such a competition being accepted include:"
@@ -1826,7 +1826,7 @@ en:
       content: 'All events that are going to be held at the competition must be specified by the Delegate when requesting the competition approval. This also includes "tentative" events (i.e. events that may be held additionally depending on the competition flow). Further additions must be approved by the WCAT.'
     paragraph5:
       title: "Competitor limits"
-      content_html: "The number of competitors may be limited per event or per competition (see <a href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>). Like for all regulations in article Z, the Delegate of the competition must get an approval of the competitor limit by the WCAT. Competitor limits should be
+      content_html: "The number of competitors may be limited per event or per competition (see <a href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>). The Delegate of the competition must get an approval of the competitor limit by the WCAT. Competitor limits should be
         chosen wisely and in accordance with the expected competitor interest. The limit should not set to a lower number for minor reasons. The intended limit should already be taken into consideration when searching for a suitable venue. The competitors
         limit must be clearly stated on the competition page on the WCA website."
     paragraph6:

--- a/WcaOnRails/config/locales/nl.yml
+++ b/WcaOnRails/config/locales/nl.yml
@@ -3371,14 +3371,9 @@ nl:
       title: Deadline voor het aankondigen van de wedstrijd
       #original_hash: 305cfb1
       content_html: >-
-        De wedstrijd zou minstens een maand van tevoren moeten worden
+        De wedstrijd moet minstens 28 dagen van tevoren worden
         aangekondigd (zie <a
-        href='https://www.worldcubeassociation.org/regulations/guidelines.html#8a4++'>Richtlijn
-        8a4++</a>). Als er speciale redenen zijn waarom deze deadline niet kan
-        worden gehaald, mogen wedstrijden tot uiterlijk twee weken van tevoren
-        worden aangekondigd, te bepalen door de WCAT. Het is sterk aan te
-        bevelen om de WCAT van deze redenen op de hoogte te brengen om latere
-        weigering te voorkomen.
+        href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>).
     paragraph4:
       #original_hash: b6dca56
       title: Nabijheidsbeleid
@@ -3444,8 +3439,7 @@ nl:
       content_html: >-
         Het aantal deelnemers kan worden beperkt per wedstrijdonderdeel of per
         wedstrijd (zie <a
-        href='https://www.worldcubeassociation.org/regulations/#Z4'>Reglement
-        Z4</a>). Zoals alle Reglementen in artikel Z, moet de WCA Delegate van
+        href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>). Zoals alle Reglementen in artikel Z, moet de WCA Delegate van
         de wedstrijd goedkeuring krijgen van de WCAT. Maximumaantallen
         deelnemers moeten zorgvuldig woren gekozen en in lijn zijn met het
         verwachte aantal aanmeldingen. Het maximumaantal mag niet voor

--- a/WcaOnRails/config/locales/nl.yml
+++ b/WcaOnRails/config/locales/nl.yml
@@ -3372,6 +3372,7 @@ nl:
       #original_hash: 305cfb1
       content_html: >-
         De wedstrijd zou minstens een maand van tevoren moeten worden
+        aangekondigd (zie <a
         href='https://www.worldcubeassociation.org/regulations/guidelines.html#8a4++'>Richtlijn
         8a4++</a>). Als er speciale redenen zijn waarom deze deadline niet kan
         worden gehaald, mogen wedstrijden tot uiterlijk twee weken van tevoren

--- a/WcaOnRails/config/locales/nl.yml
+++ b/WcaOnRails/config/locales/nl.yml
@@ -3371,9 +3371,13 @@ nl:
       title: Deadline voor het aankondigen van de wedstrijd
       #original_hash: 305cfb1
       content_html: >-
-        De wedstrijd moet minstens 28 dagen van tevoren worden
-        aangekondigd (zie <a
-        href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>).
+        De wedstrijd zou minstens een maand van tevoren moeten worden
+        href='https://www.worldcubeassociation.org/regulations/guidelines.html#8a4++'>Richtlijn
+        8a4++</a>). Als er speciale redenen zijn waarom deze deadline niet kan
+        worden gehaald, mogen wedstrijden tot uiterlijk twee weken van tevoren
+        worden aangekondigd, te bepalen door de WCAT. Het is sterk aan te
+        bevelen om de WCAT van deze redenen op de hoogte te brengen om latere
+        weigering te voorkomen.
     paragraph4:
       #original_hash: b6dca56
       title: Nabijheidsbeleid
@@ -3439,7 +3443,8 @@ nl:
       content_html: >-
         Het aantal deelnemers kan worden beperkt per wedstrijdonderdeel of per
         wedstrijd (zie <a
-        href='https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Competition Requirements</a>). Zoals alle Reglementen in artikel Z, moet de WCA Delegate van
+        href='https://www.worldcubeassociation.org/regulations/#Z4'>Reglement
+        Z4</a>). Zoals alle Reglementen in artikel Z, moet de WCA Delegate van
         de wedstrijd goedkeuring krijgen van de WCAT. Maximumaantallen
         deelnemers moeten zorgvuldig woren gekozen en in lijn zijn met het
         verwachte aantal aanmeldingen. Het maximumaantal mag niet voor


### PR DESCRIPTION
The organizer guidelines still refer to regulation Z and an non-existent guideline. I fixed the links for En and Nl, other languages still need to be fixed though.