### PR TITLE
Introduce a "confirm identity" tab

### DIFF
--- a/WcaOnRails/app/controllers/sessions_controller.rb
+++ b/WcaOnRails/app/controllers/sessions_controller.rb
@@ -23,6 +23,15 @@ class SessionsController < Devise::SessionsController
     render json: { status: "ok" }
   end
 
+  def create
+    # Overrides Devise's create sign in method and pass it a block executed
+    # after sign in, to mark use as recently authenticated upon sign in.
+    # See https://www.rubydoc.info/github/plataformatec/devise/Devise/SessionsController#create-instance_method
+    super do |resource|
+      session[:last_authenticated_at] = Time.now
+    end
+  end
+
   private
 
   def two_factor_enabled?

--- a/WcaOnRails/app/controllers/sessions_controller.rb
+++ b/WcaOnRails/app/controllers/sessions_controller.rb
@@ -15,10 +15,10 @@ class SessionsController < Devise::SessionsController
   end
 
   def generate_email_otp
-    unless session[:otp_user_id]
+    unless session[:otp_user_id] || current_user
       return render json: { error: { message: I18n.t("devise.sessions.new.2fa.errors.cant_send_email") } }
     end
-    user = User.find(session[:otp_user_id])
+    user = User.find(session[:otp_user_id] || current_user.id)
     TwoFactorMailer.send_otp_to_user(user).deliver_now
     render json: { status: "ok" }
   end

--- a/WcaOnRails/app/helpers/users_helper.rb
+++ b/WcaOnRails/app/helpers/users_helper.rb
@@ -10,4 +10,16 @@ module UsersHelper
   def qrcode_for_user(user)
     RQRCode::QRCode.new(otp_provisioning_uri_for_user(user))
   end
+
+  def protected_tab(id)
+    @recently_authenticated ? id : "#2fa-check"
+  end
+
+  def tab_to_show(section)
+    if !@recently_authenticated && %w(email password 2fa).include?(section)
+      "2fa-check"
+    else
+      section
+    end
+  end
 end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -812,7 +812,7 @@ class User < ApplicationRecord
     end
     if user == self
       fields += %i(
-        current_password password password_confirmation
+        password password_confirmation
         email preferred_events results_notifications_enabled
       )
       fields << { user_preferred_events_attributes: [:id, :event_id, :_destroy] }
@@ -1035,32 +1035,6 @@ class User < ApplicationRecord
         "personalBests" => { "type" => "array", "items" => PersonalBest.wcif_json_schema },
       },
     }
-  end
-
-  # Devise's method overriding! (the unwanted lines are commented)
-  # We have the separate form for updating password and it requires current_password to be entered.
-  # So we don't want to remove the password and password_confirmation if they are in the params and are blank.
-  # Instead we want the presence validations to fail in order to show the error messages to the user.
-  # Also see: https://github.com/plataformatec/devise/blob/48220f087bc807629b42d731f6b68fe625edbb91/lib/devise/models/database_authenticatable.rb#L58-L64
-  def update_with_password(params, *options)
-    current_password = params.delete(:current_password)
-
-    # if params[:password].blank?
-    #   params.delete(:password)
-    #   params.delete(:password_confirmation) if params[:password_confirmation].blank?
-    # end
-
-    result = if valid_password?(current_password)
-               update_attributes(params, *options)
-             else
-               self.assign_attributes(params, *options)
-               self.valid?
-               self.errors.add(:current_password, current_password.blank? ? :blank : :invalid)
-               false
-             end
-
-    clean_up_passwords
-    result
   end
 
   # This is subtle. We don't want to leak birthdate when users claim a WCA ID that is not theirs.

--- a/WcaOnRails/app/views/devise/sessions/2fa.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/2fa.html.erb
@@ -5,48 +5,12 @@
         <h4><%= t('devise.sessions.new.2fa.verify') %></h4>
       </div>
       <div class="panel-body">
