### PR TITLE
Add a very basic email validation

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -65,6 +65,11 @@ class User < ApplicationRecord
   validates :unconfirmed_wca_id, format: { with: WCA_ID_RE }, allow_nil: true
   WCA_ID_MAX_LENGTH = 10
 
+  # Very simple (and permissive) regexp, the goal is just to avoid silly typo
+  # like "aaa@bbb,com", or forgetting the '@'.
+  EMAIL_RE = /[\w.%+-]+@[\w.-]+\.\w+/.freeze
+  validates :email, format: { with: EMAIL_RE }
+
   # Virtual attribute for authenticating by WCA ID or email.
   attr_accessor :login
 

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe User, type: :model do
     expect(user).to be_valid
   end
 
+  it "allows valid fancy email" do
+    user = FactoryBot.build(:user, email: "aa124_qs.totof+topic@gmail.com")
+    expect(user).to be_valid
+  end
+
+  it "invalidates silly typos in email" do
+    user = FactoryBot.build(:user, email: "aa@bbb,com")
+    expect(user).to be_invalid_with_errors(email: ["is invalid"])
+
+    user = FactoryBot.build(:user, email: "aabbb.com")
+    expect(user).to be_invalid_with_errors(email: ["is invalid"])
+  end
+
   it "can confirm a user who has never competed before" do
     user = FactoryBot.build :user, unconfirmed_wca_id: ""
     user.confirm


### PR DESCRIPTION
We've received job failures for sending emails to invalid addresses (which contained a ","), so the idea of this patch is to just do a basic validation that the email actually does look like an email.
This regexp is currently very permissive but I don't think it's worth making it more accurate.