### PR TITLE
Update the sender for the WRC followup email to match the main Delegate report.

### DIFF
--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -104,6 +104,7 @@ class CompetitionsMailer < ApplicationMailer
     I18n.with_locale :en do
       @competition = competition
       mail(
+        from: "reports@worldcubeassociation.org",
         to: "regulations@worldcubeassociation.org",
         reply_to: "regulations@worldcubeassociation.org",
         subject: delegate_report_email_subject(competition),

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -279,14 +279,22 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       competition.delegate_report.wrc_secondary_user = FactoryBot.create :user, :wrc_member, name: "Michel"
       competition
     end
-    let(:mail) do
+    let(:main_mail) do
+      CompetitionsMailer.notify_of_delegate_report_submission(competition)
+    end
+    let(:followup_mail) do
       CompetitionsMailer.wrc_delegate_report_followup(competition)
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match(/Hello WRC members/)
-      expect(mail.body.encoded).to match(competition.delegate_report.wrc_primary_user.name)
-      expect(mail.body.encoded).to match(competition.delegate_report.wrc_secondary_user.name)
+      # Check heuristics to ensure that GMail puts these emails in the same thread.
+      expect(followup_mail.from).to eq(main_mail.from)
+      expect(followup_mail.subject).to eq(main_mail.subject)
+
+      # Check content
+      expect(followup_mail.body.encoded).to match(/Hello WRC members/)
+      expect(followup_mail.body.encoded).to match(competition.delegate_report.wrc_primary_user.name)
+      expect(followup_mail.body.encoded).to match(competition.delegate_report.wrc_secondary_user.name)
     end
   end
 


### PR DESCRIPTION
Hopefully fixes #4753.