### PR TITLE
Fix result validations and spec

### DIFF
--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -6,11 +6,32 @@ class Result < ApplicationRecord
   self.table_name = "Results"
 
   belongs_to :person, -> { current }, primary_key: :wca_id, foreign_key: :personId
+  validates :person, presence: true
+  validates :personName, presence: true
   belongs_to :country, foreign_key: :countryId
   validates :country, presence: true
 
+  # NOTE: both nil and "" exist in the database, we may consider cleaning that up.
+  MARKERS = [nil, "", "NR", "ER", "WR", "AfR", "AsR", "NAR", "OcR", "SAR"].freeze
+
+  validates_inclusion_of :regionalSingleRecord, in: MARKERS
+  validates_inclusion_of :regionalAverageRecord, in: MARKERS
+
   def country
     Country.c_find(self.countryId)
+  end
+
+  # If saving changes to personId, make sure that there is no results for
+  # that person yet for the round.
+  validate :unique_result_per_round, if: :will_save_change_to_personId?
+  def unique_result_per_round
+    has_result = Result.where(competitionId: competitionId,
+                              personId: personId,
+                              eventId: eventId,
+                              roundTypeId: roundTypeId).any?
+    if has_result
+      errors.add(:personId, "this WCA ID already has a result for that round")
+    end
   end
 
   scope :final, -> { where(roundTypeId: RoundType.final_rounds.map(&:id)) }
@@ -34,8 +55,8 @@ class Result < ApplicationRecord
       best_index: best_index,
       worst_index: worst_index,
       average: average,
-      regional_single_record: regionalSingleRecord,
-      regional_average_record: regionalAverageRecord,
+      regional_single_record: regionalSingleRecord || "",
+      regional_average_record: regionalAverageRecord || "",
     }
   end
 end

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -896,7 +896,7 @@ RSpec.describe CompetitionsController do
 
       it "sends the notification emails to users that competed" do
         FactoryBot.create_list(:user_with_wca_id, 4, results_notifications_enabled: true).each do |user|
-          FactoryBot.create_list(:result, 2, person: user.person, competitionId: competition.id, eventId: "333")
+          FactoryBot.create(:result, person: user.person, competitionId: competition.id, eventId: "333")
         end
 
         expect(competition.results_posted_at).to be nil
@@ -916,7 +916,7 @@ RSpec.describe CompetitionsController do
         FactoryBot.create_list(:registration, 3, :pending, :newcomer, competition: competition)
         FactoryBot.create_list(:registration, 4, :accepted, competition: competition)
         FactoryBot.create_list(:user_with_wca_id, 4).each do |user|
-          FactoryBot.create_list(:result, 2, person: user.person, competitionId: competition.id, eventId: "333")
+          FactoryBot.create(:result, person: user.person, competitionId: competition.id, eventId: "333")
         end
 
         expect(CompetitionsMailer).to receive(:notify_users_of_id_claim_possibility).and_call_original.exactly(2).times

--- a/WcaOnRails/spec/factories/persons.rb
+++ b/WcaOnRails/spec/factories/persons.rb
@@ -38,7 +38,6 @@ FactoryBot.define do
       after(:create) do |person|
         competition = FactoryBot.create(:competition, :with_delegate)
         FactoryBot.create :result, person: person, competitionId: competition.id
-        FactoryBot.create :result, person: person, competitionId: competition.id
       end
     end
   end

--- a/WcaOnRails/spec/helpers/competitions_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/competitions_helper_spec.rb
@@ -7,27 +7,28 @@ RSpec.describe CompetitionsHelper do
 
   describe "#winners" do
     context "333" do
-      def add_result(pos, name, event_id: "333", dnf: false)
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: event_id,
-          roundTypeId: "f",
-          formatId: "a",
-          value1: dnf ? SolveTime::DNF_VALUE : 999,
-          value2: 999,
-          value3: 999,
-          value4: dnf ? SolveTime::DNF_VALUE : 999,
-          value5: 999,
-          best: 999,
-          average: dnf ? SolveTime::DNF_VALUE : 999,
-        )
+      def add_result(pos, name, event_id: "333", dnf: false, wca_id: nil)
+        person = FactoryBot.create(:person,
+                                   wca_id: wca_id || "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: event_id,
+                          roundTypeId: "f",
+                          formatId: "a",
+                          value1: dnf ? SolveTime::DNF_VALUE : 999,
+                          value2: 999,
+                          value3: 999,
+                          value4: dnf ? SolveTime::DNF_VALUE : 999,
+                          value5: 999,
+                          best: 999,
+                          average: dnf ? SolveTime::DNF_VALUE : 999)
       end
 
-      let!(:unrelated_podium_result) { add_result(1, "joe", event_id: "333oh") }
+      let!(:unrelated_podium_result) { add_result(1, "joe", event_id: "333oh", wca_id: "2006JOJO01") }
 
       it "announces top 3 in final" do
         add_result(1, "Jeremy")
@@ -69,11 +70,11 @@ RSpec.describe CompetitionsHelper do
 
       it "handles ties in the podium" do
         add_result(1, "Jeremy")
-        add_result(1, "Dan")
+        add_result(1, "Dan", wca_id: "2006DADA01")
         add_result(3, "Steven", dnf: true)
 
         text = helper.winners(competition, Event.c_find("333"))
