### PR TITLE
Add support for bookmarking competitions.

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -56,6 +56,14 @@ $competition-nav-padding: 50px;
       border-bottom: 4px solid #ccc;
     }
   }
+
+  .bookmark-icon {
+    cursor: pointer;
+  }
+
+  #not-bookmarked {
+    color: #bbbbbb;
+  }
 }
 
 // Workaround for https://github.com/cubing/icons/issues/16

--- a/WcaOnRails/app/jobs/registration_reminder_job.rb
+++ b/WcaOnRails/app/jobs/registration_reminder_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RegistrationReminderJob < SingletonApplicationJob
+  queue_as :default
+
+  def should_send_reminder(competition)
+    # We send a reminder if we haven't sent a reminder before, or if we sent one more than 2 days ago (i.e. if there is a second registration period).
+    competition.registration_reminder_sent_at.nil? || competition.registration_reminder_sent_at < 2.days.ago
+  end
+
+  def perform
+    Competition
+      .visible
+      .where("registration_open <= ? AND registration_open >= NOW()", 1.day.from_now)
+      .includes(bookmarked_competitions: [:user])
+      .select { |c| should_send_reminder(c) }.each do |competition|
+        ActiveRecord::Base.transaction do
+          competition.update_attribute(:registration_reminder_sent_at, Time.now)
+          users_to_email = competition.bookmarked_users
+          users_to_email.concat(competition.managers)
+          registered_users = competition.registrations.accepted.pluck(:user_id)
+          pending_registered_users = competition.registrations.pending.pluck(:user_id)
+          users_to_email.select { |user| !registered_users.include?(user.id) }.uniq.each do |user|
+            CompetitionsMailer.registration_reminder(competition, user, pending_registered_users.include?(user.id)).deliver_later
+          end
+        end
+      end
+  end
+end

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -141,6 +141,16 @@ class CompetitionsMailer < ApplicationMailer
     @competition.uploaded_jsons.delete_all
   end
 
+  def registration_reminder(competition, user, registered_but_not_accepted)
+    @competition = competition
+    @user = user
+    @registered_but_not_accepted = registered_but_not_accepted
+    localized_mail @user.locale,
+                   -> { I18n.t('users.mailer.registration_reminder_email.header', competition: competition.name) },
+                   to: user.email,
+                   reply_to: competition.organizers.pluck(:email)
+  end
+
   private def delegates_to_senior_delegates_email(delegates)
     delegates.map { |delegate| delegate.senior_delegate&.email }.uniq.compact
   end

--- a/WcaOnRails/app/models/bookmarked_competition.rb
+++ b/WcaOnRails/app/models/bookmarked_competition.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BookmarkedCompetition < ApplicationRecord
+  belongs_to :competition
+  validates_presence_of :competition
+
+  belongs_to :user
+  validates_presence_of :user
+end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -25,6 +25,8 @@ class Competition < ApplicationRecord
   has_one :continent, foreign_key: :continentId, through: :country
   has_many :championships, dependent: :delete_all
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
+  has_many :bookmarked_competitions, dependent: :delete_all
+  has_many :bookmarked_users, through: :bookmarked_competitions, source: :user
 
   accepts_nested_attributes_for :competition_events, allow_destroy: true
   accepts_nested_attributes_for :championships, allow_destroy: true
@@ -117,6 +119,7 @@ class Competition < ApplicationRecord
     results_posted_at
     results_submitted_at
     results_nag_sent_at
+    registration_reminder_sent_at
     announced_at
     created_at
     updated_at
@@ -392,7 +395,9 @@ class Competition < ApplicationRecord
              'championships',
              'rounds',
              'uploaded_jsons',
-             'wcif_extensions'
+             'wcif_extensions',
+             'bookmarked_competitions',
+             'bookmarked_users'
           # Do nothing as they shouldn't be cloned.
         when 'organizers'
           clone.organizers = organizers

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -21,6 +21,8 @@ class User < ApplicationRecord
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
   has_many :user_preferred_events, dependent: :destroy
   has_many :preferred_events, through: :user_preferred_events, source: :event
