### PR TITLE
Remove sync for Europe North

### DIFF
--- a/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
+++ b/WcaOnRails/app/jobs/sync_mailing_lists_job.rb
@@ -31,10 +31,6 @@ class SyncMailingListsJob < SingletonApplicationJob
       query: "%Europe (%",
     },
     {
-      mailing_list: "delegates.europe-north-baltic-states@worldcubeassociation.org",
-      query: "%Europe North & Baltic States%",
-    },
-    {
       mailing_list: "delegates.latin-america@worldcubeassociation.org",
       query: "%Latin America%",
     },

--- a/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/WcaOnRails/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe SyncMailingListsJob, type: :job do
     asia_west_south_delegate.senior_delegate.update(region: "Asia West & South (India)")
     europe_central_eurasia_delegate = FactoryBot.create :delegate
     europe_central_eurasia_delegate.senior_delegate.update(region: "Central Eurasia (Ukraine)")
-    europe_north_baltic_states_delegate = FactoryBot.create :delegate
-    europe_north_baltic_states_delegate.senior_delegate.update(region: "Europe North & Baltic States (Denmark)")
     europe_delegate = FactoryBot.create :delegate
     europe_delegate.senior_delegate.update(region: "Europe (Germany)")
     latin_america_delegate = FactoryBot.create :delegate
@@ -37,7 +35,6 @@ RSpec.describe SyncMailingListsJob, type: :job do
                                       asia_southeast_delegate.email, asia_southeast_delegate.senior_delegate.email,
                                       asia_west_south_delegate.email, asia_west_south_delegate.senior_delegate.email,
                                       europe_central_eurasia_delegate.email, europe_central_eurasia_delegate.senior_delegate.email,
-                                      europe_north_baltic_states_delegate.email, europe_north_baltic_states_delegate.senior_delegate.email,
                                       europe_delegate.email, europe_delegate.senior_delegate.email, latin_america_delegate.email,
                                       latin_america_delegate.senior_delegate.email, oceania_delegate.email, oceania_delegate.senior_delegate.email,
                                       usa_canada_delegate.email, usa_canada_delegate.senior_delegate.email),
@@ -50,7 +47,7 @@ RSpec.describe SyncMailingListsJob, type: :job do
                                       senior_delegate.email, africa_delegate.senior_delegate.email, asia_east_delegate.senior_delegate.email,
                                       asia_southeast_delegate.senior_delegate.email,
                                       asia_west_south_delegate.senior_delegate.email, europe_central_eurasia_delegate.senior_delegate.email,
-                                      europe_north_baltic_states_delegate.senior_delegate.email, europe_delegate.senior_delegate.email,
+                                      europe_delegate.senior_delegate.email,
                                       latin_america_delegate.senior_delegate.email, oceania_delegate.senior_delegate.email, usa_canada_delegate.senior_delegate.email),
     )
 
@@ -212,12 +209,6 @@ RSpec.describe SyncMailingListsJob, type: :job do
     expect(GsuiteMailingLists).to receive(:sync_group).with(
       "delegates.central-eurasia@worldcubeassociation.org",
       a_collection_containing_exactly(europe_central_eurasia_delegate.email, europe_central_eurasia_delegate.senior_delegate.email),
-    )
-
-    # delegates.europe-north-baltic-states@ mailing list
-    expect(GsuiteMailingLists).to receive(:sync_group).with(
-      "delegates.europe-north-baltic-states@worldcubeassociation.org",
-      a_collection_containing_exactly(europe_north_baltic_states_delegate.email, europe_north_baltic_states_delegate.senior_delegate.email),
     )
 
     # delegates.europe@ mailing list


### PR DESCRIPTION
It has been merged with Europe.

Will merge when tests pass to fix the job failures.