### PR TITLE
Fixed missing translation message for MBLD old style time limit

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -177,6 +177,7 @@ en:
       across_rounds: "%{time} total for %{rounds}"
     333fm: "1 hour"
     333mbf: "10:00.00 per cube, up to 60:00.00"
+    333mbo: ""
   #context: Common word used in multiple places on the website
   common:
     world: "World"


### PR DESCRIPTION
I just added the empty string to the translation as requested.
Addresses this issue: https://github.com/thewca/worldcubeassociation.org/issues/5459