### PR TITLE
Create empty WFC panel

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -58,3 +58,4 @@
 @import "media";
 @import "incidents";
 @import "translations";
+@import "country_bands";

--- a/WcaOnRails/app/assets/stylesheets/country_bands.scss
+++ b/WcaOnRails/app/assets/stylesheets/country_bands.scss
@@ -1,0 +1,44 @@
+.common-country-styles {
+  padding: 5px 15px 5px 15px;
+  display: flex;
+  .flag {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-right: 15px;
+    .flag-icon {
+      width: 30px;
+      height: 24px;
+    }
+  }
+  .name {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+.country-band {
+  display: flex;
+  flex-wrap: wrap;
+  .title {
+    margin-bottom: 15px;
+  }
+  .country {
+    @extend .common-country-styles;
+    border: 2px solid #aaa;
+    border-radius: .25em;
+    margin: 0px -5px 7px -5px;
+    background-color: #eee;
+  }
+}
+
+.selectize-control {
+  .selectize-input.items {
+    display: flex;
+    flex-wrap: wrap;
+    & > .country {
+      @extend .common-country-styles;
+      border: 2px solid #aaa;
+    }
+  }
+}

--- a/WcaOnRails/app/assets/stylesheets/country_bands.scss
+++ b/WcaOnRails/app/assets/stylesheets/country_bands.scss
@@ -29,6 +29,9 @@
     border-radius: .25em;
     margin: 0px -5px 7px -5px;
     background-color: #eee;
+    &.highlighted {
+      border-color: $dark-green;
+    }
   }
 }
 
@@ -40,5 +43,15 @@
       @extend .common-country-styles;
       border: 2px solid #aaa;
     }
+  }
+}
+
+.filter-form {
+  text-align: center;
+  margin-bottom: 15px;
+  select.form-control {
+    margin-left: 5px;
+    display: inline-block;
+    width: auto;
   }
 }

--- a/WcaOnRails/app/controllers/country_bands_controller.rb
+++ b/WcaOnRails/app/controllers/country_bands_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CountryBandsController < ApplicationController
+  before_action :authenticate_user!, except: :index
   before_action -> { redirect_to_root_unless_user(:can_admin_finances?) }, except: :index
 
   def index

--- a/WcaOnRails/app/controllers/country_bands_controller.rb
+++ b/WcaOnRails/app/controllers/country_bands_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class CountryBandsController < ApplicationController
+  before_action -> { redirect_to_root_unless_user(:can_admin_finances?) }, except: :index
+
+  def index
+    @country_bands_by_number = CountryBand.all.group_by(&:number)
+  end
+
+  def edit
+    @number = id_from_params
+    unless CountryBand::BANDS.keys.include?(@number)
+      flash[:danger] = "Unknown band number"
+      return redirect_to country_bands_path
+    end
+    set_instance_variables
+  end
+
+  def update
+    @number = id_from_params
+    iso2s = params.require(:countries).require(:iso2s)
+    has_anything_changed = false
+    previously_in_band = CountryBand.where(number: @number).map(&:iso2)
+    begin
+      iso2s.split(",").each do |iso2|
+        cb = CountryBand.find_or_initialize_by(iso2: iso2)
+        cb.number = @number
+        has_anything_changed ||= cb.changed?
+        cb.save!
+        previously_in_band.delete(iso2)
+      end
+      if previously_in_band.any?
+        # Clean up removed countries
+        CountryBand.where(iso2: previously_in_band).delete_all
+        has_anything_changed = true
+      end
+      flash[:success] = if has_anything_changed
+                          "Successfully updated band data."
+                        else
+                          "No change to band data."
+                        end
+    rescue ActiveRecord::RecordInvalid => e
+      flash[:danger] = "Couldn't save all countries, here is the error: #{e.message}."
+    end
+    set_instance_variables
+    render :edit
+  end
+
+  private
+
+  def id_from_params
+    Integer(params.require(:id))
+  rescue ArgumentError
+    false
+  end
+
+  def set_instance_variables
+    @in_band = CountryBand.where(number: @number).map(&:country).sort_by(&:name).map(&:iso2)
+    # We do want to include countries for our band here, as they are filtered
+    # by selectize.
+    used_countries = CountryBand.where.not(number: @number).map(&:country)
+    @unused = (Country.real - used_countries).map do |c|
+      { name: c.name, iso2: c.iso2 }
+    end
+  end
+end

