### PR TITLE
Updating avatar guidelines

### DIFF
--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -13,7 +13,7 @@
       </ul>
       <h4>Additional guidelines for Staff Members</h4>
       <ul>
-        <% t('users.edit.delegate_avatar_guidelines.paragraphs').values.each do |guideline| %>
+        <% t('users.edit.staff_avatar_guidelines.paragraphs').values.each do |guideline| %>
           <li><%= guideline %></li>
         <% end %>
       </ul>

--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -7,19 +7,15 @@
     <div class="well">
       <h3>Guidelines</h3>
       <ul>
-        <li>All avatars should be pictures of real persons.</li>
-        <li>The person shown must be the involved member (as far as can be judged).</li>
-        <li>If there is more than one person on the avatar, it should be clear who is the involved member.</li>
-        <li>The head of the involved member, not necessarily the full face, should be visible.</li>
-        <li>The avatar should not include texts other than regular background texts.</li>
-        <li>If the correct orientation of the picture is clear (portrait or landscape) the picture must be submitted in that correct orientation.</li>
-        <li>The avatar must not contain offensive content (e.g. offensive gestures).</li>
+        <% t('users.edit.avatar_guidelines').values.each do |guideline| %>
+          <li><%= guideline %></li>
+        <% end %>
       </ul>
       <h4>Additional guidelines for Staff Members</h4>
       <ul>
-        <li>The avatar must be of the Staff Member's current self, depicted in the same fashion as how they would appear at a competition.</li>
-        <li>The avatar must be framed, cropped, angled, and lit, so that any competitor or spectator at a competition can use it to unambiguously identify them at a competition venue.</li>
-        <li>The thumbnail of the avatar is only a section of the avatar, and it will be used to represent the full avatar. The thumbnail must be adjusted, so the Staff Member can be recognized from it alone, and it must contain their face.</li>
+        <% t('users.edit.delegate_avatar_guidelines.paragraphs').values.each do |guideline| %>
+          <li><%= guideline %></li>
+        <% end %>
       </ul>
     </div>
 

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -197,9 +197,9 @@
                   <% end %>
                 </ul>
                 <% if @user.staff? %>
-                  <br /><strong><%= t('.delegate_avatar_guidelines.title') %></strong>
+                  <br /><strong><%= t('.staff_avatar_guidelines.title') %></strong>
                   <ul>
-                    <% t('.delegate_avatar_guidelines.paragraphs').values.each do |guideline| %>
+                    <% t('.staff_avatar_guidelines.paragraphs').values.each do |guideline| %>
                       <li><%= guideline %></li>
                     <% end %>
                   </ul>

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -104,7 +104,7 @@ ignore_unused:
   - 'simple_form.{error_notification,required}.:'
   # We iterate through the children, so we use all of them
   - 'users.edit.avatar_guidelines.*'
-  - 'users.edit.delegate_avatar_guidelines.*'
+  - 'users.edit.staff_avatar_guidelines.*'
   - 'faq.answers.*'
   - 'about.mission.paragraphs.*'
   - 'logo.paragraphs.*'

--- a/WcaOnRails/config/locales/cs.yml
+++ b/WcaOnRails/config/locales/cs.yml
@@ -1369,7 +1369,7 @@ cs:
         '7': >-
           Součástí avataru nesmí být ofenzivní obsah (napřiklad pohoršující
           gesta).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: 35abf16
         title: 'Doplňkové instrukce pro Delegáty:'
         paragraphs:

--- a/WcaOnRails/config/locales/da.yml
+++ b/WcaOnRails/config/locales/da.yml
@@ -1540,7 +1540,7 @@ da:
         '7': >-
           Avataren må ikke indeholde noget offensivt (f.eks. offensive
           håndbevægelser).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Yderligere retningslinjer for WCA Personale:'
         paragraphs:

--- a/WcaOnRails/config/locales/de.yml
+++ b/WcaOnRails/config/locales/de.yml
@@ -1733,7 +1733,7 @@ de:
         '6': Das Bild muss in korrekter Ausrichtung eingeschickt werden.
         #original_hash: 1a18831
         '7': Der Avatar darf keine offensiven Inhalte haben (z.B. offensive Gesten)
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Zusätzliche Richtlinien für Mitarbeiter:'
         paragraphs:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -925,7 +925,7 @@ en:
         '5': "The avatar should not include overlay texts or unnatural filters, including borders."
         '6': "The avatar must be submitted in correct orientation."
         '7': "The avatar must not contain offensive content (e.g. offensive gestures)."
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         title: "Additional guidelines for Staff Members:"
         paragraphs:
           '1': "The avatar must be of your current self, depicted in the same fashion as how you would appear at a competition."

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -922,7 +922,7 @@ en:
         '2': "The person shown must be you."
         '3': "If there is more than one person on the avatar, it should be clear who of them is you."
         '4': "Your head, but not necessarily the full face, should be visible."
