### PR TITLE
Fix MBF spacing in results display.

### DIFF
--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.js
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.js
@@ -64,7 +64,7 @@ const RoundResultsTable = ({ round, eventName, eventId }) => (
             </Table.Cell>
             <Table.Cell>{result.regional_average_record}</Table.Cell>
             <Table.Cell><CountryFlag iso2={result.country_iso2} /></Table.Cell>
-            <Table.Cell className={eventId === '333mbf' ? 'table-cell-solves-mbf' : 'table-cell-solves'}>
+            <Table.Cell className={(eventId === '333mbf' || eventId === '333mbo') ? 'table-cell-solves-mbf' : 'table-cell-solves'}>
               {formatAttemptsForResult(result, eventId)}
             </Table.Cell>
           </Table.Row>

--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.js
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.js
@@ -64,7 +64,7 @@ const RoundResultsTable = ({ round, eventName, eventId }) => (
             </Table.Cell>
             <Table.Cell>{result.regional_average_record}</Table.Cell>
             <Table.Cell><CountryFlag iso2={result.country_iso2} /></Table.Cell>
-            <Table.Cell className="table-cell-solves">
+            <Table.Cell className={eventId === '333mbf' ? "table-cell-solves-mbf" : "table-cell-solves"}>
               {formatAttemptsForResult(result, eventId)}
             </Table.Cell>
           </Table.Row>

--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.js
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.js
@@ -64,7 +64,7 @@ const RoundResultsTable = ({ round, eventName, eventId }) => (
             </Table.Cell>
             <Table.Cell>{result.regional_average_record}</Table.Cell>
             <Table.Cell><CountryFlag iso2={result.country_iso2} /></Table.Cell>
-            <Table.Cell className={eventId === '333mbf' ? "table-cell-solves-mbf" : "table-cell-solves"}>
+            <Table.Cell className={eventId === '333mbf' ? 'table-cell-solves-mbf' : 'table-cell-solves'}>
               {formatAttemptsForResult(result, eventId)}
             </Table.Cell>
           </Table.Row>

--- a/WcaOnRails/app/webpacker/javascript/competition_results/index.scss
+++ b/WcaOnRails/app/webpacker/javascript/competition_results/index.scss
@@ -9,6 +9,9 @@
     .table-cell-solves {
       word-spacing: 0.5em;
     }
+    .table-cell-solves-mbf {
+      word-spacing: 2em;
+    }
     .WR {
       color : $wr-color;
     }

--- a/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
+++ b/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
@@ -53,7 +53,7 @@ function formatMbldAttemptResult(attemptResult) {
   );
   const clockFormat = centisecondsToClockFormat(centiseconds);
   const shortClockFormat = clockFormat.replace(/\.00$/, '');
-  return `${solved}/${attempted} ${shortClockFormat}`;
+  return `${solved}/${attempted}\u2002${shortClockFormat}`;
 }
 
 function formatFmAttemptResult(attemptResult) {

--- a/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
+++ b/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
@@ -56,6 +56,7 @@ function formatMbldAttemptResult(attemptResult) {
   // u2002 is a special space character
   // using it here allows us to expand space between mbf results without
   //  expanding the spaces within the individual results
+  // see https://github.com/thewca/worldcubeassociation.org/issues/6375
   return `${solved}/${attempted}\u2002${shortClockFormat}`;
 }
 

--- a/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
+++ b/WcaOnRails/app/webpacker/javascript/wca-live/attempts.js
@@ -53,6 +53,9 @@ function formatMbldAttemptResult(attemptResult) {
   );
   const clockFormat = centisecondsToClockFormat(centiseconds);
   const shortClockFormat = clockFormat.replace(/\.00$/, '');
+  // u2002 is a special space character
+  // using it here allows us to expand space between mbf results without
+  //  expanding the spaces within the individual results
   return `${solved}/${attempted}\u2002${shortClockFormat}`;
 }
 


### PR DESCRIPTION
See issue #6375.

Increase space between MBF attempt results in 'all-results' display,
to make delimitation between attempts clear.