-        <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: "form" }, method: :post) do |f| %>
-          <%= f.input :remember_me, as: :hidden, input_html: { value: resource_params.fetch(:remember_me, 0) } %>
-          <%= f.input :otp_attempt, autofocus: true, class: "form-control" %>
-          <%= f.submit t('devise.sessions.new.2fa.confirm'), class: "btn btn-primary", tabindex: "3" %>
-        <% end %>
-        <h3><%= t("devise.sessions.new.2fa.email_auth") %></h3>
-        <p><%= t("devise.sessions.new.2fa.get_by_email_desc") %></p>
-        <%= link_to(t("devise.sessions.new.2fa.get_by_email"), "#", class: "btn btn-primary", id: "request_2fa_email") %>
+        <%= render "devise/sessions/2fa_form", {
+          form_object: resource,
+          form_object_name: resource_name,
+          form_url: session_path(resource_name),
+        } %>
       </div>
     </div>
   <% end %>
 </div>
-<script>
-  function restoreButton() {
-    $("#request_2fa_email").toggleClass("disabled", false);
-  }
-
-  function handleServerResponse(response) {
-    response_json = response.responseJSON;
-    if (response_json.error) {
-      alert(response_json.error.message);
-      restoreButton();
-    } else if (response_json.status === "ok") {
-      alert("<%= t('devise.sessions.new.2fa.email_sent') %>");
-      setTimeout(restoreButton, 120000);
-    } else {
-      alert("<%= t('devise.sessions.new.2fa.errors.unknown') %>");
-      restoreButton();
-    }
-  }
-
-  $("#request_2fa_email").click(function(ev) {
-    ev.preventDefault();
-    $("#request_2fa_email").toggleClass("disabled", true);
-    wca.cancelPendingAjaxAndAjax('get-2fa-backup', {
-      url: '<%= users_generate_email_otp_path %>',
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        <%= raw("'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,") unless Rails.env.test? %>
-      },
-      complete: handleServerResponse,
-    });
-  });
-</script>

--- a/WcaOnRails/app/views/devise/sessions/_2fa_form.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/_2fa_form.html.erb
@@ -1,0 +1,42 @@
+<% resource_params ||= {} %>
+<%= simple_form_for(form_object, as: form_object_name, url: form_url, html: { role: "form" }, method: :post) do |f| %>
+  <%= f.input :remember_me, as: :hidden, input_html: { value: resource_params.fetch(:remember_me, 0) } %>
+  <%= f.input :otp_attempt, autofocus: true, class: "form-control" %>
+  <%= f.submit t('devise.sessions.new.2fa.confirm'), class: "btn btn-primary", tabindex: "3" %>
+<% end %>
+<h3><%= t("devise.sessions.new.2fa.email_auth") %></h3>
+<p><%= t("devise.sessions.new.2fa.get_by_email_desc") %></p>
+<%= link_to(t("devise.sessions.new.2fa.get_by_email"), "#", class: "btn btn-primary", id: "request_2fa_email") %>
+<script>
+  function restoreButton() {
+    $("#request_2fa_email").toggleClass("disabled", false);
+  }
+
+  function handleServerResponse(response) {
+    response_json = response.responseJSON;
+    if (response_json.error) {
+      alert(response_json.error.message);
+      restoreButton();
+    } else if (response_json.status === "ok") {
+      alert("<%= t('devise.sessions.new.2fa.email_sent') %>");
+      setTimeout(restoreButton, 120000);
+    } else {
+      alert("<%= t('devise.sessions.new.2fa.errors.unknown') %>");
+      restoreButton();
+    }
+  }
+
+  $("#request_2fa_email").click(function(ev) {
+    ev.preventDefault();
+    $("#request_2fa_email").toggleClass("disabled", true);
+    wca.cancelPendingAjaxAndAjax('get-2fa-backup', {
+      url: '<%= users_generate_email_otp_path %>',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        <%= raw("'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,") unless Rails.env.test? %>
+      },
+      complete: handleServerResponse,
+    });
+  });
+</script>

