### PR TITLE
Some changes to hopefully make generating structure.sql easier.

### DIFF
--- a/WcaOnRails/lib/tasks/normalize_structure_sql.rake
+++ b/WcaOnRails/lib/tasks/normalize_structure_sql.rake
@@ -3,8 +3,9 @@
 # Copied (and modified) from https://stackoverflow.com/a/20695238
 
 def normalize_schema_dump(schema_dump)
-  schema_dump.gsub(/ AUTO_INCREMENT=\d*/, '')
-             .rstrip + "\n" # remove extra newlines at the end
+  schema_dump = schema_dump.gsub(/ AUTO_INCREMENT=\d*/, '').rstrip + "\n" # remove extra newlines at the end
+  schema_dump = schema_dump.gsub(/ *$/, '') # remove trailing whitespace
+  schema_dump.gsub(%r{\n.* DEFINER=[^*]* \*/$}, '') # remove DEFINER= declarations
 end
 
 Rake::Task["db:structure:dump"].enhance do


### PR DESCRIPTION
When running `bin/rake db:structure:dump`, I get two lines of diff in my
`structure.sql` file:
1. Some trailing space is added to a `CREATE VIEW` declaration.
   - This is pretty harmless, but it is annoying to remove each time.
2. A `DEFINER=` line gets added before our `rails_persons` `VIEW`.
   - This one regularly causes pain, as it breaks `bin/rake db:reset`
     for some reason.

This diff changes things so we remove these changes when dumping the
database schema.