-        '5': "The avatar must not include texts other than regular background texts."
+        '5': "The avatar should not include overlay texts or unnatural filters, including borders."
         '6': "The avatar must be submitted in correct orientation."
         '7': "The avatar must not contain offensive content (e.g. offensive gestures)."
       delegate_avatar_guidelines:

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -1730,7 +1730,7 @@ es:
         '6': La foto tiene que tener la orientación correcta.
         #original_hash: 1a18831
         '7': La foto no debe contener contenido ofensivo (p.e. gestos ofensivos).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Directrices adicionales para Personal WCA:'
         paragraphs:

--- a/WcaOnRails/config/locales/fi.yml
+++ b/WcaOnRails/config/locales/fi.yml
@@ -1691,7 +1691,7 @@ fi:
         '7': >-
           Profiilikuvassa ei saa olla hyökkäävää sisältöä (kuten tällaista
           elekieltä).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Additional guidelines for Staff Members:'
         paragraphs:

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -1587,7 +1587,7 @@ fr:
         '7': >-
           La photo de profil ne doit pas contenir de contenu offensant (par
           exemple : gestes offensant).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Recommandations additionnelles pour les membres du Staff :'
         paragraphs:

--- a/WcaOnRails/config/locales/hr.yml
+++ b/WcaOnRails/config/locales/hr.yml
@@ -1734,7 +1734,7 @@ hr:
         '6': Avatar mora biti prenesen u pravilnoj orijentaciji.
         #original_hash: 1a18831
         '7': Avatar ne smije sadržavati uvredljiv sadržaj (npr. uvredljive geste).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Dodatne smjernice za Osoblje:'
         paragraphs:

--- a/WcaOnRails/config/locales/hu.yml
+++ b/WcaOnRails/config/locales/hu.yml
@@ -1374,7 +1374,7 @@ hu:
         '6': A profilképet helyes orientációban kell feltölteni.
         #original_hash: 1a18831
         '7': A profilkép nem tartalmazhat sértő tartalmat (pl. sértő gesztus).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: 35abf16
         title: 'Extra útmutató delegáltaknak:'
         paragraphs:

--- a/WcaOnRails/config/locales/id.yml
+++ b/WcaOnRails/config/locales/id.yml
@@ -1347,7 +1347,7 @@ id:
         '7': >-
           Avatar tidak boleh memuat konten yang menyinggung (contoh:
           gerakan/isyarat yang menyinggung).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: 35abf16
         title: 'Pedoman tambahan untuk Delegate:'
         paragraphs:

--- a/WcaOnRails/config/locales/it.yml
+++ b/WcaOnRails/config/locales/it.yml
@@ -1736,7 +1736,7 @@ it:
         '6': L'avatar deve essere caricato nella corretta orientamento.
         #original_hash: 1a18831
         '7': L'avatar non deve contenere contenuti offensivi (es. gesti offensivi).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Ulteriori linee guida per i membri dello Staff:'
         paragraphs:

--- a/WcaOnRails/config/locales/ja.yml
+++ b/WcaOnRails/config/locales/ja.yml
@@ -1506,7 +1506,7 @@ ja:
         '6': プロフィール画像は正しい向きでアップロードしなければいけません。
         #original_hash: 1a18831
         '7': 'プロフィール画像は攻撃的な内容 (例 : 攻撃的なジェスチャー) を含んではいけません。'
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: WCA スタッフのアバターの追加ガイドライン
         paragraphs:

--- a/WcaOnRails/config/locales/nl.yml
+++ b/WcaOnRails/config/locales/nl.yml
@@ -1696,7 +1696,7 @@ nl:
         '7': >-
           De profielfoto moet geen offensieve inhoud bevatten (zoals offensieve
           gebaren).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Aanvullende richtlijnen voor stafleden:'
         paragraphs:

