### PR TITLE
Disable overcommit checks for locale files

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -27,6 +27,7 @@ PreCommit:
       - 'WcaOnRails/db/structure.sql'
       - 'WcaOnRails/node_modules/**/*'
       - 'WcaOnRails/app/webpacker/stylesheets/semantic/**/*'
+      - 'WcaOnRails/config/locales/*.yml'
       - 'chef/**/*'
       - '.gitmodules'
       - '**/*.pdf'


### PR DESCRIPTION
The locale files are generated by Internationalize and sometimes have a trailing whitespace if someone types a double space somewhere, this [causes builds to fail](https://travis-ci.org/github/thewca/worldcubeassociation.org/builds/733168618#L3582) and requires contacting the given translator, so it's quite a bit of effort for such irrelevant change. We could pre-process the submitted file, but I think it's better to leave the generated files as is, especially that those trailing whitespaces are not that common. So for now I just disabled the pre-commit checks for all locale files (conceptually it's not much to check there anyway).