### PR TITLE
Added message about the user's position in the waiting list

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -267,4 +267,29 @@ module ApplicationHelper
                                        opts: options.to_json))
     component_container + script_tag
   end
+
+  # Converts given integer to ordinal number as string (e.g. 1 to "1st", 2 to "2nd", 6 to "6th", etc.)
+  def int_to_ordinal(num)
+    result = num.to_s
+    last_two_digits = num % 100
+
+    # Special case for 11th, 12th and 13th
+    if last_two_digits >= 11 && last_two_digits <= 13
+      result += "th"
+    else
+      last_digit = num % 10
+
+      if last_digit == 1
+        result += "st"
+      elsif last_digit == 2
+        result += "nd"
+      elsif last_digit == 3
+        result += "rd"
+      else
+        result += "th"
+      end
+    end
+
+    return result
+  end
 end

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -267,29 +267,4 @@ module ApplicationHelper
                                        opts: options.to_json))
     component_container + script_tag
   end
-
-  # Converts given integer to ordinal number as string (e.g. 1 to "1st", 2 to "2nd", 6 to "6th", etc.)
-  def int_to_ordinal(num)
-    result = num.to_s
-    last_two_digits = num % 100
-
-    # Special case for 11th, 12th and 13th
-    if last_two_digits >= 11 && last_two_digits <= 13
-      result += "th"
-    else
-      last_digit = num % 10
-
-      if last_digit == 1
-        result += "st"
-      elsif last_digit == 2
-        result += "nd"
-      elsif last_digit == 3
-        result += "rd"
-      else
-        result += "th"
-      end
-    end
-
-    return result
-  end
 end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -171,6 +171,12 @@ class Registration < ApplicationRecord
     OpenStruct.new(index: index, length: pending_registrations.length)
   end
 
