### PR TITLE
Add a react component to create/edit/destroy a result

### DIFF
--- a/WcaOnRails/app/controllers/admin/persons_controller.rb
+++ b/WcaOnRails/app/controllers/admin/persons_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Admin
+  class PersonsController < AdminController
+    # NOTE: authentication is performed by admin controller
+
+    def generate_ids
+      competition = Competition.find(new_id_params[:competition_id])
+      # If a valid semi_id is provided, just use it.
+      semi_id = SemiId.new(value: new_id_params[:semi_id])
+      # Else try generating one from params
+      unless semi_id.value.present?
+        semi_id = SemiId.generate(new_id_params[:name], competition)
+      end
+
+      if semi_id.valid?
+        # compute WCA ID
+        wca_id = semi_id.generate_wca_id
+        json = {
+          semiId: semi_id.value,
+          wcaId: wca_id,
+        }
+        if wca_id.blank?
+          json[:errors] = { wca_id: "could not generate a WCA ID for that semi, try another one" }
+        end
+        render json: json
+      else
+        render json: { errors: { semi_id: semi_id.errors[:value] } }
+      end
+    end
+
+    def create
+      p = Person.new(person_params)
+      if p.save
+        render json: p
+      else
+        render json: { errors: p.errors }
+      end
+    end
+
+    private def new_id_params
+      params.permit(:name, :competition_id, :semi_id)
+    end
+
+    private def person_params
+      params.require(:person).permit(:name, :wca_id, :dob, :gender, :countryId)
+    end
+  end
+end

--- a/WcaOnRails/app/controllers/admin/results_controller.rb
+++ b/WcaOnRails/app/controllers/admin/results_controller.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Admin
+  class ResultsController < AdminController
+    # NOTE: authentication is performed by admin controller
+
+    def new
+      competition = Competition.find(params[:competition_id])
+      round = Round.find(params[:round_id])
+      # Create some basic attributes for that empty result.
+      # Using Result.new wouldn't work here: we have no idea what the country
+      # could be and so on, so serialization would fail.
+      @result = {
+        competition_id: competition.id,
+        round_type_id: round.round_type_id,
+        format_id: round.format.id,
+        event_id: round.event.id,
+      }
+    end
+
+    def show
+      respond_to do |format|
+        format.json { render json: Result.find(params.require(:id)) }
+      end
+    end
+
+    def show_events_data
+      competition = Competition.find(params[:competition_id])
+      events_data = competition.competition_events.to_h do |ce|
+        [ce.event_id, {
+          eventId: ce.event_id,
+          rounds: ce.rounds.map do |r|
+            {
+              roundTypeId: r.round_type_id,
+              formatId: r.format_id,
+            }
+          end,
+        }]
+      end
+
+      respond_to do |format|
+        format.json { render json: events_data }
+      end
+    end
+
+    def edit
+      @result = Result.includes(:competition).find(params[:id])
+    end
+
+    def create
+      json = {}
+      # Build a brand new result, validations will make sure the specified round
+      # data are valid.
+      result = Result.new(result_params)
+      if result.save
+        # We just inserted a new result, make sure we at least give it the
+        # correct position.
+        validator = ResultsValidators::PositionsValidator.new(apply_fixes: true)
+        validator.validate(competition_ids: [result.competitionId])
+        json[:messages] = ["Result inserted!"].concat(validator.infos.map(&:to_s))
+      else
+        json[:errors] = result.errors.map { |key, msg| "#{key}: #{msg}" }
+      end
+      render json: json
+    end
+
+    def update
+      result = Result.find(params.require(:id))
+      # Since we may move the result to another competition, we want to validate
+      # both competitions if needed.
+      competitions_to_validate = [result.competitionId]
+      if result.update(result_params)
+        competitions_to_validate << result.competitionId
+        competitions_to_validate.uniq!
+        validator = ResultsValidators::PositionsValidator.new(apply_fixes: true)
+        validator.validate(competition_ids: competitions_to_validate)
+        info = if result.saved_changes.empty?
+                 ["It looks like you submitted the exact same result, so no changes were made."]
+               else
+                 ["The result was saved."]
+               end
+        if competitions_to_validate.size > 1
+          info << "The results was moved to another competition, make sure to check the competition validators for both of them."
+        end
+        render json: {
+          # Make sure we emit the competition's id next to the info, because we
+          # may validate multiple competitions at the same time.
+          messages: info.concat(validator.infos.map { |i| "[#{i.competition_id}]#{i}" }),
+        }
+      else
+        render json: {
+          errors: result.errors.map { |key, msg| "#{key}: #{msg}" },
+        }
+      end
+    end
+
+    def destroy
+      result = Result.find(params.require(:id))
+      competition_id = result.competitionId
+      result.destroy!
+
+      # Create a results validator to fix positions if needed
+      validator = ResultsValidators::PositionsValidator.new(apply_fixes: true)
+      validator.validate(competition_ids: [competition_id])
+
+      render json: {
+        messages: ["Result deleted!"].concat(validator.infos.map(&:to_s)),
+      }
+    end
+
+    private def result_params
+      params.require(:result).permit(:value1, :value2, :value3, :value4, :value5,
+                                     :competitionId, :roundTypeId, :eventId, :formatId,
+                                     :personName, :personId, :countryId,
+                                     :best, :average,
+                                     :regionalSingleRecord, :regionalAverageRecord)
+    end
+  end
+end

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -125,6 +125,17 @@ class AdminController < ApplicationController
         else
           flash.now[:danger] = "Error while updating #{@person.name}."
         end
+      when "destroy"
+        if @person.results.any?
+          flash.now[:danger] = "#{@person.name} has results, can't destroy them."
+        elsif @person.user.present?
+          flash.now[:danger] = "#{@person.wca_id} is linked to a user, can't destroy them."
+        else
+          name = @person.name
+          @person.destroy
+          flash.now[:success] = "Successfully destroyed #{name}."
+          @person = Person.new
+        end
       end
     else
       @person = Person.new

--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -8,6 +8,10 @@ class Api::V0::ApiController < ApplicationController
     render status: e.status, json: { error: e.to_s }
   end
 
+  rescue_from ActiveRecord::RecordNotFound do |e|
+    render status: :not_found, json: { error: e.to_s }
+  end
+
   DEFAULT_API_RESULT_LIMIT = 20
   TNOODLE_PUBLIC_KEY_PATH = "#{Rails.root}/app/views/regulations/scrambles/tnoodle/TNoodle-WCA.pem".freeze
 

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -40,10 +40,15 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
                                   .group_by(&:round_type)
                                   .sort_by { |round_type, _| -round_type.rank }
     rounds = results_by_round.map do |round_type, results|
+      # I think all competitions now have round data, but let's be cautious
+      # and assume they may not.
+      # round data.
+      round = Round.find_for(competition.id, event.id, round_type.id)
       {
-        id: round_type.id,
+        id: round&.id,
+        roundTypeId: round_type.id,
         # Also include the (localized) name here, we don't have i18n in js yet.
-        name: round_type.name,
+        name: round&.name || "#{event.name} #{round_type.name}",
         results: results.sort_by { |r| [r.pos, r.personName] },
       }
     end

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -40,6 +40,18 @@ module Resultable
       Format.c_find(formatId)
     end
 
+    def round
+      Round.find_for(competitionId, eventId, roundTypeId, formatId)
+    end
+
+    validate :belongs_to_a_round
+    def belongs_to_a_round
+      if round.blank?
+        errors.add(:round_type,
+                   "Result must belong to a valid round. Please check that the tuple (competitionId, eventId, roundTypeId, formatId) matches an existing round.")
+      end
+    end
+
     validate :validate_each_solve, if: :event
     def validate_each_solve
       solve_times.each_with_index do |solve_time, i|

--- a/WcaOnRails/app/models/light_result.rb
+++ b/WcaOnRails/app/models/light_result.rb
@@ -19,6 +19,7 @@ class LightResult
               :personName,
               :event,
               :format,
+              :id,
               :round_type,
               :pos,
               :personId,
@@ -27,6 +28,7 @@ class LightResult
               :country
 
   def initialize(r)
+    @id = r["id"]
     @value1 = r["value1"]
     @value2 = r["value2"]
     @value3 = r["value3"]

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -238,4 +238,18 @@ class Round < ApplicationRecord
   def self.name_from_attributes(event, round_type)
     I18n.t("round.name", event_name: event.name, round_name: round_type.name)
   end
+
+  # Find a matching round the given (competition_id, event_id, round_type_id)
+  # tuple.
+  # Optionally take a format if we want a strict match.
+  def self.find_for(competition_id, event_id, round_type_id, format_id = nil)
+    Competition.find_by(id: competition_id)
+               &.competition_events
+               &.find { |ce| ce.event_id == event_id }
+               &.rounds
+               &.find do |r|
+                 r.round_type_id == round_type_id &&
+                   (format_id.nil? || format_id == r.format_id)
+               end
+  end
 end

