### PR TITLE
Fixing empty timezone in #5121

### DIFF
--- a/WcaOnRails/app/webpacker/javascript/edit-schedule/EditSchedule.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-schedule/EditSchedule.js
@@ -2,12 +2,7 @@ import React from 'react';
 import cn from 'classnames';
 import _ from 'lodash';
 import {
-  Alert,
-  Col,
-  Panel,
-  PanelGroup,
-  Row,
-  Clearfix,
+  Alert, Col, Panel, PanelGroup, Row, Clearfix,
 } from 'react-bootstrap';
 
 import rootRender from '.';
@@ -44,7 +39,9 @@ export default class EditSchedule extends React.Component {
   /* eslint camelcase: ["error", {allow: ["UNSAFE_componentWillMount"]}] */
   UNSAFE_componentWillMount() {
     const { competitionInfo } = this.props;
-    this.setState({ savedScheduleWcif: _.cloneDeep(competitionInfo.scheduleWcif) });
+    this.setState({
+      savedScheduleWcif: _.cloneDeep(competitionInfo.scheduleWcif),
+    });
     initElementsIds(competitionInfo.scheduleWcif.venues);
   }
 
@@ -79,6 +76,11 @@ export default class EditSchedule extends React.Component {
     const { saving } = this.state;
 
     const save = () => {
+      if (scheduleWcif.venues.some((v) => v.timezone === '')) {
+        alert('Please select a timezone for all of your venues');
+        return;
+      }
+
       this.setState({ saving: true });
       const onSuccess = () => this.setState({
         savedScheduleWcif: _.cloneDeep(competitionInfo.scheduleWcif),
@@ -86,9 +88,14 @@ export default class EditSchedule extends React.Component {
       });
       const onFailure = () => this.setState({ saving: false });
 
-      saveWcif(competitionInfo.id, {
-        schedule: competitionInfo.scheduleWcif,
-      }, onSuccess, onFailure);
+      saveWcif(
+        competitionInfo.id,
+        {
+          schedule: competitionInfo.scheduleWcif,
+        },
+        onSuccess,
+        onFailure,
+      );
     };
 
     const actionsHandlers = {
@@ -99,7 +106,11 @@ export default class EditSchedule extends React.Component {
       },
       removeVenue: (e, index) => {
         e.preventDefault();
-        if (!confirm(`Are you sure you want to remove the venue "${scheduleWcif.venues[index].name}" and all the associated rooms and schedules?`)) {
+        if (
+          !confirm(
+            `Are you sure you want to remove the venue "${scheduleWcif.venues[index].name}" and all the associated rooms and schedules?`,
+          )
+        ) {
           return;
         }
         scheduleWcif.venues.splice(index, 1);
@@ -107,13 +118,12 @@ export default class EditSchedule extends React.Component {
       },
     };
 
-    const isThereAnyRoom = scheduleWcif.venues.some((venue) => venue.rooms.length > 0);
+    const isThereAnyRoom = scheduleWcif.venues.some(
+      (venue) => venue.rooms.length > 0,
+    );
 
     const unsavedChanges = this.unsavedChanges() ? (
-      <UnsavedChangesAlert
-        actionHandler={save}
-        saving={saving}
-      />
+      <UnsavedChangesAlert actionHandler={save} saving={saving} />
     ) : null;
 
     return (
@@ -122,9 +132,21 @@ export default class EditSchedule extends React.Component {
         <Row>
           <IntroductionMessage />
           <Col xs={12}>
-            <PanelGroup accordion id="accordion-schedule" defaultActiveKey={isThereAnyRoom ? '2' : '1'}>
+            <PanelGroup
+              accordion
+              id="accordion-schedule"
+              defaultActiveKey={isThereAnyRoom ? '2' : '1'}
+            >
               <Panel id="venues-edit-panel" bsStyle="info" eventKey="1">
-                <div id="accordion-schedule-heading-1" className="panel-heading heading-as-link" aria-controls="accordion-schedule-body-1" role="button" data-toggle="collapse" data-target="#accordion-schedule-body-1" data-parent="#accordion-schedule">
+                <div
+                  id="accordion-schedule-heading-1"
+                  className="panel-heading heading-as-link"
+                  aria-controls="accordion-schedule-body-1"
+                  role="button"
+                  data-toggle="collapse"
+                  data-target="#accordion-schedule-body-1"
+                  data-parent="#accordion-schedule"
+                >
                   <Panel.Title>
                     Edit venues information
                     {' '}
@@ -145,7 +167,15 @@ export default class EditSchedule extends React.Component {
                 </Panel.Body>
               </Panel>
               <Panel id="schedules-edit-panel" bsStyle="info" eventKey="2">
-                <div id="accordion-schedule-heading-2" className="panel-heading heading-as-link" aria-controls="accordion-schedule-body-2" role="button" data-toggle="collapse" data-target="#accordion-schedule-body-2" data-parent="#accordion-schedule">
+                <div
+                  id="accordion-schedule-heading-2"
+                  className="panel-heading heading-as-link"
+                  aria-controls="accordion-schedule-body-2"
+                  role="button"
+                  data-toggle="collapse"
+                  data-target="#accordion-schedule-body-2"
+                  data-parent="#accordion-schedule"
+                >
                   <Panel.Title>
                     Edit schedules
                     {' '}
@@ -189,19 +219,18 @@ const IntroductionMessage = () => (
   <Col xs={12}>
     <p>
       Depending on the size and setup of the competition, it may take place in
-      several rooms of several venues.
-      Therefore a schedule is necessarily linked to a specific room.
-      Each room may have its own schedule (with all or a subset of events).
-      So you can start creating the competition&rsquo;s schedule below by adding at
-      least one venue with one room.
-      Then you will be able to select this room in the &quot;Edit schedules&quot;
-      panel, and drag and drop event rounds (or attempts for some events) on it.
+      several rooms of several venues. Therefore a schedule is necessarily
+      linked to a specific room. Each room may have its own schedule (with all
+      or a subset of events). So you can start creating the competition&rsquo;s
+      schedule below by adding at least one venue with one room. Then you will
+      be able to select this room in the &quot;Edit schedules&quot; panel, and
+      drag and drop event rounds (or attempts for some events) on it.
     </p>
     <p>
       For the typical simple competition, creating one &quot;Main venue&quot;
-      with one &quot;Main room&quot; is enough.
-      If your competition has a single venue but multiple &quot;stages&quot; with different
-      schedules, please input them as different rooms.
+      with one &quot;Main room&quot; is enough. If your competition has a single
+      venue but multiple &quot;stages&quot; with different schedules, please
+      input them as different rooms.
     </p>
   </Col>
 );
@@ -234,6 +263,12 @@ const VenuesList = ({ venues, actionsHandlers, competitionInfo }) => (
 
 const NewVenue = ({ actionHandler }) => (
   <div className="panel-venue">
-    <a href="#" className="btn btn-success new-venue-link" onClick={actionHandler}>Add a venue</a>
+    <a
+      href="#"
+      className="btn btn-success new-venue-link"
+      onClick={actionHandler}
+    >
+      Add a venue
+    </a>
   </div>
 );

--- a/WcaOnRails/app/webpacker/javascript/edit-schedule/SchedulesEditor/EditScheduleForRoom.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-schedule/SchedulesEditor/EditScheduleForRoom.js
@@ -1,15 +1,9 @@
 import React from 'react';
 import _ from 'lodash';
-import {
-  Col,
-  Row,
-} from 'react-bootstrap';
+import { Col, Row, Alert } from 'react-bootstrap';
 
 import { friendlyTimezoneName } from '../../wca/timezoneData.js.erb';
-import {
-  roomWcifFromId,
-  venueWcifFromRoomId,
-} from '../../wca/wcif-utils';
+import { roomWcifFromId, venueWcifFromRoomId } from '../../wca/wcif-utils';
 import {
   removeEventFromCalendar,
   singleSelectLastEvent,
@@ -45,7 +39,12 @@ export default class EditScheduleForRoom extends React.Component {
       eventColor: room.color,
     };
 
-    generateCalendar(this.eventFetcher, this.handleShowModal, scheduleWcif, additionalOptions);
+    generateCalendar(
+      this.eventFetcher,
+      this.handleShowModal,
+      scheduleWcif,
+      additionalOptions,
+    );
     singleSelectLastEvent(scheduleWcif, selectedRoom);
   }
 
@@ -54,7 +53,11 @@ export default class EditScheduleForRoom extends React.Component {
     if (prevProps.selectedRoom !== selectedRoom) {
       const room = roomWcifFromId(scheduleWcif, selectedRoom);
       $(scheduleElementSelector).fullCalendar('refetchEvents');
-      $(scheduleElementSelector).fullCalendar('option', 'eventColor', room.color);
+      $(scheduleElementSelector).fullCalendar(
+        'option',
+        'eventColor',
+        room.color,
+      );
       singleSelectLastEvent(scheduleWcif, selectedRoom);
     }
   }
@@ -63,9 +66,9 @@ export default class EditScheduleForRoom extends React.Component {
     // Create a deep clone, otherwise FC will add some extra attributes that
     // will make the parent component think some changes have been made...
     const { scheduleWcif, selectedRoom } = this.props;
-    callback(_.cloneDeep(
-      roomWcifFromId(scheduleWcif, selectedRoom).activities,
-    ));
+    callback(
+      _.cloneDeep(roomWcifFromId(scheduleWcif, selectedRoom).activities),
+    );
   }
 
   handleShowModal(eventProps, mode) {
@@ -101,15 +104,18 @@ export default class EditScheduleForRoom extends React.Component {
     };
 
     const handleHideModal = () => {
-      this.setState({
-        showModal: false,
-        eventProps: {},
-      }, () => $(window).keydown(keyboardHandlers.activityPicker));
+      this.setState(
+        {
+          showModal: false,
+          eventProps: {},
+        },
+        () => $(window).keydown(keyboardHandlers.activityPicker),
+      );
     };
 
     const { showModal, eventProps, actionDetails } = this.state;
 
-    return (
+    return venueWcif.timezone ? (
       <Row id="schedule-editor">
         <Col xs={2}>
           <ScheduleToolbar
@@ -134,6 +140,14 @@ export default class EditScheduleForRoom extends React.Component {
           actionDetails={actionDetails}
         />
       </Row>
+    ) : (
+      <Alert bsStyle="warning">
+        Please add a timezone to the venue `&apos;`
+        {' '}
+        {venueWcif.name}
+        {' '}
+        `&apos;`
+      </Alert>
     );
   }
 }

--- a/WcaOnRails/app/webpacker/javascript/edit-schedule/SchedulesEditor/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-schedule/SchedulesEditor/index.js
@@ -1,17 +1,10 @@
 import React from 'react';
 import _ from 'lodash';
 import {
-  Col,
-  Panel,
-  Row,
+  Col, Panel, Row, Alert,
 } from 'react-bootstrap';
-import {
-  activityCodeListFromWcif,
-  roomWcifFromId,
-} from '../../wca/wcif-utils';
-import {
-  setupConvertHandlers,
-} from './calendar-utils';
+import { activityCodeListFromWcif, roomWcifFromId } from '../../wca/wcif-utils';
+import { setupConvertHandlers } from './calendar-utils';
 import ActivityPicker from './ActivityPicker';
 import { schedulesEditPanelSelector } from './ses';
 import EditScheduleForRoom from './EditScheduleForRoom';
@@ -34,8 +27,9 @@ export default class SchedulesEditor extends React.Component {
   componentDidMount() {
     // We cannot handle well changes (such as room color) when fullCalendar's element is hidden.
     // So we unselect the room when our panel becomes hidden, to avoid running into any visual bug.
-    $(schedulesEditPanelSelector).find('.panel-collapse').on('hidden.bs.collapse',
-      () => this.setState({ selectedRoom: '' }));
+    $(schedulesEditPanelSelector)
+      .find('.panel-collapse')
+      .on('hidden.bs.collapse', () => this.setState({ selectedRoom: '' }));
   }
 
   /* eslint camelcase: ["error", {allow: ["UNSAFE_componentWillReceiveProps"]}] */
@@ -44,7 +38,9 @@ export default class SchedulesEditor extends React.Component {
     if (!roomWcifFromId(nextProps.scheduleWcif, selectedRoom)) {
       this.setState({ selectedRoom: '' });
     }
-    this.setState({ usedActivityCodeList: activityCodeListFromWcif(nextProps.scheduleWcif) });
+    this.setState({
+      usedActivityCodeList: activityCodeListFromWcif(nextProps.scheduleWcif),
+    });
   }
 
   render() {
@@ -60,7 +56,6 @@ export default class SchedulesEditor extends React.Component {
     };
 
     const { keyboardEnabled, selectedRoom, usedActivityCodeList } = this.state;
-
     return (
       <Row>
         <Col xs={3}>
@@ -72,28 +67,37 @@ export default class SchedulesEditor extends React.Component {
           />
         </Col>
         <Col xs={9}>
-          <Panel>
-            <Panel.Heading>
-              <RoomSelector
-                scheduleWcif={scheduleWcif}
-                selectedRoom={selectedRoom}
-                handleRoomChange={handleRoomChange}
-              />
-            </Panel.Heading>
-            <Panel.Body>
-              {selectedRoom.length === 0 ? (
-                <div>Please select a room to edit its schedule</div>
-              ) : (
-                <EditScheduleForRoom
-                  scheduleWcif={scheduleWcif}
-                  locale={locale}
-                  keyboardEnabled={keyboardEnabled}
-                  handleKeyboardChange={handleToggleKeyboardEnabled}
-                  selectedRoom={selectedRoom}
-                />
-              )}
-            </Panel.Body>
-          </Panel>
+          {scheduleWcif === null
+          || scheduleWcif.venues === null
+          || scheduleWcif.venues.length === 0 ? (
+            <Alert bsStyle="warning">
+              Please add a venue in the `&apos;`Edit venues information`&apos;`
+              section above
+            </Alert>
+            ) : (
+              <Panel>
+                <Panel.Heading>
+                  <RoomSelector
+                    scheduleWcif={scheduleWcif}
+                    selectedRoom={selectedRoom}
+                    handleRoomChange={handleRoomChange}
+                  />
+                </Panel.Heading>
+                <Panel.Body>
+                  {selectedRoom.length === 0 ? (
+                    <div>Please select a room to edit its schedule</div>
+                  ) : (
+                    <EditScheduleForRoom
+                      scheduleWcif={scheduleWcif}
+                      locale={locale}
+                      keyboardEnabled={keyboardEnabled}
+                      handleKeyboardChange={handleToggleKeyboardEnabled}
+                      selectedRoom={selectedRoom}
+                    />
+                  )}
+                </Panel.Body>
+              </Panel>
+            )}
         </Col>
       </Row>
     );
@@ -121,18 +125,15 @@ const RoomSelector = ({ scheduleWcif, selectedRoom, handleRoomChange }) => (
         value={selectedRoom}
       >
         {[<option key="0" value="" />].concat(
-          _.flatMap(scheduleWcif.venues, (venue) => _.map(
-            venue.rooms,
-            (room) => (
-              <option key={room.id} value={room.id}>
-                &quot;
-                {room.name}
-                &quot; in &quot;
-                {venue.name}
-                &quot;
-              </option>
-            ),
-          )),
+          _.flatMap(scheduleWcif.venues, (venue) => _.map(venue.rooms, (room) => (
+            <option key={room.id} value={room.id}>
+              &quot;
+              {room.name}
+              &quot; in &quot;
+              {venue.name}
+              &quot;
+            </option>
+          ))),
         )}
       </select>
     </Col>


### PR DESCRIPTION
This addresses the issue of saving a competition venue without a timezone (#5121). This currently add

- A warning to add a venue if there are none in the 'Edit Schedules' tab
- A warning/blocker that appears instead of the scheduler if the user adds a venue and a room, but not a timezone
- An alert if the user tries to save schedule changes without having a timezone for each venue.

I haven't added tests yet because I'm curious what people think about the setup I have added. Let me know what you think, and then I would be happy to add them in 🙂. 