+  def paid_waiting_list_info
+    pending_paid_registrations = competition.registrations.pending.order(:last_payment_date)
+    index = pending_paid_registrations.index(self)
+    OpenStruct.new(index: index, length: pending_paid_registrations.length)
+  end
+
   def to_wcif(authorized: false)
     authorized_fields = {
       "guests" => guests,

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -172,7 +172,7 @@ class Registration < ApplicationRecord
   end
 
   def paid_waiting_list_info
-    pending_paid_registrations = competition.registrations.pending.order(:last_payment_date)
+    pending_paid_registrations = competition.registrations.pending.order(registration_payments.map(&:created_at).max)
     index = pending_paid_registrations.index(self)
     OpenStruct.new(index: index, length: pending_paid_registrations.length)
   end

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -101,12 +101,12 @@
                 <% # Display the waitlist message and pass it an ordinal of the competitor's position on the list. If the competition uses Stripe, they'll see their position on the list of competitors who have paid. If they haven't paid, they will see a different message, telling them to do so. %>
                 <% if @competition.using_stripe_payments? %>
                   <% if @registration.outstanding_entry_fees == 0 %>
-                    <%= t('registrations.waiting_list', index: @registration.paid_waiting_list_info.index.ordinalize) %>
+                    <%= t('registrations.waiting_list', index: (@registration.paid_waiting_list_info.index + 1).ordinalize) %>
                   <% else %>
                     <%= t('registrations.entry_fees_not_paid') %>
                   <% end %>
                 <% else %>
-                  <%= t('registrations.waiting_list', index: @registration.waiting_list_info.index.ordinalize) %>
+                  <%= t('registrations.waiting_list', index: (@registration.waiting_list_info.index + 1).ordinalize) %>
                 <% end %>
               <% end %>
             </p>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -98,8 +98,16 @@
               <% elsif @registration.accepted? %>
                 <%= t('registrations.accepted') %>
               <% elsif @registration.pending? %>
-                <% # Display the waitlist message and pass it an ordinal of the competitor's position on the list %>
-                <%= t('registrations.waiting_list', index: @registration.waiting_list_info.index.ordinalize) %>
+                <% # Display the waitlist message and pass it an ordinal of the competitor's position on the list. If the competition uses Stripe, they'll see their position on the list of competitors who have paid. If they haven't paid, they will see a different message, telling them to do so. %>
+                <% if @competition.using_stripe_payments? %>
+                  <% if @registration.outstanding_entry_fees == 0 %>
+                    <%= t('registrations.waiting_list', index: @registration.paid_waiting_list_info.index.ordinalize) %>
+                  <% else %>
+                    <%= t('registrations.entry_fees_not_paid') %>
+                  <% end %>
+                <% else %>
+                  <%= t('registrations.waiting_list', index: @registration.waiting_list_info.index.ordinalize) %>
+                <% end %>
               <% end %>
             </p>
             <hr/>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -12,7 +12,7 @@
 
   <% if @competition.registration_not_yet_opened? %>
     <%= alert :info, t('registrations.will_open_html', days: opens_in_days, time: wca_local_time(@competition.registration_open)) %>
-  <%# Don't show this alert if we're showing the registration's details: this message is included in it! %>
+  <% # Don't show this alert if we're showing the registration's details: this message is included in it! %>
   <% elsif @competition.registration_past? && !@registration&.show_details? %>
     <%= alert :danger, t('registrations.closed_html', days: closes_in_days, time: wca_local_time(@competition.registration_close)) %>
   <% end %>
@@ -98,7 +98,8 @@
               <% elsif @registration.accepted? %>
                 <%= t('registrations.accepted') %>
               <% elsif @registration.pending? %>
-                <%= t('registrations.waiting_list', index: @registration.waiting_list_info.index) %>
+                <% # Display the waitlist message and pass it an ordinal of the competitor's position on the list %>
+                <%= t('registrations.waiting_list', index: int_to_ordinal(@registration.waiting_list_info.index)) %>
               <% end %>
             </p>
             <hr/>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -99,7 +99,7 @@
                 <%= t('registrations.accepted') %>
               <% elsif @registration.pending? %>
                 <% # Display the waitlist message and pass it an ordinal of the competitor's position on the list %>
-                <%= t('registrations.waiting_list', index: int_to_ordinal(@registration.waiting_list_info.index)) %>
+                <%= t('registrations.waiting_list', index: @registration.waiting_list_info.index.ordinalize) %>
               <% end %>
             </p>
             <hr/>

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -98,7 +98,7 @@
               <% elsif @registration.accepted? %>
                 <%= t('registrations.accepted') %>
               <% elsif @registration.pending? %>
-                <%= t('registrations.waiting_list') %>
+                <%= t('registrations.waiting_list', index: @registration.waiting_list_info.index) %>
               <% end %>
             </p>
             <hr/>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1188,6 +1188,7 @@ en:
     waiting_list: "Your registration is pending. You are currently %{index} on the waiting list. For approval, you may need to pay a registration fee. Check the competition website for details."
     accepted: "Your registration has been accepted!"
     entry_fees_fully_paid: "You have paid %{paid}, which fully covers the registration fees."
+    entry_fees_not_paid: "Registration fees not yet fully paid. You are not on the waiting list."
     will_pay_here: "You will pay them here after submitting your registration"
     wont_pay_here: "Please check competition's information for instruction about how to pay"
     refund_form:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1185,7 +1185,7 @@ en:
     check_registration_information: "Please check the information about registration to find out if you need to do something else, like paying a registration fee."
     have_registered: "You have submitted your registration for %{comp}. You can see your registration details below."
     contact_organizer: "Contact the organizer if you wish to make a change."
-    waiting_list: "Your registration is pending. For approval, you may need to pay a registration fee. Check the competition website for details."
+    waiting_list: "Your registration is pending. You are currently %{index} on the waiting list. For approval, you may need to pay a registration fee. Check the competition website for details."
     accepted: "Your registration has been accepted!"
     entry_fees_fully_paid: "You have paid %{paid}, which fully covers the registration fees."
     will_pay_here: "You will pay them here after submitting your registration"


### PR DESCRIPTION
This is a small fix that just lets the user know what their position on the waiting list is to give more transparency. The issue with the current registration process is much bigger than this though, but perhaps this will improve things slightly, although the relevant text is very small and can be easily missed by most users.

One thing to change before this can be merged: display the number in an ordinal format (e.g. "7th" instead of "7")
EDIT: that's been implemented now