### PR TITLE
Change from address for reports, results, announcements appropriately

### DIFF
--- a/WcaOnRails/app/mailers/avatars_mailer.rb
+++ b/WcaOnRails/app/mailers/avatars_mailer.rb
@@ -6,6 +6,7 @@ class AvatarsMailer < ApplicationMailer
     @reason = reason
 
     mail(
+      from: Team.wrt.email,
       to: user.email,
       reply_to: "results@worldcubeassociation.org",
       subject: "Your avatar has been rejected",

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -116,6 +116,7 @@ class CompetitionsMailer < ApplicationMailer
   def submit_results_nag(competition)
     @competition = competition
     mail(
+      from: Team.weat.email,
       to: competition.delegates.pluck(:email),
       cc: ["results@worldcubeassociation.org", "assistants@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
       reply_to: "results@worldcubeassociation.org",
@@ -126,6 +127,7 @@ class CompetitionsMailer < ApplicationMailer
   def submit_report_nag(competition)
     @competition = competition
     mail(
+      from: Team.weat.email,
       to: competition.delegates.pluck(:email),
       cc: ["assistants@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
       reply_to: delegates_to_senior_delegates_email(competition.delegates),

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -11,6 +11,7 @@ class CompetitionsMailer < ApplicationMailer
       @competition = competition
       @confirmer = confirmer
       mail(
+        from: Team.wcat.email,
         to: Team.wcat.email,
         cc: competition.delegates.flat_map { |d| [d.email, d.senior_delegate&.email] }.compact.uniq,
         reply_to: confirmer.email,
@@ -90,6 +91,7 @@ class CompetitionsMailer < ApplicationMailer
     I18n.with_locale :en do
       @competition = competition
       mail(
+        from: "reports@worldcubeassociation.org",
         to: "reports@worldcubeassociation.org",
         cc: competition.delegates.pluck(:email) +
           (competition.delegate_report.wrc_feedback_requested ? ["regulations@worldcubeassociation.org"] : []) +
@@ -143,6 +145,7 @@ class CompetitionsMailer < ApplicationMailer
       }
     end
     mail(
+      from: "results@worldcubeassociation.org",
       to: "results@worldcubeassociation.org",
       cc: competition.delegates.pluck(:email),
       reply_to: competition.delegates.pluck(:email),

--- a/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/avatars_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AvatarsMailer, type: :mailer do
       expect(mail.subject).to eq "Your avatar has been rejected"
       expect(mail.to).to eq [user.email]
       expect(mail.reply_to).to eq ["results@worldcubeassociation.org"]
-      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+      expect(mail.from).to eq ["results@worldcubeassociation.org"]
     end
 
     it "renders the body" do

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq "Comp of the Future 2016 Results"
       expect(mail.to).to match_array competition.delegates.pluck(:email)
+      expect(mail.from).to eq ["assistants@worldcubeassociation.org"]
       expect(mail.cc).to eq ["results@worldcubeassociation.org", "assistants@worldcubeassociation.org", senior.email]
       expect(mail.reply_to).to eq ["results@worldcubeassociation.org"]
     end
@@ -167,6 +168,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq "Peculiar Comp 2016 Delegate Report"
       expect(mail.to).to match_array competition.delegates.pluck(:email)
+      expect(mail.from).to eq ["assistants@worldcubeassociation.org"]
       expect(mail.cc).to eq ["assistants@worldcubeassociation.org", senior.email]
       expect(mail.reply_to).to eq [senior.email]
     end

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
     it "renders in English" do
       expect(mail.to).to eq(["competitions@worldcubeassociation.org"])
       expect(mail.cc).to match_array(competition.delegates.pluck(:email) + [senior_delegate.email, third_delegate.senior_delegate.email])
-      expect(mail.from).to eq(["notifications@worldcubeassociation.org"])
+      expect(mail.from).to eq(["competitions@worldcubeassociation.org"])
       expect(mail.reply_to).to eq([delegate.email])
 
       expect(mail.subject).to eq("#{competition.name} is confirmed")
@@ -198,7 +198,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
         expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
         expect(mail.to).to eq ["reports@worldcubeassociation.org"]
         expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["regulations@worldcubeassociation.org"] + ["disciplinary@worldcubeassociation.org"]
-        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.from).to eq ["reports@worldcubeassociation.org"]
         expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
       end
 
@@ -218,7 +218,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
         expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
         expect(mail.to).to eq ["reports@worldcubeassociation.org"]
         expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["disciplinary@worldcubeassociation.org"]
-        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.from).to eq ["reports@worldcubeassociation.org"]
         expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
       end
 
@@ -238,7 +238,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
         expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
         expect(mail.to).to eq ["reports@worldcubeassociation.org"]
         expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["regulations@worldcubeassociation.org"]
-        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.from).to eq ["reports@worldcubeassociation.org"]
         expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
       end
 
@@ -254,7 +254,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
         expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
         expect(mail.to).to eq ["reports@worldcubeassociation.org"]
         expect(mail.cc).to match_array competition.delegates.pluck(:email)
-        expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+        expect(mail.from).to eq ["reports@worldcubeassociation.org"]
         expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
       end
 
@@ -311,7 +311,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       expect(mail.subject).to eq "Results for Comp of the future 2017"
       expect(mail.to).to eq ["results@worldcubeassociation.org"]
       expect(mail.cc).to match_array competition.delegates.pluck(:email)
-      expect(mail.from).to eq ["notifications@worldcubeassociation.org"]
+      expect(mail.from).to eq ["results@worldcubeassociation.org"]
       expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
     end
 


### PR DESCRIPTION
This changes the from address from results, delegate report, and competition announcement mailers to limit the amount of incoming mail to notifications@ that the WCT has to deal with as described in #4601. This isn't a full solution, but this will provide some relief for the WCT while a more complete solution is reached.