### PR TITLE
Reworded contact text for a missing DOB to use the DOB Form

### DIFF
--- a/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
+++ b/WcaOnRails/app/views/users/_select_nearby_delegate.html.erb
@@ -11,8 +11,7 @@
   </p>
 <% elsif !@user.unconfirmed_person.dob %>
   <p>
-    <%= t '.missing_dob_html', link_id: link_id %>
-    <%= t '.contact_results_team_html' %>
+    <%= t '.missing_dob_html', link_id: link_id, dob_form_path: contact_dob_path %>
   </p>
 <% else %>
   <p>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1009,8 +1009,7 @@ en:
     select_nearby_delegate:
       select_delegate_html: "In order to assign you your WCA ID, we need a <a href='%{link_delegate}' target='_blank'>WCA Delegate</a> to confirm your identify. Please enter your birthdate and select the Delegate you think knows you best."
       already_assigned_html: "WCA ID %{link_id} is already assigned to a different account. If you believe this was done in error, contact your local <a href='%{link_delegate}' target='_blank'>WCA Delegate</a>."
-      missing_dob_html: "WCA ID %{link_id} does not have a birthdate assigned."
-      contact_results_team_html: "Please contact the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
+      missing_dob_html: "WCA ID %{link_id} does not have a birthdate assigned. Please contact with WCA Results Team using <a href=\"%{dob_form_path}\">this dedicated form</a>."
       unknown_wca_id_html: "WCA ID %{link_id} does not exist."
   #context: Key used when dealing with registration to a competition
   registrations:

--- a/WcaOnRails/spec/features/claim_wca_id_spec.rb
+++ b/WcaOnRails/spec/features/claim_wca_id_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Claim WCA ID" do
 
       fill_in_selectize "WCA ID", with: person_without_dob.wca_id
 
-      expect(page.find("#select-nearby-delegate-area")).to have_content "WCA ID #{person_without_dob.wca_id} does not have a birthdate assigned. Please contact the WCA Results Team to resolve this."
+      expect(page.find("#select-nearby-delegate-area")).to have_content "WCA ID #{person_without_dob.wca_id} does not have a birthdate assigned. Please contact with WCA Results Team using this dedicated form."
     end
 
     it 'tells you to contact Results team if you WCA ID has been incorrectly claimed too many times' do


### PR DESCRIPTION
Context:
When WRT Receives these request we always reply with an email directing them to the DOB Change Request form.

Before:
![image](https://user-images.githubusercontent.com/11577241/109405896-bf58c380-7942-11eb-9cfd-f14102d1226d.png)

After:
![image](https://user-images.githubusercontent.com/11577241/109405892-b10aa780-7942-11eb-8715-8cfb981b9b28.png)
