### PR TITLE
Fix Initializer constant deprecated autoloading

### DIFF
--- a/WcaOnRails/config/initializers/devise.rb
+++ b/WcaOnRails/config/initializers/devise.rb
@@ -1,269 +1,271 @@
 # frozen_string_literal: true
 
-# Use this hook to configure devise mailer, warden hooks and so forth.
-# Many of these configuration options can be set straight in your model.
-Devise.setup do |config|
-  config.warden do |manager|
-    manager.default_strategies(scope: :user).unshift(:two_factor_authenticatable, :two_factor_backupable)
+Rails.application.reloader.to_prepare do
+  # Use this hook to configure devise mailer, warden hooks and so forth.
+  # Many of these configuration options can be set straight in your model.
+  Devise.setup do |config|
+    config.warden do |manager|
+      manager.default_strategies(scope: :user).unshift(:two_factor_authenticatable, :two_factor_backupable)
+    end
+
+    # The secret key used by Devise. Devise uses this key to generate
+    # random tokens. Changing this key will render invalid all existing
+    # confirmation, reset password and unlock tokens in the database.
+    # config.secret_key = '0d6561d9be4e102bfbed461d523b94b70c4bebe0fdb3fcb60b61437a0f8d60e6988168085dfadcabbb3b3b56ead695621caae23e6be52db01acbc5c6e52775ff'
+
+    config.parent_controller = ApplicationController.name
+
+    # ==> Mailer Configuration
+    # Configure the e-mail address which will be shown in Devise::Mailer,
+    # note that it will be overwritten if you use your own mailer class
+    # with default "from" parameter.
+    config.mailer_sender = WcaOnRails::Application.config.default_from_address
+
+    # Configure the class responsible to send e-mails.
+    # config.mailer = 'Devise::Mailer'
+
+    # ==> ORM configuration
+    # Load and configure the ORM. Supports :active_record (default) and
+    # :mongoid (bson_ext recommended) by default. Other ORMs may be
+    # available as additional gems.
+    require 'devise/orm/active_record'
+
+    # ==> Configuration for any authentication mechanism
+    # Configure which keys are used when authenticating a user. The default is
+    # just :email. You can configure it to use [:username, :subdomain], so for
+    # authenticating a user, both parameters are required. Remember that those
+    # parameters are used only when authenticating and not when retrieving from
+    # session. If you need permissions, you should implement that in a before filter.
+    # You can also supply a hash where the value is a boolean determining whether
+    # or not authentication should be aborted when the value is not present.
+    config.authentication_keys = [:login]
+
+    # Configure parameters from the request object used for authentication. Each entry
+    # given should be a request method and it will automatically be passed to the
+    # find_for_authentication method and considered in your model lookup. For instance,
+    # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+    # The same considerations mentioned for authentication_keys also apply to request_keys.
+    # config.request_keys = []
+
+    # Configure which authentication keys should be case-insensitive.
+    # These keys will be downcased upon creating or modifying a user and when used
+    # to authenticate or find a user. Default is :email.
+    config.case_insensitive_keys = [:email]
+
+    # Configure which authentication keys should have whitespace stripped.
+    # These keys will have whitespace before and after removed upon creating or
+    # modifying a user and when used to authenticate or find a user. Default is :email.
+    config.strip_whitespace_keys = [:email]
+
+    # Tell if authentication through request.params is enabled. True by default.
+    # It can be set to an array that will enable params authentication only for the
+    # given strategies, for example, `config.params_authenticatable = [:database]` will
+    # enable it only for database (email + password) authentication.
+    # config.params_authenticatable = true
+
+    # Tell if authentication through HTTP Auth is enabled. False by default.
+    # It can be set to an array that will enable http authentication only for the
+    # given strategies, for example, `config.http_authenticatable = [:database]` will
+    # enable it only for database authentication. The supported strategies are:
+    # :database      = Support basic authentication with authentication key + password
+    # config.http_authenticatable = false
+
+    # If 401 status code should be returned for AJAX requests. True by default.
+    # config.http_authenticatable_on_xhr = true
+
+    # The realm used in Http Basic Authentication. 'Application' by default.
+    # config.http_authentication_realm = 'Application'
+
+    # It will change confirmation, password recovery and other workflows
+    # to behave the same regardless if the e-mail provided was right or wrong.
+    # Does not affect registerable.
+    # config.paranoid = true
+
+    # By default Devise will store the user in session. You can skip storage for
+    # particular strategies by setting this option.
+    # Notice that if you are skipping storage for all authentication paths, you
+    # may want to disable generating routes to Devise's sessions controller by
+    # passing skip: :sessions to `devise_for` in your config/routes.rb
+    config.skip_session_storage = [:http_auth]
+
+    # By default, Devise cleans up the CSRF token on authentication to
+    # avoid CSRF token fixation attacks. This means that, when using AJAX
+    # requests for sign in and sign up, you need to get a new CSRF token
+    # from the server. You can disable this option at your own risk.
+    # config.clean_up_csrf_token_on_authentication = true
+
+    # ==> Configuration for :database_authenticatable
+    # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+    # using other encryptors, it sets how many times you want the password re-encrypted.
+    #
+    # Limiting the stretches to just one in testing will increase the performance of
+    # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+    # a value less than 10 in other environments. Note that, for bcrypt (the default
+    # encryptor), the cost increases exponentially with the number of stretches (e.g.
+    # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+    config.stretches = Rails.env.test? ? 1 : 10
+
+    # Setup a pepper to generate the encrypted password.
+    # config.pepper = 'cea421058a34f77e92a40c6bf649450502e389783bb2736212d1a07f455b0013a870222ed00b310e26000cab244018fc0cf19a1a765d1b9e055e5b9d995734d2'
+
+    # ==> Configuration for :confirmable
+    # A period that the user is allowed to access the website even without
+    # confirming their account. For instance, if set to 2.days, the user will be
+    # able to access the website for two days without confirming their account,
+    # access will be blocked just in the third day. Default is 0.days, meaning
+    # the user cannot access the website without confirming their account.
+    # config.allow_unconfirmed_access_for = 2.days
+
+    # A period that the user is allowed to confirm their account before their
+    # token becomes invalid. For example, if set to 3.days, the user can confirm
+    # their account within 3 days after the mail was sent, but on the fourth day
+    # their account can't be confirmed with the token any more.
+    # Default is nil, meaning there is no restriction on how long a user can take
+    # before confirming their account.
+    # config.confirm_within = 3.days
+
+    # If true, requires any email changes to be confirmed (exactly the same way as
+    # initial account confirmation) to be applied. Requires additional unconfirmed_email
+    # db field (see migrations). Until confirmed, new email is stored in
+    # unconfirmed_email column, and copied to email column on successful confirmation.
+    config.reconfirmable = true
+
+    # Defines which key will be used when confirming an account
+    config.confirmation_keys = [:email]
+
+    # ==> Configuration for :rememberable
+    # The time the user will be remembered without asking for credentials again.
+    # config.remember_for = 2.weeks
+
+    # Invalidates all the remember me tokens when the user signs out.
+    config.expire_all_remember_me_on_sign_out = true
+
+    # If true, extends the user's remember period when remembered via cookie.
+    # config.extend_remember_period = false
+
+    # Options to be passed to the created cookie. For instance, you can set
+    # secure: true in order to force SSL only cookies.
+    # config.rememberable_options = {}
+
+    # ==> Configuration for :validatable
+    # Range for password length.
+    config.password_length = 3..128
+
+    # Email regex used to validate email formats. It simply asserts that
+    # one (and only one) @ exists in the given string. This is mainly
+    # to give user feedback and not to assert the e-mail validity.
+    # config.email_regexp = /\A[^@]+@[^@]+\z/
+
+    # ==> Configuration for :timeoutable
+    # The time you want to timeout the user session without activity. After this
+    # time the user will be asked for credentials again. Default is 30 minutes.
+    # config.timeout_in = 30.minutes
+
+    # If true, expires auth token on session timeout.
+    # config.expire_auth_token_on_timeout = false
+
+    # ==> Configuration for :lockable
+    # Defines which strategy will be used to lock an account.
+    # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+    # :none            = No lock strategy. You should handle locking by yourself.
+    # config.lock_strategy = :failed_attempts
+
+    # Defines which key will be used when locking and unlocking an account
+    # config.unlock_keys = [ :email ]
+
+    # Defines which strategy will be used to unlock an account.
+    # :email = Sends an unlock link to the user email
+    # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+    # :both  = Enables both strategies
+    # :none  = No unlock strategy. You should handle unlocking by yourself.
+    # config.unlock_strategy = :both
+
+    # Number of authentication tries before locking an account if lock_strategy
+    # is failed attempts.
+    # config.maximum_attempts = 20
+
+    # Time interval to unlock the account if :time is enabled as unlock_strategy.
+    # config.unlock_in = 1.hour
+
+    # Warn on the last attempt before the account is locked.
+    # config.last_attempt_warning = true
+
+    # ==> Configuration for :recoverable
+    #
+    # Defines which key will be used when recovering the password for an account
+    config.reset_password_keys = [:login]
+
+    # Time interval you can reset your password with a reset password key.
+    # Don't put a too small interval or your users won't have the time to
+    # change their passwords.
+    config.reset_password_within = 6.hours
+
+    # ==> Configuration for :encryptable
+    # Allow you to use another encryption algorithm besides bcrypt (default). You can use
+    # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,
+    # :authlogic_sha512 (then you should set stretches above to 20 for default behavior)
+    # and :restful_authentication_sha1 (then you should set stretches to 10, and copy
+    # REST_AUTH_SITE_KEY to pepper).
+    #
+    # Require the `devise-encryptable` gem when using anything other than bcrypt
+    # config.encryptor = :sha512
+
+    # ==> Scopes configuration
+    # Turn scoped views on. Before rendering "sessions/new", it will first check for
+    # "users/sessions/new". It's turned off by default because it's slower if you
+    # are using only default views.
+    # config.scoped_views = false
+
+    # Configure the default scope given to Warden. By default it's the first
+    # devise role declared in your routes (usually :user).
+    # config.default_scope = :user
+
+    # Set this configuration to false if you want /users/sign_out to sign out
+    # only the current scope. By default, Devise signs out all scopes.
+    # config.sign_out_all_scopes = true
+
+    # ==> Navigation configuration
+    # Lists the formats that should be treated as navigational. Formats like
+    # :html, should redirect to the sign in page when the user does not have
+    # access, but formats like :xml or :json, should return 401.
+    #
+    # If you have any extra navigational formats, like :iphone or :mobile, you
+    # should add them to the navigational formats lists.
+    #
+    # The "*/*" below is required to match Internet Explorer requests.
+    # config.navigational_formats = ['*/*', :html]
+
+    # The default HTTP method used to sign out a resource. Default is :delete.
+    config.sign_out_via = :delete
+
+    # ==> OmniAuth
+    # Add a new OmniAuth provider. Check the wiki for more information on setting
+    # up on your models and hooks.
+    # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+    # ==> Warden configuration
+    # If you want to use other strategies, that are not supported by Devise, or
+    # change the failure app, you can configure them inside the config.warden block.
+    #
+    # config.warden do |manager|
+    #   manager.intercept_401 = false
+    #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+    # end
+
+    # ==> Mountable engine configurations
+    # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+    # is mountable, there are some extra configurations to be taken into account.
+    # The following options are available, assuming the engine is mounted as:
+    #
+    #     mount MyEngine, at: '/my_engine'
+    #
+    # The router that invoked `devise_for`, in the example above, would be:
+    # config.router_name = :my_engine
+    #
+    # When using omniauth, Devise cannot automatically set Omniauth path,
+    # so you need to do it manually. For the users scope, it would be:
+    # config.omniauth_path_prefix = '/my_engine/users/auth'
   end
