### PR TITLE
Update Result Validators

### DIFF
--- a/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
+++ b/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
@@ -2,12 +2,12 @@
 
 module ResultsValidators
   class AdvancementConditionsValidator < GenericValidator
-    REGULATION_9M_ERROR = "Event %{event_id} has more than four rounds, which must not happen per Regulation 9m."
-    REGULATION_9M1_ERROR = "Round %{round_id} has 99 competitors or less but has at least three subsequents rounds, which must not happen per Regulation 9m1."
-    REGULATION_9M2_ERROR = "Round %{round_id} has 15 competitors or less but has at least two subsequents rounds, which must not happen per Regulation 9m2."
-    REGULATION_9M3_ERROR = "Round %{round_id} has 7 competitors or less but has at least one subsequent round, which must not happen per Regulation 9m3."
-    REGULATION_9P1_ERROR = "Round %{round_id}: there was not 25%% of competitors eliminated, which is needed per Regulation 9p1."
-    OLD_REGULATION_9P_ERROR = "Round %{round_id}: there must be at least one competitor eliminated, which is required per Regulation 9p (competitions before April 2010)."
+    REGULATION_9M_ERROR = "Event %{event_id} has more than four rounds, which is not permitted as per Regulation 9m."
+    REGULATION_9M1_ERROR = "Round %{round_id} has 99 or fewer competitors but has more than two subsequent rounds, which is not permitted as per Regulation 9m1."
+    REGULATION_9M2_ERROR = "Round %{round_id} has 15 or fewer competitors but has more than one subsequent round, which is not permitted as per Regulation 9m2."
+    REGULATION_9M3_ERROR = "Round %{round_id} has 7 or fewer competitors but has at least one subsequent round, which is not permitted as per Regulation 9m3."
+    REGULATION_9P1_ERROR = "Round %{round_id}: Fewer than 25%% of competitors were eliminated, which is not permitted as per Regulation 9p1."
+    OLD_REGULATION_9P_ERROR = "Round %{round_id}: There must be at least one competitor eliminated, which is required as per Regulation 9p (competitions before April 2010)."
 
     @@desc = "This validator checks that advancement between rounds is correct according to the regulations."
 

--- a/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
@@ -3,7 +3,7 @@
 module ResultsValidators
   class CompetitorLimitValidator < GenericValidator
     COMPETITOR_LIMIT_WARNING = "The number of persons in the competition (%{n_competitors}) is above the competitor limit (%{competitor_limit})."\
-      " Unless a specific agreement was made when announcing the competition (such as a per-day competitor limit), the results of the competitors registered after the competitor limit was reached must be removed."
+      " The results of the competitors registered after the competitor limit was reached must be removed."
 
     @@desc = "For competition with a competitor limit, this validator checks that this limit is respected."
 

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -2,8 +2,8 @@
 
 module ResultsValidators
   class EventsRoundsValidator < GenericValidator
-    CHOOSE_MAIN_EVENT_WARNING = "Your results do not contain results for 3x3x3 Cube. Please tell WRT in the comments that there was 'no main event' if no event was treated as the main event at the competition."\
-      " Otherwise, if an event other than 3x3x3 Cube was treated as the main event, please name the main event in your comments to WRT and explain how that event was treated as the main event of the competition."
+    NOT_333_MAIN_EVENT_WARNING = "The selected main event for this competition is %{main_event_id}. Please give WRT an explanation of how that event was treated as the main event of the competition."
+    NO_MAIN_EVENT_WARNING = "There is no selected main event for this competition. Please let WRT know that this is correct."
     UNEXPECTED_RESULTS_ERROR = "Results are present for %{event_id}, however it is not listed as an official event."\
       " Please remove the event from the results or contact the WCAT to request the event to be added to the WCA website."
     UNEXPECTED_ROUND_RESULTS_ERROR = "The round %{round_id} is present in the results but was not created on the events tab. Please include the round's information in the competition's manage events page."
@@ -54,9 +54,15 @@ module ResultsValidators
     private
 
     def check_main_event(competition, results)
