### PR TITLE
Add a disable 2FA button

### DIFF
--- a/WcaOnRails/app/views/users/_2fa_tab.html.erb
+++ b/WcaOnRails/app/views/users/_2fa_tab.html.erb
@@ -57,6 +57,11 @@
   <h3><%= t("devise.sessions.new.2fa.email_auth") %></h3>
   <p><%= t("devise.sessions.new.2fa.email_auth_desc") %></p>
 
+  <h2><%= t("devise.sessions.new.2fa.disable_section_title") %></h2>
+
+  <p><%= t("devise.sessions.new.2fa.disable_section_content") %></p>
+  <%= link_to t("devise.sessions.new.2fa.disable"), profile_disable_2fa_path, class: "btn btn-danger", method: :post %>
+
   <script>
     function handleServerResponse(response) {
       response_json = response.responseJSON;

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -693,6 +693,7 @@ en:
           enabled: "enabled"
           disabled: "disabled"
           enable: "Enable 2FA"
+          disable: "Disable 2FA"
           reset: "Reset 2FA secret"
           reset_if_needed: "If one of your devices has been compromised, or you want to revoke access from your devices, you can reset your two-factor authentication secret below:"
           reset_warning: "You will need to reconfigure all your 2FA devices."
@@ -708,6 +709,10 @@ en:
           generate_backup_codes: "Generate backup codes"
           backup_codes_warning: "The backup codes will be displayed below. Make sure to write/save them right away: they are store encrypted in our database and can't be shown again later."
           email_auth_desc: "You can ask for a one-time password by email when you attempt to sign in."
+          disable_section_title: "Disable two-factor"
+          disable_section_content: "The WST strongly advise you to not disable 2FA, but you can by clicking the button below. Please note that if you reactivate 2FA you will have to reconfigure your device(s)."
+          disabled_success: "Successfully disabled two-factor authentication."
+          disabled_failed: "Couldn't disable 2FA, please see errors below."
     shared:
       links:
         sign_in: "Sign in"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   get 'profile/edit' => 'users#edit'
   post 'profile/enable-2fa' => 'users#enable_2fa'
+  post 'profile/disable-2fa' => 'users#disable_2fa'
   post 'profile/generate-2fa-backup' => 'users#regenerate_2fa_backup_codes'
 
   get 'profile/claim_wca_id' => 'users#claim_wca_id'

--- a/WcaOnRails/spec/requests/users_spec.rb
+++ b/WcaOnRails/spec/requests/users_spec.rb
@@ -141,6 +141,12 @@ RSpec.describe "users" do
         expect(secret_before).to_not eq secret_after
       end
 
+      it 'can disable 2FA' do
+        post profile_disable_2fa_path
+        expect(response.body).to include "Successfully disabled two-factor"
+        expect(user.reload.otp_required_for_login).to be false
+      end
+
       it 'can (re)generate backup codes for user with 2FA' do
         expect(user.otp_backup_codes).to eq nil
         post profile_generate_2fa_backup_path


### PR DESCRIPTION
Currently the "else" branch of the update_attributes is not reachable, but hopefully it will be at some point when we require some committees/teams members to have 2FA enabled.