### PR TITLE
Create a drop-in replacement for omnisearch

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/navbar-static-top.scss
+++ b/WcaOnRails/app/assets/stylesheets/navbar-static-top.scss
@@ -56,7 +56,7 @@
     $omni-search-lg-width: 500px;
 
 
-    form.navbar-form[role="search"] .wca-autocomplete-omni + .selectize-control .selectize-input {
+    #omnisearch-form {
       @media (min-width: $screen-sm-min) {
         width: $omni-search-sm-width;
       }

--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -150,10 +150,8 @@
 
 
     <ul class="nav navbar-nav navbar-right">
-      <li class="search-container">
-        <form class="navbar-form form-inline my-2 my-lg-0" role="search">
-          <%= wca_omni_search %>
-        </form>
+      <li class="search-container my-2 my-lg-0">
+        <%= render_react_component("SearchWidget", id: "omnisearch-form") %>
       </li>
       <li class="dropdown">
         <a href="#" class="dropdown-toggle top-nav" data-toggle="dropdown" data-hover="dropdown">

--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
     evaluated first, and any pack added (like schedule) will be loaded before application.
     These javascript packs *do* include the css imported in them!
   %>
-  <% packs_to_prepend = ["application", "global_styles", "i18n"] %>
+  <% packs_to_prepend = ["application", "global_styles", "i18n", "search_widget"] %>
   <%# This loads our main locale(s) files %>
   <% [:en, I18n.locale].uniq.map { |l| packs_to_prepend << "generated_locales/#{l}" } %>
 

--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.js
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Table } from 'semantic-ui-react';
-import useLoadedData from '../requests/useLoadedData';
+import useLoadedData from '../hooks/useLoadedData';
 import { registerComponent } from '../wca/react-utils';
 import Loading from '../requests/Loading';
 import Errored from '../requests/Errored';

