### PR TITLE
Update Bundler for Ruby 3 compatibility

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -827,4 +827,4 @@ DEPENDENCIES
   wicked_pdf
 
 BUNDLED WITH
-   2.1.4
+   2.3.13


### PR DESCRIPTION
Gets rid of the deprecation warnings about `DidYouMean::SPELL_CHECKERS`. Also should be somewhat future-proof :)