+  has_many :bookmarked_competitions, dependent: :destroy
+  has_many :competitions_bookmarked, through: :bookmarked_competitions, source: :competition
 
   scope :confirmed_email, -> { where.not(confirmed_at: nil) }
 
@@ -831,6 +833,10 @@ class User < ApplicationRecord
     if !wca_id && !unconfirmed_wca_id
       CompetitionsMailer.notify_users_of_id_claim_possibility(self, competition).deliver_later
     end
+  end
+
+  def is_bookmarked?(competition)
+    BookmarkedCompetition.where(competition: competition, user: self).present?
   end
 
   def self.find_first_by_auth_conditions(warden_conditions)

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -59,6 +59,15 @@
   </div>
 
   <div class="col-md-6">
+    <% unless competition.results_posted? %>
+      <dl class="dl-horizontal">
+        <dt><%= t '.number_of_bookmarks' %></dt>
+        <dd>
+          <%= competition.bookmarked_users.length %>
+        </dd>
+      </dl>
+    <% end %>
+
     <dl class="dl-horizontal">
       <dt><%= t '.information' %></dt>
       <dd><%=md competition.information %></dd>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -1,8 +1,11 @@
 <% show_delegates ||= false %>
+<% bookmarked ||= false %>
 <% registrations_by_competition_id ||= {} %>
 <% if competitions.length < 1 %>
   <%= alert :info do %>
-    <% if !past %>
+    <% if bookmarked %>
+      <%= t '.no_bookmarked_competitions' %>
+    <% elsif !past %>
       <%= t '.no_upcoming_competitions_html', link: link_to(t('.competitions_list'), competitions_path) %>
     <% else %>
       <%= t '.no_past_competitions' %>

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -211,6 +211,14 @@
     </div>
     <div id="competition-data">
       <h3>
+        <% if current_user %>
+          <span class="bookmark-icon" id="not-bookmarked" data-toggle="tooltip" data-placement="bottom" title="<%= I18n.t('competitions.competition_info.bookmark') %>" <% if current_user.is_bookmarked?(@competition) %>style="display: none;"<% end %>>
+            <%= icon('far', 'bookmark') %>
+          </span>
+          <span class="bookmark-icon" id="bookmarked" data-toggle="tooltip" data-placement="bottom" title="<%= I18n.t('competitions.competition_info.is_bookmarked') %>" <% if !current_user.is_bookmarked?(@competition) %>style="display: none;"<% end %>>
+            <%= icon('fa', 'bookmark') %>
+          </span>
+        <% end %>
         <% if @competition.championships.any? %>
           <span class="championship-trophy" data-toggle="tooltip" data-placement="bottom" title="<%= @competition.championships.sort.map { |championship| championship.name }.join(", ") %>">
             <%= icon('fas', 'trophy') %>
@@ -270,6 +278,33 @@
           return (this.bottom = $('.footer').outerHeight(true));
         },
       },
+    });
+
+    $('#not-bookmarked').click(function() {
+      wca.cancelPendingAjaxAndAjax('bookmark', {
+        url: '<%= bookmark_path %>',
+        method: 'POST',
+        data: {
+          'id': <%= @competition.id.to_json.html_safe %>,
+        },
+        success: function(data) {
+          $('#not-bookmarked').toggle();
+          $('#bookmarked').toggle();
+        }
+      });
+    });
+    $('#bookmarked').click(function() {
+      wca.cancelPendingAjaxAndAjax('bookmark', {
+        url: '<%= unbookmark_path %>',
+        method: 'POST',
+        data: {
+          'id': <%= @competition.id.to_json.html_safe %>,
+        },
+        success: function(data) {
+          $('#not-bookmarked').toggle();
+          $('#bookmarked').toggle();
+        }
+      });
     });
   })();
 </script>

--- a/WcaOnRails/app/views/competitions/my_competitions.html.erb
+++ b/WcaOnRails/app/views/competitions/my_competitions.html.erb
@@ -43,4 +43,13 @@
     <% end %>
   <% end %>
 
