### PR TITLE
1094 - Add new result script

### DIFF
--- a/WcaOnRails/app/assets/javascripts/admin.js
+++ b/WcaOnRails/app/assets/javascripts/admin.js
@@ -36,3 +36,122 @@ onPage('admin#edit_person, admin#update_person', function() {
   // When the page is ready, disable the appropriate fields if the form is empty and normalize the url.
   $('#person_wca_id').trigger('change');
 });
+
+onPage('admin#add_new_result, admin#do_add_new_result', function() {
+
+  // Toggle between new and returning competitor
+  $('#add_new_result_is_new_competitor').on('change', function() {
+    if (this.checked) {
+      $('.add_new_result_competitor_id').hide();
+      $('.new-person-fields').show();
+    } else {
+      $('.add_new_result_competitor_id').show();
+      $('.new-person-fields').hide();
+    }
+  }).trigger('change');
+
+  var lastCompetitionId;
+  // When Competition is selected, enable event field with appropriate events
+  $('#add_new_result_competition_id').on('change', function() {
+    var selectEvent = $('#add_new_result_event_id');
+    var selectRound = $('#add_new_result_round_id');
+    var competitionId = this.value;
+    if (competitionId === '') {
+      // clear and hide event and round data
+      selectEvent.val('');
+      selectEvent.prop('disabled', true);
+      selectRound.val('');
+      selectRound.prop('disabled', true);
+      $('.value-fields :input').attr('disabled', true);
+    } else if (lastCompetitionId !== competitionId) {
+      //grab competition data
+      window.wca.cancelPendingAjaxAndAjax('grab_competition_data', {
+        url: '/admin/competition_data',
+        data: { competition_id: competitionId },
+        success: function(competitionData) {
+          // set up appropriate events in select menu based on competition selected
+          selectEvent.prop('disabled', false);
+          var selectedEventValue = selectEvent.val();
+          selectEvent.find('option').remove();
+          $("<option>", {value: '', text: ''}).appendTo(selectEvent);
+          for (var i=0; i < competitionData.events.length; i++) {
+            $("<option>", {value: competitionData.events[i].id, text: competitionData.events[i].name}).appendTo(selectEvent);
+          }
+          if (!lastCompetitionId) {
+            selectEvent.val(selectedEventValue);
+            selectEvent.trigger('change');
+          } else {
+            selectEvent.val('');
+          }
+          lastCompetitionId = competitionId;
+        }
+      });
+    }
+  }).trigger('change');
+
+  var lastEventId;
+  // When Event is selected, enable round field with appropriate rounds relative to the event
+  $('#add_new_result_event_id').on('change', function() {
+    var eventValue = this.value;
+    var selectRound = $('#add_new_result_round_id');
+    if (eventValue === '') {
+      // clear and hide round
+      selectRound.val('');
+      selectRound.prop('disabled', true);
+      $('.value-fields :input').attr('disabled', true);
+    } else {
+      //grab competition data
+      window.wca.cancelPendingAjaxAndAjax('grab_competition_data', {
+        url: '/admin/competition_data',
+        data: { competition_id: $('#add_new_result_competition_id').val() },
+        success: function(competitionData) {
+          // set up appropriate rounds in select menu based on competition and event selected
+          selectRound.prop('disabled', false);
+          var selectedRoundValue = selectRound.val();
+          selectRound.find('option').remove();
+          $("<option>", {value: '', text: ''}).appendTo(selectRound);
+          var competitionEventId = competitionData.competition_events.find(event => event.event_id === eventValue).id;
+          var rounds = competitionData.rounds.filter(round => round.competition_event_id === competitionEventId);
+          for (var i=0; i < rounds.length; i++) {
+            $("<option>", {value: rounds[i].id, text: rounds[i].number}).appendTo(selectRound);
+          }
+          if (!lastEventId) {
+            selectRound.val(selectedRoundValue);
+            selectRound.trigger('change')
+          } else {
+            selectRound.val('');
+          }
+          lastEventId = eventValue;
+        }
+      });
+    }
+  });
+
+  // When Round is selected, enable value fields
+  $('#add_new_result_round_id').on('change', function() {
+    if (this.value === '') {
+      $('.value-fields :input').attr('disabled', true);
+    } else {
+      $('.value-fields :input').attr('disabled', false);
+    }
+  });
+
+  // autofill semi_id
+  function autofillSemiId(name, competition_id) {
+    var names = name.split(" ");
+    var namePartOfId = names[names.length - 1].slice(0, 4);
+    if (namePartOfId.length < 4 && names.length > 1) namePartOfId += names.join("").slice(0, 4 - namePartOfId.length);
+    if (namePartOfId.length < 4) namePartOfId += "AAAA".slice(0, 4 - namePartOfId.length);
+    var competitionYear = competition_id.slice(-4);
+    if (!isNaN(competitionYear)) $('#add_new_result_semi_id').val(competitionYear + namePartOfId.toUpperCase());
+  }
+
+  $('#add_new_result_name').on('change', function() {
+    if (this.value && $('#add_new_result_competition_id').val() && !$('#add_new_result_semi_id').val()) autofillSemiId(this.value, $('#add_new_result_competition_id').val());
+  });
+
+  $('#add_new_result_competition_id').on('change', function() {
+    if (this.value && $('#add_new_result_name').val() && !$('#add_new_result_semi_id').val()) autofillSemiId($('#add_new_result_name').val(), this.value);
+  });
+
+});

