### PR TITLE
Add support for cancelled competitions

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -62,7 +62,7 @@ onPage('competitions#index', function() {
     $form.trigger('submit.rails');
   }
 
-  $form.on('change', '#events, #region, #state, #display, #status, #delegate', submitForm)
+  $form.on('change', '#events, #region, #state, #display, #status, #delegate, #cancelled', submitForm)
        .on('click', '#clear-all-events, #select-all-events', submitForm)
        .on('input', '#search', window.wca.lodashDebounce(submitForm, window.wca.TEXT_INPUT_DEBOUNCE_MS))
        .on('dp.change','#from_date, #to_date', submitForm);

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -120,7 +120,7 @@ $venue-map-wrapper-height: 400px;
       background-color: $state-success-bg;
     }
 
-    &.not-confirmed {
+    &.not-confirmed, &.cancelled {
       background-color: $state-danger-bg;
     }
   }
@@ -182,6 +182,10 @@ $venue-map-wrapper-height: 400px;
     display: inline-block;
     width: 300px;
   }
+
+  .cancel-selector {
+    display: block;
+  }
 }
 
 .same-line {
@@ -237,6 +241,10 @@ $venue-map-wrapper-height: 400px;
       &.break {
         text-align: center;
         font-weight: bold;
+      }
+
+      &.cancelled {
+        background-color: $state-danger-bg;
       }
     }
 

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -4,7 +4,9 @@ module CompetitionsHelper
   def competition_message_for_user(competition, user)
     messages = []
     registration = competition.registrations.find_by_user_id(user.id)
-    if registration
+    if competition.cancelled?
+      messages << t('competitions.messages.cancelled')
+    elsif registration
       messages << (registration.accepted? ? t('competitions.messages.tooltip_registered') : t('competitions.messages.tooltip_waiting_list'))
     end
     visible = competition.showAtAll?

--- a/WcaOnRails/app/helpers/notifications_helper.rb
+++ b/WcaOnRails/app/helpers/notifications_helper.rb
@@ -62,10 +62,12 @@ module NotificationsHelper
     user.delegated_competitions.visible.over.order_by_date
         .includes(:delegate_report).where(delegate_reports: { posted_at: nil })
         .each do |competition|
-          notifications << {
-            text: "The delegate report for #{competition.name} has not been submitted.",
-            url: delegate_report_path(competition),
-          }
+          if competition.user_should_post_delegate_report?(user)
+            notifications << {
+              text: "The delegate report for #{competition.name} has not been submitted.",
+              url: delegate_report_path(competition),
+            }
+          end
         end
 
     user.delegated_competitions.visible.over.order_by_date

--- a/WcaOnRails/app/jobs/registration_reminder_job.rb
+++ b/WcaOnRails/app/jobs/registration_reminder_job.rb
@@ -11,6 +11,7 @@ class RegistrationReminderJob < SingletonApplicationJob
   def perform
     Competition
       .visible
+      .not_cancelled
       .where("registration_open <= ? AND registration_open >= NOW()", 1.day.from_now)
       .includes(bookmarked_competitions: [:user])
       .select { |c| should_send_reminder(c) }.each do |competition|

--- a/WcaOnRails/app/jobs/submit_report_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_report_nag_job.rb
@@ -10,6 +10,7 @@ class SubmitReportNagJob < SingletonApplicationJob
   def perform
     Competition
       .visible
+      .not_cancelled
       .includes(:delegate_report)
       .where("start_date >= ?", DelegateReport::REPORTS_ENABLED_DATE) # Don't send nag emails for very old competitions without reports.
       .where(delegate_reports: { posted_at: nil })

--- a/WcaOnRails/app/jobs/submit_results_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_results_nag_job.rb
@@ -8,7 +8,11 @@ class SubmitResultsNagJob < SingletonApplicationJob
   end
 
   def perform
-    Competition.visible.where(results_submitted_at: nil).select { |c| nag_needed(c) }.each do |competition|
+    Competition
+      .visible
+      .not_cancelled
+      .where(results_submitted_at: nil)
+      .select { |c| nag_needed(c) }.each do |competition|
       competition.update_attribute(:results_nag_sent_at, Time.now)
       CompetitionsMailer.submit_results_nag(competition).deliver_now
     end

--- a/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_admin_index_table.html.erb
@@ -29,7 +29,7 @@
         <% competitions.each_with_index do |competition, index| %>
           <tr>
             <td>
-              <%= flag_icon competition.country.iso2 %><%= link_to competition.cellName, competition_path(competition) %>
+              <%= flag_icon competition.country.iso2 %><%= link_to competition.display_name(short: true), competition_path(competition) %>
               <br /><strong><%= competition.country.name_in(:en) %></strong>, <%= competition.cityName %>
             </td>
             <td class="admin-delegate">

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -112,6 +112,11 @@
                                  data: { data: User.where(id: params[:delegate]).to_json } %>
 </div>
 
