### PR TITLE
Bump Chef versions to enable Tarsnap again

### DIFF
--- a/chef/site-cookbooks/tarsnap/attributes/default.rb
+++ b/chef/site-cookbooks/tarsnap/attributes/default.rb
@@ -16,8 +16,8 @@
 
 
 # source install options
-default['tarsnap']['version'] = "1.0.39" # gregorbg
-default['tarsnap']['sha256'] = "5613218b2a1060c730b6c4a14c2b34ce33898dd19b38fb9ea0858c5517e42082" # gregorbg
+default['tarsnap']['version'] = "1.0.40" # gregorbg
+default['tarsnap']['sha256'] = "bccae5380c1c1d6be25dccfb7c2eaa8364ba3401aafaee61e3c5574203c27fd5" # gregorbg
 
 # tarsnap options
 default['tarsnap']['bin_path'] = '/usr/local/bin'

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -385,6 +385,7 @@ apt_repository 'legacy-php' do
   uri 'ppa:ondrej/php'
 end
 package 'php5.6-cli'
+package 'php5.6-mbstring' # gregorbg necessary for results posting when competitors have non-ASCII names
 node.default['php-fpm']['skip_repository_install'] = true
 node.default['php-fpm']['package_name'] = 'php5.6-fpm'
 node.default['php-fpm']['conf_dir'] = '/etc/php/5.6/fpm/conf.d'

--- a/scripts/wca-bootstrap.sh
+++ b/scripts/wca-bootstrap.sh
@@ -84,8 +84,8 @@ if [ "$environment" != "development" ]; then
 fi
 
 # Install chef client
-if ! command -v chef-solo &> /dev/null || ! chef-solo --version | grep 16.13.16 &> /dev/null; then
-  curl -Ls https://omnitruck.chef.io/install.sh | bash -s -- -v 16.13.16
+if ! command -v chef-solo &> /dev/null || ! chef-solo --version | grep 16.17.39 &> /dev/null; then
+  curl -Ls https://omnitruck.chef.io/install.sh | bash -s -- -v 16.17.39
   /opt/chef/embedded/bin/gem install berkshelf -v "7.2.2"
 fi
 


### PR DESCRIPTION
Kinda useful having access to our old backups... :'D
Plus bonus PHP installation for WRT, didn't want to open a separate PR for that now that we desperately need to deploy tonight