### PR TITLE
Fix icons alignment

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/edit_events.scss
+++ b/WcaOnRails/app/assets/stylesheets/edit_events.scss
@@ -10,12 +10,17 @@
       align-items: center;
 
       $cubing-icon-size: 55px;
+
       .img-thumbnail.cubing-icon {
         font-size: 40px;
         position: absolute;
         top: -5px;
         height: $cubing-icon-size;
         z-index: 1;
+
+        &::before {
+          vertical-align: 0;
+        }
       }
 
       .title {

--- a/WcaOnRails/app/assets/stylesheets/persons.scss
+++ b/WcaOnRails/app/assets/stylesheets/persons.scss
@@ -39,12 +39,12 @@
     .cubing-icon {
       font-size: 1.3em;
       line-height: normal;
-      vertical-align: middle;
     }
 
     td,
     th {
       vertical-align: middle;
+
       &.single,
       &.average {
         text-align: right;
@@ -104,7 +104,8 @@
       th,
       td {
         &.event {
-          width: 1px;
+          display: flex;
+          width: 100%;
           cursor: pointer;
 
           &:hover {
@@ -179,15 +180,15 @@
         }
 
         &.wr {
-          color : $wr-color;
+          color: $wr-color;
         }
 
         &.cr {
-          color : $cr-color;
+          color: $cr-color;
         }
 
         &.nr {
-          color : $nr-color;
+          color: $nr-color;
         }
       }
 

--- a/WcaOnRails/app/assets/stylesheets/results.scss
+++ b/WcaOnRails/app/assets/stylesheets/results.scss
@@ -29,12 +29,15 @@
       height: 25px;
       line-height: 25px;
       background-color: $link-color;
+
       &:hover {
         background-color: $link-hover-color;
       }
+
       &.active {
         background-color: $blue;
       }
+
       &.active:hover {
         background-color: $blue;
       }
@@ -44,6 +47,6 @@
 
 #search-results {
   .cubing-icon {
-    vertical-align: middle;
+    vertical-align: baseline;
   }
 }


### PR DESCRIPTION
Fixes #6082

Tried to fix where the cubing-icons show up. Please let me know if there are other pages I should look at.

## Edit Events page

### Before
#6082 

### After
<img width="1209" alt="Screen Shot 2021-10-10 at 19 24 40" src="https://user-images.githubusercontent.com/867840/136688346-a0f32e9d-28bd-4721-a36e-8638a3e7a5c5.png">


## Persons page

### Before
<img width="206" alt="Screen Shot 2021-10-10 at 19 21 28" src="https://user-images.githubusercontent.com/867840/136688284-e33c0984-b63d-4b01-a10e-cc36deec7a32.png">
<img width="307" alt="Screen Shot 2021-10-10 at 19 21 36" src="https://user-images.githubusercontent.com/867840/136688286-4d2f48db-3edf-483b-bef3-99cd6819dbba.png">


### After
<img width="207" alt="Screen Shot 2021-10-10 at 19 20 56" src="https://user-images.githubusercontent.com/867840/136688289-9fbe1f26-3eb7-4d3a-93a1-1862fbc2ab02.png">
<img width="315" alt="Screen Shot 2021-10-10 at 19 21 52" src="https://user-images.githubusercontent.com/867840/136688291-ea3b85db-6613-4e7d-a7d4-4b9fa373c43f.png">

## Results Records page

### Before
<img width="308" alt="Screen Shot 2021-10-10 at 19 26 31" src="https://user-images.githubusercontent.com/867840/136688413-f8b3adf3-c55b-4f5a-91ef-fb4ea9ae04e3.png">

### After
<img width="329" alt="Screen Shot 2021-10-10 at 19 26 16" src="https://user-images.githubusercontent.com/867840/136688419-7e21fbb8-7162-41e2-9ef3-ffd7bee3f0f6.png">
