### PR TITLE
Remove problematic SET statements from the developer database dump

### DIFF
--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -798,7 +798,10 @@ module DatabaseDumper
   end
 
   def self.mysqldump(db_name, dest_filename)
-    bash!("mysqldump #{self.mysql_cli_creds} #{db_name} -r #{dest_filename} #{filter_out_mysql_warning}")
+    # Use --set-gtid-purged=OFF to avoid having `SET @@GLOBAL.gtid_purged` and `SET @@SESSION.SQL_LOG_BIN`
+    # in the resulting dump file, as setting these require additional parmissions
+    # making it troublesome to import the dump into a managed databases like the staging one.
+    bash!("mysqldump --set-gtid-purged=OFF #{self.mysql_cli_creds} #{db_name} -r #{dest_filename} #{filter_out_mysql_warning}")
     bash!("sed -i 's_^/\\*!50013 DEFINER.*__' #{dest_filename}")
   end
 


### PR DESCRIPTION
Currently the database developer dump gives the following warning on production:

> Warning: A partial dump from a server that has GTIDs will by default include the GTIDs of all transactions, even those that changed suppressed parts of the database. If you don't want to restore GTIDs, pass --set-gtid-purged=OFF. To make a complete dump, pass --all-databases --triggers --routines --events.

The dump includes two problematic statements: `SET @@GLOBAL.gtid_purged` and `SET @@SESSION.SQL_LOG_BIN`, I guess that's been the case since we upgraded MySQL version. While loading the dump locally may work if the given database user has full permissions, it fails on the staging due to lack of the necessary permissions. Setting the option doesn't include these options, which correctly removes the warning and also omits the problematic `SET` statements, so I believe that's a reasonable thing to do.

@tussosedan please let me know if there's any reason we wouldn't want doing so =)