### PR TITLE
Lock events management for competitions with posted results

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -704,6 +704,10 @@ class User < ApplicationRecord
     can_admin_competitions? || (can_manage_competition?(competition) && !competition.confirmed?)
   end
 
+  def can_update_events?(competition)
+    can_admin_competitions? || (can_manage_competition?(competition) && !competition.results_posted?)
+  end
+
   def can_upload_competition_results?(competition)
     can_submit_competition_results?(competition, upload_only: true)
   end

--- a/WcaOnRails/app/views/competitions/edit_events.html.erb
+++ b/WcaOnRails/app/views/competitions/edit_events.html.erb
@@ -2,12 +2,18 @@
 <% add_to_packs("edit_events") %>
 
 <%= render layout: 'nav' do %>
+  <% if !current_user.can_update_events?(@competition) %>
+    <%= alert :warning, note: true do %>
+      Events management has been locked after results being posted. Please contact WRT if you want to edit them.
+    <% end %>
+  <% end %>
   <div id="events-edit-area"></div>
   <script>
     $(function() {
       window.wca.initializeEventsForm(
         <%= @competition.id.to_json.html_safe %>,
         <%= current_user.can_add_and_remove_events?(@competition).to_json.html_safe %>,
+        <%= current_user.can_update_events?(@competition).to_json.html_safe %>,
         <%= @competition.events_wcif.to_json.html_safe %>
       );
     });

