### PR TITLE
Introduce some Semantic UI related hooks

### DIFF
--- a/WcaOnRails/app/webpacker/javascript/hooks/useInputState.js
+++ b/WcaOnRails/app/webpacker/javascript/hooks/useInputState.js
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+// /!\ This can only be used with react-semantic-ui inputs /!\
+// All the react-semantic-ui inputs expect an 'onChange' handler with the signature:
+// onChange(event: ChangeEvent, data: object)
+// It's tempting to use 'event.target.value', which works in most cases
+// but not for Form.Select for instance (!!), so we better use 'data.value'
+// which always holds what we want.
+// This is a small wrapper to automatically create the appropriate callback
+// and avoid rendering the input at each render.
+// If 'data' is undefined, we consider it's a regular "setState" call and set
+// the value from the first param.
+const useInputState = (defaultVal = undefined) => {
+  const [state, setState] = useState(defaultVal);
+  const updateFromOnChange = useCallback((ev, data = undefined) => {
+    if (data) {
+      setState(data.value);
+    } else {
+      setState(ev);
+    }
+  }, [setState]);
+  return [state, updateFromOnChange];
+};
+
+export default useInputState;

--- a/WcaOnRails/app/webpacker/javascript/hooks/useNestedInputUpdater.js
+++ b/WcaOnRails/app/webpacker/javascript/hooks/useNestedInputUpdater.js
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import _ from 'lodash';
+
+// This aims to provide a quick wrapper to:
+//   - create an updater for a given path in a state created by useState or similar.
+//   - take into account how react-semantic-ui provides the input value through its
+//   onChange method, which must have this signature:
+//   onChange(event: ChangeEvent, data: object)
+// Example usage:
+// const setMyProp = useNestedInputUpdater(setGlobalState, 'myProp');
+//
+// It can be used directly like any other set method:
+// setMyProp('my val');
+// Or passed as the 'onChange' callback of a react-semantic-ui input.
+
+const useNestedInputUpdater = (updater, path) => useCallback((ev, data = undefined) => {
+  const value = data ? data.value : ev;
+  // updater is assumed to come from useState or similar, so we can pass it a
+  // function that act based on the previous state.
+  updater((prevState) => {
+    // This is a react state, we can't just modify something in prevValue,
+    // we need to create a brand new copy.
+    const newState = { ...prevState };
+    _.set(newState, path, value);
+    return newState;
+  });
+}, [updater, path]);
+
+export default useNestedInputUpdater;


### PR DESCRIPTION
This is used in #6360, but to make the review/discussion easier I've extracted them to their own pull request.

Both these hooks are motivated by how `react-semantic-ui` deals with input change; the `onChange` property expects a callback with this signature:
```js
onChange(event: ChangeEvent, data: object)
```
Where `event` is the native event and can, in most cases, be used to get the value through `event.target.value`.
However for some component this is not the case, and the recommended way to get the actual value is to use `data.value`.

Take the following code for instance:
```js
const Component = () => {
  const [id, setId] = useState('');
  return (
    <Form.Input onChange={(ev, data) => setId(data.value)} value={id} />
  );
};
```

While it may seem fine at first glance, the `onChange` prop is recomputed at each render (!!) which is definitely painfully noticeable on the developer build of react (but I *think* it's not that bad on the production one).
The easy way to work around this is to memoize the callback:
```js
const Component = () => {
  const [id, setId] = useState('');
  const onChange = useCallback((ev, data) => setId(data.value), [setId]);
  return (
    <Form.Input onChange={onChange} value={id} />
  );
};
```
This way `onChange` is only recomputed when `setId` changes, which is pretty much never.
This is short enough when you have a single state value, but when they start to pile up it's getting very verbose quite fast!
I've introduced the `useInputState` to provide a wrapper for this idiom, it's used just like `useState`:
```js
const Component = () => {
  const [id, setId] = useInputState('');
  return (
    <Form.Input onChange={setId} value={id} />
  );
};
```
Where `setId` can be used both as a regular method given by `useState` (eg: `setId('val')`), or as a callback for the `onChange` props from Semantic UI inputs.

The `useNestedInputUpdater` is motivated by the fact that sometimes the component's state is managed by the parent component, and passed down through props.
For instance take this code:
```js
const AttemptsForm = ({
  state, setState
}) => {
  const { attempts, markerBest, markerAvg } = state;
  // ....
};
```
It's fairly obvious how to get/set the state, but it means that to update only one property of the parent state through a Semantic UI input we'll need to do something like this:
```js
const AttemptsForm = ({
  state, setState, eventId, computeAverage,
}) => {
  const { attempts, markerBest, markerAvg } = state;
  const setMarkerBest = useCallback((ev, data) => setState((prev) => ({
    ...prev,
    markerBest: data.value,
  })), [setState]);
  // ...
};
```
Because we both want the memoization and the update based on the previous state.
This is quite verbose and annoying if the path to the actual value gets harder (like the nth attempt of the `attempts` array ;)).
Therefore I introduced `useNestedInputUpdater` to make the creation of such updater easier.
It can be used like this:
```js
const AttemptsForm = ({
  state, setState, eventId, computeAverage,
}) => {
  const { attempts, markerBest, markerAvg } = state;
  const setMarkerBest = useNestedInputUpdater(setState, 'markerBest');
  const setMarkerAvg = useNestedInputUpdater(setState, 'markerAvg');
  // and for attempts:
  attempts.map((attempt, index) => {
    const setAttempt = useNestedInputUpdater(setState, `attempts[${index}]`);
    // ...
  });
  // ...
};
```
Just like before, the method returned by the hook can be used to either set the value directly, or can be passed down to a Semantic UI input.

