### PR TITLE
Expose all competitions attended for person in API

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/persons_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/persons_controller.rb
@@ -16,7 +16,7 @@ class Api::V0::PersonsController < Api::V0::ApiController
 
   def show
     person = Person.current.includes(:user, :ranksSingle, :ranksAverage).find_by_wca_id!(params[:wca_id])
-    render json: person_to_json(person)
+    render json: person_to_json(person, params["competitions"] == "true")
   end
 
   def results
@@ -24,8 +24,8 @@ class Api::V0::PersonsController < Api::V0::ApiController
     render json: person.results
   end
 
-  private def person_to_json(person)
-    {
+  private def person_to_json(person, show_competitions)
+    person_json = {
       person: person.serializable_hash.slice(:wca_id, :name, :url, :gender, :country_iso2, :delegate_status, :teams, :avatar),
       competition_count: person.competitions.count,
       personal_records: person.ranksSingle.each_with_object({}) do |rank_single, ranks|
@@ -37,6 +37,10 @@ class Api::V0::PersonsController < Api::V0::ApiController
       medals: person.medals,
       records: person.records,
     }
+    if show_competitions == true
+      person_json["competitions"] = person.competitions
+    end
+    return person_json
   end
 
   private def rank_to_json(rank)

--- a/WcaOnRails/app/controllers/api/v0/persons_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/persons_controller.rb
@@ -40,7 +40,7 @@ class Api::V0::PersonsController < Api::V0::ApiController
     if show_competitions == true
       person_json["competitions"] = person.competitions
     end
-    return person_json
+    person_json
   end
 
   private def rank_to_json(rank)


### PR DESCRIPTION
Closes #4864

With this PR an API req like `http://worldcubeassociation.org/api/v0/persons/2014GROV01?competitions=true` will expose all competitions for the person.

I was also trying to expose it in the `/users` controller, but could not figure out how to. [Here's](https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/app/controllers/api/v0/api_controller.rb#L119) where I was trying to add it - simply showing accepted registrations was not matching up with competition counts (it was undercounting) but I couldn't figure out why. Any help with this is appreciated, but if not this PR should be good since at least its exposed somewhere.
