### PR TITLE
Improvements to paginated competition results

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -109,8 +109,8 @@ onPage("competitions#show_all_results", function() {
     $("#radio-" + eventId + "-bottom").prop("checked", "true");
 
     // Also update the sidebar.
-    $(".nav_event.active").removeClass("active");
-    $(".nav_event .event-" + eventId).parent().addClass("active");
+    $(".nav-event.active").removeClass("active");
+    $(".nav-event .event-" + eventId).parent().addClass("active");
 
     // Switch to the new event.
     var $results = $('.one-event');

--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -101,17 +101,25 @@ onPage('competitions#index', function() {
 });
 
 onPage("competitions#show_all_results", function() {
-  /* Show tbody for the given event. */
-  function showResultsFor(eventId) {
+  $('.event-selector input[type="radio"]').on('change', function() {
+    var eventId = $(this).val();
+
+    // Select both radio buttons on top and bottom.
+    $("#radio-" + eventId + "-top").prop("checked", "true");
+    $("#radio-" + eventId + "-bottom").prop("checked", "true");
+
+    // Also update the sidebar.
+    $(".nav_event.active").removeClass("active");
+    $(".nav_event .event-" + eventId).parent().addClass("active");
+
+    // Switch to the new event.
     var $results = $('.one-event');
     $results.hide();
     $results.filter('.event-' + eventId).show();
-  }
 
-  /* Handle events selector for results by event. */
-  $('.event-selector input[type="radio"]').on('change', function() {
-    var eventId = $(this).val();
-    showResultsFor(eventId);
+    // Scroll to the top.
+    document.getElementsByClassName('event-selector')[0].scrollIntoView();
+
     $.setUrlParams({ event:  eventId });
   });
 
@@ -120,12 +128,13 @@ onPage("competitions#show_all_results", function() {
        Hash is of the form #e444; hash.slice(2) strips the "#e" and leaves the eventId ("444"). */
     document.getElementById('radio-' + location.hash.slice(2)).click();
   } else {
-    var $checked = $('.event-selector input[checked="checked"]');
-    if ($checked.length != 0) {
-      showResultsFor($checked.val());
+    var selected = $('#selected-event').data('selected');
+    if (selected === 'all') {
+      $('.one-event').show();
+    } else if (selected) {
+      document.getElementById('radio-' + selected + '-top').click();
     } else {
-      var $toCheck = $('.event-selector input:first');
-      $toCheck.click();
+      $('.event-selector input:first').click();
     }
   }
 });

--- a/WcaOnRails/app/views/competitions/_event_selector.html.erb
+++ b/WcaOnRails/app/views/competitions/_event_selector.html.erb
@@ -1,0 +1,10 @@
+<%= content_tag :div, class: ["event-selector", "text-center"] do %>
+  <% @competition.events_with_round_types_with_results.each do |event, rounds_with_results| %>
+    <span class="event-radio">
+      <%= label_tag "radio-#{event.id}-#{name}" do %>
+        <%= radio_button_tag "event-#{name}", event.id, false, id: "radio-#{event.id}-#{name}" %>
+        <%= cubing_icon event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name %>
+      <% end %>
+    </span>
+  <% end %>
+<% end %>

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -174,7 +174,7 @@
                   <% nav_item[:tiny_children].each do |child_nav_item| %>
                     <%= link_to child_nav_item[:path],
                                 title: child_nav_item[:title],
-                                class: (child_nav_item[:active] ? " active" : ""),
+                                class: "nav_event" + (child_nav_item[:active] ? " active" : ""),
                                 data: {
                                   toggle: "tooltip",
                                   placement: "top",

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -174,7 +174,7 @@
                   <% nav_item[:tiny_children].each do |child_nav_item| %>
                     <%= link_to child_nav_item[:path],
                                 title: child_nav_item[:title],
-                                class: "nav_event" + (child_nav_item[:active] ? " active" : ""),
+                                class: "nav-event" + (child_nav_item[:active] ? " active" : ""),
                                 data: {
                                   toggle: "tooltip",
                                   placement: "top",

--- a/WcaOnRails/app/views/competitions/show_all_results.html.erb
+++ b/WcaOnRails/app/views/competitions/show_all_results.html.erb
@@ -1,17 +1,9 @@
 <% provide(:title, @competition.name) %>
 
 <%= render layout: 'results_nav' do %>
+  <%= tag :div, id: "selected-event", "data-selected": params[:event] %>
   <% cache @competition.result_cache_key("all_results") do %>
-    <div class="event-selector text-center">
-      <% @competition.events_with_round_types_with_results.each do |event, rounds_with_results| %>
-        <span class="event-radio">
-          <%= label_tag "radio-#{event.id}" do %>
-            <%= radio_button_tag "event", event.id, params[:event] == event.id, id: "radio-#{event.id}" %>
-            <%= cubing_icon event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name %>
-          <% end %>
-        </span>
-      <% end %>
-    </div>
+    <%= render partial: "event_selector", locals: {competition: @competition, name: "top"} %>
     <% @competition.events_with_round_types_with_results.each do |event, rounds_with_results| %>
       <%= content_tag :div, class: ["event-#{event.id}", "one-event"] do %>
         <% rounds_with_results.each do |round, results| %>
@@ -22,6 +14,6 @@
         <% end %>
       <% end %>
     <% end %>
-
+    <%= render partial: "event_selector", locals: {competition: @competition, name: "bottom"} %>
   <% end %>
 <% end %>

--- a/webroot/results/admin/scripts/check_comp_data.php
+++ b/webroot/results/admin/scripts/check_comp_data.php
@@ -160,7 +160,7 @@ $eventOptionsStr = implode("", array_map(function($eventId) {
 }, $eventIds));
 print "<li><p>Sanity Checks:</p>
          <ol type='a'>
-           <li><a href='/competitions/$compIdUrl' target='_blank' class='link-external external'>View the Public competition page</a></li>
+           <li><a href='/competitions/$compIdUrl/results/all?event=all' target='_blank' class='link-external external'>View the Public competition page</a></li>
            <li>
              Post the
              <a data-competition-id='$compIdUrl' href='#' id='post-results-link' target='_blank' class='link-external external'>


### PR DESCRIPTION
Followup to #4517.  Does the following:

- Fixes caching misbehavior where URL param can be ignored.
- Adds a second event selector to the bottom of the page for easier browsing.
- Allows the URL param `&event=all` to show all results at once, though this isn't advertised in the UI.
- Changes the selected icon in the left nav bar when the event selector is used.

/cc @SAuroux @Jambrose777 