--- a/WcaOnRails/app/assets/stylesheets/admin.scss
+++ b/WcaOnRails/app/assets/stylesheets/admin.scss
@@ -1,0 +1,5 @@
+#new_add_new_result {
+  .new-person-fields {
+    display: none;
+  }
+}

--- a/WcaOnRails/app/assets/stylesheets/application.css.scss
+++ b/WcaOnRails/app/assets/stylesheets/application.css.scss
@@ -55,3 +55,4 @@
 @import "incidents";
 @import "translations";
 @import "country_bands";
+@import "admin";

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -32,6 +32,28 @@ class AdminController < ApplicationController
     render 'merge_people'
   end
 
+  def add_new_result
+    @add_new_result = AddNewResult.new
+  end
+
+  def do_add_new_result
+    add_new_result_params = params.require(:add_new_result).permit(:is_new_competitor, :competitor_id, :name, :country_id, :dob, :gender, :semi_id, :competition_id, :event_id, :round_id, :value1, :value2, :value3, :value4, :value5)
+    @add_new_result = AddNewResult.new(add_new_result_params)
+    add_new_result_reponse = @add_new_result.do_add_new_result
+    if add_new_result_reponse && !add_new_result_reponse[:error]
+      flash.now[:success] = "Successfully added new result for #{view_context.link_to(add_new_result_reponse[:wca_id], person_path(add_new_result_reponse[:wca_id]))}! 
+        Please make sure to: 
+        1. #{view_context.link_to("Check Records", "/results/admin/check_regional_record_markers.php?competitionId=#{@add_new_result.competition_id}&show=Show")}. 
+        2. #{view_context.link_to("Check Competition Validators", competition_admin_check_existing_results_path(@add_new_result.competition_id))}.
+        1. #{view_context.link_to("Run Compute Auxillery Data", admin_compute_auxiliary_data_path)}. 
+        ".html_safe
+      @add_new_result = AddNewResult.new
+    else
+      flash.now[:danger] = add_new_result_reponse[:error] || "Error adding new result"
+    end
+    render 'add_new_result'
+  end
+
   def new_results
     @competition = competition_from_params
     @upload_json = UploadJson.new
@@ -139,6 +161,17 @@ class AdminController < ApplicationController
       gender: @person.gender,
       dob: @person.dob,
       incorrect_wca_id_claim_count: @person.incorrect_wca_id_claim_count,
+    }
+  end
+
+  def competition_data
+    @competition = Competition.find_by!(id: params[:competition_id])
+
+    render json: {
+      name: @competition.name,
+      events: @competition.events,
+      competition_events: @competition.competition_events,
+      rounds: @competition.rounds
     }
   end
 

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -39,18 +39,24 @@ class AdminController < ApplicationController
   def do_add_new_result
     add_new_result_params = params.require(:add_new_result).permit(:is_new_competitor, :competitor_id, :name, :country_id, :dob, :gender, :semi_id, :competition_id, :event_id, :round_id, :value1, :value2, :value3, :value4, :value5)
     @add_new_result = AddNewResult.new(add_new_result_params)
+
     add_new_result_reponse = @add_new_result.do_add_new_result
     if add_new_result_reponse && !add_new_result_reponse[:error]
+      # show success message with helpful reminders of remaining steps after a successful insert of a new result
       flash.now[:success] = "Successfully added new result for #{view_context.link_to(add_new_result_reponse[:wca_id], person_path(add_new_result_reponse[:wca_id]))}! 
         Please make sure to: 
         1. #{view_context.link_to("Check Records", "/results/admin/check_regional_record_markers.php?competitionId=#{@add_new_result.competition_id}&show=Show")}. 
         2. #{view_context.link_to("Check Competition Validators", competition_admin_check_existing_results_path(@add_new_result.competition_id))}.
-        1. #{view_context.link_to("Run Compute Auxillery Data", admin_compute_auxiliary_data_path)}. 
+        3. #{view_context.link_to("Run Compute Auxillery Data", admin_compute_auxiliary_data_path)}.
+        #{@add_new_result.is_new_competitor.to_i == 1 ? "4. Notify WFC of the additional competitor.": ""}
         ".html_safe
       @add_new_result = AddNewResult.new
     else
+      puts "Jacobe1"
+      puts @add_new_result.errors.full_messages.to_s
       flash.now[:danger] = add_new_result_reponse[:error] || "Error adding new result"
     end
