### PR TITLE
Store best and average in WCIF#Result

### DIFF
--- a/WcaOnRails/lib/round_results.rb
+++ b/WcaOnRails/lib/round_results.rb
@@ -16,19 +16,29 @@ end
 class RoundResult
   include ActiveModel::Validations
 
-  attr_accessor :person_id, :ranking, :attempts
+  attr_accessor :person_id, :ranking, :attempts, :best, :average
   validates :person_id, numericality: { only_integer: true }
   validates :ranking, numericality: { only_integer: true }, allow_nil: true
   validates :attempts, length: { maximum: 5, message: "must have at most 5 attempts" }
+  validates :best, numericality: { only_integer: true }
+  validates :average, numericality: { only_integer: true }
 
-  def initialize(person_id: nil, ranking: nil, attempts: nil)
+  def initialize(person_id: nil, ranking: nil, attempts: nil, best: nil, average: nil)
     self.person_id = person_id
     self.ranking = ranking
     self.attempts = attempts
+    self.best = best
+    self.average = average
   end
 
   def to_wcif
-    { "personId" => self.person_id, "ranking" => self.ranking, "attempts" => self.attempts.map(&:to_wcif) }
+    {
+      "personId" => self.person_id,
+      "ranking" => self.ranking,
+      "attempts" => self.attempts.map(&:to_wcif),
+      "best" => self.best,
+      "average" => self.average,
+    }
   end
 
   def ==(other)
@@ -40,7 +50,13 @@ class RoundResult
   end
 
   def self.load(json_obj)
-    self.new(person_id: json_obj['personId'], ranking: json_obj['ranking'], attempts: json_obj['attempts'].map(&Attempt.method(:load)))
+    self.new(
+      person_id: json_obj['personId'],
+      ranking: json_obj['ranking'],
+      attempts: json_obj['attempts'].map(&Attempt.method(:load)),
+      best: json_obj['best'],
+      average: json_obj['average'],
+    )
   end
 
   def self.wcif_json_schema
@@ -50,6 +66,8 @@ class RoundResult
         "personId" => { "type" => "integer" },
         "ranking" => { "type" => ["integer", "null"] },
         "attempts" => { "type" => "array", "items" => Attempt.wcif_json_schema },
+        "best" => { "type" => "integer" },
+        "average" => { "type" => "integer" },
       },
     }
   end

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -385,11 +385,15 @@ RSpec.describe "Competition WCIF" do
           "personId" => 1,
           "ranking" => 10,
           "attempts" => [{ "result" => 456, "reconstruction" => nil }] * 5,
+          "best" => 456,
+          "average" => 456,
         },
         {
           "personId" => 2,
           "ranking" => 5,
           "attempts" => [{ "result" => 784, "reconstruction" => nil }] * 5,
+          "best" => 784,
+          "average" => 784,
         },
       ]
 

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -391,6 +391,8 @@ RSpec.describe "API Competitions" do
               personId: 1,
               ranking: 10,
               attempts: [{ result: 456 }, { result: 745 }, { result: 657 }, { result: 465 }, { result: 835 }],
+              best: 456,
+              average: 622,
             },
           ]
           patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: { "CONTENT_TYPE" => "application/json" }


### PR DESCRIPTION
Quoting @jfly from mailing thread:

> I think it does make sense to include best/average/mean in the WCIF. The WCA website definitely shouldn't blindly trust it, but it does feel good to me for the WCA website to look at it and compare it to what it should be, and to complain if it's different. I think this is the only way we'll catch bugs/ensure consistency in upstream tools like cubecomps/wca live/whatever

Currently I didn't add the actual best/average validations, as we don't have direct access to `Round` from `RoundResult` and thus don't even know what event to compute average for. We plan on changing the way we store round results to have an actual table like `Results` and `InboxResults` instead of a serialized array. This will make it possible to apply all the result validators to WCIF results and also upload results from that table directly in the future.