### PR TITLE
Fix active storage migration issue

### DIFF
--- a/WcaOnRails/db/migrate/20220223163447_create_active_storage_variant_records.active_storage.rb
+++ b/WcaOnRails/db/migrate/20220223163447_create_active_storage_variant_records.active_storage.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This migration comes from active_storage (originally 20191206030411)
-class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.1]
   def change
     create_table :active_storage_variant_records do |t|
       t.belongs_to :blob, null: false, index: false


### PR DESCRIPTION
I'm not sure this should be merged, but here is the issue: I tried updating my local repo because of the recent ruby/rails/everything version updates, and when running the latest migration I ran into this failure:

```
== 20220223163447 CreateActiveStorageVariantRecords: migrating ================
-- create_table(:active_storage_variant_records)
rake aborted!
StandardError: An error has occurred, all later migrations canceled:

Column `blob_id` on table `active_storage_variant_records` does not match column `id` on `active_storage_blobs`, which has type `bigint`. To resolve this issue, change the type of the `blob_id` column on `active_storage_variant_records` to be :bigint. (For example `t.bigint :blob_id`).
```

I know it's an automatically generated migration, and it seems related to [this](https://github.com/rails/rails/issues/44767), and it's also worth noting the source code for that migration has changed quite a bit in [the main branch](https://github.com/rails/rails/blob/main/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb).

The issue I encountered can be fixed either by setting the version to 6.1, or by using the latest version of the migration.

The question is: is it just me?

I tried deploying the latest master to staging (motivating by my will to rebase #6360), but I haven't managed just yet to run chef, so I can't confirm or deny that this would be happening here.

@gregorbg did you manage to run these migrations on prod?
I tried to re-import the developer dump but it looks like these migrations are not in there yet since I had to run them again.
If that's just me it's likely something wrong with my db structure, I get this kind of diff when running the migrations locally:
```
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
```