### PR TITLE
Include nested activities in developer dump

### DIFF
--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -3,6 +3,7 @@
 module DatabaseDumper
   JOIN_WHERE_VISIBLE_COMP = "JOIN Competitions ON Competitions.id=competition_id WHERE showAtAll=1"
   DUMP_TIMESTAMP_NAME = "developer_dump_exported_at"
+  VISIBLE_ACTIVITY_IDS = "SELECT A.id FROM schedule_activities AS A JOIN venue_rooms ON (venue_rooms.id = holder_id AND holder_type='VenueRoom') JOIN competition_venues ON competition_venues.id = competition_venue_id #{JOIN_WHERE_VISIBLE_COMP}"
 
   def self.actions_to_column_sanitizers(columns_by_action)
     {}.tap do |column_sanitizers|
@@ -408,8 +409,7 @@ module DatabaseDumper
       ),
     }.freeze,
     "schedule_activities" => {
-      # FIXME: this does not handle nested activities, which will be omitted!
-      where_clause: "JOIN venue_rooms ON (venue_rooms.id = holder_id AND holder_type = \"VenueRoom\") JOIN competition_venues ON competition_venues.id = competition_venue_id #{JOIN_WHERE_VISIBLE_COMP}",
+      where_clause: "WHERE (holder_type=\"ScheduleActivity\" AND holder_id IN (#{VISIBLE_ACTIVITY_IDS}) or id in (#{VISIBLE_ACTIVITY_IDS}))",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id


### PR DESCRIPTION
Currently a lot of WCIF are broken on staging (all which used a grouping tool actually :p).
This is due to us only dumping the activity within a room, and not activity within an activity.
I had to tweak a bit the sql to include activities which id are in visible activities, or which holder id (and type) are in visible activities.