### PR TITLE
Increase PHP memory limit.

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -349,7 +349,7 @@ template "#{repo_root}/webroot/results/admin/phpMyAdmin/config.inc.php" do
 end
 
 #### Legacy PHP results system
-PHP_MEMORY_LIMIT = '512M'
+PHP_MEMORY_LIMIT = '768M'
 PHP_IDLE_TIMEOUT_SECONDS = 120
 PHP_POST_MAX_SIZE = '20M'
 PHP_MAX_INPUT_VARS = 5000


### PR DESCRIPTION
We're seeing the following crash when loading
https://www.worldcubeassociation.org/results/misc/sum_of_ranks/:

> Fatal error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 83 bytes) in /home/cubing/worldcubeassociation.org/webroot/results/includes/statistics/sum_of_ranks.php on line 42

We're not going to bother making this legacy php page more efficient, so
let's just increase the memory limit and hopefully things work =)