### PR TITLE
Rename Candidate Delegate to Junior Delegate

### DIFF
--- a/WcaOnRails/app/views/panel/index.html.erb
+++ b/WcaOnRails/app/views/panel/index.html.erb
@@ -39,10 +39,10 @@
 
     <ul>
       <li>
-        <%= link_to "WCA Candidate Delegate Nomination form", "https://docs.google.com/forms/d/e/1FAIpQLSfji_fOKEKcqS1Fb9fpu3qsBx-O8LiSJu_fG0TU7DJnR9Yj8g/viewform" %>
+        <%= link_to "WCA Delegate Nomination form", "https://docs.google.com/forms/d/e/1FAIpQLSfji_fOKEKcqS1Fb9fpu3qsBx-O8LiSJu_fG0TU7DJnR9Yj8g/viewform" %>
       </li>
       <li>
-        <%= link_to "WCA Candidate Delegate Promotion form", "https://docs.google.com/forms/d/e/1FAIpQLScq0JIOq1-2PHJoty5IE_uln_1Uq26Isp4mr3bqpfXKELQoqQ/viewform" %>
+        <%= link_to "WCA Delegate Promotion form", "https://docs.google.com/forms/d/e/1FAIpQLScq0JIOq1-2PHJoty5IE_uln_1Uq26Isp4mr3bqpfXKELQoqQ/viewform" %>
       </li>
       <li>
         <%= link_to "WCA Delegate Demotion form", "https://docs.google.com/forms/d/e/1FAIpQLSf5BnccDL656ZPD3zl72Xgz7LmzLjFeTtjXKqvupo9Tn_VIRg/viewform" %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -412,7 +412,7 @@ en:
         f: "Female"
         o: "Other"
       delegate_status:
-        candidate_delegate: "Candidate Delegate"
+        candidate_delegate: "Junior Delegate"
         delegate: "Delegate"
         senior_delegate: "Senior Delegate"
     person:
@@ -472,7 +472,7 @@ en:
         location_description: ""
         phone_number: ""
         notes: ""
-        receive_delegate_reports: "If you are a Candidate Delegate, Senior Delegate, or Member of the WRC or the WQAC, you receive Delegate Reports by default. Note: the change may take up to an hour to take effect."
+        receive_delegate_reports: "If you are a Junior Delegate, Senior Delegate, or Member of the WRC or the WQAC, you receive Delegate Reports by default. Note: the change may take up to an hour to take effect."
         otp_attempt: "Check your configured mobile application for a one-time password, or input one of your recovery codes."
       #context: for a competition
       competition:
@@ -1827,9 +1827,10 @@ en:
       #context: Hidden team for list of Delegates on Probation
       probation:
         name: "Delegates on Probation"
-      delegates_html: "<p><strong>WCA Delegate</strong> is a role defined in the WCA Motions and depicted in the WCA Regulations. The primary duty of a Delegate is to oversee competitions on behalf of the WCA. A WCA Delegate is responsible for making sure that all WCA Competitions are run according to the Mission, Spirit, and Regulations of the WCA. The WCA distinguishes between <strong>WCA Senior Delegates</strong>, <strong>WCA Delegates</strong> and <strong>WCA Candidate Delegates</strong>%{see_link}.</p>
-<p>In addition to the duties of a WCA Delegate, a WCA Senior Delegate is responsible for managing the WCA Delegates in their area and can also be contacted by the community for regional matters.</p>
-<p>New Delegates are listed as WCA Candidate Delegates at first; afterwards they are requested to show proficiency managing WCA Competitions before being promoted to WCA Delegates.</p>"
+      delegates_html: "<p><strong>WCA Delegate</strong> is a role defined in the WCA Motions and depicted in the WCA Regulations. The primary duty of a Delegate is to oversee competitions on behalf of the WCA. A WCA Delegate is responsible for making sure that all WCA Competitions are run according to the Mission, Spirit, and Regulations of the WCA. The WCA distinguishes between <strong>Senior Delegates</strong>, <strong>Regional Delegates</strong>, <strong>Full Delegates</strong>, <strong>Junior Delegates</strong>, and <strong>Trainee Delegates</strong>%{see_link}.</p>
+<p>In addition to the duties of a WCA Delegate, a Senior Delegate or Regional Delegate is responsible for managing the WCA Delegates in their area and can also be contacted by the community for regional matters.</p>
+<p>New Delegates are listed as Junior Delegates at first; afterwards they are requested to show proficiency managing WCA Competitions before being promoted to WCA Delegates.</p>
+<p>Trainee Delegates are being trained for the position of WCA Delegate and can only oversee competitions in which a WCA Delegate is present.</p>"
       see_link_html: " (see %{link})"
       members_html: "All competitors automatically become <strong>members</strong> of the WCA in their first WCA competition."
   documents:

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Api::V0::ApiController do
       end
     end
 
