### PR TITLE
Add fields to Competitions table.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -205,7 +205,7 @@ class CompetitionsController < ApplicationController
       full_post = nil
       ActiveRecord::Base.transaction do
         full_post = create_post_and_redirect(title: title, body: body, author: current_user, tags: "competitions,new", world_readable: true)
-        comp.update!(announced_at: Time.now)
+        comp.update!(announced_at: Time.now, announced_by: current_user.id)
       end
       CompetitionsMailer.notify_organizers_of_announced_competition(comp, full_post).deliver_later
     end
@@ -344,7 +344,7 @@ class CompetitionsController < ApplicationController
         end
       end
       unless comp.results_posted?
-        comp.update!(results_posted_at: Time.now)
+        comp.update!(results_posted_at: Time.now, results_posted_by: current_user.id)
         comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
         comp.registrations.accepted.each { |registration| registration.user.notify_of_id_claim_possibility(comp) }
       end
@@ -683,6 +683,7 @@ class CompetitionsController < ApplicationController
         :event_restrictions,
         :event_restrictions_reason,
         :guests_entry_fee_lowest_denomination,
+        :main_event_id,
         competition_events_attributes: [:id, :event_id, :_destroy],
         championships_attributes: [:id, :championship_type, :_destroy],
       ]

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -131,6 +131,9 @@ class Competition < ApplicationRecord
     qualification_results_reason
     event_restrictions
     event_restrictions_reason
+    announced_by
+    results_posted_by
+    main_event_id
   ).freeze
   VALID_NAME_RE = /\A([-&.:' [:alnum:]]+) (\d{4})\z/.freeze
   PATTERN_LINK_RE = /\[\{([^}]+)}\{((https?:|mailto:)[^}]+)}\]/.freeze

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -216,6 +216,13 @@
         <%= f.input :event_restrictions %>
         <%= f.input :event_restrictions_reason %>
 
+        <% if @competition.events.any? %>
+          <hr>
+          <%= f.input :main_event_id do %>
+            <%= f.select :main_event_id, options_for_select(@competition.events.map { |event| [event.name, event.id] }, @competition.main_event_id), { include_blank: "" }, { class: "form-control main-event" } %>
+          <% end %>
+        <% end %>
+
       </fieldset>
 
       <hr>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -303,6 +303,7 @@ en:
         qualification_results_reason: "Reason and details for qualification results"
         event_restrictions: "I would like to restrict competitors from registering for specific combinations of events"
         event_restrictions_reason: "Reason and details for event restrictions"
+        main_event_id: "Main event"
       #context: a registration to a competition
       registration:
         guests: "Guests"
@@ -505,6 +506,7 @@ en:
         qualification_results_reason: "Please elaborate here why you would like to use qualification times. Please fill this out in English!"
         event_restrictions: ""
         event_restrictions_reason: "Please elaborate here why you would like to restrict certain event combinations. Please fill this out in English!"
+        main_event_id: "The winner of this event will be the winner of the competition."
       website_contact:
         inquiry: ""
         competition_id: ""

--- a/WcaOnRails/db/migrate/20190825095512_add_fields_to_competitions_table.rb
+++ b/WcaOnRails/db/migrate/20190825095512_add_fields_to_competitions_table.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddFieldsToCompetitionsTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :Competitions, :announced_by, :integer, null: true, default: nil
+    add_column :Competitions, :results_posted_by, :integer, null: true, default: nil
+    add_column :Competitions, :main_event_id, :string, null: true, default: nil
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -70,6 +70,9 @@ CREATE TABLE `Competitions` (
   `event_restrictions` tinyint(1) DEFAULT NULL,
   `event_restrictions_reason` text COLLATE utf8mb4_unicode_ci,
   `registration_reminder_sent_at` datetime DEFAULT NULL,
+  `announced_by` int(11) DEFAULT NULL,
+  `results_posted_by` int(11) DEFAULT NULL,
+  `main_event_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
@@ -1595,4 +1598,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190816004605'),
 ('20190817170648'),
 ('20190817193315'),
-('20190818102517');
+('20190818102517'),
+('20190825095512');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -83,6 +83,9 @@ module DatabaseDumper
           qualification_results_reason
           event_restrictions
           event_restrictions_reason
+          announced_by
+          results_posted_by
+          main_event_id
         ),
         db_default: %w(
           connected_stripe_account_id


### PR DESCRIPTION
This is a first step towards removing the automatic posts (see discussion of #4512.) I'd like to merge this PR first so we can back-fill the information for all existing competitions first, and when that's done I will submit another PR with the rest of the work.