-
-  # The secret key used by Devise. Devise uses this key to generate
-  # random tokens. Changing this key will render invalid all existing
-  # confirmation, reset password and unlock tokens in the database.
-  # config.secret_key = '0d6561d9be4e102bfbed461d523b94b70c4bebe0fdb3fcb60b61437a0f8d60e6988168085dfadcabbb3b3b56ead695621caae23e6be52db01acbc5c6e52775ff'
-
-  config.parent_controller = ApplicationController.name
-
-  # ==> Mailer Configuration
-  # Configure the e-mail address which will be shown in Devise::Mailer,
-  # note that it will be overwritten if you use your own mailer class
-  # with default "from" parameter.
-  config.mailer_sender = WcaOnRails::Application.config.default_from_address
-
-  # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
-
-  # ==> ORM configuration
-  # Load and configure the ORM. Supports :active_record (default) and
-  # :mongoid (bson_ext recommended) by default. Other ORMs may be
-  # available as additional gems.
-  require 'devise/orm/active_record'
-
-  # ==> Configuration for any authentication mechanism
-  # Configure which keys are used when authenticating a user. The default is
-  # just :email. You can configure it to use [:username, :subdomain], so for
-  # authenticating a user, both parameters are required. Remember that those
-  # parameters are used only when authenticating and not when retrieving from
-  # session. If you need permissions, you should implement that in a before filter.
-  # You can also supply a hash where the value is a boolean determining whether
-  # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:login]
-
-  # Configure parameters from the request object used for authentication. Each entry
-  # given should be a request method and it will automatically be passed to the
-  # find_for_authentication method and considered in your model lookup. For instance,
-  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
-  # The same considerations mentioned for authentication_keys also apply to request_keys.
-  # config.request_keys = []
-
-  # Configure which authentication keys should be case-insensitive.
-  # These keys will be downcased upon creating or modifying a user and when used
-  # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
-
-  # Configure which authentication keys should have whitespace stripped.
-  # These keys will have whitespace before and after removed upon creating or
-  # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
-
-  # Tell if authentication through request.params is enabled. True by default.
-  # It can be set to an array that will enable params authentication only for the
-  # given strategies, for example, `config.params_authenticatable = [:database]` will
-  # enable it only for database (email + password) authentication.
-  # config.params_authenticatable = true
-
-  # Tell if authentication through HTTP Auth is enabled. False by default.
-  # It can be set to an array that will enable http authentication only for the
-  # given strategies, for example, `config.http_authenticatable = [:database]` will
-  # enable it only for database authentication. The supported strategies are:
-  # :database      = Support basic authentication with authentication key + password
-  # config.http_authenticatable = false
-
-  # If 401 status code should be returned for AJAX requests. True by default.
-  # config.http_authenticatable_on_xhr = true
-
-  # The realm used in Http Basic Authentication. 'Application' by default.
-  # config.http_authentication_realm = 'Application'
-
-  # It will change confirmation, password recovery and other workflows
-  # to behave the same regardless if the e-mail provided was right or wrong.
-  # Does not affect registerable.
-  # config.paranoid = true
-
-  # By default Devise will store the user in session. You can skip storage for
-  # particular strategies by setting this option.
-  # Notice that if you are skipping storage for all authentication paths, you
-  # may want to disable generating routes to Devise's sessions controller by
-  # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
-
-  # By default, Devise cleans up the CSRF token on authentication to
-  # avoid CSRF token fixation attacks. This means that, when using AJAX
-  # requests for sign in and sign up, you need to get a new CSRF token
-  # from the server. You can disable this option at your own risk.
-  # config.clean_up_csrf_token_on_authentication = true
-
-  # ==> Configuration for :database_authenticatable
-  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
-  # using other encryptors, it sets how many times you want the password re-encrypted.
-  #
-  # Limiting the stretches to just one in testing will increase the performance of
-  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
-  # a value less than 10 in other environments. Note that, for bcrypt (the default
-  # encryptor), the cost increases exponentially with the number of stretches (e.g.
-  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
-  config.stretches = Rails.env.test? ? 1 : 10
-
-  # Setup a pepper to generate the encrypted password.
-  # config.pepper = 'cea421058a34f77e92a40c6bf649450502e389783bb2736212d1a07f455b0013a870222ed00b310e26000cab244018fc0cf19a1a765d1b9e055e5b9d995734d2'
-
-  # ==> Configuration for :confirmable
-  # A period that the user is allowed to access the website even without
-  # confirming their account. For instance, if set to 2.days, the user will be
-  # able to access the website for two days without confirming their account,
-  # access will be blocked just in the third day. Default is 0.days, meaning
-  # the user cannot access the website without confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
-
-  # A period that the user is allowed to confirm their account before their
-  # token becomes invalid. For example, if set to 3.days, the user can confirm
-  # their account within 3 days after the mail was sent, but on the fourth day
-  # their account can't be confirmed with the token any more.
-  # Default is nil, meaning there is no restriction on how long a user can take
-  # before confirming their account.
-  # config.confirm_within = 3.days
-
-  # If true, requires any email changes to be confirmed (exactly the same way as
-  # initial account confirmation) to be applied. Requires additional unconfirmed_email
-  # db field (see migrations). Until confirmed, new email is stored in
-  # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
-
-  # Defines which key will be used when confirming an account
-  config.confirmation_keys = [:email]
-
-  # ==> Configuration for :rememberable
-  # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
-
-  # Invalidates all the remember me tokens when the user signs out.
-  config.expire_all_remember_me_on_sign_out = true
-
-  # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
-
-  # Options to be passed to the created cookie. For instance, you can set
-  # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
-
-  # ==> Configuration for :validatable
-  # Range for password length.
-  config.password_length = 3..128
-
-  # Email regex used to validate email formats. It simply asserts that
-  # one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
-  # config.email_regexp = /\A[^@]+@[^@]+\z/
-
-  # ==> Configuration for :timeoutable
-  # The time you want to timeout the user session without activity. After this
-  # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
-
-  # If true, expires auth token on session timeout.
-  # config.expire_auth_token_on_timeout = false
-
-  # ==> Configuration for :lockable
-  # Defines which strategy will be used to lock an account.
-  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
-  # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
-
-  # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [ :email ]
-
-  # Defines which strategy will be used to unlock an account.
-  # :email = Sends an unlock link to the user email
-  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
-  # :both  = Enables both strategies
-  # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
-
-  # Number of authentication tries before locking an account if lock_strategy
-  # is failed attempts.
-  # config.maximum_attempts = 20
-
-  # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
-
-  # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
-
-  # ==> Configuration for :recoverable
-  #
-  # Defines which key will be used when recovering the password for an account
-  config.reset_password_keys = [:login]
-
-  # Time interval you can reset your password with a reset password key.
-  # Don't put a too small interval or your users won't have the time to
-  # change their passwords.
-  config.reset_password_within = 6.hours
-
-  # ==> Configuration for :encryptable
-  # Allow you to use another encryption algorithm besides bcrypt (default). You can use
-  # :sha1, :sha512 or encryptors from others authentication tools as :clearance_sha1,
-  # :authlogic_sha512 (then you should set stretches above to 20 for default behavior)
-  # and :restful_authentication_sha1 (then you should set stretches to 10, and copy
-  # REST_AUTH_SITE_KEY to pepper).
-  #
-  # Require the `devise-encryptable` gem when using anything other than bcrypt
-  # config.encryptor = :sha512
-
-  # ==> Scopes configuration
-  # Turn scoped views on. Before rendering "sessions/new", it will first check for
-  # "users/sessions/new". It's turned off by default because it's slower if you
-  # are using only default views.
-  # config.scoped_views = false
-
-  # Configure the default scope given to Warden. By default it's the first
-  # devise role declared in your routes (usually :user).
-  # config.default_scope = :user
-
-  # Set this configuration to false if you want /users/sign_out to sign out
-  # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
-
-  # ==> Navigation configuration
-  # Lists the formats that should be treated as navigational. Formats like
-  # :html, should redirect to the sign in page when the user does not have
-  # access, but formats like :xml or :json, should return 401.
-  #
-  # If you have any extra navigational formats, like :iphone or :mobile, you
-  # should add them to the navigational formats lists.
-  #
-  # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html]
-
-  # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
-
-  # ==> OmniAuth
-  # Add a new OmniAuth provider. Check the wiki for more information on setting
-  # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-
-  # ==> Warden configuration
-  # If you want to use other strategies, that are not supported by Devise, or
-  # change the failure app, you can configure them inside the config.warden block.
-  #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
-
-  # ==> Mountable engine configurations
-  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
-  # is mountable, there are some extra configurations to be taken into account.
-  # The following options are available, assuming the engine is mounted as:
-  #
-  #     mount MyEngine, at: '/my_engine'
-  #
-  # The router that invoked `devise_for`, in the example above, would be:
-  # config.router_name = :my_engine
-  #
-  # When using omniauth, Devise cannot automatically set Omniauth path,
-  # so you need to do it manually. For the users scope, it would be:
-  # config.omniauth_path_prefix = '/my_engine/users/auth'
 end
 
 # Add session validity token on first sign in and check it on every authenticated request.

