### PR TITLE
Set user names in mailers spec

### DIFF
--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -275,8 +275,8 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     let(:competition) do
       competition = FactoryBot.create(:competition, :with_delegate_report, countryId: "Australia", cityName: "Perth, Western Australia", name: "Comp of the Future 2016", starts: Date.new(2016, 2, 1), ends: Date.new(2016, 2, 2))
       competition.delegate_report.update_attributes!(remarks: "This was a great competition")
-      competition.delegate_report.wrc_primary_user = FactoryBot.create :user, :wrc_member
-      competition.delegate_report.wrc_secondary_user = FactoryBot.create :user, :wrc_member
+      competition.delegate_report.wrc_primary_user = FactoryBot.create :user, :wrc_member, name: "Jean"
+      competition.delegate_report.wrc_secondary_user = FactoryBot.create :user, :wrc_member, name: "Michel"
       competition
     end
     let(:mail) do

--- a/WcaOnRails/spec/mailers/regional_organizations_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/regional_organizations_mailer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe RegionalOrganizationsMailer, type: :mailer do
   describe "notify_board_and_assistants_of_new_regional_organization_application" do
-    let(:user) { FactoryBot.create :user }
+    let(:user) { FactoryBot.create :user, name: "John Doe" }
     let(:regional_organization) { FactoryBot.create :regional_organization }
     let(:mail) do
       I18n.locale = :es


### PR DESCRIPTION
I noticed while looking into #4538 the following test failure:

```
1) CompetitionsMailer wrc_delegate_report_followup renders the body
     Failure/Error: expect(mail.body.encoded).to match(competition.delegate_report.wrc_secondary_user.name)
     
       expected "<html>\r\n  <head>\r\n    <link rel=\"stylesheet\" media=\"screen\" href=\"/assets/email-e7fc621ffe6...r>\r\n  🤖 Your friendly neighborhood WRC automation script.\r\n</p>\r\n\r\n  </body>\r\n</html>\r\n" to match "Johnny O'Connell"
       Diff:
       @@ -1,2 +1,34 @@
       -Johnny O'Connell
       +<html>
 [...]
       +<p>
       +  <span style="font-weight: bold">Secondary for this thread is: Johnny O&#39;Connell</span><br>
       +  Please respond if the primary hasn't had a chance to handle this thread within 24 hours.
       +</p>
```

In mailers names containing quotes are encoded into html entities, therefore the match fails.
There are several workaround:
  - prevent names with quotes
  - `CGI.escapeHTML` on the name
  - override the name in the test. Actually done here: https://github.com/thewca/worldcubeassociation.org/blob/c4845b58438af215dd472de73ef7d518f7445cd2/WcaOnRails/spec/mailers/avatars_mailer_spec.rb#L7

Since it's relevant only to mailers spec, I went with the third option.