### PR TITLE
Shared cumulative time limits fix

### DIFF
--- a/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
@@ -8,6 +8,7 @@ import formats from '../wca/formats.js.erb'
 import { rootRender } from '.'
 import { pluralize } from './modals/utils'
 import { buildActivityCode, saveWcif, roundIdToString } from '../wca/wcif-utils'
+import { removeRoundsFromSharedTimeLimits } from "./modals/index.js"
 import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton } from './modals'
 
 export default class EditEvents extends React.Component {
@@ -172,12 +173,7 @@ function EventPanel({ wcifEvents, canAddAndRemoveEvents, canUpdateEvents, wcifEv
 
     // before removing all rounds of the event, remove those rounds from any
     // shared cumulative time limits
-    _.compact(_.flatMap(wcifEvents, 'rounds')).forEach(otherWcifRound => {
-      _.pull(
-        otherWcifRound.timeLimit.cumulativeRoundIds,
-        ...wcifEvent.rounds.map(round => round.id)
-      )
-    });
+    removeRoundsFromSharedTimeLimits(wcifEvents, wcifEvent.rounds.map(round => round.id));
 
     // remove the rounds themselves
     wcifEvent.rounds = null;
@@ -195,12 +191,10 @@ function EventPanel({ wcifEvents, canAddAndRemoveEvents, canUpdateEvents, wcifEv
 
       // Rounds to remove may have been part of shared cumulative time limits,
       // so remove these rounds from those groupings
-      _.compact(_.flatMap(wcifEvents, 'rounds')).forEach(otherWcifRound => {
-        _.pull(
-          otherWcifRound.timeLimit.cumulativeRoundIds,
-          ...wcifEvent.rounds.filter((_, index) => index >= newRoundCount).map(round => round.id)
-        )
-      });
+      removeRoundsFromSharedTimeLimits(
+        wcifEvents,
+        wcifEvent.rounds.filter((_, index) => index >= newRoundCount).map(round => round.id)
+      );
 
       // Remove the extra rounds themselves
       // Note: do this after dealing with cumulative time limits above

--- a/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
@@ -8,7 +8,6 @@ import formats from '../wca/formats.js.erb'
 import { rootRender } from '.'
 import { pluralize } from './modals/utils'
 import { buildActivityCode, saveWcif, roundIdToString } from '../wca/wcif-utils'
-// NOTE: removeRoundsFromSharedTimeLimits will modify this component's state/props (specifically, wcifEvents)
 import { removeRoundsFromSharedTimeLimits } from "./modals/index.js"
 import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton } from './modals'
 

--- a/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
@@ -180,8 +180,19 @@ function EventPanel({ wcifEvents, canAddAndRemoveEvents, canUpdateEvents, wcifEv
       if(!confirm(`Are you sure you want to remove ${pluralize(roundsToRemoveCount, "round")} of ${event.name}?`)) {
         return;
       }
+      // We have too many rounds
 
-      // We have too many rounds, remove the extras.
+      // Rounds to remove may have been part of shared cumulative time limits,
+      // so remove these rounds from those groupings
+      _.compact(_.flatMap(wcifEvents, 'rounds')).forEach(otherWcifRound => {
+        _.pull(
+          otherWcifRound.timeLimit.cumulativeRoundIds,
+          ...wcifEvent.rounds.filter((_, index) => index >= newRoundCount).map(round => round.id)
+        )
+      });
+
+      // Remove the extra rounds themselves
+      // Note: do this after dealing with cumulative time limits above
       wcifEvent.rounds = _.take(wcifEvent.rounds, newRoundCount);
 
       // Final rounds must not have an advance to next round requirement.

--- a/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
@@ -8,6 +8,7 @@ import formats from '../wca/formats.js.erb'
 import { rootRender } from '.'
 import { pluralize } from './modals/utils'
 import { buildActivityCode, saveWcif, roundIdToString } from '../wca/wcif-utils'
+// NOTE: removeRoundsFromSharedTimeLimits will modify this component's state/props (specifically, wcifEvents)
 import { removeRoundsFromSharedTimeLimits } from "./modals/index.js"
 import { EditTimeLimitButton, EditCutoffButton, EditAdvancementConditionButton } from './modals'
 

--- a/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/EditEvents.js
@@ -170,9 +170,20 @@ function EventPanel({ wcifEvents, canAddAndRemoveEvents, canUpdateEvents, wcifEv
       return;
     }
 
+    // before removing all rounds of the event, remove those rounds from any
+    // shared cumulative time limits
+    _.compact(_.flatMap(wcifEvents, 'rounds')).forEach(otherWcifRound => {
+      _.pull(
+        otherWcifRound.timeLimit.cumulativeRoundIds,
+        ...wcifEvent.rounds.map(round => round.id)
+      )
+    });
+
+    // remove the rounds themselves
     wcifEvent.rounds = null;
     rootRender();
   };
+
   let setRoundCount = newRoundCount => {
     wcifEvent.rounds = wcifEvent.rounds || [];
     let roundsToRemoveCount = wcifEvent.rounds.length - newRoundCount;

--- a/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
@@ -63,7 +63,6 @@ class EditRoundAttribute extends React.Component {
     wcifRound[this.props.attribute] = this.state.value;
 
     // TODO: still need to remove from other rounds if selecting per solve
-    // TODO: still need to remove from other rounds if deleting event
 
     // This is gross. timeLimit is special because of cross round cumulative time limits.
     // If you set a time limit for 3x3x3 round 1 shared with 2x2x2 round 1, then we need

--- a/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
@@ -20,6 +20,8 @@ let RoundAttributeComponents = {
   advancementCondition: AdvancementConditionComponents,
 };
 
+// NOTE: this helper function modifies wcifEvents in place, and is used in other
+// React components, meaning it modifies their state/props for them
 export function removeRoundsFromSharedTimeLimits(wcifEvents, wcifRounds) {
   _.compact(_.flatMap(wcifEvents, 'rounds')).forEach(otherWcifRound =>
     _.pull(otherWcifRound.timeLimit.cumulativeRoundIds, ...wcifRounds)

--- a/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
@@ -63,7 +63,7 @@ class EditRoundAttribute extends React.Component {
     wcifRound[this.props.attribute] = this.state.value;
 
     // TODO: still need to remove from other rounds if selecting per solve
-    // TODO: still need to remove from other rounds if deleting round/event
+    // TODO: still need to remove from other rounds if deleting event
 
     // This is gross. timeLimit is special because of cross round cumulative time limits.
     // If you set a time limit for 3x3x3 round 1 shared with 2x2x2 round 1, then we need

--- a/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
@@ -20,8 +20,13 @@ let RoundAttributeComponents = {
   advancementCondition: AdvancementConditionComponents,
 };
 
-// NOTE: this helper function modifies wcifEvents in place, and is used in other
-// React components, meaning it modifies their state/props for them
+/**
+ * Finds the cumulativeRoundIds of each event in wcifEvents and removes any
+ * which are found in wcifRounds. Note that it modifies wicfEvents in place.
+ *
+ * @param {collection} wcifEvents Will be modified in place.
+ * @param {Array}      wcifRounds Rounds to be removed from all cumulativeRoundIds.
+ */
 export function removeRoundsFromSharedTimeLimits(wcifEvents, wcifRounds) {
   _.compact(_.flatMap(wcifEvents, 'rounds')).forEach(otherWcifRound =>
     _.pull(otherWcifRound.timeLimit.cumulativeRoundIds, ...wcifRounds)

--- a/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
+++ b/WcaOnRails/app/webpacker/javascript/edit-events/modals/index.js
@@ -62,8 +62,6 @@ class EditRoundAttribute extends React.Component {
     let wcifRound = this.getWcifRound();
     wcifRound[this.props.attribute] = this.state.value;
 
-    // TODO: still need to remove from other rounds if selecting per solve
-
     // This is gross. timeLimit is special because of cross round cumulative time limits.
     // If you set a time limit for 3x3x3 round 1 shared with 2x2x2 round 1, then we need
     // to make sure the same timeLimit gets set for both of the rounds.
@@ -78,7 +76,10 @@ class EditRoundAttribute extends React.Component {
       // First, remove all rounds which appear in cumulativeRoundIds from everywhere.
       // (although, this only affects those which previously shared a time limit with this round)
       _.compact(_.flatMap(this.props.wcifEvents, 'rounds')).forEach(otherWcifRound => {
-          _.pull(otherWcifRound.timeLimit.cumulativeRoundIds, ...cumulativeRoundIds);
+          // if time limit is changed to 'per solve', cumulativeRoundIds will be empty,
+          // but we still (potentially) need to remove the round from other cumulative time limits
+          // which is why that (wcifRound.id) is added on the end here
+          _.pull(otherWcifRound.timeLimit.cumulativeRoundIds, ...cumulativeRoundIds, wcifRound.id);
       });
 
       // Second, clobber the time limits for all rounds that this round now shares a time limit with.


### PR DESCRIPTION
Resolves #6502.

## There were a few problems
1. When updating a shared cumulative time limit, those shared rounds (and the round itself) were not updated properly (as reported in #6502).
2. When changing from a shared cumulative time limit to a per solve time limit, those shared rounds were not updated.
3. When removing rounds which were part of a shared time limit, those shared rounds were not updated.
4. When deleting events which had rounds which were part of a shared time limit, those shared rounds were not updated.

## Example of current behaviour
If there are the following shared time limits:
- 2x2, 3x3, 4x4, 5x5
- 6x6, 7x7, clock, mega

And then 5x5 is changed to share with 4x4, 6x6, 7x7, and pyra, then the new shared time limits will be:
1. 2x2, 3x3
2. clock, mega
3. 4x4, 5x5, 6x6, 7x7, pyra

(Previously, this would show 2x2 and 3x3 in a group of 2x2, 3x3, 4x4, 5x5, and incompatibly show 4x4 and 5x5 in a group of 4x4, 5x5, 6x6, 7x7, pyra.)

![Screenshot from 2022-01-15 16-44-52](https://user-images.githubusercontent.com/49137025/149671221-8f7d99bb-7789-4313-83b4-e88b541cae9d.png)
![Screenshot from 2022-01-15 16-53-39](https://user-images.githubusercontent.com/49137025/149671225-d31c5f71-946b-451c-afeb-03c23aaf39f2.png)
![Screenshot from 2022-01-15 17-06-47](https://user-images.githubusercontent.com/49137025/149671231-31e0f5d9-7c05-45a0-b9e7-431d431916a6.png)
