### PR TITLE
Assign WCA IDs when posting results

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -215,7 +215,7 @@ class CompetitionsController < ApplicationController
     ActiveRecord::Base.transaction do
       comp.update!(results_posted_at: Time.now, results_posted_by: current_user.id)
       comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
-      comp.registrations.accepted.each { |registration| registration.user.notify_of_id_claim_possibility(comp) }
+      comp.registrations.accepted.each { |registration| registration.user.maybe_assign_wca_id_by_results(comp) }
     end
 
     flash[:success] = t('competitions.messages.results_posted')

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -880,6 +880,20 @@ class User < ApplicationRecord
     end
   end
 
+  def maybe_assign_wca_id_by_results(competition, notify = true)
+    if !wca_id && !unconfirmed_wca_id
+      matches = []
+      unless country.nil?
+        matches = competition.competitors.where(name: name, year: dob.year, month: dob.month, day: dob.day, gender: gender, countryId: country.id).to_a
+      end
+      if matches.size == 1 && matches.first.user.nil?
+        update(wca_id: matches.first.wca_id)
+      elsif notify
+        notify_of_id_claim_possibility(competition)
+      end
+    end
+  end
+
   def notify_of_id_claim_possibility(competition)
     if !wca_id && !unconfirmed_wca_id
       CompetitionsMailer.notify_users_of_id_claim_possibility(self, competition).deliver_later


### PR DESCRIPTION
Fixes #21 

Once merged, we can run the following code to assign all the matching WCA IDs already in the system that aren't linked yet -- almost 19 thousand of them can be linked according to my tests. The command ran for ~20 minutes on my laptop.

However, first we need to handle some weird data of 4 registrations of non-existing users. As it crashes the code in an unexpected way, we can update the registrations to be deleted for now.

```
Registration.where.not(user_id: User.all).update_all(deleted_at: Time.now, deleted_by: 277, accepted_at: nil) 
Competition.all.order(registration_close: :desc).each {|comp| comp.registrations.accepted.each { |registration| registration.user.maybe_assign_wca_id_by_results(comp, notify=false) } }
```