### PR TITLE
Removing the now non-existent announcement link

### DIFF
--- a/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_announced_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_organizer_of_announced_competition.html.erb
@@ -5,7 +5,3 @@
 <p>
   <%= t 'users.mailer.competition_announcement_email.announced' %>
 </p>
-
-<p>
-  <%= t 'users.mailer.competition_announcement_email.link' %>
-</p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -834,7 +834,6 @@ en:
       competition_announcement_email:
         header: "The WCAT announced %{competition}"
         announced: "The WCAT approved your competition and officially announced it to the public."
-        link: "Please follow the link to get to the competition announcement: "
       #context: notification to users after they were added to a competition as organizers
       organizer_addition_email:
         header: "You were added to %{competition} as an organizer"


### PR DESCRIPTION
Since announcement posts aren't made any more there should not be an empty line in the mails sent to organizers.
I assume this should fix everything, but there might be an open end somewhere referencing the link?