### PR TITLE
Introduce the useSaveData hook

### DIFF
--- a/WcaOnRails/app/webpacker/javascript/hooks/useSaveAction.js
+++ b/WcaOnRails/app/webpacker/javascript/hooks/useSaveAction.js
@@ -1,0 +1,36 @@
+import { useState, useCallback } from 'react';
+import { fetchJsonOrError } from '../requests/fetchWithAuthenticityToken';
+
+const throwError = (err) => { throw err; };
+
+// This is a hook that can be used to save some data to the website (as json)
+// It assumes that 'url' is a valid, PATCH-able, url; the method can be changed
+// through the options.
+// Example of usage:
+// const { save, saving } = useSaveAction();
+// // and then:
+// save(modelUrl(), { /* model attrs */ }, () => console.log("success"));
+// // you may also want to override some options:
+// save(modelUrl(), {}, () => console.log("deleted"), { method: 'DELETE' });
+const useSaveAction = () => {
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback((url, data, onSuccess, options = {}, onError = throwError) => {
+    setSaving(true);
+    fetchJsonOrError(url, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+      body: JSON.stringify(data),
+      ...options,
+    }).then(onSuccess).catch(onError).finally(() => setSaving(false));
+  }, [setSaving]);
+
+  return {
+    saving,
+    save,
+  };
+};
+
+export default useSaveAction;


### PR DESCRIPTION
Supersedes #5300.

It's basically introducing the hook mentioned in that PR, which can be used by react component to create/save/delete data through an appropriate endpoint on the WCA website.
It definitely doesn't look like much without an example, but I'll submit an additional PR which actually make use of it (for the 3 create/save/delete use-cases); since it may take some time to review the other one I figured it may be easier to land these changes.