### PR TITLE
Fix year rankings condition

### DIFF
--- a/WcaOnRails/app/controllers/results_controller.rb
+++ b/WcaOnRails/app/controllers/results_controller.rb
@@ -285,9 +285,9 @@ class ResultsController < ApplicationController
     @is_until = splitted_years_param[0] == "until"
     @year = splitted_years_param[1].to_i
     if @is_only
-      @years_condition = "AND year = #{@year}"
+      @years_condition = "AND result.year = #{@year}"
     elsif @is_until
-      @years_condition = "AND year <= #{@year}"
+      @years_condition = "AND result.year <= #{@year}"
     else
       @years_condition = ""
     end


### PR DESCRIPTION
When both gender and year condition filter is specified, the `year` column is ambiguous, so we need to explicitly point out to the right table.

Trivial, gonna merge when the tests pass.