### PR TITLE
Changes to propagated fields in Discourse SSO

### DIFF
--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -166,15 +166,11 @@ class UsersController < ApplicationController
     sso.email = current_user.email
     sso.avatar_url = current_user.avatar_url
     sso.moderator = current_user.wac_team?
+    sso.locale = current_user.locale
+    sso.locale_force_update = true
     sso.add_groups = user_groups.join(",")
     sso.remove_groups = (all_groups - user_groups).join(",")
-    # Build a nice response to discourse, so that the WCA profile is linked in
-    # the user's profile.
-    sso.bio = if current_user.wca_id
-                "WCA profile: [#{current_user.wca_id}](#{person_url(current_user.wca_id)})."
-              else
-                "No WCA ID."
-              end
+    sso.custom_fields["wca_id"] = current_user.wca_id || ""
 
     redirect_to sso.to_url
   end

--- a/WcaOnRails/spec/requests/users_spec.rb
+++ b/WcaOnRails/spec/requests/users_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "users" do
       end
       expect(answer_sso.add_groups).to eq "wac"
       expect(answer_sso.remove_groups).to eq((User.all_discourse_groups - ["wac"]).join(","))
-      expect(answer_sso.bio).to match user.wca_id
+      expect(answer_sso.custom_fields["wca_id"]).to match user.wca_id
     end
 
     it "authenticates regular user" do
@@ -137,7 +137,7 @@ RSpec.describe "users" do
       expect(answer_sso.moderator).to be false
       expect(answer_sso.add_groups).to be_empty
       expect(answer_sso.remove_groups).to eq User.all_discourse_groups.join(",")
-      expect(answer_sso.bio).to match "No WCA ID"
+      expect(answer_sso.custom_fields["wca_id"]).to eq ""
     end
 
     it "authenticates admin delegate" do


### PR DESCRIPTION
Propagate locale and WCA ID, and stop propagating the WCA ID in the
"bio" field.

It turns out even though they are not visible to users/admin, custom fields *are* propagated correctly!
This is a much cleaner way to pass the information to Discourse.
Additionally to this PR, I created [this small plugin](https://github.com/thewca/discourse-wca-id) to add the information to the relevant places in discourse.