### PR TITLE
Add a warning for duplicate championships

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -331,6 +331,21 @@ class Competition < ApplicationRecord
       unless has_any_round_per_event? && schedule_includes_rounds?
         warnings[:schedule] = I18n.t('competitions.messages.schedule_must_match_rounds')
       end
+
+      if championship_warnings.any?
+        warnings = championship_warnings.merge(warnings)
+      end
+    end
+
+    warnings
+  end
+
+  def championship_warnings
+    warnings = {}
+    self.championships.each do |championship|
+      if Championship.joins(:competition).merge(Competition.visible).exists?(championship_type: championship.championship_type, Competitions: { year: self.year })
+        warnings[championship.championship_type] = I18n.t('competitions.messages.championship_exists', championship_type: championship.name, year: self.year)
+      end
     end
 
     warnings

--- a/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
@@ -18,6 +18,9 @@
     This competition is marked as <%= @competition.championships.sort.map(&:name).to_sentence %>.
   </p>
 <% end %>
+<% @competition.championship_warnings.each do |key, warning| %>
+  <h2 class="alert"><%= warning %></h2>
+<% end %>
 
 <% @competition.delegates.map do |delegate| %>
   <% if Team.probation.current_members.map { |member| member.user_id }.include?(delegate.id) %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1067,6 +1067,7 @@ en:
       not_confirmed_not_visible: "This competition is not confirmed and not visible"
       stripe_connected: "You have now successfully connected your Stripe account and can now receive registration payments for this competition."
       stripe_not_connected: "There was a problem and we could not connect your Stripe account."
+      championship_exists: "There is already a %{championship_type} in %{year}"
     #context: on the "My competitions" page
     my_competitions:
       title: "My competitions"

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -269,6 +269,25 @@ RSpec.describe Competition do
       expect(competition).to be_valid
       expect(competition.warnings_for(nil)[:events]).to eq "Please add at least one event before confirming the competition."
     end
+
+    it "does not warn about other different championships" do
+      # Different championship type
+      FactoryBot.create :competition, :confirmed, :visible, starts: Date.new(2019, 5, 6), championship_types: ["_North America"]
+      # Different year
+      FactoryBot.create :competition, :confirmed, :visible, starts: Date.new(2018, 2, 3), championship_types: ["world"]
+
+      competition = FactoryBot.create :competition, starts: Date.new(2019, 10, 1), championship_types: ["world"]
+      expect(competition).to be_valid
+      expect(competition.warnings_for(nil)["world"]).to eq nil
+    end
+
+    it "warns if championship already exists" do
+      FactoryBot.create :competition, :confirmed, :visible, starts: Date.new(2019, 5, 6), championship_types: ["world", "_Oceania"]
+
+      competition = FactoryBot.create :competition, starts: Date.new(2019, 10, 1), championship_types: ["world"]
+      expect(competition).to be_valid
+      expect(competition.championship_warnings["world"]).to eq "There is already a World Championship in 2019"
+    end
   end
 
   context "info_for" do


### PR DESCRIPTION
This PR warns when there is already a championship of the same type in the same year:
![competition_warning](https://user-images.githubusercontent.com/3885929/62988053-e3ac8800-be10-11e9-9efb-9d135c4d15f2.png)

and adds a notification to the WCAT email:
![competition_notification](https://user-images.githubusercontent.com/3885929/62988063-ec04c300-be10-11e9-8a68-95e9cdfa7114.png)

Fixes #3225 