### PR TITLE
Export locales to javascript

### DIFF
--- a/WcaOnRails/.gitignore
+++ b/WcaOnRails/.gitignore
@@ -20,6 +20,9 @@
 # More rails stuff
 public/assets/**
 
+# Ignore js-specific generated locales (they are rebuilt whenever we compile assets)
+app/webpacker/packs/generated_locales/*.js
+
 # Environment configuration
 .env*
 

--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -10,6 +10,7 @@ end
 
 gem 'rails'
 gem 'rails-i18n'
+gem 'i18n-js'
 gem 'activerecord-import'
 gem 'sassc-rails'
 gem 'uglifier'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -269,6 +269,8 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    i18n-js (3.8.0)
+      i18n (>= 0.6.6)
     i18n-spec (0.6.0)
       iso
     i18n-tasks (0.9.31)
@@ -650,6 +652,7 @@ DEPENDENCIES
   high_voltage
   http_accept_language
   i18n-country-translations!
+  i18n-js
   i18n-spec
   i18n-tasks
   icalendar

--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -11,9 +11,11 @@
   <meta name="og:image" content='<%= asset_url("og-wca_logo.png") %>'/>
 
   <title><%= full_title(yield(:title)) %></title>
-  <%# NOTE: we need to import this first, because it's used in our non-webpack application.js %>
+  <%# NOTE: we need to create our global wca object first, because it's used in our non-webpack application.js %>
   <script>
-    window.wca = {};
+    window.wca = {
+      currentLocale: '<%= I18n.locale %>',
+    };
   </script>
 
   <%#
@@ -34,10 +36,15 @@
     evaluated first, and any pack added (like schedule) will be loaded before application.
     These javascript packs *do* include the css imported in them!
   %>
-  <% packs_to_include = @all_packs.split(",").uniq.unshift("application", "global_styles") %>
+  <% packs_to_prepend = ["application", "global_styles", "i18n"] %>
+  <%# This loads our main locale(s) files %>
+  <% [:en, I18n.locale].uniq.map { |l| packs_to_prepend << "generated_locales/#{l}" } %>
+
+  <% packs_to_include = @all_packs.split(",").uniq.unshift(*packs_to_prepend) %>
   <%= javascript_packs_with_chunks_tag *packs_to_include %>
 
   <% js_assets = (@all_js_assets || "").split(",").uniq %>
+  <%# This loads fullCalendar/moment's locale files %>
   <% if I18n.locale != :en %>
     <% js_assets = js_assets.unshift("locales/#{I18n.locale.downcase}.js") %>
   <% end %>

--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.js
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.js
@@ -10,6 +10,7 @@ import './index.scss';
 import EventNavigation from '../event_navigation';
 import { getUrlParams, setUrlParams } from '../wca/utils';
 import { personUrl, competitionApiUrl, competitionEventResultsApiUrl } from '../requests/routes.js.erb';
+import I18n from '../i18n';
 
 const RoundResultsTable = ({ round, eventName, eventId }) => (
   <>
@@ -18,11 +19,13 @@ const RoundResultsTable = ({ round, eventName, eventId }) => (
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell width={1}>#</Table.HeaderCell>
-          <Table.HeaderCell width={4}>Name</Table.HeaderCell>
-          <Table.HeaderCell width={2}>Best</Table.HeaderCell>
-          <Table.HeaderCell width={2}>Average</Table.HeaderCell>
-          <Table.HeaderCell>Citizen Of</Table.HeaderCell>
-          <Table.HeaderCell>Solves</Table.HeaderCell>
+          <Table.HeaderCell width={4}>
+            {I18n.t('competitions.results_table.name')}
+          </Table.HeaderCell>
+          <Table.HeaderCell width={2}>{I18n.t('common.best')}</Table.HeaderCell>
+          <Table.HeaderCell width={2}>{I18n.t('common.average')}</Table.HeaderCell>
+          <Table.HeaderCell>{I18n.t('common.user.citizen_of')}</Table.HeaderCell>
+          <Table.HeaderCell>{I18n.t('common.solves')}</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>

--- a/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
@@ -266,7 +266,7 @@ function addRoundToEvent(wcifEvent) {
   let nextRoundNumber = wcifEvent.rounds.length + 1;
   wcifEvent.rounds.push({
     id: buildActivityCode({ eventId: wcifEvent.id, roundNumber: nextRoundNumber }),
-    format: event.recommentedFormat().id,
+    format: event.recommendedFormat().id,
     timeLimit: DEFAULT_TIME_LIMIT,
     cutoff: null,
     advancementCondition: null,

--- a/WcaOnRails/app/webpacker/javascript/i18n/index.js
+++ b/WcaOnRails/app/webpacker/javascript/i18n/index.js
@@ -1,0 +1,7 @@
+import I18n from 'i18n-js';
+
+window.I18n = window.I18n || I18n;
+window.I18n.locale = window.wca.currentLocale;
+// We always load English + the user locale so that we can fallback.
+window.I18n.fallbacks = true;
+export default window.I18n;

--- a/WcaOnRails/app/webpacker/javascript/wca/events.js.erb
+++ b/WcaOnRails/app/webpacker/javascript/wca/events.js.erb
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import formats from './formats.js.erb';
+import I18n from '../i18n'
 
 export default {
   official: <%= Event.official.to_json.html_safe %>.map(extend),
@@ -10,10 +11,11 @@ function extend(rawEvent) {
   rawEvent = _.mapKeys(rawEvent, (v, k) => _.camelCase(k));
   return {
     ...rawEvent,
+    name: I18n.t(`events.${rawEvent.id}`),
     formats() {
       return rawEvent.formatIds.map(formatId => formats.byId[formatId]);
     },
-    recommentedFormat() {
+    recommendedFormat() {
       return this.formats()[0];
     },
   }

--- a/WcaOnRails/app/webpacker/javascript/wca/formats.js.erb
+++ b/WcaOnRails/app/webpacker/javascript/wca/formats.js.erb
@@ -1,9 +1,14 @@
 import _ from 'lodash';
+import I18n from '../i18n'
 
 export default {
   byId: _.mapValues(<%= Format.all.index_by(&:id).to_json.html_safe %>, extend),
 };
 
 function extend(rawFormat) {
-  return _.mapKeys(rawFormat, (v, k) => _.camelCase(k));
+  rawFormat = _.mapKeys(rawFormat, (v, k) => _.camelCase(k));
+  return {
+    ...rawFormat,
+    name: I18n.t(`formats.${rawFormat.id}`),
+  };
 }

--- a/WcaOnRails/app/webpacker/packs/i18n.js
+++ b/WcaOnRails/app/webpacker/packs/i18n.js
@@ -1,0 +1,1 @@
+import '../javascript/i18n';

--- a/WcaOnRails/bin/webpack
+++ b/WcaOnRails/bin/webpack
@@ -14,5 +14,6 @@ require "webpacker/webpack_runner"
 
 APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
+  system('./bin/rake i18n:js:export')
   Webpacker::WebpackRunner.run(ARGV)
 end

--- a/WcaOnRails/bin/webpack-dev-server
+++ b/WcaOnRails/bin/webpack-dev-server
@@ -14,5 +14,6 @@ require "webpacker/dev_server_runner"
 
 APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
+  system('./bin/rake i18n:js:export')
   Webpacker::DevServerRunner.run(ARGV)
 end

--- a/WcaOnRails/config/environments/development.rb
+++ b/WcaOnRails/config/environments/development.rb
@@ -83,6 +83,11 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "CompetitionEvent", association: :rounds
   end
 
+  # Add i18n-js to the middleware
+  # We already run i18n:js:export when using webpack(-dev-server), but it wouldn't
+  # get ran if using only bin/rails s
+  config.middleware.use I18n::JS::Middleware
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/WcaOnRails/config/i18n-js.yml
+++ b/WcaOnRails/config/i18n-js.yml
@@ -1,0 +1,45 @@
+# Split context in several files.
+#
+# By default only one file with all translations is exported and
+# no configuration is required. Your settings for asset pipeline
+# are automatically recognized.
+#
+# If you want to split translations into several files or specify
+# locale contexts that will be exported, just use this file to do
+# so.
+#
+# For more informations about the export options with this file, please
+# refer to the README
+#
+#
+# If you're going to use the Rails 3.1 asset pipeline, change
+# the following configuration to something like this:
+#
+# translations:
+#   - file: "app/assets/javascripts/i18n/translations.js"
+#
+# If you're running an old version, you can use something
+# like this:
+#
+# translations:
+#   - file: "app/assets/javascripts/i18n/translations.js"
+#     only: "*"
+#
+export_i18n_js: false
+sort_translations_keys: true
+# We set this programatically.
+# Setting this here generates unecessary large files (such as the default
+# English locale having default values for *all* available locales).
+fallbacks: false
+# This sets which keys we export from the locale file!
+# It will need to be updated as we port more and more stuff to React.
+<% export_keys = ["common.*", "competitions.*", "events.*", "formats.*"] %>
+translations:
+<% I18n.available_locales.each do |l| %>
+  - file: "app/webpacker/packs/generated_locales/<%= l %>.js"
+    only: [<%= export_keys.map { |k|  "\"#{l}.#{k}\"" }.join(",") %>]
+    prefix: |
+      // This file is generated automatically by the rake middleware!
+      // DO NOT EDIT IT MANUALLY!
+      import I18n from '../../javascript/i18n';
+<% end %>

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -66,6 +66,7 @@ search:
   exclude:
     - app/assets/images
     - app/assets/fonts
+    - app/webpacker/packs/generated_locales
     # i18n-tasks fails on TNoodle jars and old non-utf8 translations...
     - app/views/regulations/history/files
     - app/views/regulations/scrambles/tnoodle

--- a/WcaOnRails/lib/tasks/export_i18n.rake
+++ b/WcaOnRails/lib/tasks/export_i18n.rake
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rake::Task['webpacker:compile'].enhance ['i18n:js:export']

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -30,6 +30,7 @@
     "file-loader": "^6.2.0",
     "flag-icon-css": "^3.5.0",
     "glob": "^7.1.6",
+    "i18n-js": "^3.8.0",
     "jquery": "3.4.1",
     "js-yaml": "^3.14.0",
     "leaflet": "^1.7.1",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -4785,6 +4785,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+i18n-js@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-3.8.0.tgz#b8fd6b12e1d88cb71f9806c29bca7c31c012e504"
+  integrity sha512-hDsGgPuvw/2P+lXSbOafAwspK8Ste8YrwuuUg17W3wEcO1JkQxBlPgsN1t2+852nTnz4YSYTjZc/1nAA2PC/nw==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Fixes #816

This install [i18n-js](https://github.com/fnando/i18n-js), configure it to emit one js pack per locale (exluding some non-WCA keys coming from `faker` for the most part), and make sure they are indeed generated everytime we want to build our assets.

I also included a small PoC where events/formats name are localized, and where the new competition results component is localized too.

In order for the locale fallback to work, the English locale is always loaded, but of course only the user's locale is loaded in addition to it, not all locales.
Each locale is ~50kB gzipped.
It's quite a lot (almost like jquery), and really raises the question of exporting only a few sub parts of the locale files.
Should we create a "js" namespace in the file?
Should we manually specify each subparts of the locales to export to js in the configuration files?

Here is the (production) bundle for reference: ![bundle-i18n](https://user-images.githubusercontent.com/1007485/100389167-e4c8ef00-302c-11eb-8f29-9ffbee795595.png)


The tricky part was to make sure to generate the js packs *before* webpack compiles the assets, as it needs them.
There were a few options:
  - generate them manually or automatically when a locale file is updated, and check the packs in the repository.
  I did not go that way, but that could be simpler from a rails/webpacker point of view: feel free to chim in if you have a nice idea on how we could do that.
  - generate them on the fly when compiling assets

I went with the second solution as I didn't have a great idea for the first one.
Generating them in test/production was easy enough: I could just "enhance" the `webpacker:compile` rake task, which gets called when running `assets:precompile`.
But for development, I couldn't find a way to change only one part of our configuration (and I did try to monkey patch `Webpacker::Compiler.compile`).
In the end I had to change 3 files:
  - the binstubs for `webpack` and `webpack-dev-server`, to run `rake i18n:js:export` before running webpack
  - the development environment file, to include the `i18n-js` middleware (so that locale are exported before webpack runs when running only the rails server without the `webpack-dev-server`

