### PR TITLE
Set registration email default to false

### DIFF
--- a/WcaOnRails/db/migrate/20220623121810_registration_email_default_change.rb
+++ b/WcaOnRails/db/migrate/20220623121810_registration_email_default_change.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RegistrationEmailDefaultChange < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :competition_delegates, :receive_registration_emails, from: 1, to: 0
+    change_column_default :competition_organizers, :receive_registration_emails, from: 1, to: 0
+    change_column_default :competition_trainee_delegates, :receive_registration_emails, from: 1, to: 0
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -720,7 +720,7 @@ CREATE TABLE `competition_delegates` (
   `delegate_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '1',
+  `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
@@ -749,7 +749,7 @@ CREATE TABLE `competition_organizers` (
   `organizer_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '1',
+  `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
@@ -776,7 +776,7 @@ CREATE TABLE `competition_trainee_delegates` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) DEFAULT NULL,
   `trainee_delegate_id` int(11) DEFAULT NULL,
-  `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '1',
+  `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
@@ -1761,4 +1761,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20220223163447'),
 ('20220511025003'),
 ('20220516124717'), 
-('20220619200832');
+('20220619200832'),
+('20220623121810');

--- a/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/registrations_mailer_spec.rb
@@ -51,9 +51,10 @@ RSpec.describe RegistrationsMailer, type: :mailer do
     let(:mail) { RegistrationsMailer.notify_organizers_of_new_registration(registration) }
 
     it "renders the headers" do
-      competition_delegate1 = competition_without_organizers.competition_delegates.find_by_delegate_id(delegate1.id)
-      competition_delegate1.receive_registration_emails = false
-      competition_delegate1.save!
+      # Set receive_registration_emails to true and test that the email headers are present
+      competition_delegate2 = competition_without_organizers.competition_trainee_delegates.find_by_trainee_delegate_id(delegate2.id)
+      competition_delegate2.receive_registration_emails = true
+      competition_delegate2.save!
 
       expect(mail.subject).to eq("#{registration.name} just registered for #{registration.competition.name}")
       expect(mail.to).to eq([delegate2.email])
@@ -62,18 +63,16 @@ RSpec.describe RegistrationsMailer, type: :mailer do
     end
 
     it "renders the body" do
+      # Set receive_registration_emails to true and test that the email body is present
+      competition_delegate2 = competition_without_organizers.competition_trainee_delegates.find_by_trainee_delegate_id(delegate2.id)
+      competition_delegate2.receive_registration_emails = true
+      competition_delegate2.save!
+
       expect(mail.body.encoded).to match(edit_registration_url(registration))
     end
 
     it "handles no organizers receiving email" do
-      competition_delegate1 = competition_without_organizers.competition_delegates.find_by_delegate_id(delegate1.id)
-      competition_delegate1.receive_registration_emails = false
-      competition_delegate1.save!
-
-      competition_delegate2 = competition_without_organizers.competition_trainee_delegates.find_by_trainee_delegate_id(delegate2.id)
-      competition_delegate2.receive_registration_emails = false
-      competition_delegate2.save!
-
+      # Expect no email to be sent by default (when the organizer hasn't chosen to receive registration emails)
       expect(mail.message).to be_kind_of ActionMailer::Base::NullMail
     end
   end
@@ -83,6 +82,14 @@ RSpec.describe RegistrationsMailer, type: :mailer do
     let(:mail) { RegistrationsMailer.notify_organizers_of_deleted_registration(registration) }
 
     it "renders the headers" do
+      competition_delegate1 = competition_without_organizers.competition_delegates.find_by_delegate_id(delegate1.id)
+      competition_delegate1.receive_registration_emails = true
+      competition_delegate1.save!
+
+      competition_delegate2 = competition_without_organizers.competition_trainee_delegates.find_by_trainee_delegate_id(delegate2.id)
+      competition_delegate2.receive_registration_emails = true
+      competition_delegate2.save!
+
       expect(mail.subject).to eq("#{registration.name} just deleted their registration for #{registration.competition.name}")
       expect(mail.to).to eq([delegate1.email, delegate2.email])
       expect(mail.reply_to).to eq(competition_without_organizers.managers.map(&:email))
@@ -90,6 +97,14 @@ RSpec.describe RegistrationsMailer, type: :mailer do
     end
 
     it "renders the body" do
+      competition_delegate1 = competition_without_organizers.competition_delegates.find_by_delegate_id(delegate1.id)
+      competition_delegate1.receive_registration_emails = true
+      competition_delegate1.save!
+
+      competition_delegate2 = competition_without_organizers.competition_trainee_delegates.find_by_trainee_delegate_id(delegate2.id)
+      competition_delegate2.receive_registration_emails = true
+      competition_delegate2.save!
+
       expect(mail.body.encoded).to match("just deleted their registration for #{registration.competition.name}")
     end
   end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -777,24 +777,24 @@ RSpec.describe Competition do
       expect(competition.receiving_registration_emails?(delegate.id)).to eq false
 
       competition.delegates << delegate
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq true
+      expect(competition.receiving_registration_emails?(delegate.id)).to eq false
 
       cd = competition.competition_delegates.find_by_delegate_id(delegate.id)
-      cd.update_column(:receive_registration_emails, false)
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq false
+      cd.update_column(:receive_registration_emails, true)
+      expect(competition.receiving_registration_emails?(delegate.id)).to eq true
 
       competition.organizers << delegate
       expect(competition.receiving_registration_emails?(delegate.id)).to eq true
 
       co = competition.competition_organizers.find_by_organizer_id(delegate.id)
-      co.update_column(:receive_registration_emails, false)
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq false
+      co.update_column(:receive_registration_emails, true)
+      expect(competition.receiving_registration_emails?(delegate.id)).to eq true
     end
 
     it "setting receive_registration_emails" do
       competition.delegates << delegate
       cd = competition.competition_delegates.find_by_delegate_id(delegate.id)
-      expect(cd.receive_registration_emails).to eq true
+      expect(cd.receive_registration_emails).to eq false
 
       competition.receive_registration_emails = false
       competition.editing_user_id = delegate.id
@@ -804,7 +804,7 @@ RSpec.describe Competition do
 
       competition.organizers << delegate
       co = competition.competition_organizers.find_by_organizer_id(delegate.id)
-      expect(co.receive_registration_emails).to eq true
+      expect(co.receive_registration_emails).to eq false
 
       competition.receive_registration_emails = false
       competition.editing_user_id = delegate.id


### PR DESCRIPTION
Addresses issue https://github.com/thewca/worldcubeassociation.org/issues/4673. This simply sets the default to registration emails for delegates and organizers to false, so that they can opt in to receiving these emails if they so choose.
Please review that I implemented the change correctly.