### PR TITLE
Tell nginx to serve gzipped packs

### DIFF
--- a/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
+++ b/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
@@ -355,7 +355,7 @@ server {
 
 <% if @rails_env != "development" %>
   # http://vladigleba.com/blog/2014/03/27/deploying-rails-apps-part-4-configuring-nginx/
-  location ^~ /assets/ {
+  location ~* /(assets|packs)/ {
     # From http://stackoverflow.com/a/5132440 (with tweaks by jfly)
     gzip_static on;
     gzip_vary on;


### PR DESCRIPTION
While I worked on figuring out why adding Semantic UI would introduce such a huge change in the size of our assets served, I noticed the loaded size for our webpack assets was the same as the assets size, whereas our sprockets assets have smaller loaded size (which is expected, as we should serve them gzipped).
Turns out, we never adjusted our nginx configuration for webpacker :open_mouth: 

Tried this on staging, this is game changing.