### PR TITLE
Support event=all for competition results

### DIFF
--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.js
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.js
@@ -83,10 +83,19 @@ const CompetitionResults = ({ competitionId }) => {
         selected={selectedEvent}
         onSelect={(eventId) => setSelectedEvent(eventId)}
       />
-      <EventResults
-        competitionId={competitionId}
-        eventId={selectedEvent}
-      />
+      {selectedEvent === 'all'
+        ? (
+          <>
+            {data.event_ids.map((eventId) => (
+              <EventResults key={eventId} competitionId={competitionId} eventId={eventId} />))}
+          </>
+        )
+        : (
+          <EventResults
+            competitionId={competitionId}
+            eventId={selectedEvent}
+          />
+        )}
       <EventNavigation
         eventIds={data.event_ids}
         selected={selectedEvent}


### PR DESCRIPTION
@jonatanklosko could you look over this and let me know if its good enough? This would make an API call per event in the case `event=all` is used, but since this is mostly going to be done by WRT, It should be good enough for that purpose?

Note that I didn't use the `competitions/:id/results` endpoint since that simply gives all results without any event based classification.  Perhaps separating there may work better?