### PR TITLE
Add Code of Conduct to the documents page

### DIFF
--- a/WcaOnRails/app/views/static_pages/documents.html.erb
+++ b/WcaOnRails/app/views/static_pages/documents.html.erb
@@ -16,6 +16,15 @@
     <div class="panel panel-default">
       <div class="panel-heading heading-as-link">
         <h4 class="panel-title">
+          <%= link_to "/documents/Code of Conduct.pdf", class: "full-space" do %>
+            <%= ui_icon("file alt") %> <%= t('documents.codeofconduct') %>
+          <% end %>
+        </h4>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading heading-as-link">
+        <h4 class="panel-title">
           <%= link_to "/documents/Code of Ethics.pdf", class: "full-space" do %>
             <%= ui_icon("file alt") %> <%= t('documents.codeofethics') %>
           <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1926,6 +1926,7 @@ en:
     minutes: "Minutes"
     policies: "WCA Policies"
     codeofethics: "Code of Ethics"
+    codeofconduct: "Code of Conduct"
   education:
     title: "WCA Educational Documents"
     description: "The WQAC and WMT has published several documents for the community, you can download them below."
@@ -2286,4 +2287,3 @@ en:
   footer:
     privacy: Privacy
     disclaimer: Disclaimer
-    


### PR DESCRIPTION
Adds a link to the [Code of Conduct](https://github.com/thewca/wca-documents/blob/master/documents/Code%20of%20Conduct.md), as requested by the Board.

![image](https://user-images.githubusercontent.com/17034772/97803808-0ca27e00-1c4c-11eb-8c6e-399039c36d62.png)
