### PR TITLE
Move Avatars storage to Amazon S3

### DIFF
--- a/WcaOnRails/.env.development
+++ b/WcaOnRails/.env.development
@@ -8,3 +8,6 @@ STRIPE_CLIENT_ID=ca_A2YDwmyOll0aORNYiOA41dzEWn4xIDS2
 OTP_ENCRYPTION_KEY=abcdefghijklmnopqrstuvwxyz1234567890
 DISCOURSE_SECRET=myawesomesharedsecret
 DISCOURSE_URL=https://forum.worldcubeassociation.org
+S3_AVATARS_BUCKET=wca-avatar
+S3_AVATARS_ASSET_HOST=https://avatars.worldcubeassociation.org
+S3_AVATARS_REGION=us-west-2

--- a/WcaOnRails/.env.test
+++ b/WcaOnRails/.env.test
@@ -8,3 +8,6 @@ STRIPE_CLIENT_ID=ca_A2YDwmyOll0aORNYiOA41dzEWn4xIDS2
 OTP_ENCRYPTION_KEY=abcdefghijklmnopqrstuvwxyz1234567890
 DISCOURSE_SECRET=myawesomesharedsecret
 DISCOURSE_URL=https://forum.worldcubeassociation.org
+S3_AVATARS_BUCKET=wca-avatar
+S3_AVATARS_ASSET_HOST=https://avatars.worldcubeassociation.org
+S3_AVATARS_REGION=us-west-2

--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -55,6 +55,8 @@ gem 'selectize-rails', github: 'jfly/selectize-rails'
 gem 'high_voltage'
 gem 'carrierwave'
 gem 'carrierwave-aws'
+gem 'aws-sdk-s3'
+gem 'aws-sdk-cloudfront'
 
 # Pointing to thewca/carrierwave-crop which has a workaround for
 #  https://github.com/kirtithorat/carrierwave-crop/issues/17
@@ -134,5 +136,4 @@ end
 group :production do
   gem 'unicorn'
   gem 'newrelic_rpm'
-  gem 'aws-sdk-s3', require: false
 end

--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -54,6 +54,7 @@ gem 'selectize-rails', github: 'jfly/selectize-rails'
 
 gem 'high_voltage'
 gem 'carrierwave'
+gem 'carrierwave-aws'
 
 # Pointing to thewca/carrierwave-crop which has a workaround for
 #  https://github.com/kirtithorat/carrierwave-crop/issues/17

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
       execjs
     aws-eventstream (1.2.0)
     aws-partitions (1.553.0)
