### PR TITLE
Add current (2020-08-01) version of the Regulation to the history index and fix indentation

### DIFF
--- a/WcaOnRails/app/views/regulations/history/index.html.erb
+++ b/WcaOnRails/app/views/regulations/history/index.html.erb
@@ -5,33 +5,36 @@
   <p>Until 2011, the Regulations were maintained by Ron van Bruchem and the WCA Board. Since then, the <%= mail_to "wrc@worldcubeassociation.org", "WCA Regulations Committee" %> is in charge of them.<br />For the 2013 release, the Regulations were split into two documents: the Regulations and the Guidelines.</p>
   <p>Here are all past and current versions of the Regulations.</p>
   <ul>
-    <li><%= link_to "2020-01-01", "./official/2020-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2019-05-01...official-2020-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2020" %>)</li>
-    <li><%= link_to "2019-05-01", "./official/2019-05-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2018-01-01...official-2019-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2019" %>)</li>
-    <li><%= link_to "2018-01-01", "./official/2018-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2017-06-19...official-2018-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2018" %>)</li>
-    <li><%= link_to "2017-06-19", "./official/2017-06-19/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2016-04-18...official-2017-06-19#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/changes-of-countries-recognized-by-the-wca" %>)</li>
-    <li><%= link_to "2016-04-18", "./official/2016-04-18/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2015-07-01...official-2016-04-18#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-april-2016" %>)</li>
-    <li><%= link_to "2015-07-01", "./official/2015-07-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-04-03...official-2015-07-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-july-2015" %>)</li>
-    <li><%= link_to "2014-04-03", "./files/2014-04-03/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-01-01...official-2014-04-03#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/regulations-and-guidelines-april-3-2014" %>)
+    <li><%= link_to "2020-08-01", "https://www.worldcubeassociation.org/regulations/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-01-01...official-2020-08-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-august-2020" %>)
       <ul>
-        <li><%= link_to "2014-01-01", "./files/2014-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/diff-base-2013...official-2014-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-and-guidelines-2014" %>)</li>
+        <li><%= link_to "2020-01-01", "./official/2020-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2019-05-01...official-2020-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2020" %>)</li>
       </ul></li>
-      <li><%= link_to "2013-05-21", "./files/2013-05-21/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-05-10...official-2013-05-21#files_bucket" %>)
+      <li><%= link_to "2019-05-01", "./official/2019-05-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2018-01-01...official-2019-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2019" %>)</li>
+      <li><%= link_to "2018-01-01", "./official/2018-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2017-06-19...official-2018-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2018" %>)</li>
+      <li><%= link_to "2017-06-19", "./official/2017-06-19/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2016-04-18...official-2017-06-19#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/changes-of-countries-recognized-by-the-wca" %>)</li>
+      <li><%= link_to "2016-04-18", "./official/2016-04-18/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2015-07-01...official-2016-04-18#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-april-2016" %>)</li>
+      <li><%= link_to "2015-07-01", "./official/2015-07-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-04-03...official-2015-07-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-july-2015" %>)</li>
+      <li><%= link_to "2014-04-03", "./files/2014-04-03/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-01-01...official-2014-04-03#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/regulations-and-guidelines-april-3-2014" %>)
         <ul>
-          <li><%= link_to "2013-05-10", "./files/2013-05-10/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-01-01...official-2013-05-10#files_bucket" %>)</li>
-          <li><%= link_to "2013-01-01", "./files/2013-01-01/" %></li>
+          <li><%= link_to "2014-01-01", "./files/2014-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/diff-base-2013...official-2014-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-and-guidelines-2014" %>)</li>
         </ul></li>
