### PR TITLE
Fix resources load for maps

### DIFF
--- a/WcaOnRails/app/javascript/leaflet-wca/index.js
+++ b/WcaOnRails/app/javascript/leaflet-wca/index.js
@@ -9,7 +9,7 @@ import {
   Circle,
   Popup,
   Icon,
-} from 'leaflet/dist/leaflet';
+} from 'leaflet';
 import { GeoSearchControl } from 'leaflet-geosearch';
 import iconMarker2x from 'leaflet/dist/images/marker-icon-2x.png';
 import iconMarker from 'leaflet/dist/images/marker-icon.png';

--- a/WcaOnRails/app/javascript/leaflet-wca/markers.js
+++ b/WcaOnRails/app/javascript/leaflet-wca/markers.js
@@ -1,6 +1,6 @@
 import {
   Icon,
-} from 'leaflet/dist/leaflet';
+} from 'leaflet';
 import markerBlue from 'leaflet/dist/images/marker-icon.png';
 import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 import markerRed from './marker-icon-red.png';

--- a/WcaOnRails/app/views/competitions/edit_schedule.html.erb
+++ b/WcaOnRails/app/views/competitions/edit_schedule.html.erb
@@ -1,5 +1,6 @@
 <% provide(:title, "Manage schedule for #{@competition.name}") %>
 <% provide(:include_schedule_editor, true) %>
+<% provide(:include_maps, true) %>
 
 <%= render layout: 'nav' do %>
   <% if !@competition.has_defined_dates? %>


### PR DESCRIPTION
You better not check how our map in the "edit venue" part of the schedule looks like at the moment.
The missing "include_maps" is pretty obvious but it's not failing in dev mode...
I'd guess it depends on how webpack split its chunk.

The leaflet imports are a bit more subtle: by importing from `leaflet` we end up with both leaflet-src and leaflet in our bundle (even in prod, as far as I could tell!).
So for our maps I wanted to switch specifically to `leaflet/dist/leaflet`, but I can't do the same for `react-leaflet`.
Since we updated the icons path in `leaflet/dist/leaflet` it wouldn't show up correctly for the react part :(

Anyways, merging asap.