--- a/WcaOnRails/app/controllers/country_bands_controller.rb
+++ b/WcaOnRails/app/controllers/country_bands_controller.rb
@@ -21,25 +21,27 @@ class CountryBandsController < ApplicationController
     @number = id_from_params
     iso2s = params.require(:countries).require(:iso2s)
     has_anything_changed = false
-    previously_in_band = CountryBand.where(number: @number).map(&:iso2)
+    previously_in_band = CountryBand.where(number: @number).pluck(:iso2)
     begin
-      iso2s.split(",").each do |iso2|
-        cb = CountryBand.find_or_initialize_by(iso2: iso2)
-        cb.number = @number
-        has_anything_changed ||= cb.changed?
-        cb.save!
-        previously_in_band.delete(iso2)
+      ActiveRecord::Base.transaction do
+        iso2s.split(",").each do |iso2|
+          cb = CountryBand.find_or_initialize_by(iso2: iso2)
+          cb.number = @number
+          has_anything_changed ||= cb.changed?
+          cb.save!
+          previously_in_band.delete(iso2)
+        end
+        if previously_in_band.any?
+          # Clean up removed countries
+          CountryBand.where(iso2: previously_in_band).delete_all
+          has_anything_changed = true
+        end
+        flash[:success] = if has_anything_changed
+                            "Successfully updated band data."
+                          else
+                            "No change to band data."
+                          end
       end
-      if previously_in_band.any?
-        # Clean up removed countries
-        CountryBand.where(iso2: previously_in_band).delete_all
-        has_anything_changed = true
-      end
-      flash[:success] = if has_anything_changed
-                          "Successfully updated band data."
-                        else
-                          "No change to band data."
-                        end
     rescue ActiveRecord::RecordInvalid => e
       flash[:danger] = "Couldn't save all countries, here is the error: #{e.message}."
     end
@@ -52,13 +54,14 @@ class CountryBandsController < ApplicationController
   def id_from_params
     Integer(params.require(:id))
   rescue ArgumentError
-    false
+    nil
   end
 
   def set_instance_variables
     @in_band = CountryBand.where(number: @number).map(&:country).sort_by(&:name).map(&:iso2)
-    # We do want to include countries for our band here, as they are filtered
-    # by selectize.
+    # The list of unused countries should contain both unused countries and countries for the selected band.
+    # Therefore we can get the list of relevant countries by substracting all the
+    # other bands countries to the overall list of countries.
     used_countries = CountryBand.where.not(number: @number).map(&:country)
     @unused = (Country.real - used_countries).map do |c|
       { name: c.name, iso2: c.iso2 }

--- a/WcaOnRails/app/controllers/wfc_controller.rb
+++ b/WcaOnRails/app/controllers/wfc_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class WfcController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { redirect_to_root_unless_user(:can_admin_finances?) }
+
+  def panel
+  end
+end

--- a/WcaOnRails/app/controllers/wfc_controller.rb
+++ b/WcaOnRails/app/controllers/wfc_controller.rb
@@ -6,4 +6,22 @@ class WfcController < ApplicationController
 
   def panel
   end
+
+  def competition_export
+    select_attributes = [
+      :id, :name, :start_date, :end_date,
+      :countryId, :announced_at, :results_posted_at,
+      "count(distinct rails_persons.id) as num_competitors"
+    ]
+    from = params.require(:from_date)
+    to = params.require(:to_date)
+    @competitions=Competition
+                  .select(select_attributes)
+                  .includes(:delegates)
+                  .joins(:competitors)
+                  .group("Competitions.id")
+                  .where("start_date >= ?", from)
+                  .where("end_date <= ?", to)
+                  .order(:start_date, :name)
+  end
 end

