### PR TITLE
Use contact form instead of organizer emails for contact

### DIFF
--- a/WcaOnRails/app/controllers/contacts_controller.rb
+++ b/WcaOnRails/app/controllers/contacts_controller.rb
@@ -2,7 +2,9 @@
 
 class ContactsController < ApplicationController
   def website
-    @contact = WebsiteContact.new(your_email: current_user&.email, name: current_user&.name)
+    @contact = WebsiteContact.new(your_email: current_user&.email, name: current_user&.name,
+                                  competition_id: params[:competitionId],
+                                  inquiry: params[:competitionId] ? "competition" : nil)
   end
 
   def website_create

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -31,6 +31,15 @@
         <dd><%= link_to "#{competition.name} website", competition.website, target: "_blank" %></dd>
       <% end %>
 
+      <dt><%= t '.contact' %></dt>
+      <dd>
+        <% if competition.contact.present? %>
+          <%=md competition.contact %>
+        <% else %>
+          <%= link_to t('.organization_team'), contact_website_path(competitionId: competition.id) %>
+        <% end %>
+      </dd>
+
       <% if competition.organizers.length > 0 %>
         <dt><%= t('.organizer_plural', count: competition.organizers.length) %></dt>
         <dd>
@@ -41,15 +50,6 @@
       <dt><%= t('.delegate', count: competition.delegates.length + competition.trainee_delegates.length) %></dt>
       <dd>
         <%= users_to_sentence competition.delegates + competition.trainee_delegates, include_email: true %>
-      </dd>
-
-      <dt><%= t '.contact' %></dt>
-      <dd>
-        <% if competition.contact.present? %>
-          <%=md competition.contact %>
-        <% else %>
-          <%= mail_to competition.managers.map(&:email).join(","), competition.managers.map(&:email).join(", "), subject: "Question about #{competition.name}", target: "_blank", class: "hide-new-window-icon" %>
-        <% end %>
       </dd>
     </dl>
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1278,6 +1278,7 @@ en:
       organizer_plural:
         one: "Organizer"
         other: "Organizers"
+      organization_team: "Organization team"
       #context: Pluralization of the "Delegate" label for a competition form
       delegate:
         one: "WCA Delegate"
@@ -1406,7 +1407,7 @@ en:
       name_reason_html: "A brief explanation of the competition name. The name must comply with the <a href='/documents/policies/external/Competition%20Requirements.pdf'>WCA Competition Requirements Policy</a>."
       venue_html: "The venue where the competition takes place. %{md}. For example: [Cité des Sciences et de l'Industrie](http://www.cite-sciences.fr)"
       venue_details_html: "Details about the venue (e.g., On the first floor far in the back, follow the signs). %{md}"
-      contact_html: "Optional contact information. If you do not fill this in, organizer emails will be shown to the public. %{md}. Example: [Text to display](mailto:some@email.com)"
+      contact_html: "Optional contact information. If you do not fill this in, contact inquiries will be submitted through a form without revealing organizers' emails. %{md}. Example: [Text to display](mailto:some@email.com)"
       events: "Events"
       public_and_locked_html: "This competition is publicly visible and locked for editing. If you need to make a change, please reply to the email thread where the competition was confirmed."
       confirmed_but_not_visible_html: "You've confirmed this competition, but it is not yet visible to the public. Wait for the %{contact} to make it visible."


### PR DESCRIPTION
Closes #3633, closes #5263

By default, use the website contact form with the competition name pre-filled instead of publicly exposing organizers' emails. This also prevents users without a `mailto` association set up from clicking the organizers' names and getting an unexpected result.

The contact field is also moved above the organizers and Delegates in the competition info so users are more likely to (correctly) use the contact form to contact the organizers instead of emailing the Delegate.

Organizers can still provide different contact info in the competition setup but this changes the defaults to be more user-friendly.