### PR TITLE
Fix registration requirements text

### DIFF
--- a/WcaOnRails/app/views/competitions/_registration_requirements.html.erb
+++ b/WcaOnRails/app/views/competitions/_registration_requirements.html.erb
@@ -75,8 +75,13 @@
 
 <% if @competition.has_event_change_deadline_date? %>
   <% if @competition.event_change_deadline_date?  %>
-    <%= t('competitions.competition_info.event_change_deadline_html', event_change_deadline: wca_local_time(@competition.event_change_deadline_date)) %>
-    <br>
+    <% if @competition.allow_registration_edits? %>
+      <%= t('competitions.competition_info.event_change_deadline_edits_allowed_html', event_change_deadline: wca_local_time(@competition.event_change_deadline_date), register: link_to(t('competitions.nav.menu.register'), competition_register_path(@competition))) %>
+      <br>
+    <% else %>
+      <%= t('competitions.competition_info.event_change_deadline_html', event_change_deadline: wca_local_time(@competition.event_change_deadline_date)) %>
+      <br>
+    <% end %>
   <% else %>
     <%= t('competitions.competition_info.event_change_deadline_default_html') %>
     <br>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1337,6 +1337,7 @@ en:
       no_refunds: "Registration fees won't be refunded under any circumstance."
       waiting_list_deadline_html: "Registrants on the waiting list may be accepted onto the competitor list until %{waiting_list_deadline}."
       event_change_deadline_html: "If you are a registered competitor you may change your registered events until %{event_change_deadline} by contacting the organization team."
+      event_change_deadline_edits_allowed_html: "If you are a registered competitor you may change your registered events until %{event_change_deadline} on the %{register} tab."
       event_change_deadline_default_html: "We encourage everyone to register for the events they want to compete in via your online registration, however you may add events to your registration up until the event has started."
       on_the_spot_registration_fee_html: "On the spot registrations will be accepted with a base registration fee of %{on_the_spot_base_entry_fee}."
       on_the_spot_registration_free: "On the spot registrations will be accepted for free."


### PR DESCRIPTION
This updates the registration requirements text to correctly say when a
competitor can edit their registered events.

Fixes #6546.