### PR TITLE
Added point about scr acc policy to the scrambles page

### DIFF
--- a/WcaOnRails/app/views/regulations/scrambles/index.html.erb
+++ b/WcaOnRails/app/views/regulations/scrambles/index.html.erb
@@ -28,6 +28,7 @@
         <li>Give passcodes to scramblers when the corresponding groups begin but <b>not any earlier</b>. (In particular, do not give the passcodes for all the scramble sets in a round to scramblers at the beginning of that round.)</li>
         <li>Don't put someone else in charge of the passcodes unless absolutely necessary, and only give them the minimum amount of passcodes needed.</li>
       </ul>
+      <li>Additional precautions are outlined in the <%= link_to "Scramble Accountability Policy", "https://www.worldcubeassociation.org/documents/policies/external/Scramble%20Accountability.pdf" %>.</li>
     </ul>
   <h2>Detailed Instructions for TNoodle</h2>
   <p>TNoodle requires <%= link_to "Java", "https://www.java.com/en/" %> to be installed on your computer.</p>

--- a/WcaOnRails/app/views/regulations/scrambles/index.html.erb
+++ b/WcaOnRails/app/views/regulations/scrambles/index.html.erb
@@ -16,7 +16,7 @@
   <ul>
     <li>Official competitions must always use a current version of the official scramble program (see <%= link_to "Regulation 4f", "../#4f" %>).</li>
     <li>Delegates should download TNoodle to run it on a computer. They should not use TNoodle running on a public server (for security reasons).</li>
-    <li>Delegates must save all scramble sequences generated for an official competition, and send them with the results (see the <a href="https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf">WCA Competition Requirements Policy</a>).</li>
+    <li>Delegates must save all scramble sequences generated for an official competition, and send them with the results (see the <%= link_to "WCA Competition Requirements Policy", "/documents/policies/external/Competition%20Requirements.pdf" %>).</li>
   </ul>
   <h3 id="scramble-secrecy">Scramble Secrecy</h3>
     <ul>
@@ -28,7 +28,7 @@
         <li>Give passcodes to scramblers when the corresponding groups begin but <b>not any earlier</b>. (In particular, do not give the passcodes for all the scramble sets in a round to scramblers at the beginning of that round.)</li>
         <li>Don't put someone else in charge of the passcodes unless absolutely necessary, and only give them the minimum amount of passcodes needed.</li>
       </ul>
-      <li>Additional precautions are outlined in the <%= link_to "Scramble Accountability Policy", "https://www.worldcubeassociation.org/documents/policies/external/Scramble%20Accountability.pdf" %>.</li>
+      <li>Additional precautions are outlined in the <%= link_to "Scramble Accountability Policy", "/documents/policies/external/Scramble%20Accountability.pdf" %>.</li>
     </ul>
   <h2>Detailed Instructions for TNoodle</h2>
   <p>TNoodle requires <%= link_to "Java", "https://www.java.com/en/" %> to be installed on your computer.</p>


### PR DESCRIPTION
Is there a shortcut I could use for the link? I'm sure RoR has something for that, but I don't know how to do it