### PR TITLE
Enable WRT to choose which validators to run, and fix positions on the fly

### DIFF
--- a/WcaOnRails/app/controllers/results_submission_controller.rb
+++ b/WcaOnRails/app/controllers/results_submission_controller.rb
@@ -8,7 +8,7 @@ class ResultsSubmissionController < ApplicationController
 
   def new
     @competition = competition_from_params
-    @results_validator = ResultsValidators::CompetitionsResultsValidator.new
+    @results_validator = ResultsValidators::CompetitionsResultsValidator.create_full_validation
     @results_validator.validate(@competition.id)
   end
 
@@ -29,7 +29,7 @@ class ResultsSubmissionController < ApplicationController
       @competition.uploaded_jsons.create(json_str: @upload_json.results_json_str)
       redirect_to competition_submit_results_edit_path
     else
-      @results_validator = ResultsValidators::CompetitionsResultsValidator.new
+      @results_validator = ResultsValidators::CompetitionsResultsValidator.create_full_validation
       @results_validator.validate(@competition.id)
       render :new
     end

--- a/WcaOnRails/app/helpers/admin_helper.rb
+++ b/WcaOnRails/app/helpers/admin_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AdminHelper
+  def apply_fixes_label
+    "Apply fix when possible"
+  end
+
+  def apply_fixes_hint
+    "List of validators with automated fix: #{ResultsValidators::Utils::VALIDATORS_WITH_FIX.map(&:class_name).join(",")}."
+  end
+end

--- a/WcaOnRails/app/helpers/results_submission_helper.rb
+++ b/WcaOnRails/app/helpers/results_submission_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module ResultsSubmissionHelper
-  def class_for_panel(error:, warning:)
+  def class_for_panel(error:, warning:, no_validator: false)
     if error
       "danger"
-    elsif warning
+    elsif warning || no_validator
       "warning"
     else
       "success"

--- a/WcaOnRails/app/models/results_submission.rb
+++ b/WcaOnRails/app/models/results_submission.rb
@@ -19,7 +19,7 @@ class ResultsSubmission
   end
 
   def results_validator
-    @results_validator ||= ResultsValidators::CompetitionsResultsValidator.new.validate(competition_id)
+    @results_validator ||= ResultsValidators::CompetitionsResultsValidator.create_full_validation.validate(competition_id)
   end
 
   # This is used in specs to compare two ResultsSubmission

--- a/WcaOnRails/app/views/admin/_validator_form.html.erb
+++ b/WcaOnRails/app/views/admin/_validator_form.html.erb
@@ -1,0 +1,27 @@
+<% results_validator ||= ResultsValidators::CompetitionsResultsValidator.new %>
+<% competition ||= nil %>
+<% all_validators = ResultsValidators::Utils::ALL_VALIDATORS %>
+<% selected_validators = results_validator.validators.empty? ? all_validators : results_validator.validators %>
+<div class="panel panel-default">
+  <div class="panel-heading">Configure validations to run</div>
+  <div class="panel-body">
+    <%= simple_form_for :results_validation, url: admin_run_validators_path do |f| %>
+      <%= f.input :validators, as: :string, label: false, input_html: { id: "validators" } %>
+      <%= f.input :apply_fixes, as: :boolean, label: apply_fixes_label, hint: apply_fixes_hint, input_html: { checked: results_validator.apply_fixes } %>
+      <%= f.input :competition_ids, as: :string, readonly: !competition.nil?, input_html: { value: competition&.id }, label: "Competition ID(s)" %>
+      <%= f.button :submit, value: "Run validators", class: "btn-primary" %>
+    <% end %>
+  </div>
+</div>
+<script>
+  $('#validators').selectize({
+    persist: false,
+    maxItems: null,
+    valueField: 'name',
+    labelField: 'name',
+    searchField: ['name'],
+    plugins: ['remove_button'],
+    options: <%= raw(all_validators.map(&:serialize).to_json) %>,
+    items: <%= raw(selected_validators.map(&:class_name).to_json) %>,
+  });
+</script>

--- a/WcaOnRails/app/views/admin/_validator_form.html.erb
+++ b/WcaOnRails/app/views/admin/_validator_form.html.erb
@@ -10,7 +10,7 @@
       <%# This is most likely a bug and the cleanest workaround I could find was to explicitly set the hint here. %>
       <%= f.input :validators, as: :string, label: false, hint: false, input_html: { id: "validators" } %>
       <%= f.input :apply_fixes, as: :boolean, label: apply_fixes_label, hint: apply_fixes_hint, input_html: { checked: results_validator.apply_fixes } %>
