### PR TITLE
Extended validation for 333mbf groups

### DIFF
--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -6,6 +6,7 @@ module ResultsValidators
     MISSING_SCRAMBLES_FOR_COMPETITION_ERROR = "Missing scrambles for the competition. Use the workbook assistant to add scrambles."
     UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR = "[%{round_id}] Too many scrambles. Use the workbook assistant to uncheck the unused scrambles."
     MISSING_SCRAMBLES_FOR_GROUP_ERROR = "[%{round_id}] Group %{group_id}: missing scrambles, detected only %{actual} instead of %{expected}."
+    MISSING_SCRAMBLES_FOR_MULTI_ERROR = "[%{round_id}] While you may have multiple groups in Multiple Blindfolded, at least one of the groups must contain scrambles for all attempts."
 
     @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
 
@@ -65,16 +66,26 @@ module ResultsValidators
           format = rounds_info_by_ids[round_id].format
           expected_number_of_scrambles = format.expected_solve_count
           scrambles_by_group_id = scrambles_by_round_id[round_id].group_by(&:groupId)
+          errors_for_round = []
           scrambles_by_group_id.each do |group_id, scrambles_for_group|
             # filter out extra scrambles
             actual_number_of_scrambles = scrambles_for_group.reject(&:isExtra).size
             if actual_number_of_scrambles < expected_number_of_scrambles
-              @errors << ValidationError.new(:scrambles, competition_id,
-                                             MISSING_SCRAMBLES_FOR_GROUP_ERROR,
-                                             round_id: round_id, group_id: group_id,
-                                             actual: actual_number_of_scrambles,
-                                             expected: expected_number_of_scrambles)
+              errors_for_round << ValidationError.new(:scrambles, competition_id,
+                                                      MISSING_SCRAMBLES_FOR_GROUP_ERROR,
+                                                      round_id: round_id, group_id: group_id,
+                                                      actual: actual_number_of_scrambles,
+                                                      expected: expected_number_of_scrambles)
             end
+          end
+          if round_id.start_with?("333mbf")
+            unless errors_for_round.size < scrambles_by_group_id.keys.size
+              @errors << ValidationError.new(:scrambles, competition_id,
+                                             MISSING_SCRAMBLES_FOR_MULTI_ERROR,
+                                             round_id: round_id)
+            end
+          else
+            @errors.concat(errors_for_round)
           end
         end
       end


### PR DESCRIPTION
This is a follow up for a case we had very recently, where not all attempts had groups, which fails under our current validation.
While this can be reviewed right away, I've contacted the WRT to know if that's actually something they would want to be merged.
