### PR TITLE
Validate email and WCA ID uniqueness on registrations import

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1078,6 +1078,8 @@ en:
         non_existent_wca_id: "The WCA ID %{wca_id} doesn't exist."
         email_user_with_different_wca_id: "There is already a user with email %{email}, but it has WCA ID of %{user_wca_id} instead of %{registration_wca_id}."
         email_user_with_different_unconfirmed_wca_id: "There is already a user with email %{email}, but it has unconfirmed WCA ID of %{unconfirmed_wca_id} instead of %{registration_wca_id}."
+        email_duplicates: "Emails must be unique, fond the following duplicates: %{emails}."
+        wca_id_duplicates: "WCA IDs must be unique, fond the following duplicates: %{wca_ids}."
     add:
       title: "Add registration for %{comp}"
       info: "This will create an approved registration. Use this form to add walk-ins during the competition."

--- a/WcaOnRails/spec/requests/registrations_spec.rb
+++ b/WcaOnRails/spec/requests/registrations_spec.rb
@@ -49,6 +49,32 @@ RSpec.describe "registrations" do
         expect(response.body).to include "The given file includes 2 accepted registrations, which is more than the competitor limit of 1."
       end
 
+      it "renders an error when there are email duplicates" do
+        file = csv_file [
+          ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+          ["a", "Sherlock Holmes", "United Kingdom", "", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+          ["a", "John Watson", "United Kingdom", "", "2000-01-01", "m", "sherlock@example.com", "1", "1"],
+        ]
+        expect {
+          post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+        }.to_not change { competition.registrations.count }
+        follow_redirect!
+        expect(response.body).to include "Emails must be unique, fond the following duplicates: sherlock@example.com."
+      end
+
+      it "renders an error when there are WCA ID duplicates" do
+        file = csv_file [
+          ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+          ["a", "Sherlock Holmes", "United Kingdom", "2019HOLM01", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
+          ["a", "John Watson", "United Kingdom", "2019HOLM01", "2000-01-01", "m", "watson@example.com", "1", "1"],
+        ]
+        expect {
+          post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+        }.to_not change { competition.registrations.count }
+        follow_redirect!
+        expect(response.body).to include "WCA IDs must be unique, fond the following duplicates: 2019HOLM01."
+      end
+
       describe "registrations import" do
         context "registrant has WCA ID" do
           it "renders an error if the WCA ID doesn't exist" do


### PR DESCRIPTION
We definitely expect imported emails and WCA IDs to be unique, but we should error whenever this is not the case.