### PR TITLE
Fixes #3970 and #5335: added support for disqualified competitions

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1005,7 +1005,7 @@ class Competition < ApplicationRecord
   end
 
   def user_can_view_results?(user)
-    results_posted? || (user&.can_admin_results? && !results.empty?)
+    (results_posted? || user&.can_admin_results?) && !results.empty?
   end
 
   def in_progress?

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -170,7 +170,7 @@
           <%= render "registration_requirements", show_links_to_register_page: true %>
         </div>
       </dd>
-      <% if competition.results_posted? %>
+      <% if competition.user_can_view_results?(current_user) %>
         <% records = records(competition) %>
         <% if main_event.present? || records.present? %>
           <dt><%= t '.highlights' %></dt>
@@ -214,7 +214,7 @@
   </script>
 <% end %>
 
-<% if competition.results_posted? %>
+<% if competition.user_can_view_results?(current_user) %>
   <script>
     $(function () {
       $("#highlights_text").collapse({


### PR DESCRIPTION
Fixes #3970, fixes #5335.
So, here's my proposal for a disqualified competition: the competition can have `results_submitted_at` and `results_posted_by`. For now, `results_posted_by` is set to NULL because else the website was breaking. The website was breaking due to rendering a part of it based on `results_posted?` instead of `user_can_view_results?`. I've changed it.

Also, I've changed the definition of `user_can_view_results?`: now it will return `true` only if there are any results.