--- a/WcaOnRails/app/webpacker/javascript/hooks/useDebounce.js
+++ b/WcaOnRails/app/webpacker/javascript/hooks/useDebounce.js
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Returns the persisted value and if the given value doesn't change
+ * for the specified number of milliseconds the persisted value
+ * is set to the given value.
+ */
+export default function useDebounce(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => clearTimeout(timeout);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/WcaOnRails/app/webpacker/javascript/hooks/useLoadedData.js
+++ b/WcaOnRails/app/webpacker/javascript/hooks/useLoadedData.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { fetchJsonOrError } from './fetchWithAuthenticityToken';
+import { fetchJsonOrError } from '../requests/fetchWithAuthenticityToken';
 
 // This is a hook that can be used to get a data from the website (as json)
 // It assumes that 'url' is a valid, GET-able, url.

--- a/WcaOnRails/app/webpacker/javascript/posts_widget/index.js
+++ b/WcaOnRails/app/webpacker/javascript/posts_widget/index.js
@@ -3,7 +3,7 @@ import {
   Button, Card, Icon, List, Pagination,
 } from 'semantic-ui-react';
 
-import useLoadedData from '../requests/useLoadedData';
+import useLoadedData from '../hooks/useLoadedData';
 import { postsUrl } from '../requests/routes.js.erb';
 import { registerComponent } from '../wca/react-utils';
 import Loading from '../requests/Loading';

--- a/WcaOnRails/app/webpacker/javascript/requests/routes.js.erb
+++ b/WcaOnRails/app/webpacker/javascript/requests/routes.js.erb
@@ -8,3 +8,7 @@ export const postsUrl = (page, format = 'json') => {
 export const competitionApiUrl = (id) => `<%= URI.decode(Rails.application.routes.url_helpers.api_v0_competition_path("${id}"))%>`;
 
 export const competitionEventResultsApiUrl = (id, eventId) => `<%= URI.decode(Rails.application.routes.url_helpers.api_v0_competition_event_results_path("${id}", "${eventId}")) %>`;
+
+export const omnisearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_path %>?q=${query}`;
+
+export const userSearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_users_path %>?q=${query}`;

--- a/WcaOnRails/app/webpacker/javascript/search_widget/CompetitionItem.js
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/CompetitionItem.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import CountryFlag from '../wca/CountryFlag';
+import './CompetitionItem.scss';
+
+const CompetitionItem = ({
+  item,
+}) => (
+  <div className="omnisearch-item-competition">
+    <div>{item.name}</div>
+    <div className="extra-details">
+      <CountryFlag iso2={item.country_iso2} />
+      {`${item.city} (${item.id})`}
+    </div>
+  </div>
+);
+
+export default CompetitionItem;

--- a/WcaOnRails/app/webpacker/javascript/search_widget/CompetitionItem.scss
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/CompetitionItem.scss
@@ -1,0 +1,12 @@
+.omnisearch-item-competition {
+  display: flex;
+  flex-direction: column;
+  font-size: 1.1em;
+  .extra-details {
+    font-size: 0.9em;
+    margin-top: 5px;
+    .flag-icon {
+      margin-right: 5px;
+    }
+  }
+}

--- a/WcaOnRails/app/webpacker/javascript/search_widget/OmnisearchInput.js
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/OmnisearchInput.js
@@ -1,0 +1,145 @@
+import React, {
+  useState, useEffect, useCallback,
+} from 'react';
+import { Dropdown } from 'semantic-ui-react';
+
+import CompetitionItem from './CompetitionItem';
+import RegulationItem from './RegulationItem';
+import UserItem from './UserItem';
+import TextItem from './TextItem';
+import useDebounce from '../hooks/useDebounce';
+import I18n from '../i18n';
+import { fetchJsonOrError } from '../requests/fetchWithAuthenticityToken';
+import './OmnisearchInput.scss';
+
+const classToComponent = {
+  user: UserItem,
+  person: UserItem,
+  competition: CompetitionItem,
+  regulation: RegulationItem,
+  text: TextItem,
+};
+
+const ItemFor = ({ item }) => {
+  const Component = classToComponent[item.class];
+  return (
+    <div className="selected-item">
+      <Component item={item} />
+    </div>
+  );
+};
+
+const renderLabel = ({ item }) => ({
+  color: 'blue',
+  content: <ItemFor item={item} />,
+  className: 'omnisearch-item',
+  as: 'div',
+});
+
+const itemToOption = (item) => ({
+  item,
+  id: item.id,
+  key: item.id,
+  value: item.id,
+  // 'text' is used by the search method from the component, we need to put
+  // the text with a potential match here!
+  text: [item.id, item.name, item.content_html, item.search].join(' '),
+  content: <ItemFor item={item} />,
+});
+
+const createSearchItem = (search) => itemToOption({
+  class: 'text',
+  id: 'search',
+  url: `/search?q=${encodeURIComponent(search)}`,
+  search,
+});
+
+const DEBOUNCE_MS = 300;
+
+const OmnisearchInput = ({
+  url,
+  goToItemOnSelect,
+  placeholder,
+  removeNoResultsMessage,
+}) => {
+  const [search, setSearch] = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const debouncedSearch = useDebounce(search, DEBOUNCE_MS);
+
+  const [selected, setSelected] = useState([]);
+
+  const handleChange = useCallback((e, { value, options }) => {
+    setSearch('');
+    // Here we have "value" which contains the ids of the elements selected,
+    // "oldSelected" which contains the previously selected elements,
+    // "options" which contains the currently displayed options.
+    // "options" changes over time, and may not contain previously selected
+    // elements anymore: we need to make sure the new "selected" value includes
+    // all elements details for the elements in "value", they may come either
+    // from "oldSelected" or "options".
+    setSelected((oldSelected) => {
+      const newSelected = [
+        ...new Set(oldSelected.concat(options)),
+      ].filter(({ id }) => value.includes(id));
+      // Redirect user to actual page if needed, and do not change the state.
+      if (goToItemOnSelect && newSelected.length > 0) {
+        window.location.href = newSelected[0].item.url;
+        return oldSelected;
+      }
+      return newSelected;
+    });
+  }, [setSelected, setSearch, goToItemOnSelect]);
+
+  useEffect(() => {
+    // Do nothing if search string is empty: we're just loading the page
+    // or we just selected an item.
+    // Either way, we want to keep the existing results.
+    if (debouncedSearch.length === 0) return;
+    if (debouncedSearch.length < 3) {
+      setResults([]);
+    } else {
+      setLoading(true);
+      // Note: we don't need to do any filtering on the results here,
+      // FUI's dropdown will automatically remove selected items from the
+      // options left for selection.
+      fetchJsonOrError(url(debouncedSearch))
+        .then((data) => setResults(data.result.map(itemToOption)))
+        .finally(() => setLoading(false));
+    }
+  }, [debouncedSearch, url]);
+
+  const options = [...selected, ...results];
+
+  // If we go to item on select, we want to give the user the option to go to
+  // the search page.
+  if (goToItemOnSelect && search.length > 0) {
+    options.unshift(createSearchItem(search));
+  }
+
+  // FIXME: the search filter from FUI is not the greatest: when searching for
+  // "galerie lafa" it won't match the "galeries lafayette" competitions
+  // (whereas searching for "galeries lafa" does).
+  // We should try to set our own search method that would match word by word.
+  return (
+    <Dropdown
+      fluid
+      selection
+      multiple
+      search
+      icon="search"
+      className="omnisearch-dropdown"
+      value={selected.map(({ id }) => id)}
+      searchQuery={search}
+      options={options}
+      onChange={handleChange}
+      onSearchChange={(e, { searchQuery }) => setSearch(searchQuery)}
+      loading={loading}
+      noResultsMessage={removeNoResultsMessage ? null : I18n.t('search_results.index.not_found.generic')}
+      placeholder={placeholder || I18n.t('common.search_site')}
+      renderLabel={renderLabel}
+    />
+  );
+};
+
+export default OmnisearchInput;

--- a/WcaOnRails/app/webpacker/javascript/search_widget/OmnisearchInput.scss
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/OmnisearchInput.scss
@@ -1,0 +1,12 @@
+.omnisearch-dropdown {
+  & > .ui.label.omnisearch-item {
+    display: inline-flex;
+  }
+  .selected-item {
+    display: inline-flex;
+    img {
+      height: 2.1em;
+      margin-right: 5px;
+    }
+  }
+}

--- a/WcaOnRails/app/webpacker/javascript/search_widget/RegulationItem.js
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/RegulationItem.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import './RegulationItem.scss';
+
+const RegulationItem = ({
+  item,
+}) => (
+  <div className="omnisearch-item-reg">
+    <div className="reg-id">
+      {item.id}
+      :
+    </div>
+    {/* eslint-disable-next-line react/no-danger */}
+    <div className="reg-text" dangerouslySetInnerHTML={{ __html: item.content_html }} />
+  </div>
+);
+
+export default RegulationItem;

--- a/WcaOnRails/app/webpacker/javascript/search_widget/RegulationItem.scss
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/RegulationItem.scss
@@ -1,0 +1,12 @@
+.omnisearch-item-reg {
+  display: flex;
+  .reg-id {
+    margin-right: 5px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+  }
+  .reg-text {
+    text-align: justify;
+  }
+}

--- a/WcaOnRails/app/webpacker/javascript/search_widget/TextItem.js
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/TextItem.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import I18n from '../i18n';
+
+const TextItem = ({ item }) => (
+  <div
+    className="omnisearch-item-text"
+    /* eslint-disable-next-line react/no-danger */
+    dangerouslySetInnerHTML={{
+      __html: I18n.t('search_results.index.search_for', { search_string: item.search }),
+    }}
+  />
+);
+
+export default TextItem;

--- a/WcaOnRails/app/webpacker/javascript/search_widget/UserItem.js
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/UserItem.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Image } from 'semantic-ui-react';
+import './UserItem.scss';
+
+const UserItem = ({
+  item,
+}) => (
+  <div className="omnisearch-item-user">
+    <Image src={item.avatar.thumb_url} />
+    <div className="details">
+      <span>{item.name}</span>
+      {item.wca_id && (
+        <span className="wca-id">{item.wca_id}</span>
+      )}
+    </div>
+  </div>
+);
+
+export default UserItem;

--- a/WcaOnRails/app/webpacker/javascript/search_widget/UserItem.scss
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/UserItem.scss
@@ -1,0 +1,12 @@
+.omnisearch-item-user {
+  display: flex;
+  .details {
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    .wca-id {
+      font-size: 0.9em;
+    }
+  }
+}

--- a/WcaOnRails/app/webpacker/javascript/search_widget/index.js
+++ b/WcaOnRails/app/webpacker/javascript/search_widget/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { registerComponent } from '../wca/react-utils';
+import OmnisearchInput from './OmnisearchInput';
+import { omnisearchApiUrl } from '../requests/routes.js.erb';
+
+const SearchWidget = () => (
+  <OmnisearchInput
+    removeNoResultsMessage
+    goToItemOnSelect
+    url={omnisearchApiUrl}
+  />
+);
+
+registerComponent(SearchWidget, 'SearchWidget');

--- a/WcaOnRails/app/webpacker/packs/global_styles.js
+++ b/WcaOnRails/app/webpacker/packs/global_styles.js
@@ -4,11 +4,13 @@ import 'semantic-css/button';
 import 'semantic-css/card';
 import 'semantic-css/container';
 import 'semantic-css/divider';
+import 'semantic-css/dropdown';
 import 'semantic-css/grid';
 import 'semantic-css/header';
 import 'semantic-css/icon';
 import 'semantic-css/image';
 import 'semantic-css/item';
+import 'semantic-css/label';
 import 'semantic-css/list';
 import 'semantic-css/menu';
 import 'semantic-css/message';
@@ -18,6 +20,7 @@ import 'semantic-css/reset';
 import 'semantic-css/segment';
 import 'semantic-css/site';
 import 'semantic-css/table';
+import 'semantic-css/transition';
 // NOTE: This is the js, wouldn't go fine through our module-resolver!
 import '../stylesheets/semantic/components/site.min';
 

--- a/WcaOnRails/app/webpacker/packs/search_widget.js
+++ b/WcaOnRails/app/webpacker/packs/search_widget.js
@@ -1,0 +1,1 @@
+import '../javascript/search_widget';

--- a/WcaOnRails/config/i18n-js.yml
+++ b/WcaOnRails/config/i18n-js.yml
@@ -33,7 +33,7 @@ sort_translations_keys: true
 fallbacks: false
 # This sets which keys we export from the locale file!
 # It will need to be updated as we port more and more stuff to React.
-<% export_keys = ["common.*", "competitions.*", "events.*", "formats.*"] %>
+<% export_keys = ["common.*", "competitions.*", "events.*", "formats.*", "search_results.*"] %>
 translations:
 <% I18n.available_locales.each do |l| %>
   - file: "app/webpacker/packs/generated_locales/<%= l %>.js"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -2121,8 +2121,11 @@ en:
       advanced_search: "Advanced search"
       posts: "Posts"
       regulations_and_guidelines: "Regulations and Guidelines"
+      #context: Used in the homepage's omnisearch
+      search_for: "Search for <b>%{search_string}</b>"
       #context: Used when there are no search results. E.g. "No people found for *Sherlock Holmes*".
       not_found:
+        generic: "No results found"
         competitions: "No competitions found for"
         people: "No people found for"
         posts: "No posts found for"
@@ -2167,7 +2170,7 @@ en:
   full_organizer_guidelines:
     description: "Welcome to the WQAC’s collection of Organizer Guidelines. If you’re considering being an organizer then it is highly recommended that you read these documents. They have been divided into essential and highly recommended documents. Make sure you are familiar with the information given as this will allow you to run a high-quality and enjoyable competition!"
     disclaimer_html: "<strong>Disclaimer</strong>: The WCA does not organize competitions. As an organizer of a WCA sanctioned competition you <strong>must not</strong> sign anything on behalf of the WCA. You should try reaching out to a relevant regional or national cubing association who do organize or assist with organizing competitions."
-    essential: 
+    essential:
       description: "Essential documents"
       finding-venue: "Finding a venue"
       orga-team-delegate: "Creating your organization team and approaching a Delegate"

--- a/WcaOnRails/spec/features/incident_management_spec.rb
+++ b/WcaOnRails/spec/features/incident_management_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Incident Management" do
 
       scenario "filters by text" do
         visit "/incidents"
-        within(:css, ".search") do
+        within(:css, ".incidents-log-table-container") do
           fill_in "Search", with: "Custom"
         end
         expect(page).to have_content("Custom title")


### PR DESCRIPTION
Fixes #5456.

@shzcuber I took a look back at my previous work, and I realized it only included a "multiple select" input component, and also that I made some questionable choices in the implementation.

I wanted to simplify you the work a bit by looking at how it could deal with our homepage omnisearch behavior (going to the item's page on click/select), and cleaning up the code a bit, but I ended up with a drop-in replacement for the current omnisearch...

I left a "FIXME" I didn't have the time to handle (which you're more than welcome to look at!), but otherwise I don't think there is anything left to do for that specific point.
If you still want to look into porting the navigation bar to React + FUI (which we discussed in #5457), that should make the integration of the search component very straightforward!

If you've already something working to fix #5456 I'd be more than happy to review your work, but otherwise I think we can save you some time and move forward with that PR (and I'll apologize for wasting your time already spent on the issue...).

@jonatanklosko I took your `useDebounce` hook from WCA Live instead of the external library I used originally.
I also took this opportunity to move the `useLoadedData` to a `hooks` folder, better do this now as we don't yet use it in a lot of places.

The component supports both a "multiple" select that could be used as a replacement in our form (for organizers/delegates selection for instance), and a "go to item on click" behavior.
The search endpoint can be provided for the component (to accommodate for specific user/competition/delegate search), but I did not look into how to propagate the value of the input to the parent form (for which the most likely solution will be to allow for a specific name for the input to be specified).