### PR TITLE
Fix minor test nuisances

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -127,7 +127,7 @@ group :test do
   gem 'oga' # XML parsing library introduced for testing RSS feed
   gem 'database_cleaner'
   gem 'rails-controller-testing'
-  gem 'apparition'
+  gem 'apparition', github: 'twalpole/apparition', branch: 'master'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false
   gem 'timecop'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -35,6 +35,15 @@ GIT
       railties (>= 5.0)
 
 GIT
+  remote: https://github.com/twalpole/apparition.git
+  revision: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
+  branch: master
+  specs:
+    apparition (0.6.0)
+      capybara (~> 3.13, < 4)
+      websocket-driver (>= 0.6.5)
+
+GIT
   remote: https://github.com/zpaulovics/datetimepicker-rails.git
   revision: 7a4640cb932e55866500a86c4f78808a4fca46e6
   branch: master
@@ -109,9 +118,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     api-pagination (4.8.2)
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
     ast (2.4.2)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
@@ -685,7 +691,7 @@ DEPENDENCIES
   activerecord-import
   activestorage-validator
   api-pagination
-  apparition
+  apparition!
   aws-sdk-cloudfront
   aws-sdk-s3
   better_errors

--- a/WcaOnRails/config/environments/test.rb
+++ b/WcaOnRails/config/environments/test.rb
@@ -10,7 +10,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = !defined? Spring
   config.action_view.cache_template_loading = true
 
   # Do not eager load code on boot. This avoids loading your whole application


### PR DESCRIPTION
- Dynamically determine whether or not to `cache_classes` during testing, depending on whether or not Spring is running
- Update to a version of `Apparition` JS driver that doesn't spam our logs