### PR TITLE
Show results_submitted_at instead of posted_at

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -69,7 +69,7 @@ module CompetitionsHelper
   end
 
   def results_content(competition)
-    days_results = days_after_competition(competition.results_posted_at, competition)
+    days_results = days_after_competition(competition.results_submitted_at, competition)
     if days_results
       "#{pluralize(days_results, "day")} after"
     else

--- a/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
@@ -19,7 +19,7 @@
             Report posted
           </th>
           <th class="admin-date">
-            Results posted
+            Results submitted <%= icon('fas', 'exclamation-circle', title: 'For competitions before January 2019, this is the date when results were posted', data: { toggle: "tooltip" }) %>
           </th>
           <th class="admin-button">
           </th>


### PR DESCRIPTION
Fixes #4802

I added a small (!) thing to mention that not all competitions will have the actual submission date.

![image](https://user-images.githubusercontent.com/1881933/68533645-0fed7d00-030a-11ea-96ed-ca1d7c2db9f1.png)
