### PR TITLE
Remove extra period

### DIFF
--- a/WcaOnRails/app/views/static_pages/education.html.erb
+++ b/WcaOnRails/app/views/static_pages/education.html.erb
@@ -7,6 +7,6 @@
 
   <div class="list-group">
     <%= link_to icon("fas", "file-alt", t('education.competitor_tutorial')), "/edudoc/competitor-tutorial/tutorial.pdf", class: "list-group-item" %>
-    <%= link_to icon("fas", "copy", t('education.competition_material')), "https://drive.google.com/drive/folders/1mAUFjQlZEVNwFR6XmhssLDugOo6ZCvw4", class: "list-group-item" %>.
+    <%= link_to icon("fas", "copy", t('education.competition_material')), "https://drive.google.com/drive/folders/1mAUFjQlZEVNwFR6XmhssLDugOo6ZCvw4", class: "list-group-item" %>
   </div>
 </div>


### PR DESCRIPTION
There is an extra period [here](https://www.worldcubeassociation.org/education) that I missed when creating the page.