### PR TITLE
Update nodejs and yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
-sudo: false
 language: ruby
+os: linux
 cache:
   directories:
     - $HOME/.phantomjs
@@ -16,12 +16,14 @@ before_install:
   - yes | gem update --system
   - yes | gem update bundler
 
-  - nvm install 8
-  - nvm use 8
+  - nvm install 12
+  - nvm use 12
 
   # From https://yarnpkg.com/en/docs/install-ci#travis-tab
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME/.yarn/bin:$PATH
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn=1.22.4-1
 
   - cd WcaOnRails/
 before_script:

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -4,18 +4,23 @@ require 'securerandom'
 
 include_recipe "wca::base"
 apt_repository 'nodejs' do
-  uri 'https://deb.nodesource.com/node_8.x'
+  uri 'https://deb.nodesource.com/node_12.x'
   components ['trusty', 'main']
   key 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key'
 end
-package 'nodejs'
+package 'nodejs' do
+  version '12.*'
+end
 
 apt_repository 'yarn' do
   uri 'https://dl.yarnpkg.com/debian/'
   components ['stable', 'main']
   key 'https://dl.yarnpkg.com/debian/pubkey.gpg'
 end
-package 'yarn'
+
+package 'yarn' do
+  version '1.22.4-1'
+end
 
 
 secrets = WcaHelper.get_secrets(self)


### PR DESCRIPTION
Update both:
  - in the CI, to fix nodejs to version 12, and yarn to 1.22.4
  - in chef, to use the same version

Until now we were using node version 8, and we were not pining yarn's
version, which may be harmful because travis may not have used the same
as we use in production.

It's currently deployed on staging we I ran chef (I had to run `apt-key update` and `apt-get update` manually first, because since there is no change in the file chef skips that when provisioning :(), and everything looks good.