### PR TITLE
Get rid of unnecessary 'Trainee Delegates' css

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/delegates.scss
+++ b/WcaOnRails/app/assets/stylesheets/delegates.scss
@@ -4,11 +4,7 @@ tr.senior-delegate {
   font-weight: bold;
 }
 
-tr.candidate-delegate {
-  font-style: italic;
-}
-
-tr.trainee_delegate {
+tr.trainee-delegate {
   font-style: italic;
 }
 

--- a/WcaOnRails/app/assets/stylesheets/delegates.scss
+++ b/WcaOnRails/app/assets/stylesheets/delegates.scss
@@ -4,7 +4,7 @@ tr.senior-delegate {
   font-weight: bold;
 }
 
-tr.trainee-delegate {
+tr.candidate-delegate {
   font-style: italic;
 }
 


### PR DESCRIPTION
This is what I suggested on the slack channel. If you consider that 'Junios Delegates' should still be shown in italic I can easily change the PR.

I think this change makes sense because 'Trainee Delegates' are the only Delegates that aren't WCA Staff. Therefore is reasonable to display them different from the rest of the Delegates.