### PR TITLE
Fix 'Trainee Delegate' tags

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/delegates.scss
+++ b/WcaOnRails/app/assets/stylesheets/delegates.scss
@@ -8,6 +8,10 @@ tr.candidate-delegate {
   font-style: italic;
 }
 
+tr.trainee_delegate {
+  font-style: italic;
+}
+
 .popover-content img {
   max-width: 100%;
   max-height: 100%;

--- a/WcaOnRails/app/helpers/persons_helper.rb
+++ b/WcaOnRails/app/helpers/persons_helper.rb
@@ -59,8 +59,10 @@ module PersonsHelper
         badges.push(delegate_badge("senior_delegate"))
       elsif user.full_delegate?
         badges.push(delegate_badge("delegate"))
-      else
+      elsif user.candidate_delegate?
         badges.push(delegate_badge("candidate_delegate"))
+      else
+        badges.push(delegate_badge("trainee_delegate"))
       end
     end
 

--- a/WcaOnRails/spec/helpers/persons_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/persons_helper_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe PersonsHelper do
     it "Returns a Trainee Delegate badge when passed trainee_delegate" do
       string = helper.delegate_badge("trainee_delegate")
       expect(string).to eq "<span class=\"badge delegate-badge\"><a title=\"" +
-                           t("enums.user.delegate_status.candidate_delegate") +
+                           t("enums.user.delegate_status.trainee_delegate") +
                            "\" data-toggle=\"tooltip\" data-placement=\"bottom\" href=\"/delegates\">" +
-                           t("enums.user.delegate_status.candidate_delegate") + "</a></span>"
+                           t("enums.user.delegate_status.trainee_delegate") + "</a></span>"
     end
 
     it "links to the delegates page" do

--- a/WcaOnRails/spec/helpers/persons_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/persons_helper_spec.rb
@@ -42,8 +42,16 @@ RSpec.describe PersonsHelper do
                            t("enums.user.delegate_status.senior_delegate") + "</a></span>"
     end
 
-    it "Returns a Junior Delegate badge when passed candadate_delegate" do
+    it "Returns a Junior Delegate badge when passed candidate_delegate" do
       string = helper.delegate_badge("candidate_delegate")
+      expect(string).to eq "<span class=\"badge delegate-badge\"><a title=\"" +
+                           t("enums.user.delegate_status.candidate_delegate") +
+                           "\" data-toggle=\"tooltip\" data-placement=\"bottom\" href=\"/delegates\">" +
+                           t("enums.user.delegate_status.candidate_delegate") + "</a></span>"
+    end
+
+    it "Returns a Trainee Delegate badge when passed trainee_delegate" do
+      string = helper.delegate_badge("trainee_delegate")
       expect(string).to eq "<span class=\"badge delegate-badge\"><a title=\"" +
                            t("enums.user.delegate_status.candidate_delegate") +
                            "\" data-toggle=\"tooltip\" data-placement=\"bottom\" href=\"/delegates\">" +


### PR DESCRIPTION
I also make the text of "Trainee Delegates" italic on the Delegates list.