+    aws-sdk-cloudfront (1.60.0)
+      aws-sdk-core (~> 3, >= 3.122.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-core (3.126.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -683,6 +686,7 @@ DEPENDENCIES
   activestorage-validator
   api-pagination
   apparition
+  aws-sdk-cloudfront
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -176,6 +176,9 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    carrierwave-aws (1.5.0)
+      aws-sdk-s3 (~> 1.0)
+      carrierwave (~> 2.0)
     childprocess (4.0.0)
     chunky_png (1.4.0)
     cldr-plurals-runtime-rb (1.1.0)
@@ -691,6 +694,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   carrierwave
+  carrierwave-aws
   carrierwave-crop!
   cocoon
   cookies_eu

--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -42,10 +42,6 @@ module ApplicationHelper
     competition_url(comp, anchor: "competition-schedule")
   end
 
-  def filename_to_url(filename)
-    "/" + Pathname.new(File.absolute_path(filename)).relative_path_from(Rails.public_path).to_path
-  end
-
   def anchorable(pretty_text, id = nil)
     id ||= pretty_text.parameterize
     "<span id='#{id}' class='anchorable'><a href='##{id}'><span class='glyphicon glyphicon-link'></span></a> #{pretty_text}</span>".html_safe

--- a/WcaOnRails/app/uploaders/avatar_uploader.rb
+++ b/WcaOnRails/app/uploaders/avatar_uploader.rb
@@ -5,5 +5,11 @@ class AvatarUploader < AvatarUploaderBase
   version :thumb do
     process crop: :avatar
     process resize_and_pad: [100, 100]
+
+    # override `store!` method from CarrierWave
+    def store!(new_file = nil)
+      super new_file
+      invalidate_cdn_cache "thumbnail-crop-#{Time.now.to_i}"
+    end
   end
 end

--- a/WcaOnRails/app/uploaders/avatar_uploader_base.rb
+++ b/WcaOnRails/app/uploaders/avatar_uploader_base.rb
@@ -1,7 +1,37 @@
 # frozen_string_literal: true
 
+require 'aws-sdk-cloudfront'
+
 class AvatarUploaderBase < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
+
+  def self.connection_cache
+    @connection_cache ||= {}
+  end
+
+  def cloudfront_sdk
+    @cloudfront_sdk ||= begin
+      conn_cache = self.class.connection_cache
+      conn_cache[storage.credentials] ||= ::Aws::CloudFront::Client.new(*storage.credentials)
+    end
+  end
+
+  def invalidate_cdn_cache(reference)
+    if EnvVars.CDN_AVATARS_DISTRIBUTION_ID.present?
+      # the hash keys and structure are per Amazon AWS' documentation
+      # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/CloudFront/Client.html#create_invalidation-instance_method
+      cloudfront_sdk.create_invalidation({
+                                           distribution_id: EnvVars.CDN_AVATARS_DISTRIBUTION_ID,
+                                           invalidation_batch: {
+                                             paths: {
+                                               quantity: 1,
+                                               items: ["/#{store_path}"], # AWS SDK throws an error if the path doesn't start with "/"
+                                             },
+                                             caller_reference: reference,
+                                           },
+                                         })
+    end
+  end
 
   # Copied from https://makandracards.com/makandra/12323-carrierwave-auto-rotate-tagged-jpegs.
   process :auto_orient

--- a/WcaOnRails/app/uploaders/avatar_uploader_base.rb
+++ b/WcaOnRails/app/uploaders/avatar_uploader_base.rb
@@ -16,8 +16,7 @@ class AvatarUploaderBase < CarrierWave::Uploader::Base
   end
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  storage :aws
 
   configure do |config|
     config.remove_previously_stored_files_after_update = false

--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -52,7 +52,7 @@
               </div>
 
               <div class="col-sm-6">
-                <% carousel_avatars = user.old_avatar_filenames.reverse.map { |filename| filename_to_url(filename) } %>
+                <% carousel_avatars = user.old_avatar_files.reverse.map { |file| file.public_url } %>
                 <% if user.avatar? %>
                   <% carousel_avatars.unshift(user.avatar.url) %>
                 <% end %>

--- a/WcaOnRails/app/views/users/edit_avatar_thumbnail.html.erb
+++ b/WcaOnRails/app/views/users/edit_avatar_thumbnail.html.erb
@@ -8,6 +8,11 @@
 <% provide(:title, (pending_avatar ? "Pending " : "") + "Avatar Thumbnail | #{@user.name}") %>
 
 <div class="container">
+  <%= alert :warning do %>
+    <%= t '.cdn_explanation' %>
+    <br>
+    <b><%= t '.cdn_warning' %></b>
+  <% end %>
   <%= simple_form_for @user, html: { class: 'are-you-sure' } do |f| %>
     <div class="row">
       <div class="col-md-6">

--- a/WcaOnRails/config/initializers/carrierwave.rb
+++ b/WcaOnRails/config/initializers/carrierwave.rb
@@ -1,11 +1,28 @@
 # frozen_string_literal: true
 
 CarrierWave.configure do |config|
-  config.storage = :file
+  config.storage = :aws
 
-  config.asset_host = EnvVars.ROOT_URL
+  config.asset_host = EnvVars.S3_AVATARS_ASSET_HOST
 
   if Rails.env.test? || Rails.env.cucumber?
     config.enable_processing = false
   end
+
+  config.aws_bucket = EnvVars.S3_AVATARS_BUCKET
+  config.aws_acl = 'public-read'
+
+  aws_credentials = {
+    region: EnvVars.S3_AVATARS_REGION,
+    stub_responses: Rails.env.test?, # Optional, avoid hitting S3 actual during tests
+  }
+
+  # only development needs explicit credentials to access AWS.
+  # in production, access is derived implicitly through the IAM role of the machine
+  if Rails.env.development?
+    aws_credentials['access_key_id'] = EnvVars.AWS_ACCESS_KEY_ID
+    aws_credentials['secret_access_key'] = EnvVars.AWS_SECRET_ACCESS_KEY
+  end
+
+  config.aws_credentials = aws_credentials
 end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -945,6 +945,8 @@ en:
       submit_value: "Claim WCA ID"
     #context: related to editing the avatar thumbnail
     edit_avatar_thumbnail:
+      cdn_explanation: "All avatar images are stored in the Cloud, so any changes to the thumbnail can take several minutes to be displayed correctly."
+      cdn_warning: "Please do not be confused if your thumbnail does not immediately update after saving!"
       current: "Current thumbnail:"
       new: "New thumbnail:"
       save: "Save"

--- a/WcaOnRails/env_vars.rb
+++ b/WcaOnRails/env_vars.rb
@@ -10,6 +10,9 @@ EnvVars = Env::Vars.new do
 
   if Rails.env.development?
     mandatory :DISABLE_BULLET, :bool
+
+    optional :AWS_ACCESS_KEY_ID, :string, ''
+    optional :AWS_SECRET_ACCESS_KEY, :string, ''
   end
 
   # Set WCA_LIVE_SITE to enable Google Analytics
@@ -45,4 +48,7 @@ EnvVars = Env::Vars.new do
   mandatory :OTP_ENCRYPTION_KEY, :string
   mandatory :DISCOURSE_SECRET, :string
   mandatory :DISCOURSE_URL, :string
+  mandatory :S3_AVATARS_BUCKET, :string
+  mandatory :S3_AVATARS_ASSET_HOST, :string
+  mandatory :S3_AVATARS_REGION, :string
 end

--- a/WcaOnRails/env_vars.rb
+++ b/WcaOnRails/env_vars.rb
@@ -39,6 +39,7 @@ EnvVars = Env::Vars.new do
   optional :RECAPTCHA_PUBLIC_KEY, :string, ''
   optional :RECAPTCHA_PRIVATE_KEY, :string, ''
   optional :NEW_RELIC_LICENSE_KEY, :string, ''
+  optional :CDN_AVATARS_DISTRIBUTION_ID, :string, ''
 
   mandatory :GOOGLE_MAPS_API_KEY, :string
   mandatory :GITHUB_CREATE_PR_ACCESS_TOKEN, :string

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe User, type: :model do
         avatar_crop_h: 40,
       )
       avatar = dummy_user.reload.read_attribute(:avatar)
-      expect(File).to exist("public/uploads/user/avatar/#{dummy_user.wca_id}/#{avatar}")
+      expect(dummy_user.avatar.file.path).to eq("uploads/user/avatar/#{dummy_user.wca_id}/#{avatar}")
 
       # Assigning a WCA ID to user should copy over the name from the Persons table.
       expect(user.name).to eq user.person.name
@@ -240,7 +240,7 @@ RSpec.describe User, type: :model do
       # Check that the dummy account was deleted, and we inherited its avatar.
       expect(User.find_by_id(dummy_user.id)).to be_nil
       expect(user.reload.read_attribute(:avatar)).to eq avatar
-      expect(File).to exist("public/uploads/user/avatar/#{dummy_user.wca_id}/#{avatar}")
+      expect(dummy_user.avatar.file.path).to eq("uploads/user/avatar/#{dummy_user.wca_id}/#{avatar}")
     end
 
     it "does not allow duplicate WCA IDs" do

--- a/chef/data_bags/secrets/production.json
+++ b/chef/data_bags/secrets/production.json
@@ -153,5 +153,12 @@
     "auth_tag": "+otfftT/4+3fhtPblV94Mw==\n",
     "version": 3,
     "cipher": "aes-256-gcm"
+  },
+  "CDN_AVATARS_DISTRIBUTION_ID": {
+    "encrypted_data": "NDrUDrf+pJU2VAu/V7MDCXBlraQPs8tDPlyohF9rfQ==\n",
+    "iv": "MdqiiRzgeA/TmSFT\n",
+    "auth_tag": "ML/5ZlRWhjn5Zpr1BSjQxA==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   }
 }

