### PR TITLE
Updated the COVID warning to be less alarming

### DIFF
--- a/WcaOnRails/app/views/competitions/index.html.erb
+++ b/WcaOnRails/app/views/competitions/index.html.erb
@@ -3,7 +3,7 @@
 <div class="container">
   <h2><%= yield(:title) %></h2>
 
-  <%= alert :danger, t('.disclaimer') %>
+  <%= alert :warning, t('.disclaimer') %>
 
   <%= form_tag competitions_path, method: :get, remote: true, class: "competition-select form-inline #{@display}", id: "competition-query-form" do %>
     <%= render 'index_form' %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1377,7 +1377,7 @@ en:
     #context: on the competition's index page
     index:
       title: "Competitions"
-      disclaimer: "Please note that due to the COVID-19 pandemic, many countries are currently unable to host competitions."
+      disclaimer: "Please note that due to the COVID-19 pandemic, some countries are currently unable to host competitions."
       all_events: "All"
       all_years: "All Years"
       clear: "Clear"


### PR DESCRIPTION
As requested in issue https://github.com/thewca/worldcubeassociation.org/issues/6366
I tested that this is rendered as expected. Changed one word and the color of the message (from red to yellow).