--- a/WcaOnRails/app/helpers/country_bands_helper.rb
+++ b/WcaOnRails/app/helpers/country_bands_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CountryBandsHelper
+  def continent_id_as_class(id)
+    id.tr(" ", "")
+  end
+
+  def continent_options
+    [["None", ""]].concat(Continent.real.map { |c| [c.name, continent_id_as_class(c.id)] })
+  end
+end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -299,6 +299,10 @@ class Competition < ApplicationRecord
     Country.c_find(self.countryId)
   end
 
+  def continent
+    country.continent
+  end
+
   # Enforce that the users marked as delegates for this competition are
   # actually delegates. Note: just because someone (legally) delegated a
   # competition in the past does not mean that they are still a delegate,

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -54,6 +54,10 @@ class Country < ApplicationRecord
   belongs_to :continent, foreign_key: :continentId
   has_many :competitions, foreign_key: :countryId
 
+  def continent
+    Continent.c_find(self.continentId)
+  end
+
   def self.find_by_iso2(iso2)
     c_all_by_id.values.select { |c| c.iso2 == iso2 }.first
   end

--- a/WcaOnRails/app/models/country.rb
+++ b/WcaOnRails/app/models/country.rb
@@ -53,6 +53,7 @@ class Country < ApplicationRecord
 
   belongs_to :continent, foreign_key: :continentId
   has_many :competitions, foreign_key: :countryId
+  has_one :band, foreign_key: :iso2, primary_key: :iso2, class_name: "CountryBand"
 
   def continent
     Continent.c_find(self.continentId)

--- a/WcaOnRails/app/models/country_band.rb
+++ b/WcaOnRails/app/models/country_band.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CountryBand < ApplicationRecord
+  BANDS = {
+    0 => {
+      value: 0,
+    },
+    1 => {
+      value: 0.19,
+    },
+    2 => {
+      value: 0.32,
+    },
+    3 => {
+      value: 0.45,
+    },
+    4 => {
+      value: 0.76,
+    },
+    5 => {
+      value: 1.0,
+    },
+  }.freeze
+
+  belongs_to :country, foreign_key: :iso2, primary_key: :iso2
+  validates_inclusion_of :iso2, in: Country.real.map(&:iso2).freeze
+  validates_inclusion_of :number, in: BANDS.keys.freeze
+
+  def country
+    Country.find_by_iso2(self.iso2)
+  end
+end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -592,6 +592,10 @@ class User < ApplicationRecord
     admin? || board_member? || results_team?
   end
 
+  def can_admin_finances?
+    admin? || financial_committee?
+  end
+
   # Returns true if the user can perform every action for teams.
   def can_manage_teams?
     admin? || board_member? || results_team?

--- a/WcaOnRails/app/views/country_bands/_show_band.html.erb
+++ b/WcaOnRails/app/views/country_bands/_show_band.html.erb
@@ -8,7 +8,7 @@
   </div>
   <% (@country_bands_by_number[number] || []).map(&:country).sort_by(&:name).each do |c| %>
     <div class="col-xs-6 col-sm-4 col-md-3 col">
-      <div class="country">
+      <div class="country continent-<%= continent_id_as_class(c.continent.id) %>">
         <div class="flag"><%= flag_icon c.iso2 %></div>
         <div class="name"><%= "#{c.name}" %></div>
       </div>

