### PR TITLE
Fix credentials for AWS S3

### DIFF
--- a/WcaOnRails/config/initializers/carrierwave.rb
+++ b/WcaOnRails/config/initializers/carrierwave.rb
@@ -14,12 +14,13 @@ CarrierWave.configure do |config|
 
   aws_credentials = {
     region: EnvVars.S3_AVATARS_REGION,
-    stub_responses: Rails.env.test?, # Optional, avoid hitting S3 actual during tests
   }
 
   # only development needs explicit credentials to access AWS.
   # in production, access is derived implicitly through the IAM role of the machine
-  if Rails.env.development?
+  if EnvVars.AWS_ACCESS_KEY_ID.blank? || EnvVars.AWS_SECRET_ACCESS_KEY.blank?
+    aws_credentials[:stub_responses] = true
+  else
     aws_credentials['access_key_id'] = EnvVars.AWS_ACCESS_KEY_ID
     aws_credentials['secret_access_key'] = EnvVars.AWS_SECRET_ACCESS_KEY
   end

--- a/WcaOnRails/env_vars.rb
+++ b/WcaOnRails/env_vars.rb
@@ -8,7 +8,7 @@ EnvVars = Env::Vars.new do
     mandatory :SMTP_PASSWORD, string
   end
 
-  if Rails.env.development?
+  unless Rails.env.production?
     mandatory :DISABLE_BULLET, :bool
 
     optional :AWS_ACCESS_KEY_ID, :string, ''


### PR DESCRIPTION
Fixes #6705.

I also got an error running rspec that "Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.".

I think Spring is supposed to run in the test environment so I guess the setting should be set to false, but I'm not sure why it does work in the CI.