--- a/WcaOnRails/app/views/users/_2fa_confirm.html.erb
+++ b/WcaOnRails/app/views/users/_2fa_confirm.html.erb
@@ -1,0 +1,10 @@
+<%= alert(:info, t("users.edit.sensitive.info")) %>
+
+<% if @user.two_factor_enabled? %>
+  <%= render "devise/sessions/2fa_form", form_object: @user, form_object_name: "user", form_url: users_authenticate_sensitive_path %>
+<% else %>
+  <%= simple_form_for(@user, as: "user", url: users_authenticate_sensitive_path, method: :post) do |f| %>
+    <%= f.input :password, autocomplete: "off", class: "form-control" %>
+    <%= f.submit t("users.edit.sensitive.confirm_proceed"), class: "btn btn-primary" %>
+  <% end %>
+<% end %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -55,10 +55,10 @@
   <ul class="nav nav-tabs nav-justified">
     <li><a href="#general" data-toggle="tab"><%= t '.general' %></a></li>
     <% if @user == current_user %>
-      <li><a href="#email" data-toggle="tab"><%= t '.email' %></a></li>
+      <li><a href="<%= protected_tab("#email") %>" data-toggle="tab"><%= t '.email' %></a></li>
       <li><a href="#preferences" data-toggle="tab"><%= t '.preferences' %></a></li>
-      <li><a href="#password" data-toggle="tab"><%= t '.password' %></a></li>
-      <li><a href="#2fa" data-toggle="tab">2FA</a></li>
+      <li><a href="<%= protected_tab("#password") %>" data-toggle="tab"><%= t '.password' %></a></li>
+      <li><a href="<%= protected_tab("#2fa") %>" data-toggle="tab">2FA</a></li>
     <% end %>
     <% if current_user.can_change_users_avatar?(@user) %>
       <li><a href="#avatar" data-toggle="tab">Avatar</a></li>
@@ -144,17 +144,34 @@
     </div>
 
     <% if @user == current_user %>
-      <div class="tab-pane active" id="email">
-        <%= simple_form_for @user do |f| %>
-          <%= hidden_field_tag "section", "email" %>
-          <%= f.input :email, disabled: !editable_fields.include?(:email), hint: t('.confirm_new_email') %>
+      <%# The section below holds sensitivate data changes. For this we require %>
+      <%# the user to enter again their password or 2FA.  %>
+      <% if @recently_authenticated %>
+        <div class="tab-pane active" id="email">
+          <%= simple_form_for @user do |f| %>
+            <%= hidden_field_tag "section", "email" %>
+            <%= f.input :email, disabled: !editable_fields.include?(:email), hint: t('.confirm_new_email') %>
 
-          <%= f.input :current_password %>
+            <%= f.submit t('.save'), class: "btn btn-primary" %>
+          <% end %>
+        </div>
+        <div class="tab-pane active" id="password">
+          <%= simple_form_for @user do |f| %>
+            <%= hidden_field_tag "section", "password" %>
+            <%= f.input :password, autocomplete: "off", class: "form-control" %>
+            <%= f.input :password_confirmation, class: "form-control"  %>
 
-          <%= f.submit t('.save'), class: "btn btn-primary" %>
-        <% end %>
-      </div>
-
+            <%= f.submit t('.save'), class: "btn btn-primary" %>
+          <% end %>
+        </div>
+        <div class="tab-pane active" id="2fa">
+          <%= render "2fa_tab" %>
+        </div>
+      <% else %>
+        <div class="tab-pane active" id="2fa-check">
+          <%= render "2fa_confirm.html.erb" %>
+        </div>
+      <% end %>
       <div class="tab-pane active" id="preferences">
         <%= simple_form_for @user do |f| %>
           <%= hidden_field_tag "section", "preferences" %>
@@ -170,22 +187,6 @@
 
           <%= f.submit t('.save'), class: "btn btn-primary" %>
         <% end %>
