### PR TITLE
Do not give validator errors for old competitions

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -231,7 +231,7 @@ class Competition < ApplicationRecord
   # just added.
   validate :must_have_at_least_one_event, if: :confirmed_or_visible?
   private def must_have_at_least_one_event
-    if no_events?
+    if no_events? && created_at > Date.new(2016, 12, 31)
       errors.add(:competition_events, I18n.t('competitions.errors.must_contain_event'))
     end
   end
@@ -240,7 +240,7 @@ class Competition < ApplicationRecord
   # The only exception to this is within tests, in which case we actually don't want to run this validation.
   validate :schedule_must_match_rounds, if: :confirmed_at_changed?, on: :update
   def schedule_must_match_rounds
-    unless has_any_round_per_event? && schedule_includes_rounds?
+    unless has_any_round_per_event? && schedule_includes_rounds? && created_at > Date.new(2016, 12, 31)
       errors.add(:competition_events, I18n.t('competitions.errors.schedule_must_match_rounds'))
     end
   end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -240,7 +240,7 @@ class Competition < ApplicationRecord
   # The only exception to this is within tests, in which case we actually don't want to run this validation.
   validate :schedule_must_match_rounds, if: :confirmed_at_changed?, on: :update
   def schedule_must_match_rounds
-    unless has_any_round_per_event? && schedule_includes_rounds? && created_at > Date.new(2016, 12, 31)
+    unless has_any_round_per_event? && schedule_includes_rounds? && created_at < Date.new(2019, 12, 31)
       errors.add(:competition_events, I18n.t('competitions.errors.schedule_must_match_rounds'))
     end
   end
@@ -375,7 +375,7 @@ class Competition < ApplicationRecord
       # NOTE: this will show up on the edit schedule page, and stay even if the
       # schedule matches when saved. Should we add some logic to not show this
       # message on the edit schedule page?
-      unless has_any_round_per_event? && schedule_includes_rounds?
+      unless has_any_round_per_event? && schedule_includes_rounds? && created_at < Date.new(2019, 12, 31)
         warnings[:schedule] = I18n.t('competitions.messages.schedule_must_match_rounds')
       end
 

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -231,7 +231,7 @@ class Competition < ApplicationRecord
   # just added.
   validate :must_have_at_least_one_event, if: :confirmed_or_visible?
   private def must_have_at_least_one_event
-    if no_events? && created_at > Date.new(2016, 12, 31)
+    if no_events? && created_at > Date.new(2019, 12, 31)
       errors.add(:competition_events, I18n.t('competitions.errors.must_contain_event'))
     end
   end
@@ -240,8 +240,10 @@ class Competition < ApplicationRecord
   # The only exception to this is within tests, in which case we actually don't want to run this validation.
   validate :schedule_must_match_rounds, if: :confirmed_at_changed?, on: :update
   def schedule_must_match_rounds
-    unless has_any_round_per_event? && schedule_includes_rounds? && created_at < Date.new(2019, 12, 31)
-      errors.add(:competition_events, I18n.t('competitions.errors.schedule_must_match_rounds'))
+    if created_at > Date.new(2019, 12, 31)
+      unless has_any_round_per_event? && schedule_includes_rounds?
+        errors.add(:competition_events, I18n.t('competitions.errors.schedule_must_match_rounds'))
+      end
     end
   end
 
@@ -375,7 +377,7 @@ class Competition < ApplicationRecord
       # NOTE: this will show up on the edit schedule page, and stay even if the
       # schedule matches when saved. Should we add some logic to not show this
       # message on the edit schedule page?
-      unless has_any_round_per_event? && schedule_includes_rounds? && created_at < Date.new(2019, 12, 31)
+      unless has_any_round_per_event? && schedule_includes_rounds?
         warnings[:schedule] = I18n.t('competitions.messages.schedule_must_match_rounds')
       end
 


### PR DESCRIPTION
Per discussion between WCAT/WRT/Board. This should make it possible to mark some old cancelled competitions properly as such.