### PR TITLE
Allow competitors to edit registration

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -605,6 +605,7 @@ class CompetitionsController < ApplicationController
         :extra_registration_requirements,
         :on_the_spot_registration,
         :on_the_spot_entry_fee_lowest_denomination,
+        :allow_registration_edits,
         :refund_policy_percent,
         :refund_policy_limit_date,
         :early_puzzle_submission,

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -964,6 +964,10 @@ class Competition < ApplicationRecord
     start_date.present? && start_date > Date.new(2021, 6, 24)
   end
 
+  def registration_edits_allowed?
+    self.allow_registration_edits && (!has_event_change_deadline_date? || event_change_deadline_date > DateTime.now)
+  end
+
   private def unpack_dates
     if start_date
       self.year = start_date.year

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -106,6 +106,7 @@ class Competition < ApplicationRecord
     extra_registration_requirements
     on_the_spot_registration
     on_the_spot_entry_fee_lowest_denomination
+    allow_registration_edits
     refund_policy_percent
     guests_entry_fee_lowest_denomination
     free_guest_entry_status
@@ -181,6 +182,7 @@ class Competition < ApplicationRecord
   validates :refund_policy_limit_date, presence: true, if: :refund_policy_percent?
   validates_inclusion_of :on_the_spot_registration, in: [true, false], if: :on_the_spot_registration_required?
   validates_numericality_of :on_the_spot_entry_fee_lowest_denomination, greater_than_or_equal_to: 0, if: :on_the_spot_entry_fee_required?
+  validates_inclusion_of :allow_registration_edits, in: [true, false]
   monetize :on_the_spot_entry_fee_lowest_denomination,
            as: "on_the_spot_base_entry_fee",
            allow_nil: true,

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -709,8 +709,8 @@ class User < ApplicationRecord
   end
 
   def can_edit_registration?(registration)
-    # A registration can be edited by a user if it hasn't been accepted yet, and if registrations are open.
-    editable_by_user = (!registration.accepted? || registration.competition.allow_registration_edits) && registration.competition.registration_opened?
+    # A registration can be edited by a user if it hasn't been accepted yet, and if edits are allowed.
+    editable_by_user = (!registration.accepted? || registration.competition.registration_edits_allowed?)
     can_manage_competition?(registration.competition) || (registration.user_id == self.id && editable_by_user)
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -710,7 +710,7 @@ class User < ApplicationRecord
 
   def can_edit_registration?(registration)
     # A registration can be edited by a user if it hasn't been accepted yet, and if registrations are open.
-    editable_by_user = !registration.accepted? && registration.competition.registration_opened?
+    editable_by_user = (!registration.accepted? || registration.competition.allow_registration_edits) && registration.competition.registration_opened?
     can_manage_competition?(registration.competition) || (registration.user_id == self.id && editable_by_user)
   end
 

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -214,6 +214,8 @@
         <%= f.input :on_the_spot_registration, collection: [ :true, :false ] %>
         <%= f.input :on_the_spot_entry_fee_lowest_denomination, as: :money_amount, currency: @competition.currency_code, currency_selector: "#competition_currency_code" %>
 
+        <%= f.input :allow_registration_edits, collection: [ :true, :false ] %>
+
         <%= f.input :extra_registration_requirements, input_html: { class: disable_form ? "" : "markdown-editor" } %>
 
         <hr>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -640,7 +640,7 @@ en:
           "true": "On the spot registrations will be accepted"
           "false": "On the spot registrations WILL NOT be accepted"
         allow_registration_edits:
-          "true": "Competitors may edit their registration until registration closes"
+          "true": "Competitors may edit their registration until the deadline for updating events"
           "false": "Competitors may NOT edit their registration once it has been accepted"
   mail_form:
     #context: This key is used as a label for contact form attributes

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -304,6 +304,7 @@ en:
         extra_registration_requirements: "Extra registration requirements"
         on_the_spot_registration: "On the spot registrations"
         on_the_spot_entry_fee_lowest_denomination: "On the spot base registration fee"
