### PR TITLE
Validate advancement conditions presence only when confirming the competition

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1222,6 +1222,7 @@ en:
       name_too_long: "The competition name is longer than 32 characters. We prefer shorter ones and we will be glad if you change it."
       must_have_events: "Please add at least one event before confirming the competition."
       schedule_must_match_rounds: "Please make sure the competition has at least one round per event and that the schedule you created includes all the rounds you declared before confirming the competition."
+      advancement_condition_must_be_present_for_all_non_final_rounds: "Please make sure that all non final rounds have advancement condition specified."
       create_success: "Successfully created new competition!"
       not_announced: "This competition is visible to the public but hasn't been announced yet."
       announced: "Successfully announced competition!"


### PR DESCRIPTION
Currently we always validate that advancement conditions are present, which results in errors when updating old competitions via the competition form. This change mirrors what we do for the "schedule matches rounds data", so running the validation on confirmation only and showing a warning for the competition before that.