--- a/WcaOnRails/config/locales/pl.yml
+++ b/WcaOnRails/config/locales/pl.yml
@@ -1715,7 +1715,7 @@ pl:
         '7': >-
           Zdjęcie profilowe nie może zawierać żadnych obraźliwych treści (np.
           obraźliwych gestów).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Dodatkowe wytyczne dla Członków Personelu:'
         paragraphs:

--- a/WcaOnRails/config/locales/pt-BR.yml
+++ b/WcaOnRails/config/locales/pt-BR.yml
@@ -1731,7 +1731,7 @@ pt-BR:
         '6': O avatar deve estar na orientação correta.
         #original_hash: 1a18831
         '7': Sua foto não pode conter conteúdo ofensivo (p. ex. gestos ofensivos).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Orientações adicionais para Staff Members:'
         paragraphs:

--- a/WcaOnRails/config/locales/pt.yml
+++ b/WcaOnRails/config/locales/pt.yml
@@ -1726,7 +1726,7 @@ pt:
         '6': O avatar deve ser submetido na orientação correta.
         #original_hash: 1a18831
         '7': O avatar não pode apresentar conteúdo ofensivo (ex. gestos ofensivos).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Orientações adicionais para Membros de Staff:'
         paragraphs:

--- a/WcaOnRails/config/locales/ro.yml
+++ b/WcaOnRails/config/locales/ro.yml
@@ -1583,7 +1583,7 @@ ro:
         '7': >-
           Avatarul nu trebuie să aibă conținut ofensiv (de exemplu, gesturi
           ofensive).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Îndrumări adiționale pentru Staff:'
         paragraphs:

--- a/WcaOnRails/config/locales/ru.yml
+++ b/WcaOnRails/config/locales/ru.yml
@@ -1709,7 +1709,7 @@ ru:
         '7': >-
           Аватарка не должна быть оскорбительной (например, содержать
           оскорбительные жесты).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Дополнительные указания для Сотрудников:'
         paragraphs:

--- a/WcaOnRails/config/locales/sl.yml
+++ b/WcaOnRails/config/locales/sl.yml
@@ -1268,7 +1268,7 @@ sl:
         '6': Avatar mora biti pravilno orientiran.
         #original_hash: 1a18831
         '7': Avatar ne sme vsebovati žaljivo vsebino (npr. žaljive geste).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: 35abf16
         title: 'Dodatne smernice za Delegate:'
         paragraphs:

--- a/WcaOnRails/config/locales/th.yml
+++ b/WcaOnRails/config/locales/th.yml
@@ -1484,7 +1484,7 @@ th:
         '6': รูปแทนตัวจะต้องหันในทิศทางที่ถูกต้อง
         #original_hash: 1a18831
         '7': รูปแทนตัวจะต้องไม่มีเนื้อหาที่ไม่เหมาะสม (เช่น ท่าทางที่ไม่เหมาะสม)
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: แนวทางเพิ่มเติมสำหรับ Staff
         paragraphs:

--- a/WcaOnRails/config/locales/uk.yml
+++ b/WcaOnRails/config/locales/uk.yml
@@ -1707,7 +1707,7 @@ uk:
         '7': >-
           Аватар не повинен містити непристойний вміст (наприклад, образливі
           жести).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Додаткові вказівки для Персоналу WCA:'
         paragraphs:

--- a/WcaOnRails/config/locales/vi.yml
+++ b/WcaOnRails/config/locales/vi.yml
@@ -1514,7 +1514,7 @@ vi:
         '7': >-
           Hình ảnh đại diện không được chứa nội dung phản cảm (v.d. cử chỉ phản
           cảm).
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 'Hướng dẫn bổ sung cho Nhân viên:'
         paragraphs:

--- a/WcaOnRails/config/locales/zh-TW.yml
+++ b/WcaOnRails/config/locales/zh-TW.yml
@@ -1484,7 +1484,7 @@ zh-TW:
         '6': 頭像的方向必須正確。
         #original_hash: 1a18831
         '7': 頭像不得含有冒犯他人內容（例如：無禮的手勢）
-      delegate_avatar_guidelines:
+      staff_avatar_guidelines:
         #original_hash: da9e6df
         title: 針對WCA 員工的指導方針：
         paragraphs:


### PR DESCRIPTION
- Changed Guideline #5 based on WRT and WQAC discussion: "The avatar should not include overlay texts or unnatural filters, including borders."
- Changed the list on the admin page to reflect the same list on the user's upload page. (also makes it localized!)
- Changed delegate_avatar_guidelines to staff_avatar_guidelines.
