### PR TITLE
Removes not needed styles that made member tags look weird

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/teams-and-committees.scss
+++ b/WcaOnRails/app/assets/stylesheets/teams-and-committees.scss
@@ -27,10 +27,6 @@
     a {
       color: #555555;
     }
-    @media (max-width: 576px) {
-      display: block;
-      width: max-content;
-    }
   }
 
   &.team-senior-member-badge {


### PR DESCRIPTION
This fixes that member tags on profiles needing one new line justified left each on mobile screens, which looked horrible, the style is only used there and on teams-committees page, both look nice now on mobile and desktop.