### PR TITLE
delegate admin page fix

### DIFF
--- a/WcaOnRails/app/views/delegates/stats.html.erb
+++ b/WcaOnRails/app/views/delegates/stats.html.erb
@@ -20,7 +20,7 @@
       <% @delegates.each do |delegate| %>
         <% competitions = delegate.delegated_competitions.order_by_date.select{ |c| c.confirmed_or_visible? && c.is_probably_over? } %>
         <tr class="<%= delegate.delegate_status %>">
-          <td class="delegate" data-toggle="tooltip" data-placement="top" data-container="body" title="<%= delegate.notes %>">
+          <td class="delegate" data-toggle="tooltip" data-placement="top" data-container="body">
             <%= delegate.name %>
             <%= mail_to delegate.email, icon("fas", "envelope"), target: "_blank", class: "hide-new-window-icon" %>
           </td>


### PR DESCRIPTION
Looks like in my previous commit to remove the delegate fields, I missed one part in delegate admin page, because of which the delegate admin page is not working. I've fixed that now.