-      <%= f.input :competition_ids, as: :string, readonly: !competition.nil?, hint: false, input_html: { value: competition&.id }, label: "Competition ID(s)" %>
+      <%= f.input :competition_ids, as: :string, readonly: competition.present?, hint: false, input_html: { value: competition&.id }, label: "Competition ID(s)" %>
       <%= f.button :submit, value: "Run validators", class: "btn-primary" %>
     <% end %>
   </div>

--- a/WcaOnRails/app/views/admin/_validator_form.html.erb
+++ b/WcaOnRails/app/views/admin/_validator_form.html.erb
@@ -6,9 +6,11 @@
   <div class="panel-heading">Configure validations to run</div>
   <div class="panel-body">
     <%= simple_form_for :results_validation, url: admin_run_validators_path do |f| %>
-      <%= f.input :validators, as: :string, label: false, input_html: { id: "validators" } %>
+      <%# NOTE: i18n-tasks detects "validators" and "competition_ids" as having their hints under "person". %>
+      <%# This is most likely a bug and the cleanest workaround I could find was to explicitly set the hint here. %>
+      <%= f.input :validators, as: :string, label: false, hint: false, input_html: { id: "validators" } %>
       <%= f.input :apply_fixes, as: :boolean, label: apply_fixes_label, hint: apply_fixes_hint, input_html: { checked: results_validator.apply_fixes } %>
-      <%= f.input :competition_ids, as: :string, readonly: !competition.nil?, input_html: { value: competition&.id }, label: "Competition ID(s)" %>
+      <%= f.input :competition_ids, as: :string, readonly: !competition.nil?, hint: false, input_html: { value: competition&.id }, label: "Competition ID(s)" %>
       <%= f.button :submit, value: "Run validators", class: "btn-primary" %>
     <% end %>
   </div>

--- a/WcaOnRails/app/views/admin/check_results.html.erb
+++ b/WcaOnRails/app/views/admin/check_results.html.erb
@@ -5,6 +5,8 @@
     Check existing results for the competition.
   </p>
 
+  <%= render "validator_form", results_validator: @results_validator, competition: @competition %>
+
   <%= render "results_submission/check_results_panel", results_validator: @results_validator %>
 
   <%= render "results_submission/results_preview_panel", results_validator: @results_validator %>

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -86,7 +86,14 @@
           fas_icon: "cogs",
           children: [
             { text: "Upload and check results", path: competition_admin_upload_results_edit_path(@competition), fas_icon: "check" },
-            { text: "Check existing results", path: competition_admin_check_existing_results_path(@competition), fas_icon: "check" },
+            {
+              text: "Check existing results",
+              path: competition_admin_check_existing_results_path(@competition),
+              fas_icon: "check",
+              is_active: lambda do
+                controller.is_a?(AdminController) && ["check_results", "run_validators"].include?(action_name)
+              end,
+            },
           ],
         }
       end

--- a/WcaOnRails/app/views/results_submission/_check_results_panel.html.erb
+++ b/WcaOnRails/app/views/results_submission/_check_results_panel.html.erb
@@ -2,7 +2,8 @@
   force_collapse ||= false
   # NOTE: expect valid 'results_validator' variable
   panel_style = class_for_panel(error: results_validator.has_errors?,
-                                warning: results_validator.has_warnings?)
+                                warning: results_validator.has_warnings?,
+                                no_validator: results_validator.validators.empty?)
   collapse_panel = force_collapse || !results_validator.has_results?
 %>
 <div class="panel panel-<%= panel_style %>">
@@ -17,58 +18,10 @@
     </h3>
   </div>
   <div id="collapse-check-results" class="panel-body collapse <%= "in" unless collapse_panel %>">
-    <h3>Errors</h3>
-    <% if results_validator.has_errors? %>
-      <p>Please fix the errors below:</p>
-      <% results_validator.errors.group_by(&:kind).each do |type, errors| %>
-        <% if errors.any? %>
-          <h4>Errors detected in <%= type %></h4>
-          <ul>
-            <% errors.each do |error| %>
-              <li><%= error %></li>
-            <% end %>
-          </ul>
-        <% end %>
-      <% end %>
-    <% elsif !results_validator.has_results? %>
-      <p class="text-danger">
-        <% if results_validator.check_real_results? %>
-          No results for the competition yet.
-        <% else %>
-          No results submitted yet.
-        <% end %>
-      </p>
+    <% if results_validator.validators.any? %>
+      <%= render "results_submission/validations_results", results_validator: results_validator %>
     <% else %>
