### PR TITLE
Prepend failed cron with a clear failure message

### DIFF
--- a/chef/site-cookbooks/wca/recipes/cronjobs.rb
+++ b/chef/site-cookbooks/wca/recipes/cronjobs.rb
@@ -12,6 +12,11 @@ backup_command = "#{dump_db_command} && #{dump_gh_command}"
 if node.chef_environment == "production"
   backup_command += " && #{repo_root}/scripts/backup.sh"
 end
+
+# Wrap the backup command to prepend a clear "FAILURE" message in case it fails.
+tmp_logfile = "/tmp/cron-backup.log"
+backup_command = "(#{backup_command})>#{tmp_logfile} 2>&1 || echo \"FAILURE of the backup script, see below for the error log:\"; cat #{tmp_logfile}"
+
 unless node.chef_environment.start_with?("development")
   execute "pip2 install github-backup"
 


### PR DESCRIPTION
Our cron backup script has been failing for about a year without us noticing (I initially didn't even see it in emails, as my mailer truncated the output :s).
I discovered this when looking for a db backup and noticing the last one was from last august...

The crash was due to our github backups failing because of https://github.com/josegonzalez/python-github-backup/pull/130, so I'll also update the package on the server.

But the real issue is that we couldn't tell right from the automated emails we received that something was wrong!
To fix that I've made the command prepend something making it clear that it failed.
I'll also suggest WST members to not auto-archive mails from our cron if it contains "failure" in it :p

I've quickly tested this on staging (which expectedly fails because we don't set the github API token) and the output was as expected.
I wanted to test this locally, but hit the 5000 request/hour from github (which doesn't happen on prod because we already have most of the github data locally).
I'll probably just test it right on prod, as I would like to trigger the backup job manually anyway to check tarsnap gets the archive.