### PR TITLE
Add competition events to delegate report

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -41,7 +41,7 @@
   <div>
     <strong>Events</strong>
     (<%= competition.events.count %>)
-    <%= competition.events.map { |event| event.name }.join(", ") %>
+    <%= competition.events.map(&:name).join(", ") %>
   </div>
 
   <div>

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -40,10 +40,8 @@
 
   <div>
     <strong>Events</strong>
-
-    <% competition.events.each do |event| %>
-      <%= cubing_icon(event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name) %>
-    <% end %>
+    (<%= competition.events.count %>)
+    <%= competition.events.map { |event| event.name }.join(", ") %>
   </div>
 
   <div>

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -39,6 +39,14 @@
   </div>
 
   <div>
+    <strong>Events</strong>
+
+    <% competition.events.each do |event| %>
+      <%= cubing_icon(event.id, data: { toggle: "tooltip", placement: "top" }, title: event.name) %>
+    <% end %>
+  </div>
+
+  <div>
     <strong>Equipment</strong>
     <%=md delegate_report.equipment %>
   </div>


### PR DESCRIPTION
Addresses #6378: events are added to the delegate report as html icons (with tooltips). I assume that will show up properly in the email version of the report? 

On a closely related note, I think it would be nice to show the competitor limit when the competitor count isn't available, since this also helps get an idea of the type of competition (as mentioned in the original issue). Something along the lines of:

**Competitors** Unknown, results are not posted yet. (Competitor limit was xy.)

Could I add that onto this PR, or would it be better to create a new issue and PR?