### PR TITLE
Updated Russian Translation Status

### DIFF
--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -21,6 +21,12 @@
       language_english: "Japanese",
       url: "./japanese",
     },
+    {
+      version: "2019-05-01",
+      language: "Русский",
+      language_english: "Russian",
+      url: "./russian",
+    },
   ] %>
 
   <h3><%= t("regulations_translations.current") %></h3>
@@ -76,12 +82,6 @@
       language: "Português Brasileiro",
       language_english: "Portuguese, Brazil",
       url: "./portuguese-brazilian",
-    },
-    {
-      version: "2018-01-01",
-      language: "Русский",
-      language_english: "Russian",
-      url: "./russian",
     },
     {
       version: "2018-01-01",


### PR DESCRIPTION
Russian translation is updated to May 01, 2019 version.
Translation updated PR [#74](https://github.com/thewca/wca-regulations-translations/pull/74)
Page update request [#76](https://github.com/thewca/wca-regulations-translations/issues/76)