### PR TITLE
Stop computing big blind means in CAD

### DIFF
--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -2,34 +2,10 @@
 
 module AuxiliaryDataComputation
   def self.compute_everything
-    self.compute_mean_for_bo3_as_mo3_events
     self.compute_concise_results
     self.compute_rank_tables
 
     self.delete_php_cache # Note: this should go away together with the PHP code.
-  end
-
-  ## Compute mean for 'best of 3' results in 333bf/444bf/555bf.
-  def self.compute_mean_for_bo3_as_mo3_events
-    # Set new DNF average where any of three solves is not completed.
-    Result.where(eventId: ["333bf", "444bf", "555bf"], formatId: "3", average: 0)
-          .where("LEAST(value1, value2, value3) < 0")
-          .where.not(value1: 0, value2: 0, value3: 0)
-          .update_all(average: -1)
-    # Set new averages (round times > 10:00).
-    Result.where(eventId: ["333bf", "444bf", "555bf"], formatId: "3", average: 0)
-          .where("LEAST(value1, value2, value3) > 0")
-          .update_all <<-SQL
-            average = IF(
-              (value1 + value2 + value3)/3.0 > 60000,
-              -- In order to round according to Regulation 9f2, we do the
-              -- following equivalent procedure:
-              -- - Add 50 centiseconds to the average
-              -- - Truncate centiseconds from the resulting average.
-              (value1 + value2 + value3)/3.0 + 50 - MOD((value1 + value2 + value3)/3.0 + 50, 100),
-              (value1 + value2 + value3)/3.0
-            )
-          SQL
   end
 
   ## Build 'concise results' tables.

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -4,67 +4,6 @@ require 'rails_helper'
 require 'auxiliary_data_computation'
 
 RSpec.describe "AuxiliaryDataComputation" do
-  describe ".compute_mean_for_bo3_as_mo3_events" do
-    def create_new_result(attributes = {})
-      FactoryBot.build(:result, {
-        eventId: "333bf", formatId: "3", roundTypeId: "c",
-        value1: 3000, value2: 3000, value3: 3000, best: 3000,
-        value4: SolveTime::SKIPPED_VALUE, value5: SolveTime::SKIPPED_VALUE,
-        average: SolveTime::SKIPPED_VALUE # Average is not computed yet.
-      }.merge(attributes)).tap do |result|
-        result.save! validate: false # The average is not valid until we compute it.
-      end
-    end
-
-    it "leaves average for 333bf as skipped if one of three solves is skipped" do
-      with_skipped_solve = create_new_result value3: SolveTime::SKIPPED_VALUE
-      AuxiliaryDataComputation.compute_mean_for_bo3_as_mo3_events
-      expect(with_skipped_solve.reload.average).to eq SolveTime::SKIPPED_VALUE
-    end
-
-    it "sets DNF average for 333bf if one of three solves is either DNF or DNS" do
-      with_dnf = create_new_result value3: SolveTime::DNF_VALUE
-      with_dns = create_new_result value3: SolveTime::DNS_VALUE
-      AuxiliaryDataComputation.compute_mean_for_bo3_as_mo3_events
-      expect(with_dnf.reload.average).to eq SolveTime::DNF_VALUE
-      expect(with_dns.reload.average).to eq SolveTime::DNF_VALUE
-    end
-
-    it "sets a valid average for 333bf if all three solves are completed" do
-      with_completed_solves = create_new_result
-      AuxiliaryDataComputation.compute_mean_for_bo3_as_mo3_events
-      expect(with_completed_solves.reload.average).to eq 3000
-    end
-
-    # https://www.worldcubeassociation.org/regulations/#9f2
-    it "rounds averages for 333bf over 10 minutes down to nearest second for x.49" do
-      over10 = (10.minutes + 10.49.seconds) * 100 # In centiseconds.
-      with_completed_solves = create_new_result value1: over10, value2: over10, value3: over10
-      AuxiliaryDataComputation.compute_mean_for_bo3_as_mo3_events
-      expect(with_completed_solves.reload.average).to eq((10.minutes + 10.seconds) * 100)
-    end
-
-    # https://www.worldcubeassociation.org/regulations/#9f2
-    it "rounds averages for 333bf over 10 minutes up to nearest second for x.50" do
-      over10 = (10.minutes + 10.50.seconds) * 100 # In centiseconds.
-      with_completed_solves = create_new_result value1: over10, value2: over10, value3: over10
-      AuxiliaryDataComputation.compute_mean_for_bo3_as_mo3_events
-      expect(with_completed_solves.reload.average).to eq((10.minutes + 11.seconds) * 100)
-    end
-
-    it "sets a valid average for 444bf if all three solves are completed" do
-      with_completed_solves = create_new_result eventId: "444bf"
-      AuxiliaryDataComputation.compute_mean_for_bo3_as_mo3_events
-      expect(with_completed_solves.reload.average).to eq 3000
-    end
-
-    it "sets a valid average for 555bf if all three solves are completed" do
-      with_completed_solves = create_new_result eventId: "555bf"
-      AuxiliaryDataComputation.compute_mean_for_bo3_as_mo3_events
-      expect(with_completed_solves.reload.average).to eq 3000
-    end
-  end
-
   describe ".compute_concise_results", clean_db_with_truncation: true do
     let(:person) { FactoryBot.create :person, countryId: "China" }
     let(:competition_2016) { FactoryBot.create :competition, starts: Date.parse("2016-04-04") }

