### PR TITLE
Link to profiles in teams page

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/teams-and-committees.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams-and-committees.scss
@@ -15,6 +15,9 @@
     .avatar-thumbnail {
       border-radius: 5px;
     }
+    a {
+      color: #555555;
+    }
     @media (max-width: 576px) {
       display: block;
       width: max-content;
@@ -27,7 +30,7 @@
     padding-top: 6px;
     padding-bottom: 6px;
     vertical-align: top;
-    span.team-senior-member-subtext {
+    span.team-subtext {
       font-style: oblique;
       margin-top: 6px;
       display: block;
@@ -36,6 +39,9 @@
     .avatar-thumbnail {
       vertical-align: top;
       border-radius: 5px;
+    }
+    a {
+      color: white;
     }
   }
 
@@ -46,7 +52,7 @@
     padding-top: 6px;
     padding-bottom: 6px;
     vertical-align: top;
-    span.team-leader-subtext {
+    span.team-subtext {
       font-style: oblique;
       margin-top: 6px;
       display: block;
@@ -55,6 +61,9 @@
     .avatar-thumbnail {
       vertical-align: top;
       border-radius: 5px;
+    }
+    a {
+      color: white;
     }
   }
 

--- a/WcaOnRails/app/controllers/static_pages_controller.rb
+++ b/WcaOnRails/app/controllers/static_pages_controller.rb
@@ -21,15 +21,7 @@ class StaticPagesController < ApplicationController
     # get all users who hold one or more officer positions
     officer_users = Team.all_officers.map(&:current_members).inject(&:+).map(&:user)
     treasurers = Team.wfc.current_members.select(&:team_leader).map(&:user)
-    @officers = []
-    (officer_users + treasurers).uniq.each do |user|
-      # for each officer, find all officer teams they belong to
-      positions = user.current_teams.select { |team| Team.all_officers.include? team }.map(&:name)
-      if Team.wfc.current_members.select(&:team_leader).map(&:user).include?(user)
-        positions.push(t('about.structure.treasurer.name'))
-      end
-      @officers.push([user, positions.join("<br />").html_safe])
-    end
+    @officers = (officer_users + treasurers).uniq
   end
 
   def wca_workbook_assistant

--- a/WcaOnRails/app/helpers/static_pages_helper.rb
+++ b/WcaOnRails/app/helpers/static_pages_helper.rb
@@ -6,4 +6,47 @@ module StaticPagesHelper
       u.user.name + (u.team_leader ? " (leader)" : "")
     end.to_sentence
   end
+
+  def badge_for_member(tm)
+    if tm.team_leader
+      "team-leader-badge"
+    elsif tm.team_senior_member
+      "team-senior-member-badge"
+    end
+  end
+
+  def subtext_for_member(tm)
+    if tm.team_leader
+      t("about.structure.leader")
+    elsif tm.team_senior_member
+      t("about.structure.senior_member")
+    end
+  end
+
+  def subtext_for_officer(user)
+    positions = user.current_teams.select { |team| Team.all_officers.include? team }.map(&:name)
+    if user.team_leader?(Team.wfc)
+      positions.push(t('about.structure.treasurer.name'))
+    end
+    positions.join("<br />").html_safe
+  end
+
+  def team_member_name(name)
+    content_tag(:div, class: "team-member-name") do
+      name.html_safe + tag.br + content_tag(:span, class: "team-subtext") do
+        yield
+      end
+    end
+  end
+
+  def format_team_member_content(user)
+    name = if user.wca_id
+             link_to(user.name, person_path(user.wca_id), title: t("about.structure.users.profile", user_name: user.name), data: { toggle: "tooltip", placement: "bottom" })
+           else
+             user.name
+           end
+    team_member_name(name) do
+      yield
+    end
+  end
 end

--- a/WcaOnRails/app/views/static_pages/teams_committees.html.erb
+++ b/WcaOnRails/app/views/static_pages/teams_committees.html.erb
@@ -10,15 +10,12 @@
   <br />
 
   <div class="officer-container">
-    <% @officers.each do |user, positions| %>
+    <% @officers.each do |user| %>
       <div class="badge team-member-badge officer-badge">
         <%= render "shared/user_avatar", user: user %>
-        <div class="team-member-name"><%= user.name %>
-          <br />
-          <span class="team-leader-subtext">
-            <%= positions %>
-          </span>
-        </div>
+        <%= format_team_member_content(user) do %>
+          <%= subtext_for_officer(user) %>
+        <% end %>
       </div>
     <% end %>
   </div>
@@ -29,20 +26,12 @@
     <br />
 
     <% team.current_members.includes(:user).order(team_leader: :desc).order(team_senior_member: :desc).order("users.name asc").each do |tm| %>
-      <div class="badge team-member-badge <%= tm.team_senior_member ? "team-senior-member-badge" : "" %> <%= tm.team_leader ? "team-leader-badge" : "" %>">
+      <div class="badge team-member-badge <%= badge_for_member(tm) %>">
         <%= render "shared/user_avatar", user: tm.user %>
-        <div class="team-member-name"><%= tm.user.name %>
-          <% if tm.team_senior_member %>
-            <br />
-            <span class="team-senior-member-subtext"><%= t("about.structure.senior_member") %></span>
-          <% end %>
-          <% if tm.team_leader %>
-            <br />
-            <span class="team-leader-subtext"><%= t("about.structure.leader") %></span>
-          <% end %>
-        </div>
+        <%= format_team_member_content(tm.user) do %>
+          <%= subtext_for_member(tm) %>
+        <% end %>
       </div>
     <% end %>
   <% end %>
-
 </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1645,6 +1645,8 @@ en:
         name: "WCA Vice-Chair"
       treasurer:
         name: "WCA Treasurer"
+      users:
+        profile: "%{user_name}'s profile"
       #context: WDC
       wdc:
         name: "WCA Disciplinary Committee"

--- a/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/static_pages_helper_spec.rb
@@ -28,4 +28,110 @@ RSpec.describe StaticPagesHelper do
       expect(string).to eq "Jeremy (leader) and Pedro"
     end
   end
+
+  describe "#badge_for_members" do
+    it "returns leader badge when user is leader" do
+      team = FactoryBot.create(:team)
+      member = FactoryBot.create(:user, name: "Jeremy")
+      tm = FactoryBot.create(:team_member, team_id: team.id, user_id: member.id, start_date: Date.today-1, team_leader: true)
+      string = helper.badge_for_member(tm)
+      expect(string).to eq "team-leader-badge"
+    end
+
+    it "returns senior member badge when user is senior_member" do
+      team = FactoryBot.create(:team)
+      other_member = FactoryBot.create(:user, name: "Pedro")
+      tm = FactoryBot.create(:team_member, team_id: team.id, user_id: other_member.id, start_date: Date.today-1, team_senior_member: true)
+      string = helper.badge_for_member(tm)
+      expect(string).to eq "team-senior-member-badge"
+    end
+
+    it "returns no badge when user is neither leader nor senior member" do
+      team = FactoryBot.create(:team)
+      another_member = FactoryBot.create(:user, name: "Aaron")
+      tm = FactoryBot.create(:team_member, team_id: team.id, user_id: another_member.id, start_date: Date.today-1)
+      string = helper.badge_for_member(tm)
+      expect(string).to eq nil
+    end
+  end
+
+  describe "#subtext_for_member" do
+    it "returns leader subtext when user is leader" do
+      team = FactoryBot.create(:team)
+      member = FactoryBot.create(:user, name: "Jeremy")
+      tm = FactoryBot.create(:team_member, team_id: team.id, user_id: member.id, start_date: Date.today-1, team_leader: true)
+      string = helper.subtext_for_member(tm)
+      expect(string).to eq t("about.structure.leader")
+    end
+
+    it "returns senior member subtext when user is senior_member" do
+      team = FactoryBot.create(:team)
+      other_member = FactoryBot.create(:user, name: "Pedro")
+      tm = FactoryBot.create(:team_member, team_id: team.id, user_id: other_member.id, start_date: Date.today-1, team_senior_member: true)
+      string = helper.subtext_for_member(tm)
+      expect(string).to eq t("about.structure.senior_member")
+    end
+
+    it "returns no subtext when user is neither leader nor senior member" do
+      team = FactoryBot.create(:team)
+      another_member = FactoryBot.create(:user, name: "Aaron")
+      tm = FactoryBot.create(:team_member, team_id: team.id, user_id: another_member.id, start_date: Date.today-1)
+      string = helper.subtext_for_member(tm)
+      expect(string).to eq nil
+    end
+  end
+
+  describe "#subtext_for_officer" do
+    it "includes Chair position when user is Chair" do
+      chair_member = FactoryBot.create :user, :chair
+      string = helper.subtext_for_officer(chair_member)
+      expect(string).to include(t('about.structure.chair.name'))
+    end
+
+    it "includes Vice Chair position when user is Vice Chair" do
+      vice_chair_member = FactoryBot.create :user, :vice_chair
+      string = helper.subtext_for_officer(vice_chair_member)
+      expect(string).to include(t('about.structure.vice_chair.name'))
+    end
+
+    it "includes Secretary position when user is Secretary" do
+      secretary_member = FactoryBot.create :user, :secretary
+      string = helper.subtext_for_officer(secretary_member)
+      expect(string).to include(t('about.structure.secretary.name'))
+    end
+
+    it "includes Executive Director position when user is Executive Director" do
+      executive_director_member = FactoryBot.create :user, :executive_director
+      string = helper.subtext_for_officer(executive_director_member)
+      expect(string).to include(t('about.structure.executive_director.name'))
+    end
+
+    it "Includes Treasurer position when user is Treasurer" do
+      wfc_leader_member = FactoryBot.create(:user, :wfc_member, team_leader: true)
+      string = helper.subtext_for_officer(wfc_leader_member)
+      expect(string).to include(t('about.structure.treasurer.name'))
+    end
+  end
+
+  describe "#team_member_name" do
+    it "Adds team member name div" do
+      name = "Max Faster"
+      string = helper.team_member_name(name) { "Max Faster" }
+      expect(string).to eq "<div class=\"team-member-name\">Max Faster<br><span class=\"team-subtext\">Max Faster</span></div>"
+    end
+  end
+
+  describe "#format_team_member_content" do
+    it "Doesn't add a link when there's no WCA ID" do
+      member = FactoryBot.create(:user, name: "Peter")
+      string = helper.format_team_member_content(member) { member.name }
+      expect(string).to eq "<div class=\"team-member-name\">Peter<br><span class=\"team-subtext\">Peter</span></div>"
+    end
+
+    it "Adds a link when there's WCA ID" do
+      member = FactoryBot.create(:person, name: "Peter", wca_id: "2000PETE01")
+      string = helper.format_team_member_content(member) {}
+      expect(string).to include "href=\"/persons/2000PETE01\">Peter</a>"
+    end
+  end
 end


### PR DESCRIPTION
I've added Link to WCA profiles to all Team/Committee/Council Leaders/Senior/Members who have a WCA Profile, also added an internationalized tittle attribute to help with accessibility.

![linktoprofile](https://user-images.githubusercontent.com/12932500/66269048-26ed0b00-e844-11e9-8fcf-9764e9765d71.png)