--- a/WcaOnRails/app/views/country_bands/_show_band.html.erb
+++ b/WcaOnRails/app/views/country_bands/_show_band.html.erb
@@ -1,0 +1,17 @@
+<div class="row list-group-item country-band">
+  <div class="col-xs-12 text-center title">
+    <%= t("country_bands.band_title", number: number) %>
+    (<%= t("country_bands.due_value", value: data[:value]) %>)
+    <% if current_user&.can_admin_finances? %>
+      <%= link_to(icon("fas", "pencil-alt"), edit_country_band_path(id: number)) %>
+    <% end %>
+  </div>
+  <% (@country_bands_by_number[number] || []).map(&:country).sort_by(&:name).each do |c| %>
+    <div class="col-xs-6 col-sm-4 col-md-3 col">
+      <div class="country">
+        <div class="flag"><%= flag_icon c.iso2 %></div>
+        <div class="name"><%= "#{c.name}" %></div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/WcaOnRails/app/views/country_bands/edit.html.erb
+++ b/WcaOnRails/app/views/country_bands/edit.html.erb
@@ -1,0 +1,38 @@
+<div class="container">
+  <%= link_to("Back to country bands", country_bands_path) %>
+  <h1 class="text-center">Editing Country Band <%= @number %></h1>
+  <%= simple_form_for :country_band, url: country_band_path(id: @number), method: :put do |f| %>
+    <%= f.input :number, as: :hidden %>
+    <%= simple_fields_for :countries do |c| %>
+      <%= c.input :iso2s, as: :string, label: false, input_html: { id: "iso2s" } %>
+    <% end %>
+    <%= f.button :submit, class: "btn-primary", value: "Save the country band" %>
+  <% end %>
+</div>
+<script>
+  const optionElement = '<div><%= flag_icon "%iso2" %> %name</div>';
+  const itemElement = '<div class="country"><div class="flag"><%= flag_icon "%iso2" %></div><div class="name">%name</div></div>';
+  $('#iso2s').selectize({
+    persist: false,
+    maxItems: null,
+    valueField: 'iso2',
+    labelField: 'name',
+    searchField: ['name', 'iso2'],
+    plugins: ['remove_button'],
+    options: <%= raw(@unused.to_json) %>,
+    items: <%= raw(@in_band.to_json) %>,
+    render: {
+      item: function(item, escape) {
+        console.log(item);
+        var el = itemElement.replace("%iso2", escape(item.iso2).toLowerCase());
+        el = el.replace("%name", escape(item.name));
+        return el;
+      },
+      option: function(item, escape) {
+        var el = optionElement.replace("%iso2", escape(item.iso2).toLowerCase());
+        el = el.replace("%name", escape(item.name));
+        return el;
+      }
+    },
+  });
+</script>

--- a/WcaOnRails/app/views/country_bands/edit.html.erb
+++ b/WcaOnRails/app/views/country_bands/edit.html.erb
@@ -10,8 +10,8 @@
   <% end %>
 </div>
 <script>
-  const optionElement = '<div><%= flag_icon "%iso2" %> %name</div>';
-  const itemElement = '<div class="country"><div class="flag"><%= flag_icon "%iso2" %></div><div class="name">%name</div></div>';
+  var optionElement = '<div><%= flag_icon "%iso2" %> %name</div>';
+  var itemElement = '<div class="country"><div class="flag"><%= flag_icon "%iso2" %></div><div class="name">%name</div></div>';
   $('#iso2s').selectize({
     persist: false,
     maxItems: null,
@@ -23,15 +23,12 @@
     items: <%= raw(@in_band.to_json) %>,
     render: {
       item: function(item, escape) {
-        console.log(item);
-        var el = itemElement.replace("%iso2", escape(item.iso2).toLowerCase());
-        el = el.replace("%name", escape(item.name));
-        return el;
+        return itemElement.replace("%iso2", escape(item.iso2).toLowerCase())
+          .replace("%name", escape(item.name));
       },
       option: function(item, escape) {
-        var el = optionElement.replace("%iso2", escape(item.iso2).toLowerCase());
-        el = el.replace("%name", escape(item.name));
-        return el;
+        return optionElement.replace("%iso2", escape(item.iso2).toLowerCase())
+          .replace("%name", escape(item.name));
       }
     },
   });

