### PR TITLE
Update NodeJS version in Chef and CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,7 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - uses: actions/setup-node@v2 # this also includes Yarn
         with:
-          node-version: '12'
+          node-version: '16'
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -4,25 +4,13 @@ require 'securerandom'
 
 include_recipe "wca::base"
 
-apt_repository 'nodejs' do
-  uri 'https://deb.nodesource.com/node_12.x'
-  components %w[main]
-  key 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key'
-end
-package 'nodejs' do
-  version '12.*'
-end
+node.default['nodejs']['version'] = '16.15.0'
+include_recipe "nodejs"
 
-apt_repository 'yarn' do
-  uri 'https://dl.yarnpkg.com/debian/'
-  components %w[main]
-  distribution "stable"
-  key 'https://dl.yarnpkg.com/debian/pubkey.gpg'
+npm_package 'yarn' do
+  version '1.22.18'
+  options ['--global']
 end
-package 'yarn' do
-  version '1.22.4-1'
-end
-
 
 secrets = WcaHelper.get_secrets(self)
 username, repo_root = WcaHelper.get_username_and_repo_root(self)


### PR DESCRIPTION
Use the actual NodeJS package to install NodeJS in Chef.
Fun fact: We had already loaded that package for several years but we never actually used it.