-        <li>2012: No new Regulations</li>
-        <li>2011: No new Regulations</li>
-        <li><%= link_to "2010", "./files/regulations2010.html" %> (<%= link_to "Changes", "./files/regulations_history2010.html" %>)</li>
-        <li><%= link_to "2009", "./files/regulations2009.html" %> (<%= link_to "Changes", "./files/regulations_history2009.html" %>)</li>
-        <li><%= link_to "2008", "./files/regulations2008.html" %> (<%= link_to "Changes", "./files/regulations_history2008.html" %>)</li>
-        <li><%= link_to "2007", "./files/regulations2007.html" %></li>
-        <li><%= link_to "2006 v2", "./files/regulations2006v2.html" %>
+        <li><%= link_to "2013-05-21", "./files/2013-05-21/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-05-10...official-2013-05-21#files_bucket" %>)
           <ul>
-            <li><%= link_to "2006", "./files/regulations2006.html" %></li>
+            <li><%= link_to "2013-05-10", "./files/2013-05-10/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-01-01...official-2013-05-10#files_bucket" %>)</li>
+            <li><%= link_to "2013-01-01", "./files/2013-01-01/" %></li>
           </ul></li>
-          <li><%= link_to "2005", "./files/regulations2005.html" %></li>
-          <li><%= link_to "2004", "./files/regulations2004.html" %></li>
+          <li>2012: No new Regulations</li>
+          <li>2011: No new Regulations</li>
+          <li><%= link_to "2010", "./files/regulations2010.html" %> (<%= link_to "Changes", "./files/regulations_history2010.html" %>)</li>
+          <li><%= link_to "2009", "./files/regulations2009.html" %> (<%= link_to "Changes", "./files/regulations_history2009.html" %>)</li>
+          <li><%= link_to "2008", "./files/regulations2008.html" %> (<%= link_to "Changes", "./files/regulations_history2008.html" %>)</li>
+          <li><%= link_to "2007", "./files/regulations2007.html" %></li>
+          <li><%= link_to "2006 v2", "./files/regulations2006v2.html" %>
+            <ul>
+              <li><%= link_to "2006", "./files/regulations2006.html" %></li>
+            </ul></li>
+            <li><%= link_to "2005", "./files/regulations2005.html" %></li>
+            <li><%= link_to "2004", "./files/regulations2004.html" %></li>
   </ul>
   <p>Current updates to the Regulations and Guidelines are available <%= link_to "on GitHub", "https://github.com/thewca/wca-regulations/" %>.</p>
 </div>

--- a/WcaOnRails/app/views/regulations/history/index.html.erb
+++ b/WcaOnRails/app/views/regulations/history/index.html.erb
@@ -24,7 +24,8 @@
       <ul>
         <li><%= link_to "2013-05-10", "./files/2013-05-10/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-01-01...official-2013-05-10#files_bucket" %>)</li>
         <li><%= link_to "2013-01-01", "./files/2013-01-01/" %></li>
-      </ul></li>
+      </ul>
+    </li>
     <li>2012: No new Regulations</li>
     <li>2011: No new Regulations</li>
     <li><%= link_to "2010", "./files/regulations2010.html" %> (<%= link_to "Changes", "./files/regulations_history2010.html" %>)</li>

--- a/WcaOnRails/app/views/regulations/history/index.html.erb
+++ b/WcaOnRails/app/views/regulations/history/index.html.erb
@@ -9,32 +9,32 @@
       <ul>
         <li><%= link_to "2020-01-01", "./official/2020-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2019-05-01...official-2020-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2020" %>)</li>
       </ul></li>
