### PR TITLE
Updating Regulation Translation Index Page

### DIFF
--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -10,11 +10,32 @@
 
   <% current_translations = [
     {
-      version: "2020-01-01",
+      version: "2020-08-01",
       language: "简体中文",
       language_english: "Chinese",
       url: "./chinese",
     },
+    {
+      version: "2020-08-01",
+      language: "Suomi",
+      language_english: "Finnish",
+      url: "./finnish",
+    },
+    {
+      version: "2020-08-01",
+      language: "Português Brasileiro",
+      language_english: "Portuguese, Brazil",
+      url: "./portuguese-brazilian",
+    },
+   
+  ] %>
+
+  <h3><%= t("regulations_translations.current") %></h3>
+  <div class="regulations-translations-table-container">
+    <%= render 'regulations/translations/index_table', translations: current_translations %>
+  </div>
+
+  <% old_translations = [
     {
       version: "2020-01-01",
       language: "繁體中文",
@@ -39,25 +60,11 @@
       language_english: "Kazakh",
       url: "./kazakh",
     },
-  ] %>
-
-  <h3><%= t("regulations_translations.current") %></h3>
-  <div class="regulations-translations-table-container">
-    <%= render 'regulations/translations/index_table', translations: current_translations %>
-  </div>
-
-  <% old_translations = [
     {
       version: "2018-01-01",
       language: "Nederlands",
       language_english: "Dutch",
       url: "./dutch",
-    },
-    {
-      version: "2018-01-01",
-      language: "Suomi",
-      language_english: "Finnish",
-      url: "./finnish",
     },
     {
       version: "2018-01-01",
@@ -82,12 +89,6 @@
       language: "Italiano",
       language_english: "Italian",
       url: "./italian",
-    },
-    {
-      version: "2018-01-01",
-      language: "Português Brasileiro",
-      language_english: "Portuguese, Brazil",
-      url: "./portuguese-brazilian",
     },
     {
       version: "2018-01-01",

--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -49,15 +49,15 @@
     },
     {
       version: "2020-01-01",
-      language: "Русский",
-      language_english: "Russian",
-      url: "./russian",
-    },
-    {
-      version: "2020-01-01",
       language: "Қазақ",
       language_english: "Kazakh",
       url: "./kazakh",
+    },    
+    {
+      version: "2020-01-01",
+      language: "Русский",
+      language_english: "Russian",
+      url: "./russian",
     },
     {
       version: "2018-01-01",

--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -52,7 +52,7 @@
       language: "Қазақ",
       language_english: "Kazakh",
       url: "./kazakh",
-    },    
+    },
     {
       version: "2020-01-01",
       language: "Русский",

--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -15,7 +15,7 @@
       language_english: "Chinese",
       url: "./chinese",
     },
-        {
+    {
       version: "2020-08-01",
       language: "繁體中文",
       language_english: "Chinese, Traditional",

--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -15,6 +15,12 @@
       language_english: "Chinese",
       url: "./chinese",
     },
+        {
+      version: "2020-08-01",
+      language: "繁體中文",
+      language_english: "Chinese, Traditional",
+      url: "./chinese-traditional",
+    },
     {
       version: "2020-08-01",
       language: "Suomi",
@@ -27,6 +33,12 @@
       language_english: "Portuguese, Brazil",
       url: "./portuguese-brazilian",
     },
+    {
+      version: "2020-08-01",
+      language: "Русский",
+      language_english: "Russian",
+      url: "./russian",
+    },
   ] %>
 
   <h3><%= t("regulations_translations.current") %></h3>
@@ -35,12 +47,6 @@
   </div>
 
   <% old_translations = [
-    {
-      version: "2020-01-01",
-      language: "繁體中文",
-      language_english: "Chinese, Traditional",
-      url: "./chinese-traditional",
-    },
     {
       version: "2020-01-01",
       language: "日本語",
@@ -52,12 +58,6 @@
       language: "Қазақ",
       language_english: "Kazakh",
       url: "./kazakh",
-    },
-    {
-      version: "2020-01-01",
-      language: "Русский",
-      language_english: "Russian",
-      url: "./russian",
     },
     {
       version: "2018-01-01",

--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -27,7 +27,6 @@
       language_english: "Portuguese, Brazil",
       url: "./portuguese-brazilian",
     },
-   
   ] %>
 
   <h3><%= t("regulations_translations.current") %></h3>


### PR DESCRIPTION
Updating translation status for Aug. 1st 2020 version for the following languages.

[Chinese ](https://github.com/thewca/wca-regulations-translations/pull/90)
[Finnish](https://github.com/thewca/wca-regulations-translations/pull/93)
[Portuguese Brazil](https://github.com/thewca/wca-regulations-translations/pull/89)
[Chinese, Traditional](https://github.com/thewca/wca-regulations-translations/pull/96)
[Russian](https://github.com/thewca/wca-regulations-translations/pull/91)