--- a/WcaOnRails/spec/models/result_spec.rb
+++ b/WcaOnRails/spec/models/result_spec.rb
@@ -256,6 +256,75 @@ RSpec.describe Result do
             expect(result.compute_correct_average).to eq 1000
             expect(result).to be_invalid_with_errors(average: ["should be 1000"])
           end
+
+          it "leaves average for 333bf as skipped if one of three solves is skipped" do
+            result = build_result(value1: 3000, value2: 3000,
+                                  value3: SolveTime::SKIPPED_VALUE,
+                                  value4: SolveTime::SKIPPED_VALUE,
+                                  value5: SolveTime::SKIPPED_VALUE)
+            expect(result.compute_correct_average).to eq SolveTime::SKIPPED_VALUE
+          end
+
+          it "sets DNF average for 333bf if one of three solves is either DNF or DNS" do
+            result_dns = build_result(value1: 3000, value2: 3000,
+                                      value3: SolveTime::DNS_VALUE,
+                                      value4: SolveTime::SKIPPED_VALUE,
+                                      value5: SolveTime::SKIPPED_VALUE)
+            result_dnf = build_result(value1: 3000, value2: 3000,
+                                      value3: SolveTime::DNF_VALUE,
+                                      value4: SolveTime::SKIPPED_VALUE,
+                                      value5: SolveTime::SKIPPED_VALUE)
+            expect(result_dnf.compute_correct_average).to eq SolveTime::DNF_VALUE
+            expect(result_dns.compute_correct_average).to eq SolveTime::DNF_VALUE
+          end
+
+          # https://www.worldcubeassociation.org/regulations/#9f2
+          it "rounds averages for 333bf over 10 minutes down to nearest second for x.49" do
+            over10 = (10.minutes + 10.49.seconds) * 100 # In centiseconds.
+            result = build_result(value1: over10,
+                                  value2: over10,
+                                  value3: over10,
+                                  value4: SolveTime::SKIPPED_VALUE,
+                                  value5: SolveTime::SKIPPED_VALUE)
+            expect(result.compute_correct_average).to eq((10.minutes + 10.seconds) * 100)
+          end
+
+          # https://www.worldcubeassociation.org/regulations/#9f2
+          it "rounds averages for 333bf over 10 minutes up to nearest second for x.50" do
+            over10 = (10.minutes + 10.50.seconds) * 100 # In centiseconds.
+            result = build_result(value1: over10,
+                                  value2: over10,
+                                  value3: over10,
+                                  value4: SolveTime::SKIPPED_VALUE,
+                                  value5: SolveTime::SKIPPED_VALUE)
+            expect(result.compute_correct_average).to eq((10.minutes + 11.seconds) * 100)
+          end
+        end
+
+        context "444bf" do
+          let(:eventId) { "444bf" }
+
+          it "sets a valid average for 444bf if all three solves are completed" do
+            result = build_result(value1: 999, value2: 1000, value3: 1001, value4: 0, value5: 0, best: 999, average: 1000)
+            expect(result).to be_valid
+
+            result.average = 33
+            expect(result.compute_correct_average).to eq 1000
+            expect(result).to be_invalid_with_errors(average: ["should be 1000"])
+          end
+        end
+
+        context "555bf" do
+          let(:eventId) { "555bf" }
+
+          it "sets a valid average for 555bf if all three solves are completed" do
+            result = build_result(value1: 999, value2: 1000, value3: 1001, value4: 0, value5: 0, best: 999, average: 1000)
+            expect(result).to be_valid
+
+            result.average = 33
+            expect(result.compute_correct_average).to eq 1000
+            expect(result).to be_invalid_with_errors(average: ["should be 1000"])
+          end
         end
 
         context "333fm" do


### PR DESCRIPTION
Since we enforce submitting valid averages for all blindfolded events we can safely get rid of that CAD job.

I've also moved the relevant tests performed in the CAD spec to the result model spec.