--- a/WcaOnRails/app/models/semi_id.rb
+++ b/WcaOnRails/app/models/semi_id.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class SemiId
+  include ActiveModel::Model
+  attr_accessor :value
+
+  SEMI_ID_RE = /\A[1-9][[:digit:]]{3}[[:upper:]]{4}\z/
+  # This is the char the php scripts used for filling WCA IDs.
+  PADDING_CHAR = "U"
+  validates_format_of :value, with: SEMI_ID_RE
+
+  def generate_wca_id
+    # Try finding an appropriate WCA ID for our semi ID
+    unless valid?
+      return ""
+    end
+
+    # From all persons with that semi id, take the last WCA ID, or default
+    # to "AAAABBBB00".
+    last_wca_id = Person.where("wca_id like ?", "#{value}%").order(:wca_id).pluck(:wca_id).last || "#{value}00"
+    last_index = last_wca_id.last(2).to_i
+
+    if last_index < 99
+      "#{value}#{(last_index+1).to_s.rjust(2, "0")}"
+    else
+      # Sometimes we run out of indices (like for "2019ZHAO"), there is nothing
+      # we can do but to return an empty one...
+      ""
+    end
+  end
+
+  def self.generate(name, competition)
+    semi_id_year = competition.year.to_s
+    # Extract the "roman" part of the name (everything up to "("), and transliterate
+    # remaining characters.
+    roman_name = I18n.transliterate(name.slice(/\A[^(]+/) || "")
+    # Remove any non alphabetic characters, and make all upper case
+    roman_name.gsub!(/[^[[:alpha:]] ]/, '')
+    roman_name.upcase!
+
+    # Splitting by ' ' is implied by default
+    name_parts = roman_name.split
+    if name_parts.empty?
+      # The given name has no usable parts, we can only generate an invalid SemiId
+      return SemiId.new
+    end
+    # Take the first 4 chars of the last name
+    semi_id_name = name_parts.pop.first(4)
+    # If needed, take the first few chars of the first name.
+    semi_id_name.concat((name_parts.shift || "").first(3))
+    # In the end we may have more or less than 4 chars, so pad with 'U' and truncate.
+    semi_id_name = semi_id_name.ljust(4, PADDING_CHAR).first(4)
+
+    SemiId.new(value: semi_id_year.concat(semi_id_name))
+  end
+end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -89,7 +89,7 @@ class User < ApplicationRecord
   # name empty, so long as they're a returning competitor and are claiming their
   # wca id.
   validates :name, presence: true, if: -> { !claiming_wca_id }
-  WCA_ID_RE = /\A(|\d{4}[A-Z]{4}\d{2})\z/
+  WCA_ID_RE = /\A[1-9][[:digit:]]{3}[[:upper:]]{4}[[:digit:]]{2}\z/
   validates :wca_id, format: { with: WCA_ID_RE }, allow_nil: true
   validates :unconfirmed_wca_id, format: { with: WCA_ID_RE }, allow_nil: true
   WCA_ID_MAX_LENGTH = 10

--- a/WcaOnRails/app/views/admin/edit_person.html.erb
+++ b/WcaOnRails/app/views/admin/edit_person.html.erb
@@ -32,6 +32,10 @@
         <button type="submit" name="method" value="update" class="btn btn-warning" data-confirm="Are you sure that you want to 'Change', the competitor's data?">
           <%= ui_icon("clone") %> Update
         </button>
+
+        <button type="submit" name="method" value="destroy" class="btn btn-danger pull-right" data-confirm="Are you sure that you want to remove that competitor?">
+          <%= ui_icon("trash") %> Destroy
+        </button>
       </div>
     <% end %>
   <% end %>

--- a/WcaOnRails/app/views/admin/results/edit.html.erb
+++ b/WcaOnRails/app/views/admin/results/edit.html.erb
@@ -1,0 +1,7 @@
+<% provide(:title, "Edit a result") %>
+
+<div class="container">
+  <%= react_component("EditResult", {
+    id: @result.id,
+  }) %>
+</div>

--- a/WcaOnRails/app/views/admin/results/new.html.erb
+++ b/WcaOnRails/app/views/admin/results/new.html.erb
@@ -1,0 +1,7 @@
+<% provide(:title, "Add a result") %>
+
+<div class="container">
+  <%= react_component("NewResult", {
+    result: @result,
+  }) %>
+</div>

--- a/WcaOnRails/app/views/competitions/_results_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_results_table.html.erb
@@ -61,6 +61,9 @@
             <% classes << " tied-previous" %>
           <% end %>
           <td class="<%= classes %>">
+            <% if current_user&.can_admin_results? %>
+              <%= link_to(ui_icon("pencil alt"), edit_result_path(result.id)) %>
+            <% end %>
             <%= result.pos %>
           </td>
         <% end %>

--- a/WcaOnRails/app/views/competitions/show_all_results.html.erb
+++ b/WcaOnRails/app/views/competitions/show_all_results.html.erb
@@ -3,7 +3,8 @@
 <%= render layout: 'results_nav' do %>
   <%= tag :div, id: "selected-event", "data-selected": params[:event] %>
   <%= react_component("CompetitionResults", {
-    competitionId: @competition.id
+    competitionId: @competition.id,
+    canAdminResults: current_user&.can_admin_results?,
   }, {
     id: "competition_results",
   }) %>

--- a/WcaOnRails/app/webpacker/components/CompetitionResults/ResultRow.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionResults/ResultRow.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Icon, Table } from 'semantic-ui-react';
+import cn from 'classnames';
+
+import { personUrl, editResultUrl } from '../../lib/requests/routes.js.erb';
+import CountryFlag from '../wca/CountryFlag';
+import {
+  formatAttemptResult,
+  formatAttemptsForResult,
+} from '../../lib/wca-live/attempts';
+import { getRecordClass } from '../../lib/helpers/competition-results';
+
+import '../../stylesheets/competition_results.scss';
+
+function ResultRow({
+  result, index, results, adminMode,
+}) {
+  return (
+    <Table.Row>
+      <Table.Cell className={cn({ 'text-muted': index > 0 && results[index - 1].pos === result.pos })}>
+        {result.pos}
+        {adminMode && (
+        <a href={editResultUrl(result.id)} role="menuitem" className="edit-link">
+          <Icon name="pencil" />
+        </a>
+        )}
+      </Table.Cell>
+      <Table.Cell>
+        <a href={personUrl(result.wca_id)}>{`${result.name}`}</a>
+      </Table.Cell>
+      <Table.Cell className={getRecordClass(result.regional_single_record)}>
+        {formatAttemptResult(result.best, result.event_id)}
+      </Table.Cell>
+      <Table.Cell>{result.regional_single_record}</Table.Cell>
+      <Table.Cell className={getRecordClass(result.regional_average_record)}>
+        {formatAttemptResult(result.average, result.event_id)}
+      </Table.Cell>
+      <Table.Cell>{result.regional_average_record}</Table.Cell>
+      <Table.Cell><CountryFlag iso2={result.country_iso2} /></Table.Cell>
+      <Table.Cell className={(result.event_id === '333mbf' || result.event_id === '333mbo') ? 'table-cell-solves-mbf' : 'table-cell-solves'}>
+        {formatAttemptsForResult(result, result.event_id)}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+export default ResultRow;

--- a/WcaOnRails/app/webpacker/components/CompetitionResults/ResultRowHeader.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionResults/ResultRowHeader.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Table } from 'semantic-ui-react';
+import I18n from '../../lib/i18n';
+
+function ResultRowHeader() {
+  return (
+    <Table.Row>
+      <Table.HeaderCell width={1}>#</Table.HeaderCell>
+      <Table.HeaderCell width={4}>
+        {I18n.t('competitions.results_table.name')}
+      </Table.HeaderCell>
+      <Table.HeaderCell>{I18n.t('common.best')}</Table.HeaderCell>
+      <Table.HeaderCell />
+      <Table.HeaderCell>{I18n.t('common.average')}</Table.HeaderCell>
+      <Table.HeaderCell />
+      <Table.HeaderCell>{I18n.t('common.user.citizen_of')}</Table.HeaderCell>
+      <Table.HeaderCell>{I18n.t('common.solves')}</Table.HeaderCell>
+    </Table.Row>
+  );
+}
+
+export default ResultRowHeader;

--- a/WcaOnRails/app/webpacker/components/CountrySelector/CountrySelector.js
+++ b/WcaOnRails/app/webpacker/components/CountrySelector/CountrySelector.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Form } from 'semantic-ui-react';
+
+import countries from '../../lib/wca-data/countries.js.erb';
+import CountryFlag from '../wca/CountryFlag';
+import '../../stylesheets/country_selector.scss';
+
+const countryOptions = countries.real.map((country) => ({
+  key: country.iso2,
+  text: country.name,
+  value: country.iso2,
+  image: <CountryFlag iso2={country.iso2} />,
+}));
+
+function CountrySelector({ countryIso2, onChange, error }) {
+  return (
+    <Form.Select
+      className="country-selector"
+      search
+      label="Country"
+      value={countryIso2}
+      error={error}
+      options={countryOptions}
+      onChange={onChange}
+    />
+  );
+}
+
+export default CountrySelector;

--- a/WcaOnRails/app/webpacker/components/EditResult.js
+++ b/WcaOnRails/app/webpacker/components/EditResult.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import useLoadedData from '../lib/hooks/useLoadedData';
+import { resultUrl, competitionUrl } from '../lib/requests/routes.js.erb';
+
+import Loading from './Requests/Loading';
+import Errored from './Requests/Errored';
+import ResultForm from './Results/ResultForm/ResultForm';
+import ShowSingleResult from './Results/EditResult/ShowSingleResult';
+
+function EditResult({
+  id,
+}) {
+  const {
+    data, sync, loading, error,
+  } = useLoadedData(resultUrl(id));
+  return (
+    <>
+      {error && (
+        <Errored componentName="EditResult" />
+      )}
+      {loading && (
+        <Loading />
+      )}
+      {data && (
+        <>
+          {!loading && (
+            <>
+              <h3>
+                Result previously saved in the database
+                {' '}
+                -
+                {' '}
+                <a
+                  href={competitionUrl(data.competition_id)}
+                >
+                  {data.competition_id}
+                </a>
+              </h3>
+              <ShowSingleResult result={data} />
+            </>
+          )}
+          <ResultForm result={data} sync={sync} />
+        </>
+      )}
+    </>
+  );
+}
+
+export default EditResult;

--- a/WcaOnRails/app/webpacker/components/GenderSelector/GenderSelector.js
+++ b/WcaOnRails/app/webpacker/components/GenderSelector/GenderSelector.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import _ from 'lodash';
+import { Form } from 'semantic-ui-react';
+
+import genders from '../../lib/wca-data/genders.js.erb';
+
+const genderOptions = _.map(genders.byId, (gender) => ({
+  key: gender.id,
+  text: gender.name,
+  value: gender.id,
+}));
+
+function GenderSelector({ gender, onChange }) {
+  return (
+    <Form.Select
+      label="Gender"
+      value={gender}
+      options={genderOptions}
+      onChange={onChange}
+    />
+  );
+}
+
+export default GenderSelector;

--- a/WcaOnRails/app/webpacker/components/NewResult.js
+++ b/WcaOnRails/app/webpacker/components/NewResult.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import ResultForm from './Results/ResultForm/ResultForm';
+
+function NewResult({
+  result,
+}) {
+  return (
+    <>
+      <h3>Creating a new result</h3>
+      <ResultForm result={result} sync={() => {}} />
+    </>
+  );
+}
+
+export default NewResult;

--- a/WcaOnRails/app/webpacker/components/Persons/NewPersonForm/NewPersonForm.js
+++ b/WcaOnRails/app/webpacker/components/Persons/NewPersonForm/NewPersonForm.js
@@ -1,0 +1,152 @@
+import React, { useState, useCallback, useEffect } from 'react';
+
+import {
+  Button, Icon, Form, Message,
+} from 'semantic-ui-react';
+
+import CountrySelector from '../../CountrySelector/CountrySelector';
+import GenderSelector from '../../GenderSelector/GenderSelector';
+import { adminGenerateIds, personsUrl } from '../../../lib/requests/routes.js.erb';
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+import countries from '../../../lib/wca-data/countries.js.erb';
+import useInputState from '../../../lib/hooks/useInputState';
+
+const countryIdForIso2 = (iso2) => {
+  const country = countries.byIso2[iso2];
+  return country ? country.id : undefined;
+};
+
+function NewPersonForm({
+  onCreate, competitionId, save, saving,
+}) {
+  // competitionId is necessary to compute the WCA ID for the person;
+  // it should be the first competition this person has participated in.
+  const [semiId, setSemiId] = useInputState('');
+  const [wcaId, setWcaId] = useInputState('');
+  const [name, setName] = useInputState('');
+  const [countryIso2, setCountryIso2] = useInputState('');
+  const [gender, setGender] = useInputState('');
+  const [dob, setDob] = useInputState('');
+
+  // On name change, clear ids!
+  useEffect(() => {
+    setSemiId('');
+    setWcaId('');
+  }, [setSemiId, setWcaId, name]);
+
+  const [errors, setErrors] = useState({});
+
+  // Create a function to get the semiId and wcaId from the API
+  const fetchIds = useCallback((params) => {
+    setErrors({});
+    fetchJsonOrError(`${adminGenerateIds}?${new URLSearchParams(params)}`)
+      .then((data) => {
+        if (data.semiId !== undefined) {
+          setSemiId(data.semiId);
+        }
+        if (data.wcaId !== undefined) {
+          setWcaId(data.wcaId);
+        }
+        setErrors(data.errors || {});
+      }).catch((err) => setErrors({ semi_id: err.message }));
+  }, [setErrors, setSemiId, setWcaId]);
+
+  const onError = useCallback((err) => {
+    setErrors({ message: err.message });
+  }, [setErrors]);
+
+  const onSuccess = useCallback((responseJson) => {
+    if (responseJson.errors) {
+      setErrors(responseJson.errors);
+    } else {
+      onCreate(responseJson);
+    }
+  }, [onCreate, setErrors]);
+
+  return (
+    <>
+      <Form>
+        <Form.Group widths={4}>
+          <Form.Input
+            label="Name"
+            placeholder="Name"
+            onChange={setName}
+            error={errors.name}
+            value={name}
+          />
+          <Form.Input
+            label="Date of birth"
+            placeholder="YYYY-MM-DD"
+            onChange={setDob}
+            error={errors.dob}
+            value={dob}
+          />
+          <GenderSelector
+            gender={gender}
+            onChange={setGender}
+          />
+          <CountrySelector
+            countryIso2={countryIso2}
+            error={errors.countryId}
+            onChange={setCountryIso2}
+          />
+        </Form.Group>
+        <Form.Group widths={2}>
+          <Form.Input
+            label="Semi ID"
+            onChange={setSemiId}
+            error={errors.semi_id}
+            value={semiId}
+            icon={(
+              <Icon
+                circular
+                link
+                onClick={() => fetchIds({
+                  name,
+                  competition_id: competitionId,
+                  semi_id: semiId,
+                })}
+                name="search"
+              />
+                )}
+          />
+          <Form.Input
+            label="WCA ID"
+            onChange={setWcaId}
+            error={errors.wca_id}
+            value={wcaId}
+          />
+        </Form.Group>
+      </Form>
+      <Message info>
+        <p>
+          When creating a new person, this modal will close and the person
+          data for the result will be filled.
+          <br />
+          The person will be created no matter what happens with the result!
+          <br />
+          So if you end up not using the newly created person in the result,
+          keep in mind that you may have to remove them.
+        </p>
+      </Message>
+      <Button
+        positive
+        disabled={saving}
+        onClick={() => save(personsUrl, {
+          person: {
+            name,
+            dob,
+            gender,
+            countryId: countryIdForIso2(countryIso2),
+            wca_id: wcaId,
+          },
+        }, onSuccess, {
+          method: 'POST',
+        }, onError)}
+        content="Create the person"
+      />
+    </>
+  );
+}
+
+export default NewPersonForm;

