### PR TITLE
Add tooltips to explain table headers

### DIFF
--- a/WcaOnRails/app/views/persons/_personal_records.html.erb
+++ b/WcaOnRails/app/views/persons/_personal_records.html.erb
@@ -5,14 +5,14 @@
       <thead>
         <tr>
           <th class="event"><%= t 'competitions.results_table.event' %></th>
-          <th class="country-rank"><abbr title="National rank">NR</abbr></th>
-          <th class="continent-rank"><abbr title="Continent rank">CR</abbr></th>
-          <th class="world-rank"><abbr title="World rank">WR</abbr></th>
+          <th class="country-rank"><abbr title="<%= t 'competitions.results_table.rank.national' %>">NR</abbr></th>
+          <th class="continent-rank"><abbr title="<%= t 'competitions.results_table.rank.continent' %>">CR</abbr></th>
+          <th class="world-rank"><abbr title="<%= t 'competitions.results_table.rank.world' %>">WR</abbr></th>
           <th class="single"><%= t 'common.single' %></th>
           <th class="average"><%= t 'common.average' %></th>
-          <th class="world-rank"><abbr title="World rank">WR</abbr></th>
-          <th class="continent-rank"><abbr title="Continent rank">CR</abbr></th>
-          <th class="country-rank"><abbr title="National rank">NR</abbr></th>
+          <th class="world-rank"><abbr title="<%= t 'competitions.results_table.rank.world' %>">WR</abbr></th>
+          <th class="continent-rank"><abbr title="<%= t 'competitions.results_table.rank.continent' %>">CR</abbr></th>
+          <th class="country-rank"><abbr title="<%= t 'competitions.results_table.rank.national' %>">NR</abbr></th>
           <th></th><!-- Place for the odd message -->
         </tr>
       </thead>

--- a/WcaOnRails/app/views/persons/_personal_records.html.erb
+++ b/WcaOnRails/app/views/persons/_personal_records.html.erb
@@ -5,14 +5,14 @@
       <thead>
         <tr>
           <th class="event"><%= t 'competitions.results_table.event' %></th>
-          <th class="country-rank">NR</th>
-          <th class="continent-rank">CR</th>
-          <th class="world-rank">WR</th>
+          <th class="country-rank"><abbr title="Country rank">NR</abbr></th>
+          <th class="continent-rank"><abbr title="Continent rank">CR</abbr></th>
+          <th class="world-rank"><abbr title="World rank">WR</abbr></th>
           <th class="single"><%= t 'common.single' %></th>
           <th class="average"><%= t 'common.average' %></th>
-          <th class="world-rank">WR</th>
-          <th class="continent-rank">CR</th>
-          <th class="country-rank">NR</th>
+          <th class="world-rank"><abbr title="World rank">WR</abbr></th>
+          <th class="continent-rank"><abbr title="Continent rank">CR</abbr></th>
+          <th class="country-rank"><abbr title="Country rank">NR</abbr></th>
           <th></th><!-- Place for the odd message -->
         </tr>
       </thead>

--- a/WcaOnRails/app/views/persons/_personal_records.html.erb
+++ b/WcaOnRails/app/views/persons/_personal_records.html.erb
@@ -5,14 +5,14 @@
       <thead>
         <tr>
           <th class="event"><%= t 'competitions.results_table.event' %></th>
-          <th class="country-rank"><abbr title="Country rank">NR</abbr></th>
+          <th class="country-rank"><abbr title="National rank">NR</abbr></th>
           <th class="continent-rank"><abbr title="Continent rank">CR</abbr></th>
           <th class="world-rank"><abbr title="World rank">WR</abbr></th>
           <th class="single"><%= t 'common.single' %></th>
           <th class="average"><%= t 'common.average' %></th>
           <th class="world-rank"><abbr title="World rank">WR</abbr></th>
           <th class="continent-rank"><abbr title="Continent rank">CR</abbr></th>
-          <th class="country-rank"><abbr title="Country rank">NR</abbr></th>
+          <th class="country-rank"><abbr title="National rank">NR</abbr></th>
           <th></th><!-- Place for the odd message -->
         </tr>
       </thead>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1591,7 +1591,7 @@ en:
       name: "Name"
       rank:
         national: "National rank"
-        continent: "Continent rank"
+        continent: "Continental rank"
         world: "World rank"
     scrambles_table:
       group: "Group"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1589,6 +1589,10 @@ en:
       event: "Event"
       round: "Round"
       name: "Name"
+      rank:
+        national: "National rank"
+        continent: "Continent rank"
+        world: "World rank"
     scrambles_table:
       group: "Group"
       scramble: "Scramble"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1590,9 +1590,9 @@ en:
       round: "Round"
       name: "Name"
       rank:
-        national: "National rank"
-        continent: "Continental rank"
-        world: "World rank"
+        national: "National Rank"
+        continent: "Continental Rank"
+        world: "World Rank"
     scrambles_table:
       group: "Group"
       scramble: "Scramble"


### PR DESCRIPTION
As a beginner I didn’t know what the table headers meant, so I had to dig the source for an explanation. This commit adds `<abbr>` tags so others don’t have to. The stylesheet is already configured to show these unobtrusively (Firefox 89):

![screenshot](https://user-images.githubusercontent.com/3020161/121150278-a87c1400-c843-11eb-8c2c-b641dde4ac9d.png)
