### PR TITLE
Add wca-live link, update score tools

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -62,6 +62,8 @@
             <%= icon('fas', 'list-ol') %> <%= t '.results' %> <span class="caret"></span>
           </a>
           <ul class="dropdown-menu" role="menu">
+            <li><a href="https://live.worldcubeassociation.org"><%= icon('fa', 'sort-numeric-down') %>WCA Live</a></li>
+            <li class="divider"></li>
             <li><a href="<%= rankings_path("333", "single") %>"><%= icon('fas', 'signal', class: 'fa-rotate-90') %> <%= t '.rankings' %></a></li>
             <li><a href="/results/regions.php"><%= icon('fas', 'trophy') %> <%= t '.records' %></a></li>
             <li><a href="<%= persons_path %>"><%= icon('fas', 'users') %> <%= t '.persons' %></a></li>

--- a/WcaOnRails/app/views/static_pages/score_tools.html.erb
+++ b/WcaOnRails/app/views/static_pages/score_tools.html.erb
@@ -1,15 +1,13 @@
 <% provide(:title, t('score_tools.title')) %>
 
-<% tools_variables = {
-  workbook_link: link_to("WCA Workbook Assistant", wca_workbook_assistant_path)
-} %>
-
 <div class="container">
   <h1><%= yield(:title) %></h1>
 
-  <% t('score_tools.paragraphs').values.each do |paragraph| %>
-    <p>
-      <%= raw paragraph % tools_variables %>
-    </p>
-  <% end %>
+  <ul class="list-group">
+    <% t('score_tools.paragraphs').values.each do |paragraph| %>
+      <li class="list-group-item">
+        <%= raw paragraph %>
+      </li>
+    <% end %>
+  </ul>
 </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1783,11 +1783,11 @@ en:
   score_tools:
     title: "WCA Score Taking tools"
     paragraphs:
-      '1': 'The WCA highly recommends the use of <a href="http://cubecomps.com">Cube Comps</a> before and during a competition. Cube Comps is an online system with live scoring and many interesting features, like score sheet printing and a very efficient multi-user data entry system. Created by Luis J. Iáñez and now under Open Source.'
-      '2': "Score sheets and scrambles should be processed and checked for errors using the %{workbook_link} before sending them to the WCA Results Team."
+      '1': 'The WCA highly recommends the use of <a href="https://live.worldcubeassociation.org">WCA Live</a> before and during a competition. WCA Live is a platform for running WCA competitions and sharing live results with the world.'
+      '2': 'Score sheets and scrambles should be processed and checked for errors before sending them to the WCA Results Team. You can use <a href="https://viroulep.github.io/scrambles-matcher/">Scrambles Matcher</a>, an Open Source project created by Philippe Virouleau.'
       '3': 'The latest version of the WCA competition Score sheet can be downloaded here:<br /><a href="/files/results.xls" target="_blank">WCA competition Score sheet</a>.'
       '4': >-
-        You may also want to use <a href="https://jonatanklosko.github.io/groupifier">Groupifier</a>
+        You may also want to use <a href="https://groupifier.jonatanklosko.com">Groupifier</a>
         for preparing competitor groups for a competition. It's a tool that aims to do exactly this for you.
         Among the main features you will find: sorting competitors by rankings,
         assigning tasks (judging, scrambling), deciding how many scrambles are needed,


### PR DESCRIPTION
WCA Live link added because it makes sense. It is proposed to not be translated and it's on the Results menu section.

![Captura de tela de 2019-10-19 10-40-38](https://user-images.githubusercontent.com/10170850/67146010-f8682a80-f25c-11e9-9169-30d0c3cbab5d.png)
