### PR TITLE
Optimise rankings queries

### DIFF
--- a/WcaOnRails/app/controllers/results_controller.rb
+++ b/WcaOnRails/app/controllers/results_controller.rb
@@ -24,7 +24,6 @@ class ResultsController < ApplicationController
 
     event = Event.c_find!(params[:event_id])
     event_condition = "AND eventId = '#{event.id}'"
-    event_condition_without_and = "eventId = '#{event.id}'"
 
     @is_by_region = params[:show] == "by region"
     splitted_show_param = params[:show].split
@@ -33,13 +32,12 @@ class ResultsController < ApplicationController
     @is_results = splitted_show_param[1] == "results"
     limit_condition = "LIMIT #{@show}"
 
-    id_string = @is_results ? ".id" : "Id"
     @continent = Continent.c_find(params[:region])
     @country = Country.c_find(params[:region])
     if @continent.present?
-      region_condition = "AND continentId = '#{@continent.id}'"
+      region_condition = "AND result.countryId IN (#{@continent.country_ids.map { |id| "'#{id}'" }.join(',')})"
     elsif @country.present?
-      region_condition = "AND country#{id_string} = '#{@country.id}'"
+      region_condition = "AND result.countryId = '#{@country.id}'"
     else
       region_condition = ""
     end
@@ -59,128 +57,92 @@ class ResultsController < ApplicationController
 
     if @is_persons
       query = <<-SQL
