### PR TITLE
Changed SMTP Authentication to use the SIGV4 Algorithm

### DIFF
--- a/chef/data_bags/secrets/production.json
+++ b/chef/data_bags/secrets/production.json
@@ -1,150 +1,129 @@
 {
   "id": "production",
   "_password_comment": {
-    "encrypted_data": "gsUFu45tIqYaYUV9HUGpE1kDXrTdfGLAfAFfxJe2RJRBGtZign+eQ/ksld7z\nIuERisAetzLdOLvtq2UQJXNHnRGuSYX1u4bPzBImzhJZqBwf/yD3rq5Un9Zn\noVD5vdUEPS9gtytK\n",
-    "iv": "zouRstGr+VwrhlWE\n",
-    "auth_tag": "NoE6R/dl3fKeh4wd3eD9QQ==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "TZJOfJk/+Wcgi5pERbDaEEfDJMq7zqew6O3Bjq91TRV1/9fBAFr5i24tj7fg\n4zPmcje08RZsBS45k9QxI+bMwu3AXu5UQmO1rU8gniI17X4cwfHH6PPUkPm9\nOPG2MmHJNBokVj132ey00eu3x2uhtA==\n",
+    "iv": "BaOykRDLGiDkNYCV6LOVdA==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "cubing_password": {
-    "encrypted_data": "LEtBbWd0mdLCj2Wx31izWwtxKehD8Y8c7tQkuWBXMhcflSBcZwMkt/jMi/ql\nf9+It7wY\n",
-    "iv": "1hFDDuWXg2aWAhFR\n",
-    "auth_tag": "KWpOAPGbsCGxBkzR/rB8Dg==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "89SeWuvQL2y9hrl01HkDPZ5yvwPhmXIZnAj+eDT5FHE1W7xrhqPXYeeWhG95\nMAhs3pt29cpOXSsGRp03+mTFoQ==\n",
+    "iv": "KT3uXdAGCwxkk0P3uyvW+Q==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "mysql_password": {
-    "encrypted_data": "HQTpltNufhXzf1oWRlv6BEdF99ozyCJ4jq/fuW5BjHrzOARQ0adfce4k384I\nEsqFPs4=\n",
-    "iv": "7Vh+hkdJoDBn6N33\n",
-    "auth_tag": "0zLmMzL7deyFxZDcKLXNNw==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "YVXS+goXDV4AKIFY6NbXZYuEgEbebykp8dKqOTQhlxfBCRaX/l1B+MJF1w6o\nvQvyZ4eqWf6DTJC5WfaHTJ1EFA==\n",
+    "iv": "wPvBlE08VD1FSJ2vRdggrw==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "secret_key_base_comment": {
-    "encrypted_data": "atgKPHTHcz9LYIM2Zki1JADJYl5PrAGvsoYlCBv4oeyzNgFqtl+zGcjgZ5MG\nd50=\n",
-    "iv": "bsgjULdlRmRjd3fL\n",
-    "auth_tag": "KqeXcuScVltwTOghyufz0g==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "42pokKsfYrAlG3MwFr5441nKfDsLp3qVKwS4PmIe43RTauLgW0LDK7ykcK6i\njZLk\n",
+    "iv": "bp4zR7JQ4JCTkUTAyVIfBw==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "secret_key_base": {
-    "encrypted_data": "3BoeFolIoTonlurxb7RZknXJXltyT/O2gc9qa30q+9QprwGl0GDp7hMYUTA1\ngXHBUXs/DkVyiPx6sGWmT5HkMGs53q42w62OkDuVtsjxCH2CzTKy9Q/UmOEl\nzyC4auKrinuCGxX3ZUQeSIpaGFKxj5CSqvYkbM+kPA8ADZUTQgus6OXs5QJi\nDlL5ezk9m/CfUewG\n",
-    "iv": "sizH7ys008soWIMm\n",
-    "auth_tag": "AlsDzMbp6yC1q4IOw2CvmA==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "uBGBpArIhxm1D8wcpFZuxNDYoz5GnpqKNb+VwfE3lw5x0L7pjf1yoqCwQGBh\nJty/J3XduFtriWj0xXLnHx4LkZnic+Z7xwgpv3BG0uUj+DmLjBajoqZTRBT+\nysUGdWvbAVr8c+soLS743SHm4jCVFQnJF2NyvFITipxW54inY2ZiPj/iyVdF\nOG8MvwAZ+qdrx+HkMibXrcTzfWV4hifkkQ==\n",
+    "iv": "mTxVptFvNT+sk42JTBlxTQ==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "SMTP_USERNAME": {
-    "encrypted_data": "BjyeM1gnBl/nN6JLGCOmeZgaE2sqpaqJiZ2BMMf77hoQjGoYeXG5\n",
-    "iv": "nvCeD9LVbZlZCCvo\n",
-    "auth_tag": "hvQw2lQm4k2fmB4AetWFlQ==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "pNORI8wBs5JyS+tL4KGKIQqs+qCYHfsS8Yav1A0SqZyKiV6X8MS5p/YVdiYu\nhdDS\n",
+    "iv": "O/8dYQoaMfBAiUSmHsbOmA==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "SMTP_PASSWORD": {
-    "encrypted_data": "bLtwXo8VsnyvpBxtYGPsfJQHOpDBT5w6xANIO5DNMOzv1k+Q8UcruJX4XgDa\nMQ5VLXLMTAKBvqmJYWWHzsyR\n",
-    "iv": "t7mNz5fqlUCI+U5z\n",
-    "auth_tag": "3hafTD1s5Fn6TEKszrkzOg==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "rGzYnceuiQtydE9JudOL2EruQ6v/92tBzHpY5kTJKx4e5Zg57NV02/j3uGJz\n0pd76ICsIKmr8zklKELEpWE/cg==\n",
+    "iv": "dRm8aNqt8zLVRBwHVJ5oMQ==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "RECAPTCHA_PUBLIC_KEY": {
-    "encrypted_data": "qIpeLKmM8+BNDcNntYNFkoO+WfOpQQ4SrrdyNQOFQGSmHqsUTEp2Kr1Iin1t\nHEyZk0/bORiSQ0aCq7M=\n",
-    "iv": "jS4LurLhw9MtkqJ8\n",
-    "auth_tag": "zd5NoVa6tGVMuXYee5xh5Q==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "+0HUFVKomMzvG8ECf+Sy45HfWlSwQPqQM8qeyeXffzSN13MLXvPfTdWAxWhz\ncxC6ZfZj1jVZB8enYXFCeVQ+0w==\n",
+    "iv": "A0y2AHSXh4iVzqoypKpCsg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "RECAPTCHA_PRIVATE_KEY": {
-    "encrypted_data": "Qz9eknXVHk3WowFMUGc9GYx6ygVtKvJTxCBrdncMlVNiORiyTQBOT4Ge9/fo\n4rZgELctaBMP8ICQvVA=\n",
-    "iv": "0gp/mqHAozyUS/94\n",
-    "auth_tag": "EJ8jzDORs1FcYz/zxH90/w==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "YutYoqImNBT5fqpZbUwnKYdGtMADzxd4ZldXT01vg1vWnDgRrTqz0DDjal1e\n0eRX7uvu80nI1H/aZc1WSFk+Yw==\n",
+    "iv": "xF+SCav+afPLXXwZSjvbeg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "NEW_RELIC_LICENSE_KEY": {
-    "encrypted_data": "vvCbyWxgnZhqXC/fwhKvcfmPAPqZTQyU7HAxwtwlFz4Xq8lv4mdCiXT+lUA2\npJVxjKd4+MYtG/sGiJU=\n",
-    "iv": "Tz0int74BcPdTgzC\n",
-    "auth_tag": "iXSHYmWbq/wVWY67sjiMUg==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "KItH5ko6K70k6J0tIVNLKj8CnPz8owQfsgxL8s0jNodLzfMC0sTMkZybv6G0\n1km3EytMyh0D/Qt/kO6z3s4I0w==\n",
+    "iv": "weE8HNcMIH2UdD+VP7mKvA==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "GOOGLE_MAPS_API_KEY": {
-    "encrypted_data": "0oWTNb3OsTACiDhh19nqbwISP5YM06MPV2e6JTnHJT7MvvbO2vTJ1G5NnccZ\n73wSZocVaJjlyMtIqA==\n",
-    "iv": "X1vyg6N4RuN0D/9b\n",
-    "auth_tag": "nH3CkJYOO4hNLzwhhlLauQ==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "yUAjz2dyCW9naEm+lQQ6H+8Ny98Z7z0t0eVgcRT/QgnqD2Df9z6QttQcI4du\nNDNvg+oFWMU0j0h8BAn9lksYEA==\n",
+    "iv": "pOb68W3ERdMYrB13Ma9cvg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "GITHUB_BACKUP_ACCESS_TOKEN": {
-    "encrypted_data": "jU+qSOlsUlsrTuckcQhAjsseSy4s1LuPNPYkYbqE32JwqguuVgOt8SfG8Eao\nN5RNJuTdyeB8vqOSEFE=\n",
-    "iv": "5lZUZlpevlfm1G8L\n",
-    "auth_tag": "AM4zQs1mdoJtDYXeE0J0QQ==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "BdrZTGgZH4fE4owQT0N2TLslYjaw3QE7PMtV6YyfrJcPl4KOSwMpwiSAZX4f\nMpIqzgEjnzmWs9GzpSLNKoEplw==\n",
+    "iv": "nyYR0CMBqx+f4donpPCTBg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "GITHUB_CREATE_PR_ACCESS_TOKEN": {
-    "encrypted_data": "CUqqt1crRRVdLWyTK79b8t8MEASRZgcPE4sioHmqGzKzcwzp8Blee8C386cZ\ng2ikhzfjaUa7VfJFaPc=\n",
-    "iv": "cX1xyrzGhg0fqVbd\n",
-    "auth_tag": "KELmJBstd0FiZ6TYfUfyug==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "70XlwjAiUV65u8lTqSdZm0m6GC5ZlTMsEYJBUGAOnHDfECNDGELIdcfZA75a\ngLdJnQf4BkjYpHU8qfT6KViZGg==\n",
+    "iv": "8yBqbDDtQzNPrSvgcJIMWg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "GITHUB_LIST_MEMBERS_ACCESS_TOKEN": {
-    "encrypted_data": "dzmOA0yHmVILZWecEd3O8YcqmwNrrgQcI8jFtV6cWGx8AnTXZFMGPFb/LS9v\niedvp59OWHOzj0iZtbg=\n",
-    "iv": "gNIwXjGNe8SUVo68\n",
-    "auth_tag": "BhpzKrOnDlekgTistC7RGA==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "Rjwh1z47rgGbR0TtpSdn4CEKJH+y38pPtP06iVyg4XIWO4270vBvzW4outLO\nqf7C9uJ2F5NWIiKTyDXqty0n7A==\n",
+    "iv": "KCbhqLXs4JssfNXmn+q0Zw==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "STRIPE_API_KEY": {
-    "encrypted_data": "3Io2hhUfc0r3sd7GYODHNAQLiKaPXlJ1GfdP2zx+FYYw2ssiqNFL1DfNBdpC\nJcNFpi59\n",
-    "iv": "wkutj0hLa/aRp5a9\n",
-    "auth_tag": "iqniDdwaggZBBxbkAS2MVQ==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "QLpDER90yKswhUuiqwH1+eDonFa6nDL1+27foTuMYlkOSV6WOZJ+n0JCdt77\n/55dtykTDp/p+sJw636gbiwJHQ==\n",
+    "iv": "+hZvIrU+OQjNfHs58dL+wg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "STRIPE_CLIENT_ID": {
-    "encrypted_data": "iQ5yCg0WQahw9aU8oVbcjz7nxSXK8sAzGB+rylDiFWc+TV/bKDnFqWOBdzjC\nx5Xoi1f69ah5\n",
-    "iv": "OHJN2n38jsYSfSwi\n",
-    "auth_tag": "dWpzG9dizoQQfo9R6vJ97Q==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "6JsZLudk0GQxuAP40UZkQZRuZFEdbAuE4cpphksFFXwCZspTyfd+pRpl/akN\nHMB9aeLmm7FqdctX08Tf92+Q1Q==\n",
+    "iv": "tW/Dul+ui/9YQtDAhxUnRw==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "STRIPE_PUBLISHABLE_KEY": {
-    "encrypted_data": "YLUZ7vrz+Lkb+f1Sybpgrjicuyc8sQVMg2f16Wq4IY5fG5q1yKDxh5odzPUI\nBRze2+Ac\n",
-    "iv": "VFvoJ03f6BCCHTC/\n",
-    "auth_tag": "YVnl2j5D4LlvDzWtIqRkWw==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "jiyBYWSMqtFcsmQfmoQZVRxpKTbtoacKW7G6TbhPK/MVkTQXz6Bk3HmJuQgO\nd+H9fAaX2315825F2JyPNU9W4Q==\n",
+    "iv": "g+oLYIVnrQqqiEu/haWREQ==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "AWS_ACCESS_KEY_ID": {
-    "encrypted_data": "cWeEXoFEVKRwit/BbivWbuDz68okRDyO1s1SvQ/ziwx0baA3m31D\n",
-    "iv": "/cZowOn2hfmAnBo0\n",
-    "auth_tag": "JFlepAjytg4BEgDcjBKpnQ==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "Lher48leXk43m6CQUj70c1Ohyqg93rhSxWJ6BPx0yGT9CEIi9FB2spcHe1ep\nAACb\n",
+    "iv": "XL1KRxoabpS8M5Fc9vZeaQ==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "AWS_SECRET_ACCESS_KEY": {
-    "encrypted_data": "iXi1hq/wCrxp1jVqlwSUsDwwze/lBlZKQugVTxUVAJ7LkVRR1ff6sS/Td8Mg\n3Sss9yNqok8ZGJLgMtk=\n",
-    "iv": "wtD+rM0rWpSizGph\n",
-    "auth_tag": "s5yYZBz8s7ergw2sJQyjCw==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "SNxSS4pGGZeoeJdvSV9V/usMV4E4GgAyLEsFlC6rYp7tKiVfWpDKKWIK440o\nsEUwbK9JvP0+14uwvCrlgQDv8A==\n",
+    "iv": "o/01AkHjapSUZTiTRsS5cA==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "OTP_ENCRYPTION_KEY": {
-    "encrypted_data": "S6TYn+gSHGOitwL77yD9MvkqI4fGPLUZMqlKhsO2LlkAT+REpcEvRKcENGJ5\nsg5drPT/znfOvJluP6/+OTEilD3oTNQYLQ3I+e3zColh7kRjzsd5dXx06iBl\n2fXKf+oxqZmjSLZvwRPGMxuGIuokeJc5/xsAfTqfogWuPjB+UEWqKzcbehtn\n7mTbZZsudMiQuDLx\n",
-    "iv": "TGONhXjnu6htrAns\n",
-    "auth_tag": "D5O0q8g1XYHj1/ksvfiVzg==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "RtB1isMlO3ewq/NWyHtRaom1M6gLYsXoP4U6Uq/Bl2BlSeoiz+oekw+FSfQc\nPJBznOwl2bHaHcCwuV77QQibOKfmLDP+kIVi4w2edd3PWLHj5I5AR6UFoSYq\n5UxwCmZ63o2itRvlgE+0OVz9/DkOm2pC3+oqshlD1DgFI1yQz7qNN1kE8by7\nzZqH1N63VOG7kOR71I/5SIBJq3HMCJijzQ==\n",
+    "iv": "+aN7bm2UrUzmbqilnyHUDg==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   },
   "DISCOURSE_SECRET": {
-    "encrypted_data": "JEmRSO05mr7z45tv7rycU4aqvilnH1k5wiFfVw9zuPGl6J5oWeho1oAsnlQ8\novKyKk9k4E1oZz/uX1TixRReQ8pbIOQbEniWyfoUNAPgCuzNSymwmkbKydbt\nV6kk09L9B31OoYCHrSFprOrSPEPnuqyCiLal3KKjVPtm+jichsLWOekmjDOn\nVq0EVVgwAq/p3rNg\n",
-    "iv": "JGMegxBKfhaeVUne\n",
-    "auth_tag": "kbJFwqRdDYnuhyh2NRM9kA==\n",
-    "version": 3,
-    "cipher": "aes-256-gcm"
+    "encrypted_data": "WxPn3FHvNH+IU76GzX9DL9yVuSWQqcAG/ZXJO0diqTNuTTCn51kasPDX1MI+\nh6R/veF1dRA+lwArNObEiX1wrQ5XFtUgLeaSuz2DGkQVilsxtR4x6CurtoNG\nEpMtN8BUC5Wtx5SEdTrjA3pcDeifVGASFiNw2XXYM1OUvWSkGw4hHwJ6eMlr\nfbpvK9xsNu8fiD45hxLdzIy7jzWIyQHt0A==\n",
+    "iv": "S4PfDWWPf9Q5JqJQE8XVdA==\n",
+    "version": 1,
+    "cipher": "aes-256-cbc"
   }
 }


### PR DESCRIPTION
Due to the deprecation of the SIGV2 Algorithm we needed to regenerate the SMTP credentials. 