### PR TITLE
Force the user to pick a timezone.

### DIFF
--- a/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
+++ b/WcaOnRails/app/javascript/edit-schedule/EditSchedule.jsx
@@ -199,8 +199,7 @@ function addVenueToSchedule(competitionInfo) {
     countryIso2: competitionInfo.countryIso2,
     latitudeMicrodegrees: competitionInfo.lat,
     longitudeMicrodegrees: competitionInfo.lng,
-    // There is at least one for all countries, select the first
-    timezone: Object.values(competitionInfo.countryZones)[0],
+    timezone: null,
     rooms: [],
   });
 }

--- a/WcaOnRails/app/javascript/edit-schedule/EditVenue/index.jsx
+++ b/WcaOnRails/app/javascript/edit-schedule/EditVenue/index.jsx
@@ -145,10 +145,11 @@ const TimezoneInput = ({timezone, selectKeys, actionHandler}) => (
     </Col>
     <Col xs={9}>
       <select
-        className="form-control"
+        className="venue-timezone-input form-control"
         value={timezone}
         onChange={e => actionHandler(e, "timezone")}
         >
+        <option value=""></option>
         {selectKeys.map(key => {
           return (
             <option key={key} value={timezoneData[key] || key}>{key}</option>

--- a/WcaOnRails/spec/features/competition_manage_schedule_spec.rb
+++ b/WcaOnRails/spec/features/competition_manage_schedule_spec.rb
@@ -21,6 +21,9 @@ RSpec.feature "Competition events management" do
       fill_in with: "Venue", class: "venue-name-input"
       click_on "Add room"
       fill_in with: "Youpitralala", class: "room-name-input"
+      within('.venue-timezone-input') do
+        select "Pacific Time (US & Canada)"
+      end
       save
       expect(competition.competition_venues.map(&:name)).to match_array %w(Venue)
       expect(competition.competition_venues.flat_map(&:venue_rooms).map(&:name)).to match_array %w(Youpitralala)


### PR DESCRIPTION
Right now, we pick a default for them, which is probably fine in
countries with one timezone, but does *not* work well for countries with
multiple timezones. See
https://github.com/thewca/worldcubeassociation.org/issues/4487 for more
information.

Here's what happens if the user tries to save without picking a timezone. It's not pretty, but it works.
![2019-08-18_12-03-45_dalinar](https://user-images.githubusercontent.com/277474/63229004-4a82c600-c1b0-11e9-8e53-c0dad7d459fb.gif)
