### PR TITLE
Regulations Translation Status Update (Russian)

### DIFF
--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -21,6 +21,12 @@
       language_english: "Chinese, Traditional",
       url: "./chinese-traditional",
     },
+    {
+      version: "2020-01-01",
+      language: "Русский",
+      language_english: "Russian",
+      url: "./russian",
+    },
   ] %>
 
   <h3><%= t("regulations_translations.current") %></h3>
@@ -34,12 +40,6 @@
       language: "日本語",
       language_english: "Japanese",
       url: "./japanese",
-    },
-    {
-      version: "2019-05-01",
-      language: "Русский",
-      language_english: "Russian",
-      url: "./russian",
     },
     {
       version: "2018-01-01",


### PR DESCRIPTION
Russian regulations has been updated to 2020 Ver.
The regulations has been rebuild, no need to rebuild again.
Thanks!