### PR TITLE
Regulations: update translation page layout.

### DIFF
--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -3,86 +3,124 @@
 <div class="container">
   <h1>WCA Regulations and Guidelines: Translations</h1>
 
-  <h2>Available Translations</h2>
-  <p>Note: Even though these translations are provided on the WCA website, they are not official versions: they may be useful to you, but they do not come with any guarantees. If there is a difference between a translation and the (current official) English version, the English version must be used.</p>
-  <ul>
-    <li><%= link_to "Belarusian - 2014", "./belarusian/" %>
-    <ul>
-      <li>By <%= link_to "Anatolii Kalinin", person_path("2011KALI01") %> and <%= link_to "Ilya Tereshko", person_path("2012TERE01") %>.</li>
-    </ul></li>
-    <li><%= link_to "Chinese - 2017-06-19", "./chinese/" %>
-    <ul>
-      <li>By <%= link_to "Shuang Chen", person_path("2008CHEN27") %>.</li>
-    </ul></li>
-    <li><%= link_to "Chinese, Traditional - 2018-01-01", "./chinese-traditional/" %>
-    <ul>
-      <li>By <%= link_to "Rui-Jun Liu (劉睿鈞)", person_path("2011LIUR02") %> and <%= link_to "Chia-Leo Lin (林珈樂)", person_path("2006LINC01") %>. (Previous contributions from <%= link_to "David Guo", person_path("2008GUOJ01") %> and <%= link_to "Han Wu", person_path("2008WUHA01") %>.)</li>
-    </ul></li>
-    <li><%= link_to "Croatian (Hrvatski) - 2016-04-18", "./croatian/" %>
-    <ul>
-      <li>By <%= link_to "David Vujasić", person_path("2015VUJA01") %>.</li>
-    </ul></li>
-    <li><%= link_to "Dutch (Nederlands) - 2018-01-01", "./dutch/" %>
-    <ul>
-      <li>By <%= link_to "Hans Bennis", person_path("2018BENN01") %>, <%= link_to "Ron van Bruchem", person_path("2003BRUC01") %>, <%= link_to "Olivier Vos", person_path("2016VOSO01") %>, Sandra de Geeter.</li>
-    </ul></li>
-    <li><%= link_to "Finnish (Suomi) - 2018-01-01", "./finnish/" %>
-    <ul>
-      <li>By <%= link_to "Niko Ronkainen", person_path("2010RONK01") %>, <%= link_to "Kim Jokinen", person_path("2013JOKI01") %>, and <%= link_to "Timo Norrkniivilä", person_path("2017NORR01") %>.</li>
-    </ul></li>
-    <li><%= link_to "French (Français) - 2018-01-01", "./french/" %>
-    <ul>
-      <li>By <%= link_to "Philippe Virouleau", person_path("2008VIRO01") %> and <%= link_to "Jules Desjardin", person_path("2010DESJ01") %>.</li>
-    </ul></li>
-    <li><%= link_to "German (Deutsch) - 2018-01-01", "./german/" %>
-    <ul>
-      <li>By <%= link_to "Sébastien Auroux", person_path("2008AURO01") %>, <%= link_to "Laura Ohrndorf", person_path("2009OHRN01") %>, and <%= link_to "Gregor Billing", person_path("2012BILL01") %>.</li>
-    </ul></li>
-    <li><%= link_to "Hungarian (magyar) - 2016-04-18", "./hungarian/" %>
-    <ul>
-      <li>By <%= link_to "Niki Placskó", person_path("2008PLAC01") %> and <%= link_to "Perge Olivér", person_path("2007PERG01") %>.</li>
-    </ul></li>
-    <li><%= link_to "Korean - 2016-04-18", "./korean/" %>
-    <ul>
-      <li><%= link_to "Doo Hyun Kwon (권두현)", person_path("2011KWON01") %>, Joonwon Jeong (정준원), Sangoh Kwon (권상오), Jongho Go (고종호), Hyun-june Jang (장현준), Seongwoo Park (박성우), Donghun Kang (강동훈), Kangmin Lee (이강민), Suyoung Park (박수영)</li>
-    </ul></li>
-    <li><%= link_to "Indonesian (Bahasa) - 2018-01-01", "./indonesian/" %>
-    <ul>
-      <li>By <%= link_to "Hafizh Dary Faridhan Hudoyo", person_path("2015HUDO01") %>. (Previous contributions from Ardianto Satriawan, Cendy Cahyo Rahmat, Jonathan Irvin Gunawan, Muhammad Jihan Khalilurrahman, Nathan Azaria, Stephen Adhisaputra, Vincent Hartanto Utomo, and Yohanes Theda.)</li>
-    </ul></li>
-    <li><%= link_to "Italian (Italiano) - 2018-01-01", "./italian/" %>
-    <ul>
-      <li>By <%= link_to "Matteo Colombo", person_path("2009COLO03") %>, <%= link_to "Antonio Barba", person_path("2015BARB05") %>, <%= link_to "Damiano Di Paola", person_path("2016PAOL01") %>, <%= link_to "Nicola Barbaro", person_path("2011BARB03") %>, and <%= link_to "Tommaso Raposio", person_path("2014RAPO01") %>.</li>
-    </ul></li>
-    <li><%= link_to "Japanese - 2018-01-01", "./japanese/" %>
-    <ul>
-      <li>By <%= link_to "Kotaro Terada (寺田晃太朗)", person_path("2010TERA01") %>, <%= link_to "Yuichi Hamada (濵田祐一)", person_path("2012HAMA02") %>, <%= link_to "Masayuki Hirai (平井雅之)", person_path("2014HIRA05") %>, and <%= link_to "Yuki Tanaka (田中悠樹)", person_path("2010TANA02") %>. (Previous contributions from <%= link_to "Akihiro Ishida (石田朗大)", person_path("2009ISHI01") %>, <%= link_to "Ayano Maria Yoshida (吉田彩乃)", person_path("2009YOSH01") %>, <%= link_to "Kentaro Nishi (西賢太郎)", person_path("2006NISH01") %>, <%= link_to "Sinpei Araki (荒木慎平)", person_path("2006ARAK01") %>, <%= link_to "Shiori Sato (佐藤詩織)", person_path("2013SATO01") %>, <%= link_to "Shun Sakurai (櫻井駿)", person_path("2010SAKU01") %>, <%= link_to "Shuto Ueno (上野柊斗)", person_path("2008UENO01") %>, <%= link_to "Takafumi Haseda (長谷田貴史)", person_path("2006HASE01") %>, <%= link_to "Takeshi Akuzawa (阿久沢剛史)", person_path("2005AKUZ01") %>, <%= link_to "Toru Omura (大村徹)", person_path("2008OMUR01") %>, <%= link_to "Wataru Hashimura (端村航)", person_path("2008HASH02") %>, <%= link_to "Yohei Oka (岡要平)", person_path("2006OKAY01") %>, and <%= link_to "Yohei Suzuki (鈴木洋平)", person_path("2006SUZU03") %>.)</li>
-    </ul></li>
-    <li><%= link_to "Portuguese, Brazilian (Português do Brasil) - 2018-01-01", "./portuguese-brazilian/" %>
-    <ul>
-      <li>By <%= link_to "João Gabriel de Aguiar Milani", person_path("2011MILA02") %>, <%= link_to "Marlon de Vasconcelos Marques", person_path("2014MARQ02") %>, and <%= link_to "Pedro Santos Guimarães", person_path("2007GUIM01") %>.</li>
-    </ul></li>
-    <li><%= link_to "Portuguese, European (Português Europeu) - 2015-07-01", "./portuguese-european/" %>
-    <ul>
-      <li>By António Gomes.</li>
-    </ul></li>
-    <li><%= link_to "Russian - 2018-01-01", "./russian/" %>
-    <ul>
-      <li>By <%= link_to "Anton Rostovikov", person_path("2009ROST01") %>, <%= link_to "Oleg Gritsenko", person_path("2011GRIT01") %>, and <%= link_to "Nikolay Masson", person_path("2011MASS01") %> (with the help of <%= link_to "Oksana Ruzaeva", person_path("2010RUZA01") %>, <%= link_to "Anton Goryachikh", person_path("2009GORY01") %> and <%= link_to "Dmitry Aniskin", person_path("2011ANIS01") %>).</li>
-    </ul></li>
-    <li><%= link_to "Spanish, American (Español Americano) - 2015-07-01", "./spanish-american/" %>
-    <ul>
-      <li>By Daniela Maldonado Hernández.</li>
-    </ul></li>
-    <li><%= link_to "Spanish, European (Español de España) - 2015-07-01", "./spanish-european/" %>
-    <ul>
-      <li>By <%= link_to "Luis J. Iáñez", person_path("2009PARE02") %>, <%= link_to "Carlos Méndez García-Barroso", person_path("2010GARC02") %>, <%= link_to "Raúl Morales", person_path("2013MORA02") %>, and <%= link_to "Federico Sánchez Motellón", person_path("2009SANC01") %>.</li>
-    </ul></li>
-    <li><%= link_to "Vietnamese - 2018-01-01", "./vietnamese/" %>
-    <ul>
-      <li>By <%= link_to "Trung Vương Thiện", person_path("2014TRUN01") %>.</li>
-    </ul></li>
-  </ul>
+  <p>If you speak a language other than English, you may find these translations useful.</p>
+  <p>Please note that translations do not have any official status, even though they are provided on the WCA website: they do not come with any guarantees. If there is a difference between a translation and the (current official) English version, the English version must be used.</p>
+
+  <style>
+    table {
+      border-collapse: collapse;
+    }
+    table thead {
+      font-weight: bold;
+    }
+    table td {
+      padding: 0.25em 0.5em;
+      vertical-align: top;
+    }
+    tbody {
+      border-top: 1px solid #0004;
+    }
+  </style>
+  <h3>Current Translations</h3>
+  <table>
+    <thead><tr><td colspan=2>Version</td><td>Language</td></tr></thead>
+    <tbody>
+      <tr><td rowspan=3>2019-05-01</td></tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/chinese/">TODO: 中文</a></td>
+        <td>(Chinese)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/japanese/">TODO: 日本人</a></td>
+        <td>(Japanese)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Older Translations</h3>
+  <table>
+    <thead><tr><td>Version</td><td colspan=2>Language</td></tr></thead>
+    <tbody>
+      <tr><td rowspan=11>2018-01-01</td></tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/chinese-traditional/">TODO</a></td>
+        <td>(Chinese, Traditional)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/dutch/">Nederlands</a></td>
+        <td>(Dutch)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/finnish/">Suomi</a></td>
+        <td>(Finnish)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/french/">Français</a></td>
+        <td>(French)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/german/">Deutsch</a></td>
+        <td>(German)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/indonesian/">Bahasa</a></td>
+        <td>(Indonesian)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/italian/">Italiano</a></td>
+        <td>(Italian)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/portuguese-brazilian/">Português do Brasil</a></td>
+        <td>(Portuguese, Brazil)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/russian/">TODO</a></td>
+        <td>(Russian)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/vietnamese/">TODO</a></td>
+        <td>(Vietnamese)</a></td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr><td rowspan=4>2016-04-18</td></tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/croatian/">Hrvatski</a></td>
+        <td>(Croatian)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/hungarian/">Magyar</a></td>
+        <td>(Hungarian)</a></td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/korean/">TODO</a></td>
+        <td>(Korean)</a></td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr><td rowspan=4>2015-07-01</td></tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/portuguese-european/">Português Europeu</a></td>
+        <td>(Portuguese, European)</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/spanish-american/">Español Americano</a></td>
+        <td>(Spanish, American)</</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/spanish-european/">Español de España</a></td>
+        <td>(Spanish, European)</</td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr><td rowspan=2>2014-01-01</td></tr>
+      <tr>
+        <td><a href="https://www.worldcubeassociation.org/regulations/translations/belarusian/">Беларуская мова</a></td>
+        <td>(Belarusian)</a></td>
+      </tr>
+    </tbody>
+  </table>
   <h2>Translating the Regulations</h2>
   <p>If you're interested in adding/updating a translation, please view <%= link_to "the instructions on the GitHub repository for translations", "https://github.com/thewca/wca-regulations-translations#translation-instructions" %>.</p>
 </div>


### PR DESCRIPTION
There are two big TODOs here:

1. Where should the page-specific style go? There's not a problem with inlining it per se, but it's probably not best practice.
2. We need to get the translations of the names of languages.

<img width="811" alt="Screen Shot 2019-08-17 at 13 19 54" src="https://user-images.githubusercontent.com/248078/63216964-c0c0f300-c0f2-11e9-9ed3-1044cb7cdbf3.png">
