### PR TITLE
Allow All Staff to Vote on Polls

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -728,7 +728,7 @@ class User < ApplicationRecord
   end
 
   def can_vote_in_poll?
-    any_kind_of_delegate?
+    staff?
   end
 
   def can_view_poll?

--- a/WcaOnRails/spec/controllers/polls_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/polls_controller_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe PollsController do
     end
   end
 
+  context "logged in as a staff member" do
+    sign_in { FactoryBot.create :user, :wrt_member }
+    it "shows poll results" do
+      poll = FactoryBot.create(:poll)
+      get :results, params: { id: poll.id }
+      expect(response).to render_template("results")
+    end
+  end
+
   context "logged in as board member" do
     let(:board_member) { FactoryBot.create :user, :board_member }
     before :each do

--- a/WcaOnRails/spec/controllers/votes_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/votes_controller_spec.rb
@@ -52,4 +52,37 @@ RSpec.describe VotesController do
       end
     end
   end
+
+  context "logged in as staff member" do
+    let(:staff_member) { FactoryBot.create :user, :wrt_member }
+    before :each do
+      sign_in staff_member
+    end
+
+    describe "POST #create" do
+      it "creates and updates a vote" do
+        post :create, params: { vote: { poll_option_ids: [poll.poll_options.first.id], poll_id: poll.id } }
+        vote = Vote.find_by_user_id(staff_member.id)
+        expect(vote.poll_options.length).to eq 1
+        expect(vote.poll_options.first.id).to eq poll.poll_options.first.id
+
+        post :update, params: { id: vote.id, vote: { poll_option_ids: [poll.poll_options[1].id], poll_id: poll.id } }
+        vote.reload
+        expect(vote.poll_options.length).to eq 1
+        expect(vote.poll_options.first.id).to eq poll.poll_options[1].id
+      end
+
+      it "creates and updates multiple votes" do
+        multiple_poll = FactoryBot.create(:poll, :confirmed, :multiple)
+
+        post :create, params: { vote: { poll_option_ids: multiple_poll.poll_options.pluck(:id), poll_id: multiple_poll.id } }
+        vote = Vote.find_by_user_id(staff_member.id)
+        expect(vote.poll_options.pluck(:id).sort).to eq multiple_poll.poll_options.pluck(:id).sort
+
+        post :update, params: { id: vote.id, vote: { poll_option_ids: [multiple_poll.poll_options.first.id], poll_id: multiple_poll.id } }
+        vote.reload
+        expect(vote.poll_options.length).to eq 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
Temporarily allow all staff to vote (as opposed to just delegates) until something like #5874 is implemented