--- a/WcaOnRails/app/views/country_bands/index.html.erb
+++ b/WcaOnRails/app/views/country_bands/index.html.erb
@@ -2,9 +2,26 @@
 
 <div class="container">
   <h1 class="text-center"><%= yield :title %></h1>
+  <div class="row">
+    <div class="col-xs-12 filter-form">
+      <label for="filter_continent[id]">
+        Highlight countries from continent:
+      </label>
+      <%= select("filter_continent", "id",
+                 continent_options,
+                 {}, { class: "form-control" },
+                ) %>
+    </div>
+  </div>
   <div class="list-group">
     <% CountryBand::BANDS.each do |number, data| %>
       <%= render "show_band", number: number, data: data %>
     <% end %>
   </div>
 </div>
+<script>
+  $("#filter_continent_id").change(function(ev) {
+    $(".highlighted").removeClass("highlighted");
+    $(".continent-" + ev.target.value).addClass("highlighted");
+  });
+</script>

--- a/WcaOnRails/app/views/country_bands/index.html.erb
+++ b/WcaOnRails/app/views/country_bands/index.html.erb
@@ -1,0 +1,10 @@
+<% provide(:title, t("country_bands.title")) %>
+
+<div class="container">
+  <h1 class="text-center"><%= yield :title %></h1>
+  <div class="list-group">
+    <% CountryBand::BANDS.each do |number, data| %>
+      <%= render "show_band", number: number, data: data %>
+    <% end %>
+  </div>
+</div>

--- a/WcaOnRails/app/views/panel/index.html.erb
+++ b/WcaOnRails/app/views/panel/index.html.erb
@@ -54,10 +54,13 @@
   <% end %>
 
 
-  <% if current_user.team_leader?(Team.wfc) || current_user.team_senior_member?(Team.wfc) %>
+  <% if current_user.can_admin_finances? %>
     <h2><%= Team.wfc.name %></h2>
 
     <ul>
+      <li>
+        <%= link_to "WFC panel", wfc_path %>
+      </li>
       <li>
         <%= link_to "Modify Delegates on Probation", edit_team_path(Team.probation) %>
       </li>

--- a/WcaOnRails/app/views/wfc/_nav.html.erb
+++ b/WcaOnRails/app/views/wfc/_nav.html.erb
@@ -1,0 +1,3 @@
+<div class="container">
+  <%= yield %>
+</div>

--- a/WcaOnRails/app/views/wfc/competition_export.csv.erb
+++ b/WcaOnRails/app/views/wfc/competition_export.csv.erb
@@ -1,0 +1,14 @@
+<% require 'csv' %>
+<% headers = [
+  "Id", "Name", "Country", "Continent",
+  "Start", "End", "Announced", "Posted",
+  "Link on WCA", "Competitors", "Delegates",
+] %>
+<%= CSV.generate_line(headers).html_safe -%>
+<% @competitions.each do |c| %>
+  <%= CSV.generate_line([
+    c.id, c.name, c.country.iso2, c.continent.id,
+    c.start_date, c.end_date, c.announced_at, c.results_posted_at,
+    competition_url(c.id), c.num_competitors, c.delegates.map(&:name).join(","),
+  ]).html_safe -%>
+<% end %>

--- a/WcaOnRails/app/views/wfc/competition_export.csv.erb
+++ b/WcaOnRails/app/views/wfc/competition_export.csv.erb
@@ -4,11 +4,11 @@
   "Start", "End", "Announced", "Posted",
   "Link on WCA", "Competitors", "Delegates",
 ] %>
-<%= CSV.generate_line(headers).html_safe -%>
+<%= CSV.generate_line(headers, col_sep: "\t").html_safe -%>
 <% @competitions.each do |c| %>
   <%= CSV.generate_line([
     c.id, c.name, c.country.iso2, c.continent.id,
     c.start_date, c.end_date, c.announced_at, c.results_posted_at,
     competition_url(c.id), c.num_competitors, c.delegates.map(&:name).join(","),
-  ]).html_safe -%>
+  ], col_sep: "\t").html_safe -%>
 <% end %>

