### PR TITLE
Add Instagram and Media submission info page for WCT

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -724,4 +724,4 @@ DEPENDENCIES
   wicked_pdf
 
 BUNDLED WITH
-   2.1.0
+   2.1.4

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -38,6 +38,7 @@
             <li><a href="<%= faq_path %>"><%= icon('fas', 'question-circle') %> <%= t '.faq' %></a></li>
             <li><a href="<%= tutorial_path %>"><%= icon('fas', 'graduation-cap') %> <%= t '.tutorial' %></a></li>
             <li><a href="<%= contact_website_path %>"><%= icon('fas', 'envelope') %> <%= t '.contact' %></a></li>
+            <li><a href="<%= media_instagram_path %>"><%= icon('fas', 'camera') %> <%= t '.media_submission' %></a></li>
             <li><a href="<%= privacy_path %>"><%= icon('fas', 'user-secret') %> Privacy</a></li>
             <li><a href="<%= disclaimer_path %>"><%= icon('fas', 'exclamation-circle') %> Disclaimer</a></li>
             <li class="divider"></li>

--- a/WcaOnRails/app/views/static_pages/media_instagram.html.erb
+++ b/WcaOnRails/app/views/static_pages/media_instagram.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, 'Media and Instagram Submission') %>
+<% provide(:title, t('media_and_instagram.page_title')) %>
 
 <div class="container">
 
@@ -31,7 +31,7 @@
   <p><%= t 'media_and_instagram.instagram_hosting.paragraph4' %></p>
   <a class="btn btn-primary btn" href="https://docs.google.com/forms/d/11zbKPnhZI70pl2_NCrTGMgZ_CmvLTiquuP5TIm_P_mI" role="button"><%= t 'media_and_instagram.instagram_hosting.apply_to_host' %></a>
 
-  <h2>Other Suggestions?</h2>
-  <p>Do you have other suggestions for Instagram or other social media content? <a href="https://www.worldcubeassociation.org/contact/website">Let us know</a>!</p>
+  <h2><%= t 'media_and_instagram.other_suggestions.title' %></h2>
+  <p><%= t 'media_and_instagram.other_suggestions.body_html' %></p>
 
 </div>

--- a/WcaOnRails/app/views/static_pages/media_instagram.html.erb
+++ b/WcaOnRails/app/views/static_pages/media_instagram.html.erb
@@ -1,0 +1,37 @@
+<% provide(:title, 'Media and Instagram Submission') %>
+
+<div class="container">
+
+  <h2><%= t 'media_and_instagram.general_media_submission.title' %></h2>
+  <p><%= t 'media_and_instagram.general_media_submission.body_html' %></p>
+
+  <h2><%= t 'media_and_instagram.instagram_submission.title' %></h2>
+  <p><%= t 'media_and_instagram.instagram_submission.paragraph1_html' %></p>
+  <p><%= t 'media_and_instagram.instagram_submission.paragraph2' %></p>
+  <ul>
+    <li><%= t 'media_and_instagram.instagram_submission.photo_quality' %></li>
+    <li><%= t 'media_and_instagram.instagram_submission.photo_interest' %></li>
+    <li><%= t 'media_and_instagram.instagram_submission.wca_related' %></li>
+  </ul>
+  <a class="btn btn-primary btn" href="https://docs.google.com/forms/d/1bS5K_Ou0W0e7x_x6XKsS5n80kE1TVfKSakcAU33_cJc" role="button"><%= t 'media_and_instagram.instagram_submission.submit_instagram_content' %></a>
+
+  <h2><%= t 'media_and_instagram.instagram_hosting.title' %></h2>
+  <p><%= t 'media_and_instagram.instagram_hosting.paragraph1_html' %></p>
+  <p><%= t 'media_and_instagram.instagram_hosting.paragraph2' %> <p>
+  <p><%= t 'media_and_instagram.instagram_hosting.paragraph3' %></p>
+
+  <ul>
+    <li><%= t 'media_and_instagram.instagram_hosting.short_intro' %></li>
+    <li><%= t 'media_and_instagram.instagram_hosting.venue_feel' %></li>
+    <li><%= t 'media_and_instagram.instagram_hosting.people_solving' %></li>
+    <li><%= t 'media_and_instagram.instagram_hosting.mini_interviews' %></li>
+    <li><%= t 'media_and_instagram.instagram_hosting.pictures_too' %></li>
+  </ul>
+
+  <p><%= t 'media_and_instagram.instagram_hosting.paragraph4' %></p>
+  <a class="btn btn-primary btn" href="https://docs.google.com/forms/d/11zbKPnhZI70pl2_NCrTGMgZ_CmvLTiquuP5TIm_P_mI" role="button"><%= t 'media_and_instagram.instagram_hosting.apply_to_host' %></a>
+
+  <h2>Other Suggestions?</h2>
+  <p>Do you have other suggestions for Instagram or other social media content? <a href="https://www.worldcubeassociation.org/contact/website">Let us know</a>!</p>
+
+</div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -2128,8 +2128,9 @@ en:
       confirm_accept: Are you sure you want to accept this media?
       edit: Edit
   media_and_instagram:
