### PR TITLE
Add link to the Judging Tutorial to the edudoc section

### DIFF
--- a/WcaOnRails/app/views/static_pages/education.html.erb
+++ b/WcaOnRails/app/views/static_pages/education.html.erb
@@ -10,7 +10,7 @@
       <%= ui_icon("file alt") %>
       <%= t('education.competitor_tutorial') %>
     <% end %>
-    <%= link_to "/edudoc/concise-judge-tutorial/README.pdf", class: "list-group-item" do %>
+    <%= link_to "/edudoc/judge-tutorial/README.pdf", class: "list-group-item" do %>
       <%= ui_icon("file alt") %>
       <%= t('education.judge_tutorial') %>
     <% end %>

--- a/WcaOnRails/app/views/static_pages/education.html.erb
+++ b/WcaOnRails/app/views/static_pages/education.html.erb
@@ -10,6 +10,10 @@
       <%= ui_icon("file alt") %>
       <%= t('education.competitor_tutorial') %>
     <% end %>
+    <%= link_to "/edudoc/concise-judge-tutorial/README.pdf", class: "list-group-item" do %>
+      <%= ui_icon("file alt") %>
+      <%= t('education.judge_tutorial') %>
+    <% end %>
     <%= link_to "https://drive.google.com/drive/folders/1jrMWgOgNscPDqoxzgnEQ1bnV9D4FDzLj", class: "list-group-item" do %>
       <%= ui_icon("copy") %>
       <%= t('education.certificates') %>

--- a/WcaOnRails/app/views/static_pages/education.html.erb
+++ b/WcaOnRails/app/views/static_pages/education.html.erb
@@ -10,7 +10,7 @@
       <%= ui_icon("file alt") %>
       <%= t('education.competitor_tutorial') %>
     <% end %>
-    <%= link_to "/edudoc/judge-tutorial/README.pdf", class: "list-group-item" do %>
+    <%= link_to "/edudoc/judge-tutorial/judge-tutorial.pdf", class: "list-group-item" do %>
       <%= ui_icon("file alt") %>
       <%= t('education.judge_tutorial') %>
     <% end %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1952,7 +1952,7 @@ en:
     title: "WCA Educational Documents"
     description: "The WQAC has published several documents for the community, you can download them below."
     competitor_tutorial: "Competitor tutorial"
-    judge_tutorial: "Judge tutorial for newcomers"
+    judge_tutorial: "Judging tutorial for newcomers"
     certificates: "WCT's certificate templates"
     orga_guidelines: "Organizer guidelines"
   #context: Delegates page

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1949,7 +1949,7 @@ en:
     codeofethics: "Code of Ethics"
     codeofconduct: "Code of Conduct"
   education:
-    title: "WCA Educational Documents"
+    title: "WCA Educational Resources"
     description: "The WQAC has published several documents for the community, you can download them below."
     competitor_tutorial: "Competitor tutorial"
     judge_tutorial: "Judging tutorial for newcomers"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -764,7 +764,7 @@ en:
       faq: "Frequently Asked Questions"
       forum: "Forum"
       teams: "Teams, Committees, and Councils"
-      education: "Education resources"
+      education: "Educational resources"
       contact: "Contact Information"
       speedcubing_history: "Speedcubing History"
       tools: "Tools"
@@ -1952,7 +1952,7 @@ en:
     title: "WCA Educational Documents"
     description: "The WQAC has published several documents for the community, you can download them below."
     competitor_tutorial: "Competitor tutorial"
-    judge_tutorial: "Judge tutorial"
+    judge_tutorial: "Judge tutorial for newcomers"
     certificates: "WCT's certificate templates"
     orga_guidelines: "Organizer guidelines"
   #context: Delegates page

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1952,6 +1952,7 @@ en:
     title: "WCA Educational Documents"
     description: "The WQAC has published several documents for the community, you can download them below."
     competitor_tutorial: "Competitor tutorial"
+    judge_tutorial: "Judge tutorial"
     certificates: "WCT's certificate templates"
     orga_guidelines: "Organizer guidelines"
   #context: Delegates page


### PR DESCRIPTION
This adds a link to the [Judging Tutorial](https://github.com/thewca/wca-documents/pull/240) to the edudoc section. It also renames the "Education resources" link to "Educational resources" to make it consistent with the title of the page itself.