### PR TITLE
Load all competitions at once in rankings

### DIFF
--- a/WcaOnRails/app/controllers/results_controller.rb
+++ b/WcaOnRails/app/controllers/results_controller.rb
@@ -188,6 +188,11 @@ class ResultsController < ApplicationController
     end
 
     @rows = ActiveRecord::Base.connection.exec_query(query)
+    @competitions_by_id = Hash[
+      Competition.where(id: @rows.map { |r| r["competitionId"] }.uniq).map do |c|
+        [c.id, c]
+      end
+    ]
     compute_rankings_by_region if @is_by_region
   end
 

--- a/WcaOnRails/app/views/results/_rankings_table.html.erb
+++ b/WcaOnRails/app/views/results/_rankings_table.html.erb
@@ -20,7 +20,7 @@
     <% previous_rank = 0 %>
     <% @rows.each_with_index do |row, i| %>
       <% result = LightResult.new(row) %>
-      <% competition = Competition.find(row["competitionId"]) %>
+      <% competition = @competitions_by_id[row["competitionId"]] %>
       <% value = row["value"] %>
       <% rank = value == previous_value ? previous_rank : i+1 %>
       <% tied_previous = rank == previous_rank %>


### PR DESCRIPTION
While getting rid of this n+1 query it's not improving that much for the "100" version of the rankings, it may avoid troubles for the "1000" version of it :p
