### PR TITLE
Fix a bug with registration update where you can bring yourself back to the waiting list

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -373,12 +373,21 @@ class RegistrationsController < ApplicationController
       return
     end
     registration_attributes = registration_params
-    # Don't change status columns if the status is the same.
-    if @registration.checked_status.to_s == params[:registration][:status]
-      registration_attributes = registration_attributes.except(:accepted_at, :accepted_by, :deleted_at, :deleted_by)
-    end
     was_accepted = @registration.accepted?
     was_deleted = @registration.deleted?
+    # The only case we go to this endpoint if the registration was deleted is when we register again.
+    if was_deleted
+      # Set the accepted_at/deleted_at to nil iff it's not already set,
+      # which can happen when moving from deleted to accepted.
+      registration_attributes = { accepted_at: nil, deleted_at: nil }.merge(registration_attributes)
+    end
+    # Don't rely on the status in the params, compute the new status from the
+    # timestamps.
+    new_status = Registration.status_from_timestamp(registration_attributes[:accepted_at], registration_attributes[:deleted_at])
+    # Don't change status columns if the status is the same.
+    if @registration.checked_status == new_status
+      registration_attributes = registration_attributes.except(:accepted_at, :accepted_by, :deleted_at, :deleted_by)
+    end
     if current_user.can_edit_registration?(@registration) && @registration.update(registration_attributes)
       if !was_accepted && @registration.accepted?
         mailer = RegistrationsMailer.notify_registrant_of_accepted_registration(@registration)
@@ -617,14 +626,12 @@ class RegistrationsController < ApplicationController
     permitted_params = [
       :guests,
       :comments,
-      :accepted_at,
-      :deleted_at,
       registration_competition_events_attributes: [:id, :competition_event_id, :_destroy],
     ]
-    params[:registration][:deleted_at] = nil
-    params[:registration][:accepted_at] = nil
     if current_user.can_manage_competition?(competition_from_params)
       permitted_params += [
+        :accepted_at,
+        :deleted_at,
         :accepted_by,
         :deleted_by,
       ]

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -45,14 +45,18 @@ class Registration < ApplicationRecord
     !accepted? && !deleted?
   end
 
-  def checked_status
-    if accepted?
+  def self.status_from_timestamp(accepted_at, deleted_at)
+    if !accepted_at.nil? && deleted_at.nil?
       :accepted
-    elsif pending?
+    elsif accepted_at.nil? && deleted_at.nil?
       :pending
     else
       :deleted
     end
+  end
+
+  def checked_status
+    Registration.status_from_timestamp(accepted_at, deleted_at)
   end
 
   def new_or_deleted?

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -105,6 +105,11 @@ FactoryBot.define do
       registration_close { 2.weeks.from_now.change(usec: 0) }
     end
 
+    trait :editable_registrations do
+      allow_registration_edits { true }
+      event_change_deadline_date { 2.weeks.from_now.change(usec: 0) }
+    end
+
     trait :confirmed do
       with_delegate
       with_valid_schedule


### PR DESCRIPTION
When editing registrations is allowed, competitors could throw themselves back to the waiting list by editing their registration on the page loaded right after the first registration, but after the organizer accepted them.

This bug exists because we rely on the user-provided status in the params to check if we can allow updates to `accepted_at/by` and `deleted_at/by`; the status' param should only be used when competition's admins are editing the registration (which is correctly done in registration_params).

I went for the following changes:
  - prevent `accepted_at` and `deleted_at` from being permitted unless an admin is editing the registration
  - fill them as nil when a user update their registration from the deleted status (the only case they update them is when they want to register again)
  - don't rely on the params' status to check if the status has changed, instead rely on the accepted_at/deleted_at params

I also added a couple of tests for the registration edit features, nothing too fancy but at least it show the bug without the fix.