+<div id="cancelled" class="form-group cancel-selector">
+  <%= check_box_tag(:show_cancelled, params[:show_cancelled], params[:show_cancelled] == "on") %>
+  <%= label_tag("Show cancelled competitions") %>
+</div>
+
 <div id="display" class="form-group">
   <div class="btn-group btn-group-justified" data-toggle="buttons">
     <label id="display-list" class="btn btn-info">

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -4,7 +4,10 @@
     <% if index > 0 && competition.year != competitions[index - 1].year && params[:event_ids].empty? %>
       <li class="list-group-item break"><%= competition.year %></li>
     <% end %>
-    <li class="list-group-item <%= competition.is_probably_over? ? "past" : "not-past" %>">
+    <% li_classes = ["list-group-item"] %>
+    <% li_classes << competition.is_probably_over? ? "past" : "not-past" %>
+    <% li_classes << "cancelled" if competition.cancelled? %>
+    <li class="<%= li_classes.join(' ') %>">
       <span class="date">
         <% if competition.is_probably_over? %>
           <% if competition.results_posted? %>
@@ -24,7 +27,7 @@
       <span class="competition-info">
         <div class="competition-link">
           <%= flag_icon competition.country.iso2 %>
-          <%= link_to competition.cellName, competition_path(competition) %>
+          <%= link_to competition.display_name(short: true), competition_path(competition) %>
         </div>
         <div class="location">
           <strong><%= competition.country.name %></strong>, <%= competition.cityName %>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -31,12 +31,13 @@
           <% registration = registrations_by_competition_id[competition.id] %>
           <% tr_classes = [ competition.confirmed? ? "confirmed" : "not-confirmed",
                           competition.showAtAll? ? "visible" : "not-visible",
+                          competition.cancelled? ? "cancelled" : "",
                           past ? "past" : "not-past" ].join(' ') %>
           <tr class="<%= tr_classes %>"
               data-toggle="tooltip" data-placement="bottom" data-container="body"
               title="<%= competition_message_for_user(competition, current_user) unless past %>">
             <td>
-              <%= link_to competition.name, competition_path(competition) %>
+              <%= link_to competition.display_name, competition_path(competition) %>
               <% if competition.championships.any? %>
                 <span class="championship-trophy" data-toggle="tooltip" data-placement="bottom" title="<%= competition.championships.sort.map { |championship| championship.name }.join(", ") %>">
                   <%= icon('fas', 'trophy') %>

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -231,9 +231,15 @@
             <%= icon('fas', 'trophy') %>
           </span>
         <% end %>
-        <%= @competition.name %>
+        <%= @competition.display_name %>
       </h3>
       <hr />
+
+      <% if @competition.cancelled? %>
+        <%= alert :danger, note: true do %>
+          <%= t('competitions.messages.cancelled') %>
+        <% end %>
+      <% end %>
 
       <% if @competition.user_should_post_delegate_report?(current_user) %>
         <%= alert :warning, note: true do %>

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -31,6 +31,27 @@
           </ul>
         <% end %>
       </li>
+      <li>
+        <%= button_to competition_cancel_path, class: 'btn btn-danger', disabled: !@competition.can_be_cancelled?, method: :post, data: { confirm: t('competitions.cancel_confirm') } do %>
+          <%= t 'competitions.cancel' %>
+        <% end %>
+        <% if !@competition.can_be_cancelled? && !@competition.cancelled? %>
+          <%= t 'competitions.note_before_cancel' %>
+        <% end %>
+        <% if @competition.cancelled? %>
+          <ul>
+            <li>
+              <%= t 'competitions.cancelled_by_html', name: User.find(@competition.cancelled_by).name, date_time: wca_local_time(@competition.cancelled_at) %>
+            </li>
+            <li>
+              <%= t 'competitions.cancel_mistake' %>
+              <%= button_to competition_cancel_path(undo: true), class: 'btn', method: :post do %>
+                <%= t 'competitions.uncancel' %>
+              <% end %>
+            </li>
+          </ul>
+        <% end %>
+      </li>
     </ul>
     <hr>
   <% end %>

--- a/WcaOnRails/app/views/competitions/show.html.erb
+++ b/WcaOnRails/app/views/competitions/show.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, @competition.name) %>
+<% provide(:title, @competition.display_name) %>
 <%# We use this to hide the 'Events' information for competition which didn't declared rounds %>
 <%= render layout: 'nav' do %>
   <ul class="nav nav-tabs">

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1185,6 +1185,11 @@ en:
       create_success: "Successfully created new competition!"
       not_announced: "This competition is visible to the public but hasn't been announced yet."
       announced: "Successfully announced competition!"
+      cancelled: "This competition has been cancelled. Please checkout the information section for more details."
+      cancel_success: "Successfully cancelled competition!"
+      cancel_failure: "Cannot cancel the competition."
+      uncancel_success: "Successfully uncancelled competition!"
+      uncancel_failure: "Cannot uncancel the competition."
       results_not_posted: "This competition's results are visible but haven't been posted yet."
       results_already_posted: "The results have already been posted."
       results_posted: "Successfully posted results!"
