### PR TITLE
Temporarirly limit faraday version to avoid warnings printed to stderr

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -15,6 +15,10 @@ gem 'sassc-rails'
 gem 'uglifier'
 gem 'therubyracer'
 
+# FIXME: to be removed when octokit has released a version addressing
+# https://github.com/octokit/octokit.rb/issues/1170
+gem 'faraday', "<=0.17.0"
+
 gem 'sdoc', group: :doc
 gem 'dotenv-rails', require: 'dotenv/rails-now'
 gem 'envied', '0.9.1' # https://github.com/thewca/worldcubeassociation.org/issues/4455

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       railties (>= 4.2.0)
     faker (2.8.1)
       i18n (>= 1.6, < 1.8)
-    faraday (0.17.1)
+    faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     font-awesome-sass (5.11.2)
@@ -635,6 +635,7 @@ DEPENDENCIES
   envied (= 0.9.1)
   factory_bot_rails
   faker
+  faraday (<= 0.17.0)
   font-awesome-sass
   fullcalendar-rails
   google-api-client


### PR DESCRIPTION
Cron sends an email whenever something goes wrong and the `faraday` gem gives a deprecation warning, which is later printed to our stderr by `octokit`. [The fix](https://github.com/octokit/octokit.rb/issues/1170) hasn't been released yet, so we temporarily fix the version of `faraday` to prevent the error.
Thanks to @viroulep for figuring out the solution =)