### PR TITLE
Only export registrations for visible competitions

### DIFF
--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -563,7 +563,7 @@ module DatabaseDumper
     }.freeze,
     "registration_payments" => :skip_all_rows,
     "registrations" => {
-      where_clause: "",
+      where_clause: JOIN_WHERE_VISIBLE_COMP,
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id


### PR DESCRIPTION
Currently using the website with the developer dump may crash because it dumps registrations which have `competition_id` pointing to competition not present in the database (eg: by visiting the "my competitions" page).
It may be because of two things:
  - they are "not visible" competition
  - the competition may have been deleted, without the registrations being deleted.

For the first point this PR should fix it.
For the second point, someone with access to prod should run `Registration.where.not(competition_id: Competition.all.map(&:id)).size`, and if it's not 0 we should probably delete those registrations.
It should not happen because we have [this](https://github.com/thewca/worldcubeassociation.org/blob/00424633af2be306913c2631d9aa8fe2bb9d1f5d/WcaOnRails/app/models/competition.rb#L10), but who knows...