### PR TITLE
Translation Regulations Version Status Update

### DIFF
--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -15,6 +15,12 @@
       language_english: "Chinese",
       url: "./chinese",
     },
+    {
+      version: "2020-01-01",
+      language: "繁體中文",
+      language_english: "Chinese, Traditional",
+      url: "./chinese-traditional",
+    },
   ] %>
 
   <h3><%= t("regulations_translations.current") %></h3>
@@ -23,12 +29,6 @@
   </div>
 
   <% old_translations = [
-    {
-      version: "2019-05-01",
-      language: "繁體中文",
-      language_english: "Chinese, Traditional",
-      url: "./chinese-traditional",
-    },
     {
       version: "2019-05-01",
       language: "日本語",


### PR DESCRIPTION
Regulation translation for Chinese, Traditional has been updated to 2020-01-01 version.