### PR TITLE
Display "Competition Canceled" as a Cause For Registration Deletion

### DIFF
--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
@@ -6,6 +6,9 @@
 
 <ul>
   <li>
+    <%= t 'registrations.mailer.deleted.causes.competition_cancelled' %>
+  </li>
+  <li>
     <%= t 'registrations.mailer.deleted.causes.missing_info' %>
   </li>
   <li>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
@@ -6,7 +6,7 @@
 
 <ul>
   <li>
-    <%= t 'registrations.mailer.deleted.causes.competition_cancelled' %>
+    <%= t 'registrations.mailer.deleted.causes.competition_canceled' %>
   </li>
   <li>
     <%= t 'registrations.mailer.deleted.causes.missing_info' %>

--- a/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
+++ b/WcaOnRails/app/views/registrations_mailer/notify_registrant_of_deleted_registration.html.erb
@@ -6,9 +6,6 @@
 
 <ul>
   <li>
-    <%= t 'registrations.mailer.deleted.causes.competition_canceled' %>
-  </li>
-  <li>
     <%= t 'registrations.mailer.deleted.causes.missing_info' %>
   </li>
   <li>
@@ -22,6 +19,9 @@
   </li>
   <li>
     <%= t 'registrations.mailer.deleted.causes.multiple_registrations' %>
+  </li>
+  <li>
+    <%= t 'registrations.mailer.deleted.causes.competition_canceled' %>
   </li>
 </ul>
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1117,11 +1117,11 @@ en:
         message_html: "Your registration for %{comp_name} has been deleted. Possible causes are:"
         #context: this key is one of the reasons explaining why a registration could be deleted
         causes:
-          competition_canceled: "The competition has been canceled"
           missing_info: "You did not submit all the required details"
           incomplete: "You didn't meet the registration criteria (for example, paying the registration fee in advance or meeting the qualifying times for events)"
           registrations_full: "The competitor limit has been reached and there are no more spots available"
           multiple_registrations: "You registered twice or more times"
+          competition_canceled: "The competition has been canceled"
     #context: on the registrations list
     list:
       title: "Registrations for %{comp}"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1117,6 +1117,7 @@ en:
         message_html: "Your registration for %{comp_name} has been deleted. Possible causes are:"
         #context: this key is one of the reasons explaining why a registration could be deleted
         causes:
+          competition_cancelled: "The competition has been cancelled"
           missing_info: "You did not submit all the required details"
           incomplete: "You didn't meet the registration criteria (for example, paying the registration fee in advance or meeting the qualifying times for events)"
           registrations_full: "The competitor limit has been reached and there are no more spots available"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1117,7 +1117,7 @@ en:
         message_html: "Your registration for %{comp_name} has been deleted. Possible causes are:"
         #context: this key is one of the reasons explaining why a registration could be deleted
         causes:
-          competition_cancelled: "The competition has been cancelled"
+          competition_canceled: "The competition has been canceled"
           missing_info: "You did not submit all the required details"
           incomplete: "You didn't meet the registration criteria (for example, paying the registration fee in advance or meeting the qualifying times for events)"
           registrations_full: "The competitor limit has been reached and there are no more spots available"


### PR DESCRIPTION
This is a short-term fix to #5328

A better fix, involving adding a selection menu for delegates to select the reason for deletion, will be added later. Meanwhile, I hope this will reduce the confusion when someone's registration is deleted because the competition itself is canceled!