### PR TITLE
Temporarily disable syncing the delegates.asia-west-india@ mailing list.

### DIFF
--- a/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
+++ b/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
@@ -20,10 +20,12 @@ class SyncMailingListsJob < SingletonApplicationJob
       mailing_list: "delegates.asia-southeast@worldcubeassociation.org",
       query: "%Asia Southeast%",
     },
-    {
-      mailing_list: "delegates.asia-west-india@worldcubeassociation.org",
-      query: "%Asia West & India%",
-    },
+    # TODO: This is temporarily disabled as a workaround for
+    # https://github.com/thewca/worldcubeassociation.org/issues/4674.
+    # {
+    #   mailing_list: "delegates.asia-west-india@worldcubeassociation.org",
+    #   query: "%Asia West & India%",
+    # },
     {
       mailing_list: "delegates.europe-east-middle-east@worldcubeassociation.org",
       query: "%Europe East & Middle East%",

--- a/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -211,10 +211,12 @@ RSpec.describe SyncMailingListsJob, type: :job do
     )
 
     # delegates.asia-west-india@ mailing list
-    expect(GsuiteMailingLists).to receive(:sync_group).with(
-      "delegates.asia-west-india@worldcubeassociation.org",
-      a_collection_containing_exactly(asia_west_india_delegate.email, asia_west_india_delegate.senior_delegate.email),
-    )
+    # TODO: This is temporarily disabled as a workaround for
+    # https://github.com/thewca/worldcubeassociation.org/issues/4674.
+    # expect(GsuiteMailingLists).to receive(:sync_group).with(
+    #   "delegates.asia-west-india@worldcubeassociation.org",
+    #   a_collection_containing_exactly(asia_west_india_delegate.email, asia_west_india_delegate.senior_delegate.email),
+    # )
 
     # delegates.europe-east-middle-east@ mailing list
     expect(GsuiteMailingLists).to receive(:sync_group).with(


### PR DESCRIPTION
This is a temporary workaround for
https://github.com/thewca/worldcubeassociation.org/issues/4674 until we
figure out what we want the long term solution to be.