@@ -1227,6 +1232,8 @@ en:
       address: "Address"
       details: "Details"
       website: "Website"
+      #context: Used to display an explicit tag when the competition is cancelled
+      display_name: "[Cancelled] %{name}"
       #context: Pluralization of the "Organizer" label for a competition form
       organizer_plural:
         one: "Organizer"
@@ -1432,9 +1439,15 @@ en:
     announcements: "Announcements"
     post_announcement: "Announce the competition"
     announced_by_html: "Announced by %{announcer_name} on %{date_time}"
+    cancel: "Cancel the competition"
+    uncancel: "Uncancel the competition"
+    cancelled_by_html: "Cancelled by %{name} on %{date_time}"
+    cancel_confirm: "Are you sure you want to cancel that competition?"
     upload_results: "Upload the results"
     post_results: "Post the results"
     results_posted_by_html: "Posted by %{poster_name} on %{date_time}"
+    cancel_mistake: "Made a mistake?"
+    note_before_cancel: "Note: only confirmed competitions can be cancelled."
     show:
       general_info: "General info"
       events: "Events"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
   resources :votes, only: [:create, :update]
 
   post 'competitions/:id/post_announcement' => 'competitions#post_announcement', as: :competition_post_announcement
+  post 'competitions/:id/cancel' => 'competitions#cancel_competition', as: :competition_cancel
   post 'competitions/:id/post_results' => 'competitions#post_results', as: :competition_post_results
 
   get 'panel' => 'panel#index'

--- a/WcaOnRails/db/migrate/20200607140007_add_cancelled_at_to_competition.rb
+++ b/WcaOnRails/db/migrate/20200607140007_add_cancelled_at_to_competition.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCancelledAtToCompetition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :Competitions, :cancelled_at, :datetime, null: true, default: nil
+    add_column :Competitions, :cancelled_by, :integer, null: true, default: nil
+    add_index :Competitions, :cancelled_at
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -73,11 +73,14 @@ CREATE TABLE `Competitions` (
   `announced_by` int(11) DEFAULT NULL,
   `results_posted_by` int(11) DEFAULT NULL,
   `main_event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `cancelled_at` datetime DEFAULT NULL,
+  `cancelled_by` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
   KEY `index_Competitions_on_start_date` (`start_date`),
-  KEY `index_Competitions_on_end_date` (`end_date`)
+  KEY `index_Competitions_on_end_date` (`end_date`),
+  KEY `index_Competitions_on_cancelled_at` (`cancelled_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `CompetitionsMedia`;
@@ -1648,4 +1651,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200419133415'),
 ('20200502095048'),
 ('20200522095030'),
-('20200522125145');
+('20200522125145'),
+('20200607140007');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -87,6 +87,8 @@ module DatabaseDumper
           announced_by
           results_posted_by
           main_event_id
+          cancelled_at
+          cancelled_by
         ),
         db_default: %w(
           connected_stripe_account_id

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -351,6 +351,13 @@ RSpec.describe RegistrationsController do
       patch :update, params: { id: registration.id, registration: { accepted_at: Time.now } }
       expect(registration.reload.accepted?).to eq false
     end
+
+    it "cannot register for cancelled competitions" do
+      competition.update!(cancelled_at: Time.now, cancelled_by: FactoryBot.create(:user, :wcat_member).id)
+      post :create, params: { competition_id: competition.id, registration: { registration_competition_events_attributes: [{ competition_event_id: threes_comp_event.id }], guests: 1, comments: "", status: :accepted } }
+      expect(response).to redirect_to(competition_path(competition))
+      expect(flash[:danger]).to match "You cannot register for this competition"
+    end
   end
 
   context "register" do

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -123,6 +123,13 @@ FactoryBot.define do
       announced_by { FactoryBot.create(:user, :wcat_member).id }
     end
 
+    trait :cancelled do
+      announced
+      confirmed
+      cancelled_at { Time.now }
+      cancelled_by { FactoryBot.create(:user, :wcat_member).id }
+    end
+
     trait :stripe_connected do
       # This is an actual test stripe account set up
       # for testing Stripe payments, and is connected


### PR DESCRIPTION
Fixes #5145, fixes #5296.

I'll deploy this to staging soon.

A few screenshots:

When viewing the competition:
![show_cancelled](https://user-images.githubusercontent.com/1007485/83974301-b9224300-a8ec-11ea-993a-9a9f41b9b8c6.png)

When on the competitions index page (by default cancelled competitions are *not* displayed):
![index_cancelled](https://user-images.githubusercontent.com/1007485/83974309-cccda980-a8ec-11ea-8a22-9712606a7b6e.png)

When on the "my competitions" page:
![bookmark_cancelled](https://user-images.githubusercontent.com/1007485/83974323-dce58900-a8ec-11ea-9372-2615102f9daf.png)