--- a/WcaOnRails/app/webpacker/components/Results/EditResult/ShowSingleResult.js
+++ b/WcaOnRails/app/webpacker/components/Results/EditResult/ShowSingleResult.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Table } from 'semantic-ui-react';
+import ResultRow from '../../CompetitionResults/ResultRow';
+import ResultRowHeader from '../../CompetitionResults/ResultRowHeader';
+
+function ShowSingleResult({ result }) {
+  return (
+    <div className="competition-results">
+      <Table striped className="event-results">
+        <Table.Header>
+          <ResultRowHeader />
+        </Table.Header>
+        <Table.Body>
+          <ResultRow result={result} results={[result]} index={0} />
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}
+
+export default ShowSingleResult;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/AfterActionMessage.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/AfterActionMessage.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Message, List } from 'semantic-ui-react';
+
+import {
+  adminCheckExistingResultsUrl,
+  adminCADUrl,
+  competitionAllResultsUrl,
+  personUrl,
+} from '../../../lib/requests/routes.js.erb';
+
+function AfterActionMessage({
+  wcaId, eventId, competitionId, response,
+}) {
+  return (
+    <>
+      <Message
+        positive
+        header={(
+          <>
+            Action performed for:
+            {' '}
+            <a href={personUrl(wcaId)} target="_blank" rel="noreferrer">{wcaId}</a>
+          </>
+      )}
+        list={response.messages}
+      />
+      <Message positive>
+        <div>
+          Please make sure to:
+          <List ordered>
+            <List.Item>
+              <a
+                href={adminCheckExistingResultsUrl(competitionId)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Check Competition Validators
+              </a>
+            </List.Item>
+            <List.Item>
+              <a
+                href={`/results/admin/check_rounds.php?competitionId=${competitionId}&show=Show`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Check Rounds
+              </a>
+            </List.Item>
+            <List.Item>
+              <a
+                href={`/results/admin/check_regional_record_markers.php?competitionId=${competitionId}&show=Show`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Check Records
+              </a>
+            </List.Item>
+            <List.Item>
+              <a
+                href={adminCADUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Run Compute Auxiliary Data
+              </a>
+            </List.Item>
+          </List>
+          You can also
+          {' '}
+          <a href={competitionAllResultsUrl(competitionId, eventId)}>go back to the results</a>
+          .
+        </div>
+      </Message>
+    </>
+  );
+}
+
+export default AfterActionMessage;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/AttemptsForm.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/AttemptsForm.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  Form, Grid,
+} from 'semantic-ui-react';
+
+import AttemptResultField from '../WCALive/AttemptResultField/AttemptResultField';
+import MarkerField from '../WCALive/AttemptResultField/MarkerField';
+import { average, best, formatAttemptResult } from '../../../lib/wca-live/attempts';
+import useNestedInputUpdater from '../../../lib/hooks/useNestedInputUpdater';
+
+function AttemptsForm({
+  state, setState, eventId, computeAverage,
+}) {
+  const { attempts, markerBest, markerAvg } = state;
+
+  const setMarkerBest = useNestedInputUpdater(setState, 'markerBest');
+  const setMarkerAvg = useNestedInputUpdater(setState, 'markerAvg');
+
+  // FIXME: we use padded grid here because Bootstrap's row conflicts with
+  // FUI's row and messes up the negative margins... :(
+  /* eslint react/no-array-index-key: "off" */
+  return (
+    <Form>
+      <Grid stackable padded columns={2}>
+        <Grid.Column className="attempts-column">
+          {attempts.map((attempt, index) => {
+            const setAttempt = useNestedInputUpdater(setState, `attempts[${index}]`);
+            return (
+              <AttemptResultField
+                key={index}
+                eventId={eventId}
+                label={`Attempt ${index + 1}`}
+                initialValue={attempt}
+                value={attempt}
+                onChange={setAttempt}
+              />
+            );
+          })}
+        </Grid.Column>
+        <Grid.Column>
+          <Form.Input
+            label="Best"
+            readOnly
+            value={formatAttemptResult(best(attempts), eventId)}
+            action={(
+              <MarkerField
+                onChange={setMarkerBest}
+                marker={markerBest}
+              />
+            )}
+          />
+          {computeAverage && (
+          <Form.Input
+            label="Average"
+            readOnly
+            value={formatAttemptResult(average(state.attempts, eventId), eventId)}
+            action={(
+              <MarkerField
+                onChange={setMarkerAvg}
+                marker={markerAvg}
+              />
+            )}
+          />
+          )}
+        </Grid.Column>
+      </Grid>
+    </Form>
+  );
+}
+
+export default AttemptsForm;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/DeleteResultButton.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/DeleteResultButton.js
@@ -1,0 +1,27 @@
+import React, { useState, useCallback } from 'react';
+
+import { Button, Checkbox } from 'semantic-ui-react';
+
+function DeleteResultButton({ deleteAction }) {
+  const [confirmed, setConfirmed] = useState(false);
+  const updater = useCallback(() => setConfirmed((prev) => !prev), [setConfirmed]);
+  return (
+    <div>
+      <Button
+        negative
+        className="delete-result-button"
+        disabled={!confirmed}
+        onClick={deleteAction}
+      >
+        Delete the result
+      </Button>
+      <Checkbox
+        label="Yes, I want to delete that result"
+        checked={confirmed}
+        onChange={updater}
+      />
+    </div>
+  );
+}
+
+export default DeleteResultButton;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/NewPersonModal.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/NewPersonModal.js
@@ -1,0 +1,50 @@
+/* eslint-disable */
+import React, { useState, useCallback, useEffect } from 'react';
+
+import { Button, Icon, Modal } from 'semantic-ui-react';
+
+import NewPersonForm from '../../Persons/NewPersonForm/NewPersonForm';
+import useSaveAction from '../../../lib/hooks/useSaveAction';
+
+const NewPersonModal = ({ trigger, onPersonCreate, competitionId }) => {
+  const [open, setOpen] = useState(false);
+
+  const { save, saving } = useSaveAction();
+
+  const onCreate = useCallback((data) => {
+    onPersonCreate(data);
+    setOpen(false);
+  }, [setOpen]);
+
+  return (
+    <Modal
+      dimmer="blurring"
+      closeIcon
+      closeOnDimmerClick={false}
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      open={open}
+      size="large"
+      trigger={trigger}
+    >
+      <Modal.Header>Create new person</Modal.Header>
+      <Modal.Content>
+        <Modal.Description>
+          <NewPersonForm
+            save={save}
+            saving={saving}
+            onCreate={onCreate}
+            competitionId={competitionId}
+          />
+        </Modal.Description>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button negative onClick={() => setOpen(false)}>
+          Cancel
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default NewPersonModal;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/PersonForm.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/PersonForm.js
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Icon, Form, Grid, Popup,
+} from 'semantic-ui-react';
+
+import CountrySelector from '../../CountrySelector/CountrySelector';
+import { personApiUrl } from '../../../lib/requests/routes.js.erb';
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+import useNestedInputUpdater from '../../../lib/hooks/useNestedInputUpdater';
+
+function PersonForm({ personData, setPersonData }) {
+  const { wcaId, name, countryIso2 } = personData;
+  const [wcaIdError, setWcaIdError] = useState(null);
+
+  // Clear any person data request error upon WCA ID change.
+  useEffect(() => setWcaIdError(null), [wcaId]);
+
+  const setWcaId = useNestedInputUpdater(setPersonData, 'wcaId');
+  const setName = useNestedInputUpdater(setPersonData, 'name');
+  const setCountryIso2 = useNestedInputUpdater(setPersonData, 'countryIso2');
+
+  // Create a function to get person data from the API.
+  const fetchDataForWcaId = (id) => {
+    setWcaIdError(null);
+    fetchJsonOrError(personApiUrl(id)).then(({ person }) => {
+      setPersonData({
+        wcaId: person.wca_id,
+        name: person.name,
+        countryIso2: person.country_iso2,
+      });
+    }).catch((err) => setWcaIdError(err.message));
+  };
+
+  return (
+    <Form>
+      <Grid stackable padded columns={3}>
+        <Grid.Column>
+          <Form.Input
+            label="WCA ID"
+            onChange={setWcaId}
+            error={wcaIdError}
+            value={wcaId}
+            icon={(
+              <Popup
+                trigger={(
+                  <Icon
+                    circular
+                    link
+                    onClick={() => fetchDataForWcaId(wcaId)}
+                    name="sync"
+                  />
+                )}
+                content="Get the person data for that WCA ID and fill the form"
+                position="top right"
+              />
+          )}
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Form.Input
+            label="Name"
+            onChange={setName}
+            value={name}
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <CountrySelector
+            countryIso2={countryIso2}
+            onChange={setCountryIso2}
+          />
+        </Grid.Column>
+      </Grid>
+    </Form>
+  );
+}
+
+export default PersonForm;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/ResultForm.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/ResultForm.js
@@ -1,0 +1,234 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+import { Button } from 'semantic-ui-react';
+
+import _ from 'lodash';
+import AttemptsForm from './AttemptsForm';
+import PersonForm from './PersonForm';
+import RoundForm from './RoundForm';
+import NewPersonModal from './NewPersonModal';
+import DeleteResultButton from './DeleteResultButton';
+import SaveMessage from './SaveMessage';
+import AfterActionMessage from './AfterActionMessage';
+import useSaveAction from '../../../lib/hooks/useSaveAction';
+import { average, best } from '../../../lib/wca-live/attempts';
+import { shouldComputeAverage, getExpectedSolveCount } from '../../../lib/helpers/results';
+import { resultUrl, competitionAllResultsUrl } from '../../../lib/requests/routes.js.erb';
+import countries from '../../../lib/wca-data/countries.js.erb';
+import './ResultForm.scss';
+
+const roundDataFromResult = (result) => ({
+  competitionId: result.competition_id || '',
+  roundTypeId: result.round_type_id || '',
+  formatId: result.format_id || '',
+  eventId: result.event_id || '',
+});
+
+const attemptsDataFromResult = (result) => ({
+  attempts: _.times(
+    getExpectedSolveCount(result.format_id),
+    (index) => (result.attempts && result.attempts[index]) || 0,
+  ),
+  markerBest: result.regional_single_record || '',
+  markerAvg: result.regional_average_record || '',
+});
+
+const personDataFromResult = (result) => ({
+  wcaId: result.wca_id || '',
+  name: result.name || '',
+  countryIso2: result.country_iso2 || '',
+});
+
+const dataToResult = ({
+  eventId, formatId, competitionId, roundTypeId,
+}, person, attemptsData) => {
+  const country = countries.byIso2[person.countryIso2];
+  const result = {
+    personId: person.wcaId,
+    personName: person.name,
+    countryId: country ? country.id : undefined,
+    best: best(attemptsData.attempts),
+    average: average(attemptsData.attempts, eventId, attemptsData.attempts.length),
+    regionalAverageRecord: attemptsData.markerAvg,
+    regionalSingleRecord: attemptsData.markerBest,
+    eventId,
+    formatId,
+    competitionId,
+    roundTypeId,
+  };
+  // Map individual attempts to valueN...
+  attemptsData.attempts.forEach((a, index) => { result[`value${index + 1}`] = a; });
+  return { result };
+};
+
+function ResultForm({
+  result, save, saving, onCreate, onUpdate, onDelete,
+}) {
+  const { id } = result;
+  const computeAverage = shouldComputeAverage(result);
+
+  // Person-related state.
+  const [personData, setPersonData] = useState(personDataFromResult(result));
+
+  // Round-related state.
+  const [roundData, setRoundData] = useState(roundDataFromResult(result));
+
+  // Attempts-related state.
+  const [attemptsState, setAttemptsState] = useState(attemptsDataFromResult(result));
+
+  // Populate the original states whenever the original result changes.
+  useEffect(() => {
+    setAttemptsState(attemptsDataFromResult(result));
+    setRoundData(roundDataFromResult(result));
+    setPersonData(personDataFromResult(result));
+  }, [result]);
+
+  // Use response to store errors and messages.
+  const [response, setResponse] = useState({});
+
+  const onSuccess = useCallback((data, responseJson) => {
+    // First of all, set the errors/messages.
+    setResponse(responseJson);
+    if (responseJson.errors === undefined) {
+      // Notify the parent(s) based on creation/update.
+      if (id === undefined) {
+        onCreate({ result: data, response: responseJson });
+      } else {
+        onUpdate({ result: data, response: responseJson });
+      }
+    }
+  }, [id, setResponse, onCreate, onUpdate]);
+
+  const onError = useCallback((err) => {
+    // 'onError' is called only if the request fails, which shouldn't happen
+    // whatever the user input is. If this does happen, ask them to report to us!
+    setResponse({
+      errors: [
+        'The request to the server failed. This is definitely unexpected, you may consider contacting the WST with the error below!',
+        err.toString(),
+      ],
+    });
+  }, [setResponse]);
+
+  const saveAction = useCallback((data) => {
+    const url = id === undefined ? resultUrl('') : resultUrl(id);
+    // If 'id' is undefined, then we're creating a new result and it's a POST,
+    // otherwise it's a PATCH.
+    const method = id === undefined ? 'POST' : 'PATCH';
+    save(
+      url,
+      data,
+      (responseJson) => onSuccess(data.result, responseJson),
+      { method },
+      onError,
+    );
+  }, [save, id, onSuccess, onError]);
+
+  const deleteAction = useCallback(() => {
+    save(
+      resultUrl(result.id),
+      {},
+      (responseJson) => onDelete({ result, response: responseJson }),
+      { method: 'DELETE' },
+      onError,
+    );
+  }, [result, onDelete, onError]);
+
+  const onPersonCreate = useCallback((data) => {
+    setPersonData(personDataFromResult(data));
+    setResponse({});
+  }, [setResponse, setPersonData]);
+
+  return (
+    <div className="result-form">
+      <h3>
+        Round data
+      </h3>
+      <RoundForm roundData={roundData} setRoundData={setRoundData} />
+      <h3>
+        Person data
+      </h3>
+      <NewPersonModal
+        trigger={<Button positive compact size="small">Create new person</Button>}
+        onPersonCreate={onPersonCreate}
+        competitionId={roundData.competitionId}
+      />
+      <PersonForm personData={personData} setPersonData={setPersonData} />
+      <h3>
+        Attempts
+      </h3>
+      <AttemptsForm
+        eventId={result.event_id}
+        state={attemptsState}
+        setState={setAttemptsState}
+        computeAverage={computeAverage}
+      />
+      <SaveMessage response={response} />
+      <div>
+        <Button
+          positive
+          loading={saving}
+          disabled={saving}
+          onClick={() => saveAction(dataToResult(roundData, personData, attemptsState))}
+        >
+          Save
+        </Button>
+        <Button
+          primary
+          as="a"
+          loading={saving}
+          disabled={saving}
+          href={competitionAllResultsUrl(roundData.competitionId, roundData.eventId)}
+        >
+          Go back to results
+        </Button>
+      </div>
+      {id && (
+        <DeleteResultButton deleteAction={deleteAction} />
+      )}
+    </div>
+  );
+}
+
+// This is a simple wrapper to be able to manage request-specific states,
+// and to be able to hide the form upon creation.
+function ResultFormWrapper({ result, sync }) {
+  const { save, saving } = useSaveAction();
+
+  // This is used to track if we did save something.
+  const [created, setCreated] = useState(undefined);
+  const [deleted, setDeleted] = useState(undefined);
+
+  if (created) {
+    return (
+      <AfterActionMessage
+        wcaId={created.result.personId}
+        eventId={result.event_id}
+        competitionId={result.competition_id}
+        response={created.response}
+      />
+    );
+  }
+  if (deleted) {
+    return (
+      <AfterActionMessage
+        wcaId={deleted.result.wca_id}
+        eventId={result.event_id}
+        competitionId={result.competition_id}
+        response={deleted.response}
+      />
+    );
+  }
+  return (
+    <ResultForm
+      result={result}
+      save={save}
+      saving={saving}
+      onCreate={setCreated}
+      onUpdate={sync}
+      onDelete={setDeleted}
+    />
+  );
+}
+
+export default ResultFormWrapper;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/ResultForm.scss
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/ResultForm.scss
@@ -1,0 +1,16 @@
+.result-form {
+  margin-top: 1em;
+  input[readonly] {
+    opacity: 0.7;
+  }
+  .attempts-column {
+    .row {
+      padding-top: 0.5em;
+      padding-bottom: 0.5em;
+    }
+  }
+  .delete-result-button {
+    margin-top: 1em;
+    margin-right: 1em;
+  }
+}

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/RoundForm.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/RoundForm.js
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import {
+  Form, Grid, Icon, Popup,
+} from 'semantic-ui-react';
+
+import _ from 'lodash';
+import formats from '../../../lib/wca-data/formats.js.erb';
+import events from '../../../lib/wca-data/events.js.erb';
+import roundTypes from '../../../lib/wca-data/roundTypes.js.erb';
+import useNestedInputUpdater from '../../../lib/hooks/useNestedInputUpdater';
+import { competitionEventsDataUrl } from '../../../lib/requests/routes.js.erb';
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+
+const itemFromId = (id, items) => ({
+  key: id,
+  value: id,
+  text: items.byId[id].name,
+});
+
+const formatRoundData = ({ eventId, formatId, roundTypeId }) => ({
+  [eventId]: {
+    eventId,
+    rounds: [{ formatId, roundTypeId }],
+  },
+});
+
+const extractFromRoundData = (roundData, eventId, key, items) => {
+  const ids = _.uniq(roundData[eventId].rounds.map((r) => r[key]));
+  return ids.map((id) => itemFromId(id, items));
+};
+
+function RoundForm({ roundData, setRoundData }) {
+  const {
+    competitionId, roundTypeId, eventId, formatId,
+  } = roundData;
+
+  const setCompetition = useNestedInputUpdater(setRoundData, 'competitionId');
+  const setEvent = useNestedInputUpdater(setRoundData, 'eventId');
+  const setFormat = useNestedInputUpdater(setRoundData, 'formatId');
+  const setRoundType = useNestedInputUpdater(setRoundData, 'roundTypeId');
+
+  const [competitionIdError, setCompetitionIdError] = useState(null);
+
+  const [localRoundData, setLocalRoundData] = useState(formatRoundData(roundData));
+
+  const availableEvents = Object.keys(localRoundData).map((k) => itemFromId(k, events));
+  const availableRoundTypes = extractFromRoundData(localRoundData, eventId, 'roundTypeId', roundTypes);
+  const availableFormats = extractFromRoundData(localRoundData, eventId, 'formatId', formats);
+
+  const fetchDataForCompetition = (id) => {
+    setCompetitionIdError(null);
+    fetchJsonOrError(competitionEventsDataUrl(id)).then((data) => {
+      setLocalRoundData(data);
+    }).catch((err) => setCompetitionIdError(err.message));
+  };
+
+  // FIXME: we use padded grid here because Bootstrap's row conflicts with
+  // FUI's row and messes up the negative margins... :(
+  return (
+    <Form>
+      <Grid stackable padded columns={4}>
+        <Grid.Column>
+          <Form.Input
+            label="Competition ID"
+            value={competitionId}
+            onChange={setCompetition}
+            error={competitionIdError}
+            icon={(
+              <Popup
+                trigger={(
+                  <Icon
+                    circular
+                    link
+                    onClick={() => fetchDataForCompetition(competitionId)}
+                    name="sync"
+                  />
+                )}
+                content="Get the events and round data for that competition"
+                position="top right"
+              />
+            )}
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Form.Select
+            label="Event"
+            value={eventId}
+            onChange={setEvent}
+            options={availableEvents}
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Form.Select
+            label="Round type"
+            value={roundTypeId}
+            onChange={setRoundType}
+            options={availableRoundTypes}
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Form.Select
+            label="Format"
+            value={formatId}
+            onChange={setFormat}
+            options={availableFormats}
+          />
+        </Grid.Column>
+      </Grid>
+    </Form>
+  );
+}
+
+export default RoundForm;

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/SaveMessage.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/SaveMessage.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Message } from 'semantic-ui-react';
+
+function SaveMessage({ response }) {
+  return (
+    <>
+      {response.messages && (
+      <Message
+        positive
+        header="Save was successful!"
+        list={response.messages}
+      />
+      )}
+      {response.errors && (
+      <Message
+        error
+        list={response.errors}
+        header="Something went wrong when saving the result."
+      />
+      )}
+    </>
+  );
+}
+
+export default SaveMessage;

--- a/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/AttemptResultField.js
+++ b/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/AttemptResultField.js
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import FmField from './FmField';
+import MbldField from './MbldField';
+import TimeField from './TimeField';
+
+/**
+   `AttemptResultField` is an abstraction over fields specific to the given event,
+   but each of these specific fields works in the similar way.
+
+   The idea behind an attempt result field is that it gets a `value`,
+   allows editing it in any way (by keeping a local draft value)
+   and triggers an `onChange` callback once editing is finished (a blur event).
+
+   This requires keeping both the current value in the parent component (like
+   for a controlled field) and a draft value in the field component
+   (local copy of the upstream value).
+   Whenever `value` changes we want to synchronize the local draft value,
+   which fits into the `getDerivedStateFromProps` lifecycle method.
+   The most straightforward solution would be using useEffect to keep them in sync,
+   but this performs unnecessary re-rendering with old value and leads to jumpy UI.
+   https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html
+   The above article describes alternatives, but none seems good enough in our case:
+   - keeping the draft value in the parent component (e.g. `ResultForm`) is a bad idea,
+   because each field type stores the draft value in different format
+   and it's just best to use the fields as isolated black boxes
+   - using the key prop is a better option, but it remounts the given input element,
+   which may lead to undesired *Tab* key behaviour
+   (clicking *Tab* blurs one input, which may affect the next input value
+   and remounting it as a consequence, in that case we lose focus)
+
+   Using getDerivedStateFromProps sounds justified in this case.
+   Hooks equivalent is described in the section below
+   https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops.
+*/
+
+/* eslint react/jsx-props-no-spreading: "off" */
+function AttemptResultField({ eventId, ...props }) {
+  if (eventId === '333fm') {
+    return <FmField {...props} />;
+  }
+  if (eventId === '333mbf' || eventId === '333mbo') {
+    return <MbldField {...props} />;
+  }
+  return <TimeField {...props} />;
+}
+
+export default AttemptResultField;

--- a/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/CubesField.js
+++ b/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/CubesField.js
@@ -1,0 +1,51 @@
+import React, { useState, useCallback } from 'react';
+import { Form } from 'semantic-ui-react';
+import _ from 'lodash';
+
+function numberToInput(number) {
+  if (number === 0) return '';
+  return number.toString();
+}
+
+/* eslint react/jsx-props-no-spreading: "off" */
+function CubesField({
+  value, onChange, label, disabled, TextFieldProps = {},
+}) {
+  const [prevValue, setPrevValue] = useState(value);
+  const [draftValue, setDraftValue] = useState(value);
+
+  // Sync draft value when the upstream value changes.
+  // See AttemptResultField for detailed description.
+  if (prevValue !== value) {
+    setDraftValue(value);
+    setPrevValue(value);
+  }
+
+  const handleChange = useCallback((event) => {
+    const newValue = _.toInteger(event.target.value.replace(/\D/g, '')) || 0;
+    if (newValue <= 99) {
+      setDraftValue(newValue);
+    }
+  }, [setDraftValue]);
+
+  const handleBlur = useCallback(() => {
+    onChange(draftValue);
+    // Once we emit the change, reflect the initial state.
+    setDraftValue(value);
+  }, [onChange, draftValue, setDraftValue, value]);
+
+  return (
+    <Form.Input
+      {...TextFieldProps}
+      fluid
+      label={label}
+      disabled={disabled}
+      spellCheck={false}
+      value={numberToInput(draftValue)}
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  );
+}
+
+export default CubesField;

--- a/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/FmField.js
+++ b/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/FmField.js
@@ -1,0 +1,63 @@
+import React, { useState, useCallback } from 'react';
+import { Form } from 'semantic-ui-react';
+import _ from 'lodash';
+import { DNF_KEYS, DNS_KEYS } from './keybindings';
+import {
+  SKIPPED_VALUE,
+  DNF_VALUE,
+  DNS_VALUE,
+} from '../../../../lib/wca-live/attempts';
+
+function numberToInput(number) {
+  if (number === SKIPPED_VALUE) return '';
+  if (number === DNF_VALUE) return 'DNF';
+  if (number === DNS_VALUE) return 'DNS';
+  return number.toString();
+}
+
+/* eslint react/jsx-props-no-spreading: "off" */
+function FmField({
+  value, onChange, label, disabled, TextFieldProps = {},
+}) {
+  const [prevValue, setPrevValue] = useState(value);
+  const [draftValue, setDraftValue] = useState(value);
+
+  // Sync draft value when the upstream value changes.
+  // See AttemptResultField for detailed description.
+  if (prevValue !== value) {
+    setDraftValue(value);
+    setPrevValue(value);
+  }
+
+  const handleChange = useCallback((event) => {
+    const key = event.nativeEvent.data;
+    if (DNF_KEYS.includes(key)) {
+      setDraftValue(DNF_VALUE);
+    } else if (DNS_KEYS.includes(key)) {
+      setDraftValue(DNS_VALUE);
+    } else {
+      const newValue = _.toInteger(event.target.value.replace(/\D/g, '')) || SKIPPED_VALUE;
+      setDraftValue(newValue);
+    }
+  }, [setDraftValue]);
+
+  const handleBlur = useCallback(() => {
+    onChange(draftValue);
+    // Once we emit the change, reflect the initial state.
+    setDraftValue(value);
+  }, [onChange, draftValue, setDraftValue, value]);
+
+  return (
+    <Form.Input
+      {...TextFieldProps}
+      label={label}
+      disabled={disabled}
+      spellCheck={false}
+      value={numberToInput(draftValue)}
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  );
+}
+
+export default FmField;

--- a/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/MarkerField.js
+++ b/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/MarkerField.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Dropdown } from 'semantic-ui-react';
+
+import allMarkers from '../../../../lib/wca-data/regionalMarkers.js.erb';
+
+const MarkersOptions = allMarkers.map((val) => ({
+  key: val,
+  value: val,
+  text: val,
+}));
+
+function MarkerField({ onChange, marker }) {
+  return (
+    <Dropdown
+      button
+      basic
+      onChange={onChange}
+      value={marker}
+      options={MarkersOptions}
+    />
+  );
+}
+
+export default MarkerField;

--- a/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/MbldField.js
+++ b/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/MbldField.js
@@ -1,0 +1,86 @@
+import React, { useState, useCallback } from 'react';
+import { Grid } from 'semantic-ui-react';
+import { DNF_KEYS, DNS_KEYS } from './keybindings';
+import TimeField from './TimeField';
+import CubesField from './CubesField';
+import {
+  decodeMbldAttemptResult,
+  encodeMbldAttemptResult,
+  DNF_VALUE,
+  DNS_VALUE,
+} from '../../../../lib/wca-live/attempts';
+
+/* eslint react/jsx-props-no-spreading: "off" */
+function MbldField({
+  value, onChange, disabled, label, TextFieldProps = {},
+}) {
+  const [prevValue, setPrevValue] = useState(value);
+  const [decodedDraftValue, setDecodedDraftValue] = useState(
+    decodeMbldAttemptResult(value),
+  );
+
+  // Sync draft value when the upstream value changes.
+  // See AttemptResultField for detailed description.
+  if (prevValue !== value) {
+    setDecodedDraftValue(decodeMbldAttemptResult(value));
+    setPrevValue(value);
+  }
+
+  const handleDecodedValueChange = useCallback((draft) => {
+    const updatedDecodedValue = draft;
+    if (encodeMbldAttemptResult(updatedDecodedValue) !== value) {
+      onChange(encodeMbldAttemptResult(updatedDecodedValue));
+      // Once we emit the change, reflect the initial state.
+      setDecodedDraftValue(decodeMbldAttemptResult(value));
+    } else {
+      setDecodedDraftValue(updatedDecodedValue);
+    }
+  }, [onChange, value, setDecodedDraftValue]);
+
+  const handleAnyInput = useCallback((event) => {
+    const key = event.nativeEvent.data;
+    if (DNF_KEYS.includes(key)) {
+      handleDecodedValueChange(decodeMbldAttemptResult(DNF_VALUE));
+      event.preventDefault();
+    } else if (DNS_KEYS.includes(key)) {
+      handleDecodedValueChange(decodeMbldAttemptResult(DNS_VALUE));
+      event.preventDefault();
+    }
+  }, [handleDecodedValueChange]);
+
+  return (
+    <Grid onInputCapture={handleAnyInput}>
+      <Grid.Column width={3}>
+        <CubesField
+          label="Solved"
+          value={decodedDraftValue.solved}
+          onChange={(solved) => handleDecodedValueChange({ ...decodedDraftValue, solved })}
+          disabled={disabled}
+          TextFieldProps={TextFieldProps}
+        />
+      </Grid.Column>
+      <Grid.Column width={3}>
+        <CubesField
+          label="Attempted"
+          value={decodedDraftValue.attempted}
+          onChange={(attempted) => handleDecodedValueChange({ ...decodedDraftValue, attempted })}
+          disabled={disabled}
+          TextFieldProps={TextFieldProps}
+        />
+      </Grid.Column>
+      <Grid.Column width={10}>
+        <TimeField
+          label={label}
+          value={decodedDraftValue.centiseconds}
+          onChange={
+            (centiseconds) => handleDecodedValueChange({ ...decodedDraftValue, centiseconds })
+          }
+          disabled={disabled}
+          TextFieldProps={TextFieldProps}
+        />
+      </Grid.Column>
+    </Grid>
+  );
+}
+
+export default MbldField;

--- a/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/TimeField.js
+++ b/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/TimeField.js
@@ -1,0 +1,91 @@
+import React, { useState, useCallback } from 'react';
+import { Form } from 'semantic-ui-react';
+import _ from 'lodash';
+import { DNF_KEYS, DNS_KEYS } from './keybindings';
+import {
+  DNF_VALUE,
+  SKIPPED_VALUE,
+  DNS_VALUE,
+  centisecondsToClockFormat,
+} from '../../../../lib/wca-live/attempts';
+
+function reformatInput(input) {
+  const number = _.toInteger(input.replace(/\D/g, '')) || 0;
+  if (number === 0) return '';
+  const str = `00000000${number.toString().slice(0, 8)}`;
+  const [, hh, mm, ss, cc] = str.match(/(\d\d)(\d\d)(\d\d)(\d\d)$/);
+  return `${hh}:${mm}:${ss}.${cc}`.replace(/^[0:]*(?!\.)/g, '');
+}
+
+function inputToAttemptResult(input) {
+  if (input === '') return SKIPPED_VALUE;
+  if (input === 'DNF') return DNF_VALUE;
+  if (input === 'DNS') return DNS_VALUE;
+  const num = _.toInteger(input.replace(/\D/g, '')) || 0;
+  return (
+    Math.floor(num / 1000000) * 360000
+    + Math.floor((num % 1000000) / 10000) * 6000
+    + Math.floor((num % 10000) / 100) * 100
+    + (num % 100)
+  );
+}
+
+function attemptResultToInput(attemptResult) {
+  if (attemptResult === SKIPPED_VALUE) return '';
+  if (attemptResult === DNF_VALUE) return 'DNF';
+  if (attemptResult === DNS_VALUE) return 'DNS';
+  return centisecondsToClockFormat(attemptResult);
+}
+
+function isValid(input) {
+  return input === attemptResultToInput(inputToAttemptResult(input));
+}
+
+/* eslint react/jsx-props-no-spreading: "off" */
+function TimeField({
+  value, onChange, label, disabled, TextFieldProps = {},
+}) {
+  const [prevValue, setPrevValue] = useState(value);
+  const [draftInput, setDraftInput] = useState(attemptResultToInput(value));
+
+  // Sync draft value when the upstream value changes.
+  // See AttemptResultField for detailed description.
+  if (prevValue !== value) {
+    setDraftInput(attemptResultToInput(value));
+    setPrevValue(value);
+  }
+
+  const handleChange = useCallback((event) => {
+    const key = event.nativeEvent.data;
+    if (DNF_KEYS.includes(key)) {
+      setDraftInput('DNF');
+    } else if (DNS_KEYS.includes(key)) {
+      setDraftInput('DNS');
+    } else {
+      setDraftInput(reformatInput(event.target.value));
+    }
+  }, [setDraftInput]);
+
+  const handleBlur = useCallback(() => {
+    const attempt = isValid(draftInput)
+      ? inputToAttemptResult(draftInput)
+      : SKIPPED_VALUE;
+    onChange(attempt);
+    // Once we emit the change, reflect the initial state.
+    setDraftInput(attemptResultToInput(value));
+  }, [draftInput, onChange, setDraftInput]);
+
+  return (
+    <Form.Input
+      {...TextFieldProps}
+      label={label}
+      disabled={disabled}
+      spellCheck={false}
+      value={draftInput}
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  );
+}
+
+export default TimeField;

--- a/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/keybindings.js
+++ b/WcaOnRails/app/webpacker/components/Results/WCALive/AttemptResultField/keybindings.js
@@ -1,0 +1,2 @@
+export const DNF_KEYS = ['d', 'D', '/'];
+export const DNS_KEYS = ['s', 'S', '*'];

--- a/WcaOnRails/app/webpacker/lib/helpers/competition-results.js
+++ b/WcaOnRails/app/webpacker/lib/helpers/competition-results.js
@@ -1,0 +1,12 @@
+/* eslint import/prefer-default-export: "off" */
+export function getRecordClass(record) {
+  switch (record) {
+    case '':
+      return '';
+    case 'WR': // Intentional fallthrough
+    case 'NR':
+      return record;
+    default:
+      return 'CR';
+  }
+}

--- a/WcaOnRails/app/webpacker/lib/helpers/results.js
+++ b/WcaOnRails/app/webpacker/lib/helpers/results.js
@@ -1,0 +1,9 @@
+import formats from '../wca-data/formats.js.erb';
+
+export function getExpectedSolveCount(formatId) {
+  return formatId ? formats.byId[formatId].expectedSolveCount : 0;
+}
+
+export function shouldComputeAverage(result) {
+  return [3, 5].includes(getExpectedSolveCount(result.format_id)) && !['333mbf', '333mbo'].includes(result.event_id);
+}

--- a/WcaOnRails/app/webpacker/lib/hooks/useInputState.js
+++ b/WcaOnRails/app/webpacker/lib/hooks/useInputState.js
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+// /!\ This can only be used with react-semantic-ui inputs /!\
+// All the react-semantic-ui inputs expect an 'onChange' handler with the signature:
+// onChange(event: ChangeEvent, data: object)
+// It's tempting to use 'event.target.value', which works in most cases
+// but not for Form.Select for instance (!!), so we better use 'data.value'
+// which always holds what we want.
+// This is a small wrapper to automatically create the appropriate callback
+// and avoid rendering the input at each render.
+// If 'data' is undefined, we consider it's a regular "setState" call and set
+// the value from the first param.
+const useInputState = (defaultVal = undefined) => {
+  const [state, setState] = useState(defaultVal);
+  const updateFromOnChange = useCallback((ev, data = undefined) => {
+    if (data) {
+      setState(data.value);
+    } else {
+      setState(ev);
+    }
+  }, [setState]);
+  return [state, updateFromOnChange];
+};
+
+export default useInputState;

--- a/WcaOnRails/app/webpacker/lib/hooks/useNestedInputUpdater.js
+++ b/WcaOnRails/app/webpacker/lib/hooks/useNestedInputUpdater.js
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import _ from 'lodash';
+
+// This aims to provide a quick wrapper to:
+//   - create an updater for a given path in a state created by useState or similar.
+//   - take into account how react-semantic-ui provides the input value through its
+//   onChange method, which must have this signature:
+//   onChange(event: ChangeEvent, data: object)
+// Example usage:
+// const setMyProp = useNestedInputUpdater(setGlobalState, 'myProp');
+//
+// It can be used directly like any other set method:
+// setMyProp('my val');
+// Or passed as the 'onChange' callback of a react-semantic-ui input.
+
+const useNestedInputUpdater = (updater, path) => useCallback((ev, data = undefined) => {
+  const value = data ? data.value : ev;
+  // updater is assumed to come from useState or similar, so we can pass it a
+  // function that act based on the previous state.
+  updater((prevState) => {
+    // This is a react state, we can't just modify something in prevValue,
+    // we need to create a brand new copy.
+    const newState = { ...prevState };
+    _.set(newState, path, value);
+    return newState;
+  });
+}, [updater, path]);
+
+export default useNestedInputUpdater;

--- a/WcaOnRails/app/webpacker/lib/requests/routes.js.erb
+++ b/WcaOnRails/app/webpacker/lib/requests/routes.js.erb
@@ -1,16 +1,36 @@
 export const personUrl = (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.person_path("${wcaId}"))%>`;
 
+export const personsUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.persons_path) %>`;
+
+export const newResultUrl = (competitionId, roundId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_new_result_path("${competitionId}", "${roundId}"))%>`;
+export const resultUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.result_path("${id}"))%>`;
+export const editResultUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_result_path("${id}"))%>`;
+
 export const postsUrl = (page, format = 'json') => {
   // In this case id holds the page number ;)
   return `<%= CGI.unescape(Rails.application.routes.url_helpers.posts_path(format: "${format}")) %>?page=${page}`;
 };
 
+export const competitionUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_path("${id}"))%>`;
+
 export const competitionApiUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_path("${id}"))%>`;
 
 export const competitionEventResultsApiUrl = (id, eventId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_event_results_path("${id}", "${eventId}")) %>`;
 
