### PR TITLE
Competition templates

### DIFF
--- a/WcaOnRails/app/views/static_pages/education.html.erb
+++ b/WcaOnRails/app/views/static_pages/education.html.erb
@@ -10,6 +10,10 @@
       <%= ui_icon("file alt") %>
       <%= t('education.competitor_tutorial') %>
     <% end %>
+    <%= link_to "/edudoc/competition-templates/README.pdf", class: "list-group-item" do %>
+      <%= ui_icon("file alt") %>
+      <%= t('education.competition_templates') %>
+    <% end %>
     <%= link_to "https://drive.google.com/drive/folders/1jrMWgOgNscPDqoxzgnEQ1bnV9D4FDzLj", class: "list-group-item" do %>
       <%= ui_icon("copy") %>
       <%= t('education.certificates') %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1952,6 +1952,7 @@ en:
     title: "WCA Educational Documents"
     description: "The WQAC has published several documents for the community, you can download them below."
     competitor_tutorial: "Competitor tutorial"
+    competition_templates: "Competition templates"
     certificates: "WCT's certificate templates"
     orga_guidelines: "Organizer guidelines"
   #context: Delegates page


### PR DESCRIPTION
This adds a link to the competition templates project on the education resources page.
See https://github.com/thewca/wca-documents/pull/239