### PR TITLE
Corrected dangerously_close_to formula

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -970,7 +970,7 @@ class Competition < ApplicationRecord
   end
 
   def has_date?
-    start_date != nil
+    !start_date.nil? || !end_date.nil?
   end
 
   def has_location?
@@ -998,11 +998,22 @@ class Competition < ApplicationRecord
     end
   end
 
-  def dangerously_close_to?(c)
-    if !c.start_date || !self.start_date
+  def days_until_competition?(c)
+    if !c.has_date? || !self.has_date?
       return false
     end
-    days_until = (c.start_date - self.start_date).to_i
+    days_until = (c.start_date - self.end_date).to_i
+    if days_until < 0
+      days_until = (self.start_date - c.end_date).to_i * -1
+    end
+    days_until
+  end
+
+  def dangerously_close_to?(c)
+    if !c.has_date? || !self.has_date?
+      return false
+    end
+    days_until = self.days_until_competition?(c)
     self.kilometers_to(c) < NEARBY_DISTANCE_KM_DANGER && days_until.abs < NEARBY_DAYS_DANGER
   end
 

--- a/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_nearby_competitions_table.html.erb
@@ -21,8 +21,9 @@
         <% end %>
       </td>
       <td><%= users_to_sentence c.delegates %></td>
-      <td data-toggle="tooltip" data-placement="top" data-container="body" title="<%= c.name %> starts on <%= c.start_date %>">
-      <% days_until = (c.start_date - @competition.start_date).to_i %>
+      <% days_until = @competition.days_until_competition?(c) %>
+      <% tooltipTitle = c.name + " " + (days_until < 0 ? t('competitions.nearby_competitions.ends_on') + " " + c.end_date.to_s : t('competitions.nearby_competitions.starts_on') + " " + c.start_date.to_s) %>
+      <td data-toggle="tooltip" data-placement="top" data-container="body" title="<%= tooltipTitle %>">
       <%=t('datetime.distance_in_words.x_days', count: days_until.abs) %> <%= days_until < 0 ? t('competitions.nearby_competitions.before') : t('competitions.nearby_competitions.after') %>
       </td>
       <td><%= c.cityName %>, <%= c.countryId %></td>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1477,6 +1477,8 @@ en:
       distance: "Distance"
       before: "before"
       after: "after"
+      starts_on: "starts on"
+      ends_on: "ends on"
       limit: "Limit"
       competitors: "Competitors"
     announcements: "Announcements"

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -115,7 +115,20 @@ RSpec.describe Competition do
     expect(competition.is_probably_over?).to be false
     expect(competition.started?).to be false
     expect(competition.in_progress?).to be false
+    expect(competition.has_date?).to be false
     expect(competition.dangerously_close_to?(competition2)).to be false
+  end
+
+  it "calculates the correct days until another future competition" do
+    competition = FactoryBot.build :competition, start_date: Date.parse("2021-01-01"), end_date: Date.parse("2021-01-03")
+    competition2 = FactoryBot.build :competition, start_date: Date.parse("2021-02-01"), end_date: Date.parse("2021-02-02")
+    expect(competition.days_until_competition?(competition2)).to be 29
+  end
+
+  it "calculates the correct days until another past competition" do
+    competition = FactoryBot.build :competition, start_date: Date.parse("2021-02-01"), end_date: Date.parse("2021-02-02")
+    competition2 = FactoryBot.build :competition, start_date: Date.parse("2021-01-01"), end_date: Date.parse("2021-01-03")
+    expect(competition.days_until_competition?(competition2)).to be(-29)
   end
 
   it "requires that registration_open be before registration_close" do


### PR DESCRIPTION
Fixes #4146
- fixed formula for dangerously close competitions to use both start and end date
- Fixed wording on display to match new calculation

![image](https://user-images.githubusercontent.com/11577241/103838957-5fd5ea00-505c-11eb-9ffc-db3db7ed7890.png)

![image](https://user-images.githubusercontent.com/11577241/103839002-71b78d00-505c-11eb-8d3b-47ca69821d63.png)
