### PR TITLE
Moved removed events check

### DIFF
--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -29,8 +29,8 @@ class PersonsController < ApplicationController
   def show
     @person = Person.current.includes(:user, :ranksSingle, :ranksAverage, :competitions).find_by_wca_id!(params[:id])
     @previous_persons = Person.where(wca_id: params[:id]).where.not(subId: 1).order(:subId)
-    @ranks_single = @person.ranksSingle
-    @ranks_average = @person.ranksAverage
+    @ranks_single = @person.ranksSingle.select { |r| r.event.official? }
+    @ranks_average = @person.ranksAverage.select { |r| r.event.official? }
     @medals = @person.medals
     @records = @person.records
     @results = @person.results.includes(:competition, :event, :format, :round_type).order("Events.rank, Competitions.start_date DESC, Competitions.id, RoundTypes.rank DESC")

--- a/WcaOnRails/app/views/persons/_personal_records.html.erb
+++ b/WcaOnRails/app/views/persons/_personal_records.html.erb
@@ -18,32 +18,30 @@
       </thead>
       <tbody>
         <% @ranks_single.sort_by { |rank_single| rank_single.event.rank } .each do |rank_single| %>
-          <% if rank_single.event.rank < 990 %> 
-            <% rank_average = @ranks_average.find { |rank| rank.event_id == rank_single.event_id } %>
-            <tr>
-              <td class="event" data-event="<%= rank_single.event.id %>">
-                <%= cubing_icon rank_single.event.id %>
-                <%= t "events.#{rank_single.event.id}" %>
-              </td>
-              <%= rank_td rank_single, "country" %>
-              <%= rank_td rank_single, "continent" %>
-              <%= rank_td rank_single, "world" %>
-              <td class="single">
-                <%= link_to rankings_path(rank_single.event_id, "single"), class: "plain" do %>
-                  <%= rank_single.solve_time.clock_format %>
-                <% end %>
-              </td>
-              <td class="average">
-                <%= link_to rankings_path(rank_single.event_id, "average"), class: "plain" do %>
-                  <%= rank_average&.solve_time&.clock_format %>
-                <% end %>
-              </td>
-              <%= rank_td rank_average, "world" %>
-              <%= rank_td rank_average, "continent" %>
-              <%= rank_td rank_average, "country" %>
-              <td><%= odd_rank_reason if odd_rank_reason_needed?(rank_single, rank_average) %></td>
-            </tr>
-          <% end %>
+          <% rank_average = @ranks_average.find { |rank| rank.event_id == rank_single.event_id } %>
+          <tr>
+            <td class="event" data-event="<%= rank_single.event.id %>">
+              <%= cubing_icon rank_single.event.id %>
+              <%= t "events.#{rank_single.event.id}" %>
+            </td>
+            <%= rank_td rank_single, "country" %>
+            <%= rank_td rank_single, "continent" %>
+            <%= rank_td rank_single, "world" %>
+            <td class="single">
+              <%= link_to rankings_path(rank_single.event_id, "single"), class: "plain" do %>
+                <%= rank_single.solve_time.clock_format %>
+              <% end %>
+            </td>
+            <td class="average">
+              <%= link_to rankings_path(rank_single.event_id, "average"), class: "plain" do %>
+                <%= rank_average&.solve_time&.clock_format %>
+              <% end %>
+            </td>
+            <%= rank_td rank_average, "world" %>
+            <%= rank_td rank_average, "continent" %>
+            <%= rank_td rank_average, "country" %>
+            <td><%= odd_rank_reason if odd_rank_reason_needed?(rank_single, rank_average) %></td>
+          </tr>
         <% end %>
       </tbody>
     </table>

--- a/WcaOnRails/app/views/persons/_personal_records.html.erb
+++ b/WcaOnRails/app/views/persons/_personal_records.html.erb
@@ -18,30 +18,32 @@
       </thead>
       <tbody>
         <% @ranks_single.sort_by { |rank_single| rank_single.event.rank } .each do |rank_single| %>
-          <% rank_average = @ranks_average.find { |rank| rank.event_id == rank_single.event_id } %>
-          <tr>
-            <td class="event" data-event="<%= rank_single.event.id %>">
-              <%= cubing_icon rank_single.event.id %>
-              <%= t "events.#{rank_single.event.id}" %>
-            </td>
-            <%= rank_td rank_single, "country" %>
-            <%= rank_td rank_single, "continent" %>
-            <%= rank_td rank_single, "world" %>
-            <td class="single">
-              <%= link_to rankings_path(rank_single.event_id, "single"), class: "plain" do %>
-                <%= rank_single.solve_time.clock_format %>
-              <% end %>
-            </td>
-            <td class="average">
-              <%= link_to rankings_path(rank_single.event_id, "average"), class: "plain" do %>
-                <%= rank_average&.solve_time&.clock_format %>
-              <% end %>
-            </td>
-            <%= rank_td rank_average, "world" %>
-            <%= rank_td rank_average, "continent" %>
-            <%= rank_td rank_average, "country" %>
-            <td><%= odd_rank_reason if odd_rank_reason_needed?(rank_single, rank_average) %></td>
-          </tr>
+          <% if rank_single.event.rank < 990 %> 
+            <% rank_average = @ranks_average.find { |rank| rank.event_id == rank_single.event_id } %>
+            <tr>
+              <td class="event" data-event="<%= rank_single.event.id %>">
+                <%= cubing_icon rank_single.event.id %>
+                <%= t "events.#{rank_single.event.id}" %>
+              </td>
+              <%= rank_td rank_single, "country" %>
+              <%= rank_td rank_single, "continent" %>
+              <%= rank_td rank_single, "world" %>
+              <td class="single">
+                <%= link_to rankings_path(rank_single.event_id, "single"), class: "plain" do %>
+                  <%= rank_single.solve_time.clock_format %>
+                <% end %>
+              </td>
+              <td class="average">
+                <%= link_to rankings_path(rank_single.event_id, "average"), class: "plain" do %>
+                  <%= rank_average&.solve_time&.clock_format %>
+                <% end %>
+              </td>
+              <%= rank_td rank_average, "world" %>
+              <%= rank_td rank_average, "continent" %>
+              <%= rank_td rank_average, "country" %>
+              <td><%= odd_rank_reason if odd_rank_reason_needed?(rank_single, rank_average) %></td>
+            </tr>
+          <% end %>
         <% end %>
       </tbody>
     </table>

--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -38,7 +38,6 @@ module AuxiliaryDataComputation
             JOIN Competitions competition ON competition.id = competitionId
             JOIN Countries country ON country.id = result.countryId
             JOIN Events event ON event.id = eventId
-            WHERE event.rank < 990
         SQL
       end
     end


### PR DESCRIPTION
Moved the removed events check from CAD to the person profile.

Essentially this allows rankings by person for removed events to be visible via manipulating the url (i.e. https://www.worldcubeassociation.org/results/rankings/333ft/single). Currently this doesnt work since the data for person rankings comes from ConciseSingleRanks and ConciseAverageRanks. Whereas other rankings, like by results, work: https://www.worldcubeassociation.org/results/rankings/333ft/single?show=100+results

The only other place I could find where this was affected was the persons profile. These rankings were showing up, so to keep that the same we check the event rank there instead.

I wanted to open this PR to generate discussion about if this is something that we would want to proceed with.