### PR TITLE
Use short competition names in the rankings table

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -208,6 +208,9 @@ table.wca-results {
     &.round {
     }
     &.name {
+      max-width: 250px;
+      text-overflow: ellipsis;
+      overflow: hidden;
     }
     &.wca-id {
       vertical-align: middle;

--- a/WcaOnRails/app/views/results/_rankings_by_region_table.html.erb
+++ b/WcaOnRails/app/views/results/_rankings_by_region_table.html.erb
@@ -41,7 +41,7 @@
         <td class="region <%= tied_previous ? "tied-previous" : "" %>"> <%= flag if flag.present? %> <%= show %> </td>
         <td class="result"> <%= SolveTime.new(params[:event_id], @is_average ? :average : :single, value).clock_format %> </td>
         <td class="name"> <%= link_to result.personName, person_path(result.personId) %> </td>
-        <td class="competition"> <%= flag_icon competition.country.iso2 if competition.country.real? %> <%= link_to competition.name, competition_path(competition.id) %> </td>
+        <td class="competition"> <%= flag_icon competition.country.iso2 if competition.country.real? %> <%= link_to competition.cellName, competition_path(competition.id) %> </td>
         <% if @is_average %>
           <%= solve_tds_for_result(result) %>
         <% end %>

--- a/WcaOnRails/app/views/results/_rankings_table.html.erb
+++ b/WcaOnRails/app/views/results/_rankings_table.html.erb
@@ -30,7 +30,7 @@
         <td class="name"> <%= link_to result.personName, person_path(result.personId) %> </td>
         <td class="result"> <%= SolveTime.new(params[:event_id], @is_average ? :average : :single, value).clock_format %> </td>
         <td class="country"> <%= flag_icon result.country.iso2 %> <%= result.country.name %> </td>
-        <td class="competition"> <%= flag_icon competition.country.iso2 if competition.country.real? %> <%= link_to competition.name, competition_path(competition.id) %> </td>
+        <td class="competition"> <%= flag_icon competition.country.iso2 if competition.country.real? %> <%= link_to competition.cellName, competition_path(competition.id) %> </td>
         <% if @is_average %>
           <%= solve_tds_for_result(result) %>
         <% end %>


### PR DESCRIPTION
This should prevent the horizontal scroll from appearing in some cases.