### PR TITLE
Add `--deployment` to our Travis bundler build args.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: false
 language: ruby
-bundler_args: --path $HOME/.bundle
+bundler_args: --deployment --path $HOME/.bundle
 cache:
   directories:
     - $HOME/.phantomjs

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -630,7 +630,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   enum_help
-  envied
+  envied (= 0.9.1)
   factory_bot_rails
   faker
   font-awesome-sass


### PR DESCRIPTION
Add `--deployment` to our Travis bundler build args.

I recently merged up
https://github.com/thewca/worldcubeassociation.org/pull/4456, which
updated our `Gemfile`, but not our `Gemfile.lock`. When trying to deploy
this change, I saw the following error:

> You are trying to install in deployment mode after changing
> your Gemfile. Run `bundle install` elsewhere and add the
> updated Gemfile.lock to version control.
>
> If this is a development machine, remove the
> /home/cubing/worldcubeassociation.org/WcaOnRails/Gemfile freeze
> by running `bundle install --no-deployment`.
>
> The dependencies in your gemfile changed
>
> You have added to the Gemfile:
> * envied (= 0.9.1)
>
> You have deleted from the Gemfile:
> * envied

I think we should run our Travis build with the `--deployment` arg as
well, so in the future if we ever mess this up the build will fail.

(I first verified that this broke the Travis build:
https://travis-ci.org/thewca/worldcubeassociation.org/builds/571136450,
but I have since added in the `Gemfile.lock` change necessary to fix things.)
