### PR TITLE
Changed edit event default to use start date instead of created at date

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -916,7 +916,7 @@ class Competition < ApplicationRecord
   end
 
   def has_event_change_deadline_date?
-    created_at.present? && created_at > Date.new(2021, 6, 24)
+    start_date.present? && start_date > Date.new(2021, 6, 24)
   end
 
   private def unpack_dates


### PR DESCRIPTION
I assume we want to change to using this. Please see email for #6091.