### PR TITLE
Temporarily suspend cleaning assets

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -146,13 +146,22 @@ rebuild_rails() {
     cd WcaOnRails
 
     bundle install
-    bundle exec rake assets:clean assets:precompile
+    # We used to run 'assets:clean' as part of the command below, but for some
+    # reason rake would clean *up-to-date* assets and not recompile them, leading
+    # to the website being simply broken...
+    # See https://github.com/thewca/worldcubeassociation.org/issues/5370
+    bundle exec rake assets:precompile
 
     # Note that we are intentionally not automating database migrations.
   )
 
   restart_dj
   restart_app
+
+  echo "/!\\ Cleaning assets automatically has been disabled /!\\"
+  echo "Once in a while (preferably when low traffic) we need to clear the "
+  echo "public/packs directory and recompile them."
+  echo "If you're performing the weekly dependencies updates, I suggest you to do that."
 }
 
 cd "$(dirname "$0")"/..


### PR DESCRIPTION
This is a workaround for #5370.
Not running `assets:clean` just make them pile up in the directory.
Since removing all of them and recompiling everything leads to a ~2 minutes downtime (for users who don't have assets in their cache), I'd suggest to do that when doing our weekly dependencies update.