-      <p>No error detected in the results.</p>
-    <% end %>
-    <h3>Warnings</h3>
-    <% if results_validator.has_warnings? %>
-      <p>
-        Please pay attention to the warnings below.
-        <% unless results_validator.check_real_results? %>
-          You may need to add a comment about them when submitting these results to the WRT!
-        <% end %>
-      </p>
-      <% results_validator.warnings.group_by(&:kind).each do |type, warnings| %>
-        <% if warnings.any? %>
-          <h4>Warnings detected in <%= type %></h4>
-          <ul>
-            <% warnings.each do |warning| %>
-              <li><%= warning %></li>
-            <% end %>
-          </ul>
-        <% end %>
-      <% end %>
-    <% elsif !results_validator.has_results? %>
-      <p class="text-danger">
-        <% if results_validator.check_real_results? %>
-          No results for the competition yet.
-        <% else %>
-          No results submitted yet.
-        <% end %>
-      </p>
-    <% else %>
-      <p>No warning detected in the results.</p>
+      Please run some validators to check the results.
     <% end %>
   </div>
 </div>

--- a/WcaOnRails/app/views/results_submission/_validations_results.html.erb
+++ b/WcaOnRails/app/views/results_submission/_validations_results.html.erb
@@ -1,0 +1,62 @@
+<%# Locals required: results_validator %>
+<p>
+  <% if results_validator.validators == ResultsValidators::Utils::ALL_VALIDATORS %>
+    All validators were ran.
+  <% else %>
+    The following validators were ran: <%= results_validator.validators.map(&:class_name).join(", ") %>.
+  <% end %>
+  The results of the validations are below.
+</p>
+<h3>Errors</h3>
+<% if results_validator.has_errors? %>
+  <p>Please fix the errors below:</p>
+  <% results_validator.errors.group_by(&:kind).each do |type, errors| %>
+    <% if errors.any? %>
+      <h4>Errors detected in <%= type %></h4>
+      <ul>
+        <% errors.each do |error| %>
+          <li><%= error %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+<% elsif !results_validator.has_results? %>
+  <p class="text-danger">
+  <% if results_validator.check_real_results? %>
+    No results for the competition yet.
+  <% else %>
+    No results submitted yet.
+  <% end %>
+  </p>
+<% else %>
+  <p>No error detected in the results.</p>
+<% end %>
+<h3>Warnings</h3>
+<% if results_validator.has_warnings? %>
+  <p>
+  Please pay attention to the warnings below.
+  <% unless results_validator.check_real_results? %>
+    You may need to add a comment about them when submitting these results to the WRT!
+  <% end %>
+  </p>
+  <% results_validator.warnings.group_by(&:kind).each do |type, warnings| %>
+    <% if warnings.any? %>
+      <h4>Warnings detected in <%= type %></h4>
+      <ul>
+        <% warnings.each do |warning| %>
+          <li><%= warning %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+<% elsif !results_validator.has_results? %>
+  <p class="text-danger">
+  <% if results_validator.check_real_results? %>
+    No results for the competition yet.
+  <% else %>
+    No results submitted yet.
+  <% end %>
+  </p>
+<% else %>
+  <p>No warning detected in the results.</p>
+<% end %>

--- a/WcaOnRails/app/views/results_submission/_validations_results.html.erb
+++ b/WcaOnRails/app/views/results_submission/_validations_results.html.erb
@@ -7,6 +7,20 @@
   <% end %>
   The results of the validations are below.
 </p>
+<% if results_validator.has_infos? %>
+  <%# NOTE: this can be only visible to the WRT when they apply automatic fixes. %>
+  <h3>Infos</h3>
+  <% results_validator.infos.group_by(&:kind).each do |type, infos| %>
+    <% if infos.any? %>
+      <h4>Information for <%= type %></h4>
+      <ul>
+        <% infos.each do |info| %>
+          <li><%= info %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+<% end %>
 <h3>Errors</h3>
 <% if results_validator.has_errors? %>
   <p>Please fix the errors below:</p>

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
     post '/admin/upload-json' => "admin#create_results", as: :admin_upload_results
     post '/admin/clear-submission' => "admin#clear_results_submission", as: :clear_results_submission
   end
