### PR TITLE
Assign WCA ID: ignore user without dob

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -892,7 +892,7 @@ class User < ApplicationRecord
   def maybe_assign_wca_id_by_results(competition, notify = true)
     if !wca_id && !unconfirmed_wca_id
       matches = []
-      unless country.nil?
+      unless country.nil? || dob.nil?
         matches = competition.competitors.where(name: name, year: dob.year, month: dob.month, day: dob.day, gender: gender, countryId: country.id).to_a
       end
       if matches.size == 1 && matches.first.user.nil?


### PR DESCRIPTION
Will merge asap as I just ran into it on prod.

@tussosedan: no idea how that is possible, but some users with accepted registrations have nil dob...
(The only possibility for this to happen is that an organizer/delegate removed the birthdate manually after accepting the registration...)

```
User.includes(:registrations).where(dob: nil).reject{|u| u.registrations.empty?}.map(&:id)
=> [15226, 38944, 52690, 154439, 179036, 179537, 187596]
```