--- a/WcaOnRails/app/views/wfc/panel.html.erb
+++ b/WcaOnRails/app/views/wfc/panel.html.erb
@@ -1,0 +1,7 @@
+<% provide(:title, "WFC Panel") %>
+
+<%= render layout: "nav" do %>
+  <h1><%= yield(:title) %></h1>
+
+  <%= alert(:info, "Sorry WFC, there is nothing to show here yet!") %>
+<% end %>

--- a/WcaOnRails/app/views/wfc/panel.html.erb
+++ b/WcaOnRails/app/views/wfc/panel.html.erb
@@ -3,5 +3,49 @@
 <%= render layout: "nav" do %>
   <h1><%= yield(:title) %></h1>
 
-  <%= alert(:info, "Sorry WFC, there is nothing to show here yet!") %>
+  <h3>Competitions export</h3>
+
+  <%= horizontal_simple_form_for :export, url: "", html: { id: "wfc-export-form" } do |f| %>
+
+    <div class="form-inputs">
+      <%= f.input :from_date, as: :date_picker, input_html: { value: Time.now.strftime("%Y-01-01"), id: "input-from-date" } %>
+      <%= f.input :to_date, as: :date_picker, input_html: { value: Time.now.strftime("%Y-%m-%d"), id: "input-to-date" } %>
+    </div>
+    <div class="col-sm-offset-2 col-sm-10">
+      <%= link_to "Download export", "#", class: "btn btn-primary", id: "download-wfc-export" %>
+    </div>
+    <script>
+      $(function() {
+        $("#download-wfc-export").on("click", function(ev) {
+          ev.preventDefault();
+          const from = $("#input-from-date").val();
+          const to = $("#input-to-date").val();
+          $el = $(this);
+          $el.addClass("disabled");
+          $.ajax({
+            url: '<%= wfc_competitions_export_path %>',
+            method: 'GET',
+            data: {
+              from_date: from,
+              to_date: to,
+            },
+          }).done(function(data) {
+            const fileUrl = URL.createObjectURL(new Blob([data], {type: 'text/csv'}));
+            // Create a hidden link to generate the download
+            const a = document.createElement('a');
+            a.style.display = 'none';
+            a.href = fileUrl;
+            a.download = `wfc-competitions-export-${from}-${to}.csv`;
+            document.body.appendChild(a);
+            a.click();
+            window.URL.revokeObjectURL(fileUrl);
+          }).fail(function(jqXHR, err, message) {
+            alert(message);
+          }).always(function() {
+            $el.removeClass("disabled");
+          });
+        });
+      });
+    </script>
+  <% end %>
 <% end %>

