### PR TITLE
Gender Rankings Added

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/results.scss
+++ b/WcaOnRails/app/assets/stylesheets/results.scss
@@ -6,7 +6,8 @@
   #region,
   #type,
   #years,
-  #show {
+  #show,
+  #gender {
     font-size: 12px;
     font-weight: normal;
     display: block;

--- a/WcaOnRails/app/views/results/_results_selector.html.erb
+++ b/WcaOnRails/app/views/results/_results_selector.html.erb
@@ -88,6 +88,14 @@
 
 <% if show_rankings_options %>
   <div class="form-group">
+    <%= label_tag(t("results.selector_elements.gender_selector.gender")) %>
+    <div id="gender" class="btn-group">
+      <%= link_to t("results.selector_elements.gender_selector.gender_all"), request.params.merge(gender: "All"), class: "btn btn-info" + (@gender == "All" ? " active" : "") %>
+      <%= link_to t("results.selector_elements.gender_selector.male"), request.params.merge(gender: "Male"), class: "btn btn-info" + (@gender == "Male" ? " active" : "") %>
+      <%= link_to t("results.selector_elements.gender_selector.female"), request.params.merge(gender: "Female"), class: "btn btn-info" + (@gender == "Female" ? " active" : "") %>
+    </div>
+  </div>
+  <div class="form-group">
     <%= label_tag(t("results.selector_elements.show_selector.show")) %>
     <div id="show" class="btn-group">
       <div class="btn-group">
@@ -123,15 +131,6 @@
         </ul>
       </div>
       <%= link_to t("results.selector_elements.show_selector.by_region"), request.params.merge(show: "by region"), class: "btn btn-info" + (@is_by_region ? " active" : "") %>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <%= label_tag(t("results.selector_elements.gender_selector.gender")) %>
-    <div id="gender" class="btn-group">
-      <%= link_to t("results.selector_elements.gender_selector.gender_all"), request.params.merge(gender: "All"), class: "btn btn-info" + (@gender == "All" ? " active" : "") %>
-      <%= link_to t("results.selector_elements.gender_selector.male"), request.params.merge(gender: "Male"), class: "btn btn-info" + (@gender == "Male" ? " active" : "") %>
-      <%= link_to t("results.selector_elements.gender_selector.female"), request.params.merge(gender: "Female"), class: "btn btn-info" + (@gender == "Female" ? " active" : "") %>
     </div>
   </div>
 <% elsif show_records_options %>

--- a/WcaOnRails/app/views/results/_results_selector.html.erb
+++ b/WcaOnRails/app/views/results/_results_selector.html.erb
@@ -125,6 +125,15 @@
       <%= link_to t("results.selector_elements.show_selector.by_region"), request.params.merge(show: "by region"), class: "btn btn-info" + (@is_by_region ? " active" : "") %>
     </div>
   </div>
+
+  <div class="form-group">
+    <%= label_tag(t("results.selector_elements.gender_selector.gender")) %>
+    <div id="gender" class="btn-group">
+      <%= link_to t("results.selector_elements.gender_selector.gender_all"), request.params.merge(gender: "All"), class: "btn btn-info" + (@gender == "All" ? " active" : "") %>
+      <%= link_to t("results.selector_elements.gender_selector.male"), request.params.merge(gender: "Male"), class: "btn btn-info" + (@gender == "Male" ? " active" : "") %>
+      <%= link_to t("results.selector_elements.gender_selector.female"), request.params.merge(gender: "Female"), class: "btn btn-info" + (@gender == "Female" ? " active" : "") %>
+    </div>
+  </div>
 <% elsif show_records_options %>
   <div class="form-group">
     <%= label_tag(t("results.selector_elements.show_selector.show")) %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1622,6 +1622,11 @@ en:
         separate: "Separate"
         history: "History"
         mixed_history: "Mixed history"
+      gender_selector:
+        gender: "Gender"
+        gender_all: "All"
+        male: "Male"
+        female: "Female"
     table_elements:
       name: "Name"
       result: "Result"


### PR DESCRIPTION
Fixes #168. Added Gender Rankings on Rankings page.

![image](https://user-images.githubusercontent.com/11577241/95269026-8c345d00-0806-11eb-95bf-3850db414de3.png)

Notes:
- I couldn't find any test for the result_controller. I'd be happy to add tests for the specific gender logic, but I'm not sure which tests files if any that these would go in.
- I only have filters for Male/Female. It was discussed a little on the issue, but due to the sensitivity around 'other' as well as if people want to be excluded from gender rankings they've changed their gender to other, I felt it best to not have that be a filter.
- I also did some work adding gender rankings to the RanksSingle/Average tables. I found out after that these are not used on the rankings page, but rather the person profiles. If we ever want the rankings to appear on personal profiles, that branch would be an excellent starting point with the db changes and CAD computing the rankings: https://github.com/thewca/worldcubeassociation.org/compare/master...Jambrose777:gender-rankings-db-and-cad-changes