+    page_title: Media and Instagram submission
     general_media_submission:
-      title: General Media Submission
+      title: General media submission
       body_html: 'The WCA shares articles and images from competitions provided by the community on our <a href="/media">media page</a>. If you have something you would like to share, please fill out our <a href="/media/new">general media submission form</a>!'
     instagram_submission:
       title: Instagram submission
@@ -2140,7 +2141,7 @@ en:
       wca_related: Post photos and videos that have to do with the WCA, as this is what our account is all about! We love to see cubers having fun!
       submit_instagram_content: Submit Instagram content
     instagram_hosting:
-      title: Instagram Hosting
+      title: Instagram hosting
       paragraph1_html: 'Sometimes, we will allow community members to host the official WCA Instagram story with a competition they are attending! If you&#39;re interested, please click the button and fill out the form below.  The WCA Communication Team will reach out to you after all information has been submitted if you are approved for hosting. If you have any questions, please <a href="https://www.worldcubeassociation.org/contact/website">contact us</a>.'
       paragraph2: Our goal is to share a little personal side of every cuber and of every competition. This is not supposed to be a huge burden over the weekend and, of course, we want you to enjoy the competition first and then be able to share it.
       paragraph3: 'The role of a host can be summarized as follows:'

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -798,6 +798,7 @@ en:
       api: "API"
       manage_app: "Manage your applications"
       manage_auth_app: "Manage authorized applications"
+      media_submission: "Media Submission"
   #context: Key used in the context of editing a user profile
   users:
     #context: when updating their locale (language)
@@ -2126,3 +2127,30 @@ en:
       accept: Accept
       confirm_accept: Are you sure you want to accept this media?
       edit: Edit
