### PR TITLE
Create automated assignment for monthly digest

### DIFF
--- a/WcaOnRails/app/jobs/generate_chore.rb
+++ b/WcaOnRails/app/jobs/generate_chore.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class GenerateChore < SingletonApplicationJob
+  queue_as :default
+
+  def perform
+    # Randomly select a member who has been there for at least a month
+    members = Team.wst.current_members.select { |m| m.start_date < 1.month.ago }
+    ChoreMailer.notify_wst_of_assignee(members.sample.user).deliver_now
+  end
+end

--- a/WcaOnRails/app/mailers/chore_mailer.rb
+++ b/WcaOnRails/app/mailers/chore_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ChoreMailer < ApplicationMailer
+  def notify_wst_of_assignee(assignee)
+    @assignee = assignee
+    start_of_month = Time.now.change(day: 1)
+    end_of_month = start_of_month.change(day: Time.days_in_month(start_of_month.month))
+    @pr_merged_this_month_url = "https://github.com/thewca/worldcubeassociation.org/pulls?utf8=%E2%9C%93&q=is%3Apr%20sort%3Amerged-desc%20merged%3A#{start_of_month.strftime("%F")}..#{end_of_month.strftime("%F")}"
+    mail(
+      to: "software@worldcubeassociation.org",
+      cc: @assignee.email,
+      reply_to: "software@worldcubeassociation.org",
+      subject: "WST monthly digest: #{assignee.name} has been picked",
+    )
+  end
+end

--- a/WcaOnRails/app/views/chore_mailer/notify_wst_of_assignee.html.erb
+++ b/WcaOnRails/app/views/chore_mailer/notify_wst_of_assignee.html.erb
@@ -1,0 +1,37 @@
+Hi WST,
+
+<p>
+  <%= @assignee.name %> has been picked at random to send the next monthly digest on behalf of the WST.
+  <br/>
+  @<%= @assignee.name %>: if for some reason you cannot deal with this task this month, please notify your fellow WST members so that someone can cover for you.
+</p>
+
+<p>
+  The monthly digest should contain a summary of the WST work for the past month.
+  It doesn't need to go into every detail, but should definitely mention important changes.
+  You can definitely group similar changes together, for instance by having only one bullet point for packages and locales updates, since we're having dozens of them every month.
+  If you need some inspiration for writing your email, you can check one of the several monthly digests sent in the past, such as
+  <%= link_to "this one", "https://groups.google.com/a/worldcubeassociation.org/d/msg/staff/vpJiCM1Let0/lEfGVG73CQAJ" %>
+  on the WCA Staff group.
+  <br/>
+  You can find all merged commits for the past month
+  <%= link_to("here on github", @pr_merged_this_month_url) %>
+  (remember there are still a few days left until next month).
+</p>
+
+<p>
+  Here are some additional instructions for sending the email:
+</p>
+<ul>
+  <li>Try to send the digest on the first few days of next month.</li>
+  <li>
+    In your email, be sure to include links to relevant PRs.
+    We want to encourage curiosity from our staff, maybe they'll become software team members someday!
+  </li>
+  <li>Always BCC announcements@, CC staff@, and CC software@ when sending emails.</li>
+</ul>
+
+<p>
+  See you next month,
+  Your friendly bot.
+</p>

--- a/WcaOnRails/lib/tasks/chores.rake
+++ b/WcaOnRails/lib/tasks/chores.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :chores do
+  desc 'Pick a WST member at random to send the monthly digest to WCA Staff.'
+  task generate: :environment do
+    GenerateChore.perform_later
+  end
+end

--- a/chef/site-cookbooks/wca/recipes/cronjobs.rb
+++ b/chef/site-cookbooks/wca/recipes/cronjobs.rb
@@ -84,6 +84,17 @@ unless node.chef_environment.start_with?("development")
     user username
     command "(cd #{repo_root}/WcaOnRails; RACK_ENV=production bin/rake tmp:cache:clear)"
   end
+
+  cron "send WST monthly chore" do
+    minute '0'
+    hour '8'
+    day '23'
+
+    path path
+    mailto admin_email
+    user username
+    command "(cd #{repo_root}/WcaOnRails; RACK_ENV=production bin/rake chores:generate)"
+  end
 end
 
 # Run init-php-results on our first provisioning, but not on subsequent provisions.


### PR DESCRIPTION
The topic of the WST monthly digest popped in a discussion, and to try to restore it and avoid managing the chores manually, I'd suggest to pick a (not-new) member at random at the end of each month.
Also I'm definitely fine with ignoring the given assignment if the random is bad (eg: twice the same person in a row, someone really busy at this period); anyone from the WST could cover for the person picked upon request.

Here is how it looks like:
![mail](https://user-images.githubusercontent.com/1007485/62494388-ad00bd00-b7d3-11e9-8eb8-51d206acc20a.png)

I did *not* test the cron job!
Any idea how to check it's a valid monthly cron job?