### PR TITLE
Removing 'Main Event' as a field from /edit/clone_competition form. #5187

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -219,7 +219,7 @@
         <%= f.input :event_restrictions %>
         <%= f.input :event_restrictions_reason %>
 
-        <% if @competition.events.any? %>
+        <% if !@competition.being_cloned_from.present? && @competition.events.any? %>
           <hr>
           <%= f.input :main_event_id do %>
             <%= f.select :main_event_id, options_for_select(@competition.events.map { |event| [event.name, event.id] }, @competition.main_event_id), { include_blank: "" }, { class: "form-control main-event" } %>


### PR DESCRIPTION
Closes #5187