### PR TITLE
Improving visualization on Teams & Committees page

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/teams-and-committees.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams-and-committees.scss
@@ -8,9 +8,13 @@
 .badge {
   &.team-member-badge {
     margin-right: 1em;
-    margin-bottom: 1em;
+    margin-bottom: 0.5em;
+    margin-top: 0.5em;
     color: $gray;
     background-color: $gray-lighter;
+    .avatar-thumbnail {
+      border-radius: 5px;
+    }
     @media (max-width: 576px) {
       display: block;
       width: max-content;
@@ -18,9 +22,10 @@
   }
 
   &.team-senior-member-badge {
-    background-color: $green;
+    background-color: $dark-green;
     color: white;
     padding-top: 6px;
+    padding-bottom: 6px;
     vertical-align: top;
     span.team-senior-member-subtext {
       font-style: oblique;
@@ -30,14 +35,16 @@
     }
     .avatar-thumbnail {
       vertical-align: top;
+      border-radius: 5px;
     }
   }
 
   &.team-leader-badge,
   &.officer-badge {
-    background-color: $bright-blue;
+    background-color: $dark-blue;
     color: white;
     padding-top: 6px;
+    padding-bottom: 6px;
     vertical-align: top;
     span.team-leader-subtext {
       font-style: oblique;
@@ -47,6 +54,7 @@
     }
     .avatar-thumbnail {
       vertical-align: top;
+      border-radius: 5px;
     }
   }
 
@@ -56,7 +64,6 @@
   }
 
   &.team-email {
-    background-color: $orange;
     a {
       color: white;
     }

--- a/WcaOnRails/app/assets/stylesheets/variables.scss
+++ b/WcaOnRails/app/assets/stylesheets/variables.scss
@@ -4,9 +4,11 @@ $link-color: #e64503;
 
 // Colors
 $blue: #3f91eb;
+$dark-blue: #082c52;
 $bright-blue: #007bff;
 $past-member-color: #fecd55;
 $green: #c4e8b5;
+$dark-green: #245011;
 $orange: #fc4a0a;
 $orange-bg: #ffeca8;
 


### PR DESCRIPTION
Added  2 variables for 2 colors (dark-blue and dark-green) and used those two colors for leader and senior members badges. Also added border-radius to the avatars and some minor fixes so the avatars show up centered within the badge