### PR TITLE
Compute payment amounts from associated records

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -103,7 +103,11 @@ class Registration < ApplicationRecord
 
   def paid_entry_fees
     Money.new(
-      registration_payments.sum(:amount_lowest_denomination),
+      # NOTE: we do *not* sum on the association, as it bypasses any clean
+      # registration.includes(:registration_payments) that may exist.
+      # It's fine to turn the associated records to an array and sum on ithere,
+      # as it's usually just a couple of rows.
+      registration_payments.map(&:amount_lowest_denomination).sum,
       competition.currency_code,
     )
   end

--- a/WcaOnRails/spec/requests/registrations_spec.rb
+++ b/WcaOnRails/spec/requests/registrations_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe "registrations" do
             payment_method_id: pm.id,
             amount: registration.outstanding_entry_fees.cents,
           }
-          stripe_charge_id = registration.registration_payments.first.stripe_charge_id
+          stripe_charge_id = registration.reload.registration_payments.first.stripe_charge_id
           stripe_charge = StripeCharge.find_by(stripe_charge_id: stripe_charge_id)
           expect(stripe_charge&.status).to eq "success"
           metadata = JSON.parse(stripe_charge.metadata)["metadata"]


### PR DESCRIPTION
Fixes #5113.

Using associations.sum bypasses a possible association inclusion and fires one "sql sum" per registration, which is a silly hidden n+1 query on pages which list registrations with their amount (such as the "edit registrations" one).
The worst part is that we actually already do the proper `registration.includes(:registration_payments)` to make sure they are eager loaded!

The fix simply forces the associated row to be loaded, and then do the accumulation in ruby instead of sql.

I did not test with the competition mentioned in #5113, but I tried with WC2017 (which has 1000+ registrations) and divided the request time by 2 (and the competition doesn't even have payments locally, we were firing the sql sum anyway!).
