### PR TITLE
Fix issues with the Delegate stats page

### DIFF
--- a/WcaOnRails/app/controllers/delegates_controller.rb
+++ b/WcaOnRails/app/controllers/delegates_controller.rb
@@ -5,6 +5,6 @@ class DelegatesController < ApplicationController
   before_action -> { redirect_to_root_unless_user(:can_view_delegate_matters?) }
 
   def stats
-    @delegates = User.delegates.includes(:senior_delegate)
+    @delegates = User.delegates.includes(:actually_delegated_competitions)
   end
 end

--- a/WcaOnRails/app/helpers/notifications_helper.rb
+++ b/WcaOnRails/app/helpers/notifications_helper.rb
@@ -59,8 +59,8 @@ module NotificationsHelper
       }
     end
 
-    user.delegated_competitions.visible.over.order_by_date
-        .includes(:delegate_report).where(delegate_reports: { posted_at: nil })
+    user.actually_delegated_competitions.order_by_date
+        .includes(:delegate_report, :delegates).where(delegate_reports: { posted_at: nil })
         .each do |competition|
           if competition.user_should_post_delegate_report?(user)
             notifications << {
@@ -70,7 +70,7 @@ module NotificationsHelper
           end
         end
 
-    user.delegated_competitions.visible.over.order_by_date
+    user.actually_delegated_competitions.order_by_date
         .each do |competition|
           if competition.user_should_post_competition_results?(user)
             notifications << {

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -5,7 +5,12 @@ require "fileutils"
 class User < ApplicationRecord
   has_many :competition_delegates, foreign_key: "delegate_id"
   has_many :competition_trainee_delegates, foreign_key: "trainee_delegate_id"
+  # This gives all the competitions where the user is marked as a Delegate,
+  # regardless of the competition's status.
   has_many :delegated_competitions, through: :competition_delegates, source: "competition"
+  # This gives all the competitions which actually happened and where the user
+  # was a Delegate.
+  has_many :actually_delegated_competitions, -> { over.visible.not_cancelled }, through: :competition_delegates, source: "competition"
   has_many :trainee_delegated_competitions, through: :competition_trainee_delegates, source: "competition"
   has_many :competition_organizers, foreign_key: "organizer_id"
   has_many :organized_competitions, through: :competition_organizers, source: "competition"

--- a/WcaOnRails/app/views/delegates/stats.html.erb
+++ b/WcaOnRails/app/views/delegates/stats.html.erb
@@ -17,8 +17,9 @@
       </tr>
     </thead>
     <tbody>
+      <% user_can_see_history = current_user&.can_see_admin_competitions? %>
       <% @delegates.each do |delegate| %>
-        <% competitions = delegate.delegated_competitions.order_by_date.select{ |c| c.confirmed_or_visible? && c.is_probably_over? } %>
+        <% competitions = delegate.actually_delegated_competitions.sort_by(&:start_date) %>
         <tr class="<%= delegate.delegate_status %>">
           <td class="delegate" data-toggle="tooltip" data-placement="top" data-container="body">
             <%= delegate.name %>
@@ -26,13 +27,11 @@
           </td>
           <td class="position"><%= delegate.delegate_status.humanize %></td>
           <td class="region"><%= delegate.region %></td>
-          <td class="last"><%= competitions&.last&.start_date %></td>
-          <td class="first"><%= competitions&.first&.start_date %></td>
-          <td class="total"><%= competitions&.count %></td>
+          <td class="last"><%= competitions.last&.start_date %></td>
+          <td class="first"><%= competitions.first&.start_date %></td>
+          <td class="total"><%= competitions.size %></td>
           <td>
-            <% if current_user&.can_see_admin_competitions? %>
-              <%= link_to "History", competitions_path(display: "admin", years: "all", delegate: delegate.id) %>
-            <% end %>
+            <%= link_to "History", competitions_path(display: "admin", years: "all", delegate: delegate.id) if user_can_see_history %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
Fix a n+1 query and a mistake in counting the real delegated competitions.
I also took this opportunity to fix another n+1 query in the notifications for Delegates.

Supersedes #5561.