-        SELECT result.*,
-          result.#{value}       value,
-          competition.cellName  competitionName,
-          country.name          countryName
-        FROM
-          (SELECT MIN(valueAndId) valueAndId
-            FROM Concise#{capitalized_type_param}Results result
-            WHERE #{value} > 0
+        SELECT
+          result.*,
+          result.#{value} value
+        FROM (
+          SELECT MIN(valueAndId) valueAndId
+          FROM Concise#{capitalized_type_param}Results result
+          WHERE 1
             #{event_condition}
+            AND #{value} > 0
             #{years_condition}
             #{region_condition}
-            GROUP BY personId
-            ORDER BY valueAndId
-            #{limit_condition}) top,
-          Results      result,
-          Competitions competition,
-          Countries    country
-        WHERE
-          result.id          = valueAndId % 1000000000
-          AND competition.id = competitionId
-          AND country.id     = result.countryId
-        ORDER BY
-          value, personName
+          GROUP BY personId
+          ORDER BY valueAndId
+          #{limit_condition}
+        ) top
+        JOIN Results result ON result.id = valueAndId % 1000000000
+        ORDER BY value, personName
       SQL
     elsif @is_results
       if @is_average
-        query = <<-SQL
-          SELECT result.*,
-            result.#{value}      value,
-            competition.cellName competitionName,
-            country.name         countryName
-          FROM
-            Results      result,
-            Competitions competition,
-            Countries    country
-          WHERE #{value} > 0
+        subquery = <<-SQL
+          SELECT
+            result.*,
+            average value
+          FROM Results result
+          #{years_condition.present? ? "JOIN Competitions competition on competition.id = competitionId" : ""}
+          WHERE 1
             #{event_condition}
+            AND average > 0
             #{years_condition}
             #{region_condition}
-            AND competition.id = competitionId
-            AND country.id     = result.countryId
           ORDER BY
-            value, best, personName, competitionId, roundTypeId
+            average
           #{limit_condition}
         SQL
+        query = <<-SQL
+          SELECT *
+          FROM (#{subquery}) result
+          ORDER BY average, personName, competitionId, roundTypeId
+        SQL
       else
-        subqueries = []
-        (1..5).each do |i|
-          subqueries[i-1] = <<-SQL
+        subqueries = (1..5).map do |i|
+          <<-SQL
             SELECT
-              value#{i}            value,
-              personId,            personName,
-              country.id           countryId,
-              competitionId,
-              competition.cellName competitionName,
-              roundTypeId
-            FROM
-              Results      result,
-              Competitions competition,
-              Countries    country
-            WHERE value#{i} > 0
+              result.*,
+              value#{i} value
+            FROM Results result
+            #{years_condition.present? ? "JOIN Competitions competition on competition.id = competitionId" : ""}
+            WHERE 1
               #{event_condition}
+              AND value#{i} > 0
               #{years_condition}
               #{region_condition}
-              AND competition.id = competitionId
-              AND country.id     = result.countryId
-            ORDER BY
-              value, personName
+            ORDER BY value
             #{limit_condition}
           SQL
         end
-        subquery = ("(" + subqueries.join(") UNION ALL (") + ")")
-
+        subquery = "(" + subqueries.join(") UNION ALL (") + ")"
         query = <<-SQL
           SELECT *
-          FROM
-            (#{subquery}) result
-          ORDER BY
-            value, personName, competitionId, roundTypeId
+          FROM (#{subquery}) result
+          ORDER BY value, personName, competitionId, roundTypeId
           #{limit_condition}
         SQL
       end
     elsif @is_by_region
       query = <<-SQL
         SELECT
-          result.personId      personId,
-          result.personName    personName,
-          result.eventId       eventId,
-          result.formatId      formatId,
-          result.roundTypeId   roundTypeId,
-          country.id           countryId,
-          country.name         countryName,
-          continent.id         continentId,
-          continent.name       continentName,
-          competition.id       competitionId,
-          competition.cellName competitionName,
-          #{value}             value,
-          event.format         valueFormat,
-          value1, value2, value3, value4, value5
-        FROM
-          (SELECT countryId recordCountryId, MIN(#{value}) recordValue
-            FROM Concise#{capitalized_type_param}Results result
-            WHERE 1
+          result.*,
+          result.#{value} value
+        FROM (
+          SELECT
+            countryId recordCountryId,
+            MIN(#{value}) recordValue
+          FROM Concise#{capitalized_type_param}Results result
+          WHERE 1
             #{event_condition}
             #{years_condition}
-            GROUP BY countryId) record,
-          Results      result,
-          Countries    country,
-          Continents   continent,
-          Competitions competition,
-          Events       event
-        WHERE
-          #{event_condition_without_and}
+          GROUP BY countryId
+        ) record
+        JOIN Results result ON result.#{value} = recordValue AND result.countryId = recordCountryId
+        JOIN Competitions competition on competition.id = competitionId
+        WHERE 1
+          #{event_condition}
           #{years_condition}
-          AND result.#{value}  = recordValue
-          AND result.countryId = recordCountryId
-          AND country.id       = result.countryId
-          AND continent.id     = continentId
-          AND competition.id   = competitionId
-          AND event.id         = eventId
-        ORDER BY
-          value, countryId, year, month, day, personName
+        ORDER BY value, countryId, start_date, personName
       SQL
     else
       flash[:danger] = t(".unknown_show")

--- a/WcaOnRails/db/migrate/20190814232833_add_results_index_on_value_x.rb
+++ b/WcaOnRails/db/migrate/20190814232833_add_results_index_on_value_x.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddResultsIndexOnValueX < ActiveRecord::Migration[5.2]
+  def change
+    add_index :Results, [:eventId, :value1]
+    add_index :Results, [:eventId, :value2]
+    add_index :Results, [:eventId, :value3]
+    add_index :Results, [:eventId, :value4]
+    add_index :Results, [:eventId, :value5]
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -307,7 +307,12 @@ CREATE TABLE `Results` (
   KEY `Results_regionalSingleRecordCheckSpeedup` (`eventId`,`competitionId`,`roundTypeId`,`countryId`,`best`),
   KEY `Results_fk_competitor` (`personId`),
   KEY `index_Results_on_competitionId_and_updated_at` (`competitionId`,`updated_at`),
-  KEY `_tmp_index_Results_on_countryId` (`countryId`)
+  KEY `_tmp_index_Results_on_countryId` (`countryId`),
+  KEY `index_Results_on_eventId_and_value1` (`eventId`,`value1`),
+  KEY `index_Results_on_eventId_and_value2` (`eventId`,`value2`),
+  KEY `index_Results_on_eventId_and_value3` (`eventId`,`value3`),
+  KEY `index_Results_on_eventId_and_value4` (`eventId`,`value4`),
+  KEY `index_Results_on_eventId_and_value5` (`eventId`,`value5`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RoundTypes`;
@@ -1566,4 +1571,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190601231550'),
 ('20190622173635'),
 ('20190716065618'),
-('20190728084145');
+('20190728084145'),
+('20190814232833');


### PR DESCRIPTION
Here go several optimisations to results queries. Most notably *Top 1000 Results* got from ~50s to ~200ms for me locally (on the staging it's 2s, curious to see how production does =)). Hopefully this means no more timeouts ^^
Some changes I did:
- removed `JOIN`s for selecting unnecessary data (like country name, competition name) as we either get it from our cached models or query later (e.g. competitions)
- made some `JOIN`s conditional (specifically we don't join `Competitions` if there is no condition on `year`)
- [Top N Results Single] added `Results` indices for `(eventId, valueX)`
- [Top N Results Average] moved `ORDER`ing into a top-level query, so we sort once there is `LIMIT`ed number of rows
- cleaned up the queries in general

It's currently on the staging if someone wants to play around with that.

*Note: `Concise*Results` could also use some indexing.*