### PR TITLE
Pin envied to 0.9.1.

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -17,7 +17,7 @@ gem 'therubyracer'
 
 gem 'sdoc', group: :doc
 gem 'dotenv-rails', require: 'dotenv/rails-now'
-gem 'envied'
+gem 'envied', '0.9.1' # https://github.com/thewca/worldcubeassociation.org/issues/4455
 gem 'seedbank'
 gem 'jquery-rails'
 gem 'jbuilder'


### PR DESCRIPTION
[Envied 0.9.3](https://gitlab.com/envied/envied/blob/master/CHANGELOG.md#093-2019-06-29)
deprecated support for default values for environment variables. See
[What happened to default
values??](https://gitlab.com/envied/envied/tree/master#what-happened-to-default-values)
with an explanation about why. They do still have support for defaults,
but there is now a log message to stderr that shows up when we run our
cron jobs on staging, which causes email noise we don't want.

Unfortunately, we depend on default values in our [non-production
environments](https://github.com/jfly/worldcubeassociation.org/blob/fd5a534f7b118cb192225d911aae4fcd98122969/WcaOnRails/Envfile#L1).
This is useful so people can get WcaOnRails up and running locally
without having to do any configuration. Unfortunately, [Envied's "Best
Practices"](https://gitlab.com/envied/envied/tree/master#best-practices)
suggest including a `.envrc.sample` file and setting up
[direnv](https://direnv.net/), and asking developers to copy the
provided `.envrc.sample` file to `.envrc`  and running `direnv allow`
*just to get started*. We already have enough hassle involved in getting
the website running locally, I really don't want to add more :(

For now, I'm going to pin us to envied 0.9.1 in our Gemfile. Hopefully
dependabot will honor that and not try to upgrade it again.

This is a workaround for https://github.com/thewca/worldcubeassociation.org/issues/4455.