-        expect(text).to eq "[Dan](#{person_url('2006YOYO01')}) and [Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
+        expect(text).to eq "[Dan](#{person_url('2006DADA01')}) and [Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
           "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
       end
 
@@ -81,34 +82,35 @@ RSpec.describe CompetitionsHelper do
         add_result(1, "Jeremy")
         add_result(2, "Dan")
         add_result(3, "Steven", dnf: true)
-        add_result(3, "John", dnf: true)
+        add_result(3, "John", dnf: true, wca_id: "2006JOJO03")
 
         text = helper.winners(competition, Event.c_find("333"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
           "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
-          "[John](#{person_url('2006YOYO03')}) and [Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
+          "[John](#{person_url('2006JOJO03')}) and [Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
       end
     end
 
     context "333bf" do
       def add_result(pos, name)
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: "333bf",
-          roundTypeId: "f",
-          formatId: "3",
-          value1: 60.seconds.in_centiseconds,
-          value2: 60.seconds.in_centiseconds,
-          value3: 60.seconds.in_centiseconds,
-          value4: 0,
-          value5: 0,
-          best: 60.seconds.in_centiseconds,
-          average: 60.seconds.in_centiseconds,
-        )
+        person = FactoryBot.create(:person,
+                                   wca_id: "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: "333bf",
+                          roundTypeId: "f",
+                          formatId: "3",
+                          value1: 60.seconds.in_centiseconds,
+                          value2: 60.seconds.in_centiseconds,
+                          value3: 60.seconds.in_centiseconds,
+                          value4: 0,
+                          value5: 0,
+                          best: 60.seconds.in_centiseconds,
+                          average: 60.seconds.in_centiseconds)
       end
 
       it "announces top 3 in final" do
@@ -125,23 +127,24 @@ RSpec.describe CompetitionsHelper do
 
     context "333fm" do
       def add_result(pos, name, dnf: false)
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: "333fm",
-          roundTypeId: "f",
-          formatId: "m",
-          value1: dnf ? SolveTime::DNF_VALUE : 29,
-          value2: 24,
-          value3: 30,
-          value4: 0,
-          value5: 0,
-          best: 24,
-          average: dnf ? SolveTime::DNF_VALUE : 2767,
-        )
+        person = FactoryBot.create(:person,
+                                   wca_id: "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: "333fm",
+                          roundTypeId: "f",
+                          formatId: "m",
+                          value1: dnf ? SolveTime::DNF_VALUE : 29,
+                          value2: 24,
+                          value3: 30,
+                          value4: 0,
+                          value5: 0,
+                          best: 24,
+                          average: dnf ? SolveTime::DNF_VALUE : 2767)
       end
 
       it "announces top 3 in final" do
@@ -173,23 +176,24 @@ RSpec.describe CompetitionsHelper do
         solve_time.attempted = 9
         solve_time.solved = 8
         solve_time.time_centiseconds = (45.minutes + 32.seconds).in_centiseconds
-        Result.create!(
-          pos: pos,
-          personId: "2006YOYO#{format('%.2d', pos)}",
-          personName: name,
-          countryId: "USA",
-          competitionId: competition.id,
-          eventId: "333mbf",
-          roundTypeId: "f",
-          formatId: "3",
-          value1: solve_time.wca_value,
-          value2: solve_time.wca_value,
-          value3: solve_time.wca_value,
-          value4: 0,
-          value5: 0,
-          best: solve_time.wca_value,
-          average: 0,
-        )
+        person = FactoryBot.create(:person,
+                                   wca_id: "2006YOYO#{format('%.2d', pos)}",
+                                   name: name,
+                                   countryId: "USA")
+        FactoryBot.create(:result,
+                          pos: pos,
+                          person: person,
+                          competitionId: competition.id,
+                          eventId: "333mbf",
+                          roundTypeId: "f",
+                          formatId: "3",
+                          value1: solve_time.wca_value,
+                          value2: solve_time.wca_value,
+                          value3: solve_time.wca_value,
+                          value4: 0,
+                          value5: 0,
+                          best: solve_time.wca_value,
+                          average: 0)
       end
 
       it "announces top 3 in final" do

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "AuxiliaryDataComputation" do
     let(:competition_2017) { FactoryBot.create :competition, starts: Date.parse("2017-08-08") }
 
     it "creates tables containing best results data for each person per event per year" do
-      FactoryBot.create :result, eventId: "333", best: 700, average: 800, competition: competition_2016, person: person
-      FactoryBot.create :result, eventId: "333", best: 750, average: 850, competition: competition_2016, person: person
+      FactoryBot.create :result, eventId: "333", best: 750, average: 800, competition: competition_2016, person: person, roundTypeId: "1"
+      FactoryBot.create :result, eventId: "333", best: 700, average: 850, competition: competition_2016, person: person, roundTypeId: "f"
       FactoryBot.create :result, eventId: "333", best: 800, average: 900, competition: competition_2017, person: person
       FactoryBot.create :result, eventId: "222", best: 100, average: 150, competition: competition_2017, person: person
       AuxiliaryDataComputation.compute_concise_results


### PR DESCRIPTION
Currently there are, I think, some validations missing for our `Result` model:
  - each result is for a valid person (ie: the WCA ID exists)
  - each result has a non-empty `personName`
  - there is no multiple results for a given WCA ID in the same round

This PR adds them, and fix some of our specs where we were actually creating duplicated person or results...

@thewca/wrt could you please confirm these validations are what you would expect for all results in the database?