-      unless results.map(&:eventId).uniq.include?("333")
+      if competition.main_event
+        if competition.main_event_id != "333"
+          @warnings << ValidationWarning.new(:events, competition.id,
+                                             NOT_333_MAIN_EVENT_WARNING,
+                                             main_event_id: competition.main_event_id)
+        end
+      else
         @warnings << ValidationWarning.new(:events, competition.id,
-                                           CHOOSE_MAIN_EVENT_WARNING)
+                                           NO_MAIN_EVENT_WARNING)
       end
     end
 

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -4,13 +4,12 @@ module ResultsValidators
   class EventsRoundsValidator < GenericValidator
     CHOOSE_MAIN_EVENT_WARNING = "Your results do not contain results for 3x3x3 Cube. Please tell WRT in the comments that there was 'no main event' if no event was treated as the main event at the competition."\
       " Otherwise, if an event other than 3x3x3 Cube was treated as the main event, please name the main event in your comments to WRT and explain how that event was treated as the main event of the competition."
-    UNEXPECTED_RESULTS_ERROR = "Unexpected results for %{event_id}. The event is present in the results but not listed as an official event."\
-      " Remove the event from the results or contact the WCAT to request the event to be added to the WCA website."
-    UNEXPECTED_ROUND_RESULTS_ERROR = "Unexpected results for round %{round_id}. The round is present in the results but not created on the events tab. Edit the events tab to include the round."
-    MISSING_RESULTS_WARNING = "Missing results for %{event_id}. The event is not present in the results but listed as an official event."\
-      " If the event was held, correct the results. If the event was not held, leave a comment about that to the WRT."
-    MISSING_ROUND_RESULTS_ERROR = "Missing results for round %{round_id}. There is an additional round in the events tab that is not present in the results. Edit the events tab to remove the round."
-    UNEXPECTED_COMBINED_ROUND_ERROR = "No cutoff was announced for '%{round_name}', but it has been detected as a combined round in the results. Please update the round's information in the competition's manage events page."
+    UNEXPECTED_RESULTS_ERROR = "Results are present for %{event_id}, however it is not listed as an official event."\
+      " Please remove the event from the results or contact the WCAT to request the event to be added to the WCA website."
+    UNEXPECTED_ROUND_RESULTS_ERROR = "The round %{round_id} is present in the results but was not created on the events tab. Please include the round's information in the competition's manage events page."
+    MISSING_RESULTS_WARNING = "There are no results for %{event_id}, but it is listed as an official event. If the event was held, please reupload your JSON with the results included. If the event was not held, leave a comment for the WRT."
+    MISSING_ROUND_RESULTS_ERROR = "There are no results for round %{round_id} but it is listed in the events tab. If this round was not held, please remove the round in the competition's manage events page."
+    UNEXPECTED_COMBINED_ROUND_ERROR = "No cutoff was announced for '%{round_name}', but it has been detected as a cutoff round in the results. Please update the round's information in the competition's manage events page."
 
     @@desc = "This validator checks that all events and rounds match between what has been announced and what is present in the results. It also check for a main event and emit a warning if there is none (and if 3x3 is not in the results)."
 

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -2,24 +2,25 @@
 
 module ResultsValidators
   class IndividualResultsValidator < GenericValidator
-    MBF_RESULT_OVER_TIME_LIMIT_WARNING = "[%{round_id}] Result '%{result}' for %{person_name} is over the time limit. Please make sure it is the consequence of +2 penalties before sending the results, or fix the result to DNF."
+    MBF_RESULT_OVER_TIME_LIMIT_WARNING = "[%{round_id}] Result '%{result}' for %{person_name} is over the time limit. Please ensure this is due to time penalties before sending the results, or fix the result to DNF."
 
-    RESULT_AFTER_DNS_WARNING = "[%{round_id}] %{person_name} has at least one DNS results followed by a valid result. Please make sure it is indeed a DNS and not a DNF."
-    SIMILAR_RESULTS_WARNING = "[%{round_id}] Results for %{person_name} are similar to the results for %{similar_person_name}."
+    RESULT_AFTER_DNS_WARNING = "[%{round_id}] %{person_name} has at least one DNS result followed by a valid result. Please ensure it is indeed a DNS and if so, explain what happened to WRT."
+    SIMILAR_RESULTS_WARNING = "[%{round_id}] Results for %{person_name} are similar to the results for %{similar_person_name}. Please ensure that these results are correctly recorded for both competitors."
 
