### PR TITLE
Cleaner assets inclusion

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -221,4 +221,30 @@ module ApplicationHelper
   def embedded_map_url(query)
     "#{ENVied.ROOT_URL}/map?q=#{URI.encode_www_form_component(CGI.unescapeHTML(query))}"
   end
+
+  def add_to_packs(name)
+    @all_packs = capture do
+      [@all_packs, name].compact.join(",")
+    end
+  end
+
+  def add_to_css_assets(name)
+    @all_css_assets = capture do
+      [@all_css_assets, name].compact.join(",")
+    end
+  end
+
+  def add_to_js_assets(name)
+    @all_js_assets = capture do
+      [@all_js_assets, name].compact.join(",")
+    end
+  end
+
+  def add_fullcalendar_to_packs
+    add_to_js_assets('fullcalendar/fullcalendar_wca')
+    add_to_css_assets('fullcalendar_wca')
+    if I18n.locale != :en
+      add_to_js_assets("fullcalendar/locales/#{I18n.locale}.js")
+    end
+  end
 end

--- a/WcaOnRails/app/views/competition_tabs/_competition_tab_form.html.erb
+++ b/WcaOnRails/app/views/competition_tabs/_competition_tab_form.html.erb
@@ -1,4 +1,5 @@
-<% provide(:include_markdown_editor, true) %>
+<% add_to_packs("markdown_editor") %>
+
 <%= simple_form_for @competition_tab, url: submit_url, html: { class: "competition-tab-form" } do |f| %>
   <%= f.input :name %>
   <%= f.input :content, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -1,6 +1,7 @@
-<% provide(:include_markdown_editor, true) %>
-<% provide(:include_auto_numeric, true) %>
-<% provide(:include_maps, true) %>
+<% add_to_packs("markdown_editor") %>
+<% add_to_packs("auto_numeric") %>
+<% add_to_packs("wca_maps") %>
+
 <% is_actually_confirmed = @competition.persisted? ? Competition.find(@competition.id).confirmed? : false %>
 <%= horizontal_simple_form_for @competition, html: { class: 'are-you-sure no-submit-on-enter', id: 'competition-form' } do |f| %>
   <% if @competition.persisted? %>

--- a/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
@@ -1,6 +1,7 @@
 <%# Generate round informations for the competition %>
 <% rounds_by_wcif_id = Hash[competition.rounds.map { |r| [r.wcif_id, r.to_string_map] }] %>
-<% provide(:include_schedule_viewer, true) %>
+<% add_to_packs("show_schedule") %>
+<% add_fullcalendar_to_packs %>
 
 <div class="tab-content" id="schedule-tab">
   <ul class="nav nav-pills nav-justified venue-pills">

--- a/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
@@ -1,5 +1,5 @@
 <%# We request maps assets no matter what, it can be needed upon tab change %>
-<% provide(:include_maps, true) %>
+<% add_to_packs("wca_maps") %>
 <% if @display == "list" %>
   <% if competitions.empty? %>
     <%= render 'no_competitions_found' %>

--- a/WcaOnRails/app/views/competitions/edit_events.html.erb
+++ b/WcaOnRails/app/views/competitions/edit_events.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, @competition.name) %>
-<% provide(:include_events_editor, true) %>
+<% add_to_packs("edit_events") %>
 
 <%= render layout: 'nav' do %>
   <div id="events-edit-area"></div>

--- a/WcaOnRails/app/views/competitions/edit_schedule.html.erb
+++ b/WcaOnRails/app/views/competitions/edit_schedule.html.erb
@@ -1,6 +1,7 @@
 <% provide(:title, "Manage schedule for #{@competition.name}") %>
-<% provide(:include_schedule_editor, true) %>
-<% provide(:include_maps, true) %>
+<% add_to_packs("wca_maps") %>
+<% add_to_packs("edit_schedule") %>
+<% add_fullcalendar_to_packs %>
 
 <%= render layout: 'nav' do %>
   <% if !@competition.has_defined_dates? %>

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -1,6 +1,7 @@
 <% provide(:title, "Report for #{@competition.name}") %>
 <% provide(:editing_delegate_report, true) %>
-<% provide(:include_markdown_editor, true) %>
+
+<% add_to_packs("markdown_editor") %>
 
 <%= render layout: 'nav' do %>
   <h2>Editing Delegate Report for <%= @competition.name%></h2>

--- a/WcaOnRails/app/views/incidents/_form.html.erb
+++ b/WcaOnRails/app/views/incidents/_form.html.erb
@@ -1,4 +1,5 @@
-<% provide(:include_markdown_editor, true) %>
+<% add_to_packs("markdown_editor") %>
+
 <%= horizontal_simple_form_for(@incident, html: { class: "incident-form" }) do |f| %>
 
   <div class="form-inputs">

--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -16,59 +16,30 @@
   <script>
     window.wca = {};
   </script>
-  <%= javascript_packs_with_chunks_tag 'lodash_utils' %>
-  <% js_assets = ['application'] %>
-  <% css_assets = ['application'] %>
 
-  <% js_packs = ['application'] %>
-  <% css_packs = ['application'] %>
+  <% add_to_packs("lodash_utils") %>
 