+
     render 'add_new_result'
   end
 

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -52,8 +52,6 @@ class AdminController < ApplicationController
         ".html_safe
       @add_new_result = AddNewResult.new
     else
-      puts "Jacobe1"
-      puts @add_new_result.errors.full_messages.to_s
       flash.now[:danger] = add_new_result_reponse[:error] || "Error adding new result"
     end
 

--- a/WcaOnRails/app/models/add_new_result.rb
+++ b/WcaOnRails/app/models/add_new_result.rb
@@ -1,0 +1,361 @@
+# frozen_string_literal: true
+
+class AddNewResult
+  include ActiveModel::Model
+
+  attr_reader :is_new_competitor
+  attr_reader :competitor_id
+  attr_reader :name, :country_id, :dob, :gender, :semi_id
+  attr_reader :competition_id, :event_id, :round_id
+  attr_reader :value1, :value2, :value3, :value4, :value5
+
+  def is_new_competitor=(is_new_competitor)
+    @is_new_competitor = is_new_competitor
+  end
+
+  def competitor_id=(competitor_id)
+    @competitor_id = competitor_id
+  end
+
+  def name=(name)
+    @name = name
+  end
+
+  def country_id=(country_id)
+    @country_id = country_id
+  end
+
+  def dob=(dob)
+    @dob = dob
+  end
+
+  def gender=(gender)
+    @gender = gender
+  end
+
+  def semi_id=(semi_id)
+    @semi_id = semi_id
+  end
+
+  def competition_id=(competition_id)
+    @competition_id = competition_id
+  end
+
+  def event_id=(event_id)
+    @event_id = event_id
+  end
+
+  def round_id=(round_id)
+    @round_id = round_id
+  end
+
+  def value1=(value1)
+    @value1 = value1
+    @value1_solve_time = SolveTime.new(event_id, :best, value1.to_i)
+  end
+
+  def value2=(value2)
+    @value2 = value2
+    @value2_solve_time = SolveTime.new(event_id, :best, value2.to_i)
+  end
+
+  def value3=(value3)
+    @value3 = value3
+    @value3_solve_time = SolveTime.new(event_id, :best, value3.to_i)
+  end
+
+  def value4=(value4)
+    @value4 = value4
+    @value4_solve_time = SolveTime.new(event_id, :best, value4.to_i)
+  end
+
+  def value5=(value5)
+    @value5 = value5
+    @value5_solve_time = SolveTime.new(event_id, :best, value5.to_i)
+  end
+
+  validates :competition_id, presence: true
+  validates :event_id, presence: true
+  validates :round_id, presence: true
+  validates :value1, presence: true
+  
+  validate :require_valid_competitor_id_if_returning_competitor
+  def require_valid_competitor_id_if_returning_competitor
+    if is_new_competitor.to_i == 0 
+      if competitor_id.nil? || competitor_id == ""
+        errors.add(:competitor_id, "Cannot be Blank")
+      end
+      if !Person.find_by_wca_id(competitor_id)
+        errors.add(:competitor_id, "Not found")
+      end
+    end
+  end
+  
+  validate :require_valid_name_if_new_competitor
+  def require_valid_name_if_new_competitor
+    if is_new_competitor.to_i == 1 && (name.nil? || name == "")
+      errors.add(:name, "Cannot be Blank")
+    end
+  end
+  
+  validate :require_valid_country_id_if_new_competitor
+  def require_valid_country_id_if_new_competitor
+    if is_new_competitor.to_i == 1
+      if country_id.nil? || country_id == ""
+        errors.add(:country_id, "Cannot be Blank")
+      elsif !Country.c_find(country_id)
+        errors.add(:country_id, "Not found")
+      end
+    end
+  end
+  
+  validate :require_valid_gender_if_new_competitor
+  def require_valid_gender_if_new_competitor
+    if is_new_competitor.to_i == 1
+      if gender.nil? || gender == ""
+        errors.add(:gender, "Cannot be Blank")
+      elsif !['m', 'f', 'o'].include?(gender)
+        errors.add(:gender, "Not found")
+      end
+    end
+  end
+  
+  validate :require_valid_dob_if_new_competitor
+  def require_valid_dob_if_new_competitor
+    if is_new_competitor.to_i == 1
+      # Note: DOB can be blank
+      if @dob.nil? && !dob.blank?
+        @dob = dob.strftime("%F")
+      end
+      if @dob.blank?
+        @year = @month = @day = 0
+      else
+        unless @dob =~ /\A\d{4}-\d{2}-\d{2}\z/
+          # NOTE: error message built-in rails
+          errors.add(:dob, "Invalid. Must be YYYY-MM-DD")
+          return
+        end
+        @year, @month, @day = @dob.split("-").map(&:to_i)
+        unless Date.valid_date? @year, @month, @day
+          errors.add(:dob, "Invalid. Must be YYYY-MM-DD")
+          return
+        end
+        if Date.new(@year, @month, @day) >= Date.today
+          errors.add(:dob, "Must be in the past")
+        end
+      end
+    end
+  end
+  
+  validate :require_valid_semi_id_if_new_competitor
+  def require_valid_semi_id_if_new_competitor
+    if is_new_competitor.to_i == 1 
+      if (semi_id.nil? || semi_id == "")
+        errors.add(:semi_id, "Cannot be Blank")
+        return
+      end
+      if !semi_id.match?(/[\d]{4}[A-Z]{4}/)
+        errors.add(:semi_id, "Invalid Semi ID YYYYLAST")
+      end
+    end
+  end
+  
+  validate :require_valid_competition_id
+  def require_valid_competition_id
+    if !Competition.find_by_id(competition_id)
+      errors.add(:competition_id, "Not found")
+    end
+  end
+  
+  validate :require_competition_to_have_results
+  def require_competition_to_have_results
+    return unless errors.blank?
+    if !Competition.find_by_id(competition_id).results.any?
+      errors.add(:competition_id, "Does not have results")
+    end
+  end
+  
+  validate :require_valid_event_id
+  def require_valid_event_id
+    return unless errors.blank?
+    if !Competition.find_by_id(competition_id).competition_events.find_by_event_id(event_id)
+      errors.add(:event_id, "Not found for competition")
+    end
+  end
+  
+  validate :require_valid_round_id
+  def require_valid_round_id
+    return unless errors.blank?
+    if !Competition.find_by_id(competition_id).rounds.find_by_id(round_id)
+      errors.add(:round_id, "Not found for competition")
+      return
+    end
+
+    # set round_type_id
+    round = Round.find_by_id(round_id)
+    if round.cutoff.nil?
+      case round.number
+      when round.total_number_of_rounds
+        @round_type_id = "f"
+      when 1
+        @round_type_id = "1"
+      when 2
+        @round_type_id = "2"
+      when 3
+        @round_type_id = "3"
+      end
+    else
+      case round.number
+      when round.total_number_of_rounds
+        @round_type_id = "c"
+      when 1
+        @round_type_id = "d"
+      when 2
+        @round_type_id = "e"
+      when 3
+        @round_type_id = "g"
+      end
+    end
+    # set format_id
+    @format_id = round.format_id
+  end
+  
+  validate :require_competitor_to_have_not_competed_in_round
+  def require_competitor_to_have_not_competed_in_round
+    return unless errors.blank?
+    if is_new_competitor.to_i == 0 && Competition.find_by_id(competition_id).results.where(personId: competitor_id, eventId: event_id, roundTypeId: @round_type_id).any?
+      errors.add(:round_id, "Competitor currently has results for this round. To fix them use the Fix Results script")
+    end
+  end
+
+  validate :require_valid_value1
+  def require_valid_value1
+    if !value1.nil? && !@value1_solve_time.valid?
+      errors.add(:value1, "Not Valid")
+    end
+  end
+
+  validate :require_valid_value2
+  def require_valid_value2
+    if !value2.nil? && !@value2_solve_time.valid?
+      errors.add(:value2, "Not Valid")
+    end
+  end
+
+  validate :require_valid_value3
+  def require_valid_value3
+    if !value3.nil? && !@value3_solve_time.valid?
+      errors.add(:value3, "Not Valid")
+    end
+  end
+
+  validate :require_valid_value4
+  def require_valid_value4
+    if !value4.nil? && !@value4_solve_time.valid?
+      errors.add(:value4, "Not Valid")
+    end
+  end
+
+  validate :require_valid_value5
+  def require_valid_value5
+    if !value5.nil? && !@value5_solve_time.valid?
+      errors.add(:value5, "Not Valid")
+    end
+  end
+
+  def do_add_new_result
+    if !valid?
+      return { error: "invalid forum" }
+    end
+
+    ActiveRecord::Base.transaction do
+      # create new competitor if needed and set wca_id, name, and country_id needed for the result row
+      if is_new_competitor.to_i == 1
+        if !generate_new_wca_id
+          return { error: "Error with subId: SubIds " + semi_id + "00 to " + semi_id + "99 are already taken." }
+        end
+        @new_person = Person.create(:wca_id => @new_wca_id, :name => name, :countryId => country_id, :gender => gender, :year => @year, :month => @month, :day => @day)
+        @use_wca_id = @new_wca_id
+        @use_name = name
+        @use_country_id = country_id
+      else
+        @use_wca_id = competitor_id
+        person = Person.find_by_wca_id(competitor_id)
+        @use_name = person.name
+        @use_country_id = person.countryId
+      end
+
+      # Create Result
+      new_result = Result.new(:personId => @use_wca_id, 
+                          :personName => @use_name, 
+                          :countryId => @use_country_id, 
+                          :competitionId => competition_id, 
+                          :eventId => event_id, 
+                          :roundTypeId => @round_type_id, 
+                          :formatId => @format_id, 
+                          :value1 => value1, 
+                          :value2 => value2, 
+                          :value3 => value3, 
+                          :value4 => value4, 
+                          :value5 => value5)
+      new_result.update(:best => new_result.compute_correct_best, :average => new_result.compute_correct_average)
+      if !new_result.valid?
+        if !@new_person.nil?
+          @new_person.destroy
+        end
+        new_result.destroy
+        return { error: "Error in creatining result: " + new_result.errors.messages.to_s }
+      end
+      new_result.save
+
+      # Fix pos
+      results_to_fix_position = Competition.find_by_id(competition_id).results.where(eventId: event_id, roundTypeId: @round_type_id).order(Arel.sql("if(formatId in ('a','m') and average>0, average, 2147483647), if(best>0, best, 2147483647)"))
+      current_position = 0
+      last_result = nil
+      number_of_tied = 0
+      results_to_fix_position.each do |result, index|
+        # Unless we find two exact same results, we increase the expected position
+        tied = false
+        if last_result
+          if ["a", "m"].include?(result.formatId)
+            # If the ranking is based on average, look at both average and best.
+            tied = result.average == last_result.average && result.best == last_result.best
+          else
+            # else we just compare the bests
+            tied = result.best == last_result.best
+          end
+        end
+        if tied
+          number_of_tied += 1
+        else
+          current_position += 1
+          current_position += number_of_tied
+          number_of_tied = 0
+        end
+        last_result = result
+
+        # Fix position
+        if current_position != result.pos
+          result.update(:pos => current_position)
+        end
+      end
+    end
+    
+    { wca_id: @use_wca_id }
+    # { success: "Successfully added new result for #{view_context.link_to(@use_wca_id, person_path(@use_wca_id))}!".html_safe }
+  end
+
+  def generate_new_wca_id
+    # generate new wcaid
+    similarWcaIds = Person.where("wca_id LIKE ?", semi_id + '%')
+    (1..99).each do |i|
+      if !similarWcaIds.where(wca_id: semi_id + i.to_s.rjust(2, "0")).any?
+        @new_wca_id = semi_id + i.to_s.rjust(2, "0")
+        return true
+      end
+    end
+
+    # Semi Id doesn't work
+    false
+  end
+end

