### PR TITLE
Added missing i18n on the homepage and footer

### DIFF
--- a/WcaOnRails/app/views/layouts/_footer.html.erb
+++ b/WcaOnRails/app/views/layouts/_footer.html.erb
@@ -2,13 +2,13 @@
   <div class="ui container footer-links">
     <div class="ui horizontal divided list">
       <div class="item">
-        <%= link_to "About", about_path %>
+        <%= link_to(t('homepage.about_us.title'), about_path) %>
       </div>
       <div class="item">
-        <%= link_to "FAQ", faq_path %>
+        <%= link_to(t('homepage.faq.title'), faq_path) %>
       </div>
       <div class="item">
-        <%= link_to "Contact", contact_website_path %>
+        <%= link_to(t('homepage.contact.title'), contact_website_path) %>
       </div>
       <div class="item">
         <a href="https://github.com/thewca/worldcubeassociation.org" target="_blank" class="hide-new-window-icon">
@@ -16,10 +16,10 @@
         </a>
       </div>
       <div class="item">
-        <%= link_to "Privacy", privacy_path %>
+        <%= link_to(t('footer.privacy'), privacy_path) %>
       </div>
       <div class="item">
-        <%= link_to "Disclaimer", disclaimer_path %>
+        <%= link_to(t('footer.disclaimer'), disclaimer_path) %>
       </div>
     </div>
   </div>

--- a/WcaOnRails/app/views/posts/_post_content.html.erb
+++ b/WcaOnRails/app/views/posts/_post_content.html.erb
@@ -18,4 +18,4 @@
     </div>
   </div>
 </div>
-<%= link_to "Learn more", post_path(post.slug), class: "ui button primary center" %>
+<%= link_to(t('homepage.learn_more'), post_path(post.slug), class: "ui button primary center") %>

--- a/WcaOnRails/app/views/posts/homepage.html.erb
+++ b/WcaOnRails/app/views/posts/homepage.html.erb
@@ -40,7 +40,7 @@
             <%= render_react_component("PostsWidget", id: "posts_widget", options: {
               titleOnly: true,
             }) %>
-            <%= link_to "See all announcements", posts_path, class: "ui blue button" %>
+            <%= link_to(t('homepage.see_all_announcements'), posts_path, class: "ui blue button") %>
           </div>
         </div>
       </div>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -815,6 +815,7 @@ en:
     title: "Welcome to the World Cube Association"
     latest_news: "Latest news"
     announcements: "Announcements"
+    see_all_announcements: "See all announcements"
     #context: "About us" box
     about_us:
       title: "About us"
@@ -2277,3 +2278,7 @@ en:
     other_suggestions:
       title: Other suggestions?
       body_html: 'Do you have other suggestions for Instagram or other social media content? <a href="https://www.worldcubeassociation.org/contact/website">Let us know</a>!'
+  footer:
+    privacy: Privacy
+    disclaimer: Disclaimer
+    


### PR DESCRIPTION
Just added internationalization for the texts of the buttons of the last announcement and the announcements list and also internationalized the footer (everything but the GitHub link). I've changed "About" in the footer to "About us" to be able to reuse the same key.