### PR TITLE
Competition Result React improvements

### DIFF
--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -31,6 +31,8 @@ class Result < ApplicationRecord
       wca_id: personId,
       attempts: [value1, value2, value3, value4, value5],
       best: best,
+      best_index: best_index,
+      worst_index: worst_index,
       average: average,
       regional_single_record: regionalSingleRecord,
       regional_average_record: regionalAverageRecord,

--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.scss
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.scss
@@ -1,3 +1,5 @@
+@import "../../stylesheets/variables.scss";
+
 .competition-results {
   .events-list {
     display: flex;
@@ -6,6 +8,15 @@
   .event-results {
     .table-cell-solves {
       word-spacing: 0.5em;
+    }
+    .WR {
+      color : $wr-color;
+    }
+    .CR {
+      color : $cr-color;
+    }
+    .NR {
+      color : $nr-color;
     }
   }
 }

--- a/WcaOnRails/app/webpacker/javascript/event_navigation/index.js
+++ b/WcaOnRails/app/webpacker/javascript/event_navigation/index.js
@@ -6,7 +6,7 @@ import events from '../wca/events.js.erb';
 import './index.scss';
 
 const EventNavigation = ({ selected, eventIds, onSelect }) => (
-  <Menu text>
+  <Menu text className="event-menu-bar">
     {eventIds.map((eventId, index) => (
       <Popup
         key={eventId}

--- a/WcaOnRails/app/webpacker/javascript/event_navigation/index.scss
+++ b/WcaOnRails/app/webpacker/javascript/event_navigation/index.scss
@@ -10,3 +10,7 @@
 .selected {
     color: #fc4a0a;
   }
+
+.event-menu-bar {
+  flex-wrap: wrap;
+}

--- a/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
+++ b/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
@@ -64,7 +64,17 @@ export function formatAttemptResult(attemptResult, eventId) {
   if (attemptResult === SKIPPED_VALUE) return '';
   if (attemptResult === DNF_VALUE) return 'DNF';
   if (attemptResult === DNS_VALUE) return 'DNS';
-  if (eventId === '333mbf') return formatMbldAttemptResult(attemptResult);
+  if (eventId === '333mbf' || eventId === '333mbo') return formatMbldAttemptResult(attemptResult);
   if (eventId === '333fm') return formatFmAttemptResult(attemptResult);
   return centisecondsToClockFormat(attemptResult);
+}
+
+export function formatAttemptsForResult(result, eventId) {
+  // Only highlight best and worst if the number of unskipped attempts is 5.
+  const highlightBestAndWorst = result.attempts.filter((a) => a !== 0).length === 5;
+  return result.attempts.map((attempt, index) => {
+    const attemptStr = formatAttemptResult(attempt, eventId);
+    return highlightBestAndWorst && (result.best_index === index || result.worst_index === index)
+      ? `(${attemptStr})` : attemptStr;
+  }).join(' ');
 }

--- a/WcaOnRails/app/webpacker/javascript/wca/CountryFlag.js
+++ b/WcaOnRails/app/webpacker/javascript/wca/CountryFlag.js
@@ -1,12 +1,19 @@
 import React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import classnames from 'classnames';
+import Country from './countries.js.erb';
+
+const tooltipSettings = (tooltipText) => (
+  <Tooltip id="resultCountryFlagTooptip">
+    {tooltipText}
+  </Tooltip>
+);
 
 /* eslint react/jsx-props-no-spreading: "off" */
 const CountryFlag = ({ iso2, className, ...other }) => (
-  <span
-    {...other}
-    className={classnames('flag-icon', `flag-icon-${iso2.toLowerCase()}`, className)}
-  />
+  <OverlayTrigger overlay={tooltipSettings(Country.find((country) => country.iso2 === iso2).name)} placement="top">
+    <span {...other} className={classnames('flag-icon', `flag-icon-${iso2.toLowerCase()}`, className)} />
+  </OverlayTrigger>
 );
 
 export default CountryFlag;

--- a/WcaOnRails/app/webpacker/stylesheets/variables.scss
+++ b/WcaOnRails/app/webpacker/stylesheets/variables.scss
@@ -1,0 +1,4 @@
+// Ideally these are pulled from variables.scss so they are kept in one place
+$wr-color: #0366d6;
+$cr-color: #d00404;
+$nr-color:  #28a745;


### PR DESCRIPTION
- Added Record Type Labels to Single and Average Records
![image](https://user-images.githubusercontent.com/11577241/105937591-e2cade80-6023-11eb-8e30-fc800ded4911.png)

- Added Color to records (these colors match the Persons page Records
  - Notes: Ideally we should pull these colors from the same location. Due to this being in js and the other rails I wasnt too sure how to accomplish that.
![image](https://user-images.githubusercontent.com/11577241/105937874-6b497f00-6024-11eb-9383-c039f4fa9fd3.png)

- On Hover of a Country Flag, Display the Country Name
![image](https://user-images.githubusercontent.com/11577241/105937858-6389da80-6024-11eb-9e3e-870df6224d8d.png)


- Fixed #6018 MBO format
![image](https://user-images.githubusercontent.com/11577241/105937823-553bbe80-6024-11eb-82d5-e09525f22ff2.png)

- Have Tied positions greyed out on subsequent occurances
![image](https://user-images.githubusercontent.com/11577241/105937938-8b793e00-6024-11eb-8c19-10104f63890b.png)

- Fixed part of #5963 : When event nav overflows it will scroll
![image](https://user-images.githubusercontent.com/11577241/105937995-a9df3980-6024-11eb-9785-fb5fcfb458fa.png)

