### PR TITLE
Competition form removing article z

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -226,7 +226,7 @@
       </fieldset>
 
       <hr>
-      <%= f.input :remarks, disabled: is_actually_confirmed, hint: t('simple_form.hints.competition.remarks_html', link: link_to("Article Z", "https://www.worldcubeassociation.org/regulations/#article-Z-optional", target: "_blank")) %>
+      <%= f.input :remarks, disabled: is_actually_confirmed %>
 
       <% if @competition.being_cloned_from&.tabs&.present? %>
         <%= f.input :being_cloned_from_id, as: :hidden %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -472,7 +472,7 @@ en:
         organizer_ids: "Competition organizers (they need an account to be listed here)."
         external_website: "The website of the competition. Must be a valid http(s) url."
         registration_open: "Note: Registration open and close are in UTC time"
-        remarks_html: "Some additional information you want to pass on to the WCAT. For example, elaborate your reasons if this competition is requested less than four weeks away, or if you are requesting the application of %{link}. Please fill this out in English!"
+        remarks: "Some additional information you want to pass on to the WCAT. For example, if there is something you are uncertain about, or if there are any special requests for the WCAT. Please fill this out in English!"
         clone_tabs: ""
         countryId: ""
         end_date: ""


### PR DESCRIPTION
WCAT had received a complaint from a Delegate that article z was still mentioned despite being very outdated.

Thanks Jonatan for the help in this!
