### PR TITLE
Enforce submitting results before posting report

### DIFF
--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -55,7 +55,7 @@ class DelegateReport < ApplicationRecord
   end
 
   def can_submit?(current_user)
-    can_see_submit_button?(current_user) && !competition.results_submitted_at.nil?
+    can_see_submit_button?(current_user) && (competition.results_submitted? || competition.results_posted?)
   end
 
   def posted=(new_posted)

--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -50,12 +50,12 @@ class DelegateReport < ApplicationRecord
     !!posted_at
   end
 
-  def can_submit_delegate_report?(current_user)
-    !posted? && competition.delegates.include?(current_user) && !competition.results_submitted_at.nil?
-  end
-
   def can_see_delegate_report_submit_button?(current_user)
     !posted? && competition.delegates.include?(current_user)
+  end
+
+  def can_submit_delegate_report?(current_user)
+    can_see_delegate_report_submit_button?(current_user) && !competition.results_submitted_at.nil?
   end
 
   def posted=(new_posted)

--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -51,6 +51,10 @@ class DelegateReport < ApplicationRecord
   end
 
   def can_submit_delegate_report?(current_user)
+    !posted? && competition.delegates.include?(current_user) && !competition.results_submitted_at.nil?
+  end
+
+  def can_see_delegate_report_submit_button?(current_user)
     !posted? && competition.delegates.include?(current_user)
   end
 

--- a/WcaOnRails/app/models/delegate_report.rb
+++ b/WcaOnRails/app/models/delegate_report.rb
@@ -50,12 +50,12 @@ class DelegateReport < ApplicationRecord
     !!posted_at
   end
 
-  def can_see_delegate_report_submit_button?(current_user)
+  def can_see_submit_button?(current_user)
     !posted? && competition.delegates.include?(current_user)
   end
 
-  def can_submit_delegate_report?(current_user)
-    can_see_delegate_report_submit_button?(current_user) && !competition.results_submitted_at.nil?
+  def can_submit?(current_user)
+    can_see_submit_button?(current_user) && !competition.results_submitted_at.nil?
   end
 
   def posted=(new_posted)

--- a/WcaOnRails/app/views/competitions/_nav.html.erb
+++ b/WcaOnRails/app/views/competitions/_nav.html.erb
@@ -256,6 +256,7 @@
             <%= link_to "here", delegate_report_edit_path(@competition) %>
             to work on it.
           <% end %>
+          Note that you must submit results before you can post your report.
         <% end %>
       <% end %>
 

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -26,8 +26,8 @@
     <%= f.input :remarks, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
 
     <%= f.button :submit, class: "btn-primary" %>
-    <% can_see_delegate_report_submit_button = DelegateReport.find(@delegate_report.id).can_see_delegate_report_submit_button?(@current_user) %>
-    <% can_submit_delegate_report = DelegateReport.find(@delegate_report.id).can_submit_delegate_report?(@current_user) %>
+    <% can_see_delegate_report_submit_button = @delegate_report.can_see_delegate_report_submit_button?(@current_user) %>
+    <% can_submit_delegate_report = @delegate_report.can_submit_delegate_report?(@current_user) %>
     <% if can_see_delegate_report_submit_button %>
       <%= button_tag(type: 'submit',
                      name: "delegate_report[posted]",

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -26,13 +26,16 @@
     <%= f.input :remarks, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
 
     <%= f.button :submit, class: "btn-primary" %>
+    <% can_see_delegate_report_submit_button = DelegateReport.find(@delegate_report.id).can_see_delegate_report_submit_button?(@current_user) %>
     <% can_submit_delegate_report = DelegateReport.find(@delegate_report.id).can_submit_delegate_report?(@current_user) %>
-    <% if can_submit_delegate_report %>
+    <% if can_see_delegate_report_submit_button %>
       <%= button_tag(type: 'submit',
                      name: "delegate_report[posted]",
                      value: true,
+                     disabled: !can_submit_delegate_report,
                      class: "btn btn-danger",
-                     data: { confirm: "You are about to post your report, are you sure you want to do this? Once posted, a report cannot be changed." }) do %>
+                     data: { confirm: "You are about to post your report, are you sure you want to do this? Once posted, a report cannot be changed." },
+                     title: can_submit_delegate_report ? "" : "You must first submit results before you can post the report.") do %>
         Post the report
       <% end %>
     <% end %>

--- a/WcaOnRails/app/views/delegate_reports/edit.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/edit.html.erb
@@ -26,8 +26,8 @@
     <%= f.input :remarks, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
 
     <%= f.button :submit, class: "btn-primary" %>
-    <% can_see_delegate_report_submit_button = @delegate_report.can_see_delegate_report_submit_button?(@current_user) %>
-    <% can_submit_delegate_report = @delegate_report.can_submit_delegate_report?(@current_user) %>
+    <% can_see_delegate_report_submit_button = @delegate_report.can_see_submit_button?(@current_user) %>
+    <% can_submit_delegate_report = @delegate_report.can_submit?(@current_user) %>
     <% if can_see_delegate_report_submit_button %>
       <%= button_tag(type: 'submit',
                      name: "delegate_report[posted]",

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -86,7 +86,7 @@ FactoryBot.define do
     trait :with_valid_submitted_results do
       announced
       with_rounds { true }
-      results_submitted_at { Time.now}
+      results_submitted_at { Time.now }
       after(:create) do |competition|
         person = FactoryBot.create(:inbox_person, competitionId: competition.id)
         rounds = competition.competition_events.map(&:rounds).flatten

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -86,6 +86,7 @@ FactoryBot.define do
     trait :with_valid_submitted_results do
       announced
       with_rounds { true }
+      results_submitted_at { Time.now}
       after(:create) do |competition|
         person = FactoryBot.create(:inbox_person, competitionId: competition.id)
         rounds = competition.competition_events.map(&:rounds).flatten

--- a/WcaOnRails/spec/features/delegate_report_spec.rb
+++ b/WcaOnRails/spec/features/delegate_report_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.feature "Registration management" do
   let(:delegate) { FactoryBot.create :delegate, name: "Jeremy on Bart" }
-  let(:competition) { FactoryBot.create :competition, delegates: [delegate], name: "Submit Report 2017" }
+  let(:competition) { FactoryBot.create :competition, :with_valid_submitted_results, delegates: [delegate], name: "Submit Report 2017" }
   let!(:delegate_report) { FactoryBot.create :delegate_report, competition: competition, schedule_url: "http://example.com" }
   let!(:wrc_members) { FactoryBot.create_list :user, 3, :wrc_member }
 


### PR DESCRIPTION
In delegate reports, added new function `can_see_submit_button?` and modified original `can_submit_delegate_report?` to also check whether results have been submitted (not necessarily posted) (plus rename to `can_submit?`).
If results haven't been posted, the button will be visible but disabled, with a tool tip explaining.
Also added an explanatory sentence to the 'report is not posted yet' box.
One test modified.

![tooltip on disabled button](https://user-images.githubusercontent.com/49137025/151738513-e83e1dbb-ff72-4e07-981f-8feba5b04e31.png)
