### PR TITLE
Added link to the competition templates readme

### DIFF
--- a/WcaOnRails/app/views/static_pages/education.html.erb
+++ b/WcaOnRails/app/views/static_pages/education.html.erb
@@ -14,6 +14,10 @@
       <%= ui_icon("file alt") %>
       <%= t('education.judge_tutorial') %>
     <% end %>
+    <%= link_to "/edudoc/competition-templates/competition-templates.pdf", class: "list-group-item" do %>
+      <%= ui_icon("file alt") %>
+      <%= t('education.competition_templates') %>
+    <% end %>
     <%= link_to "https://drive.google.com/drive/folders/1jrMWgOgNscPDqoxzgnEQ1bnV9D4FDzLj", class: "list-group-item" do %>
       <%= ui_icon("copy") %>
       <%= t('education.certificates') %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1983,6 +1983,7 @@ en:
     description: "The WQAC has published several documents for the community, you can download them below."
     competitor_tutorial: "Competitor tutorial"
     judge_tutorial: "Judging tutorial for newcomers"
+    competition_templates: "Competition templates"
     certificates: "WCT's certificate templates"
     orga_guidelines: "Organizer guidelines"
   #context: Delegates page


### PR DESCRIPTION
The link itself doesn't lead to the file though, even though it's been merged on wca-documents. Has the website just not been updated still?