### PR TITLE
Implement a warning for registration payment info

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -426,6 +426,10 @@ class Competition < ApplicationRecord
       if championship_warnings.any?
         warnings = championship_warnings.merge(warnings)
       end
+
+      if has_fees? && !connected_stripe_account_id
+        warnings[:registration_payment_info] = I18n.t('competitions.messages.registration_payment_info')
+      end
     else
       unless self.announced?
         warnings[:announcement] = I18n.t('competitions.messages.not_announced')

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1260,6 +1260,7 @@ en:
       time_limit_is_too_fast: "Round %{round_number} in %{event} has a time limit less than 10 seconds. Please make sure that it is correct."
       time_limit_is_too_slow: "Round %{round_number} in %{event} has a time limit more than 10 minutes in a fast event. Please make sure that it is correct."
       create_success: "Successfully created new competition!"
+      registration_payment_info: "This competition has registration fees but no Stripe account is linked. If you are using Stripe through the WCA website, please remember to link your Stripe account. If you are using an external payment system, please remember to add all the relevant details in the registration requirements."
       not_announced: "This competition is visible to the public but hasn't been announced yet."
       announced: "Successfully announced competition!"
       cancelled: "This competition has been cancelled. Please checkout the information section for more details."


### PR DESCRIPTION
I already forgot twice to link a Stripe account to a competition and I'd feel really bad should it happen a third one, so I suggested something like that to the WCAT who agreed; I'll ask Daniel to come take a look at the wording.