-    MET_CUTOFF_MISSING_RESULTS_ERROR = "[%{round_id}] %{person_name} has met the cutoff but is missing results for the second phase. Cutoff is %{cutoff}."
-    DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR = "[%{round_id}] %{person_name} has at least one result for the second phase but didn't meet the cutoff. Cutoff is %{cutoff}."
-    WRONG_ATTEMPTS_FOR_CUTOFF_ERROR = "[%{round_id}] %{person_name} is missing at least one attempt for the cutoff phase."
+    MET_CUTOFF_MISSING_RESULTS_ERROR = "[%{round_id}] %{person_name} met the cutoff but is missing results for the second phase of the round. The cutoff was %{cutoff}."
+    DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR = "[%{round_id}] %{person_name} has at least one result for the second phase of the round but didn't meet the cutoff. The cutoff was %{cutoff}."
+    WRONG_ATTEMPTS_FOR_CUTOFF_ERROR = "[%{round_id}] %{person_name} is missing at least one attempt for the cutoff phase."\
+    " Please edit the result to include the missing attempt(s) or update the round's information in the competition's Manage Events page."
     MISMATCHED_RESULT_FORMAT_ERROR = "[%{round_id}] Results for %{person_name} are in the wrong format: expected %{expected_format}, but got %{format}."
-    RESULT_OVER_TIME_LIMIT_ERROR = "[%{round_id}] At least one result for %{person_name} is over the time limit which is %{time_limit} for one solve. All solves over the time limit must be changed to DNF."
-    RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR = "[%{round_ids}] The sum of results for %{person_name} is over the cumulative time limit which is %{time_limit}."
-    NO_ROUND_INFORMATION_WARNING = "[%{round_id}] Could not find information about cutoff and timelimit for this round, these validations have been skipped."
-    SUSPICIOUS_DNF_WARNING = "[%{round_ids}] The round has a cumulative time limit, and extrapolating based on %{person_name}'s successful solves, they would have had very little time left for at least one"\
-    " of their DNFs. Please make sure every DNF and DNS is indeed correct. If the competitor did not start an attempt or did not have any remaining time before starting an attempt, it must be entered as DNS."
+    RESULT_OVER_TIME_LIMIT_ERROR = "[%{round_id}] At least one result for %{person_name} is over the time limit for the round, which is %{time_limit} per attempt. All solves over the time limit must be changed to DNF."
+    RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR = "[%{round_ids}] The sum of results for %{person_name} is over the cumulative time limit, which was %{time_limit}."
+    NO_ROUND_INFORMATION_WARNING = "[%{round_id}] There is no information about the cutoff and time limit for this round. These validations have been skipped. Please update the round's information in the competition's Manage Events page."
+    SUSPICIOUS_DNF_WARNING = "[%{round_ids}] The round has a cumulative time limit, and extrapolating based on %{person_name}'s successful solves, they would have had very little time left for at least one of their DNFs."\
+    " Please ensure that every DNF and DNS is indeed correct. If the competitor did not start an attempt or did not have any remaining time before starting an attempt, it must be entered as DNS."
 
     # Miscelaneous errors
-    MISSING_CUMULATIVE_ROUND_ID_ERROR = "[%{original_round_id}] Unable to find the round \"%{wcif_id}\" for the cumulative time limit specified in the WCIF."\
-    " Please go to the manage events page and remove %{wcif_id} from the cumulative time limit for %{original_round_id}. WST knows about this bug (GitHub issue #3254)."
+    MISSING_CUMULATIVE_ROUND_ID_ERROR = "[%{original_round_id}] Unable to find the round \%{wcif_id}\ for the cumulative time limit specified in the WCIF."\
+    " Please go to the competition's Manage Events page and remove %{wcif_id} from the cumulative time limit for %{original_round_id}. WST knows about this bug (GitHub issue #3254)."
 
     @@desc = "This validator checks that all results respect the format, time limit, and cutoff information if available. It also looks for similar results within the round."
 

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -2,21 +2,23 @@
 
 module ResultsValidators
   class PersonsValidator < GenericValidator
-    PERSON_WITHOUT_RESULTS_ERROR = "Person with id %{person_id} (%{person_name}) has no result"
-    RESULTS_WITHOUT_PERSON_ERROR = "Results for unknown person with id %{person_id}"
+    PERSON_WITHOUT_RESULTS_ERROR = "There are no results for %{person_name} with person id %{person_id}"
+    RESULTS_WITHOUT_PERSON_ERROR = "There are results for an unknown person with person id %{person_id}"
     WHITESPACE_IN_NAME_ERROR = "Person '%{name}' has leading/trailing whitespaces or double whitespaces."
     WRONG_WCA_ID_ERROR = "Person %{name} has a WCA ID which does not exist: %{wca_id}."
