### PR TITLE
Fixed refund_policy_html typo

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1225,7 +1225,7 @@ en:
       no_entry_fee: "Registering for this competition is free."
       use_stripe_link_html: "The registration fee has to be paid through Stripe %{here} once registered."
       use_stripe_below_html: "The registration fee has to be paid through Stripe below once registered."
-      refund_policy_html: "If your registration is cancelled before %{limit_date_and_time} you will be refunded a %{refund_policy_percent} of your registration fee."
+      refund_policy_html: "If your registration is cancelled before %{limit_date_and_time} you will be refunded %{refund_policy_percent} of your registration fee."
       no_refunds: "Registration fees won't be refunded under any circumstance."
       on_the_spot_registration_fee_html: "On the spot registrations will be accepted with a base registration fee of %{on_the_spot_base_entry_fee}."
       on_the_spot_registration_free: "On the spot registrations will be accepted for free."


### PR DESCRIPTION
Removed the 'a' in refund_policy_html to be correct grammatically.