### PR TITLE
Don't lock WST out on staging

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -596,7 +596,7 @@ class User < ApplicationRecord
   end
 
   def admin?
-    Rails.env.production? ? software_team_admin? : software_team?
+    Rails.env.production? && EnvVars.WCA_LIVE_SITE? ? software_team_admin? : software_team?
   end
 
   def any_kind_of_delegate?


### PR DESCRIPTION
We run staging as a `production` machine, but wst_admin is a hidden team so all members get removed during Developer Dump export. So de facto the code on staging checks whether you're the member of an empty team (assuming that staging uses a recent Developer Dump)