-  <% if content_for :include_markdown_editor %>
-    <% css_packs << 'markdown_editor' %>
-    <% js_packs << 'markdown_editor' %>
-  <% end %>
-
-  <% if content_for :include_maps %>
-    <% css_packs << 'wca_maps' %>
-    <% js_packs << 'wca_maps' %>
-  <% end %>
-
-  <% if content_for :include_auto_numeric %>
-    <% js_packs << 'auto_numeric' %>
-  <% end %>
-
-  <% if content_for :include_schedule_editor %>
-    <% js_packs << 'edit_schedule' %>
-    <% js_assets << 'fullcalendar/fullcalendar_wca' %>
-    <% css_assets << 'fullcalendar_wca' %>
-  <% end %>
-
-  <% if content_for :include_events_editor %>
-    <% js_packs << 'edit_events' %>
-  <% end %>
-
-  <% if content_for :include_schedule_viewer %>
-    <% js_packs << 'show_schedule' %>
-    <% js_assets << 'fullcalendar/fullcalendar_wca' %>
-    <% css_assets << 'fullcalendar_wca' %>
-  <% end %>
-
-  <% if I18n.locale != :en %>
-    <% js_assets << "locales/#{I18n.locale}.js" %>
-    <% if js_assets.include?('fullcalendar/fullcalendar_wca') %>
-      <% js_assets << "fullcalendar/locales/#{I18n.locale}.js" %>
-    <% end %>
-  <% end %>
-
-  <%# Our webpacker packs (automatically split in chunks) %>
-  <%= stylesheet_packs_with_chunks_tag *css_packs %>
-  <%= javascript_packs_with_chunks_tag *js_packs %>
+  <%#
+    Our webpacker packs (automatically split in chunks).
+    Always *prepend* application, so that we load jquery first.
+    We can't just add_to_packs application, because the yielded block will be
+    evaluated first, and any pack added (like schedule) will be loaded before application.
+  %>
+  <% packs_to_include = @all_packs.split(",").uniq.unshift("application") %>
+  <%= stylesheet_packs_with_chunks_tag *packs_to_include %>
+  <%= javascript_packs_with_chunks_tag *packs_to_include %>
 
   <%# Our sprockets assets %>
-  <% css_assets.uniq.each do |a| %>
+  <% css_assets = (@all_css_assets || "").split(",").uniq.unshift("application") %>
+  <% css_assets.each do |a| %>
     <%= stylesheet_link_tag a, media: 'all' %>
   <% end %>
-  <% js_assets.uniq.each do |a| %>
+  <% js_assets = (@all_js_assets || "").split(",").uniq %>
+  <% if I18n.locale != :en %>
+    <% js_assets = js_assets.unshift("locales/#{I18n.locale}.js") %>
+  <% end %>
+  <% js_assets = js_assets.unshift("application") %>
+  <% js_assets.each do |a| %>
     <%= javascript_include_tag a %>
   <% end %>
 

--- a/WcaOnRails/app/views/persons/show.html.erb
+++ b/WcaOnRails/app/views/persons/show.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, @person.name) %>
-<% provide(:include_maps, true) %>
+<% add_to_packs("wca_maps") %>
 
 <div class="container" id="person">
   <%= render "details" %>

--- a/WcaOnRails/app/views/posts/_post_form.html.erb
+++ b/WcaOnRails/app/views/posts/_post_form.html.erb
@@ -1,4 +1,5 @@
-<% provide(:include_markdown_editor, true) %>
+<% add_to_packs("markdown_editor") %>
+
 <% url = @post.new_record? ? posts_path : @post.update_path %>
 <%= simple_form_for @post, url: url, html: { class: 'form-horizontal' } do |f| %>
   <%= f.input :title, disabled: !editable_post_fields.include?(:title), autofocus: true %>

--- a/WcaOnRails/app/views/registrations/_payment_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_payment_form.html.erb
@@ -1,4 +1,4 @@
-<% provide(:include_auto_numeric, true) %>
+<% add_to_packs("auto_numeric") %>
 <%= horizontal_simple_form_for :payment, url: "", html: { id: :form_payment } do |f| %>
   <%= render 'entry_fee', label: "Paid", money_amount: @registration.paid_entry_fees %>
   <%= render 'entry_fee', label: "Remaining", money_amount: @registration.outstanding_entry_fees %>

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide(:title, t('registrations.edit_registration.title', person: @registration.name, comp: @competition.name)) %>
-<% provide(:include_auto_numeric, true) %>
+<% add_to_packs("auto_numeric") %>
 
 <%= render layout: 'nav' do %>
   <%= horizontal_simple_form_for @registration, html: { class: 'are-you-sure' } do |f| %>

--- a/WcaOnRails/app/views/results_submission/new.html.erb
+++ b/WcaOnRails/app/views/results_submission/new.html.erb
@@ -1,5 +1,6 @@
 <% provide(:title, "Results submission") %>
-<% provide(:include_markdown_editor, true) %>
+<% add_to_packs("markdown_editor") %>
+
 <%= render layout: 'nav' do %>
   <h1><%= yield(:title) %></h1>
 


### PR DESCRIPTION
We can rely on the [capture](https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html) helper for that!
The way it works is that the nested/yielded capture blocks are evaluated first, before being injected into the layout.
By making the helper reuse the existing capture, we can incrementally build a string containing all the packs required by the different views (unfortunately capture only works using strings, as far as I could understand).

In our application layout we can then prepend the main application pack, and emit our scripts/stylesheets tags.
We need to preprend the application, because if we do a capture in the layout file it will actually be evaluated after the yielded block.
In which case the application pack may not be the first one emitted, which would be very bad since it contains the jquery include :p