--- a/WcaOnRails/config/initializers/doorkeeper.rb
+++ b/WcaOnRails/config/initializers/doorkeeper.rb
@@ -1,124 +1,126 @@
 # frozen_string_literal: true
 
-Doorkeeper.configure do
-  # NOTE: Keep this at the top of the file, so we can link directly to it
-  #       without line numbers changing.
-  # Define access token scopes for your provider
-  # For more information go to
-  # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
-  default_scopes  :public
-  optional_scopes :dob, :email, :manage_competitions
+Rails.application.reloader.to_prepare do
+  Doorkeeper.configure do
+    # NOTE: Keep this at the top of the file, so we can link directly to it
+    #       without line numbers changing.
+    # Define access token scopes for your provider
+    # For more information go to
+    # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
+    default_scopes  :public
+    optional_scopes :dob, :email, :manage_competitions
 
-  base_controller ApplicationController.name
+    base_controller ApplicationController.name
 
-  # Change the ORM that doorkeeper will use.
-  # Currently supported options are :active_record, :mongoid2, :mongoid3,
-  # :mongoid4, :mongo_mapper
-  orm :active_record
+    # Change the ORM that doorkeeper will use.
+    # Currently supported options are :active_record, :mongoid2, :mongoid3,
+    # :mongoid4, :mongo_mapper
+    orm :active_record
 
