### PR TITLE
Improve the SQL on production for WFC export

### DIFF
--- a/WcaOnRails/app/controllers/wfc_controller.rb
+++ b/WcaOnRails/app/controllers/wfc_controller.rb
@@ -18,7 +18,7 @@ class WfcController < ApplicationController
     @competitions=Competition
                   .select(select_attributes)
                   .includes(:delegates)
-                  .joins(:competitors)
+                  .left_joins(:competitors)
                   .group("Competitions.id")
                   .where("start_date >= ?", from)
                   .where("end_date <= ?", to)


### PR DESCRIPTION
The original query issued for the WFC export is this one:
```sql
SELECT `Competitions`.`id`, `Competitions`.`name`, `Competitions`.`start_date`, `Competitions`.`end_date`, `Competitions`.`countryId`, `Competitions`.`announced_at`, `Competitions`.`results_posted_at`, count(distinct rails_persons.id) as num_competitors FROM `Competitions` INNER JOIN `Results` ON `Results`.`competitionId` = `Competitions`.`id` INNER JOIN `rails_persons` ON `rails_persons`.`wca_id` = `Results`.`personId` AND `rails_persons`.`subId` = 1 WHERE (results_posted_at >= '2019-01-01' and results_posted_at <= '2019-03-01') GROUP BY Competitions.id ORDER BY `Competitions`.`results_posted_at` ASC, `Competitions`.`name` ASC;
```

It takes ~200ms on my local db, and ~20s on production (!!).

Here is what explain said for prod:
```
+----+-------------+--------------+------------+--------+------------------------------------------------------------------------------------------------------------------------+-------------------------------+---------+------------------------------+--------+----------+-----------------------------------------------------------+
| id | select_type | table        | partitions | type   | possible_keys                                                                                                          | key                           | key_len | ref                          | rows   | filtered | Extra                                                     |
+----+-------------+--------------+------------+--------+------------------------------------------------------------------------------------------------------------------------+-------------------------------+---------+------------------------------+--------+----------+-----------------------------------------------------------+
|  1 | SIMPLE      | Persons      | NULL       | index  | index_Persons_on_id_and_subId,Persons_id                                                                               | index_Persons_on_id_and_subId | 43      | NULL                         | 143484 |    10.00 | Using where; Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | Results      | NULL       | ref    | Results_fk_tournament,Results_fk_competitor,index_Results_on_competitionId_and_updated_at                              | Results_fk_competitor         | 42      | cubing.Persons.id            |     15 |   100.00 | NULL                                                      |
|  1 | SIMPLE      | Competitions | NULL       | eq_ref | PRIMARY,year_month_day,index_Competitions_on_countryId,index_Competitions_on_start_date,index_Competitions_on_end_date | PRIMARY                       | 130     | cubing.Results.competitionId |      1 |    11.11 | Using where                                               |
+----+-------------+--------------+------------+--------+------------------------------------------------------------------------------------------------------------------------+-------------------------------+---------+------------------------------+--------+----------+-----------------------------------------------------------+
```
and locally:
```
+----+-------------+--------------+------------+--------+------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+---------+----------------------------------------+------+----------+----------------------------------------------+
| id | select_type | table        | partitions | type   | possible_keys                                                                                                          | key                                           | key_len | ref                                    | rows | filtered | Extra                                        |
+----+-------------+--------------+------------+--------+------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+---------+----------------------------------------+------+----------+----------------------------------------------+
|  1 | SIMPLE      | Competitions | NULL       | index  | PRIMARY,year_month_day,index_Competitions_on_countryId,index_Competitions_on_start_date,index_Competitions_on_end_date | PRIMARY                                       | 130     | NULL                                   | 5904 |    11.11 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | Results      | NULL       | ref    | Results_fk_tournament,Results_fk_competitor,index_Results_on_competitionId_and_updated_at                              | index_Results_on_competitionId_and_updated_at | 130     | wca_development.Competitions.id        |  196 |   100.00 | NULL                                         |
|  1 | SIMPLE      | Persons      | NULL       | eq_ref | index_Persons_on_id_and_subId,Persons_id                                                                               | index_Persons_on_id_and_subId                 | 43      | wca_development.Results.personId,const |    1 |   100.00 | Using index                                  |
+----+-------------+--------------+------------+--------+------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+---------+----------------------------------------+------+----------+----------------------------------------------+
```

Clearly prod's choice of selecting first `Persons` is very poor as it has 140k+ rows, but it is valid as inner-joining is commutative.
We don't need the inner join though, so I changed it for a left join (which kind of force the SQL execution plan), but I find the original behavior pretty weird :s