### PR TITLE
Ensure remember_me is propagated using 2FA

### DIFF
--- a/WcaOnRails/app/controllers/sessions_controller.rb
+++ b/WcaOnRails/app/controllers/sessions_controller.rb
@@ -43,7 +43,7 @@ class SessionsController < Devise::SessionsController
        user.invalidate_otp_backup_code!(user_params[:otp_attempt])
       # Remove any lingering user data from login
       session.delete(:otp_user_id)
-      user.remember_me! if user_params[:remember_me] == '1'
+      user.remember_me = 1 if user_params[:remember_me] == '1'
       user.save!
       sign_in(user, event: :authentication)
     else

--- a/WcaOnRails/app/views/devise/sessions/2fa.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/2fa.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="panel-body">
         <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: "form" }, method: :post) do |f| %>
-          <%= f.input :remember_me, as: :hidden, value: resource_params.fetch(:remember_me, 0) %>
+          <%= f.input :remember_me, as: :hidden, input_html: { value: resource_params.fetch(:remember_me, 0) } %>
           <%= f.input :otp_attempt, autofocus: true, class: "form-control" %>
           <%= f.submit t('devise.sessions.new.2fa.confirm'), class: "btn btn-primary", tabindex: "3" %>
         <% end %>


### PR DESCRIPTION
I didn't notice it at first but the "remember_me" option is not propagated properly when using 2FA.
This is due to a silly mistake in the form emission, and me using the same `remember_me!` method from devise as gitlab does, but from testing locally it obviously doesn't work :(
Whereas setting the `remember_me` attribute does!