### PR TITLE
Enable signing out of other devices

### DIFF
--- a/WcaOnRails/app/controllers/sessions_controller.rb
+++ b/WcaOnRails/app/controllers/sessions_controller.rb
@@ -32,6 +32,17 @@ class SessionsController < Devise::SessionsController
     end
   end
 
+  def destroy_other
+    # Override old validity token with a new one.
+    # This way we invalidate all other sessions, while maintaining the current one.
+    new_token = Devise.friendly_token
+    current_user.update_attribute(:session_validity_token, new_token)
+    warden.raw_session["validity_token"] = new_token
+
+    flash[:success] = I18n.t("devise.sessions.destroy_other.success")
+    redirect_to root_url
+  end
+
   private
 
   def two_factor_enabled?

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -156,6 +156,10 @@
 
             <%= f.submit t('.save'), class: "btn btn-primary" %>
           <% end %>
+
+          <h3><%= t('.actions') %></h3>
+          <%= link_to(t('.sign_out_of_devices'), destroy_other_user_sessions_path,
+                      method: :delete, class: "btn btn-danger") %>
         </div>
         <div class="tab-pane active" id="2fa">
           <%= render "2fa_tab" %>

--- a/WcaOnRails/config/initializers/devise.rb
+++ b/WcaOnRails/config/initializers/devise.rb
@@ -265,3 +265,20 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 end
+
+# Add session validity token on first sign in and check it on every authenticated request.
+# This way updating user's validity token invalidates all the sessions at once.
+# Based on https://stackoverflow.com/a/29214116
+
+Warden::Manager.after_set_user except: :fetch do |user, warden, opts|
+  if user.session_validity_token.nil?
+    user.update_attribute(:session_validity_token, Devise.friendly_token)
+  end
+  warden.raw_session["validity_token"] = user.session_validity_token
+end
+
+Warden::Manager.after_fetch do |user, warden, opts|
+  unless user.session_validity_token == warden.raw_session["validity_token"]
+    warden.logout
+  end
+end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -709,6 +709,8 @@ en:
           disable_section_content: "The WST strongly advise you to not disable 2FA, but you can by clicking the button below. Please note that if you reactivate 2FA you will have to reconfigure your device(s)."
           disabled_success: "Successfully disabled two-factor authentication."
           disabled_failed: "Couldn't disable 2FA, please see errors below."
+      destroy_other:
+        success: "Successfully signed out of other devices."
     shared:
       links:
         sign_in: "Sign in"
@@ -914,6 +916,8 @@ en:
       guidelines_confirmation: "I confirm that my avatar fulfills all avatar guidelines."
       confirm_guidelines: "Make sure to read avatar guidelines and submit a valid picture."
       save: "Save"
+      actions: "Actions"
+      sign_out_of_devices: "Sign out of other devices"
       remove_avatar: "Remove avatar"
       remove_avatar_confirm: "Are you sure you want to delete your avatar?"
       guidelines: "Guidelines"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
              end
     post 'users/generate-email-otp' => 'sessions#generate_email_otp'
     post 'users/authenticate-sensitive' => 'users#authenticate_user_for_sensitive_edit'
+    delete 'users/sign-out-other' => 'sessions#destroy_other', as: :destroy_other_user_sessions
   end
   post 'registration/:id/refund/:payment_id' => 'registrations#refund_payment', as: :registration_payment_refund
   post 'registration/:id/process-payment-intent' => 'registrations#process_payment_intent', as: :registration_payment_intent

--- a/WcaOnRails/db/migrate/20200627195628_add_session_validity_token_to_users.rb
+++ b/WcaOnRails/db/migrate/20200627195628_add_session_validity_token_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSessionValidityTokenToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :session_validity_token, :string
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1335,6 +1335,7 @@ CREATE TABLE `users` (
   `consumed_timestep` int(11) DEFAULT NULL,
   `otp_required_for_login` tinyint(1) DEFAULT '0',
   `otp_backup_codes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `session_validity_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
@@ -1652,4 +1653,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200502095048'),
 ('20200522095030'),
 ('20200522125145'),
-('20200607140007');
+('20200607140007'),
+('20200627195628');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -669,6 +669,7 @@ module DatabaseDumper
           reset_password_token
           sign_in_count
           unconfirmed_email
+          session_validity_token
         ),
         fake_values: {
           "dob" => "'1954-12-04'",


### PR DESCRIPTION
Fixes #5004.

Based on [this anwser](https://stackoverflow.com/a/29214116), this introduces a `session_validity_token` column to the users table. On sign in we store that token in the session (if there's no token yet, it's generated and stored in the database), then on every request we check if the token in session matches the one in the database. To invalidate all sessions we can simply change the db token.

One concern is with the existing sessions. Initially token will be `nil` both in the session and the db, so `user.session_validity_token == warden.raw_session["validity_token"]` should pass. The issue is that signing from a new devise will set the db token for the first time and effectively invalidating all other sessions. I'm not sure if there's much we can do about it though.

I think it's a fairly simple and reasonable solution, will happy to hear concerns / other ideas.

As for the UI, I didn't want to introduce another tab, so I added it to the password one for now:

![image](https://user-images.githubusercontent.com/17034772/85932787-940f6780-b8cf-11ea-8674-6116abf9e2ab.png)