### PR TITLE
Fix SOR computation

### DIFF
--- a/webroot/results/includes/statistics/sum_of_ranks.php
+++ b/webroot/results/includes/statistics/sum_of_ranks.php
@@ -33,9 +33,9 @@ function getRanks ( $sourceName, $regionId = '' ) {
   #--- Build query for the requested region
   $query = "SELECT eventId, personId, worldRank FROM Ranks$sourceName";
   if (in_array($regionId, getAllUsedCountriesIds()))
-    $query = "SELECT eventId, personId, countryRank FROM Ranks$sourceName, Persons WHERE Persons.id=personId AND subId=1 AND countryId='$regionId'";
+    $query = "SELECT eventId, personId, countryRank FROM Ranks$sourceName, Persons WHERE Persons.id=personId AND subId=1 AND countryId='$regionId' AND countryRank != 0";
   if (in_array($regionId, getAllUsedContinentIds()))
-    $query = "SELECT eventId, personId, continentRank FROM Ranks$sourceName, Persons, Countries WHERE Persons.id=personId AND subId=1 AND Countries.id=countryId AND continentId='$regionId'";
+    $query = "SELECT eventId, personId, continentRank FROM Ranks$sourceName, Persons, Countries WHERE Persons.id=personId AND subId=1 AND Countries.id=countryId AND continentId='$regionId' AND continentRank != 0";
 
   #--- Process the personal records, build ranks[event][person]
   foreach( dbQuery( $query ) as $row )


### PR DESCRIPTION
Fixes #5005 and #2399. Looks fine on staging.

Penalty calculation `count`s all ranks, but [some of them are 0](https://www.worldcubeassociation.org/persons/2011KIMN01) and shouldn't really be taken into account, so I just modified the queries to ignore them.

https://github.com/thewca/worldcubeassociation.org/blob/6a2fd500d898508d55ff297359c45f912a444b84/webroot/results/includes/statistics/sum_of_ranks.php#L56

Ignoring those ranks automatically fixes #2399.

@Baiqiang thoughts?

*On a side note: if someone changes nationality then his national rank becomes 0, but getting any result as the new citizen doesn't change anything. Only beating one's PB finally brings the rank back to normal. That's just a random thought I had, improving that would be an overkill.*