### PR TITLE
Add trophy icon to championships in the my_competitions tables

### DIFF
--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -35,7 +35,14 @@
           <tr class="<%= tr_classes %>"
               data-toggle="tooltip" data-placement="bottom" data-container="body"
               title="<%= competition_message_for_user(competition, current_user) unless past %>">
-            <td><%= link_to competition.name, competition_path(competition) %></td>
+            <td>
+              <%= link_to competition.name, competition_path(competition) %>
+              <% if competition.championships.any? %>
+                <span class="championship-trophy" data-toggle="tooltip" data-placement="bottom" title="<%= competition.championships.sort.map { |championship| championship.name }.join(", ") %>">
+                  <%= icon('fas', 'trophy') %>
+                </span>
+              <% end %>
+            </td>
             <td><%= competition.city_and_country %></td>
             <td><%= wca_date_range(competition.start_date, competition.end_date) %></td>
             <td>

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -123,6 +123,10 @@ FactoryBot.define do
       with_schedule { true }
     end
 
+    trait :world_championship do
+      championship_types { ["world"] }
+    end
+
     transient do
       championship_types { [] }
       with_rounds { false }

--- a/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "competitions/my_competitions" do
 
   it "shows upcoming competitions" do
     render
-    expect(rendered).to match '<td><a href="/competitions/MelbourneOpen2016">Melbourne Open 2016</a></td>'
+    expect(rendered).to match '<a href="/competitions/MelbourneOpen2016">Melbourne Open 2016</a>'
   end
 
   it "shows you are on the waiting list" do
@@ -28,6 +28,6 @@ RSpec.describe "competitions/my_competitions" do
 
   it "shows bookmarked competitions" do
     render
-    expect(rendered).to match '<td><a href="/competitions/CambridgeOpen2020">Cambridge Open 2020</a></td>'
+    expect(rendered).to match '<a href="/competitions/CambridgeOpen2020">Cambridge Open 2020</a>'
   end
 end

--- a/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/competitions/my_competitions.html.erb_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe "competitions/my_competitions" do
   let(:competition) { FactoryBot.create(:competition, :registration_open, name: "Melbourne Open 2016") }
   let(:registration) { FactoryBot.create(:registration, competition: competition) }
   let(:competition2) { FactoryBot.create(:competition, :visible, name: "Cambridge Open 2020") }
+  let(:competition3) { FactoryBot.create(:competition, :visible, :world_championship, name: "World Open 2020") }
 
   before do
     allow(view).to receive(:current_user) { registration.user }
     assign(:not_past_competitions, [competition])
     assign(:past_competitions, [])
     assign(:registered_for_by_competition_id, competition.id => registration)
-    assign(:bookmarked_competitions, [competition2])
+    assign(:bookmarked_competitions, [competition2, competition3])
   end
 
   it "shows upcoming competitions" do
@@ -29,5 +30,11 @@ RSpec.describe "competitions/my_competitions" do
   it "shows bookmarked competitions" do
     render
     expect(rendered).to match '<a href="/competitions/CambridgeOpen2020">Cambridge Open 2020</a>'
+  end
+
+  it "shows championship icon" do
+    render
+    expect(rendered).to match '<a href="/competitions/WorldOpen2020">World Open 2020</a>'
+    expect(rendered).to match '<span class="championship-trophy" data-toggle="tooltip" data-placement="bottom" title="World Championship">'
   end
 end


### PR DESCRIPTION
Issue #4508 
Places the trophy icon to the right of the names of championships in the my competitions view
Also has the tooltip indicating the type of championship