### PR TITLE
Set SameSite cookie attribute

### DIFF
--- a/WcaOnRails/config/initializers/session_store.rb
+++ b/WcaOnRails/config/initializers/session_store.rb
@@ -3,4 +3,5 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_WcaOnRails_session',
-                                                      secure: Rails.env.production?
+                                                      secure: Rails.env.production?,
+                                                      same_site: :lax


### PR DESCRIPTION
Chrome warns about missing `SameSite` cookie attribute (usually when performing requests from 3rd party apps).
![image](https://user-images.githubusercontent.com/17034772/71565485-73e12600-2aaf-11ea-9efc-8318d5098822.png)
I believe `Lax` is the way to go here, as it protects from including cookies in 3rd party POST requests, while sending them on normal navigation/redirects (e.g. when clicking on a link in an email).

For a brief summary look [here](https://www.owasp.org/index.php/SameSite) and [here](https://stackoverflow.com/a/58320564). For more details check out [this article](https://web.dev/samesite-cookies-explained).