-    WRONG_PARENTHESIS_FORMAT_ERROR = "Opening parenthesis in '%{name}' must be preceeded by a space."
-    DOB_0101_WARNING = "The date of birth of %{name} is on January 1st, please make sure it's correct."
-    VERY_YOUNG_PERSON_WARNING = "%{name} seems to be less than 3 years old, please make sure it's correct."
-    NOT_SO_YOUNG_PERSON_WARNING = "%{name} seems to be around 100 years old, please make sure it's correct."
-    SAME_PERSON_NAME_WARNING = "Person '%{name}' exists with one or multiple WCA IDs (%{wca_ids}) in the WCA database."\
-      " A person in the uploaded results has the same name but has no WCA ID: please make sure they are different (and add a message about this to the WRT), or fix the results JSON."
-    NON_MATCHING_DOB_WARNING = "Wrong birthdate for %{name} (%{wca_id}), expected '%{expected_dob}' got '%{dob}'."
-    NON_MATCHING_GENDER_WARNING = "Wrong gender for %{name} (%{wca_id}), expected '%{expected_gender}' got '%{gender}'."
-    EMPTY_GENDER_WARNING = "Gender for newcomer %{name} is empty, please leave a comment to the WRT about this."
-    NON_MATCHING_NAME_WARNING = "Wrong name for %{wca_id}, expected '%{expected_name}' got '%{name}'. If the competitor did not change their name then fix the name to the expected name."
-    NON_MATCHING_COUNTRY_WARNING = "Wrong country for %{name} (%{wca_id}), expected '%{expected_country}' got '%{country}'. If this is an error, fix it. Otherwise, do leave a comment to the WRT about it."
+    WRONG_PARENTHESIS_FORMAT_ERROR = "Opening parenthesis in '%{name}' must be preceded by a space."
+    DOB_0101_WARNING = "The date of birth of %{name} is on January 1st, please ensure it's correct."
+    VERY_YOUNG_PERSON_WARNING = "%{name} seems to be less than 3 years old, please ensure it's correct."
+    NOT_SO_YOUNG_PERSON_WARNING = "%{name} seems to be around 100 years old, please ensure it's correct."
+    SAME_PERSON_NAME_WARNING = "There is already at least one person with the name '%{name}' in the WCA database (%{wca_ids})."\
+      " Please ensure that your '%{name}' is a different person. If not, please assign the correct WCA ID to the user account and regenerate the results JSON."
+    NON_MATCHING_DOB_WARNING = "The birthdate '%{dob}' provided for %{name} (%{wca_id}) does not match the current record in the WCA database ('%{expected_dob}'). If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
+    NON_MATCHING_GENDER_WARNING = "The gender '%{gender}' provided for %{name} (%{wca_id}) does not match the current record in the WCA database ('%{expected_gender}')."\
+    " If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
+    EMPTY_GENDER_WARNING = "The gender for newcomer %{name} is empty. Valid gender values are 'female', 'male' and 'other'. Please leave a comment to the WRT about this."
+    NON_MATCHING_NAME_WARNING = "The name '%{name}' provided for %{wca_id} does not match the current record in the WCA database ('%{expected_name}'). "
+    NON_MATCHING_COUNTRY_WARNING = "The country '%{country}' provided for %{name} (%{wca_id}) does not match the current record in the WCA database ('%{expected_country}')."\
+    " If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
 
     @@desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."
 

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -2,7 +2,7 @@
 
 module ResultsValidators
   class PositionsValidator < GenericValidator
-    WRONG_POSITION_IN_RESULTS_ERROR = "[%{round_id}] Result for %{person_name} has a wrong position: expected %{expected_pos} and got %{pos}."
+    WRONG_POSITION_IN_RESULTS_ERROR = "[%{round_id}] %{person_name} is in the wrong position: expected %{expected_pos}, but got %{pos}."
     POSITION_FIXED_INFO = "[%{round_id}] Automatically fixed the position of %{person_name} from %{pos} to %{expected_pos}."
 
     @@desc = "This validator checks that positions stored in results are correct with regard to the actual results."

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -2,11 +2,11 @@
 
 module ResultsValidators
   class ScramblesValidator < GenericValidator
