### PR TITLE
Only show the bookmark icon for upcoming competitions.

### DIFF
--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -211,7 +211,7 @@
     </div>
     <div id="competition-data">
       <h3>
-        <% if current_user %>
+        <% if current_user && @competition.upcoming? %>
           <span class="bookmark-icon" id="not-bookmarked" data-toggle="tooltip" data-placement="bottom" title="<%= I18n.t('competitions.competition_info.bookmark') %>" <% if current_user.is_bookmarked?(@competition) %>style="display: none;"<% end %>>
             <%= icon('far', 'bookmark') %>
           </span>


### PR DESCRIPTION
In my_competitions, we only show bookmarked competitions that are upcoming.  Therefore, we shouldn't allow competitors to bookmark past competitions.

Follow-up to #4511, related to #3797.