-  # This block will be called to check whether the resource owner is authenticated or not.
-  resource_owner_authenticator do
-    current_user || warden.authenticate!(scope: :user)
-    # Put your resource owner authentication logic here.
-    # Example implementation:
-    #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
-  end
-
-  # Copied from
-  #  https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Resource-Owner-Password-Credentials-flow
-  resource_owner_from_credentials do |routes|
-    u = User.find_for_database_authentication(email: params[:username])
-    u if u && u.valid_password?(params[:password])
-  end
-
-  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
-  admin_authenticator do
-    unless current_user
-      redirect_to new_user_session_url
+    # This block will be called to check whether the resource owner is authenticated or not.
+    resource_owner_authenticator do
+      current_user || warden.authenticate!(scope: :user)
+      # Put your resource owner authentication logic here.
+      # Example implementation:
+      #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
     end
+
+    # Copied from
+    #  https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Resource-Owner-Password-Credentials-flow
+    resource_owner_from_credentials do |routes|
+      u = User.find_for_database_authentication(email: params[:username])
+      u if u && u.valid_password?(params[:password])
+    end
+
+    # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
+    admin_authenticator do
+      unless current_user
+        redirect_to new_user_session_url
+      end
+    end
+
+    # Authorization Code expiration time (default 10 minutes).
+    # authorization_code_expires_in 10.minutes
+
+    # Access token expiration time (default 2 hours).
+    # If you want to disable expiration, set this to nil.
+    # access_token_expires_in 2.hours
+
+    # Assign a custom TTL for implicit grants.
+    # custom_access_token_expires_in do |oauth_client|
+    #   oauth_client.application.additional_settings.implicit_oauth_expiration
+    # end
+
+    # Use a custom class for generating the access token.
+    # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
+    # access_token_generator "::Doorkeeper::JWT"
+
+    # Reuse access token for the same resource owner within an application (disabled by default)
+    # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+    # reuse_access_token
+
+    # Issue access tokens with refresh token (disabled by default)
+    use_refresh_token
+
+    # Provide support for an owner to be assigned to each registered application (disabled by default)
+    # Optional parameter confirmation: true (default false) if you want to enforce ownership of
+    # a registered application
+    # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
+    enable_application_owner confirmation: false
+
+    # Change the way client credentials are retrieved from the request object.
+    # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+    # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+    # Check out the wiki for more information on customization
+    # client_credentials :from_basic, :from_params
+
+    # Change the way access token is authenticated from the request object.
+    # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+    # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+    # Check out the wiki for more information on customization
+    # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+    # Change the native redirect uri for client apps
+    # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
+    # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
+    # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+    #
+    # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
+
+    # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+    # by default in non-development environments). OAuth2 delegates security in
+    # communication to the HTTPS protocol so it is wise to keep this enabled.
+    #
+    # Note that we intentionally allow HTTP for localhost urls. This is needed by
+    # TNoodle, and is also useful for local devlopment.
+    force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+    # Specify what grant flows are enabled in array of Strings. The valid
+    # strings and the flows they enable are:
+    #
+    # "authorization_code" => Authorization Code Grant Flow
+    # "implicit"           => Implicit Grant Flow
+    # "password"           => Resource Owner Password Credentials Grant Flow
+    # "client_credentials" => Client Credentials Grant Flow
+    #
+    # If not specified, Doorkeeper enables authorization_code and
+    # client_credentials.
+    #
+    # implicit and password grant flows have risks that you should understand
+    # before enabling:
+    #   http://tools.ietf.org/html/rfc6819#section-4.4.2
+    #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+    #
+    grant_flows %w(authorization_code implicit client_credentials password)
+
+    # Under some circumstances you might want to have applications auto-approved,
+    # so that the user skips the authorization step.
+    # For example if dealing with a trusted application.
+    # skip_authorization do |resource_owner, client|
+    #   client.superapp? or resource_owner.admin?
+    # end
+
+    # WWW-Authenticate Realm (default "Doorkeeper").
+    # realm "Doorkeeper"
   end
