### PR TITLE
Fix javascript mishaps

### DIFF
--- a/WcaOnRails/app/assets/javascripts/application.js
+++ b/WcaOnRails/app/assets/javascripts/application.js
@@ -42,6 +42,12 @@ window.wca.cancelPendingAjaxAndAjax = function(id, options) {
   if(window.wca._pendingAjaxById[id]) {
     window.wca._pendingAjaxById[id].abort();
   }
+  // Get the authenticity token.
+  options.headers = options.headers || {};
+  var csrfTokenElement = document.querySelector('meta[name=csrf-token]');
+  if (csrfTokenElement) {
+    options.headers['X-CSRF-Token'] = csrfTokenElement.content;
+  }
   window.wca._pendingAjaxById[id] = $.ajax(options).always(function() {
     delete window.wca._pendingAjaxById[id];
   });

--- a/WcaOnRails/app/assets/javascripts/associated-events-picker.js
+++ b/WcaOnRails/app/assets/javascripts/associated-events-picker.js
@@ -11,7 +11,7 @@ $(function() {
   $('.clear-all-events').on('click', checkboxesSetter(false));
 
   function updateEventsSelectedCount($eventsFormGroup) {
-    var count = $eventsFormGroup.find('input[type="checkbox"]:checked').size();
+    var count = $eventsFormGroup.find('input[type="checkbox"]:checked').length;
     var $eventsSelectedCount = $eventsFormGroup.find('.associated-events-label .events-selected-count');
     $eventsSelectedCount.text(count);
   }

--- a/WcaOnRails/app/javascript/edit-schedule/SchedulesEditor/keyboard-handlers.js
+++ b/WcaOnRails/app/javascript/edit-schedule/SchedulesEditor/keyboard-handlers.js
@@ -128,7 +128,7 @@ export function editScheduleKeyboardHandler(event, activityPicker) {
       break;
       // enter
     case 13:
-      if ($elemSelected.size() === 1) {
+      if ($elemSelected.length === 1) {
         addActivityToCalendar($elemSelected.data('event'));
       }
       break;

--- a/WcaOnRails/app/views/devise/sessions/_2fa_form.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/_2fa_form.html.erb
@@ -34,7 +34,6 @@
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        <%= raw("'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,") unless Rails.env.test? %>
       },
       complete: handleServerResponse,
     });

--- a/WcaOnRails/app/views/registrations/_payment_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_payment_form.html.erb
@@ -66,7 +66,7 @@
             window.wca.cancelPendingAjaxAndAjax('process-payment-confirmation', {
               url: '<%= registration_payment_intent_path(@registration) %>',
               method: 'POST',
-              headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content },
+              headers: { 'Content-Type': 'application/json' },
               data: JSON.stringify({ payment_intent_id: result.paymentIntent.id }),
               complete: handleServerResponse,
             });
@@ -116,7 +116,7 @@
             window.wca.cancelPendingAjaxAndAjax('process-payment', {
               url: '<%= registration_payment_intent_path(@registration) %>',
               method: 'POST',
-              headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content },
+              headers: { 'Content-Type': 'application/json' },
               data: JSON.stringify({ payment_method_id: result.paymentMethod.id, amount: amount }),
               complete: handleServerResponse,
             });

--- a/WcaOnRails/app/views/users/_2fa_tab.html.erb
+++ b/WcaOnRails/app/views/users/_2fa_tab.html.erb
@@ -78,7 +78,7 @@
       window.wca.cancelPendingAjaxAndAjax('get-2fa-backup', {
         url: '<%= profile_generate_2fa_backup_path %>',
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content },
+        headers: { 'Content-Type': 'application/json' },
         complete: handleServerResponse,
       });
     });


### PR DESCRIPTION
Fixes #5319, fixes #5317.

The bookmark thing was not working because of missing csrf token, so I figured it would just be simpler to include it whenever doing an ajax query (since all target our website!).

The other bug was due to `size()` having been removed in jQuery 3.0+, I also fixed the other use in the codebase.