### PR TITLE
Update results submitted at when uploading results via admin results

### DIFF
--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -85,7 +85,7 @@ class AdminController < ApplicationController
 
     # This makes sure the json structure is valid!
     if @upload_json.import_to_inbox
-      if @competition.results_submitted_at == nil
+      if @competition.results_submitted_at.nil?
         @competition.update!(results_submitted_at: Time.now)
       end
       flash[:success] = "JSON file has been imported."

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -85,6 +85,9 @@ class AdminController < ApplicationController
 
     # This makes sure the json structure is valid!
     if @upload_json.import_to_inbox
+      if @competition.results_submitted_at == nil
+        @competition.update!(results_submitted_at: Time.now)
+      end
       flash[:success] = "JSON file has been imported."
       redirect_to competition_admin_upload_results_edit_path
     else


### PR DESCRIPTION
Fixes #5984. The issue described there is kinda incorrect (in the scenario described, the WRT member would just upload the results w/o clearing the submission, which is something I didn't realize at the time of writing that issue), however it's still an issue in the scenario that a Delegate neglects to upload results and the Senior / WRT have to take action w/o the Delegate. In any case, whenever the results are uploaded via the admin results, we would want to assume that the results_submitted_at field is filled at some point as WRT would be taking care of the results at that point.

CC: @thewca/wrt 