### PR TITLE
Remove user-specific setup from the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,3 @@ webroot/forum/files/*
 webroot/forum/images/avatars/gallery/*
 webroot/forum/images/avatars/upload/*
 webroot/forum/store/*
-
-# JetBrains IDE stuff
-*.iml
-.idea/


### PR DESCRIPTION
I came across the changes when investigating #6311, and in my opinion these are not project-specific files to ignore, and rather belong to a user specific gitignore.
For instance I have this in my `$HOME/.gitconfig`:
```config
[core]
  excludesfile = ~/.gitignore
```
Where the `~/.gitignore` file contains some exclusions specific to my text editor and other tools.

You may definitely ignore this PR if you don't mind these exclusion being there though :)