### PR TITLE
Disable other regions also affected by the recent shuffle.

### DIFF
--- a/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
+++ b/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
@@ -26,17 +26,17 @@ class SyncMailingListsJob < SingletonApplicationJob
     #   mailing_list: "delegates.asia-west-india@worldcubeassociation.org",
     #   query: "%Asia West & India%",
     # },
-    {
-      mailing_list: "delegates.europe-east-middle-east@worldcubeassociation.org",
-      query: "%Europe East & Middle East%",
-    },
+    # {
+    #   mailing_list: "delegates.europe-east-middle-east@worldcubeassociation.org",
+    #   query: "%Europe East & Middle East%",
+    # },
+    # {
+    #   mailing_list: "delegates.europe-west@worldcubeassociation.org",
+    #   query: "%Europe West%",
+    # },
     {
       mailing_list: "delegates.europe-north-baltic-states@worldcubeassociation.org",
       query: "%Europe North & Baltic States%",
-    },
-    {
-      mailing_list: "delegates.europe-west@worldcubeassociation.org",
-      query: "%Europe West%",
     },
     {
       mailing_list: "delegates.latin-america@worldcubeassociation.org",

--- a/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -219,10 +219,10 @@ RSpec.describe SyncMailingListsJob, type: :job do
     # )
 
     # delegates.europe-east-middle-east@ mailing list
-    expect(GsuiteMailingLists).to receive(:sync_group).with(
-      "delegates.europe-east-middle-east@worldcubeassociation.org",
-      a_collection_containing_exactly(europe_east_middle_east_delegate.email, europe_east_middle_east_delegate.senior_delegate.email),
-    )
+    # expect(GsuiteMailingLists).to receive(:sync_group).with(
+    #   "delegates.europe-east-middle-east@worldcubeassociation.org",
+    #   a_collection_containing_exactly(europe_east_middle_east_delegate.email, europe_east_middle_east_delegate.senior_delegate.email),
+    # )
 
     # delegates.europe-north-baltic-states@ mailing list
     expect(GsuiteMailingLists).to receive(:sync_group).with(
@@ -231,10 +231,10 @@ RSpec.describe SyncMailingListsJob, type: :job do
     )
 
     # delegates.europe-west@ mailing list
-    expect(GsuiteMailingLists).to receive(:sync_group).with(
-      "delegates.europe-west@worldcubeassociation.org",
-      a_collection_containing_exactly(europe_west_delegate.email, europe_west_delegate.senior_delegate.email),
-    )
+    # expect(GsuiteMailingLists).to receive(:sync_group).with(
+    #   "delegates.europe-west@worldcubeassociation.org",
+    #   a_collection_containing_exactly(europe_west_delegate.email, europe_west_delegate.senior_delegate.email),
+    # )
 
     # delegates.latin-america@ mailing list
     expect(GsuiteMailingLists).to receive(:sync_group).with(


### PR DESCRIPTION
This is a workaround for
https://github.com/thewca/worldcubeassociation.org/issues/4674.