### PR TITLE
Move webpack-cli to prod dependency to satisfy new webpacker release

### DIFF
--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -14,8 +14,8 @@
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.14.2",
     "@babel/preset-react": "^7.13.13",
-    "@rails/ujs": "^6.1.3",
     "@cubing/icons": "^1.0.4",
+    "@rails/ujs": "^6.1.3",
     "@rails/webpacker": "5.4.0",
     "autonumeric": "^4.6.0",
     "autoprefixer": "^9.8.6",
@@ -55,6 +55,7 @@
     "semantic-ui-react": "^2.0.3",
     "style-loader": "^2.0.0",
     "webpack": "^4.44.2",
+    "webpack-cli": "^4.7.0",
     "webpack-manifest-plugin": "^3.1.1",
     "webpack-merge": "^5.7.3",
     "whatwg-fetch": "^3.6.2"
@@ -72,7 +73,6 @@
     "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-scss": "^3.19.0",
     "webpack-bundle-analyzer": "^4.4.2",
-    "webpack-cli": "^4.7.0",
     "webpack-dev-server": "^3.11.2"
   },
   "scripts": {


### PR DESCRIPTION
Otherwise it breaks as per https://github.com/rails/webpacker/issues/1561