--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -26,6 +26,7 @@
         { text: "Server status", path: server_status_path, fa_icon: "info" },
         { text: "WCA All Voting Members", path: eligible_voters_path, fa_icon: "download" },
         { text: "WCA Leaders and Seniors", path: leader_senior_voters_path, fa_icon: "download" },
+        { text: "Add New Result", path: admin_add_new_result_path, fa_icon: "plus" },
       ].each do |nav_item| %>
         <%= link_to nav_item[:path], class: "list-group-item" + (current_page?(nav_item[:path]) ? ' active' : '') do %>
           <%= ui_icon(nav_item[:fa_icon]) %> <%= nav_item[:text] %>

--- a/WcaOnRails/app/views/admin/add_new_result.html.erb
+++ b/WcaOnRails/app/views/admin/add_new_result.html.erb
@@ -1,0 +1,61 @@
+<% provide(:title, 'Add New Result') %>
+
+<div class="container">
+  <%= render layout: "nav" do %>
+    <h1><%= yield(:title) %></h1>
+
+    <p>
+      Please fill out the form below to add a new result.
+    </p>
+
+    <p>
+      Checking the new competitor field will also create a new person with the personal data. The new generated person id will be given whenever the script has successfully executed.
+    </p>
+
+    <p>
+      After adding a new result, you must run these scripts to ensure that the changes are sound:
+      <ol>
+        <li><%= link_to "Check Records", "/results/admin/check_regional_record_markers.php" %> (if needed - add or remove any record markers this result affects)</li>
+        <li>Check Competition Validators</li>
+        <li><%= link_to "Run Compute Auxillery Data", admin_compute_auxiliary_data_path %></li>
+      </ol>
+    </p>
+
+    <%= simple_form_for @add_new_result, url: admin_add_new_result_path, method: :post do |f| %>
+      <%= f.input :is_new_competitor, as: :boolean, inline_label: "The competitor is a new competitor" %>
+      <%= f.input :competitor_id, as: :user_ids, persons_table: true, only_one: true, class: "returning-competitor" %>
+      <div class="new-person-fields">
+        <%= f.input :name %>
+        <%= f.input :country_id, collection: Country.real, value_method: lambda { |c| c.id }, label_method: lambda { |c| c.name } %>
+        <%= f.input :gender do %>
+          <%= f.select :gender, options_for_select([["Male", "m"], ["Female", "f"], ["Other", "o"]], f.object.gender), { include_blank: "" }, { class: "form-control" } %>
+        <% end %>
+        <%= f.input :dob, as: :date_picker %>
+      </div>
+      <%= f.input :competition_id, as: :competition_id, only_one: true %>
+      <div class="new-person-fields">
+        <div>This is the WCAID without the ending numbers (Autofilled after Name and competition fields are filled in)</div>
+        <%= f.input :semi_id %>
+      </div>
+      <%= f.input :event_id do %>
+        <%= f.collection_select :event_id, Event.all, :id, :name, { :include_blank => true }, { class: "form-control", :disabled => "disabled" } %>
+      <% end %>
+      <%= f.input :round_id do %>
+        <%= f.select :round_id, [@add_new_result.round_id], {}, { class: "form-control", :disabled => "disabled" } %>
+      <% end %>
+      <div>Note: These values are entered as they appear on the database. Ie. 1:30.48 should be inputted as 90048, 59 in FMC inputted as 59, and MBLD values as 0DDTTTTTMM. -1 for DNF. -2 for DNS. 0 or blank for blank</div>
+      <br>
+      <div class="value-fields">
+        <%= f.input :value1, :disabled => true %>
+        <%= f.input :value2, :disabled => true %>
+        <%= f.input :value3, :disabled => true %>
+        <%= f.input :value4, :disabled => true %>
+        <%= f.input :value5, :disabled => true %>
+      </div>
+
+      <button type="submit" class="btn btn-success">
+        <%= ui_icon("plus") %> Add new result
+      </button>
+    <% end %>
+  <% end %>
+</div>

