### PR TITLE
Validate user details before setting WCA ID

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -871,6 +871,7 @@ en:
       wca_id_no_name_html: "We do not have a name recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
       avatar_requires_wca_id: "requires a WCA ID to be assigned"
       email_used_by_locked_account_html: "is already used by another account. It's been created automatically as a result of you registering for a competition via an external service. If you are the owner of this email, you can use the account after resetting your password <a href='/users/password/new'>here</a>."
+      must_match_person: "must match person details corresponding to the WCA ID"
     #context: when an action was successful
     successes:
       messages:

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe UsersController do
     end
 
     it "cannot claim wca id if already has a wca id" do
-      other_person = FactoryBot.create :person
-      user.wca_id = other_person.wca_id
-      user.save!
+      other_person = FactoryBot.create(:person)
+      user.update!(wca_id: other_person.wca_id, name: other_person.name, country_iso2: other_person.country_iso2,
+                   dob: other_person.dob, gender: other_person.gender)
 
       patch :update, params: { id: user, user: { claiming_wca_id: true, unconfirmed_wca_id: person.wca_id, delegate_id_to_handle_wca_id_claim: delegate.id } }
       new_user = assigns(:user)
@@ -80,8 +80,10 @@ RSpec.describe UsersController do
       expect(user.delegate_to_handle_wca_id_claim).to be_nil
     end
 
-    it "can set id to something not claimed" do
-      person2 = FactoryBot.create :person
+    it "can set id to something not claimed if the details match" do
+      person2 = FactoryBot.create :person, name: user.name, countryId: user.country.id,
+                                           year: user.dob.year, month: user.dob.month,
+                                           day: user.dob.day, gender: user.gender
       patch :update, params: { id: user, user: { wca_id: person2.wca_id } }
       user.reload
       expect(user.wca_id).to eq person2.wca_id

--- a/WcaOnRails/spec/factories/users.rb
+++ b/WcaOnRails/spec/factories/users.rb
@@ -170,13 +170,22 @@ FactoryBot.define do
       end
     end
 
+    wca_id { person&.wca_id }
+
+    after(:build) do |user|
+      if user.person
+        user.name = user.person.name
+        user.country_iso2 = user.person.country_iso2
+        user.dob = user.person.dob
+        user.gender = user.person.gender
+      end
+    end
+
     trait :french_locale do
       after(:create) do |user|
         user.preferred_locale = :fr
       end
     end
-
-    wca_id { person&.wca_id }
 
     factory :user_with_wca_id, traits: [:wca_id]
 

--- a/WcaOnRails/spec/features/edit_user_spec.rb
+++ b/WcaOnRails/spec/features/edit_user_spec.rb
@@ -6,7 +6,10 @@ RSpec.feature "Edit user" do
   let(:admin) { FactoryBot.create(:admin) }
   let(:existing_user) { FactoryBot.create(:user_with_wca_id) }
   let(:new_person) { FactoryBot.create(:person) }
-  let(:new_user) { FactoryBot.create(:user) }
+  let(:new_user) do
+    FactoryBot.create(:user, name: new_person.name, country_iso2: new_person.country_iso2,
+                             dob: new_person.dob, gender: new_person.gender)
+  end
 
   def navigate_to_form(user)
     visit edit_user_path(user)

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -234,6 +234,18 @@ RSpec.describe User, type: :model do
       user2.wca_id = user.wca_id
       expect(user2).not_to be_valid
     end
+
+    it "does not allows assigning WCA ID if user and person details don't match" do
+      user = FactoryBot.create(:user, name: "Whatever", country_iso2: "US", dob: Date.new(1950, 12, 12), gender: "m")
+      person = FactoryBot.create(:person, name: "Else", countryId: "United Kingdom", year: 1900, gender: "f")
+      user.wca_id = person.wca_id
+      expect(user).to be_invalid_with_errors(
+        name: [I18n.t('users.errors.must_match_person')],
+        country_iso2: [I18n.t('users.errors.must_match_person')],
+        dob: [I18n.t('users.errors.must_match_person')],
+        gender: [I18n.t('users.errors.must_match_person')],
+      )
+    end
   end
 
   it "can create user with empty password" do

--- a/WcaOnRails/spec/requests/registrations_spec.rb
+++ b/WcaOnRails/spec/requests/registrations_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "registrations" do
                     user = FactoryBot.create(:user, :wca_id)
                     file = csv_file [
                       ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                      ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                      ["a", dummy_user.name, dummy_user.country.id, dummy_user.wca_id, dummy_user.dob, dummy_user.gender, user.email, "1", "0"],
                     ]
                     expect {
                       post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -89,7 +89,7 @@ RSpec.describe "registrations" do
                     user = FactoryBot.create(:user)
                     file = csv_file [
                       ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                      ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                      ["a", dummy_user.name, dummy_user.country.id, dummy_user.wca_id, dummy_user.dob, dummy_user.gender, user.email, "1", "0"],
                     ]
                     expect {
                       post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -108,7 +108,7 @@ RSpec.describe "registrations" do
                   expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
                   file = csv_file [
                     ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                    ["a", "Sherlock Holmes", "United Kingdom", dummy_user.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                    ["a", dummy_user.name, dummy_user.country.id, dummy_user.wca_id, dummy_user.dob, dummy_user.gender, "sherlock@example.com", "1", "0"],
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -128,7 +128,7 @@ RSpec.describe "registrations" do
                 user = FactoryBot.create(:user, :wca_id)
                 file = csv_file [
                   ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                  ["a", "Sherlock Holmes", "United Kingdom", user.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                  ["a", user.name, user.country.id, user.wca_id, user.dob, user.gender, "sherlock@example.com", "1", "0"],
                 ]
                 expect {
                   post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -153,7 +153,7 @@ RSpec.describe "registrations" do
                   )
                   file = csv_file [
                     ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                    ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                    ["a", person.name, person.country.id, person.wca_id, person.dob, person.gender, user.email, "1", "0"],
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -169,7 +169,7 @@ RSpec.describe "registrations" do
                   user = FactoryBot.create(:user)
                   file = csv_file [
                     ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                    ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                    ["a", person.name, person.country.id, person.wca_id, person.dob, person.gender, user.email, "1", "0"],
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -188,7 +188,7 @@ RSpec.describe "registrations" do
                   user = FactoryBot.create(:user)
                   file = csv_file [
                     ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                    ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", user.email, "1", "0"],
+                    ["a", person.name, person.country.id, person.wca_id, person.dob, person.gender, user.email, "1", "0"],
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -206,7 +206,7 @@ RSpec.describe "registrations" do
                 person = FactoryBot.create(:person)
                 file = csv_file [
                   ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
-                  ["a", "Sherlock Holmes", "United Kingdom", person.wca_id, "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+                  ["a", person.name, person.country.id, person.wca_id, person.dob, person.gender, "sherlock@example.com", "1", "0"],
                 ]
                 expect {
                   post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
@@ -382,7 +382,7 @@ RSpec.describe "registrations" do
           expect {
             post competition_registrations_do_add_path(competition), params: {
               registration_data: {
-                name: user.name, country: user.country, birth_date: user.dob,
+                name: user.name, country: user.country.id, birth_date: user.dob,
                 gender: user.gender, email: user.email, event_ids: ["444"]
               },
             }


### PR DESCRIPTION
Fixes #4681.

So far we've been copying details from person to user unconditionally. I prevented it from happening if a WCA ID is set directly, in which case we want to validate if the person and user match each other.