+  <h3>
+    <%= icon('fa', 'bookmark') %>
+    <%= t '.bookmarked_title' %>
+  </h3>
+
+  <%= t '.bookmarked_explanation' %>
+
+  <%= render "my_competitions_table", competitions: @bookmarked_competitions, registrations_by_competition_id: @registered_for_by_competition_id, past: false, bookmarked: true %>
+
 </div>

--- a/WcaOnRails/app/views/competitions_mailer/registration_reminder.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/registration_reminder.html.erb
@@ -1,0 +1,18 @@
+<p>
+  <%= t 'users.mailer.registration_reminder_email.intro', name: @user.name %>
+</p>
+
+<p>
+  <%= t 'users.mailer.registration_reminder_email.information_html', competition_url: competition_url(@competition), competition: @competition.name %>
+</p>
+
+<p>
+  <% if @registered_but_not_accepted %>
+    <%= t 'users.mailer.registration_reminder_email.not_accepted_html' %>
+  <% end %>
+  <%= t 'users.mailer.registration_reminder_email.more_info_html', competition_url: competition_url(@competition) %>
+</p>
+
+<p>
+  <%= t 'registrations.mailer.regards_html', people: users_to_sentence(@competition.managers) %>
+</p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -779,6 +779,12 @@ en:
       organizer_removal_email:
         header: "You were removed from %{competition} as an organizer"
         information: "%{remover} removed you from %{competition} as an organizer."
+      registration_reminder_email:
+        header: "%{competition} registration opens soon"
+        intro: "Hello %{name},"
+        information_html: "This is a reminder that registration for <a href=%{competition_url}>%{competition}</a> opens in less than 24 hours."
+        not_accepted_html: "You have registered but your registration has not been accepted."
+        more_info_html: "Please see the <a href=%{competition_url}>competition website</a> for more information and registration requirements."
     #context: related to claiming a WCA ID
     claim_wca_id:
       title: "Claim WCA ID"
@@ -1077,6 +1083,8 @@ en:
       title: "My competitions"
       disclaimer: "Only competitions that use the WCA registration system are shown here. If your competition isn't listed here, check the competition website's own competitor list."
       past_competitions: "Past competitions"
+      bookmarked_title: "Bookmarked competitions"
+      bookmarked_explanation: "Competitions that you've bookmarked on the WCA site. We'll send you an email 24 hours before registration opens."
     #context: on the competition's information page
     competition_info:
       #context: used on the pdf export
@@ -1131,6 +1139,9 @@ en:
         range_future_html: "Online registration will be open from %{start_date_and_time} to %{end_date_and_time}."
         range_ongoing_html: "Online registration opened %{start_date_and_time} and will close %{end_date_and_time}."
         range_past_html: "Online registration opened %{start_date_and_time} and closed %{end_date_and_time}."
+      bookmark: "Bookmark this competition"
+      is_bookmarked: "You've bookmarked this competition"
+      number_of_bookmarks: "Number of times bookmarked"
     #context: on the competition's index page
     index:
       title: "Competitions"
@@ -1186,6 +1197,8 @@ en:
       no_upcoming_competitions_html: "You currently have no upcoming competitions! Check out the %{link}."
       competitions_list: "competitions list"
       no_past_competitions: "You have no past competitions."
+      no_bookmarked_competitions: "You haven't bookmarked any upcoming competitions. Click the bookmark icon on a competition page to save it here!"
+    #context: on the competition's information page
     #context: in the competition edition form
     competition_form:
       wcat: "WCA Competition Announcement Team"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
 
   get 'competitions/mine' => 'competitions#my_competitions', as: :my_comps
   get 'competitions/for_senior(/:user_id)' => 'competitions#for_senior', as: :competitions_for_senior
+  post 'competitions/bookmark' => 'competitions#bookmark', as: :bookmark
+  post 'competitions/unbookmark' => 'competitions#unbookmark', as: :unbookmark
 
   resources :competitions, only: [:index, :show, :edit, :update, :new, :create] do
     get 'results/podiums' => 'competitions#show_podiums'