-      <li><%= link_to "2019-05-01", "./official/2019-05-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2018-01-01...official-2019-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2019" %>)</li>
-      <li><%= link_to "2018-01-01", "./official/2018-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2017-06-19...official-2018-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2018" %>)</li>
-      <li><%= link_to "2017-06-19", "./official/2017-06-19/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2016-04-18...official-2017-06-19#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/changes-of-countries-recognized-by-the-wca" %>)</li>
-      <li><%= link_to "2016-04-18", "./official/2016-04-18/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2015-07-01...official-2016-04-18#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-april-2016" %>)</li>
-      <li><%= link_to "2015-07-01", "./official/2015-07-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-04-03...official-2015-07-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-july-2015" %>)</li>
-      <li><%= link_to "2014-04-03", "./files/2014-04-03/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-01-01...official-2014-04-03#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/regulations-and-guidelines-april-3-2014" %>)
-        <ul>
-          <li><%= link_to "2014-01-01", "./files/2014-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/diff-base-2013...official-2014-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-and-guidelines-2014" %>)</li>
-        </ul></li>
-        <li><%= link_to "2013-05-21", "./files/2013-05-21/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-05-10...official-2013-05-21#files_bucket" %>)
-          <ul>
-            <li><%= link_to "2013-05-10", "./files/2013-05-10/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-01-01...official-2013-05-10#files_bucket" %>)</li>
-            <li><%= link_to "2013-01-01", "./files/2013-01-01/" %></li>
-          </ul></li>
-          <li>2012: No new Regulations</li>
-          <li>2011: No new Regulations</li>
-          <li><%= link_to "2010", "./files/regulations2010.html" %> (<%= link_to "Changes", "./files/regulations_history2010.html" %>)</li>
-          <li><%= link_to "2009", "./files/regulations2009.html" %> (<%= link_to "Changes", "./files/regulations_history2009.html" %>)</li>
-          <li><%= link_to "2008", "./files/regulations2008.html" %> (<%= link_to "Changes", "./files/regulations_history2008.html" %>)</li>
-          <li><%= link_to "2007", "./files/regulations2007.html" %></li>
-          <li><%= link_to "2006 v2", "./files/regulations2006v2.html" %>
-            <ul>
-              <li><%= link_to "2006", "./files/regulations2006.html" %></li>
-            </ul></li>
-            <li><%= link_to "2005", "./files/regulations2005.html" %></li>
-            <li><%= link_to "2004", "./files/regulations2004.html" %></li>
+    <li><%= link_to "2019-05-01", "./official/2019-05-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2018-01-01...official-2019-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2019" %>)</li>
+    <li><%= link_to "2018-01-01", "./official/2018-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2017-06-19...official-2018-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2018" %>)</li>
+    <li><%= link_to "2017-06-19", "./official/2017-06-19/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2016-04-18...official-2017-06-19#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/changes-of-countries-recognized-by-the-wca" %>)</li>
+    <li><%= link_to "2016-04-18", "./official/2016-04-18/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2015-07-01...official-2016-04-18#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-april-2016" %>)</li>
+    <li><%= link_to "2015-07-01", "./official/2015-07-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-04-03...official-2015-07-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-july-2015" %>)</li>
+    <li><%= link_to "2014-04-03", "./files/2014-04-03/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-01-01...official-2014-04-03#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/regulations-and-guidelines-april-3-2014" %>)
+      <ul>
+        <li><%= link_to "2014-01-01", "./files/2014-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/diff-base-2013...official-2014-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-and-guidelines-2014" %>)</li>
+      </ul></li>
+    <li><%= link_to "2013-05-21", "./files/2013-05-21/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-05-10...official-2013-05-21#files_bucket" %>)
+      <ul>
+        <li><%= link_to "2013-05-10", "./files/2013-05-10/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-01-01...official-2013-05-10#files_bucket" %>)</li>
+        <li><%= link_to "2013-01-01", "./files/2013-01-01/" %></li>
+      </ul></li>
+    <li>2012: No new Regulations</li>
+    <li>2011: No new Regulations</li>
+    <li><%= link_to "2010", "./files/regulations2010.html" %> (<%= link_to "Changes", "./files/regulations_history2010.html" %>)</li>
+    <li><%= link_to "2009", "./files/regulations2009.html" %> (<%= link_to "Changes", "./files/regulations_history2009.html" %>)</li>
+    <li><%= link_to "2008", "./files/regulations2008.html" %> (<%= link_to "Changes", "./files/regulations_history2008.html" %>)</li>
+    <li><%= link_to "2007", "./files/regulations2007.html" %></li>
+    <li><%= link_to "2006 v2", "./files/regulations2006v2.html" %>
+      <ul>
+        <li><%= link_to "2006", "./files/regulations2006.html" %></li>
+      </ul></li>
+    <li><%= link_to "2005", "./files/regulations2005.html" %></li>
+    <li><%= link_to "2004", "./files/regulations2004.html" %></li>
   </ul>
   <p>Current updates to the Regulations and Guidelines are available <%= link_to "on GitHub", "https://github.com/thewca/wca-regulations/" %>.</p>
 </div>

