### PR TITLE
Use send_keys instead of fill_in

### DIFF
--- a/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
+++ b/WcaOnRails/app/javascript/edit-events/EditEvents.jsx
@@ -3,12 +3,12 @@ import cn from 'classnames'
 import ReactDOM from 'react-dom'
 import _ from 'lodash';
 
-import events from 'wca/events.js.erb'
-import formats from 'wca/formats.js.erb'
-import { rootRender } from 'edit-events'
-import { pluralize } from 'edit-events/modals/utils'
-import { buildActivityCode, saveWcif, roundIdToString } from 'wca/wcif-utils'
-import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton } from 'edit-events/modals'
+import events from '../wca/events.js.erb'
+import formats from '../wca/formats.js.erb'
+import { rootRender } from '.'
+import { pluralize } from './modals/utils'
+import { buildActivityCode, saveWcif, roundIdToString } from '../wca/wcif-utils'
+import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton } from './modals'
 
 export default class EditEvents extends React.Component {
   save = e => {

--- a/WcaOnRails/app/javascript/edit-events/index.jsx
+++ b/WcaOnRails/app/javascript/edit-events/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import _ from 'lodash';
 
 import EditEvents from './EditEvents'
-import events from 'wca/events.js.erb'
+import events from '../wca/events.js.erb'
 
 let state = {};
 export function rootRender() {

--- a/WcaOnRails/app/javascript/edit-events/modals/AdvancementCondition.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/AdvancementCondition.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import AttemptResultInput from './AttemptResultInput'
 import { attemptResultToString, matchResult } from './utils'
-import { roundIdToString } from 'wca/wcif-utils'
+import { roundIdToString } from '../../wca/wcif-utils'
 
 const MIN_ADVANCE_PERCENT = 1;
 const MAX_ADVANCE_PERCENT = 75;

--- a/WcaOnRails/app/javascript/edit-events/modals/AttemptResultInput.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/AttemptResultInput.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import events from 'wca/events.js.erb'
+import events from '../../wca/events.js.erb'
 import {
   MINUTE_IN_CS,
   SECOND_IN_CS,

--- a/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/Cutoff.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import events from 'wca/events.js.erb'
-import formats from 'wca/formats.js.erb'
+import events from '../../wca/events.js.erb'
+import formats from '../../wca/formats.js.erb'
 import AttemptResultInput from './AttemptResultInput'
 import {
   pluralize,
@@ -11,7 +11,7 @@ import {
 import {
   roundIdToString,
   parseActivityCode,
-} from 'wca/wcif-utils'
+} from '../../wca/wcif-utils'
 
 function roundCutoffToString(wcifRound, { short } = {}) {
   let cutoff = wcifRound.cutoff;

--- a/WcaOnRails/app/javascript/edit-events/modals/TimeLimit.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/TimeLimit.jsx
@@ -4,12 +4,12 @@ import ReactDOM from 'react-dom'
 import Modal from 'react-bootstrap/lib/Modal'
 import Radio from 'react-bootstrap/lib/Radio'
 
-import events from 'wca/events.js.erb'
-import formats from 'wca/formats.js.erb'
+import events from '../../wca/events.js.erb'
+import formats from '../../wca/formats.js.erb'
 import AttemptResultInput from './AttemptResultInput'
 import { centisecondsToString } from './utils'
-import { roundIdToString, parseActivityCode } from 'wca/wcif-utils'
-import ButtonActivatedModal from 'edit-events/ButtonActivatedModal'
+import { roundIdToString, parseActivityCode } from '../../wca/wcif-utils'
+import ButtonActivatedModal from '../ButtonActivatedModal'
 
 class RadioGroup extends React.Component {
   get value() {

--- a/WcaOnRails/app/javascript/edit-events/modals/index.jsx
+++ b/WcaOnRails/app/javascript/edit-events/modals/index.jsx
@@ -5,14 +5,14 @@ import Button from 'react-bootstrap/lib/Button'
 import Checkbox from 'react-bootstrap/lib/Checkbox'
 import _ from 'lodash';
 
-import events from 'wca/events.js.erb'
-import formats from 'wca/formats.js.erb'
-import { rootRender } from 'edit-events'
+import events from '../../wca/events.js.erb'
+import formats from '../../wca/formats.js.erb'
+import { rootRender } from '..'
 
 import CutoffComponents from './Cutoff'
 import TimeLimitComponents from './TimeLimit'
 import AdvancementConditionComponents from './AdvancementCondition'
-import ButtonActivatedModal from 'edit-events/ButtonActivatedModal'
+import ButtonActivatedModal from '../ButtonActivatedModal'
 
 let RoundAttributeComponents = {
   timeLimit: TimeLimitComponents,

--- a/WcaOnRails/spec/features/competition_events_spec.rb
+++ b/WcaOnRails/spec/features/competition_events_spec.rb
@@ -45,9 +45,9 @@ RSpec.feature "Competition events management" do
       scenario "close with unsaved changes prompts user before discarding changes", js: true do
         within_round("333", 1) { find("[name=timeLimit]").click }
 
-        page.accept_confirm "Are you sure you want to discard your changes?" do
+        page.accept_confirm "Are you sure you want to discard your changes?", wait: 10 do
           within_modal do
-            fill_in "minutes", with: "4"
+            wca_fill_in("minutes", "4")
             click_button "Close"
           end
         end
@@ -66,7 +66,7 @@ RSpec.feature "Competition events management" do
       end
 
       scenario "change scramble group count to 42", js: true do
-        within_round("333", 1) { fill_in("scrambleSetCount", with: 42) }
+        within_round("333", 1) { wca_fill_in("scrambleSetCount", "42") }
         save
         expect(round_333_1.reload.scramble_set_count).to eq 42
       end
@@ -75,7 +75,7 @@ RSpec.feature "Competition events management" do
         within_round("333", 1) { find("[name=timeLimit]").click }
 
         within_modal do
-          fill_in "minutes", with: "5"
+          wca_fill_in "minutes", "5"
           click_button "Ok"
         end
         save
@@ -88,7 +88,7 @@ RSpec.feature "Competition events management" do
 
         within_modal do
           select "Best of 2", from: "Cutoff format"
-          fill_in "minutes", with: "2"
+          wca_fill_in "minutes", "2"
           click_button "Ok"
         end
         save
@@ -104,7 +104,7 @@ RSpec.feature "Competition events management" do
 
         within_modal do
           select "Ranking", from: "Type"
-          fill_in "Ranking", with: "12"
+          wca_fill_in "Ranking", "12"
           click_button "Ok"
         end
         save

--- a/WcaOnRails/spec/rails_helper.rb
+++ b/WcaOnRails/spec/rails_helper.rb
@@ -83,3 +83,15 @@ end
 
 # See: https://github.com/rspec/rspec-expectations/issues/664#issuecomment-58134735
 RSpec::Matchers.define_negated_matcher :not_change, :change
+
+# Assumes value to be a string
+# We use a unmaintained and most probably deprecated capybara driver (poltergeist)
+# We run into this for some of our tests: https://github.com/teamcapybara/capybara/issues/2105
+# Therefore this is a fix by going the "send_keys" way instead of the "fill_in"
+def wca_fill_in(selector, value)
+  elem = find_field(selector)
+  unless elem.value.blank?
+    elem.native.send_keys(*Array.new(elem.value.length, :backspace))
+  end
+  elem.native.send_keys(*value.split(''))
+end


### PR DESCRIPTION
May be related/fix #897, and #4296.

Our capybara driver interacts very weirdly with react (I investigated the failures [here](https://travis-ci.org/github/thewca/worldcubeassociation.org/builds/668648770?utm_source=github_status&utm_medium=notification) and [here](https://travis-ci.org/github/thewca/worldcubeassociation.org/builds/668648399?utm_source=github_status&utm_medium=notification)).
One was super weird because despite the packs being compiled and presumably included, nothing (not even an error) would show up on the edit events page.
My best guess for this is that webpacker uses the imports to sort the dependencies out and do his split thing, so I just clearly specified the same dependencies in the edit events pack (and after all, eslint was complaining about them until I decided to go the easy way and not validate the whole edit-events pack in #5259).

But the most interesting (and reproducible!) one was the other one, where fill_in was actually not triggering the "onchange" event of the input! It's apparently expected in some drivers, so I made a custom fill_in to rely on the native send_keys instead, which does trigger the onchange event.

Hopefully that means no more weird behavior in our js tests.