-      </div>
-
-      <div class="tab-pane active" id="password">
-        <%= simple_form_for @user do |f| %>
-          <%= hidden_field_tag "section", "password" %>
-          <%= f.input :password, autocomplete: "off", class: "form-control" %>
-          <%= f.input :password_confirmation, class: "form-control"  %>
-
-          <%= f.input :current_password %>
-
-          <%= f.submit t('.save'), class: "btn btn-primary" %>
-        <% end %>
-      </div>
-
-      <div class="tab-pane active" id="2fa">
-        <%= render "2fa_tab" %>
       </div>
     <% end %>
 
@@ -240,6 +241,6 @@
     <% end %>
   </div>
   <script>
-    $('a[href="#<%=j params[:section] %>"]').tab('show');
+    $('a[href="#<%=j tab_to_show(params[:section]) %>"]').tab('show');
   </script>
 </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -248,7 +248,6 @@ en:
         gender: "Gender"
         email: "Email"
         password: "Password"
-        current_password: "Current password"
         password_confirmation: "Re-enter password"
         remember_me: "Remember me"
         pending_avatar: "Upload new avatar"
@@ -454,7 +453,6 @@ en:
         email: ""
         pending_avatar: "After uploading a new avatar, you will have to wait for the WCA Results Team to approve it."
         country_iso2: ""
-        current_password: ""
         delegate_status: ""
         dob_verification: ""
         gender: ""
@@ -676,8 +674,8 @@ en:
             unknown: "Unknown error when sending your email. Please contact the WST."
           otp_email:
             subject: "Your one-time password for the WCA"
-            2fa_attempt: "You are attempting to sign in the WCA website. You have two-factor authentication enabled and you just requested to be sent a one-time password by email. Please find it below:"
-            disclaimer: "If you did not request that authentication code, please contact the WST right away by replying to this email, and change your password as it is most likely compromized."
+            2fa_attempt: "You are attempting to authenticate on the WCA website. You have two-factor authentication enabled and you just requested to be sent a one-time password by email. Please find it below:"
+            disclaimer: "If you did not request that authentication code, please contact the WST right away by replying to this email: you may have an open session somewhere or your password may be compromized."
           name: "Two-Factor Authentication (2FA)"
           support_desc_html: "The WCA website supports %{two_factor_link} using a one-time password:"
           #context: describes the 2FA options
@@ -873,7 +871,7 @@ en:
       profile: "Profile"
       approve: "Approve"
       unconfirmed_email: "This account's email address (%{email}) is not confirmed."
-      confirm_new_email: "Changing your email will require confirming the new email."
+      confirm_new_email: "Changing your email will require confirming the new email before being effective."
       pending_mail_confirmation: "This account is pending confirmation of new email address %{email}."
       pending_avatar_confirmation: "This account is pending confirmation of a new avatar."
       pending_claim_confirmation_html: "This account is waiting for %{delegate} to confirm their claimed WCA ID %{wca_id}."
@@ -909,7 +907,13 @@ en:
           '1': "The avatar must be of your current self, depicted in the same fashion as how you would appear at a competition."
           '2': "The avatar must be framed, cropped, angled, and lit, so that any competitor or spectator at a competition can use it to unambiguously identify you at a competition venue."
           '3': "The thumbnail of the avatar is only a section of the avatar, and it will be used to represent your full avatar. The thumbnail must be adjusted, so you can be recognized from it alone, and it must contain your face."
-
+      #context: used on the tab where the user has to confirm its password/2fa to be able to edit their sensitive data
+      sensitive:
+        info: "This section enables you to edit sensitive data, to be able to do so please confirm your identity below."
+        success: "Successfully verified your identity"
+        failure: "Couldn't verify your identity"
+        confirm_proceed: "Confirm and proceed"
+        identity_error: "Cannot edit your data, please confirm your identity below before trying again."
     #context: when an error occured during the edition
     errors:
       not_found: "not found"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
                get :cancel
              end
     post 'users/generate-email-otp' => 'sessions#generate_email_otp'
+    post 'users/authenticate-sensitive' => 'users#authenticate_user_for_sensitive_edit'
   end
   post 'registration/:id/refund/:payment_id' => 'registrations#refund_payment', as: :registration_payment_refund
   post 'registration/:id/process-payment-intent' => 'registrations#process_payment_intent', as: :registration_payment_intent

