### PR TITLE
Fixes #4490 can confirm competition only if advancement_condition is …

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1568,4 +1568,11 @@ class Competition < ApplicationRecord
     cal.publish
     cal
   end
+
+  validate :advancement_condition_must_be_present_for_all_non_final_rounds, if: :confirmed_or_visible?
+  def advancement_condition_must_be_present_for_all_non_final_rounds
+    unless rounds.all?(&:advancement_condition_is_valid?)
+      errors.add(:competition_events, I18n.t('competitions.errors.advancement_condition_must_be_present_for_all_non_final_rounds'))
+    end
+  end
 end

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -137,6 +137,10 @@ class Round < ApplicationRecord
     can_change_time_limit? && time_limit == TimeLimit::UNDEF_TL
   end
 
+  def advancement_condition_is_valid?
+    final_round? || advancement_condition
+  end
+
   def self.parse_wcif_id(wcif_id)
     event_id, round_number = /^([^-]+)-r([^-]+)$/.match(wcif_id).captures
     round_number = round_number.to_i

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1407,6 +1407,7 @@ en:
       refund_date_after_start: "Refund limit date cannot be after start date."
       span_too_many_days: "Competition cannot last more than %{max_days} days."
       invalid_currency_code: "Selected currency code is invalid"
+      advancement_condition_must_be_present_for_all_non_final_rounds: "must have an advancement condition to all non final rounds."
     new:
       create_competition: "Create competition"
       note_clone: "To clone an existing competition visit the information page for that competition and click the \"Clone\" link in the menu."


### PR DESCRIPTION
…present for all non final rounds.
Fixes #4490.