### PR TITLE
Stripe: fill receipt_email

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -473,6 +473,7 @@ class RegistrationsController < ApplicationController
           currency: registration.outstanding_entry_fees.currency.iso_code,
           confirmation_method: "manual",
           confirm: true,
+          receipt_email: user.email,
           description: "Registration payment for #{competition.name} by #{registration.user.name}",
           metadata: registration_metadata,
         }

--- a/WcaOnRails/spec/requests/registrations_spec.rb
+++ b/WcaOnRails/spec/requests/registrations_spec.rb
@@ -525,6 +525,7 @@ RSpec.describe "registrations" do
           expect(registration.paid_entry_fees).to eq competition.base_entry_fee
           charge = Stripe::Charge.retrieve(registration.registration_payments.first.stripe_charge_id, stripe_account: competition.connected_stripe_account_id)
           expect(charge.amount).to eq competition.base_entry_fee.cents
+          expect(charge.receipt_email).to eq user.email
           expect(charge.metadata.wca_id).to eq user.wca_id
           expect(charge.metadata.email).to eq user.email
           expect(charge.metadata.competition).to eq competition.name


### PR DESCRIPTION
This will allow Stripe to automatically send receipts for payments to
that email address.

Suggested by @SimoneCantarelli.
I think it's a very nice addition as it will enable registrants to have a receipt to show to organizers in case something wrong happens.

The fix is trivial, I'll merge when tests pass and test this directly on production :)