+export const competitionAllResultsUrl = (id, eventId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_results_all_path("${id}", event: "${eventId}")) %>`;
+
 export const omnisearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_path %>?q=${query}`;
 
-export const userSearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_users_path %>?q=${query}`;
+export const competitionSearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_competitions_path %>?q=${query}`;
 
 export const competitionEventScramblesApiUrl = (id, eventId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_event_scrambles_path("${id}", "${eventId}")) %>`;
+
+export const adminCheckExistingResultsUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_check_existing_results_path("${competitionId}")) %>`;
+
+export const competitionEventsDataUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_events_data_path("${id}"))%>`;
+
+export const adminCADUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.admin_compute_auxiliary_data_path) %>`;
+
+export const adminGenerateIds = `<%= CGI.unescape(Rails.application.routes.url_helpers.persons_new_id_path) %>`;
+
+export const personApiUrl = (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_person_path("${wcaId}"))%>`;

--- a/WcaOnRails/app/webpacker/lib/wca-data/genders.js.erb
+++ b/WcaOnRails/app/webpacker/lib/wca-data/genders.js.erb
@@ -1,0 +1,13 @@
+import _ from 'lodash';
+import I18n from '../i18n'
+
+export default {
+  byId: _.mapValues(<%= User::ALLOWABLE_GENDERS.index_by(&:itself).to_json.html_safe %>, extend),
+};
+
+function extend(gender) {
+  return {
+    id: gender,
+    name: I18n.t(`enums.user.gender.${gender}`),
+  };
+}

--- a/WcaOnRails/app/webpacker/lib/wca-data/regionalMarkers.js.erb
+++ b/WcaOnRails/app/webpacker/lib/wca-data/regionalMarkers.js.erb
@@ -1,0 +1,1 @@
+export default <%= Result::MARKERS.compact %>;

--- a/WcaOnRails/app/webpacker/lib/wca-data/roundTypes.js.erb
+++ b/WcaOnRails/app/webpacker/lib/wca-data/roundTypes.js.erb
@@ -1,0 +1,9 @@
+import _ from 'lodash';
+
+export default {
+  byId: _.mapValues(<%= RoundType.all.index_by(&:id).to_json.html_safe %>, extend),
+};
+
+function extend(rawFormat) {
+  return _.mapKeys(rawFormat, (v, k) => _.camelCase(k));
+}

--- a/WcaOnRails/app/webpacker/packs/global_styles.js
+++ b/WcaOnRails/app/webpacker/packs/global_styles.js
@@ -3,18 +3,23 @@ import '@cubing/icons';
 
 import 'semantic-css/button';
 import 'semantic-css/card';
+import 'semantic-css/checkbox';
 import 'semantic-css/container';
+import 'semantic-css/dimmer';
 import 'semantic-css/divider';
 import 'semantic-css/dropdown';
+import 'semantic-css/form';
 import 'semantic-css/grid';
 import 'semantic-css/header';
 import 'semantic-css/icon';
 import 'semantic-css/image';
+import 'semantic-css/input';
 import 'semantic-css/item';
 import 'semantic-css/label';
 import 'semantic-css/list';
 import 'semantic-css/menu';
 import 'semantic-css/message';
+import 'semantic-css/modal';
 import 'semantic-css/placeholder';
 import 'semantic-css/popup';
 import 'semantic-css/reset';
@@ -23,6 +28,13 @@ import 'semantic-css/site';
 import 'semantic-css/table';
 import 'semantic-css/transition';
 // NOTE: This is the js, wouldn't go fine through our module-resolver!
+import '../stylesheets/semantic/components/checkbox.min';
+import '../stylesheets/semantic/components/dropdown.min';
+import '../stylesheets/semantic/components/dimmer.min';
+import '../stylesheets/semantic/components/modal.min';
+import '../stylesheets/semantic/components/popup.min';
 import '../stylesheets/semantic/components/site.min';
+import '../stylesheets/semantic/components/form.min';
+import '../stylesheets/semantic/components/transition.min';
 
 import '../stylesheets/override.scss';

--- a/WcaOnRails/app/webpacker/stylesheets/competition_results.scss
+++ b/WcaOnRails/app/webpacker/stylesheets/competition_results.scss
@@ -21,5 +21,8 @@
     .NR {
       color : $nr-color;
     }
+    .edit-link {
+      margin-left: 1em;
+    }
   }
 }

--- a/WcaOnRails/app/webpacker/stylesheets/country_selector.scss
+++ b/WcaOnRails/app/webpacker/stylesheets/country_selector.scss
@@ -1,0 +1,5 @@
+.country-selector {
+  .flag-icon {
+    margin-right: 10px;
+  }
+}

--- a/WcaOnRails/app/webpacker/stylesheets/override.scss
+++ b/WcaOnRails/app/webpacker/stylesheets/override.scss
@@ -14,6 +14,25 @@ body, html {
     }
   }
 
+  // The FUI's basic style doesn't have the '!important' tag, and hovering
+  // an icon doesn't look as good as it should.
+  // I suspect this is fixed in more recent version of the stylesheets, as it
+  // is fixed in the online documentation.
+  i.link.icon:hover,
+  i.link.icons:hover {
+    opacity: 1 !important;
+  }
+
+  // FIXME: yet another bootstrap conflict override :(
+  .ui.modal {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    overflow: visible;
+    outline: none;
+  }
+
   .navbar-brand {
     .icon {
       margin: 0;

--- a/WcaOnRails/config/i18n-js.yml
+++ b/WcaOnRails/config/i18n-js.yml
@@ -33,7 +33,7 @@ sort_translations_keys: true
 fallbacks: false
 # This sets which keys we export from the locale file!
 # It will need to be updated as we port more and more stuff to React.
-<% export_keys = ["common.*", "competitions.*", "events.*", "formats.*", "search_results.*", "round.*", "countries.*"] %>
+<% export_keys = ["common.*", "competitions.*", "events.*", "formats.*", "search_results.*", "round.*", "countries.*", "enums.*"] %>
 translations:
 <% I18n.available_locales.each do |l| %>
   - file: "app/webpacker/packs/generated_locales/<%= l %>.js"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
     get '/admin/check-existing-results' => "admin#check_results", as: :admin_check_existing_results
     post '/admin/upload-json' => "admin#create_results", as: :admin_upload_results
     post '/admin/clear-submission' => "admin#clear_results_submission", as: :clear_results_submission
+    get '/admin/results/:round_id/new' => 'admin/results#new', as: :new_result
   end
   post 'admin/check-existing-results' => "admin#run_validators", as: :admin_run_validators
 
@@ -102,10 +103,18 @@ Rails.application.routes.draw do
   get 'results/rankings/:event_id/:type' => 'results#rankings', as: :rankings
   get 'results/records' => 'results#records', as: :records
 
+  scope '/admin' do
+    resources :results, except: [:index, :new], controller: 'admin/results'
+    post 'results' => 'admin/results#create'
+    get 'events_data/:competition_id' => 'admin/results#show_events_data', as: :competition_events_data
+  end
+
   get "media/validate" => 'media#validate', as: :validate_media
   resources :media, only: [:index, :new, :create, :edit, :update, :destroy]
 
+  get 'persons/new_id' => 'admin/persons#generate_ids'
   resources :persons, only: [:index, :show]
+  post 'persons' => 'admin/persons#create'
 
   resources :polls, only: [:edit, :new, :vote, :create, :update, :index, :destroy]
   get 'polls/:id/vote' => 'votes#vote', as: 'polls_vote'

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -896,7 +896,7 @@ RSpec.describe CompetitionsController do
 
       it "sends the notification emails to users that competed" do
         FactoryBot.create_list(:user_with_wca_id, 4, results_notifications_enabled: true).each do |user|
-          FactoryBot.create_list(:result, 2, person: user.person, competitionId: competition.id, eventId: "333")
+          FactoryBot.create(:result, person: user.person, competitionId: competition.id, eventId: "333")
         end
 
         expect(competition.results_posted_at).to be nil
@@ -916,7 +916,7 @@ RSpec.describe CompetitionsController do
         FactoryBot.create_list(:registration, 3, :pending, :newcomer, competition: competition)
         FactoryBot.create_list(:registration, 4, :accepted, competition: competition)
         FactoryBot.create_list(:user_with_wca_id, 4).each do |user|
-          FactoryBot.create_list(:result, 2, person: user.person, competitionId: competition.id, eventId: "333")
+          FactoryBot.create(:result, person: user.person, competitionId: competition.id, eventId: "333")
         end
 
         expect(CompetitionsMailer).to receive(:notify_users_of_id_claim_possibility).and_call_original.exactly(2).times

--- a/WcaOnRails/spec/factories/persons.rb
+++ b/WcaOnRails/spec/factories/persons.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
     month { 4 }
     day { 4 }
 
+    trait :skip_validation do
+      to_create { |res| res.save(validate: false) }
+    end
+
     trait :missing_dob do
       year { 0 }
       month { 0 }
@@ -37,7 +41,6 @@ FactoryBot.define do
     factory :person_who_has_competed_once do
       after(:create) do |person|
         competition = FactoryBot.create(:competition, :with_delegate)
-        FactoryBot.create :result, person: person, competitionId: competition.id
         FactoryBot.create :result, person: person, competitionId: competition.id
       end
     end

--- a/WcaOnRails/spec/factories/results.rb
+++ b/WcaOnRails/spec/factories/results.rb
@@ -4,6 +4,19 @@ FactoryBot.define do
   resultable_instance_members = ->(*args) {
     transient do
       competition { FactoryBot.create(:competition, event_ids: ["333oh"]) }
+      skip_round_creation { false }
+    end
+
+    trait :skip_validation do
+      to_create { |res| res.save(validate: false) }
+    end
+
+    after(:build) do |result, options|
+      # In order to be valid, a result must have a round.
+      # Make sure it exists before going through validations.
+      if !result.round && !options.skip_round_creation
+        FactoryBot.create(:round, competition: result.competition, event_id: result.eventId, format_id: result.formatId)
+      end
     end
 
     competitionId { competition.id }

--- a/WcaOnRails/spec/factories/rounds.rb
+++ b/WcaOnRails/spec/factories/rounds.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     format { Format.c_find(format_id) }
-    competition_event { competition.competition_events.find_by_event_id!(event_id) }
+    competition_event { competition.competition_events.find_or_create_by!(event_id: event_id) }
     number { 1 }
     total_number_of_rounds { 1 }
   end

--- a/WcaOnRails/spec/features/claim_wca_id_spec.rb
+++ b/WcaOnRails/spec/features/claim_wca_id_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Claim WCA ID" do
   let!(:user) { FactoryBot.create(:user) }
   let!(:person) { FactoryBot.create(:person_who_has_competed_once, year: 1988, month: 2, day: 3) }
-  let!(:person_without_dob) { FactoryBot.create :person, year: 0, month: 0, day: 0 }
+  let!(:person_without_dob) { FactoryBot.create :person, :skip_validation, :missing_dob }
 
   context 'when signed in as user without wca id', js: true do
     before :each do

--- a/WcaOnRails/spec/features/competition_results_spec.rb
+++ b/WcaOnRails/spec/features/competition_results_spec.rb
@@ -7,8 +7,8 @@ RSpec.feature "competition results" do
   let(:person_1) { FactoryBot.create :person, name: "Fast Cuber", countryId: "USA" }
   let(:person_2) { FactoryBot.create :person, name: "Slow Cuber", countryId: "USA" }
 
-  let!(:result_1) { FactoryBot.create :result, competition: competition, eventId: "333", roundTypeId: "c", pos: 1, person: person_1 }
-  let!(:result_2) { FactoryBot.create :result, competition: competition, eventId: "333", roundTypeId: "c", pos: 2, person: person_2 }
+  let!(:result_1) { FactoryBot.create :result, competition: competition, eventId: "333", roundTypeId: "f", pos: 1, person: person_1 }
+  let!(:result_2) { FactoryBot.create :result, competition: competition, eventId: "333", roundTypeId: "f", pos: 2, person: person_2 }
 
   describe "winners" do
     it "displays the winners for each event" do

--- a/WcaOnRails/spec/features/sign_up_spec.rb
+++ b/WcaOnRails/spec/features/sign_up_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.feature "Sign up" do
   let!(:person) { FactoryBot.create(:person_who_has_competed_once, year: 1988, month: 2, day: 3) }
-  let!(:person_without_dob) { FactoryBot.create :person, year: 0, month: 0, day: 0 }
   let!(:custom_delegate) { FactoryBot.create(:delegate) }
 
   before :each do
@@ -225,9 +224,10 @@ RSpec.feature "Sign up" do
 
       click_on "I have competed in a WCA competition."
       click_button "Sign up"
-      expect(page).to have_selector(".alert.alert-danger li", count: 2)
+      expect(page).to have_selector(".alert.alert-danger li", count: 3)
       expect(page.find(".alert.alert-danger")).to have_content "Delegate id to handle wca id claim required"
       expect(page.find(".alert.alert-danger")).to have_content "Unconfirmed WCA ID required"
+      expect(page.find(".alert.alert-danger")).to have_content "Unconfirmed WCA ID is invalid"
     end
   end
 

--- a/WcaOnRails/spec/helpers/competitions_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/competitions_helper_spec.rb
@@ -7,27 +7,28 @@ RSpec.describe CompetitionsHelper do
 
   describe "#winners" do
     context "333" do
-      def add_result(pos, name, event_id: "333", dnf: false)
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: event_id,
-          roundTypeId: "f",
-          formatId: "a",
-          value1: dnf ? SolveTime::DNF_VALUE : 999,
-          value2: 999,
-          value3: 999,
-          value4: dnf ? SolveTime::DNF_VALUE : 999,
-          value5: 999,
-          best: 999,
-          average: dnf ? SolveTime::DNF_VALUE : 999,
-        )
+      def add_result(pos, name, event_id: "333", dnf: false, wca_id: nil)
+        person = FactoryBot.create(:person,
+                                   wca_id: wca_id || "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: event_id,
+                          roundTypeId: "f",
+                          formatId: "a",
+                          value1: dnf ? SolveTime::DNF_VALUE : 999,
+                          value2: 999,
+                          value3: 999,
+                          value4: dnf ? SolveTime::DNF_VALUE : 999,
+                          value5: 999,
+                          best: 999,
+                          average: dnf ? SolveTime::DNF_VALUE : 999)
       end
 
-      let!(:unrelated_podium_result) { add_result(1, "joe", event_id: "333oh") }
+      let!(:unrelated_podium_result) { add_result(1, "joe", event_id: "333oh", wca_id: "2006JOJO01") }
 
       it "announces top 3 in final" do
         add_result(1, "Jeremy")
@@ -69,11 +70,11 @@ RSpec.describe CompetitionsHelper do
 
       it "handles ties in the podium" do
         add_result(1, "Jeremy")
-        add_result(1, "Dan")
+        add_result(1, "Dan", wca_id: "2006DADA01")
         add_result(3, "Steven", dnf: true)
 
         text = helper.winners(competition, Event.c_find("333"))
-        expect(text).to eq "[Dan](#{person_url('2006YOYO01')}) and [Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
+        expect(text).to eq "[Dan](#{person_url('2006DADA01')}) and [Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
                            "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
       end
 
@@ -81,34 +82,35 @@ RSpec.describe CompetitionsHelper do
         add_result(1, "Jeremy")
         add_result(2, "Dan")
         add_result(3, "Steven", dnf: true)
-        add_result(3, "John", dnf: true)
+        add_result(3, "John", dnf: true, wca_id: "2006JOJO03")
 
         text = helper.winners(competition, Event.c_find("333"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
                            "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
-                           "[John](#{person_url('2006YOYO03')}) and [Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
+                           "[John](#{person_url('2006JOJO03')}) and [Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
       end
     end
 
     context "333bf" do
       def add_result(pos, name)
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: "333bf",
-          roundTypeId: "f",
-          formatId: "3",
-          value1: 60.seconds.in_centiseconds,
-          value2: 60.seconds.in_centiseconds,
-          value3: 60.seconds.in_centiseconds,
-          value4: 0,
-          value5: 0,
-          best: 60.seconds.in_centiseconds,
-          average: 60.seconds.in_centiseconds,
-        )
+        person = FactoryBot.create(:person,
+                                   wca_id: "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: "333bf",
+                          roundTypeId: "f",
+                          formatId: "3",
+                          value1: 60.seconds.in_centiseconds,
+                          value2: 60.seconds.in_centiseconds,
+                          value3: 60.seconds.in_centiseconds,
+                          value4: 0,
+                          value5: 0,
+                          best: 60.seconds.in_centiseconds,
+                          average: 60.seconds.in_centiseconds)
       end
 
       it "announces top 3 in final" do
@@ -125,23 +127,24 @@ RSpec.describe CompetitionsHelper do
 
     context "333fm" do
       def add_result(pos, name, dnf: false)
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: "333fm",
-          roundTypeId: "f",
-          formatId: "m",
-          value1: dnf ? SolveTime::DNF_VALUE : 29,
-          value2: 24,
-          value3: 30,
-          value4: 0,
-          value5: 0,
-          best: 24,
-          average: dnf ? SolveTime::DNF_VALUE : 2767,
-        )
+        person = FactoryBot.create(:person,
+                                   wca_id: "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: "333fm",
+                          roundTypeId: "f",
+                          formatId: "m",
+                          value1: dnf ? SolveTime::DNF_VALUE : 29,
+                          value2: 24,
+                          value3: 30,
+                          value4: 0,
+                          value5: 0,
+                          best: 24,
+                          average: dnf ? SolveTime::DNF_VALUE : 2767)
       end
 
       it "announces top 3 in final" do
@@ -173,23 +176,24 @@ RSpec.describe CompetitionsHelper do
         solve_time.attempted = 9
         solve_time.solved = 8
         solve_time.time_centiseconds = (45.minutes + 32.seconds).in_centiseconds
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: "333mbf",
-          roundTypeId: "f",
-          formatId: "3",
-          value1: solve_time.wca_value,
-          value2: solve_time.wca_value,
-          value3: solve_time.wca_value,
-          value4: 0,
-          value5: 0,
-          best: solve_time.wca_value,
-          average: 0,
-        )
+        person = FactoryBot.create(:person,
+                                   wca_id: "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: "333mbf",
+                          roundTypeId: "f",
+                          formatId: "3",
+                          value1: solve_time.wca_value,
+                          value2: solve_time.wca_value,
+                          value3: solve_time.wca_value,
+                          value4: 0,
+                          value5: 0,
+                          best: solve_time.wca_value,
+                          average: 0)
       end
 
       it "announces top 3 in final" do

--- a/WcaOnRails/spec/helpers/results_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/results_helper_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe ResultsHelper do
     end
 
     it "doesn't mark uncompleted solves as PB" do
+      combined_round = FactoryBot.create(:round, cutoff: Cutoff.new(number_of_attempts: 2, attempt_result: 60*100))
       combined_final = RoundType.find("c")
       results = []
-      results << FactoryBot.create(:result, person: person, best: SolveTime::DNF_VALUE, average: SolveTime::SKIPPED_VALUE, round_type: combined_final)
+      results << FactoryBot.create(:result, competition: combined_round.competition, person: person, best: SolveTime::DNF_VALUE, average: SolveTime::SKIPPED_VALUE, round_type: combined_final, eventId: "333")
 
       pb_markers = helper.historical_pb_markers results
       expect(pb_markers).to eq({})

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -11,8 +11,10 @@ RSpec.describe "AuxiliaryDataComputation" do
     let(:competition_2017) { FactoryBot.create :competition, starts: Date.parse("2017-08-08") }
 
     it "creates tables containing best results data for each person per event per year" do
-      FactoryBot.create :result, eventId: "333", best: 700, average: 800, competition: competition_2016, person: person
-      FactoryBot.create :result, eventId: "333", best: 750, average: 850, competition: competition_2016, person: person
+      FactoryBot.create :round, competition: competition_2016, total_number_of_rounds: 2
+      FactoryBot.create :round, competition: competition_2016, total_number_of_rounds: 2, number: 2
+      FactoryBot.create :result, eventId: "333", best: 750, average: 800, competition: competition_2016, person: person, roundTypeId: "1"
+      FactoryBot.create :result, eventId: "333", best: 700, average: 850, competition: competition_2016, person: person, roundTypeId: "f"
       FactoryBot.create :result, eventId: "333", best: 800, average: 900, competition: competition_2017, person: person
       FactoryBot.create :result, eventId: "222", best: 100, average: 150, competition: competition_2017, person: person
       AuxiliaryDataComputation.compute_concise_results

--- a/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe ACV do
         fake_person = build_person(result_kind, competition1)
         # Collecting all the results and using bulk import for better performance.
         results = []
-        results += FactoryBot.build_list(result_kind, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 16, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 8, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 5, competition: competition2, eventId: "222", roundTypeId: "2", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 16, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 8, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 5, competition: competition2, eventId: "222", roundTypeId: "f", person: fake_person, skip_round_creation: true)
         model.import(results)
       end
 
@@ -50,10 +50,10 @@ RSpec.describe ACV do
       fake_person = build_person(:result, competition1)
       # Collecting all the results and using bulk import for better performance.
       results = []
-      results += FactoryBot.build_list(:result, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person)
-      results += FactoryBot.build_list(:result, 8, competition: competition1, eventId: "333oh", roundTypeId: "b", person: fake_person)
-      results += FactoryBot.build_list(:result, 32, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person)
-      Result.import(results)
+      results += FactoryBot.build_list(:result, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person, skip_round_creation: true)
+      results += FactoryBot.build_list(:result, 8, competition: competition1, eventId: "333oh", roundTypeId: "b", person: fake_person, skip_round_creation: true)
+      results += FactoryBot.build_list(:result, 32, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person, skip_round_creation: true)
+      Result.import(results, validate: false)
 
       validator_args.each do |arg|
         acv = ACV.new.validate(**arg)
@@ -78,16 +78,15 @@ RSpec.describe ACV do
         fake_person = build_person(result_kind, competition1)
         # Collecting all the results and using bulk import for better performance.
         results = []
-        results += FactoryBot.build_list(result_kind, 99, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 15, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 4, competition: competition1, eventId: "333oh", roundTypeId: "c", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 4, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person)
-        results += FactoryBot.build_list(result_kind, 7, competition: competition2, eventId: "222", roundTypeId: "2", person: fake_person)
-        model.import(results)
+        results += FactoryBot.build_list(result_kind, 99, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 15, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 4, competition: competition1, eventId: "333oh", roundTypeId: "c", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 4, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 7, competition: competition2, eventId: "222", roundTypeId: "2", person: fake_person, skip_round_creation: true)
+        model.import(results, validate: false)
       end
-
       expected_errors = [
         RV::ValidationError.new(:rounds, competition1.id,
                                 ACV::REGULATION_9M1_ERROR,

--- a/WcaOnRails/spec/lib/results_validators/events_rounds_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/events_rounds_validator_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ERV do
         result_kind = model.model_name.singular.to_sym
         FactoryBot.create(result_kind, competition: competition1, eventId: "333oh")
         FactoryBot.create(result_kind, competition: competition2, eventId: "222")
-        FactoryBot.create(result_kind, competition: competition2, eventId: "444")
+        FactoryBot.create(result_kind, :skip_validation, competition: competition2, eventId: "444", skip_round_creation: true)
       end
 
       expected_warnings = [
@@ -54,6 +54,9 @@ RSpec.describe ERV do
         RV::ValidationError.new(:events, competition2.id,
                                 ERV::UNEXPECTED_RESULTS_ERROR,
                                 event_id: "444"),
+        RV::ValidationError.new(:rounds, competition2.id,
+                                ERV::UNEXPECTED_ROUND_RESULTS_ERROR,
+                                round_id: '444-f'),
       ]
 
       validator_args.each do |arg|
@@ -85,15 +88,17 @@ RSpec.describe ERV do
       [Result, InboxResult].each do |model|
         result_kind = model.model_name.singular.to_sym
         # Create a result over a cutoff which does not exist in rounds data.
-        FactoryBot.create(result_kind, :over_cutoff,
+        FactoryBot.create(result_kind, :over_cutoff, :skip_validation,
                           competition: competition1, eventId: "333oh",
-                          cutoff: cutoff)
+                          cutoff: cutoff, skip_round_creation: true)
         FactoryBot.create(result_kind, competition: competition1, eventId: "333")
         # This creates results below the cutoff for 5x5, which effectively turns
         # it into a "regular" round instead of a cutoff round.
-        FactoryBot.create(result_kind, competition: competition2, eventId: "555")
-        FactoryBot.create(result_kind,
-                          competition: competition2, eventId: "222", roundTypeId: "c")
+        FactoryBot.create(result_kind, :skip_validation,
+                          competition: competition2, eventId: "555", skip_round_creation: true)
+        FactoryBot.create(result_kind, :skip_validation,
+                          competition: competition2, eventId: "222", roundTypeId: "c",
+                          skip_round_creation: true)
       end
       expected_errors = [
         RV::ValidationError.new(:rounds, competition1.id,

--- a/WcaOnRails/spec/lib/results_validators/individual_results_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/individual_results_validator_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe IRV do
         # Create a result which meets the cutoff but doesn't have all the necessary values
         res_fm = FactoryBot.create(result_kind, :over_cutoff,
                                    competition: competition2, cutoff: cutoff_fm,
-                                   eventId: "333fm")
-        res_fm.update(value1: 30, formatId: "m")
+                                   formatId: "m", eventId: "333fm")
+        res_fm.update(value1: 30)
 
         errs << RV::ValidationError.new(:results, competition2.id,
                                         IRV::MET_CUTOFF_MISSING_RESULTS_ERROR,
@@ -137,7 +137,7 @@ RSpec.describe IRV do
 
       [Result, InboxResult].each do |model|
         result_kind = model.model_name.singular.to_sym
-        FactoryBot.create(result_kind, competition: competition1, eventId: "333oh")
+        FactoryBot.create(result_kind, :skip_validation, competition: competition1, eventId: "333oh", skip_round_creation: true)
       end
       irv = IRV.new.validate(competition_ids: competition1.id)
 
@@ -153,8 +153,8 @@ RSpec.describe IRV do
     it "triggers undef time limit warning" do
       # Triggers UNDEF_TL_WARNING
 
-      FactoryBot.create(:result, competition: competition1, eventId: "333oh")
       FactoryBot.create(:round, competition: competition1, event_id: "333oh", format_id: "a", time_limit: nil)
+      FactoryBot.create(:result, competition: competition1, eventId: "333oh")
       irv = IRV.new.validate(competition_ids: competition1.id)
 
       expected_warnings = [
@@ -178,7 +178,7 @@ RSpec.describe IRV do
       [Result, InboxResult].each do |model|
         result_kind = model.model_name.singular.to_sym
         FactoryBot.create(result_kind, competition: competition1, eventId: "444")
-        res_ko = FactoryBot.create(result_kind, :mo3, competition: competition1, eventId: "444")
+        res_ko = FactoryBot.create(result_kind, :skip_validation, :mo3, competition: competition1, eventId: "444", skip_round_creation: true)
         errs[model.to_s] << RV::ValidationError.new(:results, competition1.id,
                                                     IRV::MISMATCHED_RESULT_FORMAT_ERROR,
                                                     round_id: "444-f",

--- a/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
@@ -62,10 +62,8 @@ RSpec.describe SV do
         [Result, InboxResult].each do |model|
           result_kind = model.model_name.singular.to_sym
           FactoryBot.create(result_kind, competition: competition1, eventId: "333oh")
-          FactoryBot.create(result_kind, competition: competition2, eventId: "333bf")
+          FactoryBot.create(result_kind, :blind_mo3, competition: competition2)
         end
-
-        FactoryBot.create(:round, competition: competition2, event_id: "333bf", format_id: "3")
 
         create_scramble_set(2, competitionId: competition2.id, eventId: "333bf")
 
@@ -87,12 +85,12 @@ RSpec.describe SV do
       end
 
       it "correctly (in)validates scramble sets not matching" do
+        FactoryBot.create(:round, competition: competition1, event_id: "333oh", scramble_set_count: 2)
+
         [Result, InboxResult].each do |model|
           result_kind = model.model_name.singular.to_sym
           FactoryBot.create(result_kind, competition: competition1, eventId: "333oh")
         end
-
-        FactoryBot.create(:round, competition: competition1, event_id: "333oh", scramble_set_count: 2)
 
         # Create three groups of scrambles:
         create_scramble_set(5, competitionId: competition1.id, eventId: "333oh", groupId: "A")

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -818,7 +818,14 @@ RSpec.describe Competition do
   describe "results" do
     let(:three_by_three) { Event.find "333" }
     let(:two_by_two) { Event.find "222" }
-    let(:competition) { FactoryBot.create :competition, events: [three_by_three, two_by_two] }
+    let!(:competition) {
+      c = FactoryBot.create :competition, events: [three_by_three, two_by_two]
+      # Create the results rounds right now so that we can use them later.
+      FactoryBot.create :round, competition: c, total_number_of_rounds: 2, number: 1, event_id: "333"
+      FactoryBot.create :round, competition: c, total_number_of_rounds: 2, number: 2, event_id: "333"
+      FactoryBot.create :round, competition: c, total_number_of_rounds: 1, number: 1, event_id: "222", cutoff: Cutoff.new(number_of_attempts: 2, attempt_result: 60*100)
+      c
+    }
 
     let(:person_one) { FactoryBot.create :person, name: "One" }
     let(:person_two) { FactoryBot.create :person, name: "Two" }

--- a/WcaOnRails/spec/models/person_spec.rb
+++ b/WcaOnRails/spec/models/person_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Person, type: :model do
 
     context "fixing the person" do
       it "fixing countryId fails if there exists an old person with the same wca id, greater subId and the same countryId" do
-        Person.create(wca_id: person.wca_id, subId: 2, name: person.name, countryId: "New Zealand")
+        FactoryBot.create(:person, wca_id: person.wca_id, subId: 2, name: person.name, countryId: "New Zealand")
         person.countryId = "New Zealand"
         expect(person).to be_invalid_with_errors(countryId: ["Cannot change the country to a country the person has already represented in the past."])
       end
@@ -151,8 +151,8 @@ RSpec.describe Person, type: :model do
 
     it "ignores DNF results on the podium" do
       expect do
-        FactoryBot.create :result, person: us_competitor, competition: us_nationals2017, pos: 2, eventId: "555bf",
-                                   best: SolveTime::DNF_VALUE, average: SolveTime::DNF_VALUE
+        FactoryBot.create :result, :blind_dnf_mo3, person: us_competitor, competition: us_nationals2017,
+                                                   pos: 2, eventId: "555bf", best: SolveTime::DNF_VALUE
       end.to_not change { us_competitor.championship_podiums[:national] }
     end
 

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe User, type: :model do
 
   describe "WCA ID" do
     let(:user) { FactoryBot.create :user_with_wca_id }
-    let(:birthdayless_person) { FactoryBot.create :person, :missing_dob }
+    let(:birthdayless_person) { FactoryBot.create :person, :missing_dob, :skip_validation }
     let(:genderless_person) { FactoryBot.create :person, :missing_gender }
 
     it "validates WCA ID" do
@@ -399,7 +399,7 @@ RSpec.describe User, type: :model do
                                dob_verification: "1990-01-2")
     end
 
-    let!(:person_without_dob) { FactoryBot.create :person, year: 0, month: 0, day: 0 }
+    let!(:person_without_dob) { FactoryBot.create :person, :skip_validation, year: 0, month: 0, day: 0 }
     let!(:person_without_gender) { FactoryBot.create :person, gender: nil }
     let!(:user_with_wca_id) { FactoryBot.create :user_with_wca_id }
 
@@ -431,7 +431,7 @@ RSpec.describe User, type: :model do
 
     it "requires unconfirmed_wca_id" do
       user.unconfirmed_wca_id = ""
-      expect(user).to be_invalid_with_errors(unconfirmed_wca_id: ['required'])
+      expect(user).to be_invalid_with_errors(unconfirmed_wca_id: ['is invalid', 'required'])
     end
 
     it "requires dob verification" do


### PR DESCRIPTION
Fixes #2107, fixes #1094, fixes #6097, fixes #6985, supersedes #6096.
Based on #6359, which needs to be merged first.

When working on #5300 I did a first attempt at making an "edit result" form, which I did not manage to finish at the time.
I've refreshed my changes now that we have a "proper" react setup, and here is what I did:
  - a form to create/edit a result (creation is based on a competition's round, edition is based on result's id).
  - made sure results validation are ran and displayed to the user. Most of them already existed, but interestingly some didn't; I tried matching what @Jambrose777 validated in #6096, hopefully I didn't overlook anything.
  - for the "person" part of the form, you can fill a WCA ID and fetch the person data (to avoid human mistakes).
  - attempts field are taken from WCA Live, so you can just input results just like you would do there.
  - whenever a change to the results is made, the `PositionsValidator` is always ran to fix the positions.

Left to do:
  - [x] give the user the ability to add a new person. I'm working on it, but I wanted to get some feedback on the rest right away. I plan on adding a "create person" button in the form, that will show a modal with the person creation form, where you will be able to input the appropriate data and get a valid new WCA ID from a semi ID.

Known "issues" that I don't intend to fix, but that would probably be relatively easy to fix:
  - when creating/editing a result, round data are immutable (it's filled with what the result had in it, or with the round data where the user clicked the "add result" button, see screenshots). I would assume the general use-case for this form is not to move data between rounds. It's definitely possible to do, but I believe the most user friendly way would be to offer a "round selection", and there is a bit of work to do on the rails part here.
  - the selection of which result to edit, or to which round a result should be added, occurs in the results tables of a competition. It would definitely be possible to add a "select result" form which takes the competition's id, then the round, and so on, but I think it should be fine to just find the result one wants to edit, and click on it.
  - validation errors are all gathered at the end of the form in an alert message. It's technically possible to display them next to the relevant field, but I'll left it as-is since it's a minor UI issue.
  - I'm sure I had a couple of other minor issues I had in mind, but I can't remember them... They will probably show up during the review or the first uses though :)

## Screenshots

Here are some screenshots of how it looks during a typical use.

### Links to create/add results

![show](https://user-images.githubusercontent.com/1007485/124328184-77180f00-db89-11eb-9419-c92ac32631ef.png)

This shows up only for people who `can_admin_results?` obviously, each round has its own "add a result to this round", each result has its own "pencil" link.

### Edit form

My screen is not quite long enough so here are two screenshots:

![edit-1](https://user-images.githubusercontent.com/1007485/124328486-002f4600-db8a-11eb-9740-fe1f0958361b.png)
![edit-2](https://user-images.githubusercontent.com/1007485/124328487-002f4600-db8a-11eb-8773-fc1f4d57930d.png)

FM and multi fields:

![fm](https://user-images.githubusercontent.com/1007485/124328566-2654e600-db8a-11eb-8794-21e39d75a1e7.png)
![multi](https://user-images.githubusercontent.com/1007485/124328568-2654e600-db8a-11eb-8be3-7717e3d97e61.png)

When creating a result the form is the same, but almost empty:
![create-result-form](https://user-images.githubusercontent.com/1007485/124328906-c6127400-db8a-11eb-8fdc-1f494f43669e.png)


### Fetching person data

Changing the WCA ID and clicking the "sync" icon fetches the person data, and tells you if it doesn't exist:
![fetch-person-error](https://user-images.githubusercontent.com/1007485/124328610-3ff62d80-db8a-11eb-96da-e47628effed8.png)

### Submission for edit result

With/without errors:

![edit-result-error](https://user-images.githubusercontent.com/1007485/124328805-96636c00-db8a-11eb-88f2-cf8c2f65900d.png)
![edit-result-ok](https://user-images.githubusercontent.com/1007485/124328806-96636c00-db8a-11eb-9337-53a32c210b9e.png)

### Submission for create/delete result

I followed what Jacob did and displayed the same message.
Creating:
![create-result-ok](https://user-images.githubusercontent.com/1007485/124328850-aaa76900-db8a-11eb-90bd-9abe5720094f.png)
Deleting:
![delete-result-ok](https://user-images.githubusercontent.com/1007485/124328878-b98e1b80-db8a-11eb-8a9e-15245bd815bc.png)