--- a/WcaOnRails/app/views/admin/add_new_result.html.erb
+++ b/WcaOnRails/app/views/admin/add_new_result.html.erb
@@ -18,6 +18,7 @@
         <li><%= link_to "Check Records", "/results/admin/check_regional_record_markers.php" %> (if needed - add or remove any record markers this result affects)</li>
         <li>Check Competition Validators</li>
         <li><%= link_to "Run Compute Auxillery Data", admin_compute_auxiliary_data_path %></li>
+        <li>If you are adding a new competitior, be sure to notify WFC of the change</li>
       </ol>
     </p>
 

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -183,6 +183,9 @@ Rails.application.routes.draw do
   get '/admin/compute_auxiliary_data' => 'admin#compute_auxiliary_data'
   get '/admin/do_compute_auxiliary_data' => 'admin#do_compute_auxiliary_data'
   get '/admin/update_statistics' => 'admin#update_statistics'
+  get '/admin/add_new_result' => 'admin#add_new_result'
+  post '/admin/add_new_result' => 'admin#do_add_new_result'
+  get '/admin/competition_data' => 'admin#competition_data'
 
   get '/search' => 'search_results#index'
 

--- a/WcaOnRails/spec/controllers/admin_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/admin_controller_spec.rb
@@ -44,6 +44,47 @@ RSpec.describe AdminController, type: :controller do
     end
   end
 
