### PR TITLE
Include August 2020 Regulations in the History tab

### DIFF
--- a/WcaOnRails/app/views/regulations/history/index.html.erb
+++ b/WcaOnRails/app/views/regulations/history/index.html.erb
@@ -5,7 +5,8 @@
   <p>Until 2011, the Regulations were maintained by Ron van Bruchem and the WCA Board. Since then, the <%= mail_to "wrc@worldcubeassociation.org", "WCA Regulations Committee" %> is in charge of them.<br />For the 2013 release, the Regulations were split into two documents: the Regulations and the Guidelines.</p>
   <p>Here are all past and current versions of the Regulations.</p>
   <ul>
-    <li><%= link_to "2020-08-01", "https://www.worldcubeassociation.org/regulations/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-01-01...official-2020-08-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-august-2020" %>)
+    <li><%= link_to "2021-05-01", "https://www.worldcubeassociation.org/regulations/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-08-01...official-2021-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2020" %>)</li>
+    <li><%= link_to "2020-08-01", "./official/2020-08-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-01-01...official-2020-08-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-august-2020" %>)
       <ul>
         <li><%= link_to "2020-01-01", "./official/2020-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2019-05-01...official-2020-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2020" %>)</li>
       </ul>


### PR DESCRIPTION
⚠️ Don't merge these changes until the new version of the WCA Regulations and Guidelines is released.