### PR TITLE
Fix the date warning for WCAT mails

### DIFF
--- a/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
+++ b/WcaOnRails/app/views/competitions_mailer/notify_wcat_of_confirmed_competition.html.erb
@@ -7,8 +7,8 @@
 </p>
 
 <p class="<%= 'alert' if (@competition.start_date - Time.now.to_date).to_i <= 30 %>">
-  The competition will take place on <%= wca_date_range(@competition.start_date, @competition.end_date) %> in <%= (@competition.start_date - Time.now.to_date).to_i %> days.
-  <% if (@competition.start_date - Time.now.utc.to_date).to_i <= 30 %>
+  The competition will take place on <%= wca_date_range(@competition.start_date, @competition.end_date) %> in <%= (@competition.days_until).to_i %> days.
+  <% if (@competition.days_until).to_i <= 30 %>
     There are less than 48 hours remaining for the competition to be announced. @<%= "Delegate".pluralize(@competition.all_delegates.count) %>: please respond to any WCAT concerns as soon as possible to ensure that the competition becomes announced. If the competition becomes less than 28 days away, the WCAT cannot announce it.
   <% end %>
 </p>


### PR DESCRIPTION
Currently, the email WCAT gets about a new competition is calculating the amount of days left until the competition happening incorrectly (it says there is one more day left than there actually is). This should fix it.