### PR TITLE
Link organizer delegate profiles

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -144,9 +144,9 @@ module ApplicationHelper
     content_tag :div, content, class: "alert alert-#{type}"
   end
 
-  def users_to_sentence(users, include_email: false)
+  def users_to_sentence(users, include_profile: false)
     "".html_safe + users.sort_by(&:name).map do |user|
-      include_email ? mail_to(user.email, user.name) : user.name
+      include_profile && user.wca_id ? link_to(user.name, person_path(user.wca_id)) : user.name
     end.xss_aware_to_sentence
   end
 

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -146,7 +146,7 @@ module ApplicationHelper
 
   def users_to_sentence(users, include_profile: false)
     "".html_safe + users.sort_by(&:name).map do |user|
-      include_profile && user.wca_id ? link_to(user.name, person_path(user.wca_id)) : user.name
+      include_profile && user.wca_id ? link_to(html_escape(user.name), person_path(user.wca_id)) : html_escape(user.name)
     end.xss_aware_to_sentence
   end
 

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -146,7 +146,7 @@ module ApplicationHelper
 
   def users_to_sentence(users, include_profile: false)
     "".html_safe + users.sort_by(&:name).map do |user|
-      include_profile && user.wca_id ? link_to(html_escape(user.name), person_path(user.wca_id)) : html_escape(user.name)
+      include_profile && user.wca_id ? link_to(ERB::Util.html_escape(user.name), person_path(user.wca_id)) : ERB::Util.html_escape(user.name)
     end.xss_aware_to_sentence
   end
 

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -34,13 +34,13 @@
       <% if competition.organizers.length > 0 %>
         <dt><%= t('.organizer_plural', count: competition.organizers.length) %></dt>
         <dd>
-          <%= users_to_sentence competition.organizers, include_email: false %>
+          <%= users_to_sentence competition.organizers, include_profile: true %>
         </dd>
       <% end %>
 
       <dt><%= t('.delegate', count: competition.delegates.length + competition.trainee_delegates.length) %></dt>
       <dd>
-        <%= users_to_sentence competition.delegates + competition.trainee_delegates, include_email: true %>
+        <%= users_to_sentence competition.delegates + competition.trainee_delegates, include_profile: true %>
       </dd>
 
       <dt><%= t '.contact' %></dt>

--- a/WcaOnRails/spec/helpers/application_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/application_helper_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe ApplicationHelper do
 
     it "includes email" do
       users = []
-      users << FactoryBot.create(:user, name: "Jonatan O'Klosko", email: "jonatan@worldcubeassociation.org")
-      users << FactoryBot.create(:user, name: "Jeremy", email: "jfly@worldcubeassociation.org")
-      string = helper.users_to_sentence(users, include_email: true)
-      expect(string).to eq '<a href="mailto:jfly@worldcubeassociation.org">Jeremy</a> and <a href="mailto:jonatan@worldcubeassociation.org">Jonatan O&#39;Klosko</a>'
+      users << FactoryBot.create(:person, name: "Jonatan O'Klosko", wca_id: "2013KOSK01")
+      users << FactoryBot.create(:user_with_wca_id, name: "Jonatan O'Klosko", wca_id: "2013KOSK01")
+      users << FactoryBot.create(:user, name: "Jeremy")
+      string = helper.users_to_sentence(users, include_profile: true)
+      expect(string).to eq 'Jeremy and <a href="/persons/2013KOSK01">Jonatan O&#39;Klosko</a>'
     end
   end
 

--- a/WcaOnRails/spec/helpers/application_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/application_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ApplicationHelper do
 
     it "includes email" do
       users = []
-      users << FactoryBot.create(:person, name: "Jonatan O'Klosko", wca_id: "2013KOSK01")
+      FactoryBot.create(:person, name: "Jonatan O'Klosko", wca_id: "2013KOSK01")
       users << FactoryBot.create(:user_with_wca_id, name: "Jonatan O'Klosko", wca_id: "2013KOSK01")
       users << FactoryBot.create(:user, name: "Jeremy")
       string = helper.users_to_sentence(users, include_profile: true)


### PR DESCRIPTION
Closes #4985

This links Delegate and organizer names to their WCA IDs (if they have one). As the contact field already has information on how to get in touch with competition organizers, the `mailto` links for Delegates may mislead users into contacting the Delegate instead, and I think a link to the profile is more useful to most competitors.