### PR TITLE
CSS is extracted automatically by webpack

### DIFF
--- a/WcaOnRails/config/webpacker.yml
+++ b/WcaOnRails/config/webpacker.yml
@@ -91,7 +91,7 @@ production:
   compile: false
 
   # Extract and emit a css file
-  extract_css: true
+  extract_css: false
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
I need to investigate more the information in https://github.com/rails/webpacker/issues/2202 and https://github.com/rails/webpacker/issues/2342, but currently setting to false seems fine as it just means that no css packs will be produced, not that the styles won't be there.

Tested this on staging and it works, I'll merge asap.