--- a/WcaOnRails/app/webpacker/javascript/edit-events/ButtonActivatedModal.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/ButtonActivatedModal.js
@@ -24,7 +24,7 @@ export default class ButtonActivatedModal extends React.Component {
 
   render() {
     return (
-      <button type="button" name={this.props.name} className={cn("btn", this.props.buttonClass)} onClick={this.open}>
+      <button type="button" name={this.props.name} className={cn("btn", this.props.buttonClass)} onClick={this.open} disabled={this.props.disabled}>
         {this.props.buttonValue}
         <Modal show={this.state.showModal} onHide={this.close}>
           <form className={this.props.formClass}

--- a/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
@@ -47,7 +47,7 @@ export default class EditEvents extends React.Component {
   }
 
   render() {
-    let { competitionId, canAddAndRemoveEvents, wcifEvents } = this.props;
+    let { competitionId, canAddAndRemoveEvents, canUpdateEvents, wcifEvents } = this.props;
     let unsavedChanges = null;
     if(this.unsavedChanges()) {
       unsavedChanges = (
@@ -69,7 +69,7 @@ export default class EditEvents extends React.Component {
           {wcifEvents.map(wcifEvent => {
             return (
               <div key={wcifEvent.id} className="col-xs-12 col-sm-12 col-md-12 col-lg-4">
-                <EventPanel wcifEvents={wcifEvents} wcifEvent={wcifEvent} canAddAndRemoveEvents={canAddAndRemoveEvents} />
+                <EventPanel wcifEvents={wcifEvents} wcifEvent={wcifEvent} canAddAndRemoveEvents={canAddAndRemoveEvents} canUpdateEvents={canUpdateEvents} />
               </div>
             );
           })}
@@ -80,7 +80,7 @@ export default class EditEvents extends React.Component {
   }
 }
 
-function RoundsTable({ wcifEvents, wcifEvent }) {
+function RoundsTable({ wcifEvents, wcifEvent, disabled }) {
   let event = events.byId[wcifEvent.id];
   return (
     <div className="table-responsive">
@@ -127,27 +127,27 @@ function RoundsTable({ wcifEvents, wcifEvent }) {
               <tr key={roundNumber} className={`round-${roundNumber}`}>
                 <td>{roundNumber}</td>
                 <td>
-                  <select name="format" className="form-control input-xs" value={wcifRound.format} onChange={roundFormatChanged}>
+                  <select name="format" className="form-control input-xs" value={wcifRound.format} onChange={roundFormatChanged} disabled={disabled}>
                     {event.formats().map(format => <option key={format.id} value={format.id}>{abbreviate(format.name)}</option>)}
                   </select>
                 </td>
 
                 <td className="text-center">
-                  <input name="scrambleSetCount" className="form-control input-xs" type="number" min={1} value={wcifRound.scrambleSetCount} onChange={scrambleSetCountChanged} />
+                  <input name="scrambleSetCount" className="form-control input-xs" type="number" min={1} value={wcifRound.scrambleSetCount} onChange={scrambleSetCountChanged} disabled={disabled} />
                 </td>
 
                 {event.canChangeTimeLimit && (
                   <td className="text-center">
-                    <EditTimeLimitButton wcifEvents={wcifEvents} wcifEvent={wcifEvent} roundNumber={roundNumber} />
+                    <EditTimeLimitButton wcifEvents={wcifEvents} wcifEvent={wcifEvent} roundNumber={roundNumber} disabled={disabled} />
                   </td>
                 )}
 
                 <td className="text-center">
-                  <EditCutoffButton wcifEvents={wcifEvents} wcifEvent={wcifEvent} roundNumber={roundNumber} />
+                  <EditCutoffButton wcifEvents={wcifEvents} wcifEvent={wcifEvent} roundNumber={roundNumber} disabled={disabled} />
                 </td>
 
                 <td className="text-center">
-                  {!isLastRound && <EditAdvancementConditionButton wcifEvents={wcifEvents} wcifEvent={wcifEvent} roundNumber={roundNumber} />}
+                  {!isLastRound && <EditAdvancementConditionButton wcifEvents={wcifEvents} wcifEvent={wcifEvent} roundNumber={roundNumber} disabled={disabled} />}
                 </td>
               </tr>
             );
@@ -158,7 +158,7 @@ function RoundsTable({ wcifEvents, wcifEvent }) {
   );
 }
 
-function EventPanel({ wcifEvents, canAddAndRemoveEvents, wcifEvent }) {
+function EventPanel({ wcifEvents, canAddAndRemoveEvents, canUpdateEvents, wcifEvent }) {
   let event = events.byId[wcifEvent.id];
 
   let removeEvent = () => {
@@ -195,6 +195,7 @@ function EventPanel({ wcifEvents, canAddAndRemoveEvents, wcifEvent }) {
   };
 
   let roundsCountSelector = null;
+  let disabled = !canUpdateEvents;
   if(wcifEvent.rounds) {
     let disableRemove = !canAddAndRemoveEvents;
     roundsCountSelector = (
@@ -204,6 +205,7 @@ function EventPanel({ wcifEvents, canAddAndRemoveEvents, wcifEvent }) {
           name="selectRoundCount"
           value={wcifEvent.rounds.length}
           onChange={e => setRoundCount(parseInt(e.target.value))}
+          disabled={disabled}
         >
           <option value={0}># of rounds?</option>
           <option disabled="disabled">────────</option>
@@ -251,7 +253,7 @@ function EventPanel({ wcifEvents, canAddAndRemoveEvents, wcifEvent }) {
 
       {wcifEvent.rounds && (
         <div className="panel-body">
-          <RoundsTable wcifEvents={wcifEvents} wcifEvent={wcifEvent} />
+          <RoundsTable wcifEvents={wcifEvents} wcifEvent={wcifEvent} disabled={disabled} />
         </div>
       )}
     </div>

--- a/WcaOnRails/app/webpacker/javascript/edit-events/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/index.js
@@ -8,7 +8,7 @@ import events from '../wca/events.js.erb'
 let state = {};
 export function rootRender() {
   ReactDOM.render(
-    <EditEvents competitionId={state.competitionId} canAddAndRemoveEvents={state.canAddAndRemoveEvents} wcifEvents={state.wcifEvents} />,
+    <EditEvents competitionId={state.competitionId} canAddAndRemoveEvents={state.canAddAndRemoveEvents} canUpdateEvents={state.canUpdateEvents} wcifEvents={state.wcifEvents} />,
     document.getElementById('events-edit-area'),
   )
 }
@@ -27,9 +27,10 @@ function normalizeWcifEvents(wcifEvents) {
   return ret.concat(wcifEvents);
 }
 
-window.wca.initializeEventsForm = (competitionId, canAddAndRemoveEvents, wcifEvents) => {
+window.wca.initializeEventsForm = (competitionId, canAddAndRemoveEvents, canUpdateEvents, wcifEvents) => {
   state.competitionId = competitionId;
   state.canAddAndRemoveEvents = canAddAndRemoveEvents;
+  state.canUpdateEvents = canUpdateEvents;
   state.wcifEvents = normalizeWcifEvents(wcifEvents);
   rootRender();
 }

--- a/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
@@ -91,7 +91,7 @@ class EditRoundAttribute extends React.Component {
   }
 
   render() {
-    let { wcifEvents, wcifEvent, roundNumber, attribute } = this.props;
+    let { wcifEvents, wcifEvent, roundNumber, attribute, disabled } = this.props;
     let wcifRound = this.getWcifRound();
     let Show = RoundAttributeComponents[attribute].Show;
     let Input = RoundAttributeComponents[attribute].Input;
@@ -107,6 +107,7 @@ class EditRoundAttribute extends React.Component {
         reset={this.reset}
         hasUnsavedChanges={this.hasUnsavedChanges}
         ref={c => this._modal = c}
+        disabled={disabled}
       >
         <Modal.Header closeButton>
           <Modal.Title><Title wcifRound={wcifRound} /></Modal.Title>


### PR DESCRIPTION
This fixes #5513.

Here are a screenshot with events management locked.
![image](https://user-images.githubusercontent.com/2390434/89640929-32391900-d8e3-11ea-9d91-01c4fdd22388.png)
