### PR TITLE
Enable scroll in maps

### DIFF
--- a/WcaOnRails/app/javascript/leaflet-wca/index.js
+++ b/WcaOnRails/app/javascript/leaflet-wca/index.js
@@ -64,7 +64,6 @@ wca.createCompetitionsMapLeaflet = (elementId, center = [0, 0], iframeTrick = tr
   let map = new LeafletMap(elementId, {
     zoom: 2,
     center: center,
-    scrollWheelZoom: false,
   });
   let provider = userTileProvider;
   let layer = new TileLayer(provider.url, {


### PR DESCRIPTION
Currently scrolling in maps is disabled, but cannot think of any actual reason for that and I believe most users would expect it to work.