### PR TITLE
Temporarily(?) disable Stripe integration tests

### DIFF
--- a/WcaOnRails/spec/features/sca_payments_spec.rb
+++ b/WcaOnRails/spec/features/sca_payments_spec.rb
@@ -21,10 +21,12 @@ RSpec.feature "Strong Customer Authentification payment" do
     end
 
     scenario "user pays with a 3D secure enabled card", js: true do
+      pending("figure out why iframes suddenly don't get rendered in headless mode any more")
       fill_confirm_and_expect(card, "test-source-authorize-3ds", "Your payment was successful")
     end
 
     it "user fails to complete the 3D secure challenge", js: true do
+      pending("figure out why iframes suddenly don't get rendered in headless mode any more")
       fill_confirm_and_expect(card, "test-source-fail-3ds", "We are unable to authenticate your payment method")
     end
   end


### PR DESCRIPTION
The iframes don't get rendered in headless mode.

My best guess right now is this is due to Stripe deploying a new version on their end, but since their CDN URL is not versioned there is no way to tell.

Symptom: Tests fail in the GitHub Actions CI container. Running them locally fails as well. Setting `headless: false` in `rails_helper.rb` fixes the problem, but that's not an option for CI.

According to https://github.com/actions/virtual-environments/blame/main/images/linux/Ubuntu2004-README.md#L157 the `ChromeDriver` has not been updated since the hiccup started occuring. Nonetheless, I have tried installing older versions of Chrome on my machine (latest v90, several v91 releases, v92) and the problem persists. So I concluded that this is not an issue with Chrome itself.

If anybody knows where to find a Stripe.js changelog, please shout!