### PR TITLE
Enforce consistent test language headers across OSes

### DIFF
--- a/WcaOnRails/spec/rails_helper.rb
+++ b/WcaOnRails/spec/rails_helper.rb
@@ -47,6 +47,14 @@ Capybara.javascript_driver = :poltergeist
 Capybara.server = :webrick
 
 RSpec.configure do |config|
+  # enforce consistent locale behaviour across OSes, especially Linux
+  # see https://github.com/ariya/phantomjs/issues/13166 to understand why this is necessaryqq
+  config.before(:each) do
+    if defined? page.driver.add_header
+      page.driver.add_header("Accept-Language", "en-US", permanent: true)
+    end
+  end
+
   # We're using database_cleaner instead of rspec-rails's implicit wrapping of
   # tests in database transactions.
   # See http://devblog.avdi.org/2012/08/31/configuring-database_cleaner-with-rails-rspec-capybara-and-selenium/


### PR DESCRIPTION
Our driver internally uses PhantomJS as a "browser", which in turn is implemented on top of `Qt` network code.
This network code behaves differently on different OSes, causing test failures on Linux if the user is on a non-English locale but we assume English text to have Capybara click buttons and stuff.

The only alternative I can see would be to i18nize all of the test code, which is too much work right now. This is a more consistent solution in my opinion.