### PR TITLE
sort competitions by  announcement date

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -68,6 +68,7 @@ class Competition < ApplicationRecord
       ).group(:id)
   }
   scope :order_by_date, -> { order(:start_date, :end_date) }
+  scope :order_by_announcement_date, -> { order(announced_at: :desc) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :not_confirmed, -> { where(confirmed_at: nil) }
 
@@ -1219,7 +1220,7 @@ class Competition < ApplicationRecord
       competitions = competitions.where(like_query, part: "%#{part}%")
     end
 
-    orderable_fields = %i(name start_date end_date)
+    orderable_fields = %i(name start_date end_date announced_at)
     if params[:sort]
       order = params[:sort].split(',')
                            .map do |part|

--- a/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_competitions_list.html.erb
@@ -13,6 +13,10 @@
       <div class="col-md-12" id="past-comps">
         <%= render 'index_table', competitions: competitions, title: t('competitions.index.titles.recent', count: Competition::RECENT_DAYS) %>
       </div>
+    <% elsif @by_announcement_selected %>
+      <div class="col-md-12" id="past-comps">
+        <%= render 'index_table', competitions: competitions, title: t('competitions.index.titles.by_announcement') %>
+      </div>
     <% elsif @custom_selected %>
       <div class="col-md-12" id="past-comps">
         <%= render 'index_table', competitions: competitions, title: t('competitions.index.titles.custom') %>
@@ -53,6 +57,8 @@
         <%= render 'admin_index_table', id: "distant-comps", competitions: competitions, title: "Past competitions" %>
       <% elsif @recent_selected %>
         <%= render 'admin_index_table', id: "recent-comps", competitions: competitions, title: "Competitions within the last #{Competition::RECENT_DAYS} days" %>
+      <% elsif @by_announcement_selected %>
+        <%= render 'admin_index_table', id: "by-announcement-comps", competitions: competitions, title: t('competitions.index.titles.by_announcement') %>
       <% else %>
         <%= render 'admin_index_table', id: "ongoing-and-upcoming-comps", competitions: competitions, title: "Ongoing and upcoming competitions" %>
       <% end %>

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -63,6 +63,10 @@
         <% end %>
       </span>
     </label>
+    <label id="by_announcement" class="btn btn-primary" data-toggle="tooltip" title="<%= t 'competitions.index.sort_by_announcement' %>">
+      <%= radio_button_tag "state", "by_announcement" %>
+      <span class="caption"><%= t 'competitions.index.by_announcement' %></span>
+    </label>
     <label id="custom" class="btn btn-primary">
       <%= radio_button_tag "state", "custom" %>
       <span class="caption"><%= t 'competitions.index.custom' %></span>
@@ -133,6 +137,10 @@
   });
 
   $('#recent').on('click', function() {
+    $('#past .caption').html("<%= t('competitions.index.past') %>");
+  });
+
+  $('#by_announcement').on('click', function() {
     $('#past .caption').html("<%= t('competitions.index.past') %>");
   });
 

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -14,6 +14,8 @@
           <% end %>
         <% elsif competition.in_progress? %>
           <%= icon('fas', 'hourglass-half', title: t('competitions.index.tooltips.hourglass.in_progress'), data: { toggle: "tooltip" }) %>
+        <% elsif @by_announcement_selected %>
+          <%= icon('fas', 'hourglass-start', title: t('competitions.index.tooltips.hourglass.announced_on', announcement_date: competition.announced_at.strftime(" %F %H:%M:%S")), data: { toggle: "tooltip" }) %>
         <% else %>
           <%= icon('fas', 'hourglass-start', title: t('competitions.index.tooltips.hourglass.starts_in', days: t('common.days', count:(competition.start_date - Date.today).to_i)), data: { toggle: "tooltip" }) %>
         <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1292,6 +1292,8 @@ en:
       recent: "Recent"
       past: "Past"
       custom: "Custom"
+      by_announcement: "By announcement"
+      sort_by_announcement: "Sort by announcement"
       from_date: "From"
       to_date: "To"
       #context: selecting a specific year ('year' is a number)
@@ -1306,6 +1308,7 @@ en:
         recent: "Recent competitions (last %{count} days)"
         upcoming: "Upcoming competitions"
         custom: "Competitions in the selected period of time"
+        by_announcement: "Competitions sorted by announcement date, newest on top"
       no_access: "You don't have access to this page!"
       #context: tooltip displayed when hovering
       tooltips:
@@ -1315,6 +1318,7 @@ en:
           in_progress: "In progress!"
           posted: "Results are posted!"
           starts_in: "Starts in %{days}"
+          announced_on: "Announced on %{announcement_date}"
         #context: the "search" button
         search: "Name or city"
         #context: the "recent" button

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CompetitionsController do
       end
     end
 
-    describe "selecting present/past/recent/custom competitions" do
+    describe "selecting present/past/recent/by_announcement/custom competitions" do
       let!(:past_comp1) { FactoryBot.create(:competition, :confirmed, :visible, starts: 1.year.ago) }
       let!(:past_comp2) { FactoryBot.create(:competition, :confirmed, :visible, starts: 3.years.ago) }
       let!(:in_progress_comp1) { FactoryBot.create(:competition, :confirmed, :visible, starts: Date.today, ends: 1.day.from_now) }
@@ -85,6 +85,18 @@ RSpec.describe CompetitionsController do
 
         it "shows in progress competition that ends today" do
           expect(assigns(:competitions)).to match_array [in_progress_comp2]
+        end
+      end
+
+      context "when by_announcement is selected" do
+        before do
+          get :index, params: { state: :by_announcement }
+          upcoming_comp1.update_column(:announced_at, 2.month.ago)
+          upcoming_comp2.update_column(:announced_at, 1.month.ago)
+        end
+
+        it "competitions are sorted by announcement_date" do
+          expect(assigns(:competitions).first(2)).to eq [upcoming_comp2, upcoming_comp1]
         end
       end
 


### PR DESCRIPTION
Fixes #5163.

I've just gone ahead and pushed the changes with the inverse ordering (recently announced competitions on top), which seems more logical we can create the dropdowns I suggested on #5163 on a different issue.