+  media_and_instagram:
+    general_media_submission:
+      title: General Media Submission
+      body_html: 'The WCA shares articles and images from competitions provided by the community on our <a href="/media">media page</a>. If you have something you would like to share, please fill out our <a href="/media/new">general media submission form</a>!'
+    instagram_submission:
+      title: Instagram submission
+      paragraph1_html: 'As you may have seen, the WCA has an <a href="https://www.instagram.com/thewcaofficial/">active Instagram</a>! To best reflect the global cubing community, we post content submitted to us by cubers from around the world.'
+      paragraph2: 'If you have high-quality photos or videos you would like us to post, please click the button below and fill out the form! In order us to post your content, you must own it and must give the WCA permission to post it. Due to the large number of submissions we receive, we can not post everything, but here are some tips to get your content posted:'
+      photo_quality: Make sure the photo/video quality is good. It doesn't have to be professionally shot but the quality shouldn't detract from the photo or video.
+      photo_interest: Try to make your content interesting to a broad audience. Content that is only interesting for a few people does not belong here.
+      wca_related: Post photos and videos that have to do with the WCA, as this is what our account is all about! We love to see cubers having fun!
+      submit_instagram_content: Submit Instagram content
+    instagram_hosting:
+      title: Instagram Hosting
+      paragraph1_html: 'Sometimes, we will allow community members to host the official WCA Instagram story with a competition they are attending! If you&#39;re interested, please click the button and fill out the form below.  The WCA Communication Team will reach out to you after all information has been submitted if you are approved for hosting. If you have any questions, please <a href="https://www.worldcubeassociation.org/contact/website">contact us</a>.'
+      paragraph2: Our goal is to share a little personal side of every cuber and of every competition. This is not supposed to be a huge burden over the weekend and, of course, we want you to enjoy the competition first and then be able to share it.
+      paragraph3: 'The role of a host can be summarized as follows:'
+      short_intro: Make a short introduction, talk about yourself and the competition
+      venue_feel: Get some clips to get a feeling of the venue and the people, this could be just a shot from the competitor area and solving area
+      people_solving: Try to get some shots of people solving (fast people at their main events preferably)
+      mini_interviews: You could try to get mini interviews of people (organizers, delegates, etc...) saying what they are feeling about the competition
+      pictures_too: You can also send pictures, it doesn't have to be only videos
+      paragraph4: 'Our communications throughout the weekend typically go through a WhatsApp group. Please ensure that you are familiar with this messaging platform or let us know if you are not able to use it so that we can arrange other plans.'
+      apply_to_host: Apply to host
+    other_suggestions:
+      title: Other suggestions?
+      body_html: 'Do you have other suggestions for Instagram or other social media content? <a href="https://www.worldcubeassociation.org/contact/website">Let us know</a>!'

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -1491,7 +1491,7 @@ es:
       manage_app: Controlar tus aplicaciones
       #original_hash: 0e8b212
       manage_auth_app: Controlar aplicaciones autorizadas
-      media_submission: "Entrega de medios"
+      media_submission: "Enviar material audiovisual"
   users:
     update_locale:
       #original_hash: 4cde9bc

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -1491,7 +1491,7 @@ es:
       manage_app: Controlar tus aplicaciones
       #original_hash: 0e8b212
       manage_auth_app: Controlar aplicaciones autorizadas
-      media_submission: "Entregada de medios"
+      media_submission: "Entrega de medios"
   users:
     update_locale:
       #original_hash: 4cde9bc

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -1491,6 +1491,7 @@ es:
       manage_app: Controlar tus aplicaciones
       #original_hash: 0e8b212
       manage_auth_app: Controlar aplicaciones autorizadas
+      media_submission: "Entregada de medios"
   users:
     update_locale:
       #original_hash: 4cde9bc

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -1350,7 +1350,7 @@ fr:
       manage_app: Gérer vos applications
       #original_hash: 0e8b212
       manage_auth_app: Gérer vos applications authentifiées
-      media_submission: Soumission aux médias
+      media_submission: Partager des photos et vidéos
   users:
     update_locale:
       #original_hash: 4cde9bc

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -1350,6 +1350,7 @@ fr:
       manage_app: Gérer vos applications
       #original_hash: 0e8b212
       manage_auth_app: Gérer vos applications authentifiées
+      media_submission: Soumission aux médias
   users:
     update_locale:
       #original_hash: 4cde9bc

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
   get 'faq' => 'static_pages#faq'
   get 'score-tools' => 'static_pages#score_tools'
   get 'logo' => 'static_pages#logo'
+  get 'media-instagram' => 'static_pages#media_instagram'
   get 'wca-workbook-assistant' => 'static_pages#wca_workbook_assistant'
   get 'wca-workbook-assistant-versions' => 'static_pages#wca_workbook_assistant_versions'
   get 'organizer-guidelines' => 'static_pages#organizer_guidelines'


### PR DESCRIPTION
The WCT would like to add a page to provide information on Instagram content submission and hosting, as well as general media submission.