-    MISSING_SCRAMBLES_FOR_ROUND_ERROR = "[%{round_id}] Missing scrambles. Use the workbook assistant to add the correct scrambles to the round."
-    MISSING_SCRAMBLES_FOR_COMPETITION_ERROR = "Missing scrambles for the competition. Use the workbook assistant to add scrambles."
-    UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR = "[%{round_id}] Too many scrambles. Use the workbook assistant to uncheck the unused scrambles."
+    MISSING_SCRAMBLES_FOR_ROUND_ERROR = "[%{round_id}] Missing scrambles. Use Scrambles Matcher to add the correct scrambles to the round."
+    MISSING_SCRAMBLES_FOR_COMPETITION_ERROR = "Missing scrambles for the competition. Use Scrambles Matcher to add scrambles."
+    UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR = "[%{round_id}] Too many scrambles. Use Scrambles Matcher to uncheck the unused scrambles."
     MISSING_SCRAMBLES_FOR_GROUP_ERROR = "[%{round_id}] Group %{group_id}: missing scrambles, detected only %{actual} instead of %{expected}."
-    MISSING_SCRAMBLES_FOR_MULTI_ERROR = "[%{round_id}] While you may have multiple groups in Multiple Blindfolded, at least one of the groups must contain scrambles for all attempts."
+    MISSING_SCRAMBLES_FOR_MULTI_ERROR = "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
 
     @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
 

--- a/WcaOnRails/spec/lib/results_validators/events_rounds_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/events_rounds_validator_spec.rb
@@ -7,8 +7,8 @@ ERV = RV::EventsRoundsValidator
 
 RSpec.describe ERV do
   context "on InboxResult and Result" do
-    let!(:competition1) { FactoryBot.create(:competition, :past, event_ids: ["333", "333oh"]) }
-    let!(:competition2) { FactoryBot.create(:competition, :past, event_ids: ["222", "555"]) }
+    let!(:competition1) { FactoryBot.create(:competition, :past, event_ids: ["333", "333oh"], main_event_id: nil) }
+    let!(:competition2) { FactoryBot.create(:competition, :past, event_ids: ["222", "555"], main_event_id: "222") }
 
     # The idea behind this variable is the following: the validator can be applied
     # on either a particular model for given competition ids, or on a set of results.
@@ -24,7 +24,8 @@ RSpec.describe ERV do
 
     it "triggers events-related errors and warnings" do
       # Triggers:
-      # CHOOSE_MAIN_EVENT_WARNING
+      # NOT_333_MAIN_EVENT_WARNING
+      # NO_MAIN_EVENT_WARNING
       # UNEXPECTED_RESULTS_ERROR
       # MISSING_RESULTS_WARNING
       # UNEXPECTED_COMBINED_ROUND_ERROR
@@ -37,9 +38,10 @@ RSpec.describe ERV do
 
       expected_warnings = [
         RV::ValidationWarning.new(:events, competition1.id,
-                                  ERV::CHOOSE_MAIN_EVENT_WARNING),
+                                  ERV::NO_MAIN_EVENT_WARNING),
         RV::ValidationWarning.new(:events, competition2.id,
-                                  ERV::CHOOSE_MAIN_EVENT_WARNING),
+                                  ERV::NOT_333_MAIN_EVENT_WARNING,
+                                  main_event_id: "222"),
         RV::ValidationWarning.new(:events, competition2.id,
                                   ERV::MISSING_RESULTS_WARNING,
                                   event_id: "555"),
@@ -63,7 +65,8 @@ RSpec.describe ERV do
 
     it "triggers rounds-related errors and warnings" do
       # Triggers:
-      # CHOOSE_MAIN_EVENT_WARNING
+      # NOT_333_MAIN_EVENT_WARNING
+      # NO_MAIN_EVENT_WARNING
       # UNEXPECTED_ROUND_RESULTS_ERROR
       # MISSING_ROUND_RESULTS_ERROR
       cutoff = Cutoff.new(number_of_attempts: 2, attempt_result: 50*100)
@@ -105,8 +108,11 @@ RSpec.describe ERV do
       ]
 
       expected_warnings = [
+        RV::ValidationWarning.new(:events, competition1.id,
+                                  ERV::NO_MAIN_EVENT_WARNING),
         RV::ValidationWarning.new(:events, competition2.id,
-                                  ERV::CHOOSE_MAIN_EVENT_WARNING),
+                                  ERV::NOT_333_MAIN_EVENT_WARNING,
+                                  main_event_id: "222"),
       ]
       validator_args.each do |arg|
         erv = ERV.new.validate(arg)


### PR DESCRIPTION
WRT has done a review of the current result validators and has come up with these changes to them to make them more understandable for Delegates and/or to make them conform with the WCA's official terminology.

Only thing remaining after this commit is a planned overhaul of `CHOOSE_MAIN_EVENT_WARNING` in `events_rounds_validator.rb` that I believe I am leaving to @SAuroux with input from @viroulep 