### PR TITLE
Manually update momentjs-rails to 2.29.1.1

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -69,7 +69,7 @@ gem 'premailer-rails'
 gem 'nokogiri'
 gem 'cocoon'
 gem 'momentjs-rails', github: 'derekprior/momentjs-rails'
-gem 'datetimepicker-rails', github: 'zpaulovics/datetimepicker-rails', branch: 'master', submodules: true
+gem 'datetimepicker-rails', github: 'zpaulovics/datetimepicker-rails', submodules: true
 gem 'blocks'
 gem 'rack-cors', require: 'rack/cors'
 gem 'api-pagination'
@@ -127,7 +127,7 @@ group :test do
   gem 'oga' # XML parsing library introduced for testing RSS feed
   gem 'database_cleaner'
   gem 'rails-controller-testing'
-  gem 'apparition', github: 'twalpole/apparition', branch: 'master'
+  gem 'apparition', github: 'twalpole/apparition'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false
   gem 'timecop'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/derekprior/momentjs-rails.git
-  revision: e2b2dd166b121ded02cdcc54f49fa1f0146c7094
+  revision: b7ff0d1a6da70cce64bddb5311cf09bbbaa9286d
   specs:
-    momentjs-rails (2.20.1)
+    momentjs-rails (2.29.1.1)
       railties (>= 3.1)
 
 GIT
@@ -37,7 +37,6 @@ GIT
 GIT
   remote: https://github.com/twalpole/apparition.git
   revision: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
-  branch: master
   specs:
     apparition (0.6.0)
       capybara (~> 3.13, < 4)
@@ -46,7 +45,6 @@ GIT
 GIT
   remote: https://github.com/zpaulovics/datetimepicker-rails.git
   revision: 7a4640cb932e55866500a86c4f78808a4fca46e6
-  branch: master
   submodules: true
   specs:
     datetimepicker-rails (4.7.16)


### PR DESCRIPTION
For some reason, Dependabot cannot figure this one out. Probably a missing Git tag? Whatever...
Treating this as a standard Dependabot PR, that is I will merge as soon as tests pass.