+  post 'admin/check-existing-results' => "admin#run_validators", as: :admin_run_validators
 
   get 'competitions/:competition_id/report/edit' => 'delegate_reports#edit', as: :delegate_report_edit
   get 'competitions/:competition_id/report' => 'delegate_reports#show', as: :delegate_report

--- a/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
+++ b/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
@@ -11,6 +11,10 @@ module ResultsValidators
 
     @@desc = "This validator checks that advancement between rounds is correct according to the regulations."
 
+    def self.has_automated_fix?
+      false
+    end
+
     def validate(competition_ids: [], model: Result, results: nil)
       reset_state
       # Get all results if not provided

--- a/WcaOnRails/lib/results_validators/competitions_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitions_results_validator.rb
@@ -81,6 +81,7 @@ module ResultsValidators
       other_validators.each do |v|
         @errors.concat(v.errors)
         @warnings.concat(v.warnings)
+        @infos.concat(v.infos)
       end
     end
   end

--- a/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
@@ -7,6 +7,10 @@ module ResultsValidators
 
     @@desc = "For competition with a competitor limit, this validator checks that this limit is respected."
 
+    def self.has_automated_fix?
+      false
+    end
+
     def validate(competition_ids: [], model: Result, results: nil)
       reset_state
 

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -14,6 +14,10 @@ module ResultsValidators
 
     @@desc = "This validator checks that all events and rounds match between what has been announced and what is present in the results. It also check for a main event and emit a warning if there is none (and if 3x3 is not in the results)."
 
+    def self.has_automated_fix?
+      false
+    end
+
     def validate(competition_ids: [], model: Result, results: nil)
       reset_state
       # Get all results if not provided.

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -2,7 +2,7 @@
 
 module ResultsValidators
   class GenericValidator
-    attr_reader :errors, :warnings, :apply_fixes
+    attr_reader :errors, :warnings, :infos, :apply_fixes
 
     @@desc = "Please override that class variable with a proper description when you inherit the class."
 
@@ -17,6 +17,10 @@ module ResultsValidators
 
     def has_warnings?
       @warnings.any?
+    end
+
+    def has_infos?
+      @infos.any?
     end
 
     # User must provide either:
@@ -45,6 +49,7 @@ module ResultsValidators
     def reset_state
       @errors = []
       @warnings = []
+      @infos = []
     end
 
     protected

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -2,10 +2,12 @@
 
 module ResultsValidators
   class GenericValidator
-    attr_reader :errors, :warnings
+    attr_reader :errors, :warnings, :apply_fixes
+
     @@desc = "Please override that class variable with a proper description when you inherit the class."
 
-    def initialize
+    def initialize(apply_fixes: false)
+      @apply_fixes = apply_fixes
       reset_state
     end
 
@@ -26,6 +28,16 @@ module ResultsValidators
 
     def description
       @@desc
+    end
+
+    def self.class_name
+      self.name.split('::').last
+    end
+
+    def self.serialize
+      {
+        name: class_name,
+      }
     end
 
     private

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -23,6 +23,10 @@ module ResultsValidators
 
     @@desc = "This validator checks that all results respect the format, time limit, and cutoff information if available. It also looks for similar results within the round."
 
+    def self.has_automated_fix?
+      false
+    end
+
     def validate(competition_ids: [], model: Result, results: nil)
       reset_state
       # Get all results if not provided

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -20,6 +20,10 @@ module ResultsValidators
 
     @@desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."
 
+    def self.has_automated_fix?
+      false
+    end
+
     def validate(competition_ids: [], model: Result, results: nil)
       reset_state
       # Get all results if not provided

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -46,12 +46,16 @@ module ResultsValidators
             last_result = result
 
             if expected_pos != result.pos
-              @errors << ValidationError.new(:results, competition_id,
-                                             WRONG_POSITION_IN_RESULTS_ERROR,
-                                             round_id: round_id,
-                                             person_name: result.personName,
-                                             expected_pos: expected_pos,
-                                             pos: result.pos)
+              if @apply_fixes
+                result.update_attributes(pos: expected_pos)
+              else
+                @errors << ValidationError.new(:results, competition_id,
+                                               WRONG_POSITION_IN_RESULTS_ERROR,
+                                               round_id: round_id,
+                                               person_name: result.personName,
+                                               expected_pos: expected_pos,
+                                               pos: result.pos)
+              end
             end
           end
         end

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -3,6 +3,7 @@
 module ResultsValidators
   class PositionsValidator < GenericValidator
     WRONG_POSITION_IN_RESULTS_ERROR = "[%{round_id}] Result for %{person_name} has a wrong position: expected %{expected_pos} and got %{pos}."
