### PR TITLE
Fix link to sign in page in the accoutn confirmation email

### DIFF
--- a/WcaOnRails/app/views/new_registration_mailer/send_registration_mail.html.erb
+++ b/WcaOnRails/app/views/new_registration_mailer/send_registration_mail.html.erb
@@ -13,7 +13,7 @@
 <p>
   <%= t 'users.mailer.create_new_account.activate' %>
 
-  <%= link_to('login form', new_user_registration_url) %>
+  <%= link_to(t('users.mailer.create_new_account.login_form'), new_user_session_url) %>.
 </p>
 
 <p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -758,6 +758,7 @@ en:
         confirm: "Your account is created and must be activated before you can use it. Please confirm your account through the link below: "
         confirmation_link: "Confirm my account."
         activate: "After activation you may log in to the website of the World Cube Association: "
+        login_form: "login form"
         addendum: "This email is generated automatically. If you didn't register an account on the website of the World Cube Association and received this message by mistake, please ignore and delete it."
         questions: "Do you have more questions? We will be happy to answer them! Feel free to send a mail to %{contact_link}."
       #context: user changing mail address and receiving reconfirmation mail

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -1369,6 +1369,7 @@ es:
         confirmation_link: Confirmar mi cuenta.
         #original_hash: d484f70
         activate: 'Tras la activación, puedes identificarte en la web de la WCA:'
+        login_form: 'formulario de inicio de sesión'
         #original_hash: 333999b
         addendum: >-
           Este correo se genera automáticamente. Si no has registrado una cuenta


### PR DESCRIPTION
Reported by Roman Ostapenko, we've been linking to the wrong page for quite a long time.
On a side note I'm wondering if it makes sense to include sentence about sign in possibility, as the purpose of the email is to confirm the account and it's quite obvious how to proceed after that.