+  describe 'add_new_result' do
+    sign_in { FactoryBot.create :admin }
+
+    let(:person) { FactoryBot.create(:person) }
+    let(:competition) { FactoryBot.create(:competition, :with_results) }
+    let(:round) { FactoryBot.create(:round, competition: competition, event_id: "333") }
+
+    it 'can add new result' do
+      post :do_add_new_result, params: { 
+        add_new_result: {
+          is_new_competitor: "0",
+          competitor_id: person.wca_id,
+          competition_id: competition.id,
+          event_id: "333",
+          round_id: round.id,
+          value1: "1200",
+          value2: "1400",
+          value3: "1400",
+          value4: "1400",
+          value5: "1400"
+        } 
+      }
+      
+      expect(response.status).to eq 200
+      expect(response).to render_template :add_new_result
+      expect(flash.now[:success]).to eq "Successfully added new result for <a href=\"/persons/#{person.wca_id}\">#{person.wca_id}</a>! \n        Please make sure to: \n        1. <a href=\"/results/admin/check_regional_record_markers.php?competitionId=#{competition.id}&amp;show=Show\">Check Records</a>. \n        2. <a href=\"/competitions/#{competition.id}/admin/check-existing-results\">Check Competition Validators</a>.\n        3. <a href=\"/admin/compute_auxiliary_data\">Run Compute Auxillery Data</a>.\n        \n        "
+    end
+  end
+
+  describe 'competition_data' do
+    sign_in { FactoryBot.create :admin }
+
+    let(:competition) { FactoryBot.create(:competition) }
+
+    it 'can get competition data' do
+      get :competition_data, params: { competition_id: competition.id }
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body)["name"]).to eq competition.name
+    end
+  end
+
   describe 'PATCH #update person' do
     sign_in { FactoryBot.create :admin }
 

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -45,6 +45,12 @@ FactoryBot.define do
       competitor_limit_reason { "The hall only fits 100 competitors." }
     end
 
+    trait :with_results do
+      after(:create) do |competition|
+        competition.results = [FactoryBot.create(:result, competitionId: competition.id)] 
+      end
+    end
+
     events { Event.where(id: event_ids) }
     main_event_id { events.first.id if events.any? }
 

