### PR TITLE
Add support for a `countryIso2` to WCIF venues.

### DIFF
--- a/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
+++ b/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
@@ -196,6 +196,7 @@ function addVenueToSchedule(competitionInfo) {
   competitionInfo.scheduleWcif.venues.push({
     id: newVenueId(),
     name: competitionInfo.venue,
+    countryIso2: competitionInfo.countryIso2,
     latitudeMicrodegrees: competitionInfo.lat,
     longitudeMicrodegrees: competitionInfo.lng,
     // There is at least one for all countries, select the first

--- a/WcaOnRails/app/javascript/edit-schedule/EditVenue/VenueLocationInput.jsx.erb
+++ b/WcaOnRails/app/javascript/edit-schedule/EditVenue/VenueLocationInput.jsx.erb
@@ -9,6 +9,5 @@ import React from 'react'
 <% if Rails.env.test? %>
   export const VenueLocationInput = () => (<div/>);
 <% else %>
-  import { VenueLocationInputImpl } from './VenueLocationInputImpl.jsx'
-  export const VenueLocationInput = (props) => (<VenueLocationInputImpl {...props} />);
+  export { VenueLocationInputImpl as VenueLocationInput } from './VenueLocationInputImpl.jsx';
 <% end %>

--- a/WcaOnRails/app/javascript/edit-schedule/EditVenue/index.jsx
+++ b/WcaOnRails/app/javascript/edit-schedule/EditVenue/index.jsx
@@ -9,6 +9,7 @@ import { defaultRoomColor } from './constants.js.erb'
 import { EditRoom } from './EditRoom'
 import { Button, Panel, Row, Col } from 'react-bootstrap'
 import { timezoneData } from 'wca/timezoneData.js.erb'
+import countries from 'wca/countries.js.erb'
 import { VenueLocationInput } from './VenueLocationInput.jsx.erb'
 
 export class EditVenue extends React.Component {
@@ -22,6 +23,11 @@ export class EditVenue extends React.Component {
 
   handleNameChange = e => {
     this.props.venueWcif.name = e.target.value;
+    rootRender();
+  }
+
+  handleCountryChange = e => {
+    this.props.venueWcif.countryIso2 = e.target.value;
     rootRender();
   }
 
@@ -85,6 +91,7 @@ export class EditVenue extends React.Component {
                 lng={venueWcif.longitudeMicrodegrees}
                 actionHandler={this.handlePositionChange}
               />
+              <CountryInput value={venueWcif.countryIso2} onChange={this.handleCountryChange} />
               <TimezoneInput
                 timezone={venueWcif.timezone}
                 selectKeys={selectKeys}
@@ -106,6 +113,27 @@ const NameInput = ({name, actionHandler}) => (
     </Col>
     <Col xs={9}>
       <input type="text" className="venue-name-input form-control" value={name} onChange={e => actionHandler(e, "name")} />
+    </Col>
+  </Row>
+);
+
+const CountryInput = ({value, onChange}) => (
+  <Row>
+    <Col xs={3}>
+      <span className="venue-form-label control-label">Country:</span>
+    </Col>
+    <Col xs={9}>
+      <select
+        className="form-control"
+        value={value}
+        onChange={onChange}
+      >
+        {countries.map(country => (
+          <option key={country.iso2} value={country.iso2}>
+            {country.name}
+          </option>
+        ))}
+      </select>
     </Col>
   </Row>
 );

--- a/WcaOnRails/app/javascript/wca/countries.js.erb
+++ b/WcaOnRails/app/javascript/wca/countries.js.erb
@@ -1,0 +1,1 @@
+export default <%= Country::ALL_STATES.to_json.html_safe %>;

--- a/WcaOnRails/app/models/competition_venue.rb
+++ b/WcaOnRails/app/models/competition_venue.rb
@@ -46,6 +46,7 @@ class CompetitionVenue < ApplicationRecord
       "name" => name,
       "latitudeMicrodegrees" => latitude_microdegrees,
       "longitudeMicrodegrees" => longitude_microdegrees,
+      "countryIso2" => country_iso2,
       "timezone" => timezone_id,
       "rooms" => venue_rooms.map(&:to_wcif),
       "extensions" => wcif_extensions.map(&:to_wcif),
@@ -60,11 +61,12 @@ class CompetitionVenue < ApplicationRecord
         "name" => { "type" => "string" },
         "latitudeMicrodegrees" => { "type" => "integer" },
         "longitudeMicrodegrees" => { "type" => "integer" },
+        "countryIso2" => { "type" => "string" },
         "timezone" => { "type" => "string", "enum" => VALID_TIMEZONES },
         "rooms" => { "type" => "array", "items" => VenueRoom.wcif_json_schema },
         "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
-      "required" => ["id", "name", "latitudeMicrodegrees", "longitudeMicrodegrees", "timezone", "rooms"],
+      "required" => ["id", "name", "latitudeMicrodegrees", "countryIso2", "longitudeMicrodegrees", "timezone", "rooms"],
     }
   end
 
@@ -72,6 +74,7 @@ class CompetitionVenue < ApplicationRecord
     {
       wcif_id: wcif["id"],
       name: wcif["name"],
+      country_iso2: wcif["countryIso2"],
       latitude_microdegrees: wcif["latitudeMicrodegrees"],
       longitude_microdegrees: wcif["longitudeMicrodegrees"],
       timezone_id: wcif["timezone"],

--- a/WcaOnRails/app/views/competitions/edit_schedule.html.erb
+++ b/WcaOnRails/app/views/competitions/edit_schedule.html.erb
@@ -2,7 +2,19 @@
 <%= javascript_pack_tag 'edit_schedule' %>
 
 <%= render layout: 'nav' do %>
-  <% if @competition.has_defined_dates? %>
+  <% if !@competition.has_defined_dates? %>
+    <div class="alert alert-danger">
+      There is no start and/or end date assigned to this competition yet.
+      Before you can manage your schedule, you have to add them
+      <%= link_to "here", edit_competition_path(@competition, anchor: "competition_start_date")%>.
+    </div>
+  <% elsif @competition.country.blank? %>
+    <div class="alert alert-danger">
+      There is no country assigned to this competition yet.
+      Before you can manage your schedule, you have to add one
+      <%= link_to "here", edit_competition_path(@competition, anchor: "competition_countryId")%>.
+    </div>
+  <% else %>
     <div id="edit-schedule-area"></div>
     <script>
       $(function() {
@@ -10,6 +22,7 @@
           id: <%= @competition.id.to_json.html_safe %>,
           venue: <%= @competition.venue.to_json.html_safe %>,
           venueDetails: <%= @competition.venueDetails.to_json.html_safe %>,
+          countryIso2: <%= @competition.country.iso2.to_json.html_safe %>,
           lat: <%= @competition.latitude.to_json.html_safe %>,
           lng: <%= @competition.longitude.to_json.html_safe %>,
           countryZones: <%= @competition.country_zones.to_json.html_safe %>,
@@ -22,11 +35,5 @@
         );
       });
     </script>
-  <% else %>
-    <div class="alert alert-danger">
-      There is no start and/or end date assigned to this competition yet.
-      Before you can manage your schedule, you have to add them by clicking
-      <%=link_to "here", edit_competition_path(@competition, anchor: "competition_start_date")%>.
-    </div>
   <% end %>
 <% end %>

--- a/WcaOnRails/db/migrate/20190817170648_add_country_iso2_to_venue.rb
+++ b/WcaOnRails/db/migrate/20190817170648_add_country_iso2_to_venue.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddCountryIso2ToVenue < ActiveRecord::Migration[5.2]
+  def change
+    add_column :competition_venues, :country_iso2, :string, null: false, default: nil
+
+    reversible do |dir|
+      dir.up do
+        # Backfill the country for all venues. Jeremy manually checked all
+        # competitions with multiple venues (there aren't that many), and
+        # confirmed that they all happened in a single country:
+        #  SELECT c.id FROM Competitions c JOIN competition_venues cv ON cv.competition_id = c.id GROUP BY c.id HAVING COUNT(*) > 1
+        execute "UPDATE competition_venues JOIN Competitions JOIN Countries ON Countries.id=Competitions.countryId SET competition_venues.country_iso2 = Countries.iso2;"
+      end
+      dir.down do
+      end
+    end
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -743,6 +743,7 @@ CREATE TABLE `competition_venues` (
   `timezone_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
+  `country_iso2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_venues_on_competition_id_and_wcif_id` (`competition_id`,`wcif_id`),
   KEY `index_competition_venues_on_competition_id` (`competition_id`)
@@ -1576,4 +1577,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190728084145'),
 ('20190814232833'),
 ('20190816001639'),
-('20190816004605');
+('20190816004605'),
+('20190817170648');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -380,6 +380,7 @@ module DatabaseDumper
           competition_id
           wcif_id
           name
+          country_iso2
           latitude_microdegrees
           longitude_microdegrees
           timezone_id

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -149,6 +149,7 @@ FactoryBot.define do
           venue_attributes = {
             name: "Venue #{i+1}",
             wcif_id: i+1,
+            country_iso2: competition.country.iso2,
             latitude_microdegrees: 123_456,
             longitude_microdegrees: 123_456,
             timezone_id: "Europe/Paris",

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe "Competition WCIF" do
               "name" => "Venue 1",
               "latitudeMicrodegrees" => 123_456,
               "longitudeMicrodegrees" => 123_456,
+              "countryIso2" => "US",
               "timezone" => "Europe/Paris",
               "extensions" => [],
               "rooms" => [
@@ -213,6 +214,7 @@ RSpec.describe "Competition WCIF" do
               "name" => "Venue 2",
               "latitudeMicrodegrees" => 123_456,
               "longitudeMicrodegrees" => 123_456,
+              "countryIso2" => "US",
               "timezone" => "Europe/Paris",
               "extensions" => [],
               "rooms" => [
@@ -609,6 +611,7 @@ RSpec.describe "Competition WCIF" do
         schedule_wcif["venues"] << {
           "id" => 44,
           "name" => "My new venue",
+          "countryIso2" => "GB",
           "latitudeMicrodegrees" => 123,
           "longitudeMicrodegrees" => 456,
           "timezone" => "Europe/London",
@@ -620,6 +623,7 @@ RSpec.describe "Competition WCIF" do
         competition.reload
         venue = competition.competition_venues.find_by(wcif_id: 44)
         expect(venue.name).to eq "My new venue"
+        expect(venue.country_iso2).to eq "GB"
         expect(venue.latitude_microdegrees).to eq 123
         expect(venue.longitude_microdegrees).to eq 456
         expect(venue.timezone_id).to eq "Europe/London"

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -268,6 +268,7 @@ RSpec.describe "API Competitions" do
             # keep the WCIF id to update the venue
             id: 2,
             name: "new name",
+            countryIso2: "FR",
             latitudeMicrodegrees: 0,
             longitudeMicrodegrees: 0,
             timezone: "Europe/Paris",
@@ -286,6 +287,7 @@ RSpec.describe "API Competitions" do
           }
           wcif["schedule"]["venues"][1] = new_venue_attributes
           patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
+          expect(response).to be_successful
           # We expect these objects to change!
           expect(venue.reload.name).to eq "new name"
           expect(room.reload.name).to eq "my new third room"


### PR DESCRIPTION
I've suggested a corresponding change to the WCIF `Venue` definition: https://docs.google.com/document/d/1lE70gW2rA2J2WlXeSl6N2mLnJ52ibTP_VsIwrAVdl2I/edit#heading=h.u7ocsusv3huw

WCA Live needs this information in order to show pretty flags for
competitions =)

This was pretty straightforward: I added a new database column on
`competition_venues` and updated our react based schedule editor to
allow picking a country for each venue.

![image](https://user-images.githubusercontent.com/277474/63216017-ac292e80-c0e3-11e9-80db-978232e5ad82.png)
