### PR TITLE
Fixes #5623 Validating Scramble Groups = Scramble Sets

### DIFF
--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -9,6 +9,9 @@ module ResultsValidators
     MISSING_SCRAMBLES_FOR_MULTI_ERROR = "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
     MULTIPLE_FMC_GROUPS_WARNING = "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused "\
       "scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
+    # , detected %{actual} instead of %{expected}
+    WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR = "[%{round_id}] Has a different number of scrambles than specified on the Edit Events tab. "\
+      "Please adjust the number of scramble sets in the Edit Events tab to the number of attempts that were used."
 
     @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
 
@@ -83,6 +86,14 @@ module ResultsValidators
                                                       actual: actual_number_of_scrambles,
                                                       expected: expected_number_of_scrambles)
             end
+          end
+          # Check if the number of groups match the number of scramble sets specified.
+          if scrambles_by_group_id.size != rounds_info_by_ids[round_id].scramble_set_count
+            errors_for_round << ValidationError.new(:scrambles, competition_id,
+                                                    WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR,
+                                                    round_id: round_id)
+                                                    # actual: rounds_info_by_ids[round_id].scramble_set_count
+                                                    # expected: scrambles_by_group_id.size)
           end
           if round_id.start_with?("333fm") && scrambles_by_group_id.size > 1
             @warnings << ValidationWarning.new(:scrambles, competition_id,

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -9,8 +9,8 @@ module ResultsValidators
     MISSING_SCRAMBLES_FOR_MULTI_ERROR = "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
     MULTIPLE_FMC_GROUPS_WARNING = "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused "\
       "scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
-    WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR = "[%{round_id}] Has a different number of scrambles than specified on the Edit Events tab. "\
-      "Please adjust the number of scramble sets in the Edit Events tab to the number of attempts that were used."
+    WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR = "[%{round_id}] This round has a different number of scramble sets than specified on the Manage Events tab. "\
+      "Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
 
     @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
 

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -9,7 +9,6 @@ module ResultsValidators
     MISSING_SCRAMBLES_FOR_MULTI_ERROR = "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
     MULTIPLE_FMC_GROUPS_WARNING = "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused "\
       "scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
-    # , detected %{actual} instead of %{expected}
     WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR = "[%{round_id}] Has a different number of scrambles than specified on the Edit Events tab. "\
       "Please adjust the number of scramble sets in the Edit Events tab to the number of attempts that were used."
 
@@ -92,8 +91,6 @@ module ResultsValidators
             errors_for_round << ValidationError.new(:scrambles, competition_id,
                                                     WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR,
                                                     round_id: round_id)
-                                                    # actual: rounds_info_by_ids[round_id].scramble_set_count
-                                                    # expected: scrambles_by_group_id.size)
           end
           if round_id.start_with?("333fm") && scrambles_by_group_id.size > 1
             @warnings << ValidationWarning.new(:scrambles, competition_id,

--- a/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe SV do
 
         expected_errors = [
           RV::ValidationError.new(:scrambles, competition1.id,
-                                    SV::WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR,
-                                    round_id: "333oh-f"),
+                                  SV::WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR,
+                                  round_id: "333oh-f"),
         ]
 
         validator_args.each do |arg|

--- a/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe SV do
       end
 
       it "correctly (in)validates multiple groups for 333fm" do
-        FactoryBot.create(:round, competition: competition3, event_id: "333fm", format_id: "m")
+        FactoryBot.create(:round, competition: competition3, event_id: "333fm", format_id: "m", scramble_set_count: 2)
 
         [Result, InboxResult].each do |model|
           result_kind = model.model_name.singular.to_sym
@@ -113,8 +113,8 @@ RSpec.describe SV do
       end
 
       it "correctly (in)validates multiple groups for 333mbf" do
-        FactoryBot.create(:round, competition: competition1, event_id: "333mbf", format_id: "3")
-        FactoryBot.create(:round, competition: competition2, event_id: "333mbf", format_id: "3")
+        FactoryBot.create(:round, competition: competition1, event_id: "333mbf", format_id: "3", scramble_set_count: 2)
+        FactoryBot.create(:round, competition: competition2, event_id: "333mbf", format_id: "3", scramble_set_count: 2)
 
         [Result, InboxResult].each do |model|
           result_kind = model.model_name.singular.to_sym


### PR DESCRIPTION
Fixes #5623 

Notes: 
- [x] Adding a test for this later this week (took a bit longer to get my local instance working today than I originally anticipated)
- Changing the Scramble Sets # in the events tab and going back to the Results Uploader runs the validations again without needing to reupload the JSON :D (I didn't know that was a thing!)

Tagging @SAuroux for wording.