-
-  # Authorization Code expiration time (default 10 minutes).
-  # authorization_code_expires_in 10.minutes
-
-  # Access token expiration time (default 2 hours).
-  # If you want to disable expiration, set this to nil.
-  # access_token_expires_in 2.hours
-
-  # Assign a custom TTL for implicit grants.
-  # custom_access_token_expires_in do |oauth_client|
-  #   oauth_client.application.additional_settings.implicit_oauth_expiration
-  # end
-
-  # Use a custom class for generating the access token.
-  # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
-  # access_token_generator "::Doorkeeper::JWT"
-
-  # Reuse access token for the same resource owner within an application (disabled by default)
-  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
-  # reuse_access_token
-
-  # Issue access tokens with refresh token (disabled by default)
-  use_refresh_token
-
-  # Provide support for an owner to be assigned to each registered application (disabled by default)
-  # Optional parameter confirmation: true (default false) if you want to enforce ownership of
-  # a registered application
-  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
-  enable_application_owner confirmation: false
-
-  # Change the way client credentials are retrieved from the request object.
-  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
-  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
-  # Check out the wiki for more information on customization
-  # client_credentials :from_basic, :from_params
-
-  # Change the way access token is authenticated from the request object.
-  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
-  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
-  # Check out the wiki for more information on customization
-  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
-
-  # Change the native redirect uri for client apps
-  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
-  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
-  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
-  #
-  # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
-
-  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
-  # by default in non-development environments). OAuth2 delegates security in
-  # communication to the HTTPS protocol so it is wise to keep this enabled.
-  #
-  # Note that we intentionally allow HTTP for localhost urls. This is needed by
-  # TNoodle, and is also useful for local devlopment.
-  force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
-
-  # Specify what grant flows are enabled in array of Strings. The valid
-  # strings and the flows they enable are:
-  #
-  # "authorization_code" => Authorization Code Grant Flow
-  # "implicit"           => Implicit Grant Flow
-  # "password"           => Resource Owner Password Credentials Grant Flow
-  # "client_credentials" => Client Credentials Grant Flow
-  #
-  # If not specified, Doorkeeper enables authorization_code and
-  # client_credentials.
-  #
-  # implicit and password grant flows have risks that you should understand
-  # before enabling:
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
-  #
-  grant_flows %w(authorization_code implicit client_credentials password)
-
-  # Under some circumstances you might want to have applications auto-approved,
-  # so that the user skips the authorization step.
-  # For example if dealing with a trusted application.
-  # skip_authorization do |resource_owner, client|
-  #   client.superapp? or resource_owner.admin?
-  # end
-
-  # WWW-Authenticate Realm (default "Doorkeeper").
-  # realm "Doorkeeper"
 end


### PR DESCRIPTION
Devise and Doorkeeper use autoloading for some Helper classes that is deprecated in the new Zeitwerk class loader.
Wrapping it in `do_prepare` calls creates virtual loading environments that should get rid of the long debug messages for now :)