### PR TITLE
Update GitHub token formats

### DIFF
--- a/chef/data_bags/secrets/production.json
+++ b/chef/data_bags/secrets/production.json
@@ -1,135 +1,157 @@
 {
   "id": "production",
   "_password_comment": {
-    "encrypted_data": "Pb1lEx82JUO84tlPO/MOrEMcN4QbPW00j/NIL43efS581iEBDsNAnPrwJKnC\nirJO9M9enyMZ0si60Sqfkr6k3prxbOHDSMZmeQEp6PDP2TIY2+KKHgb0JaV3\nUoaQhabzxtK3MQuHNeYaznF/02vsBA==\n",
-    "iv": "QMSgv7TQ1W9s2li0RK7GAw==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "ZODGC4+BZK5VNTu3yhWINY743R60idCrTIximX08C/I+1noy9UZUuA1IvHef\nEXnA5PH8Pxg1p3G+ypGuPqxFklozL3tN41dc1T5CxvGIztiWyj3OrnY8Wba/\nHgOQNwtXvNnSPiBR\n",
+    "iv": "opn4muV1s8QV86wm\n",
+    "auth_tag": "NZK+2WVtJXsXpFjUWW7ujA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "cubing_password": {
-    "encrypted_data": "DSOXWA/GZUVn5TiYET/JPrHOvm+Pm7Ay+O/jj3Kxlj8O3eGdrDMB0y98kqsP\nC2yFmFJluR8XJVYvUqxF4ZB8BQ==\n",
-    "iv": "wiK2wICgB71gp8WTXNnRxg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "KPD8DE4F3/oI7Dl87+Pa87LmF/d9pUCP/hIZv/R6sXYGZreSbaBXvCZ1VN/f\nkjDiUIXX\n",
+    "iv": "ZgKSzu96BOdMc/uy\n",
+    "auth_tag": "Q1LJiSftABPMhyNA8r5mHQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "mysql_password": {
-    "encrypted_data": "yCl7yKPdgJ2K4/hJXyGDw+/A5i3mQUangPu6SIeEAwCBJOD022hXoEnL/jlH\nujobPPnNg7jQadFeejYUvvES1g==\n",
-    "iv": "08p9/8hQB6ZLimYqx9SKtA==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "mRaSBP46UEhoSKE/HgEA0cNaO4KveCiVC+mQ0uDZAmzGUVuJC438pqrUe297\nU2OzUi4=\n",
+    "iv": "fmZlGb1gfb7GbJIV\n",
+    "auth_tag": "TX162t9aavuhL8l+hNulAA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "secret_key_base_comment": {
-    "encrypted_data": "O+fO7RvgLyvMHHRUpBvHDf9OkUouVSd3bqXJdvkRfvTQApgb5z4yVXpzi4XI\n7TGV\n",
-    "iv": "R8Q/fJEB5d0Z60ot+OYDdw==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "93gsUTpiGHz6bhUKV8z8wUOmaJ7pq41phZrOo2HK8WWg6wEvwUlALr6OKV6B\nTcM=\n",
+    "iv": "y+qH6pj36pJZWeLd\n",
+    "auth_tag": "sCHTltYN+yOGeOWr/rUjyg==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "secret_key_base": {
-    "encrypted_data": "Y7DNo/W4QGwH05VDupF4JUfjF529axPaWIBhdv9mxALF1A65wKEql8bcbI+I\nJM8LbrFgwpmPC+XWjdLBNgx8NCPsJb8ExJQ+u7Uieer3KPv003pcyrcRWTJH\nwT/mUQsee+qRjeqARjHKThAhBwHzcR2f7TfVMj3fumCjMQ8wbP5h01Tl4my4\nFLpIHzcVvtF0y4KGSPZF2L9rh21fZ7vbqQ==\n",
-    "iv": "10OokT19UAWWC1DsVOjLqg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "/jiS45LSBA8CQRtrC0NQL+zrwBRpBf53lrt96tu740owL818ydmmd03T7r+U\n0XuBhkSCkG3aYbXg1tuiaoE9c6kAxaiIuVKGolhYSl+7aLQfAsjLSRwjyFpw\nASHRPNh/xik43Rnk+g8lN5TUlynegkCyD0pYNcZVXraqou9RhyFCh5TYoN0m\nV5r5OEBjalgsbLw1\n",
+    "iv": "EINokNIRd+5LrDgJ\n",
+    "auth_tag": "6Q51baSRiCZ/KSUqB0aSrQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "SMTP_USERNAME": {
-    "encrypted_data": "Xbre1coN3lwTwZa0Co8FdhnSnjmc40b9JEAcQbU3pNVQsdOCHn714AJDZDog\nbWMz\n",
-    "iv": "NP6HH6aCLUB5zY4qOW8BNg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "Eoa0yX5KkQFKpZbtNXUb4r/5fZd/HCLIkY6GHr3kCR8indHkbw+p\n",
+    "iv": "bmisfitaaYNdfO6a\n",
+    "auth_tag": "8yXv0AOhVux3NtN26wlWxQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "SMTP_PASSWORD": {
-    "encrypted_data": "b4+rePPbLAycjbk9rls8PcUmBnFguf7yM5l0BjO0PlabACAo4MDsMJWH/HrI\ndc8qm/2b2P0pYbZXrQN77ygcDw==\n",
-    "iv": "1ngidrYdyhRVd6RCur43vg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "LuTQzOaVDFh+OBAzVSVCQuGsqNeVoW9gpLoZp1JbKjwSnImhsua/x3TxPdch\nR5Zm9rTIBE/WUhShdeg0N7k9\n",
+    "iv": "WqExU290wjUEk4s7\n",
+    "auth_tag": "EcA0u8W4jqYKiL9KGL7D4A==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "RECAPTCHA_PUBLIC_KEY": {
-    "encrypted_data": "Y0/5+nE+GubAhs/6TLkQbs34UKkBfvD32eAhjScYsLflEOKDAFvFD8W6kyEu\nIKk7eZg1Sj8w5evVQYAPRZOvRw==\n",
-    "iv": "aO0qgBVHLEmRGf56ylW+6Q==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "1tGZ0fj/PHtCOfG/bMF95VXnPyfipKBZ3nT+s3RjGMsy7w/QGF5lgq8mh6rX\nY2dAvGE4bCegAyGoI7A=\n",
+    "iv": "RWm+EiQ5TqFjnd7V\n",
+    "auth_tag": "rEoyY/r5uUj0Bjr1bj4R6A==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "RECAPTCHA_PRIVATE_KEY": {
-    "encrypted_data": "5qH8vbTPgk0BhXuyyOL4/cv0BPobG5B+PkKpbl3tLEnAwISfPoz5Slyy4Tvp\n/C3pl8fl9ZAM7NknItfde+S6Zw==\n",
-    "iv": "QXVpKwZqBeSZ4YZ1nY2i2w==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "L1oUBtPaXnbo7dHhXgEuV+qZ0dvFm5QBYpqohNJdcsrH8EgES44uir77Yae0\ndArYj6sxi3HRZYOLjas=\n",
+    "iv": "3ZThOrLvhKKjnzwN\n",
+    "auth_tag": "ovTubUDyDYOPDdcn0UWtvA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "NEW_RELIC_LICENSE_KEY": {
-    "encrypted_data": "446mZvkt2gTgKSU7QfB9gLechulPf8ttIlb4yEf/5A23v9doVBpYIYqF2cdL\nm7K7iuSUwOEpF0QHZZ/8uc3meg==\n",
-    "iv": "IeQPLS1rO6INHvj3lmnemg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "fe3itIA5EyvlyChZqF6Vdsls1udP86R90vZMuU6SnzuAZKJ2SzrtF56XRny5\nfooGfhc00oWViEPdV2I=\n",
+    "iv": "A14WBj9BxWKSD4Z1\n",
+    "auth_tag": "Z3Iy8gQ8ZP/UCcLv35SlXA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GOOGLE_MAPS_API_KEY": {
-    "encrypted_data": "BEGt3x3b+EqmsOTn0HU0UNp/rFijXO8yJJPrK2GA50tAAveU2DrHqSmbgwwt\nmg+YcxZJ9VV39KRDGipuN9AM5Q==\n",
-    "iv": "M7gRncoEZtLyg5gnQQeOsQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "STUQmYIaCAimrevG/efBVZqnRULrCT1DQuYgqfIi18byF2jevS4mP0Fm8rEK\nAcSUECNSZxIBboC0Uw==\n",
+    "iv": "VIzxgwRgTKuk3SA1\n",
+    "auth_tag": "c8kJFfCKxhJcUQ7DFva2Vw==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_BACKUP_ACCESS_TOKEN": {
-    "encrypted_data": "n1VAIBnoPrF1DcRHlZQK+1aza9uEhbfzdBW7eX3hh2m9YhOMZaA/OytagsUQ\nBdhKuQnK9GReKAsFRwTFuF1Ang==\n",
-    "iv": "MZtrL9Aiyyd+HP7z0Q9E4g==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "fDykmXCpmZLcOGd/w/dippvcWliTIwxwKFaU4J6O8Ckn50Seu6I8RVkNCcIR\nVPmQpq0J6qBrF3gSt44=\n",
+    "iv": "KXuEPHxxukdQ5wU6\n",
+    "auth_tag": "wY17kzfAxpceJzSsSVUfWA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_CREATE_PR_ACCESS_TOKEN": {
-    "encrypted_data": "e/3kLHJyQKMY0YO7CleaEO5mNIEc6gMHncO5jmhin7tq4LfLOs8Ky7uKIzcs\nkGFz302xU/PbGRe+ktcmtoSXDg==\n",
-    "iv": "vlbbDwVDhC0/Q3FJC9ZRKA==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "/uqQQ8BtoO/v7cHN2InHb620AAXjwqg6Mv1JKQBbFqUplIFVSw3PP90ZNMDz\nRSGIK9HW+Q+QINlhK44=\n",
+    "iv": "QCT6p8d22zKvMNx+\n",
+    "auth_tag": "gbLXROlY8+a8/3+IUpWa0g==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_LIST_MEMBERS_ACCESS_TOKEN": {
-    "encrypted_data": "eYlU4WncnaO79V/xzIFRAWcqhk3R1aj2ysVPoYbWO5ky09eF+Gr64/VptWtV\n7v1vQFTQ7FMkl3ljGQOgXkjtTg==\n",
-    "iv": "U/oIotu43KDDGhLGd4k//g==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "NfGsdmqHKi4tAfyq4zxBOc7YqZzkfLyAhWtjn87Vhad19EiUpAoP5Viw1eZf\nfctCos7rP2hU+mqsxyc=\n",
+    "iv": "f9dvsjVNWC1lYG2+\n",
+    "auth_tag": "FTkV9aLcOnbYFT3Nj35m8A==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_READ_DEPLOY_REPOSITORY_TOKEN": {
-    "encrypted_data": "1IoM30gb7RiPuebIzM8aw/O9rQQEwHUtsP7ZwVRLh+vrnb+3mto5onFr1sjT\nLn3bhW4p6uaS4u9W9ONrtC1QHA==\n",
-    "iv": "Ps1/CYvKxVCyi+YkNdAKJg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "5IgWI+CXmeaeQglA7RaEMGbDWQ6SyPI5D33iJ/C194G5nYC6eiesJ0CIcDMv\nlk8dDASqed0FtNHw+jw=\n",
+    "iv": "NR2XL3yfb4zwCR1P\n",
+    "auth_tag": "ExZVl9tglSZo5yqv4cfP5g==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "STRIPE_API_KEY": {
-    "encrypted_data": "TQZfJM1XLEMy3amWs+4RvPbp0YGutnV98V8wPcEYe4LojLBT+v1Dn/zvw0g3\nv0iwn+435G9H9bqHMkouXTKIrg==\n",
-    "iv": "5mKBbfp5oU+gZJIQMNJ4dw==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "hzOgApO04lMVanZzxFPTCVwvGY46KXpyPciwKMHVvQSoh3XU7q9eGloqAf0E\nakkA6nmn\n",
+    "iv": "Uq35AoxR0vHHpU5B\n",
+    "auth_tag": "/LrVa2Lfq1onHyWxR11rGA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "STRIPE_CLIENT_ID": {
-    "encrypted_data": "CbljxGHEI8gFzNiUKlch+LJfVUOLWlyxIK6gaYnGqAFFelvhZG/aI7mDs4Xb\nhv5qtVvGhi58emlc5/XJF0amsA==\n",
-    "iv": "1dEYFFrMoWogmYztufJnbQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "/2tfDc8qZniyyYc1Frp2ZYu54g/NHAGKmmmBAVUcZAIFHbI/GOz17SWSOGEF\nCExSC9YNmdBj\n",
+    "iv": "DkK2p6omu4LH6O1N\n",
+    "auth_tag": "2WmAlYLtu/D4KTHtutc6Rg==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "STRIPE_PUBLISHABLE_KEY": {
-    "encrypted_data": "zWtblRjsOmTgXaVIYgOClGz8ujuedpvhZj+D+woQR6CHS9FSV5DsZC63ZDLa\nlzYZpY6TZosS51SoZG7H/dcmAQ==\n",
-    "iv": "mEasCuS+O2VWZMmTkRJd6g==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "tmYl0WIZgOJNiMz4J2kWdca2r69+Bjlj8hs6zPXC0OB0sIt1QNBB7qz1mB3x\nLyggMSgN\n",
+    "iv": "9YkEzWuG7LNSK5b8\n",
+    "auth_tag": "nB02S4tbnviDDYA/6ONwqA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "AWS_ACCESS_KEY_ID": {
-    "encrypted_data": "exixX0CHAl0WmOrcHgwjT9ywo9hWKF2hyvQ3KJd7oupxCIT7EtOmLNB/J08l\ncJf8\n",
-    "iv": "l+8p3kI4NXXFOcAS+2JRSA==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "8XVY8vobKH5XH0Q6mWRq9dPX3w2CFgrKj+t1LqKPR3p1cv4efP/2\n",
+    "iv": "11bARVM2OOt1/L6e\n",
+    "auth_tag": "AwClXBUoV6rnWxwxBgAEqA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "AWS_SECRET_ACCESS_KEY": {
-    "encrypted_data": "iaJgdfL/J8bUedOHRYRQCDGojAoVaq8xPBoIWnwErq7Qp5Qk/Sc2F9BNnOrM\nNv+NIFdHwGEt1gQlNX3TFAm44g==\n",
-    "iv": "UJHDIwneUMYD6WM56uB8HA==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "WVnETvovJ4g1siS2J8HQpeva5N20xFGIP/YZZf6S47fg2mTHnyIvaL74rMux\nZMgeB7gmFAQPDZt9wbQ=\n",
+    "iv": "zMpfa8auFi7kZLPf\n",
+    "auth_tag": "DNClO5gpM7QZWo8eXKL8pw==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "OTP_ENCRYPTION_KEY": {
-    "encrypted_data": "QJGVSXDEIkl8AHzFJSJvPbo/kGO6tdwkjR5VvApUo4MeJkPOd/xKp1BjWgub\nOadm77xcSv1Bx/d74R4qMBvDR/kgFXn98nBuORVMXwrBq+QVnmOPQ7r2qjPA\ncy8TX9wrz/GvIkRhh3s4M22JFWoFleuR9SO/0i5TQS0wDqJ7k+2aWY3gKnzE\nCfq9MliptWIlKtoleL3xzMdErsKhoB2mSg==\n",
-    "iv": "RvLXDDfa2+ndt1iT9nAAoA==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "I3kh2rQ4vJdUJe24ySuYXKOT0tnhG9nM23me4VBiohRqXFXa8kGQsDMeDkdA\nleMGBOVcrosq7/d0p6adWpI8ON8olLlaxDj9JGUrd2cwlRa+0tJz6sxwTQon\nIsE0l2lsZBnsYmA+nqZ0U3RlNT9TNmM9CEH+W0+Mz8bZG2xLSIrjYgtVBbno\nXHYCeVmfIziGOews\n",
+    "iv": "FIV9OTl/TvsEUQZ5\n",
+    "auth_tag": "W+LXoImGeHSjaJcnEXCaoQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "DISCOURSE_SECRET": {
-    "encrypted_data": "QKnNX8hSWa3XFM5GVw11clHAThqtLVtT/T0u5i07g4/12sXmOwmLbc/aM69U\nufNHaVwh9wBuKz/4+MSaBzOFzqaMaTkZTyId0FeM9e1bLcqcxhkTS9oFITzN\ndllum5TzUtmAM3fjAFY11+jZbEQ1yarSt0HjRnUH/Wzn4FdIFz21Ef8FzmgW\n/wu78X0JMGNBitwCc3Am758x/fMZXw2Mag==\n",
-    "iv": "pSuFjIaFcV0zU1+uRPNFYQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "t2lZv7JUEOSiReePN9zJ+lP0zUE2+q8omS44dY81p3/EaKGNzpRpcHCn+ZOu\nyyyKdE4jEkgL9/jlpTOJE1U8ajFkFdFdfZPKrap+z9TK4CQOefGVN0VZPYl1\nlyvCsyK6OiCf2b1xHyzdPABfNRbLheCSzl/KuQE9Z9ksagL1oeS8DUtY4cdg\n6xSXZLS6+Ylzzz6L\n",
+    "iv": "ZlgwjMVMztQUoCDm\n",
+    "auth_tag": "+otfftT/4+3fhtPblV94Mw==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   }
 }

--- a/chef/data_bags/secrets/staging.json
+++ b/chef/data_bags/secrets/staging.json
@@ -1,123 +1,143 @@
 {
   "id": "staging",
   "_password_comment": {
-    "encrypted_data": "Q21GxBLbv3jhN9W6GBC0Vo/F9H3FZMisJ6I1O7xBquBwHzLAd6WyrUixJy0W\noxf/PB1H/Dgik5+hABWU16/a6QWA8w4nNkxjRP2v6Cuy3VlumsHAubSOOAwJ\nqFK3UNXVy9ydx3kuuvBxDV8qPo7N5w==\n",
-    "iv": "4ONTlrovucVLWbri33sFog==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "owSBWGUykV/V6Yl5XZAIzQ76qNGpeos1KUoUl0d5o1ytmORJptYh7Tr9yh7h\nhY+bx4sD4BI+A6tDRVKMeOHxkjHdX2A9S46sQG3g2tndNJQxWm65JxPL4tZh\nP3VRd7xLqL49w4wI\n",
+    "iv": "0bpvr/miUh2CmcO+\n",
+    "auth_tag": "ggur5e9xdLwKNizcYP5dgQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "cubing_password": {
-    "encrypted_data": "Fgk5CiDCHrZp8JzpA6egDRJg2p1d50NNj/2LrS9UCRtPxGtPzHS7wmQrkAqo\nHd7HxagnTKnaBOF2rsyP09h0jA==\n",
-    "iv": "rmhrf5SpxBlQ43QZvu/P6g==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "tOKqkCLMMONt9PwlWqOZPDhg2rgRCAj86FNHL68PQF6b7HoHJ68jm+sq32VJ\nVcK8QRRNkW4w\n",
+    "iv": "A04o8fRaL0H7mmYI\n",
+    "auth_tag": "m/iUlc12dgkVqTFP0D4E/g==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "mysql_password": {
-    "encrypted_data": "wwlE/fJtvAHDUkHHfhe/E25GJZjH1mSPPgjpR2dzDhXKwiwnqz1CTqflTg29\nC85HHnYMCjDxBxuRIxQ4pk4PkQ==\n",
-    "iv": "1mWz6eL9nyBW0IghcDSPwQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "sTgwktkx9P6OuxiEr1OG2gXEpoDnJuGxbuGw1fBS4Ngu/fAy28TRQEuE9Z0R\n6bzXZ+jNGyfwPw==\n",
+    "iv": "pCB8aBoF2Lx39OY0\n",
+    "auth_tag": "hSbFRxXrB7Q0vAuCZ1nscw==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "secret_key_base_comment": {
-    "encrypted_data": "yw/KksGyorDjsUD6BiwlFQ08bB81mbSmMr3tSq04YyGWgb5vPwjXP8dZTn1p\ng8E/\n",
-    "iv": "jbcHp0l2Svx752kDgGHHJQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "PIw6ocQgbUCRrzGhwhp6xhcHOEp1btfxRG9Ji6YSQHZsOAm3Cj5P5b8GNuOs\ng74=\n",
+    "iv": "KRbjjtIeahsCRMxB\n",
+    "auth_tag": "UMNiAvTdhaYAsWy21DIEyg==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "secret_key_base": {
-    "encrypted_data": "DsCL8UsefxM2REbkMoQkPDPwoju6H7mofwyfisuULpgYYmhBLX5EEY7pmGxK\n/wkGJHzpT0FwckvLj867OXDvJn+QXhmA0/yJW/jgPJ8uxm7w1AJksEE3QIop\nq1O/3JGhffYDlewyym0AwLb68H7E1RfF6gtNxZlR1dOaXF4imeVumUGd7Cd6\nheN7e7mYKw8LKEApHYd3T70rOv2dH5+HLw==\n",
-    "iv": "FluJJYdQ8z1a7Ux6I1jA7A==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "KQPdq84oEW286G2150txThUEOPsaqYStN/koIsodnaO+ZRAT84qowG7sWIW3\nXtE5nkJtGVgi22+oKpYW0H8oK3K64maBVH3fTkCUieJOUGrCjOQANWuoo9oW\nqA0u1DD7a9R2TwWWvrr+S+pNZDmdPOpmFwhzR0J9E2VnHhNrq9gy3xVMhxuD\nAQmsOvw7fJjQJvEg\n",
+    "iv": "QjAmThFNIdiDjgBw\n",
+    "auth_tag": "rXFoXMiaEq3mbm4FDJO07Q==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "SMTP_USERNAME": {
-    "encrypted_data": "Of0eZup+d7ImmmkVIhjfieOMYyUprBsXNSwi/qErSME=\n",
-    "iv": "Jy4pHaNCqwij/EqglnX87w==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "qDlm+5LUvPQ7Udc3OUrfFEw3MQ==\n",
+    "iv": "N78/xbeoh1jWWj/N\n",
+    "auth_tag": "ER2lrFXaY66J16DIbKTWGA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "SMTP_PASSWORD": {
-    "encrypted_data": "CHCeBnUVWHfNCamelgpdA8y1hotnm+E5lRCLOLnl/84=\n",
-    "iv": "V1bP+P6IljWkOclk3WXCtQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "j+26E23UKsJL6eAREKuJGDwMjw==\n",
+    "iv": "73gEFVpLl2mYOdUV\n",
+    "auth_tag": "7lWI0/gYdF5ZZyUadPQReQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "RECAPTCHA_PUBLIC_KEY": {
-    "encrypted_data": "3AXCFziJs9t4/u6D4EvWEBKjyMz4FmC3iIZ9qDFiQ1imEdtesbhpofW7azSG\nSh8G1iYSZ5ZwLs15Xxd0kPqljQ==\n",
-    "iv": "nbeEegnO3Ml3aY5ajkV50g==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "F/rNzNg29fPHcGOh1vnNveqqjjCb5gy8VvAsQy0ht8HNEsukJNrTPT5nKQeN\nFjKxEQTIVYC2duNMExg=\n",
+    "iv": "odWA+kfUO3gADEJS\n",
+    "auth_tag": "6GPF8yl/aUDOOX5nTv5fBg==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "RECAPTCHA_PRIVATE_KEY": {
-    "encrypted_data": "Uwug9wEnPsmguMgimuzDGyhDegnm5t87Xx6fUYzNkxsjRBZIjP2Ukh2mvfzq\nYSbCLW0f3H2PN5PLCDLqtFSd0g==\n",
-    "iv": "3jkC0xgD2Rd+t0azrdMt/w==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "kIAiUHH7f3NlnZQKf0h26fz2OWKBPtCvoQ08KdmN+ST8cQ895MyA106MhsXd\ny/04NCvyxDIgYDpCPHY=\n",
+    "iv": "1FRNrGc/EJDthkH1\n",
+    "auth_tag": "WNFvXRTa63oc1H7d/VFP8Q==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "NEW_RELIC_LICENSE_KEY": {
-    "encrypted_data": "U1CA1IrH/YBF+JsRJeQY4NaBCq2lHc+h/ObX5ByNlLwHCXwuz2lS/mXuSD8p\nonQFr2xiQhxQwaNUZ07hmDrhqw==\n",
-    "iv": "3OgIwhXPQboBYezI98K8tw==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "sy6WtAgY+7RNR8ERkmeULv66tw8+T5fHGN9DfiYmoWpycpiqCAShc6TX+uSV\nwNhhFREXwIhF7W7nM6w=\n",
+    "iv": "FpQWVzBl6DCGYTl5\n",
+    "auth_tag": "w3j4c6dlhA/K4uo99ruSSg==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GOOGLE_MAPS_API_KEY": {
-    "encrypted_data": "4CJ4hXo39RIFSFHYtY4gC2gIkSMbS37yHVNxJBeKmunIzixoDWLxx44YidsC\nqCgedsYki3NTVPvhpiaJekvJdQ==\n",
-    "iv": "JdFpLOfU/q4vZl7/WDY3/A==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "0BEdBV1ZHUzWZDB95MjJw7H3KltQo5zP7LJqmV36EfAf/eNXjiqqDZrnL3yu\nXbEIAkzy2SD1BNzPhg==\n",
+    "iv": "ZWI8Ann9TyUXHCqr\n",
+    "auth_tag": "NFAiSEpXb+vBV5QEYsEdFw==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_BACKUP_ACCESS_TOKEN": {
-    "encrypted_data": "V5H9+uoQwsyAI7Uor/VzgRHRV5glSFZLQc1bFXzVo0Q=\n",
-    "iv": "mvfzsw0STcyYpqKyB70X5A==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "WcaOmXB2oGLAXlkNRO+gsEmjxg==\n",
+    "iv": "plf4tEPJfOFpaz3p\n",
+    "auth_tag": "UUqsvs6O14igHIGk1FD/Zw==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_CREATE_PR_ACCESS_TOKEN": {
-    "encrypted_data": "fw8y5vjQHNT/5QHx+iqDzme3Cm0hO68LgRagKaN8H2Q=\n",
-    "iv": "tyDnqTFPnXIFgFAsy2EqGg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "Oxpy0Brd+JwtI+5SrN9IuSYYIQ==\n",
+    "iv": "gpMUh/OpMzxRXvja\n",
+    "auth_tag": "5624NkNa7ROwcfuQY3DpJQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_LIST_MEMBERS_ACCESS_TOKEN": {
-    "encrypted_data": "VulNvKtbtA01SfoAUSE1smXcH0eQLdbrnA6KXZU3MdFuqw5FQDAxCWEWw9sS\n2WdRZC+KMYQIWAznZ4nrnCbAWA==\n",
-    "iv": "LKScCJz4iEI1ugvTfyCqhQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "zU63t2L9QpsHq11uxkxzKaaUFKnS76O+GyvYFw3Ngyv0OROVBLkoIEjFOCz3\nv2EzMMX/bmLjTd7uozg=\n",
+    "iv": "X5D6QQ8gejwM+GA6\n",
+    "auth_tag": "3qBFhRRSOKvwY5ryFsGC8w==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "GITHUB_READ_DEPLOY_REPOSITORY_TOKEN": {
-    "encrypted_data": "52qif3jNLUjMZxuK39sy2rul0abBzwtZcZbv3uOg93RLjVr55fj41tWiwUw5\nmCRBYhVWFHIoiK8rNcq1IZUGAg==\n",
-    "iv": "Z0RV3eIEQgegX2mTFxpNTw==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "6KHSGixuR6i7Ubuf84XS55spyEjD2MmzfEiYnEDd4vQUP6a7n29FWdqrMJCz\nKVlIm8QXiqecoF1eLF0=\n",
+    "iv": "J6ndZOtN7oQ2q8vb\n",
+    "auth_tag": "RM6Slve+8ZUhFXS96VpcoA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "STRIPE_API_KEY": {
-    "encrypted_data": "dc3qlSveWoa1oJN1TqC8PannTEVaOKCo38CC3LmLpco=\n",
-    "iv": "zExjkaEVC36kV5HX1Xwv2Q==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "ePZcOwGbeB9Bra86CzNRq/29hw==\n",
+    "iv": "mmBhCM+fVZOxDlQf\n",
+    "auth_tag": "4m9sYRp8ccI5d1AwF7uz2g==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "STRIPE_CLIENT_ID": {
-    "encrypted_data": "3doox1ray2TWHS0PR5oQEBjPXlX2lHpqMd9Mg4wjPho=\n",
-    "iv": "Jv/XoPQOazwdawwnLSgSjg==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "8VOIBMoN3pQZOGRvfsOpMST0Mg==\n",
+    "iv": "4tuw/NhLkT7sMTVD\n",
+    "auth_tag": "r4CQxl6ms4Hm1cLfCTNl4w==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "STRIPE_PUBLISHABLE_KEY": {
-    "encrypted_data": "wXpmVRu8BYLxdTA20E+PLZcJH2XTZ3TnzHYG5WywXZk=\n",
-    "iv": "fsgUKQpZAPV6uWPG7Q51hQ==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "jTOAzWhb/C8MvwNsAvcg9ycKbQ==\n",
+    "iv": "GPvosATY4+cB6bh/\n",
+    "auth_tag": "IWOwe5oHLVNAcEXpI4P/0A==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "AWS_ACCESS_KEY_ID": {
-    "encrypted_data": "vCF2cM5OhQ7XMw6IV/UCEXQpcNxgGwu/I45KlQMmx2aVpmF53Z1zfCJ1tRSU\n6xIc\n",
-    "iv": "dnO68n50Dh7dtB/nOZBjTA==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "6zgCa7PEUrnKBUBFbxqKQgmjKco5+dLW+UJuVWoYhTfPkGaGDloB\n",
+    "iv": "By9ry19Dzzp+bHvm\n",
+    "auth_tag": "xLvRX3nzTR5Pt38GFAyoDA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   },
   "AWS_SECRET_ACCESS_KEY": {
-    "encrypted_data": "SbTnrI+7D5OHhQ76RB1yWv9yHjhgCYs7Lp1h6nl3mgWpecw5Jvz3WIe0ijSz\nUSPxG+gntAMeBlFFNM95D7Mi0g==\n",
-    "iv": "OpZcxwxulyGQyT/HpOGZEA==\n",
-    "version": 1,
-    "cipher": "aes-256-cbc"
+    "encrypted_data": "lllk2M9+3UT5KqAUiqzpS7RbPGAD6G10qlg49idvziIZd4kE08alUHtUMogb\nSNaUhNnhDzZnnJOYAyw=\n",
+    "iv": "fYO0mK5O04vi522f\n",
+    "auth_tag": "jI9+VasG73U5USCyL75kDQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   }
 }


### PR DESCRIPTION
Diff looks like all secrets were updated because the newer Chef versions use a slightly newer encryption algorithm