### PR TITLE
Enforce using overcommit from Gemfile

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -15,6 +15,8 @@
 #
 # Uncomment the following lines to make the configuration take effect.
 
+gemfile: 'WcaOnRails/Gemfile'
+
 PreCommit:
   ALL:
     exclude:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository contains all of the code that runs on [worldcubeassociation.org]
   ```shell
   (cd WcaOnRails; bundle install && bin/yarn && bundle exec overcommit --install)
   ```
+  If some changes are made to this hook, you will have to update it running this command from the repository's root directory: `BUNDLE_GEMFILE=WcaOnRails/Gemfile bundle exec overcommit --sign`.
 
 ## Run directly with Ruby (lightweight, but only runs the Rails portions of the site)
 


### PR DESCRIPTION
Using overcommit from the default environment will lead to using rubocop from the default environment, which can be very different from the one used by the WCA website.
Forcing overcommit to use a Gemfile will make sure that everything runs within the WCA website "gem-environment".