### PR TITLE
Install a version of mysql-client that is compatible with mysql-server 5.6

### DIFF
--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -93,7 +93,7 @@ execute gen_auth_keys_path do
 end
 
 #### Mysql
-package 'mysql-client'
+package 'mysql-client-5.6'
 db = {
   'user' => 'root',
 }


### PR DESCRIPTION
Without this change, chef crashes when trying to `apt-get install mysql-server-5.6`. Here's a simulation of what happened using docker:

    $ docker run -it ubuntu:14.04
    root@9a93cac5210c:/# apt-get update
    root@9a93cac5210c:/# apt-get install mysql-client
    Reading package lists... Done
    Building dependency tree
    Reading state information... Done
    The following extra packages will be installed:
      libdbd-mysql-perl libdbi-perl libmysqlclient18 libterm-readkey-perl
      mysql-client-5.5 mysql-client-core-5.5 mysql-common
    Suggested packages:
      libclone-perl libmldbm-perl libnet-daemon-perl libplrpc-perl
      libsql-statement-perl
    The following NEW packages will be installed:
      libdbd-mysql-perl libdbi-perl libmysqlclient18 libterm-readkey-perl
      mysql-client mysql-client-5.5 mysql-client-core-5.5 mysql-common
    0 upgraded, 8 newly installed, 0 to remove and 1 not upgraded.
    Need to get 3781 kB of archives.
    After this operation, 43.8 MB of additional disk space will be used.
    Do you want to continue? [Y/n] y
    ...
    root@9a93cac5210c:/# apt-get install mysql-server-5.6
    Reading package lists... Done
    Building dependency tree
    Reading state information... Done
    Some packages could not be installed. This may mean that you have
    requested an impossible situation or if you are using the unstable
    distribution that some required packages have not yet been created
    or been moved out of Incoming.
    The following information may help to resolve the situation:

    The following packages have unmet dependencies:
     mysql-server-5.6 : Depends: mysql-client-5.6 (>= 5.6.33-0ubuntu0.14.04.1) but it is not going to be installed
    E: Unable to correct problems, you have held broken packages.

We didn't run into this problem previously because we didn't actually
explicitly install `mysql-client` for our staging server, instead it
would get installed as a transitive dependency of `mysql-server-5.6`. It
feels better to me to explicitly mention the version of mysql-client we
use, so I've gone ahead and done that here.