--- a/WcaOnRails/db/migrate/20190818102517_create_bookmarked_competitions.rb
+++ b/WcaOnRails/db/migrate/20190818102517_create_bookmarked_competitions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateBookmarkedCompetitions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bookmarked_competitions do |t|
+      t.string :competition_id, null: false
+      t.integer :user_id, null: false
+      t.timestamps
+    end
+    add_index :bookmarked_competitions, :competition_id
+    add_index :bookmarked_competitions, :user_id
+    add_index :bookmarked_competitions, [:competition_id, :user_id]
+
+    add_column :Competitions, :registration_reminder_sent_at, :datetime, null: true, default: nil
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -69,6 +69,7 @@ CREATE TABLE `Competitions` (
   `confirmed_at` datetime DEFAULT NULL,
   `event_restrictions` tinyint(1) DEFAULT NULL,
   `event_restrictions_reason` text COLLATE utf8mb4_unicode_ci,
+  `registration_reminder_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
@@ -658,6 +659,18 @@ CREATE TABLE `assignments` (
   PRIMARY KEY (`id`),
   KEY `index_assignments_on_registration_id` (`registration_id`),
   KEY `index_assignments_on_schedule_activity_id` (`schedule_activity_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `bookmarked_competitions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `bookmarked_competitions` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_bookmarked_competitions_on_competition_id` (`competition_id`),
+  KEY `index_bookmarked_competitions_on_user_id` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `championships`;
@@ -1580,4 +1593,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190816001639'),
 ('20190816004605'),
 ('20190817170648'),
-('20190817193315');
+('20190817193315'),
+('20190818102517');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -64,6 +64,7 @@ module DatabaseDumper
           results_posted_at
           results_submitted_at
           results_nag_sent_at
+          registration_reminder_sent_at
           generate_website
           announced_at
           base_entry_fee_lowest_denomination
@@ -722,6 +723,16 @@ module DatabaseDumper
     }.freeze,
     "stripe_charges" => :skip_all_rows,
     "uploaded_jsons" => :skip_all_rows,
+    "bookmarked_competitions" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          user_id
+          competition_id
+        ),
+      ),
+    }.freeze,
   }.freeze
 
   def self.development_dump(dump_filename)

--- a/WcaOnRails/lib/tasks/work.rake
+++ b/WcaOnRails/lib/tasks/work.rake
@@ -9,6 +9,7 @@ namespace :work do
     ComputeLinkings.perform_later
     DumpDeveloperDatabase.perform_later
     UnstickPosts.perform_later
+    RegistrationReminderJob.perform_later
     # NOTE: we want to only do this on the actual "production" server, as we need the real users' emails.
     SyncMailingListsJob.perform_later if ENVied.WCA_LIVE_SITE
   end

--- a/WcaOnRails/spec/jobs/registration_reminder_job_spec.rb
+++ b/WcaOnRails/spec/jobs/registration_reminder_job_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RegistrationReminderJob, type: :job do
+  describe "registration reminder job" do
+    let(:user) { FactoryBot.create :user }
+    let(:delegate) { FactoryBot.create :delegate }
+    let(:organizers) { FactoryBot.create_list :user, 3 }
+    let(:competition) { FactoryBot.create :competition, :visible, organizers: organizers, delegates: [delegate] }
+
+    it "does not send more than 24h in advance" do
+      competition.registration_open = 2.days.from_now
+
+      expect do
+        RegistrationReminderJob.perform_now
+      end.to change { enqueued_jobs.size }.by(0)
+    end
+
+    it "schedules registration reminder emails" do
+      BookmarkedCompetition.create(competition: competition, user: user)
+      competition.update_column(:registration_open, 12.hours.from_now)
+
+      expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, user, false).and_call_original
+      expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, delegate, false).and_call_original
+      organizers.each do |organizer|
+        expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, organizer, false).and_call_original
+      end
+
+      expect do
+        RegistrationReminderJob.perform_now
+      end.to change { enqueued_jobs.size }.by(5)
+
+      # Running the job again won't send any more emails.
+      expect do
+        RegistrationReminderJob.perform_now
+      end.to change { enqueued_jobs.size }.by(0)
+    end
+
+    it "resends when registration period changes" do
+      BookmarkedCompetition.create(competition: competition, user: user)
+      competition.update_column(:registration_reminder_sent_at, 7.days.ago)
+      competition.update_column(:registration_open, 12.hours.from_now)
+
+      expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, user, false).and_call_original
+      expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, delegate, false).and_call_original
+      organizers.each do |organizer|
+        expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, organizer, false).and_call_original
+      end
+
+      expect do
+        RegistrationReminderJob.perform_now
+      end.to change { enqueued_jobs.size }.by(5)
+    end
+
+    it "does not send to registered and accepted users" do
+      BookmarkedCompetition.create(competition: competition, user: user)
+      FactoryBot.create(:registration, :accepted, competition: competition, user: user)
+      FactoryBot.create(:registration, :pending, competition: competition, user: delegate)
+      competition.update_column(:registration_open, 12.hours.from_now)
+
+      expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, delegate, true).and_call_original
+      organizers.each do |organizer|
+        expect(CompetitionsMailer).to receive(:registration_reminder).with(competition, organizer, false).and_call_original
+      end
+
+      expect do
+        RegistrationReminderJob.perform_now
+      end.to change { enqueued_jobs.size }.by(4)
+    end
+  end
+end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -301,4 +301,35 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       expect(mail.body.encoded).to include(link_to_competition_schedule_tab(competition))
     end
   end
