### PR TITLE
Add link to main competition page in result submission mail

### DIFF
--- a/WcaOnRails/app/views/competitions_mailer/results_submitted.erb
+++ b/WcaOnRails/app/views/competitions_mailer/results_submitted.erb
@@ -1,7 +1,7 @@
 <p>Results Team,</p>
 
 <p>
-  <%= @submitter_user.name %> has uploaded the results for <%= @competition.name %>.
+  <%= @submitter_user.name %> has uploaded the results for <%= link_to @competition.name, competition_url(@competition) %>.
   You can check and preview the uploaded results <%= link_to "here", competition_admin_upload_results_edit_url(@competition) %>, or you can go ahead with the posting process <%= link_to "here", "#{root_url}results/admin/upload_results.php?competitionId=#{@competition.id}" %>.
   <br>
   The latest uploaded json by the Delegate is attached.


### PR DESCRIPTION
Just a small addition so that there is a direct link to the competition main page in the result submission mail, implemented analogously to the competition confirmation mail for WCAT.