### PR TITLE
Add a test to make sure that our database names, English translations, and wca-state names are all in agreement.

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -22,6 +22,27 @@
 en:
   #context: Special country name
   countries:
+    AG: "Antigua and Barbuda"
+    BA: "Bosnia and Herzegovina"
+    CD: "Democratic Republic of the Congo"
+    CG: "Congo"
+    CI: "Côte d'Ivoire"
+    CV: "Cabo Verde"
+    FM: "Federated States of Micronesia"
+    GW: "Guinea Bissau"
+    HK: "Hong Kong"
+    KN: "Saint Kitts and Nevis"
+    KP: "Democratic People’s Republic of Korea"
+    KR: "Republic of Korea"
+    LC: "Saint Lucia"
+    MM: "Myanmar"
+    MO: "Macau"
+    PS: "Palestine"
+    ST: "São Tomé and Príncipe"
+    TT: "Trinidad and Tobago"
+    VA: "Holy See"
+    VC: "Saint Vincent and the Grenadines"
+
     XF: "Multiple Countries (Africa)"
     XM: "Multiple Countries (Americas)"
     XA: "Multiple Countries (Asia)"
@@ -30,9 +51,6 @@ en:
     XO: "Multiple Countries (Oceania)"
     XS: "Multiple Countries (South America)"
     XW: "Multiple Countries (World)"
-    MO: "Macao"
-    HK: "Hong Kong"
-    KR: "Korea"
   #context: Continent name
   continents:
     "Multiple Continents": "Multiple Continents"

--- a/WcaOnRails/spec/i18n_spec.rb
+++ b/WcaOnRails/spec/i18n_spec.rb
@@ -29,4 +29,18 @@ RSpec.describe 'I18n' do
       expect(allowed_values).to include time_format
     end
   end
+
+  it "English country translations, database names, all match the names in wca-states.json" do
+    Country::WCA_STATES["states_lists"].map do |list|
+      list["states"].map do |state|
+        state_id = state["id"] || I18n.transliterate(state["name"]).tr("'", "_")
+        country = Country.c_find(state_id)
+        db_name = country.read_attribute(:name)
+        wca_regs_name = state["name"]
+        i18n_en_name = country.name
+        expect(i18n_en_name).to eq wca_regs_name
+        expect(db_name).to eq wca_regs_name
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes
https://github.com/thewca/worldcubeassociation.org/issues/4389.
While working on this, I noticed that we use both APOSTROPHE and RIGHT
SINGLE QUOTATION MARK in wca-states.md, I filed to
https://github.com/thewca/wca-regulations/issues/774 hopefully make that
consistent.