--- a/WcaOnRails/app/views/wfc/panel.html.erb
+++ b/WcaOnRails/app/views/wfc/panel.html.erb
@@ -34,12 +34,12 @@
               to_date: to,
             },
           }).done(function(data) {
-            const fileUrl = URL.createObjectURL(new Blob([data], {type: 'text/csv'}));
+            const fileUrl = URL.createObjectURL(new Blob([data], {type: 'text/tab-separated-value'}));
             // Create a hidden link to generate the download
             const a = document.createElement('a');
             a.style.display = 'none';
             a.href = fileUrl;
-            a.download = `wfc-competitions-export-${from}-${to}.csv`;
+            a.download = `wfc-competitions-export-${from}-${to}.tsv`;
             document.body.appendChild(a);
             a.click();
             window.URL.revokeObjectURL(fileUrl);

--- a/WcaOnRails/app/views/wfc/panel.html.erb
+++ b/WcaOnRails/app/views/wfc/panel.html.erb
@@ -3,6 +3,10 @@
 <%= render layout: "nav" do %>
   <h1><%= yield(:title) %></h1>
 
+  <h3>Country bands</h3>
+
+  <%= link_to "Go to country bands", country_bands_path %>
+
   <h3>Competitions export</h3>
 
   <%= horizontal_simple_form_for :export, url: "", html: { id: "wfc-export-form" } do |f| %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -594,6 +594,9 @@ en:
         extra_file: "Must be in PDF format. If you need to add more files, please merge them together"
         start_date: ""
         end_date: ""
+      wfc:
+        from_date: ""
+        to_date: ""
     #context: and a label for an option
     options:
       #context: about registration

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -62,6 +62,11 @@ en:
     "North America": "North America"
     Oceania: "Oceania"
     "South America": "South America"
+  #context: On the country bands page
+  country_bands:
+    title: "WCA Country Bands"
+    band_title: "Band %{number}"
+    due_value: "$%{value} per competitor per competition"
   #context: Event name
   events:
     "333": "3x3x3 Cube"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -187,6 +187,7 @@ Rails.application.routes.draw do
 
   # WFC section
   get '/wfc' => 'wfc#panel'
+  get '/wfc/competitions_export' => 'wfc#competition_export', defaults: { format: :csv }
 
   scope :archive do
     # NOTE: This is meant for displaying old content of the phpBB forum. It is DEPRECATED!

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -187,7 +187,10 @@ Rails.application.routes.draw do
 
   # WFC section
   get '/wfc' => 'wfc#panel'
-  get '/wfc/competitions_export' => 'wfc#competition_export', defaults: { format: :csv }
+  scope 'wfc' do
+    get '/competitions_export' => 'wfc#competition_export', defaults: { format: :csv }, as: :wfc_competitions_export
+    resources :country_bands, only: [:index, :update, :edit], path: '/country-bands'
+  end
 
   scope :archive do
     # NOTE: This is meant for displaying old content of the phpBB forum. It is DEPRECATED!

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -185,6 +185,9 @@ Rails.application.routes.draw do
   get '/relations' => 'relations#index'
   get '/relation' => 'relations#relation'
 
+  # WFC section
+  get '/wfc' => 'wfc#panel'
+
   scope :archive do
     # NOTE: This is meant for displaying old content of the phpBB forum. It is DEPRECATED!
     resources :forums, only: [:index, :show]

--- a/WcaOnRails/db/migrate/20191013211511_create_country_bands.rb
+++ b/WcaOnRails/db/migrate/20191013211511_create_country_bands.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCountryBands < ActiveRecord::Migration[5.2]
+  def change
+    create_table :country_bands do |t|
+      t.integer :number, null: false
+      t.string :iso2, limit: 2, null: false
+    end
+    add_index :country_bands, :number
+    add_index :country_bands, :iso2, unique: true
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -781,6 +781,18 @@ CREATE TABLE `completed_jobs` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `country_bands`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `country_bands` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `number` int(11) NOT NULL,
+  `iso2` varchar(2) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `index_country_bands_on_iso2` (`iso2`),
+  KEY `index_country_bands_on_number` (`number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delayed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1605,4 +1617,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190825095512'),
 ('20190826005902'),
 ('20190916133253'),
-('20191005203556');
+('20191005203556'),
+('20191013211511');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -738,6 +738,16 @@ module DatabaseDumper
         ),
       ),
     }.freeze,
+    "country_bands" => {
+      where_clause: "",
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          number
+          iso2
+        ),
+      ),
+    }.freeze,
   }.freeze
 
   def self.development_dump(dump_filename)

--- a/WcaOnRails/spec/models/country_band_spec.rb
+++ b/WcaOnRails/spec/models/country_band_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CountryBand do
+  it "validates valid band" do
+    cb = CountryBand.new(number: 0, iso2: "FR")
+    expect(cb).to be_valid
+  end
+
+  it "invalidates band with invalid country" do
+    cb = CountryBand.new(number: 0, iso2: "HELLO")
+    expect(cb).to be_invalid_with_errors(iso2: ["is not included in the list"])
+  end
+
+  it "invalidates band with invalid band id" do
+    cb = CountryBand.new(number: 6, iso2: "HELLO")
+    expect(cb).to be_invalid_with_errors(number: ["is not included in the list"])
+  end
+end

--- a/WcaOnRails/spec/requests/country_bands_spec.rb
+++ b/WcaOnRails/spec/requests/country_bands_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Country bands controller" do
+  describe "GET /index" do
+    context "when not signed in" do
+      sign_out
+      it "shows the page" do
+        get country_bands_path
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "GET /edit" do
+    context "when not signed in" do
+      sign_out
+      it "redirect to login page" do
+        get edit_country_band_path(0)
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "when signed in as a regular user" do
+      sign_in { FactoryBot.create :user }
+      it "redirect to root" do
+        get edit_country_band_path(0)
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context "when signed in as a WFC member" do
+      sign_in { FactoryBot.create :user, :wfc_member }
+      it "shows the page" do
+        get edit_country_band_path(0)
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "PUT /update" do
+    let(:some_countries) { ["US", "AL"] }
+
+    context "when signed in as a regular user" do
+      sign_in { FactoryBot.create :user }
+      it "redirect to root" do
+        put country_band_path(0, params: { countries: { iso2s: some_countries.join(",") } })
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context "when signed in as a WFC member" do
+      before :each do
+        sign_in(FactoryBot.create(:user, :wfc_member))
+      end
+
+      it "adds country to band" do
+        put country_band_path(0, params: { countries: { iso2s: some_countries.join(",") } })
+        expect(response).to be_successful
+        expect(CountryBand.where(number: 0).map(&:iso2)).to match_array some_countries
+      end
+
+      it "removes country from band" do
+        some_countries.each do |iso2|
+          CountryBand.create(number: 0, iso2: iso2)
+        end
+        new_countries = ["FR", "SA"]
+        expect(CountryBand.where(number: 0).map(&:iso2)).to match_array some_countries
+        put country_band_path(0, params: { countries: { iso2s: new_countries.join(",") } })
+        expect(response).to be_successful
+        expect(CountryBand.where(number: 0).map(&:iso2)).to match_array new_countries
+      end
+
+      it "changes country from band" do
+        CountryBand.create(number: 0, iso2: "FR")
+        put country_band_path(1, params: { countries: { iso2s: "FR" } })
+        expect(response).to be_successful
+        expect(CountryBand.where(number: 0)).to be_empty
+        expect(CountryBand.where(number: 1).map(&:iso2)).to eq ["FR"]
+      end
+    end
+  end
+end

--- a/WcaOnRails/spec/requests/wfc_spec.rb
+++ b/WcaOnRails/spec/requests/wfc_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe "WFC controller" do
       end
     end
   end
+  describe "GET /competitions_export" do
+    context "when signed in as a regular user" do
+      sign_in { FactoryBot.create :user }
+      it "redirect to root" do
+        get wfc_competitions_export_path(from_date: Time.now, to_date: Time.now)
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context "when signed in as a WFC member" do
+      sign_in { FactoryBot.create :user, :wfc_member }
+      it "shows the page" do
+        get wfc_competitions_export_path(from_date: Time.now, to_date: Time.now)
+        expect(response).to be_successful
+        # Don't bother checking the actual data here, the WFC will complain if it's broken and may want to change it overtime.
+      end
+    end
+  end
 end

--- a/WcaOnRails/spec/requests/wfc_spec.rb
+++ b/WcaOnRails/spec/requests/wfc_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "WFC controller" do
+  describe "GET /panel" do
+    context "when not signed in" do
+      sign_out
+      it "redirect to login page" do
+        get wfc_path
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "when signed in as a regular user" do
+      sign_in { FactoryBot.create :user }
+      it "redirect to root" do
+        get wfc_path
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context "when signed in as a WFC member" do
+      sign_in { FactoryBot.create :user, :wfc_member }
+      it "shows the page" do
+        get wfc_path
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4708, fixes #4713.

It adds a competitions export that the WFC needs to (the previous requests for that were sent to the WRT and I just created a form to let the WFC run the query on-demand).