### PR TITLE
Support qualification/b-final in rounds

### DIFF
--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -43,6 +43,11 @@ class CompetitionEvent < ApplicationRecord
   end
 
   def load_wcif!(wcif)
+    if self.rounds.pluck(:old_type).compact.any?
+      raise WcaExceptions::BadApiParameter.new(
+        "Cannot edit rounds for a competition which has qualification rounds or b-finals. Please contact WRT or WST if you need to make change to this competition.",
+      )
+    end
     self.rounds.destroy_all!
     total_rounds = wcif["rounds"].size
     wcif["rounds"].each_with_index do |wcif_round, index|

--- a/WcaOnRails/app/models/round_type.rb
+++ b/WcaOnRails/app/models/round_type.rb
@@ -23,7 +23,7 @@ class RoundType < ApplicationRecord
 
   # Returns the equivalent round_type_id with cutoff (or without cutoff)
   def self.toggle_cutoff(round_type_id)
-    [%w(c f), %w(d 1), %w(e 2), %w(g 3)]
+    [%w(c f), %w(d 1), %w(e 2), %w(g 3), %w(h 0)]
       .flat_map { |pair| [pair, pair.reverse] }
       .to_h[round_type_id]
   end

--- a/WcaOnRails/db/migrate/20200502095048_add_old_type_to_round.rb
+++ b/WcaOnRails/db/migrate/20200502095048_add_old_type_to_round.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOldTypeToRound < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rounds, :old_type, :string, limit: 1, default: nil
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1172,6 +1172,7 @@ CREATE TABLE `rounds` (
   `scramble_set_count` int(11) NOT NULL DEFAULT '1',
   `round_results` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `total_number_of_rounds` int(11) NOT NULL,
+  `old_type` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1645,4 +1646,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200304044931'),
 ('20200331082313'),
 ('20200415151734'),
-('20200419133415');
+('20200419133415'),
+('20200502095048');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -295,6 +295,7 @@ module DatabaseDumper
           round_results
           created_at
           updated_at
+          old_type
         ),
       ),
     }.freeze,

--- a/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -45,6 +45,25 @@ RSpec.describe ACV do
       end
     end
 
+    it "ignores b-final" do
+      # Using a single fake person for all the results for better performance.
+      fake_person = build_person(:result, competition1)
+      # Collecting all the results and using bulk import for better performance.
+      results = []
+      results += FactoryBot.build_list(:result, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person)
+      results += FactoryBot.build_list(:result, 8, competition: competition1, eventId: "333oh", roundTypeId: "b", person: fake_person)
+      results += FactoryBot.build_list(:result, 32, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person)
+      Result.import(results)
+
+      validator_args.each do |arg|
+        acv = ACV.new.validate(arg)
+        # If it wouldn't ignore b-final, it would complain about competitors not
+        # being eliminated.
+        expect(acv.warnings).to be_empty
+        expect(acv.errors).to be_empty
+      end
+    end
+
     # Triggers:
     # REGULATION_9M_ERROR
     # REGULATION_9M1_ERROR


### PR DESCRIPTION
The WRT is currently filling up the old competitions events and rounds data to have a consistency between what is "declared" in these and what is actually present in the results.
Unfortunately there are these old and deprecated "(combined) qualification" and "b-final" rounds.
Basically they are not taken into account when computing advancement conditions, and they are not "real" rounds...
It's actually very annoying to support them cleanly, so I'd very much enjoy suggestions on how to do so.

Here is a suggested implementation:
  - such round is given the round number "0" (there are no competitions with both qualification and b-final)
  - they have an additional column stating which "old type" it is (qualification or b-final).
  - the round's round_type_id is determined accurately from that.
  - it should not be possible to change these through UI (it's filled once for all, most likely by the WRT through sql updates!).
  - editing a competition's events/rounds through the WCIF would actually break the existing data, so attempting to do so results in an error.
  - the advancement conditions validator has been extended to ignore such rounds (and interestingly, the cutoff validator just works fine on combined qualification rounds :))