-    context 'signed in as candidate delegate' do
+    context 'signed in as Junior delegate' do
       before :each do
         api_sign_in_as(FactoryBot.create(:candidate_delegate))
       end

--- a/WcaOnRails/spec/helpers/persons_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/persons_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PersonsHelper do
                            t("enums.user.delegate_status.senior_delegate") + "</a></span>"
     end
 
-    it "Returns a Candidate Delegate badge when passed candadate_delegate" do
+    it "Returns a Junior Delegate badge when passed candadate_delegate" do
       string = helper.delegate_badge("candidate_delegate")
       expect(string).to eq "<span class=\"badge delegate-badge\"><a title=\"" +
                            t("enums.user.delegate_status.candidate_delegate") +

--- a/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
       user.update!(delegate_status: "candidate_delegate", senior_delegate: senior_delegate1)
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(user, senior_delegate1)
 
-      expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Jon Snow from Registered Speedcuber to Candidate Delegate.")
+      expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Jon Snow from Registered Speedcuber to Junior Delegate.")
       expect(mail.body.encoded).not_to match("Warning")
       expect(mail.body.encoded).to match(edit_user_url(user))
     end
@@ -33,7 +33,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
       delegate.update!(delegate_status: "delegate")
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(delegate, senior_delegate1)
 
-      expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Daenerys Targaryen from Candidate Delegate to Delegate.")
+      expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Daenerys Targaryen from Junior Delegate to Delegate.")
       expect(mail.body.encoded).not_to match("Warning")
       expect(mail.body.encoded).to match(edit_user_url(delegate))
     end
@@ -42,7 +42,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
       delegate.update!(delegate_status: nil, senior_delegate: nil)
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(delegate, senior_delegate1)
 
-      expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Daenerys Targaryen from Candidate Delegate to Registered Speedcuber.")
+      expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Daenerys Targaryen from Junior Delegate to Registered Speedcuber.")
       expect(mail.body.encoded).not_to match("Warning")
       expect(mail.body.encoded).to match(edit_user_url(delegate))
     end

--- a/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
       expect(mail.body.encoded).to match(edit_user_url(user))
     end
 
-    it "promoting a candidate delegate to a delegate" do
+    it "promoting a Junior delegate to a delegate" do
       delegate.update!(delegate_status: "delegate")
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(delegate, senior_delegate1)
 
@@ -38,7 +38,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
       expect(mail.body.encoded).to match(edit_user_url(delegate))
     end
 
-    it "demoting a candidate delegate to a registered speedcuber" do
+    it "demoting a Junior delegate to a registered speedcuber" do
       delegate.update!(delegate_status: nil, senior_delegate: nil)
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(delegate, senior_delegate1)
 


### PR DESCRIPTION
Updates "About" page and changes delegate_status candidate_delegate to "Junior Delegate". Removes the word "Candidate" from the links on the Panel. Adds a description of the role of Trainee Delegates on the About page.