### PR TITLE
Fix event icons color when used as checkboxes/radioboxes

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -382,6 +382,8 @@ textarea {
 .event-radio {
   .cubing-icon {
     font-size: 2em;
+    margin: 0;
+    width: auto;
   }
 
   label {

--- a/WcaOnRails/app/inputs/events_picker_input.rb
+++ b/WcaOnRails/app/inputs/events_picker_input.rb
@@ -18,7 +18,7 @@ class EventsPickerInput < SimpleForm::Inputs::Base
               :label,
               (
                 check_box.render +
-                template.content_tag(:span, "", class: "cubing-icon event-#{event.id}", data: { toggle: "tooltip", placement: "top" }, title: event.name)
+                template.cubing_icon(event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name)
               ),
               for: check_box.send(:tag_id),
             ),

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -10,7 +10,7 @@
       <%= label_tag "checkbox-#{event.id}" do %>
         <%= check_box_tag "event_ids[]", event.id, params[:event_ids].include?(event.id), id: "checkbox-#{event.id}" %>
         <%# Not using cubing_icon here, because the selector js code uses span %>
-        <%= content_tag :span, "", class: "event-#{event.id} cubing-icon", data: { toggle: "tooltip", placement: "top" }, title: event.name %>
+        <%= cubing_icon event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name %>
       <% end %>
     </span>
     <% end %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -41,11 +41,7 @@ Note: form_builder.object is the object having associated events.
         <% end %>
         <%= label_tag "#{events_association_name}_#{event.id}" do %>
           <%= f.check_box "_destroy", { checked: selected_events.include?(event), id: "#{events_association_name}_#{event.id}", disabled: disabled }, "0", "1" %>
-          <%= content_tag(:span, "",
-                          class: "cubing-icon event-#{event.id}",
-                          data: { toggle: "tooltip", placement: "top" },
-                          title: event.name
-          ) %>
+          <%= cubing_icon(event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name) %>
         <% end %>
         <%= f.hidden_field :id %>
       </span>


### PR DESCRIPTION
Fixes #5730.

In #5340 cubing icons were migrated to use the `<i>` tag and so was the corresponding CSS and JS, but there are still several places where we use a `<span>` with `cubing-icon` class directly (all the places where event icons are used as checkboxes), so the `i.cubing-icon` selector doesn't work for these.