### PR TITLE
Add WFC to Delegate status change mailer

### DIFF
--- a/WcaOnRails/app/mailers/delegate_status_change_mailer.rb
+++ b/WcaOnRails/app/mailers/delegate_status_change_mailer.rb
@@ -15,7 +15,7 @@ class DelegateStatusChangeMailer < ApplicationMailer
         @user_senior_delegate = User.find_by_id!(user_whose_delegate_status_changed.senior_delegate_id_before_last_save)
       end
       to = ["board@worldcubeassociation.org"]
-      cc = ["assistants@worldcubeassociation.org", user_who_made_the_change.email, @user_senior_delegate.email]
+      cc = ["assistants@worldcubeassociation.org", "finance@worldcubeassociation.org", user_who_made_the_change.email, @user_senior_delegate.email]
       mail(
         to: to,
         cc: cc,

--- a/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
 
       expect(mail.subject).to eq("Eddard Stark just changed the Delegate status of Jon Snow")
       expect(mail.to).to eq(["board@worldcubeassociation.org"])
-      expect(mail.cc).to eq(["assistants@worldcubeassociation.org", senior_delegate1.email, senior_delegate1.email])
+      expect(mail.cc).to eq(["assistants@worldcubeassociation.org", "finance@worldcubeassociation.org", senior_delegate1.email, senior_delegate1.email])
       expect(mail.from).to eq(["notifications@worldcubeassociation.org"])
       expect(mail.reply_to).to eq([senior_delegate1.email])
     end


### PR DESCRIPTION
After discussion with the Board it was decided to add the WFC to the Delegate status change mailer. I think I have done that but I have no idea what I'm doing so I could have messed it all up.