### PR TITLE
Validate competition organizers have personal data

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -604,6 +604,15 @@ class Competition < ApplicationRecord
     end
   end
 
+  validate :organizers_can_organize_competition
+  private def organizers_can_organize_competition
+    organizers.each do |organizer|
+      if organizer&.cannot_organize_competition_reasons.present?
+        errors.add(:organizer_ids, "#{organizer.name}: #{organizer.cannot_organize_competition_reasons.to_sentence}")
+      end
+    end
+  end
+
   validate :registration_must_close_after_it_opens
   def registration_must_close_after_it_opens
     if registration_open && registration_close && !(registration_open < registration_close)

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -779,6 +779,15 @@ class User < ApplicationRecord
     end
   end
 
+  def cannot_organize_competition_reasons
+    [].tap do |reasons|
+      reasons << I18n.t('registrations.errors.need_name') if name.blank?
+      reasons << I18n.t('registrations.errors.need_gender') if gender.blank?
+      reasons << I18n.t('registrations.errors.need_dob') if dob.blank?
+      reasons << I18n.t('registrations.errors.need_country') if country_iso2.blank?
+    end
+  end
+
   def cannot_edit_data_reason_html(user_to_edit)
     # Don't allow editing data if they have a WCA ID assigned, or if they
     # have already registered for a competition. We do allow admins and delegates

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -907,4 +907,11 @@ RSpec.describe Competition do
       expect(competition.has_defined_dates?).to eq true
     end
   end
+
+  it "cannot add organizers with missing data" do
+    organizer = FactoryBot.create :user, country_iso2: nil
+    competition = FactoryBot.build :competition, organizers: [organizer]
+    expect(competition).not_to be_valid
+    expect(competition.errors.messages[:organizer_ids].first).to match "Need a country"
+  end
 end


### PR DESCRIPTION
Fixes #5200.

I've already manually fixed all the organizers with missing data. For unknown birthdates I used `0000-01-01`, in some cases there was a corresponding competitor at the competition so I used it instead.