### PR TITLE
Change registration user validations to run on creation only

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -197,7 +197,11 @@ class Registration < ApplicationRecord
     }
   end
 
-  validate :user_can_register_for_competition
+  # Only run the validations when creating the registration as we don't want user changes
+  # to invalidate all the corresponding registrations (e.g. if the user gets banned).
+  # Instead the validations should be placed such that they ensure that a user
+  # change doesn't lead to an invalid state.
+  validate :user_can_register_for_competition, on: :create
   private def user_can_register_for_competition
     if user&.cannot_register_for_competition_reasons.present?
       errors.add(:user_id, user.cannot_register_for_competition_reasons.to_sentence)

--- a/WcaOnRails/spec/models/registration_spec.rb
+++ b/WcaOnRails/spec/models/registration_spec.rb
@@ -26,32 +26,42 @@ RSpec.describe Registration do
     expect(registration).to be_valid
   end
 
-  it "requires user on create" do
-    expect(FactoryBot.build(:registration, user_id: nil)).to be_invalid_with_errors(user: ["can't be blank"])
+  describe "on create" do
+    let(:registration) { FactoryBot.build :registration }
+
+    it "requires user on create" do
+      expect(FactoryBot.build(:registration, user_id: nil)).to be_invalid_with_errors(user: ["can't be blank"])
+    end
+
+    it "requires user country" do
+      user = FactoryBot.create(:user, country_iso2: nil)
+      registration.user = user
+      expect(registration).to be_invalid_with_errors(user_id: ["Need a country"])
+    end
+
+    it "requires user gender" do
+      user = FactoryBot.create(:user, gender: nil)
+      registration.user = user
+      expect(registration).to be_invalid_with_errors(user_id: ["Need a gender"])
+    end
+
+    it "requires user dob" do
+      user = FactoryBot.create(:user, dob: nil)
+      registration.user = user
+      expect(registration).to be_invalid_with_errors(user_id: ["Need a birthdate"])
+    end
+
+    it "requires user not banned" do
+      user = FactoryBot.create(:user, :banned)
+      registration.user = user
+      expect(registration).to be_invalid_with_errors(user_id: [I18n.t('registrations.errors.banned_html').html_safe])
+    end
   end
 
-  it "requires country" do
-    user = FactoryBot.create(:user, country_iso2: nil)
-    registration.user = user
-    expect(registration).to be_invalid_with_errors(user_id: ["Need a country"])
-  end
-
-  it "requires gender" do
-    user = FactoryBot.create(:user, gender: nil)
-    registration.user = user
-    expect(registration).to be_invalid_with_errors(user_id: ["Need a gender"])
-  end
-
-  it "requires user not banned" do
+  it "doesn't invalidate existing registration when the competitor is banned" do
     user = FactoryBot.create(:user, :banned)
     registration.user = user
-    expect(registration).to be_invalid_with_errors(user_id: [I18n.t('registrations.errors.banned_html').html_safe])
-  end
-
-  it "requires dob" do
-    user = FactoryBot.create(:user, dob: nil)
-    registration.user = user
-    expect(registration).to be_invalid_with_errors(user_id: ["Need a birthdate"])
+    expect(registration).to be_valid
   end
 
   it "requires at least one event" do


### PR DESCRIPTION
Context: if a competitor registers and then gets banned, the registration is left in a permanent invalid state. One of the consequences is that saving WCIF fails due to the validation errors. Thinking about it, I believe it's better to run the user-related validations only when creating registrations.

If someone has a better solution in mind (specifically when it comes to WCIF update), please let me know!