### PR TITLE
Improve notifications for WCAT

### DIFF
--- a/WcaOnRails/app/helpers/notifications_helper.rb
+++ b/WcaOnRails/app/helpers/notifications_helper.rb
@@ -11,7 +11,7 @@ module NotificationsHelper
       #                                           so people cannot change old competitions.
       Competition.confirmed.not_visible.each do |competition|
         notifications << {
-          text: "#{competition.name} is waiting to be announced",
+          text: "#{competition.name} is pending announcement. The competition is happening in #{competition.days_until} days.",
           url: admin_edit_competition_path(competition),
         }
       end

--- a/WcaOnRails/spec/helpers/notifications_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/notifications_helper_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe NotificationsHelper do
         notifications = helper.notifications_for_user(wcat_member)
         expect(notifications).to eq [
           {
-            text: "#{confirmed_competition.name} is pending announcement. The competition is happening in #{competition.days_until} days.",
+            text: "#{confirmed_competition.name} is pending announcement. The competition is happening in #{confirmed_competition.days_until} days.",
             url: admin_edit_competition_path(confirmed_competition),
           },
           {

--- a/WcaOnRails/spec/helpers/notifications_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/notifications_helper_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe NotificationsHelper do
         notifications = helper.notifications_for_user(wcat_member)
         expect(notifications).to eq [
           {
-            text: "#{competition.name} is pending announcement. The competition is happening in #{competition.days_until} days.",
+            text: "#{confirmed_competition.name} is pending announcement. The competition is happening in #{competition.days_until} days.",
             url: admin_edit_competition_path(confirmed_competition),
           },
           {

--- a/WcaOnRails/spec/helpers/notifications_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/notifications_helper_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe NotificationsHelper do
         notifications = helper.notifications_for_user(wcat_member)
         expect(notifications).to eq [
           {
-            text: "#{confirmed_competition.name} is waiting to be announced",
+            text: "#{competition.name} is pending announcement. The competition is happening in #{competition.days_until} days.",
             url: admin_edit_competition_path(confirmed_competition),
           },
           {


### PR DESCRIPTION
Include the amount of days until the competition, so WCAT can more easily see if there is a competition close to announcement deadline.