### PR TITLE
Expose a user's ongoing competitions

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -122,18 +122,10 @@ class Api::V0::ApiController < ApplicationController
     if user
       json = { user: user }
       if params[:upcoming_competitions]
-        json[:upcoming_competitions] = user.registrations
-                                           .accepted
-                                           .includes(competition: [:delegates, :organizers, :events])
-                                           .map(&:competition)
-                                           .select(&:upcoming?)
+        json[:upcoming_competitions] = user.accepted_competitions.select(&:upcoming?)
       end
       if params[:ongoing_competitions]
-        json[:ongoing_competitions] = user.registrations
-                                          .accepted
-                                          .includes(competition: [:delegates, :organizers, :events])
-                                          .map(&:competition)
-                                          .select(&:ongoing?)
+        json[:ongoing_competitions] = user.accepted_competitions.select(&:in_progress?)
       end
       render status: :ok, json: json
     else

--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -128,6 +128,13 @@ class Api::V0::ApiController < ApplicationController
                                            .map(&:competition)
                                            .select(&:upcoming?)
       end
+      if params[:ongoing_competitions]
+        json[:ongoing_competitions] = user.registrations
+                                          .accepted
+                                          .includes(competition: [:delegates, :organizers, :events])
+                                          .map(&:competition)
+                                          .select(&:ongoing?)
+      end
       render status: :ok, json: json
     else
       render status: :not_found, json: { user: nil }

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1284,10 +1284,6 @@ class Competition < ApplicationRecord
     start_date.present? && start_date < Date.today
   end
 
-  def ongoing?
-    self.started? && !self.is_probably_over?
-  end
-
   def organizers_or_delegates
     self.organizers.empty? ? self.all_delegates : self.organizers
   end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1284,6 +1284,10 @@ class Competition < ApplicationRecord
     start_date.present? && start_date < Date.today
   end
 
+  def ongoing?
+    self.started? && !self.is_probably_over?
+  end
+
   def organizers_or_delegates
     self.organizers.empty? ? self.all_delegates : self.organizers
   end

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -1192,4 +1192,14 @@ class User < ApplicationRecord
       !competitions_announced.empty? ||
       !competitions_results_posted.empty?
   end
+
+  def accepted_registrations
+    self.registrations.accepted
+  end
+
+  def accepted_competitions
+    self.accepted_registrations
+        .includes(competition: [:delegates, :organizers, :events])
+        .map(&:competition)
+  end
 end


### PR DESCRIPTION
This calculates if a competition is ongoing by looking at if it has 1. started and 2. probably not over.
It then exposes this as a query param when fetching `/users/{userid}`

This directly fixes #6970 but I'd like to also, in a later PR, expose a route `/api/v0/users/{userid}/competitions` to fetch all of a user's competitions.

Alternatively, I could modify the `/api/v0/competitions` to add a query param to search for competitions with registrations containing a certain userId. 