### PR TITLE
Prevent refund for old registrations

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -503,6 +503,12 @@ class RegistrationsController < ApplicationController
 
   def refund_payment
     registration = Registration.find(params[:id])
+    unless registration.competition.using_stripe_payments?
+      flash[:danger] = "You cannot emit refund for this competition anymore. Please use your Stripe dashboard to do so."
+      redirect_to edit_registration_path(registration)
+      return
+    end
+
     payment = RegistrationPayment.find(params[:payment_id])
     refund_amount_param = params.require(:payment).require(:refund_amount)
     refund_amount = refund_amount_param.to_i

--- a/WcaOnRails/app/jobs/clear_connected_stripe_account.rb
+++ b/WcaOnRails/app/jobs/clear_connected_stripe_account.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ClearConnectedStripeAccount < SingletonApplicationJob
+  DELAY_IN_DAYS = 21
+  queue_as :default
+
+  def perform
+    Competition.where("end_date < ?", DELAY_IN_DAYS.days.ago).update_all(connected_stripe_account_id: nil)
+  end
+end

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -43,7 +43,12 @@
           Amount: <%= format_money payment.amount %>
           <br />
           Made by: <%= name_for_payment(payment) %>
-          <% if payment.amount_available_for_refund > 0 %>
+          <%#
+            NOTE: the connected Stripe account id is cleared roughly 3 weeks
+            after the competition, therefore we need to check for that before
+            offering the refund payment button.
+          %>
+          <% if @competition.using_stripe_payments? && payment.amount_available_for_refund > 0 %>
             <%= horizontal_simple_form_for :payment, url: registration_payment_refund_path(@registration, payment), html: { id: :form_refund } do |f| %>
               <%= f.input :refund_amount, as: :money_amount, currency: payment.amount.currency.iso_code, value: payment.amount_available_for_refund, label: t('registrations.refund_form.labels.refund_amount'), hint: t('registrations.refund_form.hints.refund_amount') %>
               <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>

--- a/WcaOnRails/lib/tasks/work.rake
+++ b/WcaOnRails/lib/tasks/work.rake
@@ -3,6 +3,7 @@
 namespace :work do
   desc 'Schedule work to be done'
   task schedule: :environment do
+    ClearConnectedStripeAccount.perform_later
     CleanupPdfs.perform_later
     SubmitResultsNagJob.perform_later
     SubmitReportNagJob.perform_later


### PR DESCRIPTION
Fixes #3224.
This change addresses a potential financial loss if an organizer or WCA staff decides to go crazy.
I initially prevented this at a controller level, but I realized some WCA staff may change the competition's date and overrun a check doing roughly `current_date > competition_date + 21.days`.
So instead I created a job that clears the `connected_stripe_account_id` after an arbitrary amount of days (I set it to 21).

This way there is no way for anyone to issue refund, except by going directly to the connected Stripe account dashboard.

cc @Mollerz, @ChrisWrightWCA, @EdHollingdale