### PR TITLE
Add support for qualifications.

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -27,10 +27,6 @@ onPage('competitions#edit, competitions#update, competitions#admin_edit, competi
     $('.competition_early_puzzle_submission_reason').toggle(this.checked);
   }).trigger('change');
 
-  $('input[name="competition[qualification_results]"]').on('change', function() {
-    $('.competition_qualification_results_reason').toggle(this.checked);
-  }).trigger('change');
-
   $('input[name="competition[event_restrictions]"]').on('change', function() {
     $('.competition_event_restrictions_reason').toggle(this.checked);
   }).trigger('change');

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -621,7 +621,6 @@ class CompetitionsController < ApplicationController
         :refund_policy_limit_date,
         :early_puzzle_submission,
         :early_puzzle_submission_reason,
-        :qualification_results,
         :qualification_results_reason,
         :event_restrictions,
         :event_restrictions_reason,

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -195,7 +195,7 @@ class Competition < ApplicationRecord
            allow_nil: true,
            with_model_currency: :currency_code
   validates :early_puzzle_submission_reason, presence: true, if: :early_puzzle_submission?
-  validates :qualification_results_reason, presence: true, if: :qualification_results?
+  validates :qualification_results_reason, presence: true, if: :persisted_uses_qualification?
   validates :event_restrictions_reason, presence: true, if: :event_restrictions?
   validates_inclusion_of :main_event_id, in: ->(comp) { [nil].concat(comp.persisted_events_id) }
 
@@ -204,6 +204,12 @@ class Competition < ApplicationRecord
   def persisted_events_id
     with_old_id do
       self.competition_events.map(&:event_id)
+    end
+  end
+
+  def persisted_uses_qualification?
+    with_old_id do
+      self.uses_qualification?
     end
   end
 
@@ -1208,6 +1214,14 @@ class Competition < ApplicationRecord
     competition_events.any? { |ce| ce.rounds.any? { |r| r.time_limit.cumulative_round_ids.size > 1 } }
   end
 
+  def uses_qualification?
+    competition_events.any?(&:qualification)
+  end
+
+  def qualification_date_to_events
+    competition_events.select(&:qualification).group_by { |e| e.qualification.when_date }
+  end
+
   # The name `is_probably_over` is meant to be surprising.
   # We don't actually know when competitions are over, because we don't know their schedules, nor
   # do we know their timezones.
@@ -1567,6 +1581,7 @@ class Competition < ApplicationRecord
           raise WcaExceptions::BadApiParameter.new("Cannot update events")
         end
         competition_events.find_by_event_id!(wcif_event["id"]).load_wcif!(wcif_event)
+        competition_events.find_by_event_id!(wcif_event["id"]).save
       end
     end
 

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1581,7 +1581,6 @@ class Competition < ApplicationRecord
           raise WcaExceptions::BadApiParameter.new("Cannot update events")
         end
         competition_events.find_by_event_id!(wcif_event["id"]).load_wcif!(wcif_event)
-        competition_events.find_by_event_id!(wcif_event["id"]).save
       end
     end
 

--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -66,9 +66,9 @@ class CompetitionEvent < ApplicationRecord
     end
     self.rounds = new_rounds
     WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
-    self
     self.qualification = Qualification.load(wcif["qualification"])
     self.save
+    self
   end
 
   def self.wcif_json_schema

--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -14,6 +14,9 @@ class CompetitionEvent < ApplicationRecord
            as: "fee",
            with_model_currency: :currency_code
 
+  serialize :qualification, Qualification
+  validates_associated :qualification
+
   validate do
     remaining_rounds = rounds.reject(&:marked_for_destruction?)
     numbers = remaining_rounds.map(&:number).sort
@@ -34,11 +37,16 @@ class CompetitionEvent < ApplicationRecord
     Event.c_find(event_id)
   end
 
+  def qualification_to_s
+    qualification&.to_s(self)
+  end
+
   def to_wcif
     {
       "id" => self.event.id,
       "rounds" => self.rounds.map(&:to_wcif),
       "extensions" => wcif_extensions.map(&:to_wcif),
+      "qualification" => qualification&.to_wcif,
     }
   end
 
@@ -59,6 +67,8 @@ class CompetitionEvent < ApplicationRecord
     self.rounds = new_rounds
     WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     self
+    self.qualification = Qualification.load(wcif["qualification"])
+    self.save
   end
 
   def self.wcif_json_schema
@@ -68,7 +78,7 @@ class CompetitionEvent < ApplicationRecord
         "id" => { "type" => "string" },
         "rounds" => { "type" => ["array", "null"], "items" => Round.wcif_json_schema },
         "competitorLimit" => { "type" => ["integer", "null"] },
-        "qualification" => { "type" => ["object", "null"] }, # TODO: expand on this
+        "qualification" => Qualification.wcif_json_schema,
         "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
     }

--- a/WcaOnRails/app/models/competition_event.rb
+++ b/WcaOnRails/app/models/competition_event.rb
@@ -67,7 +67,7 @@ class CompetitionEvent < ApplicationRecord
     self.rounds = new_rounds
     WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     self.qualification = Qualification.load(wcif["qualification"])
-    self.save
+    self.update!({ "qualification" => self.qualification })
     self
   end
 

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -306,11 +306,10 @@
         <%= f.input :extra_registration_requirements, input_html: { class: disable_form ? "" : "markdown-editor" } %>
 
         <hr>
+        <%= f.input :qualification_results_reason %>
+
         <%= f.input :early_puzzle_submission %>
         <%= f.input :early_puzzle_submission_reason %>
-
-        <%= f.input :qualification_results %>
-        <%= f.input :qualification_results_reason %>
 
         <%= f.input :event_restrictions %>
         <%= f.input :event_restrictions_reason %>

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -306,7 +306,9 @@
         <%= f.input :extra_registration_requirements, input_html: { class: disable_form ? "" : "markdown-editor" } %>
 
         <hr>
-        <%= f.input :qualification_results_reason %>
+        <% if @competition.uses_qualification? %>
+          <%= f.input :qualification_results_reason %>
+        <% end %>
 
         <%= f.input :early_puzzle_submission %>
         <%= f.input :early_puzzle_submission_reason %>

--- a/WcaOnRails/app/views/competitions/_events_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_events_tab.html.erb
@@ -9,6 +9,9 @@
         <th><%= link_to t("competitions.events.cutoff"), "#cutoff" %></th>
       <% end %>
       <th><%= t("competitions.events.proceed") %></th>
+      <% if @competition.uses_qualification? %>
+        <th><%= link_to t("competitions.events.qualification"), "#qualification" %></th>
+      <% end %>
     </tr>
   <thead>
 
@@ -37,6 +40,13 @@
             <td><%= round.cutoff_to_s %></td>
           <% end %>
           <td><%= round.advancement_condition_to_s %></td>
+          <% if @competition.uses_qualification? %>
+            <% if round.number == 1 %>
+              <td><%= competition_event.qualification_to_s %></td>
+            <% else %>
+              <td></td>
+            <% end %>
+          <% end %>
         </tr>
       <% end %>
     <% end %>

--- a/WcaOnRails/app/views/competitions/_time_limit_cutoff_format_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_time_limit_cutoff_format_info.html.erb
@@ -38,18 +38,21 @@
           link_to_9b: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9b"), regulations_path + "#9b", target: "_blank"),
           link_to_9f: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9f"), regulations_path + "#9f", target: "_blank")) %>
   </p>
-  <h4 id="qualification"><%= t("competitions.events.qualification") %></h4>
-  <p>
-    <%= t("competitions.events.time_limit_information.qualification_html") %>
-    <% date_to_events = competition.qualification_date_to_events %>
-    <% if (date_to_events.length() > 1) %>
-      <% date_to_events.each do |date, events| %>
-        <%= t("competitions.events.time_limit_information.qualification_some_events_html",
-              date: wca_date_range(date, date), events: events.map{ |e| e.event.name }.join(", ")) %>
+
+  <% if show_qualifications %>
+    <h4 id="qualification"><%= t("competitions.events.qualification") %></h4>
+    <p>
+      <%= t("competitions.events.time_limit_information.qualification_html") %>
+      <% date_to_events = competition.qualification_date_to_events %>
+      <% if (date_to_events.length() > 1) %>
+        <% date_to_events.each do |date, events| %>
+          <%= t("competitions.events.time_limit_information.qualification_some_events_html",
+                date: wca_date_range(date, date), events: events.map{ |e| e.event.name }.join(", ")) %>
+        <% end %>
+      <% else %>
+        <%= t("competitions.events.time_limit_information.qualification_all_events_html",
+              date: wca_date_range(date_to_events.keys.first, date_to_events.keys.first)) %>
       <% end %>
-    <% else %>
-      <%= t("competitions.events.time_limit_information.qualification_all_events_html",
-            date: wca_date_range(date_to_events.keys.first, date_to_events.keys.first)) %>
-    <% end %>
-  </p>
+    </p>
+  <% end %>
 </div>

--- a/WcaOnRails/app/views/competitions/_time_limit_cutoff_format_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_time_limit_cutoff_format_info.html.erb
@@ -2,6 +2,7 @@
   show_cumulative_one_round = competition.uses_cumulative?
   show_cumulative_across_rounds = competition.uses_cumulative_across_rounds?
   show_cutoff = competition.uses_cutoff?
+  show_qualifications = competition.uses_qualification?
 %>
 <div class="time-limit-information">
   <h4 id="time-limit"><%= t("competitions.events.time_limit") %></h4>
@@ -36,5 +37,19 @@
     <%= t("competitions.events.time_limit_information.format_html",
           link_to_9b: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9b"), regulations_path + "#9b", target: "_blank"),
           link_to_9f: link_to(t("competitions.events.time_limit_information.regulation_link_text", number: "9f"), regulations_path + "#9f", target: "_blank")) %>
+  </p>
+  <h4 id="qualification"><%= t("competitions.events.qualification") %></h4>
+  <p>
+    <%= t("competitions.events.time_limit_information.qualification_html") %>
+    <% date_to_events = competition.qualification_date_to_events %>
+    <% if (date_to_events.length() > 1) %>
+      <% date_to_events.each do |date, events| %>
+        <%= t("competitions.events.time_limit_information.qualification_some_events_html",
+              date: wca_date_range(date, date), events: events.map{ |e| e.event.name }.join(", ")) %>
+      <% end %>
+    <% else %>
+      <%= t("competitions.events.time_limit_information.qualification_all_events_html",
+            date: wca_date_range(date_to_events.keys.first, date_to_events.keys.first)) %>
+    <% end %>
   </p>
 </div>

--- a/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
@@ -68,7 +68,7 @@
     <br>
   <% end %>
 
-  <% if @competition.qualification_results? %>
+  <% if @competition.uses_qualification? %>
     The <%= "Delegate".pluralize(@competition.all_delegates.count) %> requested the adoption of <b>qualification results</b> because "<%= @competition.qualification_results_reason %>".
   <% end %>
 

