### PR TITLE
Align registration info table footer

### DIFF
--- a/WcaOnRails/app/views/registrations/_edit_registrations_table_footer.html.erb
+++ b/WcaOnRails/app/views/registrations/_edit_registrations_table_footer.html.erb
@@ -5,13 +5,17 @@
     </td>
     <% country_count = registrations.map(&:country).uniq.length %>
     <td><%= t('registrations.list.country_plural', count: country_count) %></td>
-    <td></td>
+    <% if @show_birthdays %>
+      <td></td>
+    <% end %>
     <% if @show_events %>
       <% @competition.events.each do |event| %>
         <td><%= registrations.select { |r| r.events.include?(event) }.length %></td>
       <% end %>
     <% end %>
+    <%# registered on %>
     <td></td>
+    <%# number of events %>
     <td></td>
     <td>
       <% if @competition.guests_enabled? %>
@@ -22,6 +26,7 @@
         <%= registrations.to_a.sum(&:guests) %>
       <% end %>
     </td>
+    <%# comments %>
     <td></td>
     <% if @competition.using_stripe_payments? %>
       <td>


### PR DESCRIPTION
When birthdays were hidden, it was misaligned.

Also add comments for clarity on other empty columns in footer.

![image](https://user-images.githubusercontent.com/49137025/156702724-73122791-fa88-4b76-add9-a96f24491612.png)
