### PR TITLE
Fix WCIF JSON schema to conform to the spec

### DIFF
--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -63,8 +63,8 @@ class CompetitionEvent < ApplicationRecord
       "properties" => {
         "id" => { "type" => "string" },
         "rounds" => { "type" => ["array", "null"], "items" => Round.wcif_json_schema },
-        "competitorLimit" => { "type" => "integer" },
-        "qualification" => { "type" => "object" }, # TODO: expand on this
+        "competitorLimit" => { "type" => ["integer", "null"] },
+        "qualification" => { "type" => ["object", "null"] }, # TODO: expand on this
         "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
     }


### PR DESCRIPTION
See [WCIF#Event](https://github.com/thewca/wcif/blob/master/specification.md#event). Currently when sending `null` values the request fails due to JSON schema validation.