### PR TITLE
Change competition medium timestampDecided column to nullable

### DIFF
--- a/WcaOnRails/app/models/competition_medium.rb
+++ b/WcaOnRails/app/models/competition_medium.rb
@@ -27,4 +27,11 @@ class CompetitionMedium < ApplicationRecord
       "countryId = :region_id OR Countries.continentId = :region_id", region_id: region_id
     )
   }
+
+  before_save :set_timestamp_decided
+  private def set_timestamp_decided
+    if status_change && status == "accepted"
+      self.timestampDecided = Time.now
+    end
+  end
 end

--- a/WcaOnRails/db/migrate/20200725152218_change_media_timestamp_decided_to_nullable.rb
+++ b/WcaOnRails/db/migrate/20200725152218_change_media_timestamp_decided_to_nullable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class ChangeMediaTimestampDecidedToNullable < ActiveRecord::Migration[5.2]
+  def up
+    change_column :CompetitionsMedia, :timestampDecided, :timestamp, default: nil, null: true
+
+    # Depending on @@SQL_MODE the MySQL may throw an error seeing the invalid timestamp below,
+    # so we temporarily allow those invalid timestamps.
+    execute("SET @OLD_SQL_MODE = @@SQL_MODE, @@SQL_MODE = '';")
+
+    # Due to implementation error, the timestamp may be unset for some accepted media.
+    CompetitionMedium
+      .where(status: "accepted").where("timestampDecided = '0000-00-00 00:00:00'")
+      .update_all("timestampDecided = timestampSubmitted")
+
+    CompetitionMedium
+      .where(status: "pending").where("timestampDecided = '0000-00-00 00:00:00'")
+      .update_all(timestampDecided: nil)
+
+    execute("SET @@SQL_MODE = @OLD_SQL_MODE;")
+  end
+
+  def down
+    # Depending on @@SQL_MODE the MySQL may throw an error seeing the invalid timestamp below,
+    # so we temporarily allow those invalid timestamps.
+    execute("SET @OLD_SQL_MODE = @@SQL_MODE, @@SQL_MODE = '';")
+
+    CompetitionMedium
+      .where(timestampDecided: nil)
+      .update_all("timestampDecided = '0000-00-00 00:00:00'")
+
+    # We need an explicit query as Rails parses '0000-00-00 00:00:00' as nil.
+    execute("ALTER TABLE CompetitionsMedia MODIFY timestampDecided timestamp NOT NULL DEFAULT '0000-00-00 00:00:00'")
+
+    execute("SET @@SQL_MODE = @OLD_SQL_MODE;")
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -96,7 +96,7 @@ CREATE TABLE `CompetitionsMedia` (
   `submitterComment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `submitterEmail` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `timestampSubmitted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `timestampDecided` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `timestampDecided` timestamp NULL DEFAULT NULL,
   `status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1655,4 +1655,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20200522125145'),
 ('20200607140007'),
 ('20200627195628'),
-('20200319193625');
+('20200319193625'),
+('20200725152218');


### PR DESCRIPTION
Supersedes #5611.

The current default value for column `timestampDecided` in the `CompetitionsMedia` table is an invalid timestamp `0000-00-00 00:00:00`. It hasn't been an issue before, but with new MySQL setups an error is raised whenever such timestamp is used directly. This column indicates the point at which the given medium was approved, so the reasonable approach is to let it be `NULL` by default and set when the status changes to accepted.

The current code (ported in #2103) doesn't actually set this column anywhere, so for all newly submitted media it just has the invalid value, even after approval. The migration fixes those cases as well by using the submission timestamp.