### PR TITLE
Faraday bump

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -14,11 +14,7 @@ gem 'activerecord-import'
 gem 'sassc-rails'
 gem 'uglifier'
 gem 'therubyracer'
-
-# FIXME: to be removed when octokit has released a version addressing
-# https://github.com/octokit/octokit.rb/issues/1170
-gem 'faraday', "<=0.17.0"
-
+gem 'faraday'
 gem 'sdoc', group: :doc
 gem 'dotenv-rails', require: 'dotenv/rails-now'
 gem 'envied', '0.9.1' # https://github.com/thewca/worldcubeassociation.org/issues/4455

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       railties (>= 4.2.0)
     faker (2.10.2)
       i18n (>= 1.6, < 2)
-    faraday (0.17.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
     font-awesome-sass (5.12.0)
@@ -653,7 +653,7 @@ DEPENDENCIES
   envied (= 0.9.1)
   factory_bot_rails
   faker
-  faraday (<= 0.17.0)
+  faraday
   font-awesome-sass
   fullcalendar-rails
   google-api-client


### PR DESCRIPTION
Reverse #4945 as the Octokit update has been released and we're actually using it :smile:. This will also greatly reduce a large amount of garbage being spewed by Ruby due to the old version of Faraday.