### PR TITLE
Add line for Gen 5 Pro Timer to delegate reports

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/_equipment_default.md
+++ b/WcaOnRails/app/views/delegate_reports/_equipment_default.md
@@ -1,6 +1,7 @@
 Gen 2 Timer: 0
 Gen 3 Pro Timer: 0
 Gen 4 Pro Timer: 0
+Gen 5 Pro Timer: 0
 
 Gen 2 Display: 0
 Gen 3 Display: 0


### PR DESCRIPTION
Addresses #6597.

1. When I run locally to test changes, all the reports are blank (makes sense). So technically I haven't confirmed that the changes work as expected, but it's an extremely simple change.
2. It seems a bit odd to add a default amount of 0 to each line, given that we ask people to delete unused lines.