+        allow_registration_edits: "Registration edits"
         refund_policy_percent: "Percent to be refunded"
         refund_policy_limit_date: "Limit date for refunds"
         waiting_list_deadline_date: "Deadline for accepting competitors from the waiting list"
@@ -514,6 +515,7 @@ en:
         extra_registration_requirements: "Please indicate here any extra registration requirements not covered above, like for example directions on how to pay. <br/>Please fill this out <b>in English</b> and whatever other languages your competitors speak; this will be displayed on the competition's information page, as well on the registration page if you are using the WCA website registrations."
         on_the_spot_registration: ""
         on_the_spot_entry_fee_lowest_denomination: "If this is set to 0, a sentence will be displayed saying that on the spot registrations will be accepted for free."
+        allow_registration_edits: ""
         refund_policy_percent: "For now this number is informational only, refunds will have to be issued manually. If this is set to 0, a sentence will be displayed saying that registration fees won't be refunded under any circumstance."
         refund_policy_limit_date: "Date after which no more refunds will be issued."
         waiting_list_deadline_date: "The date when waitlisted registrants will no longer be accepted. If you have a deadline for refunds, the deadline for being accepted should not be before the deadline for refunds."
@@ -637,6 +639,9 @@ en:
         on_the_spot_registration:
           "true": "On the spot registrations will be accepted"
           "false": "On the spot registrations WILL NOT be accepted"
+        allow_registration_edits:
+          "true": "Competitors may edit their registration until registration closes"
+          "false": "Competitors may NOT edit their registration once it has been accepted"
   mail_form:
     #context: This key is used as a label for contact form attributes
     attributes:

--- a/WcaOnRails/db/migrate/20210521195423_add_allow_registration_edits_to_competition.rb
+++ b/WcaOnRails/db/migrate/20210521195423_add_allow_registration_edits_to_competition.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAllowRegistrationEditsToCompetition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :Competitions, :allow_registration_edits, :bool, null: false, default: false
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -78,6 +78,7 @@ CREATE TABLE `Competitions` (
   `waiting_list_deadline_date` datetime DEFAULT NULL,
   `event_change_deadline_date` datetime DEFAULT NULL,
   `free_guest_entry_status` int NOT NULL DEFAULT '0',
+  `allow_registration_edits` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
   KEY `index_Competitions_on_countryId` (`countryId`),
@@ -1705,5 +1706,6 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20210301002636'),
 ('20210325202019'),
 ('20210501213332'),
+('20210521195423'),
 ('20210727081850'),
 ('20210802065056');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -92,6 +92,7 @@ module DatabaseDumper
           cancelled_by
           waiting_list_deadline_date
           event_change_deadline_date
+          allow_registration_edits
         ),
         db_default: %w(
           connected_stripe_account_id

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -776,16 +776,17 @@ RSpec.describe User, type: :model do
       expect(competitor.can_edit_registration?(registration)).to be false
     end
 
-    it "if registration edits are allowed" do
+    it "if event edit deadline is in the future" do
       registration.accepted_at = Time.now
       competition.allow_registration_edits = true
+      competition.event_change_deadline_date = 2.weeks.from_now
       expect(competitor.can_edit_registration?(registration)).to be true
     end
 
-    it "unless registration is closed" do
+    it "unless event edit deadline has passed" do
       registration.accepted_at = Time.now
-      competition.registration_close = 2.weeks.ago
       competition.allow_registration_edits = true
+      competition.event_change_deadline_date = 2.weeks.ago
       expect(competitor.can_edit_registration?(registration)).to be false
     end
   end


### PR DESCRIPTION
This adds a new option to the competition form.  If selected, then
competitors are allowed to edit the events they're registered for.

The default is to not allow edits.

Fixes #941.