### PR TITLE
Remove illegal cutoff formats

### DIFF
--- a/WcaOnRails/app/models/format.rb
+++ b/WcaOnRails/app/models/format.rb
@@ -21,8 +21,8 @@ class Format < ApplicationRecord
     {
       "1" => [],
       "2" => ["1"],
-      "3" => ["1", "2"],
-      "m" => ["1", "2"],
+      "3" => ["1"],
+      "m" => ["1"],
       "a" => ["2"], # https://www.worldcubeassociation.org/regulations/#9b1
     }[self.id]
   end


### PR DESCRIPTION
Very simple fix. These cutoff formats are not legal anymore, so they need to be removed. Please let me know if there's somewhere else in the code where this might need to be fixed. Afaik, it's just the model that needed to be updated.