### PR TITLE
Fix name warnings for numbers

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -384,7 +384,7 @@ class Competition < ApplicationRecord
         warnings[:name] = I18n.t('competitions.messages.name_too_long')
       end
 
-      unless /^[[:upper:]]/.match(self.id)
+      unless /^[[:upper:]]|^\d/.match(self.id)
         warnings[:id] = I18n.t('competitions.messages.id_starts_with_lowercase')
       end
 

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -431,6 +431,12 @@ RSpec.describe Competition do
       expect(competition.warnings_for(nil)[:id]).to eq I18n.t('competitions.messages.id_starts_with_lowercase')
     end
 
+    it "do not warn if competition id starts with a number" do
+      competition = FactoryBot.build :competition, id: "1stNumberedComp2021"
+      expect(competition).to be_valid
+      expect(competition.warnings_for(nil)[:id]).to eq nil
+    end
+
     it "warns if advancement condition isn't present for a non final round" do
       FactoryBot.create :round, competition: competition, event_id: "333", number: 1
       FactoryBot.create :round, competition: competition, event_id: "333", number: 2


### PR DESCRIPTION
You get the error "Note: The competition id starts with a lowercase letter. We prefer to have it start with an uppercase." when a competition name starts with a number. This seems quite inaccurate, so here is a regex update.