--- a/WcaOnRails/app/webpacker/components/EditEvents/AttemptResultInput.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/AttemptResultInput.js
@@ -74,7 +74,11 @@ export default class AttemptResultInput extends React.Component {
     if(event.isTimedEvent) {
       return this.centisecondsInput.value;
     } else if(event.isFewestMoves) {
-      return parseInt(this.movesInput.value);
+      if (this.props.isAverage) {
+        return Math.round(parseFloat(this.movesInput.value) * 100);
+      } else {
+        return parseInt(this.movesInput.value);
+      }
     } else if(event.isMultipleBlindfolded) {
       return mbPointsToAttemptResult(parseInt(this.mbldPointsInput.value));
     } else {
@@ -83,7 +87,7 @@ export default class AttemptResultInput extends React.Component {
   }
 
   render() {
-    let { id, autoFocus } = this.props;
+    let { id, autoFocus, isAverage } = this.props;
     let event = events.byId[this.props.eventId];
 
     if(event.isTimedEvent) {
@@ -94,14 +98,16 @@ export default class AttemptResultInput extends React.Component {
                                 ref={c => this.centisecondsInput = c}
       />;
     } else if(event.isFewestMoves) {
+      let value = isAverage ? this.props.value / 100 : this.props.value;
       return (
         <div>
           <input type="number"
                  min={1} max={MAX_FMC_SOLUTION_LENGTH}
+                 step={isAverage ? 0.01 : 1}
                  id={id}
                  className="form-control"
                  autoFocus={autoFocus}
-                 value={this.props.value}
+                 value={value}
                  ref={c => this.movesInput = c}
                  onChange={this.onChange} />
           moves

--- a/WcaOnRails/app/webpacker/components/EditEvents/EditRoundAttribute.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EditRoundAttribute.js
@@ -13,11 +13,16 @@ import CutoffComponents from './Cutoff'
 import TimeLimitComponents from './TimeLimit'
 import AdvancementConditionComponents from './AdvancementCondition'
 import ButtonActivatedModal from './ButtonActivatedModal'
+import QualificationComponents from './Qualification'
 
 let RoundAttributeComponents = {
   timeLimit: TimeLimitComponents,
   cutoff: CutoffComponents,
   advancementCondition: AdvancementConditionComponents,
+};
+
+let EventAttributeComponents = {
+  qualification: QualificationComponents,
 };
 
 /**
@@ -147,4 +152,71 @@ export function EditCutoffButton(props) {
 
 export function EditAdvancementConditionButton(props) {
   return <EditRoundAttribute {...props} attribute="advancementCondition" />;
+};
+
+class EditEventAttribute extends React.Component {
+  UNSAFE_componentWillMount() {
+    this.reset();
+  }
+
+  UNSAFE_componentWillReceiveProps() {
+    this.reset();
+  }
+
+  getSavedValue() {
+    let { wcifEvent, attribute } = this.props;
+    return wcifEvent[attribute];
+  }
+
+  hasUnsavedChanges = () => {
+    return !_.isEqual(this.getSavedValue(), this.state.value);
+  }
+
+  onChange = (value) => {
+    this.setState({ value });
+  }
+
+  onOk = () => {
+    let { wcifEvent, attribute } = this.props;
+    wcifEvent[attribute] = this.state.value;
+
+    this._modal.close({ skipUnsavedChangesCheck: true });
+    rootRender();
+  }
+
+  reset = () => {
+    this.setState({ value: this.getSavedValue() });
+  }
+
+  render() {
+    let { wcifEvent, attribute, disabled } = this.props;
+    let Show = EventAttributeComponents[attribute].Show;
+    let Input = EventAttributeComponents[attribute].Input;
+    let Title = EventAttributeComponents[attribute].Title;
+
+    return (
+      <ButtonActivatedModal
+        buttonValue={<Show value={this.getSavedValue()} wcifEvent={wcifEvent} />}
+        name={attribute}
+        buttonClass="btn-default btn-xs"
+        formClass="form-horizontal"
+        onOk={this.onOk}
+        reset={this.reset}
+        hasUnsavedChanges={this.hasUnsavedChanges}
+        ref={c => this._modal = c}
+        disabled={disabled}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title><Title wcifEvent={wcifEvent} /></Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Input value={this.state.value} wcifEvent={wcifEvent} onChange={this.onChange} autoFocus />
+        </Modal.Body>
+      </ButtonActivatedModal>
+    );
+  }
+}
+
+export function EditQualificationButton(props) {
+  return <EditEventAttribute {...props} attribute="qualification" />;
 };

--- a/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
@@ -1,52 +1,18 @@
 import React from 'react'
 
-import events from '../../wca/events.js.erb'
-import formats from '../../wca/formats.js.erb'
-import AttemptResultInput from './AttemptResultInput'
-import DatePicker from "react-datepicker";
+import events from '../../lib/wca-data/events.js.erb';
+import formats from '../../lib/wca-data/formats.js.erb';
+import AttemptResultInput from './AttemptResultInput';
+import DatePicker from 'react-datepicker';
 
-import {
-  pluralize,
-  matchResult,
-  attemptResultToString,
-} from './utils'
-import {
-  roundIdToString,
-  parseActivityCode,
-} from '../../wca/wcif-utils'
+import { eventQualificationToString } from '../../lib/utils/wcif';
+import I18n from '../../lib/i18n';
 
-import "react-datepicker/dist/react-datepicker.css";
-
-function toUTCDate(dateString) {
-  if (!dateString) {
-    return null;
-  }
-  let date = new Date(dateString);
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-}
-
-function eventQualificationToString(wcifEvent, qualification, { short } = {}) {
-  if (!qualification) {
-    return "-";
-  }
-  let dateString = "-";
-  if (qualification.whenDate) {
-    let whenDate = moment(qualification.whenDate).toDate();
-    dateString = whenDate.toISOString().substring(0, 10);
-  }
-  switch (qualification.type) {
-    case "ranking":
-      return `Top ${qualification.level} competitors by ${dateString}`;
-    case "single":
-      return `Single of ${attemptResultToString(qualification.level, wcifEvent.id, short)} by ${dateString}`;
-    case "average":
-      return `Average of ${attemptResultToString(qualification.level, wcifEvent.id, short)} by ${dateString}`;
-  }
-}
+import 'react-datepicker/dist/react-datepicker.css';
 
 export default {
   Title({ wcifEvent }) {
-    return <span>Qualification for {wcifEvent.id}</span>;
+    return <span>{ I18n.t('qualification.for_event', {event: wcifEvent.id}) }</span>;
   },
   Show({ value: cutoff, wcifEvent }) {
     return <span>{eventQualificationToString(wcifEvent, wcifEvent.qualification, { short: true })}</span>;
@@ -92,7 +58,7 @@ export default {
     let qualificationType = qualification ? qualification.type : "";
     switch(qualificationType) {
       case "ranking":
-        valueLabel = "Top N";
+        valueLabel = I18n.t('qualification.ranking_short');
         qualificationInput = (
           <input type="number"
                  id="qualification-number-value"
@@ -104,7 +70,7 @@ export default {
         );
         break;
       case "single":
-        valueLabel = "Single";
+        valueLabel = I18n.t('common.single');
         qualificationInput = (
           <AttemptResultInput eventId={wcifEvent.id}
                               id="qualification-single-value"
@@ -114,7 +80,7 @@ export default {
         );
         break;
       case "average":
-        valueLabel = "Average";
+        valueLabel = I18n.t('common.average');
         qualificationInput = (
           <AttemptResultInput eventId={wcifEvent.id}
                               id="qualification-average-value"
@@ -128,7 +94,7 @@ export default {
     let whenDateBlock = qualificationInput ? (
       <div className="form-group">
         <label htmlFor="whenDate-input" className="col-sm-3 control-label">
-          Qualification Deadline
+          { I18n.t('qualification.deadline.description') }
         </label>
         <div className="col-sm-9">
           <DatePicker name="whenDate"
@@ -144,7 +110,7 @@ export default {
     return (
       <div>
         <div className="form-group">
-          <label htmlFor="qualification-type-input" className="col-sm-3 control-label">Qualification Type</label>
+          <label htmlFor="qualification-type-input" className="col-sm-3 control-label">{ I18n.t('qualification.type_label' )}</label>
           <div className="col-sm-9">
             <div className="input-group">
               <select value={qualificationType}
@@ -155,10 +121,10 @@ export default {
                       id="qualification-type-input"
                       ref={c => qualificationTypeInput = c}
               >
-                <option value="none">No qualification</option>
-                <option value="ranking">Top N competitors</option>
-                <option value="single">Single</option>
-                <option value="average">Average</option>
+                <option value="none">{ I18n.t('qualification.none') }</option>
+                <option value="ranking">{ I18n.t('qualification.ranking_short') }</option>
+                <option value="single">{ I18n.t('common.single') }</option>
+                <option value="average">{ I18n.t('common.average') }</option>
               </select>
             </div>
           </div>

--- a/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
@@ -32,6 +32,7 @@ export default {
         }
         if (qualificationMethodInput) {
           let method = qualificationMethodInput.value;
+          newQualification.method = method;
           if (method == "ranking") {
             newQualification.level = rankingInput ? parseInt(rankingInput.value) : 0;
           } else if (type == "single") {
@@ -43,6 +44,7 @@ export default {
           newQualification.level = 0;
         }
       }
+      console.log(newQualification);
       onChange(newQualification);
     };
 
@@ -75,6 +77,7 @@ export default {
                             id="qualification-single-value"
                             value={qualification.level}
                             onChange={onChangeAggregator}
+                            isAverage={false}
                             ref={c => singleInput = c} />
       );
     } else if (qualificationType == "average") {
@@ -84,6 +87,7 @@ export default {
                             id="qualification-average-value"
                             value={qualification.level}
                             onChange={onChangeAggregator}
+                            isAverage={true}
                             ref={c => averageInput = c} />
       );
     }

--- a/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
@@ -19,25 +19,27 @@ export default {
     return <span>{eventQualificationToString(wcifEvent, wcifEvent.qualification, { short: true })}</span>;
   },
   Input({ value: qualification, onChange, autoFocus, wcifEvent }) {
-    let qualificationTypeInput, qualificationMethodInput, rankingInput, singleInput, averageInput, whenDateInput;
+    let qualificationResultTypeInput, qualificationTypeInput, rankingInput, singleInput, averageInput, whenDateInput;
 
     let onChangeAggregator = () => {
-      let type = qualificationTypeInput.value;
+      let resultType = qualificationResultTypeInput.value;
       let newQualification = null;
-      if (type != "none") {
-        newQualification = { type };
+      if (resultType != "none") {
+        newQualification = { resultType };
         if (qualification) {
           // Copy the deadline from the previous Qualification, or default to today.
           newQualification.whenDate = qualification.whenDate || moment(new Date()).format("YYYY-MM-DD");
         }
-        if (qualificationMethodInput) {
-          let method = qualificationMethodInput.value;
-          newQualification.method = method;
-          if (method == "ranking") {
+        if (qualificationTypeInput) {
+          let type = qualificationTypeInput.value;
+          newQualification.type = type;
+          if (type == "ranking") {
             newQualification.level = rankingInput ? parseInt(rankingInput.value) : 0;
-          } else if (type == "single") {
+          } else if (type == "anyResult") {
+            newQualification.level = null;
+          } else if (resultType == "single") {
             newQualification.level = singleInput ? parseInt(singleInput.value) : 0;
-          } else if (type == "average") {
+          } else if (resultType == "average") {
             newQualification.level = averageInput ? parseInt(averageInput.value) : 0;
           }
         } else {
@@ -56,11 +58,11 @@ export default {
 
     let valueLabel, qualificationInput;
     let helpBlock = qualification ? eventQualificationToString(wcifEvent, qualification) : null;
+    let qualificationResultType = qualification ? qualification.resultType : "";
     let qualificationType = qualification ? qualification.type : "";
-    let qualificationMethod = qualification ? qualification.method : "";
 
-    if (qualification && qualification.method == "ranking") {
-      valueLabel = I18n.t('qualification.ranking_short');
+    if (qualification && qualification.type == "ranking") {
+      valueLabel = I18n.t('qualification.type.ranking');
       qualificationInput = (
         <input type="number"
                id="qualification-number-value"
@@ -70,26 +72,28 @@ export default {
                onChange={onChangeAggregator}
                ref={c => rankingInput = c} />
       );
-    } else if (qualificationType == "single") {
-      valueLabel = I18n.t('common.single');
-      qualificationInput = (
-        <AttemptResultInput eventId={wcifEvent.id}
-                            id="qualification-single-value"
-                            value={qualification.level}
-                            onChange={onChangeAggregator}
-                            isAverage={false}
-                            ref={c => singleInput = c} />
-      );
-    } else if (qualificationType == "average") {
-      valueLabel = I18n.t('common.average');
-      qualificationInput = (
-        <AttemptResultInput eventId={wcifEvent.id}
-                            id="qualification-average-value"
-                            value={qualification.level}
-                            onChange={onChangeAggregator}
-                            isAverage={true}
-                            ref={c => averageInput = c} />
-      );
+    } else if (qualification && qualification.type == "attemptResult") {
+      if (qualificationResultType == "single") {
+        valueLabel = I18n.t('common.single');
+        qualificationInput = (
+          <AttemptResultInput eventId={wcifEvent.id}
+                              id="qualification-single-value"
+                              value={qualification.level}
+                              onChange={onChangeAggregator}
+                              isAverage={false}
+                              ref={c => singleInput = c} />
+        );
+      } else if (qualificationResultType == "average") {
+        valueLabel = I18n.t('common.average');
+        qualificationInput = (
+          <AttemptResultInput eventId={wcifEvent.id}
+                              id="qualification-average-value"
+                              value={qualification.level}
+                              onChange={onChangeAggregator}
+                              isAverage={true}
+                              ref={c => averageInput = c} />
+        );
+      }
     }
 
     let whenDateBlock = qualificationInput ? (
@@ -108,22 +112,23 @@ export default {
       </div>
     ) : null;
 
-    let bottomSection = qualificationType ? (
+    let bottomSection = qualificationResultType ? (
         <div>
           <div className="form-group">
-            <label htmlFor="qualification-method-input" className="col-sm-3 control-label">{ I18n.t('qualification.method_label')}</label>
+            <label htmlFor="qualification-type-input" className="col-sm-3 control-label">{ I18n.t('qualification.type_label')}</label>
             <div className="col-sm-9">
               <div className="input-group">
-                <select value={qualificationMethod}
+                <select value={qualificationType}
                         name="type"
                         autoFocus={autoFocus}
                         onChange={onChangeAggregator}
                         className="form-control"
-                        id="qualification-type-input"
-                        ref={c => qualificationMethodInput = c}
+                        id="qualification-result-type-input"
+                        ref={c => qualificationTypeInput = c}
                 >
-                  <option value="result">{ I18n.t('qualification.result') }</option>
-                  <option value="ranking">{ I18n.t('qualification.ranking_short') }</option>
+                  <option value="attemptResult">{ I18n.t('qualification.type.result') }</option>
+                  <option value="ranking">{ I18n.t('qualification.type.ranking') }</option>
+                  <option value="anyResult">{ I18n.t('qualification.type.any_result') }</option>
                 </select>
               </div>
             </div>
@@ -144,18 +149,18 @@ export default {
     return (
       <div>
         <div className="form-group">
-          <label htmlFor="qualification-type-input" className="col-sm-3 control-label">{ I18n.t('qualification.type_label' )}</label>
+          <label htmlFor="qualification-result-type-input" className="col-sm-3 control-label">{ I18n.t('qualification.result_type' )}</label>
           <div className="col-sm-9">
             <div className="input-group">
-              <select value={qualificationType}
+              <select value={qualificationResultType}
                       name="type"
                       autoFocus={autoFocus}
                       onChange={onChangeAggregator}
                       className="form-control"
-                      id="qualification-type-input"
-                      ref={c => qualificationTypeInput = c}
+                      id="qualification-result-type-input"
+                      ref={c => qualificationResultTypeInput = c}
               >
-                <option value="none">{ I18n.t('qualification.none') }</option>
+                <option value="none">{ I18n.t('qualification.type.none') }</option>
                 <option value="single">{ I18n.t('common.single') }</option>
                 <option value="average">{ I18n.t('common.average') }</option>
               </select>

--- a/WcaOnRails/app/webpacker/components/EditEvents/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/index.js
@@ -9,7 +9,7 @@ import rootRender from '../../lib/edit-events'
 import { pluralize } from '../../lib/utils/edit-events'
 import { buildActivityCode, saveWcif, roundIdToString } from '../../lib/utils/wcif'
 import { removeRoundsFromSharedTimeLimits } from "./EditRoundAttribute"
-import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton } from './EditRoundAttribute'
+import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton, EditQualificationButton } from './EditRoundAttribute'
 
 export default class EditEvents extends React.Component {
   save = e => {
@@ -154,6 +154,9 @@ function RoundsTable({ wcifEvents, wcifEvent, disabled }) {
           })}
         </tbody>
       </table>
+      <h5>
+        Qualification: <EditQualificationButton wcifEvent={wcifEvent} disabled={disabled} />
+      </h5>
     </div>
   );
 }

--- a/WcaOnRails/app/webpacker/components/EditEvents/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/index.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import events from '../../lib/wca-data/events.js.erb'
 import formats from '../../lib/wca-data/formats.js.erb'
 import rootRender from '../../lib/edit-events'
+import I18n from '../../lib/i18n'
 import { pluralize } from '../../lib/utils/edit-events'
 import { buildActivityCode, saveWcif, roundIdToString } from '../../lib/utils/wcif'
 import { removeRoundsFromSharedTimeLimits } from "./EditRoundAttribute"
@@ -155,7 +156,7 @@ function RoundsTable({ wcifEvents, wcifEvent, disabled }) {
         </tbody>
       </table>
       <h5>
-        Qualification: <EditQualificationButton wcifEvent={wcifEvent} disabled={disabled} />
+        { I18n.t('competitions.events.qualification') }: <EditQualificationButton wcifEvent={wcifEvent} disabled={disabled} />
       </h5>
     </div>
   );

--- a/WcaOnRails/app/webpacker/javascript/edit-events/modals/Qualification.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/modals/Qualification.js
@@ -1,0 +1,179 @@
+import React from 'react'
+
+import events from '../../wca/events.js.erb'
+import formats from '../../wca/formats.js.erb'
+import AttemptResultInput from './AttemptResultInput'
+import DatePicker from "react-datepicker";
+
+import {
+  pluralize,
+  matchResult,
+  attemptResultToString,
+} from './utils'
+import {
+  roundIdToString,
+  parseActivityCode,
+} from '../../wca/wcif-utils'
+
+import "react-datepicker/dist/react-datepicker.css";
+
+function toUTCDate(dateString) {
+  if (!dateString) {
+    return null;
+  }
+  let date = new Date(dateString);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function eventQualificationToString(wcifEvent, qualification, { short } = {}) {
+  if (!qualification) {
+    return "-";
+  }
+  let dateString = "-";
+  if (qualification.whenDate) {
+    let whenDate = moment(qualification.whenDate).toDate();
+    dateString = whenDate.toISOString().substring(0, 10);
+  }
+  switch (qualification.type) {
+    case "ranking":
+      return `Top ${qualification.level} competitors by ${dateString}`;
+    case "single":
+      return `Single of ${attemptResultToString(qualification.level, wcifEvent.id, short)} by ${dateString}`;
+    case "average":
+      return `Average of ${attemptResultToString(qualification.level, wcifEvent.id, short)} by ${dateString}`;
+  }
+}
+
+export default {
+  Title({ wcifEvent }) {
+    return <span>Qualification for {wcifEvent.id}</span>;
+  },
+  Show({ value: cutoff, wcifEvent }) {
+    return <span>{eventQualificationToString(wcifEvent, wcifEvent.qualification, { short: true })}</span>;
+  },
+  Input({ value: qualification, onChange, autoFocus, wcifEvent }) {
+    let qualificationTypeInput, rankingInput, singleInput, averageInput, whenDateInput;
+
+    let onChangeAggregator = () => {
+      let type = qualificationTypeInput.value;
+      let newQualification = null;
+      if (type != "none") {
+        newQualification = { type };
+        if (qualification) {
+          // Copy the deadline from the previous Qualification, or default to today.
+          newQualification.whenDate = qualification.whenDate || moment(new Date()).format("YYYY-MM-DD");
+        }
+        switch (type) {
+          case "ranking":
+            newQualification.level = rankingInput ? parseInt(rankingInput.value) : 0;
+            break;
+          case "single":
+            newQualification.level = singleInput ? parseInt(singleInput.value) : 0;
+            break;
+          case "average":
+            newQualification.level = averageInput ? parseInt(averageInput.value) : 0;
+            break;
+          default:
+            throw new Error(`Unrecognized value ${type}`);
+            break;
+        }
+      }
+      onChange(newQualification);
+    };
+
+    let onDateSelect = (date) => {
+      let newQualification = qualification;
+      newQualification.whenDate = moment(date).format("YYYY-MM-DD");
+      onChange(newQualification);
+    }
+
+    let valueLabel, qualificationInput;
+    let helpBlock = qualification ? eventQualificationToString(wcifEvent, qualification) : null;
+    let qualificationType = qualification ? qualification.type : "";
+    switch(qualificationType) {
+      case "ranking":
+        valueLabel = "Top N";
+        qualificationInput = (
+          <input type="number"
+                 id="qualification-number-value"
+                 min="0"
+                 className="form-control"
+                 value={qualification.level}
+                 onChange={onChangeAggregator}
+                 ref={c => rankingInput = c} />
+        );
+        break;
+      case "single":
+        valueLabel = "Single";
+        qualificationInput = (
+          <AttemptResultInput eventId={wcifEvent.id}
+                              id="qualification-single-value"
+                              value={qualification.level}
+                              onChange={onChangeAggregator}
+                              ref={c => singleInput = c} />
+        );
+        break;
+      case "average":
+        valueLabel = "Average";
+        qualificationInput = (
+          <AttemptResultInput eventId={wcifEvent.id}
+                              id="qualification-average-value"
+                              value={qualification.level}
+                              onChange={onChangeAggregator}
+                              ref={c => averageInput = c} />
+        );
+        break;
+    }
+
+    let whenDateBlock = qualificationInput ? (
+      <div className="form-group">
+        <label htmlFor="whenDate-input" className="col-sm-3 control-label">
+          Qualification Deadline
+        </label>
+        <div className="col-sm-9">
+          <DatePicker name="whenDate"
+                      onChange={date => onDateSelect(date)}
+                      className="form-control"
+                      id="whenDate-input"
+                      selected={moment(qualification.whenDate).toDate()}
+                      ref={c => whenDateInput = c}/>
+        </div>
+      </div>
+    ) : null;
+
+    return (
+      <div>
+        <div className="form-group">
+          <label htmlFor="qualification-type-input" className="col-sm-3 control-label">Qualification Type</label>
+          <div className="col-sm-9">
+            <div className="input-group">
+              <select value={qualificationType}
+                      name="type"
+                      autoFocus={autoFocus}
+                      onChange={onChangeAggregator}
+                      className="form-control"
+                      id="qualification-type-input"
+                      ref={c => qualificationTypeInput = c}
+              >
+                <option value="none">No qualification</option>
+                <option value="ranking">Top N competitors</option>
+                <option value="single">Single</option>
+                <option value="average">Average</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div className="form-group">
+          <label htmlFor="ranking-input" className="col-sm-3 control-label">
+            {valueLabel}
+          </label>
+          <div className="col-sm-9">
+            {qualificationInput}
+          </div>
+        </div>
+        {whenDateBlock}
+        {helpBlock}
+      </div>
+    );
+  },
+};

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -112,15 +112,15 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
     case 'single':
     case 'average':
       if (event.isTimedEvent) {
-        let messageName = `qualification.${qualification.type}.time`;
+        const messageName = `qualification.${qualification.type}.time`;
         return `${I18n.t(messageName, { time: attemptResultToString(qualification.level, short) })} ${deadlineString}`;
       }
       if (event.isFewestMoves) {
-        let messageName = `qualification.${qualification.type}.moves`;
+        const messageName = `qualification.${qualification.type}.moves`;
         return `${I18n.t(messageName, { moves: qualification.level })} ${deadlineString}`;
       }
       if (event.isMultipleBlindfolded) {
-        let messageName = `qualification.${qualification.type}.points`;
+        const messageName = `qualification.${qualification.type}.points`;
         return `${I18n.t(messageName, { points: qualification.level })} ${deadlineString}`;
       }
       return '-';

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -106,24 +106,28 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
   }
   const deadlineString = I18n.t('qualification.deadline.by_date', { date: dateString });
   const event = events.byId[wcifEvent.id];
-  switch (qualification.type) {
+  switch (qualification.resultType) {
     case 'single':
     case 'average':
-      if (qualification.method === 'ranking') {
-        const messageName = `qualification.${qualification.type}.ranking`;
+      if (qualification.type === 'ranking') {
+        const messageName = `qualification.${qualification.resultType}.ranking`;
         return `${I18n.t(messageName, { ranking: qualification.level })} ${deadlineString}`;
       }
+      if (qualification.type === 'anyResult') {
+        const messageName = `qualification.${qualification.resultType}.any_result`;
+        return `${I18n.t(messageName)} ${deadlineString}`;
+      }
       if (event.isTimedEvent) {
-        const messageName = `qualification.${qualification.type}.time`;
+        const messageName = `qualification.${qualification.resultType}.time`;
         return `${I18n.t(messageName, { time: attemptResultToString(qualification.level, wcifEvent.id, short) })} ${deadlineString}`;
       }
       if (event.isFewestMoves) {
-        const messageName = `qualification.${qualification.type}.moves`;
-        const moves = qualification.type === 'average' ? qualification.level / 100 : qualification.level;
+        const messageName = `qualification.${qualification.resultType}.moves`;
+        const moves = qualification.resultType === 'average' ? qualification.level / 100 : qualification.level;
         return `${I18n.t(messageName, { moves })} ${deadlineString}`;
       }
       if (event.isMultipleBlindfolded) {
-        const messageName = `qualification.${qualification.type}.points`;
+        const messageName = `qualification.${qualification.resultType}.points`;
         return `${I18n.t(messageName, { points: attemptResultToMbPoints(qualification.level) })} ${deadlineString}`;
       }
       return '-';

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -4,7 +4,6 @@ import { fetchWithAuthenticityToken } from '../requests/fetchWithAuthenticityTok
 import I18n from '../i18n';
 import { attemptResultToString } from './edit-events';
 
-
 function promiseSaveWcif(competitionId, data) {
   const url = `/api/v0/competitions/${competitionId}/wcif`;
   const fetchOptions = {
@@ -98,26 +97,28 @@ export function activityCodeListFromWcif(scheduleWcif) {
 
 export function eventQualificationToString(wcifEvent, qualification, { short } = {}) {
   if (!qualification) {
-    return "-";
+    return '-';
   }
-  let dateString = "-";
+  let dateString = '-';
   if (qualification.whenDate) {
-    let whenDate = moment(qualification.whenDate).toDate();
+    const whenDate = window.moment(qualification.whenDate).toDate();
     dateString = whenDate.toISOString().substring(0, 10);
   }
-  let deadlineString = I18n.t('qualification.deadline.by_date', { date: dateString })
+  const deadlineString = I18n.t('qualification.deadline.by_date', { date: dateString });
+  const event = events.byId[wcifEvent.id];
   switch (qualification.type) {
     case "ranking":
-      return `${ I18n.t('qualification.ranking', { ranking: qualification.level } )} ` + deadlineString
+      return `${ I18n.t('qualification.ranking', {ranking: qualification.level})} ${deadlineString}`;
     case "single":
-    case "average": 
-      const event = events.byId[wcifEvent.id];
+    case "average":
       if (event.isTimedEvent) {
-        return `${ I18n.t('qualification.' + qualification.type + '.time', { time: attemptResultToString(qualification.level) } ) } ` + deadlineString;
+        return `${I18n.t('qualification.' + qualification.type + '.time', {time: attemptResultToString(qualification.level, short)})} ${deadlineString}`
       } if (event.isFewestMoves) {
-        return `${ I18n.t('qualification.' + qualification.type + '.moves', { moves: qualification.level } ) } ` + deadlineString;
-      } if (event.isMultipleBlindfolded) { 
-        return `${ I18n.t('qualification.' + qualification.type + '.points', { points: qualification.level } ) } ` + deadlineString;
+        return `${I18n.t('qualification.' + qualification.type + '.moves', {moves: qualification.level})} ${deadlineString}`;
+      } if (event.isMultipleBlindfolded) {
+        return `${I18n.t('qualification.' + qualification.type + '.points', {points: qualification.level})} ${deadlineString}`;
       }
+    default:
+      return '-';
   }
 }

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -107,17 +107,23 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
   const deadlineString = I18n.t('qualification.deadline.by_date', { date: dateString });
   const event = events.byId[wcifEvent.id];
   switch (qualification.type) {
-    case "ranking":
-      return `${ I18n.t('qualification.ranking', {ranking: qualification.level})} ${deadlineString}`;
-    case "single":
-    case "average":
+    case 'ranking':
+      return `${I18n.t('qualification.ranking', { ranking: qualification.level })} ${deadlineString}`;
+    case 'single':
+    case 'average':
       if (event.isTimedEvent) {
-        return `${I18n.t('qualification.' + qualification.type + '.time', {time: attemptResultToString(qualification.level, short)})} ${deadlineString}`
-      } if (event.isFewestMoves) {
-        return `${I18n.t('qualification.' + qualification.type + '.moves', {moves: qualification.level})} ${deadlineString}`;
-      } if (event.isMultipleBlindfolded) {
-        return `${I18n.t('qualification.' + qualification.type + '.points', {points: qualification.level})} ${deadlineString}`;
+        let messageName = `qualification.${qualification.type}.time`;
+        return `${I18n.t(messageName, { time: attemptResultToString(qualification.level, short) })} ${deadlineString}`;
       }
+      if (event.isFewestMoves) {
+        let messageName = `qualification.${qualification.type}.moves`;
+        return `${I18n.t(messageName, { moves: qualification.level })} ${deadlineString}`;
+      }
+      if (event.isMultipleBlindfolded) {
+        let messageName = `qualification.${qualification.type}.points`;
+        return `${I18n.t(messageName, { points: qualification.level })} ${deadlineString}`;
+      }
+      return '-';
     default:
       return '-';
   }

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -113,7 +113,7 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
     case 'average':
       if (event.isTimedEvent) {
         const messageName = `qualification.${qualification.type}.time`;
-        return `${I18n.t(messageName, { time: attemptResultToString(qualification.level, short) })} ${deadlineString}`;
+        return `${I18n.t(messageName, { time: attemptResultToString(qualification.level, wcifEvent.id, short) })} ${deadlineString}`;
       }
       if (event.isFewestMoves) {
         const messageName = `qualification.${qualification.type}.moves`;

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -119,7 +119,8 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
       }
       if (event.isFewestMoves) {
         const messageName = `qualification.${qualification.type}.moves`;
-        return `${I18n.t(messageName, { moves: qualification.level })} ${deadlineString}`;
+        const moves = qualification.type == 'average' ? qualification.level / 100 : qualification.level;
+        return `${I18n.t(messageName, { moves })} ${deadlineString}`;
       }
       if (event.isMultipleBlindfolded) {
         const messageName = `qualification.${qualification.type}.points`;

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -109,7 +109,7 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
   switch (qualification.type) {
     case 'single':
     case 'average':
-      if (qualification.method == "ranking") {
+      if (qualification.method === 'ranking') {
         const messageName = `qualification.${qualification.type}.ranking`;
         return `${I18n.t(messageName, { ranking: qualification.level })} ${deadlineString}`;
       }
@@ -119,7 +119,7 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
       }
       if (event.isFewestMoves) {
         const messageName = `qualification.${qualification.type}.moves`;
-        const moves = qualification.type == 'average' ? qualification.level / 100 : qualification.level;
+        const moves = qualification.type === 'average' ? qualification.level / 100 : qualification.level;
         return `${I18n.t(messageName, { moves })} ${deadlineString}`;
       }
       if (event.isMultipleBlindfolded) {

--- a/WcaOnRails/app/webpacker/lib/utils/wcif.js
+++ b/WcaOnRails/app/webpacker/lib/utils/wcif.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import events from '../wca-data/events.js.erb';
 import { fetchWithAuthenticityToken } from '../requests/fetchWithAuthenticityToken';
 import I18n from '../i18n';
-import { attemptResultToString } from './edit-events';
+import { attemptResultToString, attemptResultToMbPoints } from './edit-events';
 
 function promiseSaveWcif(competitionId, data) {
   const url = `/api/v0/competitions/${competitionId}/wcif`;
@@ -107,10 +107,12 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
   const deadlineString = I18n.t('qualification.deadline.by_date', { date: dateString });
   const event = events.byId[wcifEvent.id];
   switch (qualification.type) {
-    case 'ranking':
-      return `${I18n.t('qualification.ranking', { ranking: qualification.level })} ${deadlineString}`;
     case 'single':
     case 'average':
+      if (qualification.method == "ranking") {
+        const messageName = `qualification.${qualification.type}.ranking`;
+        return `${I18n.t(messageName, { ranking: qualification.level })} ${deadlineString}`;
+      }
       if (event.isTimedEvent) {
         const messageName = `qualification.${qualification.type}.time`;
         return `${I18n.t(messageName, { time: attemptResultToString(qualification.level, wcifEvent.id, short) })} ${deadlineString}`;
@@ -121,7 +123,7 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
       }
       if (event.isMultipleBlindfolded) {
         const messageName = `qualification.${qualification.type}.points`;
-        return `${I18n.t(messageName, { points: qualification.level })} ${deadlineString}`;
+        return `${I18n.t(messageName, { points: attemptResultToMbPoints(qualification.level) })} ${deadlineString}`;
       }
       return '-';
     default:

--- a/WcaOnRails/config/i18n-js.yml
+++ b/WcaOnRails/config/i18n-js.yml
@@ -33,7 +33,7 @@ sort_translations_keys: true
 fallbacks: false
 # This sets which keys we export from the locale file!
 # It will need to be updated as we port more and more stuff to React.
-<% export_keys = ["common.*", "competitions.*", "events.*", "formats.*", "search_results.*", "round.*", "countries.*", "enums.*", "regional_organizations.*"] %>
+<% export_keys = ["common.*", "competitions.*", "events.*", "formats.*", "search_results.*", "round.*", "countries.*", "enums.*", "regional_organizations.*", "qualification.*"] %>
 translations:
 <% I18n.available_locales.each do |l| %>
   - file: "app/webpacker/packs/generated_locales/<%= l %>.js"

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -126,6 +126,9 @@ ignore_unused:
   - 'advancement_condition.*'
   # The keys below are all used on the records page
   - 'results.selector_elements.show_selector.{mixed,slim,separate,history,mixed_history}'
+  # These keys are only used in javascript
+  - 'qualification.single.*'
+  - 'qualification.average.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -178,6 +178,17 @@ en:
     333fm: "1 hour"
     333mbf: "10:00.00 per cube, up to 60:00.00"
     333mbo: ""
+  #context: Words used to describe qualification limits.
+  qualification:
+    ranking: "Top %{ranking} registered competitors"
+    single:
+      time: "Single solve under %{time}"
+      moves: "Single solve under %{moves} moves"
+      points: "Single solve under %{points} points"
+    average:
+      time: "Average under %{time}"
+      moves: "Average under %{moves} moves"
+      points: "Average under %{points} points"
   #context: Common word used in multiple places on the website
   common:
     world: "World"
@@ -314,7 +325,6 @@ en:
         free_guest_entry_status: "Display message for free guest entry"
         early_puzzle_submission: "I would like to require competitors to submit puzzles at a specific time before an event is scheduled to begin"
         early_puzzle_submission_reason: "Reason and details for submitting puzzles early"
-        qualification_results: "I would like to use qualification results to limit who can compete in certain events"
         qualification_results_reason: "Reason and details for qualification results"
         event_restrictions: "I would like to restrict competitors from registering for specific combinations of events"
         event_restrictions_reason: "Reason and details for event restrictions"
@@ -526,7 +536,6 @@ en:
         free_guest_entry_status: ""
         early_puzzle_submission: ""
         early_puzzle_submission_reason: "Please elaborate here why you would like to require competitors to submit puzzles early. Please fill this out in English!"
-        qualification_results: ""
         qualification_results_reason: "Please elaborate here why you would like to use qualification times. Please fill this out in English!"
         event_restrictions: ""
         event_restrictions_reason: "Please elaborate here why you would like to restrict certain event combinations. Please fill this out in English!"
@@ -1577,10 +1586,14 @@ en:
         cumulative_across_rounds_html: "A %{cumulative_time_limit} may be enforced across rounds (see %{guideline_link})."
         cutoff_html: "The result to beat to proceed to the second phase of a cutoff round (see %{regulation_link})."
         format_html: "The format describes how to determine the ranking of competitors based on their results. The list of allowed formats per event is described in %{link_to_9b}. See %{link_to_9f} for a description of each format."
+        qualification_html: "Qualification times must be set in other WCA competitions in order to compete."
+        qualification_all_events_html: "The deadline for setting qualification times is <b>%{date}</b>."
+        qualification_some_events_html: "The deadline for setting qualification times in %{events} is <b>%{date}</b>."
       format: "Format"
       time_limit: "Time limit"
       cutoff: "Cutoff"
       proceed: "Proceed"
+      qualification: "Qualification"
     #context: competition's schedule tab
     schedule:
       #context: when selecting the kind of schedule to display

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -181,18 +181,21 @@ en:
   #context: Words used to describe qualification limits.
   qualification:
     type_label: "Qualification Type"
+    method_label: "Qualification Method"
     for_event: "Qualification for %{event}"
-    ranking: "Top %{ranking} registered competitors"
     ranking_short: "Top N"
+    result: "By Result"
     none: "No qualification"
     single:
       time: "Single solve under %{time}"
       moves: "Single solve under %{moves} moves"
       points: "Single solve over %{points} points"
+      ranking: "Top %{ranking} by single"
     average:
       time: "Average under %{time}"
       moves: "Average under %{moves} moves"
       points: "Average over %{points} points"
+      ranking: "Top %{ranking} by average"
     deadline:
       description: "Qualification Deadline"
       by_date: "by %{date}"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -180,15 +180,22 @@ en:
     333mbo: ""
   #context: Words used to describe qualification limits.
   qualification:
+    type_label: "Qualification Type"
+    for_event: "Qualification for %{event}"
     ranking: "Top %{ranking} registered competitors"
+    ranking_short: "Top N"
+    none: "No qualification"
     single:
       time: "Single solve under %{time}"
       moves: "Single solve under %{moves} moves"
-      points: "Single solve under %{points} points"
+      points: "Single solve over %{points} points"
     average:
       time: "Average under %{time}"
       moves: "Average under %{moves} moves"
-      points: "Average under %{points} points"
+      points: "Average over %{points} points"
+    deadline:
+      description: "Qualification Deadline"
+      by_date: "by %{date}"
   #context: Common word used in multiple places on the website
   common:
     world: "World"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -181,21 +181,25 @@ en:
   #context: Words used to describe qualification limits.
   qualification:
     type_label: "Qualification Type"
-    method_label: "Qualification Method"
+    result_type: "Result Type"
     for_event: "Qualification for %{event}"
-    ranking_short: "Top N"
-    result: "By Result"
-    none: "No qualification"
+    type:
+      none: "No qualification"
+      result: "By Result"
+      ranking: "Top N"
+      any_result: "Any result"
     single:
       time: "Single solve under %{time}"
       moves: "Single solve under %{moves} moves"
       points: "Single solve over %{points} points"
       ranking: "Top %{ranking} by single"
+      any_result: "Any single solve"
     average:
       time: "Average under %{time}"
       moves: "Average under %{moves} moves"
       points: "Average over %{points} points"
       ranking: "Top %{ranking} by average"
+      any_result: "Any average"
     deadline:
       description: "Qualification Deadline"
       by_date: "by %{date}"

--- a/WcaOnRails/db/migrate/20210506205912_add_qualification_to_event.rb
+++ b/WcaOnRails/db/migrate/20210506205912_add_qualification_to_event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddQualificationToEvent < ActiveRecord::Migration[5.2]
+  def change
+    add_column :competition_events, :qualification, :text, null: true, default: nil
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -735,6 +735,7 @@ CREATE TABLE `competition_events` (
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
+  `qualification` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
@@ -1749,6 +1750,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20210301002636'),
 ('20210325202019'),
 ('20210501213332'),
+('20210506205912'),
 ('20210521195423'),
 ('20210727081850'),
 ('20210802065056'),

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -13,26 +13,26 @@ DROP TABLE IF EXISTS `Competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Competitions` (
-  `id` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cityName` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `information` mediumtext COLLATE utf8mb4_unicode_ci,
+  `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cityName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `information` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endMonth` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endDay` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `venue` varchar(240) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `venueAddress` varchar(120) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `venueDetails` varchar(120) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `external_website` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `venue` varchar(240) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `venueAddress` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `venueDetails` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `external_website` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `showAtAll` tinyint(1) NOT NULL DEFAULT '0',
   `latitude` int(11) DEFAULT NULL,
   `longitude` int(11) DEFAULT NULL,
-  `contact` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `remarks` text COLLATE utf8mb4_unicode_ci,
+  `contact` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `registration_open` datetime DEFAULT NULL,
   `registration_close` datetime DEFAULT NULL,
   `use_wca_registration` tinyint(1) NOT NULL DEFAULT '1',
@@ -42,16 +42,16 @@ CREATE TABLE `Competitions` (
   `generate_website` tinyint(1) DEFAULT NULL,
   `announced_at` datetime DEFAULT NULL,
   `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
-  `currency_code` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
+  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
   `endYear` smallint(6) NOT NULL DEFAULT '0',
-  `connected_stripe_account_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `connected_stripe_account_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
   `competitor_limit_enabled` tinyint(1) DEFAULT NULL,
   `competitor_limit` int(11) DEFAULT NULL,
-  `competitor_limit_reason` text COLLATE utf8mb4_unicode_ci,
-  `extra_registration_requirements` text COLLATE utf8mb4_unicode_ci,
+  `competitor_limit_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `extra_registration_requirements` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `on_the_spot_registration` tinyint(1) DEFAULT NULL,
   `on_the_spot_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `refund_policy_percent` int(11) DEFAULT NULL,
@@ -61,23 +61,23 @@ CREATE TABLE `Competitions` (
   `updated_at` datetime DEFAULT NULL,
   `results_submitted_at` datetime DEFAULT NULL,
   `early_puzzle_submission` tinyint(1) DEFAULT NULL,
-  `early_puzzle_submission_reason` text COLLATE utf8mb4_unicode_ci,
+  `early_puzzle_submission_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `qualification_results` tinyint(1) DEFAULT NULL,
-  `qualification_results_reason` text COLLATE utf8mb4_unicode_ci,
-  `name_reason` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `external_registration_page` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `qualification_results_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `name_reason` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `external_registration_page` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `confirmed_at` datetime DEFAULT NULL,
   `event_restrictions` tinyint(1) DEFAULT NULL,
-  `event_restrictions_reason` text COLLATE utf8mb4_unicode_ci,
+  `event_restrictions_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `registration_reminder_sent_at` datetime DEFAULT NULL,
   `announced_by` int(11) DEFAULT NULL,
   `results_posted_by` int(11) DEFAULT NULL,
-  `main_event_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `main_event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cancelled_at` datetime DEFAULT NULL,
   `cancelled_by` int(11) DEFAULT NULL,
   `waiting_list_deadline_date` datetime DEFAULT NULL,
   `event_change_deadline_date` datetime DEFAULT NULL,
-  `free_guest_entry_status` int(11) NOT NULL DEFAULT '0',
+  `free_guest_entry_status` int NOT NULL DEFAULT '0',
   `allow_registration_edits` tinyint(1) NOT NULL DEFAULT '0',
   `allow_registration_self_delete_after_acceptance` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
@@ -93,18 +93,18 @@ DROP TABLE IF EXISTS `CompetitionsMedia`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `CompetitionsMedia` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `type` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `text` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `uri` text COLLATE utf8mb4_unicode_ci,
-  `submitterName` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `submitterComment` text COLLATE utf8mb4_unicode_ci,
-  `submitterEmail` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `type` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `text` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `submitterName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `submitterComment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `submitterEmail` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `timestampSubmitted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `timestampDecided` timestamp NULL DEFAULT NULL,
-  `status` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=11850 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ConciseAverageResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -112,11 +112,11 @@ DROP TABLE IF EXISTS `ConciseAverageResults`;
 CREATE TABLE `ConciseAverageResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
-  `valueAndId` bigint(20) DEFAULT NULL,
-  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `valueAndId` bigint(22) DEFAULT NULL,
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
@@ -128,11 +128,11 @@ DROP TABLE IF EXISTS `ConciseSingleResults`;
 CREATE TABLE `ConciseSingleResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
-  `valueAndId` bigint(20) DEFAULT NULL,
-  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `valueAndId` bigint(22) DEFAULT NULL,
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
@@ -142,9 +142,9 @@ DROP TABLE IF EXISTS `Continents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Continents` (
-  `id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `recordName` char(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `recordName` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `latitude` int(11) NOT NULL DEFAULT '0',
   `longitude` int(11) NOT NULL DEFAULT '0',
   `zoom` tinyint(4) NOT NULL DEFAULT '0',
@@ -155,10 +155,10 @@ DROP TABLE IF EXISTS `Countries`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Countries` (
-  `id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `iso2` char(2) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `iso2` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `iso2` (`iso2`),
   KEY `fk_continents` (`continentId`)
@@ -168,11 +168,11 @@ DROP TABLE IF EXISTS `Events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Events` (
-  `id` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(54) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(54) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `format` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `format` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=0;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -180,10 +180,10 @@ DROP TABLE IF EXISTS `Formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Formats` (
-  `id` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `sort_by` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `sort_by_second` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `sort_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sort_by_second` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `expected_solve_count` int(11) NOT NULL,
   `trim_fastest_n` int(11) NOT NULL,
   `trim_slowest_n` int(11) NOT NULL,
@@ -194,13 +194,13 @@ DROP TABLE IF EXISTS `InboxPersons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxPersons` (
-  `id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wcaId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wcaId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
   `dob` date NOT NULL,
-  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `index_InboxPersons_on_competitionId_and_id` (`competitionId`,`id`),
   KEY `InboxPersons_fk_country` (`countryId`),
   KEY `InboxPersons_id` (`wcaId`),
@@ -211,12 +211,12 @@ DROP TABLE IF EXISTS `InboxResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxResults` (
-  `personId` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `personId` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -236,15 +236,15 @@ DROP TABLE IF EXISTS `Persons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Persons` (
-  `id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `subId` tinyint(4) NOT NULL DEFAULT '1',
-  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `subId` tinyint(6) NOT NULL DEFAULT '1',
+  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
   `year` smallint(6) NOT NULL DEFAULT '0',
   `month` tinyint(4) NOT NULL DEFAULT '0',
   `day` tinyint(4) NOT NULL DEFAULT '0',
-  `comments` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `comments` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rails_id` int(11) NOT NULL AUTO_INCREMENT,
   `incorrect_wca_id_claim_count` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`rails_id`),
@@ -253,15 +253,15 @@ CREATE TABLE `Persons` (
   KEY `Persons_id` (`id`),
   KEY `Persons_name` (`name`),
   FULLTEXT KEY `index_Persons_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=160929 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksAverage`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksAverage` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -269,15 +269,15 @@ CREATE TABLE `RanksAverage` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=445851712 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksSingle`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksSingle` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -285,7 +285,7 @@ CREATE TABLE `RanksSingle` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=524555046 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Results`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -293,13 +293,13 @@ DROP TABLE IF EXISTS `Results`;
 CREATE TABLE `Results` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `personName` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personName` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -307,8 +307,8 @@ CREATE TABLE `Results` (
   `value5` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
-  `regionalSingleRecord` char(3) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `regionalAverageRecord` char(3) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `regionalSingleRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `regionalAverageRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `Results_fk_tournament` (`competitionId`),
@@ -329,16 +329,16 @@ CREATE TABLE `Results` (
   KEY `index_Results_on_eventId_and_value5` (`eventId`,`value5`),
   KEY `index_Results_on_regionalSingleRecord_and_eventId` (`regionalSingleRecord`,`eventId`),
   KEY `index_Results_on_regionalAverageRecord_and_eventId` (`regionalAverageRecord`,`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=4007642 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RoundTypes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RoundTypes` (
-  `id` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `final` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -348,24 +348,24 @@ DROP TABLE IF EXISTS `Scrambles`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Scrambles` (
   `scrambleId` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `groupId` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `groupId` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `isExtra` tinyint(1) NOT NULL,
   `scrambleNum` int(11) NOT NULL,
-  `scramble` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `scramble` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`scrambleId`),
   KEY `competitionId` (`competitionId`,`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=1952493 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_attachments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_attachments` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `record_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `record_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `record_id` bigint(20) NOT NULL,
   `blob_id` bigint(20) NOT NULL,
   `created_at` datetime NOT NULL,
@@ -380,12 +380,12 @@ DROP TABLE IF EXISTS `active_storage_blobs`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_blobs` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `key` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `filename` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `content_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `metadata` text COLLATE utf8mb4_unicode_ci,
+  `key` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `filename` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `byte_size` bigint(20) NOT NULL,
-  `checksum` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `checksum` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `service_name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
@@ -398,7 +398,7 @@ DROP TABLE IF EXISTS `active_storage_variant_records`;
 CREATE TABLE `active_storage_variant_records` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `blob_id` bigint(20) NOT NULL,
-  `variation_digest` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `variation_digest` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_variant_records_uniqueness` (`blob_id`,`variation_digest`),
   CONSTRAINT `fk_rails_993965df05` FOREIGN KEY (`blob_id`) REFERENCES `active_storage_blobs` (`id`)
@@ -409,7 +409,7 @@ DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ar_internal_metadata` (
   `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`key`)
@@ -423,48 +423,48 @@ CREATE TABLE `archive_phpbb3_forums` (
   `parent_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `left_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `right_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_parents` mediumtext COLLATE utf8_bin NOT NULL,
-  `forum_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_desc` text COLLATE utf8_bin NOT NULL,
-  `forum_desc_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_desc_options` int(10) unsigned NOT NULL DEFAULT '7',
-  `forum_desc_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_link` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_password` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_parents` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `forum_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `forum_desc_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT '7',
+  `forum_desc_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_image` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules` text COLLATE utf8_bin NOT NULL,
-  `forum_rules_link` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules_options` int(10) unsigned NOT NULL DEFAULT '7',
-  `forum_rules_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_image` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `forum_rules_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT '7',
+  `forum_rules_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_topics_per_page` tinyint(4) NOT NULL DEFAULT '0',
   `forum_type` tinyint(4) NOT NULL DEFAULT '0',
   `forum_status` tinyint(4) NOT NULL DEFAULT '0',
   `forum_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_last_post_subject` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_last_post_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `forum_last_poster_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_last_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `forum_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_flags` tinyint(4) NOT NULL DEFAULT '32',
-  `display_on_index` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `enable_indexing` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `enable_icons` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `enable_prune` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `prune_next` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `prune_next` int(11) unsigned NOT NULL DEFAULT '0',
   `prune_days` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `display_subforum_list` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `forum_options` int(10) unsigned NOT NULL DEFAULT '0',
+  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `forum_options` int(20) unsigned NOT NULL DEFAULT '0',
   `forum_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_topics_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_topics_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_topics_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `enable_shadow_prune` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `enable_shadow_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `prune_shadow_days` mediumint(8) unsigned NOT NULL DEFAULT '7',
   `prune_shadow_freq` mediumint(8) unsigned NOT NULL DEFAULT '1',
   `prune_shadow_next` int(11) NOT NULL DEFAULT '0',
@@ -482,29 +482,29 @@ CREATE TABLE `archive_phpbb3_posts` (
   `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poster_ip` varchar(40) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `post_reported` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `enable_bbcode` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `enable_smilies` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `enable_magic_url` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `enable_sig` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `post_username` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `poster_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `post_username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `post_text` mediumtext CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `post_checksum` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_attachment` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `bbcode_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `bbcode_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_postcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `post_edit_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `post_edit_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_checksum` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `post_edit_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `post_edit_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_edit_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `post_edit_count` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `post_edit_locked` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `post_visibility` tinyint(4) NOT NULL DEFAULT '0',
-  `post_delete_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `post_delete_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `post_visibility` tinyint(3) NOT NULL DEFAULT '0',
+  `post_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `post_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`post_id`),
   KEY `forum_id` (`forum_id`),
@@ -525,38 +525,38 @@ CREATE TABLE `archive_phpbb3_topics` (
   `topic_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
   `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_attachment` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `topic_reported` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `topic_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `topic_poster` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `topic_time_limit` int(10) unsigned NOT NULL DEFAULT '0',
+  `topic_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT '0',
   `topic_views` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_status` tinyint(4) NOT NULL DEFAULT '0',
-  `topic_type` tinyint(4) NOT NULL DEFAULT '0',
+  `topic_status` tinyint(3) NOT NULL DEFAULT '0',
+  `topic_type` tinyint(3) NOT NULL DEFAULT '0',
   `topic_first_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_first_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `topic_first_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `topic_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_last_poster_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_subject` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `topic_last_view_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `topic_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT '0',
   `topic_moved_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_bumped` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poll_title` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `poll_start` int(10) unsigned NOT NULL DEFAULT '0',
-  `poll_length` int(10) unsigned NOT NULL DEFAULT '0',
+  `poll_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `poll_start` int(11) unsigned NOT NULL DEFAULT '0',
+  `poll_length` int(11) unsigned NOT NULL DEFAULT '0',
   `poll_max_options` tinyint(4) NOT NULL DEFAULT '1',
-  `poll_last_vote` int(10) unsigned NOT NULL DEFAULT '0',
-  `poll_vote_change` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT '0',
+  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `poll_vote_name` tinyint(1) NOT NULL DEFAULT '0',
-  `topic_visibility` tinyint(4) NOT NULL DEFAULT '0',
-  `topic_delete_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `topic_delete_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_visibility` tinyint(3) NOT NULL DEFAULT '0',
+  `topic_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `topic_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
@@ -575,71 +575,71 @@ DROP TABLE IF EXISTS `archive_phpbb3_users`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_phpbb3_users` (
   `user_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `user_type` tinyint(4) NOT NULL DEFAULT '0',
+  `user_type` tinyint(2) NOT NULL DEFAULT '0',
   `group_id` mediumint(8) unsigned NOT NULL DEFAULT '3',
-  `user_permissions` mediumtext COLLATE utf8_bin NOT NULL,
+  `user_permissions` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
   `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_ip` varchar(40) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_regdate` int(10) unsigned NOT NULL DEFAULT '0',
-  `username` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `username_clean` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_password` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_passchg` int(10) unsigned NOT NULL DEFAULT '0',
-  `user_email` varchar(100) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_regdate` int(11) unsigned NOT NULL DEFAULT '0',
+  `username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `username_clean` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_passchg` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_email` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_email_hash` bigint(20) NOT NULL DEFAULT '0',
-  `user_birthday` varchar(10) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_lastvisit` int(10) unsigned NOT NULL DEFAULT '0',
-  `user_lastmark` int(10) unsigned NOT NULL DEFAULT '0',
-  `user_lastpost_time` int(10) unsigned NOT NULL DEFAULT '0',
-  `user_lastpage` varchar(200) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_last_confirm_key` varchar(10) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_last_search` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_birthday` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_lastmark` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_lastpage` varchar(200) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_last_search` int(11) unsigned NOT NULL DEFAULT '0',
   `user_warnings` tinyint(4) NOT NULL DEFAULT '0',
-  `user_last_warning` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_last_warning` int(11) unsigned NOT NULL DEFAULT '0',
   `user_login_attempts` tinyint(4) NOT NULL DEFAULT '0',
-  `user_inactive_reason` tinyint(4) NOT NULL DEFAULT '0',
-  `user_inactive_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT '0',
+  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT '0',
   `user_posts` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_lang` varchar(30) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_timezone` varchar(100) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_dateformat` varchar(64) COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
+  `user_lang` varchar(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
   `user_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `user_rank` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_new_privmsg` int(11) NOT NULL DEFAULT '0',
-  `user_unread_privmsg` int(11) NOT NULL DEFAULT '0',
-  `user_last_privmsg` int(10) unsigned NOT NULL DEFAULT '0',
-  `user_message_rules` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `user_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_new_privmsg` int(4) NOT NULL DEFAULT '0',
+  `user_unread_privmsg` int(4) NOT NULL DEFAULT '0',
+  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `user_full_folder` int(11) NOT NULL DEFAULT '-3',
-  `user_emailtime` int(10) unsigned NOT NULL DEFAULT '0',
-  `user_topic_show_days` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `user_topic_sortby_type` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_topic_sortby_dir` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 'd',
-  `user_post_show_days` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `user_post_sortby_type` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_post_sortby_dir` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 'a',
-  `user_notify` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `user_notify_pm` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `user_emailtime` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_topic_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_post_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'a',
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `user_notify_type` tinyint(4) NOT NULL DEFAULT '0',
-  `user_allow_pm` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewonline` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewemail` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `user_allow_massemail` tinyint(3) unsigned NOT NULL DEFAULT '1',
-  `user_options` int(10) unsigned NOT NULL DEFAULT '230271',
-  `user_avatar` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_avatar_type` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_avatar_width` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `user_avatar_height` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `user_sig` mediumtext COLLATE utf8_bin NOT NULL,
-  `user_sig_bbcode_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_sig_bbcode_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_jabber` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_actkey` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_newpasswd` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_form_salt` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_new` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_options` int(11) unsigned NOT NULL DEFAULT '230271',
+  `user_avatar` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_sig` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_new` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `user_reminded` tinyint(4) NOT NULL DEFAULT '0',
-  `user_reminded_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username_clean` (`username_clean`),
   KEY `user_birthday` (`user_birthday`),
@@ -652,18 +652,18 @@ DROP TABLE IF EXISTS `archive_registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `birthYear` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `birthMonth` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `birthDay` tinyint(3) unsigned NOT NULL DEFAULT '0',
-  `email` varchar(80) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `guests_old` text COLLATE utf8mb4_unicode_ci,
-  `comments` text COLLATE utf8mb4_unicode_ci,
-  `ip` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `birthYear` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `birthMonth` tinyint(4) unsigned NOT NULL DEFAULT '0',
+  `birthDay` tinyint(4) unsigned NOT NULL DEFAULT '0',
+  `email` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `guests_old` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -681,42 +681,42 @@ CREATE TABLE `assignments` (
   `registration_id` bigint(20) DEFAULT NULL,
   `schedule_activity_id` bigint(20) DEFAULT NULL,
   `station_number` int(11) DEFAULT NULL,
-  `assignment_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `assignment_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_assignments_on_registration_id` (`registration_id`),
   KEY `index_assignments_on_schedule_activity_id` (`schedule_activity_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1757500 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `bookmarked_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `bookmarked_competitions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_bookmarked_competitions_on_competition_id` (`competition_id`),
   KEY `index_bookmarked_competitions_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=48279 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `championships`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `championships` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `championship_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_championships_on_competition_id_and_championship_type` (`competition_id`,`championship_type`),
   KEY `index_championships_on_championship_type` (`championship_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=556 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_delegates`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_delegates` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -725,28 +725,28 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=15010 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
   `qualification` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=81288 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_organizers`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_organizers` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `organizer_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -755,27 +755,27 @@ CREATE TABLE `competition_organizers` (
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=17120 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_tabs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_tabs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `content` text COLLATE utf8mb4_unicode_ci,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `display_order` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_tabs_on_display_order_and_competition_id` (`display_order`,`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=19657 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_trainee_delegates`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_trainee_delegates` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) DEFAULT NULL,
   `trainee_delegate_id` int(11) DEFAULT NULL,
   `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL,
@@ -783,26 +783,26 @@ CREATE TABLE `competition_trainee_delegates` (
   PRIMARY KEY (`id`),
   KEY `index_competition_trainee_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_trainee_delegates_on_trainee_delegate_id` (`trainee_delegate_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=641 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_venues`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_venues` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `latitude_microdegrees` int(11) NOT NULL,
   `longitude_microdegrees` int(11) NOT NULL,
-  `timezone_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `timezone_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `country_iso2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_venues_on_competition_id_and_wcif_id` (`competition_id`,`wcif_id`),
   KEY `index_competition_venues_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3594 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `completed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -811,9 +811,9 @@ CREATE TABLE `completed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text COLLATE utf8mb4_unicode_ci,
+  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
-  `queue` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `completed_at` datetime DEFAULT NULL,
@@ -826,11 +826,11 @@ DROP TABLE IF EXISTS `country_bands`;
 CREATE TABLE `country_bands` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `number` int(11) NOT NULL,
-  `iso2` varchar(2) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `iso2` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_country_bands_on_iso2` (`iso2`),
   KEY `index_country_bands_on_number` (`number`)
-) ENGINE=InnoDB AUTO_INCREMENT=122 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delayed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -839,13 +839,13 @@ CREATE TABLE `delayed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text COLLATE utf8mb4_unicode_ci,
-  `last_error` text COLLATE utf8mb4_unicode_ci,
+  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `locked_at` datetime DEFAULT NULL,
   `failed_at` datetime DEFAULT NULL,
-  `locked_by` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `queue` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `locked_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -857,39 +857,39 @@ DROP TABLE IF EXISTS `delegate_reports`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `delegate_reports` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `equipment` text COLLATE utf8mb4_unicode_ci,
-  `venue` text COLLATE utf8mb4_unicode_ci,
-  `organization` text COLLATE utf8mb4_unicode_ci,
-  `schedule_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `incidents` text COLLATE utf8mb4_unicode_ci,
-  `remarks` text COLLATE utf8mb4_unicode_ci,
-  `discussion_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `equipment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `venue` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `organization` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `schedule_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `incidents` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `discussion_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `posted_by_user_id` int(11) DEFAULT NULL,
   `posted_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `nag_sent_at` datetime DEFAULT NULL,
   `wrc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
-  `wrc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wrc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wdc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
-  `wdc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wdc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wrc_primary_user_id` int(11) DEFAULT NULL,
   `wrc_secondary_user_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=9255 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `eligible_country_iso2s_for_championship`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `eligible_country_iso2s_for_championship` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `championship_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `eligible_country_iso2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `eligible_country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_eligible_iso2s_for_championship_on_type_and_country_iso2` (`championship_type`,`eligible_country_iso2`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -897,12 +897,12 @@ DROP TABLE IF EXISTS `incident_competitions`;
 CREATE TABLE `incident_competitions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `incident_id` bigint(20) NOT NULL,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_competitions_on_incident_id_and_competition_id` (`incident_id`,`competition_id`),
   KEY `index_incident_competitions_on_incident_id` (`incident_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=91 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -910,36 +910,36 @@ DROP TABLE IF EXISTS `incident_tags`;
 CREATE TABLE `incident_tags` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `incident_id` bigint(20) NOT NULL,
-  `tag` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_tags_on_incident_id_and_tag` (`incident_id`,`tag`),
   KEY `index_incident_tags_on_incident_id` (`incident_id`),
   KEY `index_incident_tags_on_tag` (`tag`)
-) ENGINE=InnoDB AUTO_INCREMENT=112 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incidents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `incidents` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `title` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `private_description` text COLLATE utf8mb4_unicode_ci,
-  `private_wrc_decision` text COLLATE utf8mb4_unicode_ci,
-  `public_summary` text COLLATE utf8mb4_unicode_ci,
+  `title` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `private_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `private_wrc_decision` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `public_summary` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `resolved_at` datetime DEFAULT NULL,
   `digest_worthy` tinyint(1) DEFAULT '0',
   `digest_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=63 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `linkings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `linkings` (
-  `wca_id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wca_ids` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wca_id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wca_ids` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `index_linkings_on_wca_id` (`wca_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -964,15 +964,15 @@ CREATE TABLE `oauth_access_grants` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) NOT NULL,
   `application_id` int(11) NOT NULL,
-  `token` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `expires_in` int(11) NOT NULL,
-  `redirect_uri` text COLLATE utf8mb4_unicode_ci,
+  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `revoked_at` datetime DEFAULT NULL,
-  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_grants_on_token` (`token`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_tokens`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -981,45 +981,45 @@ CREATE TABLE `oauth_access_tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) DEFAULT NULL,
   `application_id` int(11) DEFAULT NULL,
-  `token` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `refresh_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `refresh_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `expires_in` int(11) DEFAULT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
-  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_tokens_on_token` (`token`),
   UNIQUE KEY `index_oauth_access_tokens_on_refresh_token` (`refresh_token`),
   KEY `index_oauth_access_tokens_on_resource_owner_id` (`resource_owner_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_applications`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `oauth_applications` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `uid` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `secret` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `redirect_uri` text COLLATE utf8mb4_unicode_ci,
-  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `uid` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `owner_id` int(11) DEFAULT NULL,
-  `owner_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `owner_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `dangerously_allow_any_redirect_uri` tinyint(1) NOT NULL DEFAULT '0',
   `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `poll_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `poll_options` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `description` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `poll_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `poll_id` (`poll_id`) USING BTREE
@@ -1030,12 +1030,12 @@ DROP TABLE IF EXISTS `polls`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `polls` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `question` text COLLATE utf8mb4_unicode_ci,
+  `question` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `multiple` tinyint(1) NOT NULL,
   `deadline` datetime NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `comment` text COLLATE utf8mb4_unicode_ci,
+  `comment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `confirmed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1046,21 +1046,21 @@ DROP TABLE IF EXISTS `post_tags`;
 CREATE TABLE `post_tags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `post_id` int(11) NOT NULL,
-  `tag` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_post_tags_on_post_id_and_tag` (`post_id`,`tag`),
   KEY `index_post_tags_on_post_id` (`post_id`),
   KEY `index_post_tags_on_tag` (`tag`)
-) ENGINE=InnoDB AUTO_INCREMENT=22361 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `posts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `posts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `body` text COLLATE utf8mb4_unicode_ci,
-  `slug` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `slug` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sticky` tinyint(1) NOT NULL DEFAULT '0',
   `author_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
@@ -1072,14 +1072,14 @@ CREATE TABLE `posts` (
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`sticky`,`created_at`),
   KEY `index_posts_on_world_readable_and_created_at` (`created_at`),
   KEY `idx_show_wr_sticky_created_at` (`show_on_homepage`,`sticky`,`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=14062 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `preferred_formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `preferred_formats` (
-  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `format_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `format_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `ranking` int(11) NOT NULL,
   UNIQUE KEY `index_preferred_formats_on_event_id_and_format_id` (`event_id`,`format_id`),
   KEY `fk_rails_c3e0098ed3` (`format_id`)
@@ -1089,7 +1089,7 @@ DROP TABLE IF EXISTS `rails_persons`;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `rails_persons` AS SELECT 
+/*!50001 CREATE VIEW `rails_persons` AS SELECT
  1 AS `id`,
  1 AS `wca_id`,
  1 AS `subId`,
@@ -1107,24 +1107,24 @@ DROP TABLE IF EXISTS `regional_organizations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `regional_organizations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `country` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `website` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `country` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `website` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `email` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `address` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `directors_and_officers` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `area_description` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `past_and_current_activities` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `future_plans` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `extra_information` text COLLATE utf8mb4_unicode_ci,
+  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `address` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `directors_and_officers` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `area_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `past_and_current_activities` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `future_plans` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extra_information` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_regional_organizations_on_name` (`name`),
   KEY `index_regional_organizations_on_country` (`country`)
-) ENGINE=InnoDB AUTO_INCREMENT=38 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1136,7 +1136,7 @@ CREATE TABLE `registration_competition_events` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_registration_competition_events_on_reg_id_and_comp_event_id` (`registration_id`,`competition_event_id`),
   KEY `index_reg_events_reg_id_comp_event_id` (`registration_id`,`competition_event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2334458 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_payments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1145,8 +1145,8 @@ CREATE TABLE `registration_payments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `registration_id` int(11) DEFAULT NULL,
   `amount_lowest_denomination` int(11) DEFAULT NULL,
-  `currency_code` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `stripe_charge_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `refunded_registration_payment_id` int(11) DEFAULT NULL,
@@ -1161,9 +1161,9 @@ DROP TABLE IF EXISTS `registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `comments` text COLLATE utf8mb4_unicode_ci,
-  `ip` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competition_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1172,10 +1172,10 @@ CREATE TABLE `registrations` (
   `accepted_by` int(11) DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `deleted_by` int(11) DEFAULT NULL,
-  `roles` text COLLATE utf8mb4_unicode_ci,
+  `roles` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=495241 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `rounds`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1183,27 +1183,27 @@ DROP TABLE IF EXISTS `rounds`;
 CREATE TABLE `rounds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_event_id` int(11) NOT NULL,
-  `format_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `format_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `number` int(11) NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `time_limit` text COLLATE utf8mb4_unicode_ci,
-  `cutoff` text COLLATE utf8mb4_unicode_ci,
-  `advancement_condition` text COLLATE utf8mb4_unicode_ci,
+  `time_limit` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `cutoff` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `advancement_condition` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `scramble_set_count` int(11) NOT NULL DEFAULT '1',
-  `round_results` mediumtext COLLATE utf8mb4_unicode_ci,
+  `round_results` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `total_number_of_rounds` int(11) NOT NULL,
   `old_type` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
-) ENGINE=InnoDB AUTO_INCREMENT=778693 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_check_categories`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sanity_check_categories` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_check_categories_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1214,8 +1214,8 @@ DROP TABLE IF EXISTS `sanity_check_exclusions`;
 CREATE TABLE `sanity_check_exclusions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `sanity_check_id` bigint(20) NOT NULL,
-  `exclusion` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` text COLLATE utf8mb4_unicode_ci,
+  `exclusion` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `fk_rails_c9112973d2` (`sanity_check_id`),
   CONSTRAINT `fk_rails_c9112973d2` FOREIGN KEY (`sanity_check_id`) REFERENCES `sanity_checks` (`id`)
@@ -1227,9 +1227,9 @@ DROP TABLE IF EXISTS `sanity_checks`;
 CREATE TABLE `sanity_checks` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `sanity_check_category_id` bigint(20) NOT NULL,
-  `topic` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` text COLLATE utf8mb4_unicode_ci,
-  `query` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `topic` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_checks_on_topic` (`topic`),
   KEY `fk_rails_fddad5fbb5` (`sanity_check_category_id`),
@@ -1241,11 +1241,11 @@ DROP TABLE IF EXISTS `schedule_activities`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schedule_activities` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `holder_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `holder_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `holder_id` bigint(20) NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `activity_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `activity_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_time` datetime NOT NULL,
   `end_time` datetime NOT NULL,
   `scramble_set_id` int(11) DEFAULT NULL,
@@ -1254,13 +1254,13 @@ CREATE TABLE `schedule_activities` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_activities_on_their_id_within_holder` (`holder_type`,`holder_id`,`wcif_id`),
   KEY `index_schedule_activities_on_holder_type_and_holder_id` (`holder_type`,`holder_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=169090 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
-  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1282,14 +1282,14 @@ DROP TABLE IF EXISTS `starburst_announcements`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `starburst_announcements` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `title` text COLLATE utf8mb4_unicode_ci,
-  `body` text COLLATE utf8mb4_unicode_ci,
+  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_delivering_at` datetime DEFAULT NULL,
   `stop_delivering_at` datetime DEFAULT NULL,
-  `limit_to_users` text COLLATE utf8mb4_unicode_ci,
+  `limit_to_users` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `category` text COLLATE utf8mb4_unicode_ci,
+  `category` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1298,10 +1298,10 @@ DROP TABLE IF EXISTS `stripe_charges`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `stripe_charges` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `metadata` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `stripe_charge_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `status` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `error` text COLLATE utf8mb4_unicode_ci,
+  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
@@ -1322,27 +1322,27 @@ CREATE TABLE `team_members` (
   `updated_at` datetime NOT NULL,
   `team_senior_member` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=517 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `teams`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `teams` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `friendly_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `friendly_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `email` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `hidden` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_teams_on_friendly_id` (`friendly_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `timestamps`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `timestamps` (
-  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `date` datetime DEFAULT NULL,
   UNIQUE KEY `index_timestamps_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1352,8 +1352,8 @@ DROP TABLE IF EXISTS `uploaded_jsons`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `uploaded_jsons` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `json_str` longtext COLLATE utf8mb4_unicode_ci,
+  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `json_str` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_uploaded_jsons_on_competition_id` (`competition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1364,39 +1364,39 @@ DROP TABLE IF EXISTS `user_preferred_events`;
 CREATE TABLE `user_preferred_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_user_preferred_events_on_user_id_and_event_id` (`user_id`,`event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=230950 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `encrypted_password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `reset_password_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `encrypted_password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `reset_password_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `reset_password_sent_at` datetime DEFAULT NULL,
   `remember_created_at` datetime DEFAULT NULL,
   `sign_in_count` int(11) NOT NULL DEFAULT '0',
   `current_sign_in_at` datetime DEFAULT NULL,
   `last_sign_in_at` datetime DEFAULT NULL,
-  `current_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `last_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `confirmation_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `current_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `confirmation_token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `confirmed_at` datetime DEFAULT NULL,
   `confirmation_sent_at` datetime DEFAULT NULL,
-  `unconfirmed_email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unconfirmed_email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `delegate_status` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `delegate_status` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `senior_delegate_id` int(11) DEFAULT NULL,
-  `region` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `wca_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `avatar` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `pending_avatar` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `region` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wca_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pending_avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `saved_avatar_crop_x` int(11) DEFAULT NULL,
   `saved_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_avatar_crop_w` int(11) DEFAULT NULL,
@@ -1405,23 +1405,23 @@ CREATE TABLE `users` (
   `saved_pending_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_w` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_h` int(11) DEFAULT NULL,
-  `unconfirmed_wca_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unconfirmed_wca_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id_to_handle_wca_id_claim` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
-  `gender` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `country_iso2` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `gender` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `country_iso2` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `results_notifications_enabled` tinyint(1) DEFAULT '0',
-  `preferred_locale` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `preferred_locale` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `competition_notifications_enabled` tinyint(1) DEFAULT NULL,
   `receive_delegate_reports` tinyint(1) NOT NULL DEFAULT '0',
   `dummy_account` tinyint(1) NOT NULL DEFAULT '0',
-  `encrypted_otp_secret` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `encrypted_otp_secret_iv` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `encrypted_otp_secret_salt` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret_iv` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret_salt` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `consumed_timestep` int(11) DEFAULT NULL,
   `otp_required_for_login` tinyint(1) DEFAULT '0',
-  `otp_backup_codes` text COLLATE utf8mb4_unicode_ci,
-  `session_validity_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `otp_backup_codes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `session_validity_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cookies_acknowledged` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
@@ -1429,7 +1429,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB AUTO_INCREMENT=276377 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `venue_rooms`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1438,14 +1438,14 @@ CREATE TABLE `venue_rooms` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `competition_venue_id` bigint(20) NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `color` varchar(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_venue_rooms_on_competition_venue_id_and_wcif_id` (`competition_venue_id`,`wcif_id`),
   KEY `index_venue_rooms_on_competition_venue_id` (`competition_venue_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4322 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `vote_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1463,7 +1463,7 @@ DROP TABLE IF EXISTS `votes`;
 CREATE TABLE `votes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
-  `comment` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `comment` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `poll_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_votes_on_user_id` (`user_id`)
@@ -1474,11 +1474,11 @@ DROP TABLE IF EXISTS `wcif_extensions`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wcif_extensions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `extendable_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `extendable_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `extension_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `spec_url` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `data` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extendable_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `extendable_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `extension_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `spec_url` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `data` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_wcif_extensions_on_extendable_type_and_extendable_id` (`extendable_type`,`extendable_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1491,7 +1491,6 @@ CREATE TABLE `wcif_extensions` (
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments`,`Persons`.`incorrect_wca_id_claim_count` AS `incorrect_wca_id_claim_count` from `Persons` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -1751,7 +1750,6 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20210301002636'),
 ('20210325202019'),
 ('20210501213332'),
-('20210506205912'),
 ('20210521195423'),
 ('20210727081850'),
 ('20210802065056'),

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -13,26 +13,26 @@ DROP TABLE IF EXISTS `Competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Competitions` (
-  `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cityName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `information` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `id` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cityName` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `information` mediumtext COLLATE utf8mb4_unicode_ci,
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endMonth` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endDay` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `venue` varchar(240) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `venueAddress` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `venueDetails` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `external_website` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `venue` varchar(240) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `venueAddress` varchar(120) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `venueDetails` varchar(120) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `external_website` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `showAtAll` tinyint(1) NOT NULL DEFAULT '0',
   `latitude` int(11) DEFAULT NULL,
   `longitude` int(11) DEFAULT NULL,
-  `contact` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `contact` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `remarks` text COLLATE utf8mb4_unicode_ci,
   `registration_open` datetime DEFAULT NULL,
   `registration_close` datetime DEFAULT NULL,
   `use_wca_registration` tinyint(1) NOT NULL DEFAULT '1',
@@ -42,16 +42,16 @@ CREATE TABLE `Competitions` (
   `generate_website` tinyint(1) DEFAULT NULL,
   `announced_at` datetime DEFAULT NULL,
   `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
-  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
+  `currency_code` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
   `endYear` smallint(6) NOT NULL DEFAULT '0',
-  `connected_stripe_account_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `connected_stripe_account_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
   `competitor_limit_enabled` tinyint(1) DEFAULT NULL,
   `competitor_limit` int(11) DEFAULT NULL,
-  `competitor_limit_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `extra_registration_requirements` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `competitor_limit_reason` text COLLATE utf8mb4_unicode_ci,
+  `extra_registration_requirements` text COLLATE utf8mb4_unicode_ci,
   `on_the_spot_registration` tinyint(1) DEFAULT NULL,
   `on_the_spot_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `refund_policy_percent` int(11) DEFAULT NULL,
@@ -61,23 +61,23 @@ CREATE TABLE `Competitions` (
   `updated_at` datetime DEFAULT NULL,
   `results_submitted_at` datetime DEFAULT NULL,
   `early_puzzle_submission` tinyint(1) DEFAULT NULL,
-  `early_puzzle_submission_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `early_puzzle_submission_reason` text COLLATE utf8mb4_unicode_ci,
   `qualification_results` tinyint(1) DEFAULT NULL,
-  `qualification_results_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `name_reason` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `external_registration_page` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `qualification_results_reason` text COLLATE utf8mb4_unicode_ci,
+  `name_reason` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `external_registration_page` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `confirmed_at` datetime DEFAULT NULL,
   `event_restrictions` tinyint(1) DEFAULT NULL,
-  `event_restrictions_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `event_restrictions_reason` text COLLATE utf8mb4_unicode_ci,
   `registration_reminder_sent_at` datetime DEFAULT NULL,
   `announced_by` int(11) DEFAULT NULL,
   `results_posted_by` int(11) DEFAULT NULL,
-  `main_event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `main_event_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cancelled_at` datetime DEFAULT NULL,
   `cancelled_by` int(11) DEFAULT NULL,
   `waiting_list_deadline_date` datetime DEFAULT NULL,
   `event_change_deadline_date` datetime DEFAULT NULL,
-  `free_guest_entry_status` int NOT NULL DEFAULT '0',
+  `free_guest_entry_status` int(11) NOT NULL DEFAULT '0',
   `allow_registration_edits` tinyint(1) NOT NULL DEFAULT '0',
   `allow_registration_self_delete_after_acceptance` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
@@ -93,18 +93,18 @@ DROP TABLE IF EXISTS `CompetitionsMedia`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `CompetitionsMedia` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `type` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `text` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `submitterName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `submitterComment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `submitterEmail` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `type` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `text` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `uri` text COLLATE utf8mb4_unicode_ci,
+  `submitterName` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `submitterComment` text COLLATE utf8mb4_unicode_ci,
+  `submitterEmail` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `timestampSubmitted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `timestampDecided` timestamp NULL DEFAULT NULL,
-  `status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `status` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11850 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ConciseAverageResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -112,11 +112,11 @@ DROP TABLE IF EXISTS `ConciseAverageResults`;
 CREATE TABLE `ConciseAverageResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
-  `valueAndId` bigint(22) DEFAULT NULL,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `valueAndId` bigint(20) DEFAULT NULL,
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
@@ -128,11 +128,11 @@ DROP TABLE IF EXISTS `ConciseSingleResults`;
 CREATE TABLE `ConciseSingleResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
-  `valueAndId` bigint(22) DEFAULT NULL,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `valueAndId` bigint(20) DEFAULT NULL,
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
@@ -142,9 +142,9 @@ DROP TABLE IF EXISTS `Continents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Continents` (
-  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `recordName` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `recordName` char(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `latitude` int(11) NOT NULL DEFAULT '0',
   `longitude` int(11) NOT NULL DEFAULT '0',
   `zoom` tinyint(4) NOT NULL DEFAULT '0',
@@ -155,10 +155,10 @@ DROP TABLE IF EXISTS `Countries`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Countries` (
-  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `iso2` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `iso2` char(2) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `iso2` (`iso2`),
   KEY `fk_continents` (`continentId`)
@@ -168,11 +168,11 @@ DROP TABLE IF EXISTS `Events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Events` (
-  `id` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(54) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(54) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `format` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `format` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=0;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -180,10 +180,10 @@ DROP TABLE IF EXISTS `Formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Formats` (
-  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `sort_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `sort_by_second` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `id` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `sort_by` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sort_by_second` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `expected_solve_count` int(11) NOT NULL,
   `trim_fastest_n` int(11) NOT NULL,
   `trim_slowest_n` int(11) NOT NULL,
@@ -194,13 +194,13 @@ DROP TABLE IF EXISTS `InboxPersons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxPersons` (
-  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wcaId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wcaId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `dob` date NOT NULL,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `index_InboxPersons_on_competitionId_and_id` (`competitionId`,`id`),
   KEY `InboxPersons_fk_country` (`countryId`),
   KEY `InboxPersons_id` (`wcaId`),
@@ -211,12 +211,12 @@ DROP TABLE IF EXISTS `InboxResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxResults` (
-  `personId` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `personId` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -236,15 +236,15 @@ DROP TABLE IF EXISTS `Persons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Persons` (
-  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `subId` tinyint(6) NOT NULL DEFAULT '1',
-  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `subId` tinyint(4) NOT NULL DEFAULT '1',
+  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `year` smallint(6) NOT NULL DEFAULT '0',
   `month` tinyint(4) NOT NULL DEFAULT '0',
   `day` tinyint(4) NOT NULL DEFAULT '0',
-  `comments` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `comments` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rails_id` int(11) NOT NULL AUTO_INCREMENT,
   `incorrect_wca_id_claim_count` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`rails_id`),
@@ -253,15 +253,15 @@ CREATE TABLE `Persons` (
   KEY `Persons_id` (`id`),
   KEY `Persons_name` (`name`),
   FULLTEXT KEY `index_Persons_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=160929 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksAverage`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksAverage` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -269,15 +269,15 @@ CREATE TABLE `RanksAverage` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=445851712 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksSingle`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksSingle` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -285,7 +285,7 @@ CREATE TABLE `RanksSingle` (
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=524555046 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Results`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -293,13 +293,13 @@ DROP TABLE IF EXISTS `Results`;
 CREATE TABLE `Results` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `personName` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personName` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -307,8 +307,8 @@ CREATE TABLE `Results` (
   `value5` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
-  `regionalSingleRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `regionalAverageRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `regionalSingleRecord` char(3) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `regionalAverageRecord` char(3) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `Results_fk_tournament` (`competitionId`),
@@ -329,16 +329,16 @@ CREATE TABLE `Results` (
   KEY `index_Results_on_eventId_and_value5` (`eventId`,`value5`),
   KEY `index_Results_on_regionalSingleRecord_and_eventId` (`regionalSingleRecord`,`eventId`),
   KEY `index_Results_on_regionalAverageRecord_and_eventId` (`regionalAverageRecord`,`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB AUTO_INCREMENT=4007642 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RoundTypes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RoundTypes` (
-  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `final` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -348,24 +348,24 @@ DROP TABLE IF EXISTS `Scrambles`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Scrambles` (
   `scrambleId` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `groupId` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `groupId` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL,
   `isExtra` tinyint(1) NOT NULL,
   `scrambleNum` int(11) NOT NULL,
-  `scramble` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `scramble` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`scrambleId`),
   KEY `competitionId` (`competitionId`,`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1952493 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_attachments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_attachments` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `record_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `record_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `record_id` bigint(20) NOT NULL,
   `blob_id` bigint(20) NOT NULL,
   `created_at` datetime NOT NULL,
@@ -380,12 +380,12 @@ DROP TABLE IF EXISTS `active_storage_blobs`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_blobs` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `key` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `filename` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `content_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `key` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `filename` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `metadata` text COLLATE utf8mb4_unicode_ci,
   `byte_size` bigint(20) NOT NULL,
-  `checksum` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `checksum` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `service_name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
@@ -398,7 +398,7 @@ DROP TABLE IF EXISTS `active_storage_variant_records`;
 CREATE TABLE `active_storage_variant_records` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `blob_id` bigint(20) NOT NULL,
-  `variation_digest` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `variation_digest` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_variant_records_uniqueness` (`blob_id`,`variation_digest`),
   CONSTRAINT `fk_rails_993965df05` FOREIGN KEY (`blob_id`) REFERENCES `active_storage_blobs` (`id`)
@@ -409,7 +409,7 @@ DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ar_internal_metadata` (
   `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `value` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`key`)
@@ -423,48 +423,48 @@ CREATE TABLE `archive_phpbb3_forums` (
   `parent_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `left_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `right_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_parents` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_desc` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_desc_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT '7',
-  `forum_desc_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_parents` mediumtext COLLATE utf8_bin NOT NULL,
+  `forum_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc` text COLLATE utf8_bin NOT NULL,
+  `forum_desc_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc_options` int(10) unsigned NOT NULL DEFAULT '7',
+  `forum_desc_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_link` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_password` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_image` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_rules_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT '7',
-  `forum_rules_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_image` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules` text COLLATE utf8_bin NOT NULL,
+  `forum_rules_link` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_options` int(10) unsigned NOT NULL DEFAULT '7',
+  `forum_rules_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_topics_per_page` tinyint(4) NOT NULL DEFAULT '0',
   `forum_type` tinyint(4) NOT NULL DEFAULT '0',
   `forum_status` tinyint(4) NOT NULL DEFAULT '0',
   `forum_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `forum_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_post_subject` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_post_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `forum_last_poster_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_flags` tinyint(4) NOT NULL DEFAULT '32',
-  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `prune_next` int(11) unsigned NOT NULL DEFAULT '0',
+  `display_on_index` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `enable_indexing` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `enable_icons` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `enable_prune` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `prune_next` int(10) unsigned NOT NULL DEFAULT '0',
   `prune_days` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `forum_options` int(20) unsigned NOT NULL DEFAULT '0',
+  `display_subforum_list` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `forum_options` int(10) unsigned NOT NULL DEFAULT '0',
   `forum_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_topics_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_topics_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_topics_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `enable_shadow_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `enable_shadow_prune` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `prune_shadow_days` mediumint(8) unsigned NOT NULL DEFAULT '7',
   `prune_shadow_freq` mediumint(8) unsigned NOT NULL DEFAULT '1',
   `prune_shadow_next` int(11) NOT NULL DEFAULT '0',
@@ -482,29 +482,29 @@ CREATE TABLE `archive_phpbb3_posts` (
   `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poster_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `post_username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `poster_ip` varchar(40) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `post_reported` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `enable_bbcode` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `enable_smilies` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `enable_magic_url` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `enable_sig` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `post_username` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `post_text` mediumtext CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `post_checksum` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `post_edit_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_edit_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_checksum` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_attachment` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `bbcode_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_postcount` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `post_edit_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `post_edit_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_edit_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `post_visibility` tinyint(3) NOT NULL DEFAULT '0',
-  `post_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_edit_count` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `post_edit_locked` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `post_visibility` tinyint(4) NOT NULL DEFAULT '0',
+  `post_delete_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `post_delete_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`post_id`),
   KEY `forum_id` (`forum_id`),
@@ -525,38 +525,38 @@ CREATE TABLE `archive_phpbb3_topics` (
   `topic_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
   `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `topic_attachment` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `topic_reported` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `topic_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `topic_poster` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `topic_time_limit` int(10) unsigned NOT NULL DEFAULT '0',
   `topic_views` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_status` tinyint(3) NOT NULL DEFAULT '0',
-  `topic_type` tinyint(3) NOT NULL DEFAULT '0',
+  `topic_status` tinyint(4) NOT NULL DEFAULT '0',
+  `topic_type` tinyint(4) NOT NULL DEFAULT '0',
   `topic_first_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_first_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `topic_first_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
   `topic_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_last_poster_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `topic_last_view_time` int(10) unsigned NOT NULL DEFAULT '0',
   `topic_moved_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `topic_bumped` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poll_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `poll_start` int(11) unsigned NOT NULL DEFAULT '0',
-  `poll_length` int(11) unsigned NOT NULL DEFAULT '0',
+  `poll_title` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `poll_start` int(10) unsigned NOT NULL DEFAULT '0',
+  `poll_length` int(10) unsigned NOT NULL DEFAULT '0',
   `poll_max_options` tinyint(4) NOT NULL DEFAULT '1',
-  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT '0',
-  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `poll_last_vote` int(10) unsigned NOT NULL DEFAULT '0',
+  `poll_vote_change` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `poll_vote_name` tinyint(1) NOT NULL DEFAULT '0',
-  `topic_visibility` tinyint(3) NOT NULL DEFAULT '0',
-  `topic_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_visibility` tinyint(4) NOT NULL DEFAULT '0',
+  `topic_delete_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `topic_delete_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `topic_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
@@ -575,71 +575,71 @@ DROP TABLE IF EXISTS `archive_phpbb3_users`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_phpbb3_users` (
   `user_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `user_type` tinyint(2) NOT NULL DEFAULT '0',
+  `user_type` tinyint(4) NOT NULL DEFAULT '0',
   `group_id` mediumint(8) unsigned NOT NULL DEFAULT '3',
-  `user_permissions` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `user_permissions` mediumtext COLLATE utf8_bin NOT NULL,
   `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_regdate` int(11) unsigned NOT NULL DEFAULT '0',
-  `username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `username_clean` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_passchg` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_email` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_ip` varchar(40) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_regdate` int(10) unsigned NOT NULL DEFAULT '0',
+  `username` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `username_clean` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_password` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_passchg` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_email` varchar(100) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_email_hash` bigint(20) NOT NULL DEFAULT '0',
-  `user_birthday` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_lastmark` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_lastpage` varchar(200) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_last_confirm_key` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_last_search` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_birthday` varchar(10) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_lastvisit` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_lastmark` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_lastpost_time` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_lastpage` varchar(200) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_last_search` int(10) unsigned NOT NULL DEFAULT '0',
   `user_warnings` tinyint(4) NOT NULL DEFAULT '0',
-  `user_last_warning` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_last_warning` int(10) unsigned NOT NULL DEFAULT '0',
   `user_login_attempts` tinyint(4) NOT NULL DEFAULT '0',
-  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT '0',
-  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_inactive_reason` tinyint(4) NOT NULL DEFAULT '0',
+  `user_inactive_time` int(10) unsigned NOT NULL DEFAULT '0',
   `user_posts` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_lang` varchar(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_timezone` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_dateformat` varchar(64) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
+  `user_lang` varchar(30) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
   `user_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `user_rank` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_new_privmsg` int(4) NOT NULL DEFAULT '0',
-  `user_unread_privmsg` int(4) NOT NULL DEFAULT '0',
-  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `user_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_new_privmsg` int(11) NOT NULL DEFAULT '0',
+  `user_unread_privmsg` int(11) NOT NULL DEFAULT '0',
+  `user_last_privmsg` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_message_rules` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `user_full_folder` int(11) NOT NULL DEFAULT '-3',
-  `user_emailtime` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_topic_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_topic_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd',
-  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_post_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_post_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'a',
-  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_emailtime` int(10) unsigned NOT NULL DEFAULT '0',
+  `user_topic_show_days` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `user_topic_sortby_type` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `user_post_sortby_type` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 'a',
+  `user_notify` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `user_notify_pm` tinyint(3) unsigned NOT NULL DEFAULT '1',
   `user_notify_type` tinyint(4) NOT NULL DEFAULT '0',
-  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_options` int(11) unsigned NOT NULL DEFAULT '230271',
-  `user_avatar` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_avatar_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_sig` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `user_sig_bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_sig_bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_jabber` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_actkey` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_newpasswd` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_form_salt` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_new` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_allow_pm` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewonline` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewemail` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `user_allow_massemail` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `user_options` int(10) unsigned NOT NULL DEFAULT '230271',
+  `user_avatar` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar_width` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `user_avatar_height` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `user_sig` mediumtext COLLATE utf8_bin NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_new` tinyint(3) unsigned NOT NULL DEFAULT '1',
   `user_reminded` tinyint(4) NOT NULL DEFAULT '0',
-  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_reminded_time` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username_clean` (`username_clean`),
   KEY `user_birthday` (`user_birthday`),
@@ -652,18 +652,18 @@ DROP TABLE IF EXISTS `archive_registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `birthYear` smallint(6) unsigned NOT NULL DEFAULT '0',
-  `birthMonth` tinyint(4) unsigned NOT NULL DEFAULT '0',
-  `birthDay` tinyint(4) unsigned NOT NULL DEFAULT '0',
-  `email` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `guests_old` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `birthYear` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `birthMonth` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `birthDay` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `email` varchar(80) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `guests_old` text COLLATE utf8mb4_unicode_ci,
+  `comments` text COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -681,42 +681,42 @@ CREATE TABLE `assignments` (
   `registration_id` bigint(20) DEFAULT NULL,
   `schedule_activity_id` bigint(20) DEFAULT NULL,
   `station_number` int(11) DEFAULT NULL,
-  `assignment_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `assignment_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_assignments_on_registration_id` (`registration_id`),
   KEY `index_assignments_on_schedule_activity_id` (`schedule_activity_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1757500 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `bookmarked_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `bookmarked_competitions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_bookmarked_competitions_on_competition_id` (`competition_id`),
   KEY `index_bookmarked_competitions_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=48279 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `championships`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `championships` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `championship_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_championships_on_competition_id_and_championship_type` (`competition_id`,`championship_type`),
   KEY `index_championships_on_championship_type` (`championship_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=556 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_delegates`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_delegates` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -725,28 +725,28 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=15010 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
-  `qualification` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `qualification` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=81288 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_organizers`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_organizers` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `organizer_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -755,27 +755,27 @@ CREATE TABLE `competition_organizers` (
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=17120 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_tabs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_tabs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci,
   `display_order` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_tabs_on_display_order_and_competition_id` (`display_order`,`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=19657 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_trainee_delegates`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_trainee_delegates` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `trainee_delegate_id` int(11) DEFAULT NULL,
   `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL,
@@ -783,26 +783,26 @@ CREATE TABLE `competition_trainee_delegates` (
   PRIMARY KEY (`id`),
   KEY `index_competition_trainee_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_trainee_delegates_on_trainee_delegate_id` (`trainee_delegate_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=641 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_venues`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_venues` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `latitude_microdegrees` int(11) NOT NULL,
   `longitude_microdegrees` int(11) NOT NULL,
-  `timezone_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `timezone_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `country_iso2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_venues_on_competition_id_and_wcif_id` (`competition_id`,`wcif_id`),
   KEY `index_competition_venues_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3594 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `completed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -811,9 +811,9 @@ CREATE TABLE `completed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `handler` text COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
-  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `completed_at` datetime DEFAULT NULL,
@@ -826,11 +826,11 @@ DROP TABLE IF EXISTS `country_bands`;
 CREATE TABLE `country_bands` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `number` int(11) NOT NULL,
-  `iso2` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `iso2` varchar(2) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_country_bands_on_iso2` (`iso2`),
   KEY `index_country_bands_on_number` (`number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=122 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delayed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -839,13 +839,13 @@ CREATE TABLE `delayed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `handler` text COLLATE utf8mb4_unicode_ci,
+  `last_error` text COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `locked_at` datetime DEFAULT NULL,
   `failed_at` datetime DEFAULT NULL,
-  `locked_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `locked_by` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -857,39 +857,39 @@ DROP TABLE IF EXISTS `delegate_reports`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `delegate_reports` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `equipment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `venue` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `organization` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `schedule_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `incidents` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `discussion_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `equipment` text COLLATE utf8mb4_unicode_ci,
+  `venue` text COLLATE utf8mb4_unicode_ci,
+  `organization` text COLLATE utf8mb4_unicode_ci,
+  `schedule_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `incidents` text COLLATE utf8mb4_unicode_ci,
+  `remarks` text COLLATE utf8mb4_unicode_ci,
+  `discussion_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `posted_by_user_id` int(11) DEFAULT NULL,
   `posted_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `nag_sent_at` datetime DEFAULT NULL,
   `wrc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
-  `wrc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wrc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wdc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
-  `wdc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wdc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wrc_primary_user_id` int(11) DEFAULT NULL,
   `wrc_secondary_user_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=9255 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `eligible_country_iso2s_for_championship`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `eligible_country_iso2s_for_championship` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `eligible_country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `championship_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `eligible_country_iso2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_eligible_iso2s_for_championship_on_type_and_country_iso2` (`championship_type`,`eligible_country_iso2`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -897,12 +897,12 @@ DROP TABLE IF EXISTS `incident_competitions`;
 CREATE TABLE `incident_competitions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `incident_id` bigint(20) NOT NULL,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_competitions_on_incident_id_and_competition_id` (`incident_id`,`competition_id`),
   KEY `index_incident_competitions_on_incident_id` (`incident_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=91 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -910,36 +910,36 @@ DROP TABLE IF EXISTS `incident_tags`;
 CREATE TABLE `incident_tags` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `incident_id` bigint(20) NOT NULL,
-  `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tag` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_tags_on_incident_id_and_tag` (`incident_id`,`tag`),
   KEY `index_incident_tags_on_incident_id` (`incident_id`),
   KEY `index_incident_tags_on_tag` (`tag`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=112 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incidents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `incidents` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `title` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `private_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `private_wrc_decision` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `public_summary` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `title` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `private_description` text COLLATE utf8mb4_unicode_ci,
+  `private_wrc_decision` text COLLATE utf8mb4_unicode_ci,
+  `public_summary` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `resolved_at` datetime DEFAULT NULL,
   `digest_worthy` tinyint(1) DEFAULT '0',
   `digest_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=63 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `linkings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `linkings` (
-  `wca_id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wca_ids` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wca_id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wca_ids` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `index_linkings_on_wca_id` (`wca_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -964,15 +964,15 @@ CREATE TABLE `oauth_access_grants` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) NOT NULL,
   `application_id` int(11) NOT NULL,
-  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `expires_in` int(11) NOT NULL,
-  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `redirect_uri` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `revoked_at` datetime DEFAULT NULL,
-  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_grants_on_token` (`token`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_tokens`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -981,45 +981,45 @@ CREATE TABLE `oauth_access_tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) DEFAULT NULL,
   `application_id` int(11) DEFAULT NULL,
-  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `refresh_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `token` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `refresh_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `expires_in` int(11) DEFAULT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
-  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_tokens_on_token` (`token`),
   UNIQUE KEY `index_oauth_access_tokens_on_refresh_token` (`refresh_token`),
   KEY `index_oauth_access_tokens_on_resource_owner_id` (`resource_owner_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_applications`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `oauth_applications` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `uid` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `uid` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secret` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `redirect_uri` text COLLATE utf8mb4_unicode_ci,
+  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `owner_id` int(11) DEFAULT NULL,
-  `owner_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `owner_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `dangerously_allow_any_redirect_uri` tinyint(1) NOT NULL DEFAULT '0',
   `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `poll_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `poll_options` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `description` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,
   `poll_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `poll_id` (`poll_id`) USING BTREE
@@ -1030,12 +1030,12 @@ DROP TABLE IF EXISTS `polls`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `polls` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `question` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `question` text COLLATE utf8mb4_unicode_ci,
   `multiple` tinyint(1) NOT NULL,
   `deadline` datetime NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `comment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `comment` text COLLATE utf8mb4_unicode_ci,
   `confirmed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1046,21 +1046,21 @@ DROP TABLE IF EXISTS `post_tags`;
 CREATE TABLE `post_tags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `post_id` int(11) NOT NULL,
-  `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tag` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_post_tags_on_post_id_and_tag` (`post_id`,`tag`),
   KEY `index_post_tags_on_post_id` (`post_id`),
   KEY `index_post_tags_on_tag` (`tag`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=22361 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `posts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `posts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `slug` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `body` text COLLATE utf8mb4_unicode_ci,
+  `slug` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sticky` tinyint(1) NOT NULL DEFAULT '0',
   `author_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
@@ -1072,14 +1072,14 @@ CREATE TABLE `posts` (
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`sticky`,`created_at`),
   KEY `index_posts_on_world_readable_and_created_at` (`created_at`),
   KEY `idx_show_wr_sticky_created_at` (`show_on_homepage`,`sticky`,`created_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14062 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `preferred_formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `preferred_formats` (
-  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `format_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `format_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `ranking` int(11) NOT NULL,
   UNIQUE KEY `index_preferred_formats_on_event_id_and_format_id` (`event_id`,`format_id`),
   KEY `fk_rails_c3e0098ed3` (`format_id`)
@@ -1089,7 +1089,7 @@ DROP TABLE IF EXISTS `rails_persons`;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `rails_persons` AS SELECT
+/*!50001 CREATE VIEW `rails_persons` AS SELECT 
  1 AS `id`,
  1 AS `wca_id`,
  1 AS `subId`,
@@ -1107,24 +1107,24 @@ DROP TABLE IF EXISTS `regional_organizations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `regional_organizations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `country` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `website` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `country` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `website` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `address` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `directors_and_officers` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `area_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `past_and_current_activities` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `future_plans` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `extra_information` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `email` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `address` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `directors_and_officers` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `area_description` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `past_and_current_activities` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `future_plans` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extra_information` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_regional_organizations_on_name` (`name`),
   KEY `index_regional_organizations_on_country` (`country`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=38 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1136,7 +1136,7 @@ CREATE TABLE `registration_competition_events` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_registration_competition_events_on_reg_id_and_comp_event_id` (`registration_id`,`competition_event_id`),
   KEY `index_reg_events_reg_id_comp_event_id` (`registration_id`,`competition_event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2334458 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_payments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1145,8 +1145,8 @@ CREATE TABLE `registration_payments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `registration_id` int(11) DEFAULT NULL,
   `amount_lowest_denomination` int(11) DEFAULT NULL,
-  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `currency_code` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `stripe_charge_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `refunded_registration_payment_id` int(11) DEFAULT NULL,
@@ -1161,9 +1161,9 @@ DROP TABLE IF EXISTS `registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competition_id` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `comments` text COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1172,10 +1172,10 @@ CREATE TABLE `registrations` (
   `accepted_by` int(11) DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `deleted_by` int(11) DEFAULT NULL,
-  `roles` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `roles` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=495241 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `rounds`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1183,27 +1183,27 @@ DROP TABLE IF EXISTS `rounds`;
 CREATE TABLE `rounds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_event_id` int(11) NOT NULL,
-  `format_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `format_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `number` int(11) NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `time_limit` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `cutoff` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `advancement_condition` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `time_limit` text COLLATE utf8mb4_unicode_ci,
+  `cutoff` text COLLATE utf8mb4_unicode_ci,
+  `advancement_condition` text COLLATE utf8mb4_unicode_ci,
   `scramble_set_count` int(11) NOT NULL DEFAULT '1',
-  `round_results` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `round_results` mediumtext COLLATE utf8mb4_unicode_ci,
   `total_number_of_rounds` int(11) NOT NULL,
   `old_type` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=778693 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_check_categories`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sanity_check_categories` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_check_categories_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1214,8 +1214,8 @@ DROP TABLE IF EXISTS `sanity_check_exclusions`;
 CREATE TABLE `sanity_check_exclusions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `sanity_check_id` bigint(20) NOT NULL,
-  `exclusion` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `exclusion` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `fk_rails_c9112973d2` (`sanity_check_id`),
   CONSTRAINT `fk_rails_c9112973d2` FOREIGN KEY (`sanity_check_id`) REFERENCES `sanity_checks` (`id`)
@@ -1227,9 +1227,9 @@ DROP TABLE IF EXISTS `sanity_checks`;
 CREATE TABLE `sanity_checks` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `sanity_check_category_id` bigint(20) NOT NULL,
-  `topic` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `topic` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` text COLLATE utf8mb4_unicode_ci,
+  `query` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_checks_on_topic` (`topic`),
   KEY `fk_rails_fddad5fbb5` (`sanity_check_category_id`),
@@ -1241,11 +1241,11 @@ DROP TABLE IF EXISTS `schedule_activities`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schedule_activities` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `holder_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `holder_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `holder_id` bigint(20) NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `activity_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `activity_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_time` datetime NOT NULL,
   `end_time` datetime NOT NULL,
   `scramble_set_id` int(11) DEFAULT NULL,
@@ -1254,13 +1254,13 @@ CREATE TABLE `schedule_activities` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_activities_on_their_id_within_holder` (`holder_type`,`holder_id`,`wcif_id`),
   KEY `index_schedule_activities_on_holder_type_and_holder_id` (`holder_type`,`holder_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=169090 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
-  `version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1282,14 +1282,14 @@ DROP TABLE IF EXISTS `starburst_announcements`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `starburst_announcements` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `title` text COLLATE utf8mb4_unicode_ci,
+  `body` text COLLATE utf8mb4_unicode_ci,
   `start_delivering_at` datetime DEFAULT NULL,
   `stop_delivering_at` datetime DEFAULT NULL,
-  `limit_to_users` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `limit_to_users` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `category` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `category` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1298,10 +1298,10 @@ DROP TABLE IF EXISTS `stripe_charges`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `stripe_charges` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `status` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `metadata` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stripe_charge_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `error` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
@@ -1322,27 +1322,27 @@ CREATE TABLE `team_members` (
   `updated_at` datetime NOT NULL,
   `team_senior_member` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=517 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `teams`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `teams` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `friendly_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `friendly_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `hidden` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_teams_on_friendly_id` (`friendly_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `timestamps`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `timestamps` (
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `date` datetime DEFAULT NULL,
   UNIQUE KEY `index_timestamps_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1352,8 +1352,8 @@ DROP TABLE IF EXISTS `uploaded_jsons`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `uploaded_jsons` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `json_str` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `json_str` longtext COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_uploaded_jsons_on_competition_id` (`competition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1364,39 +1364,39 @@ DROP TABLE IF EXISTS `user_preferred_events`;
 CREATE TABLE `user_preferred_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_user_preferred_events_on_user_id_and_event_id` (`user_id`,`event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=230950 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `encrypted_password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `reset_password_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `encrypted_password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `reset_password_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `reset_password_sent_at` datetime DEFAULT NULL,
   `remember_created_at` datetime DEFAULT NULL,
   `sign_in_count` int(11) NOT NULL DEFAULT '0',
   `current_sign_in_at` datetime DEFAULT NULL,
   `last_sign_in_at` datetime DEFAULT NULL,
-  `current_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `last_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `confirmation_token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `current_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `confirmation_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `confirmed_at` datetime DEFAULT NULL,
   `confirmation_sent_at` datetime DEFAULT NULL,
-  `unconfirmed_email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unconfirmed_email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `delegate_status` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `delegate_status` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `senior_delegate_id` int(11) DEFAULT NULL,
-  `region` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `wca_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `pending_avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `region` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wca_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `avatar` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pending_avatar` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `saved_avatar_crop_x` int(11) DEFAULT NULL,
   `saved_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_avatar_crop_w` int(11) DEFAULT NULL,
@@ -1405,23 +1405,23 @@ CREATE TABLE `users` (
   `saved_pending_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_w` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_h` int(11) DEFAULT NULL,
-  `unconfirmed_wca_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unconfirmed_wca_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id_to_handle_wca_id_claim` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
-  `gender` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `country_iso2` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `gender` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `country_iso2` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `results_notifications_enabled` tinyint(1) DEFAULT '0',
-  `preferred_locale` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `preferred_locale` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `competition_notifications_enabled` tinyint(1) DEFAULT NULL,
   `receive_delegate_reports` tinyint(1) NOT NULL DEFAULT '0',
   `dummy_account` tinyint(1) NOT NULL DEFAULT '0',
-  `encrypted_otp_secret` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `encrypted_otp_secret_iv` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `encrypted_otp_secret_salt` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret_iv` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret_salt` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `consumed_timestep` int(11) DEFAULT NULL,
   `otp_required_for_login` tinyint(1) DEFAULT '0',
-  `otp_backup_codes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `session_validity_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `otp_backup_codes` text COLLATE utf8mb4_unicode_ci,
+  `session_validity_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cookies_acknowledged` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
@@ -1429,7 +1429,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=276377 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `venue_rooms`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1438,14 +1438,14 @@ CREATE TABLE `venue_rooms` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `competition_venue_id` bigint(20) NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `color` varchar(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_venue_rooms_on_competition_venue_id_and_wcif_id` (`competition_venue_id`,`wcif_id`),
   KEY `index_venue_rooms_on_competition_venue_id` (`competition_venue_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4322 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `vote_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1463,7 +1463,7 @@ DROP TABLE IF EXISTS `votes`;
 CREATE TABLE `votes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
-  `comment` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `comment` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `poll_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_votes_on_user_id` (`user_id`)
@@ -1474,11 +1474,11 @@ DROP TABLE IF EXISTS `wcif_extensions`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wcif_extensions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `extendable_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `extendable_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `extension_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `spec_url` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `data` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extendable_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `extendable_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `extension_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `spec_url` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `data` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_wcif_extensions_on_extendable_type_and_extendable_id` (`extendable_type`,`extendable_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1491,6 +1491,7 @@ CREATE TABLE `wcif_extensions` (
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments`,`Persons`.`incorrect_wca_id_claim_count` AS `incorrect_wca_id_claim_count` from `Persons` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -13,26 +13,26 @@ DROP TABLE IF EXISTS `Competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Competitions` (
-  `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cityName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `information` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `id` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cityName` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `information` mediumtext COLLATE utf8mb4_unicode_ci,
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endMonth` smallint(5) unsigned NOT NULL DEFAULT '0',
   `endDay` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `venue` varchar(240) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `venueAddress` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `venueDetails` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `external_website` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `venue` varchar(240) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `venueAddress` varchar(120) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `venueDetails` varchar(120) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `external_website` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `showAtAll` tinyint(1) NOT NULL DEFAULT '0',
   `latitude` int(11) DEFAULT NULL,
   `longitude` int(11) DEFAULT NULL,
-  `contact` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `contact` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `remarks` text COLLATE utf8mb4_unicode_ci,
   `registration_open` datetime DEFAULT NULL,
   `registration_close` datetime DEFAULT NULL,
   `use_wca_registration` tinyint(1) NOT NULL DEFAULT '1',
@@ -42,16 +42,16 @@ CREATE TABLE `Competitions` (
   `generate_website` tinyint(1) DEFAULT NULL,
   `announced_at` datetime DEFAULT NULL,
   `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
-  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
+  `currency_code` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
   `endYear` smallint(6) NOT NULL DEFAULT '0',
-  `connected_stripe_account_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `connected_stripe_account_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
   `competitor_limit_enabled` tinyint(1) DEFAULT NULL,
   `competitor_limit` int(11) DEFAULT NULL,
-  `competitor_limit_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `extra_registration_requirements` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `competitor_limit_reason` text COLLATE utf8mb4_unicode_ci,
+  `extra_registration_requirements` text COLLATE utf8mb4_unicode_ci,
   `on_the_spot_registration` tinyint(1) DEFAULT NULL,
   `on_the_spot_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `refund_policy_percent` int(11) DEFAULT NULL,
@@ -61,23 +61,23 @@ CREATE TABLE `Competitions` (
   `updated_at` datetime DEFAULT NULL,
   `results_submitted_at` datetime DEFAULT NULL,
   `early_puzzle_submission` tinyint(1) DEFAULT NULL,
-  `early_puzzle_submission_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `early_puzzle_submission_reason` text COLLATE utf8mb4_unicode_ci,
   `qualification_results` tinyint(1) DEFAULT NULL,
-  `qualification_results_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `name_reason` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `external_registration_page` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `qualification_results_reason` text COLLATE utf8mb4_unicode_ci,
+  `name_reason` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `external_registration_page` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `confirmed_at` datetime DEFAULT NULL,
   `event_restrictions` tinyint(1) DEFAULT NULL,
-  `event_restrictions_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `event_restrictions_reason` text COLLATE utf8mb4_unicode_ci,
   `registration_reminder_sent_at` datetime DEFAULT NULL,
   `announced_by` int(11) DEFAULT NULL,
   `results_posted_by` int(11) DEFAULT NULL,
-  `main_event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `main_event_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cancelled_at` datetime DEFAULT NULL,
   `cancelled_by` int(11) DEFAULT NULL,
   `waiting_list_deadline_date` datetime DEFAULT NULL,
   `event_change_deadline_date` datetime DEFAULT NULL,
-  `free_guest_entry_status` int NOT NULL DEFAULT '0',
+  `free_guest_entry_status` int(11) NOT NULL DEFAULT '0',
   `allow_registration_edits` tinyint(1) NOT NULL DEFAULT '0',
   `allow_registration_self_delete_after_acceptance` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
@@ -93,16 +93,16 @@ DROP TABLE IF EXISTS `CompetitionsMedia`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `CompetitionsMedia` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `type` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `text` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `submitterName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `submitterComment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `submitterEmail` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `type` varchar(15) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `text` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `uri` text COLLATE utf8mb4_unicode_ci,
+  `submitterName` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `submitterComment` text COLLATE utf8mb4_unicode_ci,
+  `submitterEmail` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `timestampSubmitted` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `timestampDecided` timestamp NULL DEFAULT NULL,
-  `status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `status` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -113,10 +113,10 @@ CREATE TABLE `ConciseAverageResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
   `valueAndId` bigint(22) DEFAULT NULL,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
@@ -129,10 +129,10 @@ CREATE TABLE `ConciseSingleResults` (
   `id` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
   `valueAndId` bigint(22) DEFAULT NULL,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `year` smallint(5) unsigned NOT NULL DEFAULT '0',
   `month` smallint(5) unsigned NOT NULL DEFAULT '0',
   `day` smallint(5) unsigned NOT NULL DEFAULT '0'
@@ -142,9 +142,9 @@ DROP TABLE IF EXISTS `Continents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Continents` (
-  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `recordName` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `recordName` char(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `latitude` int(11) NOT NULL DEFAULT '0',
   `longitude` int(11) NOT NULL DEFAULT '0',
   `zoom` tinyint(4) NOT NULL DEFAULT '0',
@@ -155,10 +155,10 @@ DROP TABLE IF EXISTS `Countries`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Countries` (
-  `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `iso2` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `continentId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `iso2` char(2) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `iso2` (`iso2`),
   KEY `fk_continents` (`continentId`)
@@ -168,11 +168,11 @@ DROP TABLE IF EXISTS `Events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Events` (
-  `id` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(54) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(54) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `format` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `format` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=0;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -180,10 +180,10 @@ DROP TABLE IF EXISTS `Formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Formats` (
-  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `sort_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `sort_by_second` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `id` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `sort_by` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sort_by_second` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `expected_solve_count` int(11) NOT NULL,
   `trim_fastest_n` int(11) NOT NULL,
   `trim_slowest_n` int(11) NOT NULL,
@@ -194,13 +194,13 @@ DROP TABLE IF EXISTS `InboxPersons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxPersons` (
-  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wcaId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` char(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wcaId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `dob` date NOT NULL,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `index_InboxPersons_on_competitionId_and_id` (`competitionId`,`id`),
   KEY `InboxPersons_fk_country` (`countryId`),
   KEY `InboxPersons_id` (`wcaId`),
@@ -211,12 +211,12 @@ DROP TABLE IF EXISTS `InboxResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxResults` (
-  `personId` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `personId` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -236,15 +236,15 @@ DROP TABLE IF EXISTS `Persons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Persons` (
-  `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `subId` tinyint(6) NOT NULL DEFAULT '1',
-  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `year` smallint(6) NOT NULL DEFAULT '0',
   `month` tinyint(4) NOT NULL DEFAULT '0',
   `day` tinyint(4) NOT NULL DEFAULT '0',
-  `comments` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `comments` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rails_id` int(11) NOT NULL AUTO_INCREMENT,
   `incorrect_wca_id_claim_count` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`rails_id`),
@@ -253,15 +253,15 @@ CREATE TABLE `Persons` (
   KEY `Persons_id` (`id`),
   KEY `Persons_name` (`name`),
   FULLTEXT KEY `index_Persons_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksAverage`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksAverage` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -276,8 +276,8 @@ DROP TABLE IF EXISTS `RanksSingle`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksSingle` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `best` int(11) NOT NULL DEFAULT '0',
   `worldRank` int(11) NOT NULL DEFAULT '0',
   `continentRank` int(11) NOT NULL DEFAULT '0',
@@ -293,13 +293,13 @@ DROP TABLE IF EXISTS `Results`;
 CREATE TABLE `Results` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pos` smallint(6) NOT NULL DEFAULT '0',
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `personName` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `personName` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `formatId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `value1` int(11) NOT NULL DEFAULT '0',
   `value2` int(11) NOT NULL DEFAULT '0',
   `value3` int(11) NOT NULL DEFAULT '0',
@@ -307,8 +307,8 @@ CREATE TABLE `Results` (
   `value5` int(11) NOT NULL DEFAULT '0',
   `best` int(11) NOT NULL DEFAULT '0',
   `average` int(11) NOT NULL DEFAULT '0',
-  `regionalSingleRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `regionalAverageRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `regionalSingleRecord` char(3) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `regionalAverageRecord` char(3) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `Results_fk_tournament` (`competitionId`),
@@ -335,10 +335,10 @@ DROP TABLE IF EXISTS `RoundTypes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RoundTypes` (
-  `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `id` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `rank` int(11) NOT NULL DEFAULT '0',
-  `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cellName` varchar(45) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `final` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -348,13 +348,13 @@ DROP TABLE IF EXISTS `Scrambles`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Scrambles` (
   `scrambleId` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `groupId` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `eventId` varchar(6) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `roundTypeId` char(1) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `groupId` varchar(3) COLLATE utf8mb4_unicode_ci NOT NULL,
   `isExtra` tinyint(1) NOT NULL,
   `scrambleNum` int(11) NOT NULL,
-  `scramble` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `scramble` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`scrambleId`),
   KEY `competitionId` (`competitionId`,`eventId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -364,8 +364,8 @@ DROP TABLE IF EXISTS `active_storage_attachments`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_attachments` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `record_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `record_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `record_id` bigint(20) NOT NULL,
   `blob_id` bigint(20) NOT NULL,
   `created_at` datetime NOT NULL,
@@ -380,12 +380,12 @@ DROP TABLE IF EXISTS `active_storage_blobs`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_blobs` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `key` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `filename` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `content_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `key` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `filename` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `metadata` text COLLATE utf8mb4_unicode_ci,
   `byte_size` bigint(20) NOT NULL,
-  `checksum` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `checksum` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `service_name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
@@ -398,7 +398,7 @@ DROP TABLE IF EXISTS `active_storage_variant_records`;
 CREATE TABLE `active_storage_variant_records` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `blob_id` bigint(20) NOT NULL,
-  `variation_digest` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `variation_digest` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_variant_records_uniqueness` (`blob_id`,`variation_digest`),
   CONSTRAINT `fk_rails_993965df05` FOREIGN KEY (`blob_id`) REFERENCES `active_storage_blobs` (`id`)
@@ -409,7 +409,7 @@ DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ar_internal_metadata` (
   `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `value` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `value` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`key`)
@@ -423,30 +423,30 @@ CREATE TABLE `archive_phpbb3_forums` (
   `parent_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `left_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `right_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_parents` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_desc` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_desc_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_parents` mediumtext COLLATE utf8_bin NOT NULL,
+  `forum_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc` text COLLATE utf8_bin NOT NULL,
+  `forum_desc_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_desc_options` int(11) unsigned NOT NULL DEFAULT '7',
-  `forum_desc_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_link` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_password` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_image` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_rules_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_image` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules` text COLLATE utf8_bin NOT NULL,
+  `forum_rules_link` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_rules_options` int(11) unsigned NOT NULL DEFAULT '7',
-  `forum_rules_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_topics_per_page` tinyint(4) NOT NULL DEFAULT '0',
   `forum_type` tinyint(4) NOT NULL DEFAULT '0',
   `forum_status` tinyint(4) NOT NULL DEFAULT '0',
   `forum_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `forum_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_post_subject` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `forum_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_poster_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
   `forum_flags` tinyint(4) NOT NULL DEFAULT '32',
   `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT '1',
@@ -482,29 +482,29 @@ CREATE TABLE `archive_phpbb3_posts` (
   `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poster_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `poster_ip` varchar(40) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_time` int(11) unsigned NOT NULL DEFAULT '0',
   `post_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `post_username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_username` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `post_text` mediumtext CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `post_checksum` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_checksum` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `bbcode_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `post_edit_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_edit_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_edit_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_edit_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT '0',
   `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `post_visibility` tinyint(3) NOT NULL DEFAULT '0',
   `post_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_delete_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `post_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`post_id`),
   KEY `forum_id` (`forum_id`),
@@ -536,18 +536,18 @@ CREATE TABLE `archive_phpbb3_topics` (
   `topic_type` tinyint(3) NOT NULL DEFAULT '0',
   `topic_first_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_first_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `topic_first_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
   `topic_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_poster_name` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
   `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT '0',
   `topic_moved_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poll_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `poll_title` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `poll_start` int(11) unsigned NOT NULL DEFAULT '0',
   `poll_length` int(11) unsigned NOT NULL DEFAULT '0',
   `poll_max_options` tinyint(4) NOT NULL DEFAULT '1',
@@ -556,7 +556,7 @@ CREATE TABLE `archive_phpbb3_topics` (
   `poll_vote_name` tinyint(1) NOT NULL DEFAULT '0',
   `topic_visibility` tinyint(3) NOT NULL DEFAULT '0',
   `topic_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_delete_reason` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `topic_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
@@ -577,22 +577,22 @@ CREATE TABLE `archive_phpbb3_users` (
   `user_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
   `user_type` tinyint(2) NOT NULL DEFAULT '0',
   `group_id` mediumint(8) unsigned NOT NULL DEFAULT '3',
-  `user_permissions` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `user_permissions` mediumtext COLLATE utf8_bin NOT NULL,
   `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_ip` varchar(40) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_regdate` int(11) unsigned NOT NULL DEFAULT '0',
-  `username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `username_clean` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `username` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `username_clean` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_password` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_passchg` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_email` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_email` varchar(100) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_email_hash` bigint(20) NOT NULL DEFAULT '0',
-  `user_birthday` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_birthday` varchar(10) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_lastvisit` int(11) unsigned NOT NULL DEFAULT '0',
   `user_lastmark` int(11) unsigned NOT NULL DEFAULT '0',
   `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_lastpage` varchar(200) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_last_confirm_key` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_lastpage` varchar(200) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_last_search` int(11) unsigned NOT NULL DEFAULT '0',
   `user_warnings` tinyint(4) NOT NULL DEFAULT '0',
   `user_last_warning` int(11) unsigned NOT NULL DEFAULT '0',
@@ -600,12 +600,12 @@ CREATE TABLE `archive_phpbb3_users` (
   `user_inactive_reason` tinyint(2) NOT NULL DEFAULT '0',
   `user_inactive_time` int(11) unsigned NOT NULL DEFAULT '0',
   `user_posts` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_lang` varchar(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_timezone` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_dateformat` varchar(64) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
+  `user_lang` varchar(30) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
   `user_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
   `user_rank` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_colour` varchar(6) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_new_privmsg` int(4) NOT NULL DEFAULT '0',
   `user_unread_privmsg` int(4) NOT NULL DEFAULT '0',
   `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT '0',
@@ -613,11 +613,11 @@ CREATE TABLE `archive_phpbb3_users` (
   `user_full_folder` int(11) NOT NULL DEFAULT '-3',
   `user_emailtime` int(11) unsigned NOT NULL DEFAULT '0',
   `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_topic_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_topic_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd',
+  `user_topic_sortby_type` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 'd',
   `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_post_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_post_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'a',
+  `user_post_sortby_type` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) COLLATE utf8_bin NOT NULL DEFAULT 'a',
   `user_notify` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `user_notify_type` tinyint(4) NOT NULL DEFAULT '0',
@@ -626,17 +626,17 @@ CREATE TABLE `archive_phpbb3_users` (
   `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `user_options` int(11) unsigned NOT NULL DEFAULT '230271',
-  `user_avatar` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_avatar_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT '0',
   `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_sig` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `user_sig_bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_sig_bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_jabber` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_actkey` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_newpasswd` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_form_salt` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_sig` mediumtext COLLATE utf8_bin NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(255) COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) COLLATE utf8_bin NOT NULL DEFAULT '',
   `user_new` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `user_reminded` tinyint(4) NOT NULL DEFAULT '0',
   `user_reminded_time` int(11) unsigned NOT NULL DEFAULT '0',
@@ -652,18 +652,18 @@ DROP TABLE IF EXISTS `archive_registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competitionId` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(80) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `personId` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `countryId` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `gender` char(1) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `birthYear` smallint(6) unsigned NOT NULL DEFAULT '0',
   `birthMonth` tinyint(4) unsigned NOT NULL DEFAULT '0',
   `birthDay` tinyint(4) unsigned NOT NULL DEFAULT '0',
-  `email` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `guests_old` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `email` varchar(80) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `guests_old` text COLLATE utf8mb4_unicode_ci,
+  `comments` text COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -681,7 +681,7 @@ CREATE TABLE `assignments` (
   `registration_id` bigint(20) DEFAULT NULL,
   `schedule_activity_id` bigint(20) DEFAULT NULL,
   `station_number` int(11) DEFAULT NULL,
-  `assignment_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `assignment_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_assignments_on_registration_id` (`registration_id`),
   KEY `index_assignments_on_schedule_activity_id` (`schedule_activity_id`)
@@ -692,7 +692,7 @@ DROP TABLE IF EXISTS `bookmarked_competitions`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `bookmarked_competitions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_bookmarked_competitions_on_competition_id` (`competition_id`),
@@ -704,8 +704,8 @@ DROP TABLE IF EXISTS `championships`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `championships` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `championship_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_championships_on_competition_id_and_championship_type` (`competition_id`,`championship_type`),
   KEY `index_championships_on_championship_type` (`championship_type`)
@@ -716,7 +716,7 @@ DROP TABLE IF EXISTS `competition_delegates`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_delegates` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -725,28 +725,28 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
-  `qualification` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `qualification` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_organizers`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_organizers` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `organizer_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -762,9 +762,9 @@ DROP TABLE IF EXISTS `competition_tabs`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_tabs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` text COLLATE utf8mb4_unicode_ci,
   `display_order` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_tabs_on_display_order_and_competition_id` (`display_order`,`competition_id`)
@@ -775,7 +775,7 @@ DROP TABLE IF EXISTS `competition_trainee_delegates`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_trainee_delegates` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `trainee_delegate_id` int(11) DEFAULT NULL,
   `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL,
@@ -790,19 +790,19 @@ DROP TABLE IF EXISTS `competition_venues`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_venues` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `latitude_microdegrees` int(11) NOT NULL,
   `longitude_microdegrees` int(11) NOT NULL,
-  `timezone_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `timezone_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `country_iso2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_venues_on_competition_id_and_wcif_id` (`competition_id`,`wcif_id`),
   KEY `index_competition_venues_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `completed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -811,9 +811,9 @@ CREATE TABLE `completed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `handler` text COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
-  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `completed_at` datetime DEFAULT NULL,
@@ -826,7 +826,7 @@ DROP TABLE IF EXISTS `country_bands`;
 CREATE TABLE `country_bands` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `number` int(11) NOT NULL,
-  `iso2` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `iso2` varchar(2) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_country_bands_on_iso2` (`iso2`),
   KEY `index_country_bands_on_number` (`number`)
@@ -839,13 +839,13 @@ CREATE TABLE `delayed_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `priority` int(11) NOT NULL DEFAULT '0',
   `attempts` int(11) NOT NULL DEFAULT '0',
-  `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `handler` text COLLATE utf8mb4_unicode_ci,
+  `last_error` text COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `locked_at` datetime DEFAULT NULL,
   `failed_at` datetime DEFAULT NULL,
-  `locked_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `locked_by` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `queue` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -857,39 +857,39 @@ DROP TABLE IF EXISTS `delegate_reports`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `delegate_reports` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `equipment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `venue` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `organization` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `schedule_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `incidents` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `discussion_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `equipment` text COLLATE utf8mb4_unicode_ci,
+  `venue` text COLLATE utf8mb4_unicode_ci,
+  `organization` text COLLATE utf8mb4_unicode_ci,
+  `schedule_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `incidents` text COLLATE utf8mb4_unicode_ci,
+  `remarks` text COLLATE utf8mb4_unicode_ci,
+  `discussion_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `posted_by_user_id` int(11) DEFAULT NULL,
   `posted_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `nag_sent_at` datetime DEFAULT NULL,
   `wrc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
-  `wrc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wrc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wdc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
-  `wdc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wdc_incidents` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wrc_primary_user_id` int(11) DEFAULT NULL,
   `wrc_secondary_user_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `eligible_country_iso2s_for_championship`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `eligible_country_iso2s_for_championship` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `eligible_country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `championship_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `eligible_country_iso2` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_eligible_iso2s_for_championship_on_type_and_country_iso2` (`championship_type`,`eligible_country_iso2`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -897,8 +897,8 @@ DROP TABLE IF EXISTS `incident_competitions`;
 CREATE TABLE `incident_competitions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `incident_id` bigint(20) NOT NULL,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_competitions_on_incident_id_and_competition_id` (`incident_id`,`competition_id`),
   KEY `index_incident_competitions_on_incident_id` (`incident_id`)
@@ -910,7 +910,7 @@ DROP TABLE IF EXISTS `incident_tags`;
 CREATE TABLE `incident_tags` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `incident_id` bigint(20) NOT NULL,
-  `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tag` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_tags_on_incident_id_and_tag` (`incident_id`,`tag`),
   KEY `index_incident_tags_on_incident_id` (`incident_id`),
@@ -922,10 +922,10 @@ DROP TABLE IF EXISTS `incidents`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `incidents` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `title` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `private_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `private_wrc_decision` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `public_summary` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `title` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `private_description` text COLLATE utf8mb4_unicode_ci,
+  `private_wrc_decision` text COLLATE utf8mb4_unicode_ci,
+  `public_summary` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `resolved_at` datetime DEFAULT NULL,
@@ -938,8 +938,8 @@ DROP TABLE IF EXISTS `linkings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `linkings` (
-  `wca_id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wca_ids` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wca_id` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `wca_ids` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE KEY `index_linkings_on_wca_id` (`wca_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -964,12 +964,12 @@ CREATE TABLE `oauth_access_grants` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) NOT NULL,
   `application_id` int(11) NOT NULL,
-  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `expires_in` int(11) NOT NULL,
-  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `redirect_uri` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `revoked_at` datetime DEFAULT NULL,
-  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_grants_on_token` (`token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -981,12 +981,12 @@ CREATE TABLE `oauth_access_tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_owner_id` int(11) DEFAULT NULL,
   `application_id` int(11) DEFAULT NULL,
-  `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `refresh_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `token` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `refresh_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `expires_in` int(11) DEFAULT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
-  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_tokens_on_token` (`token`),
   UNIQUE KEY `index_oauth_access_tokens_on_refresh_token` (`refresh_token`),
@@ -998,15 +998,15 @@ DROP TABLE IF EXISTS `oauth_applications`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `oauth_applications` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `uid` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `uid` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secret` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `redirect_uri` text COLLATE utf8mb4_unicode_ci,
+  `scopes` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `owner_id` int(11) DEFAULT NULL,
-  `owner_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `owner_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `dangerously_allow_any_redirect_uri` tinyint(1) NOT NULL DEFAULT '0',
   `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
@@ -1019,7 +1019,7 @@ DROP TABLE IF EXISTS `poll_options`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `poll_options` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `description` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,
   `poll_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `poll_id` (`poll_id`) USING BTREE
@@ -1030,12 +1030,12 @@ DROP TABLE IF EXISTS `polls`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `polls` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `question` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `question` text COLLATE utf8mb4_unicode_ci,
   `multiple` tinyint(1) NOT NULL,
   `deadline` datetime NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `comment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `comment` text COLLATE utf8mb4_unicode_ci,
   `confirmed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1046,7 +1046,7 @@ DROP TABLE IF EXISTS `post_tags`;
 CREATE TABLE `post_tags` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `post_id` int(11) NOT NULL,
-  `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tag` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_post_tags_on_post_id_and_tag` (`post_id`,`tag`),
   KEY `index_post_tags_on_post_id` (`post_id`),
@@ -1058,9 +1058,9 @@ DROP TABLE IF EXISTS `posts`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `posts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `slug` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `body` text COLLATE utf8mb4_unicode_ci,
+  `slug` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sticky` tinyint(1) NOT NULL DEFAULT '0',
   `author_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
@@ -1078,8 +1078,8 @@ DROP TABLE IF EXISTS `preferred_formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `preferred_formats` (
-  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `format_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `format_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `ranking` int(11) NOT NULL,
   UNIQUE KEY `index_preferred_formats_on_event_id_and_format_id` (`event_id`,`format_id`),
   KEY `fk_rails_c3e0098ed3` (`format_id`)
@@ -1089,7 +1089,7 @@ DROP TABLE IF EXISTS `rails_persons`;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
-/*!50001 CREATE VIEW `rails_persons` AS SELECT
+/*!50001 CREATE VIEW `rails_persons` AS SELECT 
  1 AS `id`,
  1 AS `wca_id`,
  1 AS `subId`,
@@ -1107,20 +1107,20 @@ DROP TABLE IF EXISTS `regional_organizations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `regional_organizations` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `country` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `website` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `country` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `website` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `address` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `directors_and_officers` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `area_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `past_and_current_activities` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `future_plans` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `extra_information` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `email` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `address` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `directors_and_officers` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `area_description` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `past_and_current_activities` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `future_plans` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extra_information` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_regional_organizations_on_name` (`name`),
   KEY `index_regional_organizations_on_country` (`country`)
@@ -1145,8 +1145,8 @@ CREATE TABLE `registration_payments` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `registration_id` int(11) DEFAULT NULL,
   `amount_lowest_denomination` int(11) DEFAULT NULL,
-  `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `currency_code` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `stripe_charge_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `refunded_registration_payment_id` int(11) DEFAULT NULL,
@@ -1161,9 +1161,9 @@ DROP TABLE IF EXISTS `registrations`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registrations` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `competition_id` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `comments` text COLLATE utf8mb4_unicode_ci,
+  `ip` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1172,7 +1172,7 @@ CREATE TABLE `registrations` (
   `accepted_by` int(11) DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
   `deleted_by` int(11) DEFAULT NULL,
-  `roles` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `roles` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1183,27 +1183,27 @@ DROP TABLE IF EXISTS `rounds`;
 CREATE TABLE `rounds` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_event_id` int(11) NOT NULL,
-  `format_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `format_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `number` int(11) NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `time_limit` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `cutoff` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `advancement_condition` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `time_limit` text COLLATE utf8mb4_unicode_ci,
+  `cutoff` text COLLATE utf8mb4_unicode_ci,
+  `advancement_condition` text COLLATE utf8mb4_unicode_ci,
   `scramble_set_count` int(11) NOT NULL DEFAULT '1',
-  `round_results` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `round_results` mediumtext COLLATE utf8mb4_unicode_ci,
   `total_number_of_rounds` int(11) NOT NULL,
   `old_type` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_check_categories`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sanity_check_categories` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_check_categories_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1214,8 +1214,8 @@ DROP TABLE IF EXISTS `sanity_check_exclusions`;
 CREATE TABLE `sanity_check_exclusions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `sanity_check_id` bigint(20) NOT NULL,
-  `exclusion` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `exclusion` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `fk_rails_c9112973d2` (`sanity_check_id`),
   CONSTRAINT `fk_rails_c9112973d2` FOREIGN KEY (`sanity_check_id`) REFERENCES `sanity_checks` (`id`)
@@ -1227,9 +1227,9 @@ DROP TABLE IF EXISTS `sanity_checks`;
 CREATE TABLE `sanity_checks` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `sanity_check_category_id` bigint(20) NOT NULL,
-  `topic` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `topic` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `comments` text COLLATE utf8mb4_unicode_ci,
+  `query` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_checks_on_topic` (`topic`),
   KEY `fk_rails_fddad5fbb5` (`sanity_check_category_id`),
@@ -1241,11 +1241,11 @@ DROP TABLE IF EXISTS `schedule_activities`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schedule_activities` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `holder_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `holder_type` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `holder_id` bigint(20) NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `activity_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `activity_code` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_time` datetime NOT NULL,
   `end_time` datetime NOT NULL,
   `scramble_set_id` int(11) DEFAULT NULL,
@@ -1254,13 +1254,13 @@ CREATE TABLE `schedule_activities` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_activities_on_their_id_within_holder` (`holder_type`,`holder_id`,`wcif_id`),
   KEY `index_schedule_activities_on_holder_type_and_holder_id` (`holder_type`,`holder_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
-  `version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1282,14 +1282,14 @@ DROP TABLE IF EXISTS `starburst_announcements`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `starburst_announcements` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `title` text COLLATE utf8mb4_unicode_ci,
+  `body` text COLLATE utf8mb4_unicode_ci,
   `start_delivering_at` datetime DEFAULT NULL,
   `stop_delivering_at` datetime DEFAULT NULL,
-  `limit_to_users` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `limit_to_users` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `category` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `category` text COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1298,10 +1298,10 @@ DROP TABLE IF EXISTS `stripe_charges`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `stripe_charges` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `status` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `metadata` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stripe_charge_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `error` text COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
@@ -1329,20 +1329,20 @@ DROP TABLE IF EXISTS `teams`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `teams` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `friendly_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `friendly_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `hidden` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_teams_on_friendly_id` (`friendly_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `timestamps`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `timestamps` (
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `date` datetime DEFAULT NULL,
   UNIQUE KEY `index_timestamps_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1352,8 +1352,8 @@ DROP TABLE IF EXISTS `uploaded_jsons`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `uploaded_jsons` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `json_str` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `competition_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `json_str` longtext COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `index_uploaded_jsons_on_competition_id` (`competition_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1364,7 +1364,7 @@ DROP TABLE IF EXISTS `user_preferred_events`;
 CREATE TABLE `user_preferred_events` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) DEFAULT NULL,
-  `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `event_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_user_preferred_events_on_user_id_and_event_id` (`user_id`,`event_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1374,29 +1374,29 @@ DROP TABLE IF EXISTS `users`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `encrypted_password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `reset_password_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `encrypted_password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `reset_password_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `reset_password_sent_at` datetime DEFAULT NULL,
   `remember_created_at` datetime DEFAULT NULL,
   `sign_in_count` int(11) NOT NULL DEFAULT '0',
   `current_sign_in_at` datetime DEFAULT NULL,
   `last_sign_in_at` datetime DEFAULT NULL,
-  `current_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `last_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `confirmation_token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `current_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_sign_in_ip` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `confirmation_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `confirmed_at` datetime DEFAULT NULL,
   `confirmation_sent_at` datetime DEFAULT NULL,
-  `unconfirmed_email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unconfirmed_email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `delegate_status` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `delegate_status` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `senior_delegate_id` int(11) DEFAULT NULL,
-  `region` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `wca_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `pending_avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `region` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wca_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `avatar` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pending_avatar` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `saved_avatar_crop_x` int(11) DEFAULT NULL,
   `saved_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_avatar_crop_w` int(11) DEFAULT NULL,
@@ -1405,23 +1405,23 @@ CREATE TABLE `users` (
   `saved_pending_avatar_crop_y` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_w` int(11) DEFAULT NULL,
   `saved_pending_avatar_crop_h` int(11) DEFAULT NULL,
-  `unconfirmed_wca_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unconfirmed_wca_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_id_to_handle_wca_id_claim` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
-  `gender` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `country_iso2` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `gender` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `country_iso2` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `results_notifications_enabled` tinyint(1) DEFAULT '0',
-  `preferred_locale` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `preferred_locale` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `competition_notifications_enabled` tinyint(1) DEFAULT NULL,
   `receive_delegate_reports` tinyint(1) NOT NULL DEFAULT '0',
   `dummy_account` tinyint(1) NOT NULL DEFAULT '0',
-  `encrypted_otp_secret` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `encrypted_otp_secret_iv` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `encrypted_otp_secret_salt` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret_iv` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `encrypted_otp_secret_salt` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `consumed_timestep` int(11) DEFAULT NULL,
   `otp_required_for_login` tinyint(1) DEFAULT '0',
-  `otp_backup_codes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `session_validity_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `otp_backup_codes` text COLLATE utf8mb4_unicode_ci,
+  `session_validity_token` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cookies_acknowledged` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
@@ -1429,7 +1429,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `venue_rooms`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1438,14 +1438,14 @@ CREATE TABLE `venue_rooms` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `competition_venue_id` bigint(20) NOT NULL,
   `wcif_id` int(11) NOT NULL,
-  `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `color` varchar(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `color` varchar(7) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_venue_rooms_on_competition_venue_id_and_wcif_id` (`competition_venue_id`,`wcif_id`),
   KEY `index_venue_rooms_on_competition_venue_id` (`competition_venue_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `vote_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1463,7 +1463,7 @@ DROP TABLE IF EXISTS `votes`;
 CREATE TABLE `votes` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
-  `comment` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `comment` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `poll_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_votes_on_user_id` (`user_id`)
@@ -1474,14 +1474,14 @@ DROP TABLE IF EXISTS `wcif_extensions`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wcif_extensions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `extendable_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `extendable_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `extension_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `spec_url` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `data` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extendable_type` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `extendable_id` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `extension_id` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `spec_url` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `data` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_wcif_extensions_on_extendable_type_and_extendable_id` (`extendable_type`,`extendable_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 /*!50001 SET @saved_cs_client          = @@character_set_client */;
@@ -1491,6 +1491,7 @@ CREATE TABLE `wcif_extensions` (
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments`,`Persons`.`incorrect_wca_id_claim_count` AS `incorrect_wca_id_claim_count` from `Persons` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -1762,6 +1763,8 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20220223163446'),
 ('20220223163447'),
 ('20220511025003'),
-('20220516124717'), 
+('20220516124717'),
 ('20220619200832'),
 ('20220623121810');
+
+

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -735,7 +735,7 @@ CREATE TABLE `competition_events` (
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
-  `qualification` text COLLATE utf8mb4_unicode_ci,
+  `qualification` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
@@ -1750,6 +1750,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20210301002636'),
 ('20210325202019'),
 ('20210501213332'),
+('20210506205912'),
 ('20210521195423'),
 ('20210727081850'),
 ('20210802065056'),

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -372,6 +372,7 @@ module DatabaseDumper
           competition_id
           event_id
           fee_lowest_denomination
+          qualification
         ),
       ),
     }.freeze,

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -3,8 +3,10 @@
 class Qualification
   include ActiveModel::Validations
 
-  attr_accessor :when_date, :level
+  attr_accessor :when_date, :level, :wcif_type, :method
   validates :when_date, presence: true
+  validates :wcif_type, presence: true, inclusion: { in: ["single", "average"] }
+  validates :method, presence: true, inclusion: { in: ["result", "ranking"] }
   validates :level, numericality: { only_integer: true, greater_than: 0 }
 
   def ==(other)
@@ -15,21 +17,14 @@ class Qualification
     self.to_wcif.hash
   end
 
-  def self.wcif_type_to_class
-    @@wcif_type_to_class ||= {
-      "ranking" => RankingQualification,
-      "single" => SingleQualification,
-      "average" => AverageQualification,
-    }
-  end
-
   def self.load(json)
     if json.nil? || json.is_a?(self)
       json
     else
       json_obj = json.is_a?(Hash) ? json : JSON.parse(json)
-      wcif_type = json_obj['type']
-      out = self.wcif_type_to_class[wcif_type].new
+      out = Qualification.new
+      out.wcif_type = json_obj['type']
+      out.method = json_obj['method']
       out.level = json_obj['level']
       begin
         out.when_date = Date.iso8601(json_obj['whenDate'])
@@ -49,7 +44,8 @@ class Qualification
       "type" => ["object", "null"],
       "properties" => {
         "whenDate" => { "type" => "string" },
-        "type" => { "type" => "string", "enum" => ["ranking", "single", "average"] },
+        "type" => { "type" => "string", "enum" => ["single", "average"] },
+        "method" => { "type" => "string", "enum" => ["result", "ranking"] },
         "level" => { "type" => "integer" },
       },
     }
@@ -57,43 +53,21 @@ class Qualification
 
   def to_wcif
     {
-      "type" => self.class.wcif_type,
+      "type" => self.wcif_type,
       "whenDate" => @when_date&.strftime("%Y-%m-%d"),
       "level" => @level,
     }
   end
-end
-
-class RankingQualification < Qualification
-  def self.wcif_type
-    "ranking"
-  end
 
   def to_s(event)
-    I18n.t("qualification.ranking", ranking: level)
-  end
-end
-
-class TimeQualification < Qualification
-  def to_s(event)
-    if event.event.timed_event?
-      I18n.t("qualification." + self.class.wcif_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
+    if self.method == "ranking"
+      I18n.t("qualification." + self.wcif_type + ".ranking", ranking: level)
+    elsif event.event.timed_event?
+      I18n.t("qualification." + self.wcif_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
     elsif event.event.fewest_moves?
-      I18n.t("qualification." + self.class.wcif_type + ".moves", moves: level)
+      I18n.t("qualification." + self.wcif_type + ".moves", moves: level)
     elsif event.event.multiple_blindfolded?
-      I18n.t("qualification." + self.class.wcif_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
+      I18n.t("qualification." + self.wcif_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
     end
-  end
-end
-
-class SingleQualification < TimeQualification
-  def self.wcif_type
-    "single"
-  end
-end
-
-class AverageQualification < TimeQualification
-  def self.wcif_type
-    "average"
   end
 end

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -3,11 +3,15 @@
 class Qualification
   include ActiveModel::Validations
 
-  attr_accessor :when_date, :level, :wcif_type, :method
+  attr_accessor :when_date, :level, :wcif_type, :result_type
   validates :when_date, presence: true
-  validates :wcif_type, presence: true, inclusion: { in: ["single", "average"] }
-  validates :method, presence: true, inclusion: { in: ["result", "ranking"] }
-  validates :level, numericality: { only_integer: true, greater_than: 0 }
+  validates :result_type, presence: true, inclusion: { in: ["single", "average"] }
+  validates :wcif_type, presence: true, inclusion: { in: ["attemptResult", "ranking", "anyResult"] }
+  validates :level, numericality: { only_integer: true, greater_than: 0 }, if: :result_or_ranking?
+
+  def result_or_ranking?
+    self.wcif_type == 'attemptResult' || self.wcif_type == 'ranking'
+  end
 
   def ==(other)
     other.class == self.class && other.to_wcif == self.to_wcif
@@ -24,13 +28,14 @@ class Qualification
       json_obj = json.is_a?(Hash) ? json : JSON.parse(json)
       out = Qualification.new
       out.wcif_type = json_obj['type']
-      out.method = json_obj['method']
+      out.result_type = json_obj['resultType']
       out.level = json_obj['level']
       begin
         out.when_date = Date.iso8601(json_obj['whenDate'])
       rescue ArgumentError
         nil
       end
+      p out
       out
     end
   end
@@ -44,9 +49,9 @@ class Qualification
       "type" => ["object", "null"],
       "properties" => {
         "whenDate" => { "type" => "string" },
-        "type" => { "type" => "string", "enum" => ["single", "average"] },
-        "method" => { "type" => "string", "enum" => ["result", "ranking"] },
-        "level" => { "type" => "integer" },
+        "resultType" => { "type" => "string", "enum" => ["single", "average"] },
+        "type" => { "type" => "string", "enum" => ["attemptResult", "ranking", "anyResult"] },
+        "level" => { "type" => ["integer", "null"] },
       },
     }
   end
@@ -54,22 +59,24 @@ class Qualification
   def to_wcif
     {
       "type" => @wcif_type,
-      "method" => @method,
+      "resultType" => @result_type,
       "whenDate" => @when_date&.strftime("%Y-%m-%d"),
       "level" => @level,
     }
   end
 
   def to_s(event)
-    if self.method == "ranking"
-      I18n.t("qualification." + self.wcif_type + ".ranking", ranking: level)
+    if self.wcif_type == "ranking"
+      I18n.t("qualification." + self.result_type + ".ranking", ranking: level)
+    elsif self.wcif_type == "anyResult"
+      I18n.t("qualification." + self.result_type + ".any_result")
     elsif event.event.timed_event?
-      I18n.t("qualification." + self.wcif_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
+      I18n.t("qualification." + self.result_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
     elsif event.event.fewest_moves?
-      moves = self.wcif_type == "average" ? (level.to_f / 100).round(2) : level
-      I18n.t("qualification." + self.wcif_type + ".moves", moves: moves)
+      moves = self.result_type == "average" ? (level.to_f / 100).round(2) : level
+      I18n.t("qualification." + self.result_type + ".moves", moves: moves)
     elsif event.event.multiple_blindfolded?
-      I18n.t("qualification." + self.wcif_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
+      I18n.t("qualification." + self.result_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
     end
   end
 end

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -77,11 +77,11 @@ end
 class TimeQualification < Qualification
   def to_s(event)
     if event.event.timed_event?
-      I18n.t("qualification." + self.wcif_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
+      I18n.t("qualification." + self.class.wcif_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
     elsif event.event.fewest_moves?
-      I18n.t("qualification." + self.wcif_type + ".moves", moves: level)
+      I18n.t("qualification." + self.class.wcif_type + ".moves", moves: level)
     elsif event.event.multiple_blindfolded?
-      I18n.t("qualification." + self.wcif_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
+      I18n.t("qualification." + self.class.wcif_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
     end
   end
 end

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -16,7 +16,7 @@ class Qualification
   end
 
   def self.wcif_type_to_class
-    @@wcif_type_to_class ||= Qualification.subclasses.map { |cls| [cls.wcif_type, cls] }.to_h
+    @@wcif_type_to_class ||= Qualification.subclasses.map.to_h { |cls| [cls.wcif_type, cls] }
   end
 
   def self.load(json)

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -55,7 +55,7 @@ class Qualification
     {
       "type" => self.class.wcif_type,
       "whenDate" => @when_date&.strftime("%Y-%m-%d"),
-      "level" => level,
+      "level" => @level,
     }
   end
 end

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -70,34 +70,26 @@ class RankingQualification < Qualification
   end
 end
 
-class SingleQualification < Qualification
-  def self.wcif_type
-    "single"
-  end
-
+class TimeQualification < Qualification
   def to_s(event)
     if event.event.timed_event?
-      I18n.t("qualification.single.time", time: SolveTime.centiseconds_to_clock_format(level))
+      I18n.t("qualification." + self.wcif_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
     elsif event.event.fewest_moves?
-      I18n.t("qualification.single.moves", moves: level)
+      I18n.t("qualification." + self.wcif_type + ".moves", moves: level)
     elsif event.event.multiple_blindfolded?
-      I18n.t("qualification.single.points", points: SolveTime.multibld_attempt_to_points(level))
+      I18n.t("qualification." + self.wcif_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
     end
   end
 end
 
-class AverageQualification < Qualification
+class SingleQualification < TimeQualification
+  def self.wcif_type
+    "single"
+  end
+end
+
+class AverageQualification < TimeQualification
   def self.wcif_type
     "average"
-  end
-
-  def to_s(event, short: false)
-    if event.event.timed_event?
-      I18n.t("qualification.average.time", time: SolveTime.centiseconds_to_clock_format(level))
-    elsif event.event.fewest_moves?
-      I18n.t("qualification.average.moves", moves: level)
-    elsif event.event.multiple_blindfolded?
-      I18n.t("qualification.average.points", points: SolveTime.multibld_attempt_to_points(level))
-    end
   end
 end

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -53,7 +53,8 @@ class Qualification
 
   def to_wcif
     {
-      "type" => self.wcif_type,
+      "type" => @wcif_type,
+      "method" => @method,
       "whenDate" => @when_date&.strftime("%Y-%m-%d"),
       "level" => @level,
     }

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -16,7 +16,11 @@ class Qualification
   end
 
   def self.wcif_type_to_class
-    @@wcif_type_to_class ||= Qualification.subclasses.map.to_h { |cls| [cls.wcif_type, cls] }
+    @@wcif_type_to_class ||= {
+      "ranking" => RankingQualification,
+      "single" => SingleQualification,
+      "average" => AverageQualification,
+    }
   end
 
   def self.load(json)
@@ -45,7 +49,7 @@ class Qualification
       "type" => ["object", "null"],
       "properties" => {
         "whenDate" => { "type" => "string" },
-        "type" => { "type" => "string", "enum" => Qualification.subclasses.map(&:wcif_type) },
+        "type" => { "type" => "string", "enum" => ["ranking", "single", "average"] },
         "level" => { "type" => "integer" },
       },
     }

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+class Qualification
+  include ActiveModel::Validations
+
+  attr_accessor :when_date, :level
+  validates :when_date, presence: true
+  validates :level, numericality: { only_integer: true, greater_than: 0 }
+
+  def ==(other)
+    other.class == self.class && other.to_wcif == self.to_wcif
+  end
+
+  def hash
+    self.to_wcif.hash
+  end
+
+  def self.wcif_type_to_class
+    @@wcif_type_to_class ||= Qualification.subclasses.map { |cls| [cls.wcif_type, cls] }.to_h
+  end
+
+  def self.load(json)
+    if json.nil? || json.is_a?(self)
+      json
+    else
+      json_obj = json.is_a?(Hash) ? json : JSON.parse(json)
+      wcif_type = json_obj['type']
+      out = self.wcif_type_to_class[wcif_type].new
+      out.level = json_obj['level']
+      begin
+        out.when_date = Date.iso8601(json_obj['whenDate'])
+      rescue ArgumentError
+        nil
+      end
+      out
+    end
+  end
+
+  def self.dump(qualification)
+    qualification ? JSON.dump(qualification.to_wcif) : nil
+  end
+
+  def self.wcif_json_schema
+    {
+      "type" => ["object", "null"],
+      "properties" => {
+        "whenDate" => { "type" => "string" },
+        "type" => { "type" => "string", "enum" => Qualification.subclasses.map(&:wcif_type) },
+        "level" => { "type" => "integer" },
+      },
+    }
+  end
+
+  def to_wcif
+    {
+      "type" => self.class.wcif_type,
+      "whenDate" => @when_date&.strftime("%Y-%m-%d"),
+      "level" => level,
+    }
+  end
+end
+
+class RankingQualification < Qualification
+  def self.wcif_type
+    "ranking"
+  end
+
+  def to_s(event)
+    I18n.t("qualification.ranking", ranking: level)
+  end
+end
+
+class SingleQualification < Qualification
+  def self.wcif_type
+    "single"
+  end
+
+  def to_s(event)
+    if event.event.timed_event?
+      I18n.t("qualification.single.time", time: SolveTime.centiseconds_to_clock_format(level))
+    elsif event.event.fewest_moves?
+      I18n.t("qualification.single.moves", moves: level)
+    elsif event.event.multiple_blindfolded?
+      I18n.t("qualification.single.points", points: SolveTime.multibld_attempt_to_points(level))
+    end
+  end
+end
+
+class AverageQualification < Qualification
+  def self.wcif_type
+    "average"
+  end
+
+  def to_s(event, short: false)
+    if event.event.timed_event?
+      I18n.t("qualification.average.time", time: SolveTime.centiseconds_to_clock_format(level))
+    elsif event.event.fewest_moves?
+      I18n.t("qualification.average.moves", moves: level)
+    elsif event.event.multiple_blindfolded?
+      I18n.t("qualification.average.points", points: SolveTime.multibld_attempt_to_points(level))
+    end
+  end
+end

--- a/WcaOnRails/lib/qualification.rb
+++ b/WcaOnRails/lib/qualification.rb
@@ -66,7 +66,8 @@ class Qualification
     elsif event.event.timed_event?
       I18n.t("qualification." + self.wcif_type + ".time", time: SolveTime.centiseconds_to_clock_format(level))
     elsif event.event.fewest_moves?
-      I18n.t("qualification." + self.wcif_type + ".moves", moves: level)
+      moves = self.wcif_type == "average" ? (level.to_f / 100).round(2) : level
+      I18n.t("qualification." + self.wcif_type + ".moves", moves: moves)
     elsif event.event.multiple_blindfolded?
       I18n.t("qualification." + self.wcif_type + ".points", points: SolveTime.multibld_attempt_to_points(level))
     end

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -47,6 +47,7 @@
     "rails-erb-loader": "^5.5.2",
     "react": "^16.14.0",
     "react-bootstrap": "^0.33.1",
+    "react-datepicker": "^4.1.1",
     "react-dom": "^16.14.0",
     "react-leaflet": "^2.8.0",
     "react_ujs": "^2.6.2",

--- a/WcaOnRails/spec/lib/qualification_spec.rb
+++ b/WcaOnRails/spec/lib/qualification_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Qualification do
   context "Single" do
     it "requires single" do
       input = {
-        'type' => 'single',
-        'method' => 'ranking',
+        'resultType' => 'single',
+        'type' => 'ranking',
         'whenDate' => '2021-06-01',
       }
       model = Qualification.load(input)
@@ -14,17 +14,17 @@ RSpec.describe Qualification do
 
     it "requires date" do
       input = {
-        'type' => 'single',
-        'method' => 'ranking',
+        'resultType' => 'single',
+        'type' => 'ranking',
         'level' => 1000,
       }
       model = Qualification.load(input)
       expect(model).to be_invalid
     end
 
-    it "requires method" do
+    it "requires type" do
       input = {
-        'type' => 'single',
+        'resultType' => 'single',
         'level' => 1000,
         'whenDate' => '2021-06-01',
       }
@@ -34,10 +34,20 @@ RSpec.describe Qualification do
 
     it "parses correctly" do
       input = {
-        'type' => 'single',
-        'method' => 'result',
+        'resultType' => 'single',
+        'type' => 'attemptResult',
         'whenDate' => '2021-06-01',
         'level' => 1000,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_valid
+    end
+
+    it "parses anyResult correctly" do
+      input = {
+        'resultType' => 'single',
+        'type' => 'anyResult',
+        'whenDate' => '2021-06-01',
       }
       model = Qualification.load(input)
       expect(model).to be_valid
@@ -47,8 +57,8 @@ RSpec.describe Qualification do
   context "Average" do
     it "requires average" do
       input = {
-        'type' => 'average',
-        'method' => 'result',
+        'resultType' => 'average',
+        'type' => 'attemptResult',
         'whenDate' => '2021-06-01',
       }
       model = Qualification.load(input)
@@ -57,17 +67,17 @@ RSpec.describe Qualification do
 
     it "requires date" do
       input = {
-        'type' => 'average',
-        'method' => 'result',
+        'resultType' => 'average',
+        'type' => 'attemptResult',
         'level' => 1000,
       }
       model = Qualification.load(input)
       expect(model).to be_invalid
     end
 
-    it "requires method" do
+    it "requires type" do
       input = {
-        'type' => 'average',
+        'resultType' => 'average',
         'level' => 1000,
         'whenDate' => '2021-06-01',
       }
@@ -77,8 +87,8 @@ RSpec.describe Qualification do
 
     it "parses correctly" do
       input = {
-        'type' => 'average',
-        'method' => 'result',
+        'resultType' => 'average',
+        'type' => 'attemptResult',
         'whenDate' => '2021-06-01',
         'level' => 1000,
       }

--- a/WcaOnRails/spec/lib/qualification_spec.rb
+++ b/WcaOnRails/spec/lib/qualification_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Qualification do
+  context "Ranking" do
+    it "requires ranking" do
+      input = {
+        'type' => 'ranking',
+        'whenDate' => '2021-06-01',
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
+    it "requires date" do
+      input = {
+        'type' => 'ranking',
+        'level' => 50,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
+    it "parses correctly" do
+      input = {
+        'type' => 'ranking',
+        'whenDate' => '2021-06-01',
+        'level' => 50,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_valid
+    end
+  end
+
+  context "Single" do
+    it "requires single" do
+      input = {
+        'type' => 'single',
+        'whenDate' => '2021-06-01',
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
+    it "requires date" do
+      input = {
+        'type' => 'single',
+        'level' => 1000,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
+    it "parses correctly" do
+      input = {
+        'type' => 'single',
+        'whenDate' => '2021-06-01',
+        'level' => 1000,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_valid
+    end
+  end
+
+  context "Average" do
+    it "requires average" do
+      input = {
+        'type' => 'average',
+        'whenDate' => '2021-06-01',
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
+    it "requires date" do
+      input = {
+        'type' => 'average',
+        'level' => 1000,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
+    it "parses correctly" do
+      input = {
+        'type' => 'average',
+        'whenDate' => '2021-06-01',
+        'level' => 1000,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_valid
+    end
+  end
+end

--- a/WcaOnRails/spec/lib/qualification_spec.rb
+++ b/WcaOnRails/spec/lib/qualification_spec.rb
@@ -1,40 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Qualification do
-  context "Ranking" do
-    it "requires ranking" do
-      input = {
-        'type' => 'ranking',
-        'whenDate' => '2021-06-01',
-      }
-      model = Qualification.load(input)
-      expect(model).to be_invalid
-    end
-
-    it "requires date" do
-      input = {
-        'type' => 'ranking',
-        'level' => 50,
-      }
-      model = Qualification.load(input)
-      expect(model).to be_invalid
-    end
-
-    it "parses correctly" do
-      input = {
-        'type' => 'ranking',
-        'whenDate' => '2021-06-01',
-        'level' => 50,
-      }
-      model = Qualification.load(input)
-      expect(model).to be_valid
-    end
-  end
-
   context "Single" do
     it "requires single" do
       input = {
         'type' => 'single',
+        'method' => 'ranking',
         'whenDate' => '2021-06-01',
       }
       model = Qualification.load(input)
@@ -44,15 +15,27 @@ RSpec.describe Qualification do
     it "requires date" do
       input = {
         'type' => 'single',
+        'method' => 'ranking',
         'level' => 1000,
       }
       model = Qualification.load(input)
       expect(model).to be_invalid
     end
 
+    it "requires method" do
+      input = {
+        'type' => 'single',
+        'level' => 1000,
+        'whenDate' => '2021-06-01',
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
     it "parses correctly" do
       input = {
         'type' => 'single',
+        'method' => 'result',
         'whenDate' => '2021-06-01',
         'level' => 1000,
       }
@@ -65,6 +48,7 @@ RSpec.describe Qualification do
     it "requires average" do
       input = {
         'type' => 'average',
+        'method' => 'result',
         'whenDate' => '2021-06-01',
       }
       model = Qualification.load(input)
@@ -74,7 +58,18 @@ RSpec.describe Qualification do
     it "requires date" do
       input = {
         'type' => 'average',
+        'method' => 'result',
         'level' => 1000,
+      }
+      model = Qualification.load(input)
+      expect(model).to be_invalid
+    end
+
+    it "requires method" do
+      input = {
+        'type' => 'average',
+        'level' => 1000,
+        'whenDate' => '2021-06-01',
       }
       model = Qualification.load(input)
       expect(model).to be_invalid
@@ -83,6 +78,7 @@ RSpec.describe Qualification do
     it "parses correctly" do
       input = {
         'type' => 'average',
+        'method' => 'result',
         'whenDate' => '2021-06-01',
         'level' => 1000,
       }

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -452,6 +452,7 @@ RSpec.describe "Competition WCIF" do
       wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
       wcif_333_event["qualification"] = {
         "type" => "average",
+        "method" => "result",
         "whenDate" => "2021-07-01",
         "level" => 6000,
       }

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -451,8 +451,8 @@ RSpec.describe "Competition WCIF" do
     it "can set event qualifications" do
       wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
       wcif_333_event["qualification"] = {
-        "type" => "average",
-        "method" => "result",
+        "resultType" => "average",
+        "type" => "attemptResult",
         "whenDate" => "2021-07-01",
         "level" => 6000,
       }

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "Competition WCIF" do
                 "extensions" => [],
               },
             ],
+            "qualification" => nil,
           },
           {
             "id" => "444",
@@ -99,6 +100,7 @@ RSpec.describe "Competition WCIF" do
                 "extensions" => [],
               },
             ],
+            "qualification" => nil,
           },
           {
             "id" => "333fm",
@@ -115,6 +117,7 @@ RSpec.describe "Competition WCIF" do
                 "extensions" => [],
               },
             ],
+            "qualification" => nil,
           },
           {
             "id" => "333mbf",
@@ -139,6 +142,7 @@ RSpec.describe "Competition WCIF" do
                 ],
               },
             ],
+            "qualification" => nil,
           },
         ],
         "schedule" => {
@@ -302,6 +306,7 @@ RSpec.describe "Competition WCIF" do
             "extensions" => [],
           },
         ],
+        "qualification" => nil,
       }
       # Add 5x5x5 after 4x4x4 to match the expected order.
       wcif["events"].insert(2, wcif555)
@@ -440,6 +445,19 @@ RSpec.describe "Competition WCIF" do
       competition.set_wcif_events!(wcif["events"], delegate)
 
       wcif_333mbf_event["rounds"][0]["extensions"] = extensions
+      expect(competition.to_wcif["events"]).to eq(wcif["events"])
+    end
+
+    it "can set event qualifications" do
+      wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
+      wcif_333_event["qualification"] = {
+        "type" => "average",
+        "whenDate" => "2021-07-01",
+        "level" => 6000,
+      }
+
+      competition.set_wcif_events!(wcif["events"], delegate)
+
       expect(competition.to_wcif["events"]).to eq(wcif["events"])
     end
   end

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -1224,7 +1224,7 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@popperjs/core@^2.6.0":
+"@popperjs/core@^2.6.0", "@popperjs/core@^2.9.2":
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
@@ -2466,7 +2466,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.3.1:
+classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -3081,6 +3081,11 @@ damerau-levenshtein@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
+
+date-fns@^2.0.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -7606,6 +7611,18 @@ react-bootstrap@^0.33.1:
     uncontrollable "^7.0.2"
     warning "^3.0.0"
 
+react-datepicker@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.1.1.tgz#5ecef49c672b2250fca26327c988464e6ba52b62"
+  integrity sha512-vtZIA7MbUrffRw1CHiyOGtmTO/tTdZGr5BYaiRucHMTb6rCqA8TkaQhzX6tTwMwP8vV38Khv4UWohrJbiX1rMw==
+  dependencies:
+    "@popperjs/core" "^2.9.2"
+    classnames "^2.2.6"
+    date-fns "^2.0.1"
+    prop-types "^15.7.2"
+    react-onclickoutside "^6.10.0"
+    react-popper "^2.2.5"
+
 react-dom@^16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
@@ -7645,6 +7662,11 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-onclickoutside@^6.10.0:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.11.2.tgz#790e2100b9a3589eefca1404ecbf0476b81b7928"
+  integrity sha512-640486eSwU/t5iD6yeTlefma8dI3bxPXD93hM9JGKyYITAd0P1JFkkcDeyHZRqNpY/fv1YW0Fad9BXr44OY8wQ==
 
 react-overlays@^0.9.0:
   version "0.9.1"

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -7680,7 +7680,7 @@ react-overlays@^0.9.0:
     react-transition-group "^2.2.1"
     warning "^3.0.0"
 
-react-popper@^2.3.0:
+react-popper@^2.2.5, react-popper@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
   integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==


### PR DESCRIPTION
Partial implementation of #2051.  Implements WCIF change made in thewca/wcif#3.

This does the following:

- Adds a column to competition_events for qualification times.
- Adds support in the event editor for selecting qualifications.
- Displays qualifications in the events table.

This does not have any impact on competitors' ability to register for events; I'm saving that for a followup PR.

Screenshots:

![image](https://user-images.githubusercontent.com/3885929/121747521-88638380-cad5-11eb-8a10-2a75cad3b9fb.png)
Setting an average qualification

![image](https://user-images.githubusercontent.com/3885929/121747651-c06ac680-cad5-11eb-93d9-ef8e20bb957b.png)
Setting a Top N qualification

![image](https://user-images.githubusercontent.com/3885929/121747718-d5475a00-cad5-11eb-8403-016b34ac3a9b.png)
Events list

![image](https://user-images.githubusercontent.com/3885929/121747759-e4c6a300-cad5-11eb-9eec-1fc23ab4c443.png)
Text at bottom of events list