--- a/WcaOnRails/spec/models/add_new_result_spec.rb
+++ b/WcaOnRails/spec/models/add_new_result_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AddNewResult do
+  let(:competition) { FactoryBot.create(:competition, :with_results) }
+  let(:round) { FactoryBot.create(:round, competition: competition, event_id: "333") }
+  let(:person) { FactoryBot.create(:person_who_has_competed_once) }
+  let(:add_new_result_returner) { AddNewResult.new(
+    is_new_competitor: "0",
+    competitor_id: person.wca_id,
+    competition_id: competition.id,
+    event_id: "333",
+    round_id: round.id,
+    value1: 1400,
+    value2: 1500,
+    value3: 1500,
+    value4: 1500,
+    value5: -1
+  ) }
+  let(:add_new_result_new_competitor) { AddNewResult.new(
+    is_new_competitor: "1",
+    name: "Billy Bob",
+    country_id: "USA",
+    dob: "2000-04-20",
+    gender: "m",
+    semi_id: "2019BOBB",
+    competition_id: competition.id,
+    event_id: "333",
+    round_id: round.id,
+    value1: 1400,
+    value2: 1500,
+    value3: 1500,
+    value4: 1500,
+    value5: -1
+  ) }
+
+  it "is valid" do
+    expect(add_new_result_returner).to be_valid
+    expect(add_new_result_new_competitor).to be_valid
+  end
+
+  it "handles invalid competition_id" do
+    add_new_result_returner.competition_id = ""
+    expect(add_new_result_returner).to be_invalid_with_errors(competition_id: ["can't be blank"])
+
+    add_new_result_returner.competition_id = "bad competition id"
+    expect(add_new_result_returner).to be_invalid_with_errors(competition_id: ["Not found"])
+  end
+
+  it "handles invalid event_id" do
+    add_new_result_returner.event_id = ""
+    expect(add_new_result_returner).to be_invalid_with_errors(event_id: ["can't be blank"])
+
+    add_new_result_returner.event_id = "333mbfo"
+    expect(add_new_result_returner).to be_invalid_with_errors(event_id: ["Not found for competition"])
+  end
+
+  it "handles invalid round_id" do
+    add_new_result_returner.round_id = ""
+    expect(add_new_result_returner).to be_invalid_with_errors(round_id: ["can't be blank"])
+
+    add_new_result_returner.round_id = 2147483647
+    expect(add_new_result_returner).to be_invalid_with_errors(round_id: ["Not found for competition"])
+  end
+
+  it "handles requiring value1" do
+    add_new_result_returner.value1 = ""
+    expect(add_new_result_returner).to be_invalid_with_errors(value1: ["can't be blank"])
+  end
+
+  it "handles invalid competitor_id if returning" do
+    add_new_result_returner.competitor_id = ""
+    expect(add_new_result_returner).to be_invalid_with_errors(competitor_id: ["can't be blank"])
+
+    add_new_result_returner.competitor_id = "bad wca id"
+    expect(add_new_result_returner).to be_invalid_with_errors(competitor_id: ["Not found"])
+  end
+
+  it "handles invalid name if new competitor" do
+    add_new_result_new_competitor.name = ""
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(name: ["can't be blank"])
+  end
+
+  it "handles invalid country_id if new competitor" do
+    add_new_result_new_competitor.country_id = ""
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(country_id: ["can't be blank"])
+
+    add_new_result_new_competitor.country_id = "Bad country"
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(country_id: ["Not found"])
+  end
+
+  it "handles invalid gender if new competitor" do
+    add_new_result_new_competitor.gender = ""
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(gender: ["can't be blank"])
+
+    add_new_result_new_competitor.gender = "Bad gender"
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(gender: ["Not found"])
+  end
+
+  it "handles blank dob as valid if new competitor" do
+    add_new_result_new_competitor.dob = ""
+    expect(add_new_result_new_competitor).to be_valid
+  end
+
+  it "handles invalid dob if new competitor" do
+    add_new_result_new_competitor.dob = "April 20th 2000"
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(dob: ["Invalid. Must be YYYY-MM-DD"])
+
+    add_new_result_new_competitor.dob = "2000-01-32"
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(dob: ["Invalid. Must be YYYY-MM-DD"])
+
+    add_new_result_new_competitor.dob = 1.year.from_now.strftime("%F")
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(dob: ["Must be in the past"])
+  end
+
+  it "handles invalid semi_id if new competitor" do
+    add_new_result_new_competitor.semi_id = ""
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(semi_id: ["can't be blank"])
+
+    add_new_result_new_competitor.semi_id = "Bad semi_id"
+    expect(add_new_result_new_competitor).to be_invalid_with_errors(semi_id: ["Invalid. Must be YYYYLAST"])
+  end
+
+  it "requires competition to have results" do
+    new_competition = FactoryBot.create(:competition)
+    add_new_result_returner.competition_id = new_competition.id
+    expect(add_new_result_returner).to be_invalid_with_errors(competition_id: ["Does not have results"])
+  end
+
+  it "requires competitor to not have already competed in the round" do
+    add_new_result_returner.do_add_new_result
+    expect(add_new_result_returner).to be_invalid_with_errors(round_id: ["Competitor currently has results for this round. To fix them use the Fix Results script"])
+  end
+
+  it "requires valid values" do
+    add_new_result_returner.value1 = "-3"
+    add_new_result_returner.value2 = "-3"
+    add_new_result_returner.value3 = "-3"
+    add_new_result_returner.value4 = "-3"
+    add_new_result_returner.value5 = "-3"
+    expect(add_new_result_returner).to be_invalid_with_errors(value1: ["Not Valid"])
+    expect(add_new_result_returner).to be_invalid_with_errors(value2: ["Not Valid"])
+    expect(add_new_result_returner).to be_invalid_with_errors(value3: ["Not Valid"])
+    expect(add_new_result_returner).to be_invalid_with_errors(value4: ["Not Valid"])
+    expect(add_new_result_returner).to be_invalid_with_errors(value5: ["Not Valid"])
+  end
+
+  describe "create_new_person" do
+    it "creates a new competitor if new competitor" do
+      expect(add_new_result_new_competitor).to be_valid
+      num_people_before = Person.all.length
+      add_new_result_new_competitor.create_new_person
+      expect(num_people_before + 1).to eq Person.all.length
+    end
+    it "does not create a new competitor if returner" do
+      expect(add_new_result_returner).to be_valid
+      num_people_before = Person.all.length
+      add_new_result_returner.create_new_person
+      expect(num_people_before).to eq Person.all.length
+    end
+  end
+
+  it "can do add new result" do
+    response = add_new_result_new_competitor.do_add_new_result
+    expect(!!response).to eq true
+    expect(response[:error]).to be_nil
+    expect(response[:wca_id]).to be_truthy
+    expect(Person.find_by_wca_id(response[:wca_id]).results).to be_truthy
+  end
+end


