### PR TITLE
Restrict submission to announced competitions

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -699,7 +699,7 @@ class User < ApplicationRecord
   def can_submit_competition_results?(competition)
     appropriate_role = can_admin_results? || competition.delegates.include?(self)
     appropriate_time = competition.in_progress? || competition.is_probably_over?
-    appropriate_role && appropriate_time && !competition.results_posted?
+    competition.announced? && appropriate_role && appropriate_time && !competition.results_posted?
   end
 
   def can_create_poll?

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -80,6 +80,7 @@ FactoryBot.define do
     registration_close { 1.week.ago.change(usec: 0) }
 
     trait :with_valid_submitted_results do
+      announced
       with_rounds { true }
       after(:create) do |competition|
         person = FactoryBot.create(:inbox_person, competitionId: competition.id)
@@ -110,6 +111,12 @@ FactoryBot.define do
     trait :visible do
       with_delegate
       showAtAll { true }
+    end
+
+    trait :announced do
+      visible
+      announced_at { start_date }
+      announced_by { FactoryBot.create(:user, :wcat_member).id }
     end
 
     trait :stripe_connected do

--- a/WcaOnRails/spec/requests/results_submission_spec.rb
+++ b/WcaOnRails/spec/requests/results_submission_spec.rb
@@ -42,7 +42,14 @@ RSpec.describe ResultsSubmissionController, type: :request do
     describe "Seeing results submission page" do
       it "returns http success" do
         get competition_submit_results_edit_path(comp.id)
-        expect(response.successful?)
+        # Checking the response status: we want a successful get without redirect.
+        expect(response.status).to eq(200)
+      end
+
+      it "redirects to homepage if competition is not announced" do
+        comp.update!(announced_at: nil)
+        get competition_submit_results_edit_path(comp.id)
+        expect(response).to redirect_to(root_url)
       end
     end
 
@@ -85,6 +92,12 @@ RSpec.describe ResultsSubmissionController, type: :request do
 
         expect(flash[:success]).not_to be_empty
         expect(response).to redirect_to(competition_path(comp))
+      end
+
+      it "redirects to homepage if competition is not announced" do
+        comp.update!(announced_at: nil)
+        post competition_submit_results_path(comp.id), params: { results_submission: results_submission_params }
+        expect(response).to redirect_to(root_url)
       end
     end
   end


### PR DESCRIPTION
Turns out Delegates can submit results for unannounced competitions, which it's not what we want (cc @SAuroux).