### PR TITLE
Install WCA Regulations compiler via Python3

### DIFF
--- a/chef/site-cookbooks/wca/recipes/regulations.rb
+++ b/chef/site-cookbooks/wca/recipes/regulations.rb
@@ -2,7 +2,7 @@ username, repo_root = WcaHelper.get_username_and_repo_root(self)
 
 #### Regulations dependencies
 package "git"
-package "python-pip"
+package "python3-pip"
 package "fonts-unfonts-core"
 package "fonts-wqy-microhei"
 package "fonts-ipafont"
@@ -19,7 +19,7 @@ bash "install_wkhtmltopdf" do
   EOH
 end
 
-execute "pip install wrc --upgrade"
+execute "pip3 install wrc --upgrade"
 
 execute "#{repo_root}/scripts/deploy.sh rebuild_regs" do
   user username


### PR DESCRIPTION
Tested on staging. Artifact is available at https://pypi.org/project/wrc/1.3.1/