### PR TITLE
Update Scrambles Matcher url

### DIFF
--- a/WcaOnRails/app/views/static_pages/score_tools.html.erb
+++ b/WcaOnRails/app/views/static_pages/score_tools.html.erb
@@ -53,10 +53,10 @@
   },
   after: {
     matcher: {
-      url: "https://viroulep.github.io/scrambles-matcher/",
-      src_url: "https://github.com/viroulep/scrambles-matcher/",
-      maintainer: "Philippe Virouleau",
-      wst: false,
+      url: "https://scrambles-matcher.worldcubeassociation.org",
+      src_url: "https://github.com/thewca/scrambles-matcher/",
+      maintainer: "WCA Software Team",
+      wst: true,
     }.merge(t("score_tools.tools.matcher")),
   },
 } %>


### PR DESCRIPTION
I moved it to `thewca` org.