### PR TITLE
Don't use justified tabs on the competition page

### DIFF
--- a/WcaOnRails/app/views/competitions/show.html.erb
+++ b/WcaOnRails/app/views/competitions/show.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, @competition.name) %>
 <%# We use this to hide the 'Events' information for competition which didn't declared rounds %>
 <%= render layout: 'nav' do %>
-  <ul class="nav nav-tabs nav-justified">
+  <ul class="nav nav-tabs">
     <li><a href="#general-info" data-toggle="tab"><%=t 'competitions.show.general_info' %></a></li>
     <% if @competition.has_rounds? %>
       <li><a href="#competition-events" data-toggle="tab"><%=t 'competitions.show.events' %></a></li>


### PR DESCRIPTION
As part of #4646 I changed competition tabs to justified version, which stacks tabs on mobile (while normal tabs look poorly). Apparently this could go weird for too long tabs or if there's too many of them:
![image](https://user-images.githubusercontent.com/17034772/65649516-244e1280-e007-11e9-9cd2-47ba0fd2522a.png)
For now let's revert that, but we should improve how tabs look on mobile.