### PR TITLE
Fix typo in translation key

### DIFF
--- a/WcaOnRails/app/views/regulations/translations/_index_table.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/_index_table.html.erb
@@ -1,7 +1,7 @@
 <%= wca_table(table_class: "regulations-translations-table", floatThead: false, greedy: false) do %>
   <thead>
     <tr>
-      <th><%= t("regulations_translations.table_elements.verison") %></th>
+      <th><%= t("regulations_translations.table_elements.version") %></th>
       <th><%= t("regulations_translations.table_elements.language") %></th>
     </tr>
   </thead>

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -67,9 +67,8 @@ search:
     - app/assets/images
     - app/assets/fonts
     # i18n-tasks fails on TNoodle jars and old non-utf8 translations...
-    - app/views/regulations/history
-    - app/views/regulations/scrambles
-    - app/views/regulations/translations
+    - app/views/regulations/history/files
+    - app/views/regulations/scrambles/tnoodle
 
   ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
   ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
@@ -124,8 +123,6 @@ ignore_unused:
   - 'devise.mailer.*'
   # These are keys dynamically built in lib/advancement_condition.rb
   - 'advancement_condition.*'
-  # These keys are used on the regulations translations page
-  - 'regulations_translations.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:


### PR DESCRIPTION
Having built regs and tnoodle locally, we can remove or make more accurate restrictions for i18n-tasks.
This actually help us in checking the recently introduced regulations translations page, which had a typo :)