### PR TITLE
Remove trailing white space from competition highlights phrases

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -66,18 +66,21 @@ module CompetitionsHelper
                                                      result_sentence: pretty_print_result(winners.first),
                                                      event_name: main_event.name)
     if results_by_place[2]
-      text += t('competitions.competition_info.first_runner_up', first_runner_up: people_to_sentence(results_by_place[2]),
-                                                                 first_runner_up_result: pretty_print_result(top_three.second, short: true))
+      text += " " + t('competitions.competition_info.first_runner_up',
+                      first_runner_up: people_to_sentence(results_by_place[2]),
+                      first_runner_up_result: pretty_print_result(top_three.second, short: true))
       if results_by_place[3]
-        text += t('competitions.competition_info.and')
-        text += t('competitions.competition_info.second_runner_up', second_runner_up: people_to_sentence(results_by_place[3]),
-                                                                    second_runner_up_result: pretty_print_result(top_three.third, short: true))
+        text += " " + t('competitions.competition_info.and')
+        text += " " + t('competitions.competition_info.second_runner_up',
+                        second_runner_up: people_to_sentence(results_by_place[3]),
+                        second_runner_up_result: pretty_print_result(top_three.third, short: true))
       else
         text += "."
       end
     elsif results_by_place[3]
-      text += t('competitions.competition_info.second_runner_up', second_runner_up: people_to_sentence(results_by_place[3]),
-                                                                  second_runner_up_result: pretty_print_result(top_three.third, short: true))
+      text += " " + t('competitions.competition_info.second_runner_up',
+                      second_runner_up: people_to_sentence(results_by_place[3]),
+                      second_runner_up_result: pretty_print_result(top_three.third, short: true))
     end
 
     text

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1275,9 +1275,9 @@ en:
       mean: "a mean"
       result_sentence: "with %{a_win_by_word} of %{result}"
       winner: "%{winner} won %{result_sentence} in the %{event_name} event."
-      first_runner_up: " %{first_runner_up} finished second (%{first_runner_up_result})"
-      and: " and"
-      second_runner_up: " %{second_runner_up} finished third (%{second_runner_up_result})."
+      first_runner_up: "%{first_runner_up} finished second (%{first_runner_up_result})"
+      and: "and"
+      second_runner_up: "%{second_runner_up} finished third (%{second_runner_up_result})."
       records:
         wr: "World records"
         afr: "African records"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17034772/85604590-b5fbb680-b651-11ea-8013-b637eea30b0b.png)

We combine phrases to compute this text by adding trailing spaces to those phrases. This makes it easy to omit when translating and is not really a good aproach anyway.