### PR TITLE
Add indexes on records in Results

### DIFF
--- a/WcaOnRails/db/migrate/20200415151734_add_index_to_results_on_records.rb
+++ b/WcaOnRails/db/migrate/20200415151734_add_index_to_results_on_records.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexToResultsOnRecords < ActiveRecord::Migration[5.2]
+  def change
+    add_index :Results, [:regionalSingleRecord, :eventId]
+    add_index :Results, [:regionalAverageRecord, :eventId]
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -318,7 +318,9 @@ CREATE TABLE `Results` (
   KEY `index_Results_on_eventId_and_value2` (`eventId`,`value2`),
   KEY `index_Results_on_eventId_and_value3` (`eventId`,`value3`),
   KEY `index_Results_on_eventId_and_value4` (`eventId`,`value4`),
-  KEY `index_Results_on_eventId_and_value5` (`eventId`,`value5`)
+  KEY `index_Results_on_eventId_and_value5` (`eventId`,`value5`),
+  KEY `index_Results_on_regionalSingleRecord_and_eventId` (`regionalSingleRecord`,`eventId`),
+  KEY `index_Results_on_regionalAverageRecord_and_eventId` (`regionalAverageRecord`,`eventId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RoundTypes`;
@@ -1628,4 +1630,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20191107212356'),
 ('20200125180554'),
 ('20200206012756'),
-('20200331082313');
+('20200331082313'),
+('20200415151734');


### PR DESCRIPTION
Thanks to the new RDS Performance Insights, we now know the [records history query](https://github.com/thewca/worldcubeassociation.org/blob/51e6602bbbe9decbc0ada4edbe541d68f8bae65f/WcaOnRails/app/controllers/results_controller.rb#L163) is constantly the "heaviest" one, occasionally even causing downtime. 

These two indexes improve its performance ~5x without any code changes. Because MySQL materializes inline views (any views really), the external predicates cannot be pushed down into it, which means the `eventId` part of the index will not be helpful right now. We'll probably need to refactor the query to get much better performance -- in any case we'll need these indexes on the records columns.