--- a/chef/data_bags/secrets/staging.json
+++ b/chef/data_bags/secrets/staging.json
@@ -139,5 +139,12 @@
     "auth_tag": "jI9+VasG73U5USCyL75kDQ==\n",
     "version": 3,
     "cipher": "aes-256-gcm"
+  },
+  "CDN_AVATARS_DISTRIBUTION_ID": {
+    "encrypted_data": "FCv/PamIGFqG8q0Q+DMxLR/C1DlhXEGMBkL3CZPpdQ==\n",
+    "iv": "1PwJTNf9FHJML8RU\n",
+    "auth_tag": "j3vlg5t7uanNoNvX8vEK/g==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   }
 }

--- a/chef/site-cookbooks/wca/templates/env.production.erb
+++ b/chef/site-cookbooks/wca/templates/env.production.erb
@@ -68,3 +68,31 @@ DISCOURSE_URL=<%=
     "production" => "https://forum.worldcubeassociation.org",
   }[node.chef_environment]
 %>
+S3_AVATARS_BUCKET=<%=
+  {
+    "development" => "",
+    "staging" => "wca-avatar",
+    "production" => "wca-avatar",
+  }[node.chef_environment]
+%>
+S3_AVATARS_ASSET_HOST=<%=
+  {
+    "development" => "",
+    "staging" => "https://avatars.worldcubeassociation.org",
+    "production" => "https://avatars.worldcubeassociation.org",
+  }[node.chef_environment]
+%>
+S3_AVATARS_REGION=<%=
+  {
+    "development" => "",
+    "staging" => "us-west-2",
+    "production" => "us-west-2",
+  }[node.chef_environment]
+%>
+CDN_AVATARS_DISTRIBUTION_ID=<%=
+  {
+    "development" => "",
+    "staging" => @secrets['CDN_AVATARS_DISTRIBUTION_ID'],
+    "production" => @secrets['CDN_AVATARS_DISTRIBUTION_ID'],
+  }[node.chef_environment]
+%>


### PR DESCRIPTION
Up until now, user uploaded Avatars were stored in the `secrets` folder on the hard disk of our server. This continues to cause problems because (a) it costs more than S3 storage and (b) it takes ~25 minutes to spin up a new server because we have to sync over several GB worth of picture data.

By storing the Avatars on S3 and caching them via a CloudFront CDN we hope to save costs and we are also a big step closer to enabling multiple server instances with load balancing <3