--- a/WcaOnRails/app/views/regulations/history/index.html.erb
+++ b/WcaOnRails/app/views/regulations/history/index.html.erb
@@ -8,7 +8,8 @@
     <li><%= link_to "2020-08-01", "https://www.worldcubeassociation.org/regulations/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-01-01...official-2020-08-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-august-2020" %>)
       <ul>
         <li><%= link_to "2020-01-01", "./official/2020-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2019-05-01...official-2020-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2020" %>)</li>
-      </ul></li>
+      </ul>
+    </li>
     <li><%= link_to "2019-05-01", "./official/2019-05-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2018-01-01...official-2019-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2019" %>)</li>
     <li><%= link_to "2018-01-01", "./official/2018-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2017-06-19...official-2018-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2018" %>)</li>
     <li><%= link_to "2017-06-19", "./official/2017-06-19/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2016-04-18...official-2017-06-19#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/changes-of-countries-recognized-by-the-wca" %>)</li>
@@ -17,7 +18,8 @@
     <li><%= link_to "2014-04-03", "./files/2014-04-03/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2014-01-01...official-2014-04-03#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/regulations-and-guidelines-april-3-2014" %>)
       <ul>
         <li><%= link_to "2014-01-01", "./files/2014-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/diff-base-2013...official-2014-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-and-guidelines-2014" %>)</li>
-      </ul></li>
+      </ul>
+    </li>
     <li><%= link_to "2013-05-21", "./files/2013-05-21/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-05-10...official-2013-05-21#files_bucket" %>)
       <ul>
         <li><%= link_to "2013-05-10", "./files/2013-05-10/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2013-01-01...official-2013-05-10#files_bucket" %>)</li>

--- a/WcaOnRails/app/views/regulations/history/index.html.erb
+++ b/WcaOnRails/app/views/regulations/history/index.html.erb
@@ -34,7 +34,8 @@
     <li><%= link_to "2006 v2", "./files/regulations2006v2.html" %>
       <ul>
         <li><%= link_to "2006", "./files/regulations2006.html" %></li>
-      </ul></li>
+      </ul>
+    </li>
     <li><%= link_to "2005", "./files/regulations2005.html" %></li>
     <li><%= link_to "2004", "./files/regulations2004.html" %></li>
   </ul>


### PR DESCRIPTION
This commit adds the current version of the Regulations to the [history page](https://www.worldcubeassociation.org/regulations/history/) of the Regulations.

A WCA Delegate recently approached the WRC and pointed out that even though the history page of the Regulations states that the page shows all past and current versions of the Regulations, only the past versions were being displayed.

This commit therefore adds the current (2020-08-01) version of the Regulations to the history page.

It makes it easier for someone to access what was changed in the current version of the Regulations.

Besides, after some research, it seems like this was what was practiced in the past (as in [this](https://github.com/thewca/worldcubeassociation.org/commit/f088abb0da19253d9b6972f7747bbcdf1afcb737#diff-dfdcdad65271fa74be24e90039016542) commit), but was forgotten in the 2019 Regulations update.

It seems like the GitHub diff doesn't exactly capture what this commit is - the addition of the current version of the Regulations on top of the file + the adaption to the 2020-01-01 version so that it appears as a subtopic of the current version (as what happened in 2014) + an adjustment to the indentation of the rest of the versions in the file.