### PR TITLE
Add warnings for registration starting too early

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -356,6 +356,10 @@ class Competition < ApplicationRecord
       if self.name.length > 32
         warnings[:name] = I18n.t('competitions.messages.name_too_long')
       end
+      
+      if (self.registration_open - Time.now) > 172800
+        warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
+      end
 
       if no_events?
         warnings[:events] = I18n.t('competitions.messages.must_have_events')
@@ -375,7 +379,11 @@ class Competition < ApplicationRecord
       unless self.announced?
         warnings[:announcement] = I18n.t('competitions.messages.not_announced')
       end
-
+      
+      if (self.registration_open - self.announced_at) > 172800
+        warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
+      end
+      
       if self.results.any? && !self.results_posted?
         warnings[:results] = I18n.t('competitions.messages.results_not_posted')
       end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -210,7 +210,7 @@ class Competition < ApplicationRecord
 
   # 1. on https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf
   MUST_BE_ANNOUNCED_GTE_THIS_MANY_DAYS = 28
-    
+
   # Time in seconds from 6.2.1 in https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf
   REGISTRATION_OPENING_EARLIEST = 172_800
 
@@ -399,7 +399,7 @@ class Competition < ApplicationRecord
           warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
         end
       end
-      
+
       warnings
     end
 
@@ -973,8 +973,9 @@ class Competition < ApplicationRecord
     latitude.present? && longitude.present?
   end
 
+  # The division is to convert the end result from secods to days. .to_date removed some hours from the subtraction
   def days_until
-    start_date ? (start_date - Time.now.utc.to_date).to_i : nil
+    start_date ? ((start_date - Time.now.utc)/(86_400)).to_i : nil
   end
 
   def has_date_errors?

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -402,9 +402,9 @@ class Competition < ApplicationRecord
           warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
         end
       end
-
-      warnings
     end
+
+    warnings
   end
 
   def championship_warnings

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -383,11 +383,14 @@ class Competition < ApplicationRecord
         warnings[:results] = I18n.t('competitions.messages.results_not_posted')
       end
     end
+    if reg_warnings.any?
+      warnings = reg_warnings.merge(warnings)
+    end
 
     warnings
   end
 
-  def reg_warnings(user)
+  def reg_warnings
     warnings = {}
     if registration_range_specified? && !registration_past?
       if self.announced?
@@ -395,13 +398,14 @@ class Competition < ApplicationRecord
           warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
         end
       else
-        if (self.registration_open - Time.now) < REGISTRATION_OPENING_EARLIEST
+        if (self.registration_open - Time.now.utc) < REGISTRATION_OPENING_EARLIEST
           warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
         end
       end
 
       warnings
     end
+  end
 
   def championship_warnings
     warnings = {}
@@ -975,7 +979,7 @@ class Competition < ApplicationRecord
 
   # The division is to convert the end result from secods to days. .to_date removed some hours from the subtraction
   def days_until
-    start_date ? ((start_date - Time.now.utc)/(86_400)).to_i : nil
+    start_date ? ((start_date.to_time(:utc) - Time.now.utc)/(86_400)).to_i : nil
   end
 
   def has_date_errors?

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -356,8 +356,8 @@ class Competition < ApplicationRecord
       if self.name.length > 32
         warnings[:name] = I18n.t('competitions.messages.name_too_long')
       end
-      
-      if (self.registration_open - Time.now) > 172800
+
+      if (self.registration_open - Time.now) > 172_800
         warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
       end
 
@@ -379,11 +379,11 @@ class Competition < ApplicationRecord
       unless self.announced?
         warnings[:announcement] = I18n.t('competitions.messages.not_announced')
       end
-      
-      if (self.registration_open - self.announced_at) > 172800
+
+      if (self.registration_open - self.announced_at) > 172_800
         warnings[:regearly] = I18n.t('competitions.messages.reg_opens_too_early')
       end
-      
+
       if self.results.any? && !self.results_posted?
         warnings[:results] = I18n.t('competitions.messages.results_not_posted')
       end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1203,6 +1203,7 @@ en:
       no_results: "There are no results."
       no_main_event_results: "There are no results for the main event (%{event_name})."
       in_progress: "This competition is ongoing. Come back after %{date} to see the results!"
+      reg_opens_too_early: "Registration is set to start in less than the required 48 hours."
       tooltip_registered: "You are registered."
       tooltip_waiting_list: "You are currently on the waiting list."
       confirmed_visible: "This competition is confirmed and visible"


### PR DESCRIPTION
It has happened a few times where a competition was announced and registration opened in less than the required 48 hours.