### PR DESCRIPTION
fixes #1094. Added a script for @thewca/wrt to enter a new result from the admin panel.

Notes:
- generate_new_wca_id i yanked from PR #6086 . Ideally this would be a shared method that both can use. I'm not quite sure where that belongs, but I can change it depending on which PR is reviewed first.
- Inputting the values is kinda jank, as described on the page, the WRT member inputs the time as seen on the db. This isn't ideal, but not a show stopper for us. I'll create a follow up issue to address this, as it'll also be needed to port result scripts to from php to rails. (see: #6097)
- Tests fail due to the same i18n keys error I see on #6086 , I figure once I know how to resolve it there, it shouldn't be too hard to resolve it here too.

Here's the Flow:
1. the Add New Result item in the nav will take you to a new admin page
![image](https://user-images.githubusercontent.com/11577241/112790194-d0255380-902c-11eb-94b8-691ef6f1fa18.png)

2. You can select between a new competitor or a returning competitor. This will bring up the appropriate fields needed for a new competitor.
![image](https://user-images.githubusercontent.com/11577241/112790310-12e72b80-902d-11eb-97b2-400b871c2b7b.png)
![image](https://user-images.githubusercontent.com/11577241/112790328-1c709380-902d-11eb-8377-0c14f3d83bcc.png)

3. For a new competitor, once the name and competition fields are filled in, the semi id field will automatically be generated. You are able to change it if there are any issues.
![image](https://user-images.githubusercontent.com/11577241/112790486-6f4a4b00-902d-11eb-8341-c45da2c25051.png)

4. Once the competition is selected, the event field will enable and be filled with the appropriate events for the competition.
![image](https://user-images.githubusercontent.com/11577241/112790523-89842900-902d-11eb-8143-55ea7a77a4bb.png)

5. Once the event is selected, the round field will enable and be filled with the appropriate rounds for the event at that competition.
![image](https://user-images.githubusercontent.com/11577241/112790553-a3257080-902d-11eb-8f0e-ce149c2be5fc.png)

6. Once the round is selected, the value fields will enable.
![image](https://user-images.githubusercontent.com/11577241/112790597-b8020400-902d-11eb-9431-2f1a3691b9fa.png)

7. Once the user clicks submit, the form will be validated with many validations.
- These validations utilize the SolveTime model to ensure the values are valid.
- I believe the validations should explain themselves via their names, if there are any questions, feel free to ask! Also if you think I missed any please let me know.

8. After clicking submit and the form is valid.
- If a new competitor was selected, a new competitor will be created
- A new result will be added
- The best and average are automatically calculated via the resulatable model
- The positions of the round are fixed to be correct.
![image](https://user-images.githubusercontent.com/11577241/112790923-6c038f00-902e-11eb-9036-4b53646f8e05.png)
