### PR TITLE
Keep sanity checks query as text column as there is no clear limit

### DIFF
--- a/WcaOnRails/db/migrate/20210129181657_add_sanity_check_tables_constraints.rb
+++ b/WcaOnRails/db/migrate/20210129181657_add_sanity_check_tables_constraints.rb
@@ -8,8 +8,7 @@ class AddSanityCheckTablesConstraints < ActiveRecord::Migration[5.2]
     change_column :sanity_checks, :topic, :string, null: false
     add_index :sanity_checks, :topic, unique: true
 
-    change_column :sanity_checks, :query, :string, limit: 500, null: false
-    add_index :sanity_checks, :query, unique: true
+    change_column :sanity_checks, :query, :text, null: false
 
     change_column :sanity_check_categories, :name, :string, null: false
     add_index :sanity_check_categories, :name, unique: true
@@ -27,7 +26,6 @@ class AddSanityCheckTablesConstraints < ActiveRecord::Migration[5.2]
     remove_index :sanity_checks, :topic
     change_column :sanity_checks, :topic, :string, null: true
 
-    remove_index :sanity_checks, :query
     change_column :sanity_checks, :query, :text, null: true
 
     remove_index :sanity_check_categories, :name

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1210,10 +1210,9 @@ CREATE TABLE `sanity_checks` (
   `sanity_check_category_id` bigint(20) NOT NULL,
   `topic` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `query` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_checks_on_topic` (`topic`),
-  UNIQUE KEY `index_sanity_checks_on_query` (`query`),
   KEY `fk_rails_fddad5fbb5` (`sanity_check_category_id`),
   CONSTRAINT `fk_rails_fddad5fbb5` FOREIGN KEY (`sanity_check_category_id`) REFERENCES `sanity_check_categories` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Follow up for #6022, as we already have sanity queries of ~2k characters and `text` sounds like the only reasonable choice. Also having a unique constraint on so long columns is not really a good idea.