+
+  describe "registration_reminder_email" do
+    let(:competitor) { FactoryBot.create(:user) }
+    let(:competition) { FactoryBot.create :competition, :with_organizer, :with_delegate, name: "Comp of the future 2020", id: "CompFut2020" }
+
+    context "non-registered user" do
+      let(:mail) { CompetitionsMailer.registration_reminder(competition, competitor, false) }
+
+      it "renders the headers" do
+        expect(mail.subject).to eq "Comp of the future 2020 registration opens soon"
+        expect(mail.to).to eq [competitor.email]
+        expect(mail.reply_to).to eq competition.organizers.pluck(:email)
+      end
+
+      it "renders the body" do
+        expect(mail.body.encoded).to match(/This is a reminder that registration/)
+        expect(mail.body.encoded).to_not match(/You have registered/)
+        expect(mail.body.encoded).to include(competition_url(competition))
+      end
+    end
+
+    context "registered but not accepted user" do
+      let(:mail) { CompetitionsMailer.registration_reminder(competition, competitor, true) }
+
+      it "says the user is registered" do
+        expect(mail.body.encoded).to match(/This is a reminder that registration/)
+        expect(mail.body.encoded).to match(/You have registered/)
+        expect(mail.body.encoded).to include(competition_url(competition))
+      end
+    end
+  end
 end

--- a/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
@@ -5,12 +5,14 @@ require "rails_helper"
 RSpec.describe "competitions/my_competitions" do
   let(:competition) { FactoryBot.create(:competition, :registration_open, name: "Melbourne Open 2016") }
   let(:registration) { FactoryBot.create(:registration, competition: competition) }
+  let(:competition2) { FactoryBot.create(:competition, :visible, name: "Cambridge Open 2020") }
 
   before do
     allow(view).to receive(:current_user) { registration.user }
     assign(:not_past_competitions, [competition])
     assign(:past_competitions, [])
     assign(:registered_for_by_competition_id, competition.id => registration)
+    assign(:bookmarked_competitions, [competition2])
   end
 
   it "shows upcoming competitions" do
@@ -22,5 +24,10 @@ RSpec.describe "competitions/my_competitions" do
     render
     expect(rendered).to match 'You are currently on the waiting list'
     expect(rendered).to match '<i class="fas fa-hourglass-half"></i>'
+  end
+
+  it "shows bookmarked competitions" do
+    render
+    expect(rendered).to match '<td><a href="/competitions/CambridgeOpen2020">Cambridge Open 2020</a></td>'
   end
 end


### PR DESCRIPTION
This does the following:

-Adds a table for bookmarked competitions.
-Adds an icon to the competition view page allowing a user to bookmark a competition.
-Adds a table to my_competitions listed bookmarked competitions.
-Adds a mailer notifying competitors who have bookmarked a competition that registration opens in less than 24 hours.

Fixes #3797 