+    POSITION_FIXED_INFO = "[%{round_id}] Automatically fixed the position of %{person_name} from %{pos} to %{expected_pos}."
 
     @@desc = "This validator checks that positions stored in results are correct with regard to the actual results."
 
@@ -47,7 +48,13 @@ module ResultsValidators
 
             if expected_pos != result.pos
               if @apply_fixes
-                result.update_attributes(pos: expected_pos)
+                @infos << ValidationInfo.new(:results, competition_id,
+                                             POSITION_FIXED_INFO,
+                                             round_id: round_id,
+                                             person_name: result.personName,
+                                             expected_pos: expected_pos,
+                                             pos: result.pos)
+                result.update_attributes!(pos: expected_pos)
               else
                 @errors << ValidationError.new(:results, competition_id,
                                                WRONG_POSITION_IN_RESULTS_ERROR,

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -6,6 +6,10 @@ module ResultsValidators
 
     @@desc = "This validator checks that positions stored in results are correct with regard to the actual results."
 
+    def self.has_automated_fix?
+      true
+    end
+
     def validate(competition_ids: [], model: Result, results: nil)
       reset_state
       # Get all results if not provided

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -10,6 +10,10 @@ module ResultsValidators
 
     @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
 
+    def self.has_automated_fix?
+      false
+    end
+
     def validate(competition_ids: [], model: Result, results: nil)
       reset_state
       # Get all results if not provided

--- a/WcaOnRails/lib/results_validators/utils.rb
+++ b/WcaOnRails/lib/results_validators/utils.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  module Utils
+    ALL_VALIDATORS = [
+      AdvancementConditionsValidator,
+      CompetitorLimitValidator,
+      EventsRoundsValidator,
+      IndividualResultsValidator,
+      PersonsValidator,
+      PositionsValidator,
+      ScramblesValidator,
+    ].freeze
+
+    VALIDATORS_WITH_FIX = ALL_VALIDATORS.select(&:has_automated_fix?).freeze
+
+    def self.validator_class_from_name(name)
+      ALL_VALIDATORS.find { |v| v.class_name == name }
+    end
+  end
+end

--- a/WcaOnRails/lib/results_validators/validation_info.rb
+++ b/WcaOnRails/lib/results_validators/validation_info.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class ValidationInfo < ValidationIssue
+  end
+end

--- a/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe ResultsValidators::PositionsValidator do
           expect(pv.errors).to match_array(expected_errors[arg[:model].to_s])
         end
       end
+
+      it "fixes messed up positions in given competitions when requested to" do
+        [InboxResult, Result].each do |model|
+          model.where(pos: 1, eventId: "333oh").update(pos: 2)
+          model.where(pos: 5, eventId: "222").update(pos: 7)
+        end
+        validator_args.each do |arg|
+          pv = ResultsValidators::PositionsValidator.new(apply_fixes: true).validate(arg)
+          expect(pv.has_errors?).to eq false
+        end
+      end
     end
 
     context "tied results" do


### PR DESCRIPTION
This is a necessary piece for #1094 and #2107, as implementing these would use/redirect to the check results page with the position validator.

(@SAuroux FYI, even if I'll email the WRT after creating this)
This PR introduces a small form for the WRT to choose which validators to run on the results (when first loading the page it runs nothing, and pre-select all validators so that in most case the WRT just has to press one button); it looks like this:
![default](https://user-images.githubusercontent.com/1007485/72933005-2d56b280-3d61-11ea-97ef-3931131c73cc.png)

If not all validators are selected they show up in the input: 
![validators-select](https://user-images.githubusercontent.com/1007485/72933042-3fd0ec00-3d61-11ea-8d59-9ff1b1b6a313.png)

Note that this is only available when checking *real* results, when uploading results Delegates can't choose which validations to run and everything is ran.

This PR also introduces validators which can have "automated fix", such as the position validator, and implement the automatic position fix.

These changes are currently deploying on staging if you want to test them!