--- a/WcaOnRails/spec/features/2fa_spec.rb
+++ b/WcaOnRails/spec/features/2fa_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Sign in with 2FA" do
     end
   end
 
-  context '' do
+  context 'Signing in with 2FA' do
     let!(:user) { FactoryBot.create(:user, :with_2fa) }
 
     it 'works with an otp' do

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -586,7 +586,7 @@ RSpec.describe User, type: :model do
     let(:user) { FactoryBot.create(:user, password: "wca") }
 
     context "when the password is not given in the params" do
-      it "updates the attributes if the current_password matches" do
+      it "updates the unconfirmed email" do
         user.update(email: "new@email.com")
         expect(user.reload.unconfirmed_email).to eq "new@email.com"
       end

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -580,34 +580,29 @@ RSpec.describe User, type: :model do
     expect(user.name).to eq 'test user'
   end
 
-  describe "#update_with_password" do
+  describe "#update" do
+    # NOTE: users are required to verify authentication recently to be able
+    # to use controller's action which allow for updating attributes.
     let(:user) { FactoryBot.create(:user, password: "wca") }
 
     context "when the password is not given in the params" do
       it "updates the attributes if the current_password matches" do
-        user.update_with_password(email: "new@email.com", current_password: "wca")
+        user.update(email: "new@email.com")
         expect(user.reload.unconfirmed_email).to eq "new@email.com"
       end
 
-      it "does not update the attributes if the current_password does not match" do
-        user.update_with_password(email: "new@email.com", current_password: "wrong")
-        expect(user.reload.unconfirmed_email).to_not eq "new@email.com"
-      end
-    end
-
-    context "when the password is given in the params" do
-      it "updates the password if the current_password matches" do
-        user.update_with_password(password: "new", password_confirmation: "new", current_password: "wca")
+      it "updates the password if the password_confirmation matches" do
+        user.update(password: "new", password_confirmation: "new")
         expect(user.reload.valid_password?("new")).to eq true
       end
 
-      it "does not update the password if the current_password does not match" do
-        user.update_with_password(password: "new", password_confirmation: "new", current_password: "wrong")
+      it "does not update the password if the password_confirmation does not match" do
+        user.update(password: "new", password_confirmation: "wrong")
         expect(user.reload.valid_password?("new")).to eq false
       end
 
       it "does not allow blank password" do
-        user.update_with_password(password: " ", password_confirmation: " ", current_password: "wca")
+        user.update(password: " ", password_confirmation: " ")
         expect(user.errors.full_messages).to include "Password can't be blank"
       end
     end

--- a/WcaOnRails/spec/requests/users_spec.rb
+++ b/WcaOnRails/spec/requests/users_spec.rb
@@ -26,10 +26,9 @@ RSpec.describe "users" do
   it 'cannot change password when not recently authenticated' do
     user = FactoryBot.create :user
 
-    # sign in
-    post user_session_path, params: { 'user[login]' => user.email, 'user[password]' => user.password }
-    follow_redirect!
-    expect(response).to be_successful
+    # Using sign_in here instead of the post action, as it does *not* trigger setting the
+    # recently_authenticated_at session variable.
+    sign_in user
     get profile_edit_path
     expect(response).to be_successful
 


### PR DESCRIPTION
Currently when changing email or password we request the user to provide their password.
However it would make sense to also do the same to display/edit the 2FA settings (eg: to avoid someone accidentally letting their session open to be locked out of their account because someone else would enable 2FA).

So instead of just requiring password on all of these tabs we can introduce a "recently authenticated" concept, where we would require the user to have provided their password (or 2FA if activated) authentication within the last 10 minutes (arbitrary time frame that I picked) to be able to edit their data.

Here is how it looks when trying to edit its password without having fulfilled a recent check:
![2fa_check](https://user-images.githubusercontent.com/1007485/72683348-df2e7e80-3ad6-11ea-8447-a2bd36ff85fd.png)

In my opinion this is slightly better than providing the password for all changes.

Happy to hear @jfly or @lgarron thoughts on this.
