### PR TITLE
Remove hardcoded API version

### DIFF
--- a/WcaOnRails/config/initializers/stripe.rb
+++ b/WcaOnRails/config/initializers/stripe.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
 Stripe.api_key = ENVied.STRIPE_API_KEY
-Stripe.api_version = "2019-09-09"


### PR DESCRIPTION
It is updated in our Stripe API dashboard.