### PR TITLE
Paginate competition results.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -99,3 +99,33 @@ onPage('competitions#index', function() {
     }, 0);
   });
 });
+
+onPage("competitions#show_all_results", function() {
+  /* Show tbody for the given event. */
+  function showResultsFor(eventId) {
+    var $results = $('.one-event');
+    $results.hide();
+    $results.filter('.event-' + eventId).show();
+  }
+
+  /* Handle events selector for results by event. */
+  $('.event-selector input[type="radio"]').on('change', function() {
+    var eventId = $(this).val();
+    showResultsFor(eventId);
+    $.setUrlParams({ event:  eventId });
+  });
+
+  if(location.hash) {
+    /* Support old URLs with hash indicating an eventId.
+       Hash is of the form #e444; hash.slice(2) strips the "#e" and leaves the eventId ("444"). */
+    document.getElementById('radio-' + location.hash.slice(2)).click();
+  } else {
+    var $checked = $('.event-selector input[checked="checked"]');
+    if ($checked.length != 0) {
+      showResultsFor($checked.val());
+    } else {
+      var $toCheck = $('.event-selector input:first');
+      $toCheck.click();
+    }
+  }
+});

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -64,6 +64,10 @@ $competition-nav-padding: 50px;
   #not-bookmarked {
     color: #bbbbbb;
   }
+
+  .one-event {
+    display: none;
+  }
 }
 
 // Workaround for https://github.com/cubing/icons/issues/16

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1015,7 +1015,7 @@ class Competition < ApplicationRecord
       .map do |event, results_for_event|
         round_types_with_results = results_for_event
                                    .group_by(&:round_type)
-                                   .sort_by { |format, _results| format.rank }
+                                   .sort_by { |format, _results| format.rank }.reverse
                                    .map { |round_type, results| [round_type, results.sort_by { |r| [r.pos, r.personName] }] }
 
         [event, round_types_with_results]

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -16,7 +16,7 @@
               path: competition_results_all_path(@competition),
               fas_icon: "list",
               tiny_children: @competition.events.map do |event|
-                { text: event.id, path: competition_results_all_path(@competition, anchor: "e#{event.id}"), cubing_icon: event.id, title: event.name }
+                { text: event.id, path: competition_results_all_path(@competition, {:event => event.id}), cubing_icon: event.id, title: event.name }
               end
             },
             { text: t('.menu.by_person'), path: competition_results_by_person_path(@competition), fas_icon: "user" },

--- a/WcaOnRails/app/views/competitions/show_all_results.html.erb
+++ b/WcaOnRails/app/views/competitions/show_all_results.html.erb
@@ -2,16 +2,24 @@
 
 <%= render layout: 'results_nav' do %>
   <% cache @competition.result_cache_key("all_results") do %>
+    <div class="event-selector text-center">
+      <% @competition.events_with_round_types_with_results.each do |event, rounds_with_results| %>
+        <span class="event-radio">
+          <%= label_tag "radio-#{event.id}" do %>
+            <%= radio_button_tag "event", event.id, params[:event] == event.id, id: "radio-#{event.id}" %>
+            <%= cubing_icon event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name %>
+          <% end %>
+        </span>
+      <% end %>
+    </div>
     <% @competition.events_with_round_types_with_results.each do |event, rounds_with_results| %>
-
-      <% # Empty div to allow linking directly to results for an event %>
-      <%= content_tag :div, "", id: "e#{event.id}" %>
-
-      <% rounds_with_results.each do |round, results| %>
-        <h3>
-          <%= anchorable "#{event.name} #{round.name}", "e#{event.id}_#{round.id}" %>
-        </h3>
-        <%= render "results_table", results: results, hide_event: true, hide_round: true %>
+      <%= content_tag :div, class: ["event-#{event.id}", "one-event"] do %>
+        <% rounds_with_results.each do |round, results| %>
+          <h3>
+            <%= cubing_icon event.id %> <%= "#{event.name} #{round.name}" %>
+          </h3>
+          <%= render "results_table", results: results, hide_event: true, hide_round: true %>
+        <% end %>
       <% end %>
     <% end %>
 

--- a/WcaOnRails/spec/features/competition_results_spec.rb
+++ b/WcaOnRails/spec/features/competition_results_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "competition results" do
   end
 
   describe "all results" do
-    it "displays the results for each person" do
+    it "displays the results for each person", js: true do
       visit competition_results_all_path(competition)
       expect(page).to have_content(person_1.name)
       expect(page).to have_content(person_2.name)

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -684,10 +684,10 @@ RSpec.describe Competition do
       results = competition.events_with_round_types_with_results
       expect(results.size).to eq 2
       expect(results[0].first).to eq three_by_three
-      expect(results[0].second.first.first).to eq RoundType.find("1")
-      expect(results[0].second.first.last.map(&:value1)).to eq [3000] * 4
-      expect(results[0].second.first.last.map(&:eventId)).to eq ["333"] * 4
-      expect(results[0].second.second.last.map(&:value1)).to eq [3000] * 3
+      expect(results[0].second.first.first).to eq RoundType.find("f")
+      expect(results[0].second.first.last.map(&:value1)).to eq [3000] * 3
+      expect(results[0].second.first.last.map(&:eventId)).to eq ["333"] * 3
+      expect(results[0].second.second.last.map(&:value1)).to eq [3000] * 4
 
       expect(results[1].first).to eq two_by_two
       expect(results[1].second.first.first).to eq RoundType.find("c")


### PR DESCRIPTION
This should help results for large competitions render faster, especially on mobile.

In addition, reverse-order rounds so that the final is shown on top.

Desktop:
![competition_results](https://user-images.githubusercontent.com/3885929/63560876-bef99400-c525-11e9-85d6-926b36d37ea9.png)

Mobile:
![competition_results_mobile](https://user-images.githubusercontent.com/3885929/63560881-c15bee00-c525-11e9-9add-9a6d84881065.png)

Fixes #4469 