### PR TITLE
Move Update Translation to top

### DIFF
--- a/WcaOnRails/app/views/translations/index.html.erb
+++ b/WcaOnRails/app/views/translations/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, 'Translations Status') %>
 <div class="container">
   <h1><%= yield(:title) %></h1>
-
+  <%= link_to "Update Translation", translations_edit_path, class: "btn btn-info" %>
   <% (I18n.available_locales - [:en]).sort.each do |locale| %>
     <%
       bad_keys_by_type = @bad_i18n_keys[locale]
@@ -51,5 +51,4 @@
 
     </div>
   <% end %>
-  <%= link_to "Update Translation", translations_edit_path, class: "btn btn-info" %>
 </div>


### PR DESCRIPTION
The button is at the very bottom, and many people probably don't even know it exists, as the list of languages is growing.

Before:
![Peek 01-11-2019 14-39](https://user-images.githubusercontent.com/1881933/68045314-f750e780-fcb7-11e9-949d-397dcbe5b202.gif)

Can't post a "after" picture because I'm having trouble running the server locally.