### PR TITLE
Enable mean validation for 444bf and 555bf

### DIFF
--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -123,7 +123,9 @@ module Resultable
     #    - 333fm legal formats changed from "123" to "123m".
     #  - December 9, 2013: https://github.com/thewca/wca-regulations/issues/109 and https://github.com/thewca/wca-regulations/commit/80ebf04e3ed0752df8047f4428277bf186f374c2
     #    - All events that allow "mean of 3" no longer allow "best of 3".
-    formatId == "a" || formatId == "m" || (formatId == "3" && %w(333ft 333fm 333bf).include?(eventId))
+    #  - May 1, 2019
+    #    - 444bf and 555bf mean are officially recognized
+    formatId == "a" || formatId == "m" || (formatId == "3" && %(333ft 333fm 333bf 444bf 555bf).include?(eventId))
   end
 
   def compute_correct_best


### PR DESCRIPTION
@SAuroux FYI
This must not be merged until the submitted results json has correctly computed means (ie: created using scrambles matcher or when thewca/wca-workbook-assistant#120 is fixed and released).