### PR TITLE
Update RuboCop style definitions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 3.1
   DisplayCopNames: true
+  NewCops: enable
   Exclude:
     - 'WcaOnRails/node_modules/**/*'
     - 'WcaOnRails/bin/**/*'
@@ -79,12 +80,6 @@ Metrics/ClassLength:
 
 Metrics/CyclomaticComplexity:
   Max: 23
-  Exclude:
-    - 'WcaOnRails/app/controllers/competitions_controller.rb'
-    - 'WcaOnRails/app/controllers/registrations_controller.rb'
-    - 'WcaOnRails/app/jobs/sync_mailing_lists_job.rb'
-    - 'WcaOnRails/app/models/competition.rb'
-    - 'WcaOnRails/lib/results_validators/*.rb'
 
 Metrics/ParameterLists:
   Max: 5
@@ -92,12 +87,6 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Max: 25
-  Exclude:
-    - 'WcaOnRails/app/controllers/competitions_controller.rb'
-    - 'WcaOnRails/app/controllers/registrations_controller.rb'
-    - 'WcaOnRails/app/jobs/sync_mailing_lists_job.rb'
-    - 'WcaOnRails/app/models/competition.rb'
-    - 'WcaOnRails/lib/results_validators/*.rb'
 
 Layout/LineLength:
   Max: 245
@@ -210,347 +199,23 @@ Style/FormatStringToken:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: false
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Layout/BeginEndAlignment:
-  Enabled: true
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: false
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/BinaryOperatorWithIdenticalOperands:
-  Enabled: true
-
-Lint/ConstantDefinitionInBlock:
-  Enabled: true
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-Lint/DuplicateRequire:
-  Enabled: true
-
-Lint/DuplicateRescueException:
-  Enabled: true
-
-Lint/EmptyConditionalBody:
-  Enabled: true
-
 Lint/EmptyFile:
-  Enabled: true
   Exclude:
     - 'WcaOnRails/db/seeds.rb'
 
-Lint/FloatComparison:
-  Enabled: true
-
-Lint/HashCompareByIdentity:
-  Enabled: true
-
-Lint/IdentityComparison:
-  Enabled: true
-
-Lint/MissingSuper:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/OutOfRangeRegexpRef:
-  Enabled: false
-
-Lint/RedundantSafeNavigation:
-  Enabled: true
-
-Lint/SelfAssignment:
-  Enabled: true
-
-Lint/TopLevelReturnWithArgument:
-  Enabled: true
-
-Lint/TrailingCommaInAttributeDeclaration:
-  Enabled: true
-
-Lint/UnreachableLoop:
-  Enabled: true
-
-Lint/UselessMethodDefinition:
-  Enabled: true
-
-Lint/UselessTimes:
-  Enabled: true
-
-Style/AccessorGrouping:
-  Enabled: false
-
-Style/BisectedAttrAccessor:
-  Enabled: true
-
-Style/CaseLikeIf:
-  Enabled: true
-
-Style/ClassEqualityComparison:
-  Enabled: true
-
-Style/CombinableLoops:
-  Enabled: true
-
-Style/ExplicitBlockArgument:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/GlobalStdStream:
-  Enabled: true
-
-Style/HashAsLastArrayItem:
-  Enabled: true
-
-Style/HashLikeCase:
-  Enabled: true
-
-Style/KeywordParametersOrder:
-  Enabled: true
-
-Style/OptionalBooleanParameter:
-  Enabled: true
-
-Style/RedundantAssignment:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/RedundantSelfAssignment:
-  Enabled: true
-
-Style/SingleArgumentDig:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: false
-
-Style/SoleNestedConditional:
-  Enabled: false
-
-Style/StringConcatenation:
-  Enabled: false
-
-Layout/SpaceBeforeBrackets:
-  Enabled: true
-
-Lint/AmbiguousAssignment:
-  Enabled: true
-
-Lint/DeprecatedConstants:
-  Enabled: true
-
-Lint/DuplicateBranch:
-  Enabled: true
-
-Lint/DuplicateRegexpCharacterClassElement:
-  Enabled: true
-
-Lint/EmptyBlock:
-  Enabled: false
-
-Lint/EmptyClass:
-  Enabled: true
-
-Lint/LambdaWithoutLiteralBlock:
-  Enabled: true
-
-Lint/NoReturnInBeginEndBlocks:
-  Enabled: true
-
-Lint/NumberedParameterAssignment:
-  Enabled: true
-
-Lint/OrAssignmentToConstant:
-  Enabled: true
-
-Lint/RedundantDirGlobSort:
-  Enabled: true
-
-Lint/SymbolConversion:
-  Enabled: false
-
-Lint/ToEnumArguments:
-  Enabled: true
-
-Lint/TripleQuotes:
-  Enabled: true
-
-Lint/UnexpectedBlockArity:
-  Enabled: true
-
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: true
-
-Style/ArgumentsForwarding:
-  Enabled: true
-
-Style/CollectionCompact:
-  Enabled: true
-
-Style/DocumentDynamicEvalDefinition:
-  Enabled: true
-
-Style/EndlessMethod:
-  Enabled: true
-
-Style/HashExcept:
-  Enabled: true
-
-Style/IfWithBooleanLiteralBranches:
-  Enabled: true
-
-Style/NegatedIfElseCondition:
-  Enabled: false
-
-Style/NilLambda:
-  Enabled: true
-
-Style/RedundantArgument:
-  Enabled: true
-
-Style/SwapValues:
-  Enabled: true
-
+# We have too many event IDs and Comp Years with numbers in them
 Naming/VariableNumber:
   Enabled: false
 
-Gemspec/DateAssignment:
-  Enabled: true
-
-Layout/LineEndStringConcatenationIndentation:
-  Enabled: false
-
-Lint/AmbiguousRange:
-  Enabled: true
-
-Lint/EmptyInPattern:
-  Enabled: true
-
+# If an external library requires us to use terms like "blacklist",
+# we have no choice but to follow their conventions until they update
 Naming/InclusiveLanguage:
-  Enabled: true
   Exclude:
     - 'WcaOnRails/config/**/*'
 
-Style/HashConversion:
-  Enabled: true
-
-Style/InPatternThen:
-  Enabled: true
-
-Style/MultilineInPatternThen:
-  Enabled: true
-
-Style/QuotedSymbols:
-  Enabled: false
-
-Style/RedundantSelfAssignmentBranch:
-  Enabled: true
-
-Style/StringChars:
-  Enabled: true
-
-Style/CommentAnnotation:
-  Enabled: false
-
-Gemspec/RequireMFA:
-  Enabled: true
-
-Lint/AmbiguousOperatorPrecedence:
-  Enabled: true
-
-Lint/IncompatibleIoSelectWithFiberScheduler:
-  Enabled: true
-
-Lint/RefinementImportMethods:
-  Enabled: true
-
-Lint/RequireRelativeSelfPath:
-  Enabled: true
-
-Lint/UselessRuby2Keywords:
-  Enabled: true
-
-Naming/BlockForwarding:
-  Enabled: true
-
-Security/CompoundHash:
-  Enabled: true
-
-Security/IoMethods:
-  Enabled: true
-
-Style/FetchEnvVar:
-  Enabled: true
-
-Style/FileRead:
-  Enabled: true
-
-Style/FileWrite:
-  Enabled: true
-
-Style/MapToHash:
-  Enabled: true
-
-Style/NestedFileDirname:
-  Enabled: true
-
-Style/NumberedParameters:
-  Enabled: true
-
-Style/NumberedParametersLimit:
-  Enabled: true
-
-Style/ObjectThen:
-  Enabled: true
-
 Style/OpenStructUse:
-  Enabled: true
   Exclude:
     - 'WcaOnRails/spec/lib/middlewares/warden_user_logger_spec.rb'
 
-Style/RedundantInitialize:
-  Enabled: true
-
-Style/SelectByRegexp:
-  Enabled: true
-
 Style/HashSyntax:
-  Enabled: false
-
-Style/EnvHome:
-  Enabled: true
+  EnforcedShorthandSyntax: never

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,3 +33,37 @@ Naming/VariableName:
 # See https://github.com/bbatsov/rubocop/pull/4237
 Lint/AmbiguousBlockAssociation:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'WcaOnRails/app/controllers/competitions_controller.rb'
+    - 'WcaOnRails/app/controllers/registrations_controller.rb'
+    - 'WcaOnRails/app/jobs/sync_mailing_lists_job.rb'
+    - 'WcaOnRails/app/models/competition.rb'
+    - 'WcaOnRails/lib/results_validators/*.rb'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'WcaOnRails/app/controllers/competitions_controller.rb'
+    - 'WcaOnRails/app/controllers/registrations_controller.rb'
+    - 'WcaOnRails/app/jobs/sync_mailing_lists_job.rb'
+    - 'WcaOnRails/app/models/competition.rb'
+    - 'WcaOnRails/lib/results_validators/*.rb'
+
+Lint/StructNewOverride:
+  Enabled: false
+
+Style/AccessorGrouping:
+  Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+
+Style/SoleNestedConditional:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false
+
+Lint/EmptyBlock:
+  Enabled: false

--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -28,7 +28,7 @@ gem 'recaptcha', require: 'recaptcha/rails'
 gem 'kaminari'
 gem 'kaminari-i18n'
 gem 'devise'
-# Note: we put devise-18n before devise-bootstrap-views intentionally.
+# NOTE: we put devise-18n before devise-bootstrap-views intentionally.
 # See https://github.com/hisea/devise-bootstrap-views/issues/55 for more details.
 gem 'devise-i18n'
 gem 'devise-bootstrap-views'

--- a/WcaOnRails/app/controllers/media_controller.rb
+++ b/WcaOnRails/app/controllers/media_controller.rb
@@ -29,7 +29,7 @@ class MediaController < ApplicationController
     params[:region] ||= "all"
 
     media = CompetitionMedium.includes(:competition).where(status: params[:status]).order(timestampSubmitted: :desc)
-    media = media.where("Competitions.year": params[:year]) unless params[:year] == "all years"
+    media = media.where('Competitions.year': params[:year]) unless params[:year] == "all years"
     media = media.belongs_to_region(params[:region]) unless params[:region] == "all"
 
     media

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -77,12 +77,12 @@ class RegistrationsController < ApplicationController
     @competition = competition_from_params
     @registration = Registration.find(params[:id])
     if params.key?(:user_is_deleting_theirself)
-      if !current_user.can_edit_registration?(@registration)
-        flash[:danger] = I18n.t('registrations.flash.cannot_delete')
-      else
+      if current_user.can_edit_registration?(@registration)
         @registration.update!(deleted_at: Time.now, deleted_by: current_user.id)
         RegistrationsMailer.notify_organizers_of_deleted_registration(@registration).deliver_later
         flash[:success] = I18n.t('registrations.flash.deleted', comp: @competition.name)
+      else
+        flash[:danger] = I18n.t('registrations.flash.cannot_delete')
       end
       redirect_to competition_register_path(@competition)
     elsif current_user.can_manage_competition?(@competition)

--- a/WcaOnRails/app/controllers/results_controller.rb
+++ b/WcaOnRails/app/controllers/results_controller.rb
@@ -161,17 +161,7 @@ class ResultsController < ApplicationController
 
     shared_constants_and_conditions
 
-    if !@is_histories
-      @query = <<-SQL
-        SELECT *
-        FROM
-          (#{current_records_query("best", "single")}
-          UNION
-          #{current_records_query("average", "average")}) helper
-        ORDER BY
-          `rank`, type DESC, year, month, day, roundTypeId, personName
-      SQL
-    else
+    if @is_histories
       if @is_history
         order = 'event.`rank`, type desc, value, year desc, month desc, day desc, roundType.`rank` desc'
       else
@@ -214,6 +204,16 @@ class ResultsController < ApplicationController
           #{@years_condition_competition}
         ORDER BY
           #{order}
+      SQL
+    else
+      @query = <<-SQL
+        SELECT *
+        FROM
+          (#{current_records_query("best", "single")}
+          UNION
+          #{current_records_query("average", "average")}) helper
+        ORDER BY
+          `rank`, type DESC, year, month, day, roundTypeId, personName
       SQL
     end
   end

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -177,10 +177,10 @@ class UsersController < ApplicationController
         # Sign in the user, bypassing validation in case their password changed
         bypass_sign_in @user
       end
-      flash[:success] = if @user.confirmation_sent_at != old_confirmation_sent_at
-                          I18n.t('users.successes.messages.account_updated_confirm', email: @user.unconfirmed_email)
-                        else
+      flash[:success] = if @user.confirmation_sent_at == old_confirmation_sent_at
                           I18n.t('users.successes.messages.account_updated')
+                        else
+                          I18n.t('users.successes.messages.account_updated_confirm', email: @user.unconfirmed_email)
                         end
       if @user.claiming_wca_id
         flash[:success] = I18n.t('users.successes.messages.wca_id_claimed',

--- a/WcaOnRails/app/helpers/persons_helper.rb
+++ b/WcaOnRails/app/helpers/persons_helper.rb
@@ -16,7 +16,7 @@ module PersonsHelper
   end
 
   def odd_rank?(rank)
-    any_missing = rank.continent_rank == 0 || rank.country_rank == 0 # Note: world rank is always present.
+    any_missing = rank.continent_rank == 0 || rank.country_rank == 0 # NOTE: world rank is always present.
     any_missing || rank.continent_rank < rank.country_rank
   end
 

--- a/WcaOnRails/app/helpers/results_helper.rb
+++ b/WcaOnRails/app/helpers/results_helper.rb
@@ -11,7 +11,7 @@ module ResultsHelper
     end.reduce(:+)
   end
 
-  # Note: PB markers are computed in the order in which results are given.
+  # NOTE: PB markers are computed in the order in which results are given.
   def historical_pb_markers(results)
     Hash.new { |hash, key| hash[key] = {} }.tap do |markers|
       pb_single = results.first.best_solve

--- a/WcaOnRails/app/inputs/money_amount_input.rb
+++ b/WcaOnRails/app/inputs/money_amount_input.rb
@@ -31,8 +31,8 @@ class MoneyAmountInput < SimpleForm::Inputs::Base
                                         id: input_id,
                                         type: "text",
                                         data: {
-                                          'target': "##{@builder.object_name}_#{attribute_name}",
-                                          'currency': currency,
+                                          target: "##{@builder.object_name}_#{attribute_name}",
+                                          currency: currency,
                                           'currency-selector': currency_selector,
                                         },
                                         class: merged_input_options[:class],

--- a/WcaOnRails/app/models/anonymize_person.rb
+++ b/WcaOnRails/app/models/anonymize_person.rb
@@ -87,12 +87,12 @@ class AnonymizePerson
         current_country_id = person.countryId
 
         previous_persons.each do |p|
-          if p.countryId != current_country_id
+          if p.countryId == current_country_id
+            p.delete
+          else
             current_sub_id += 1
             current_country_id = p.countryId
             p.update(wca_id: new_wca_id, name: ANONYMIZED_NAME, gender: "o", year: 0, month: 0, day: 0, subId: current_sub_id)
-          else
-            p.delete
           end
         end
 

--- a/WcaOnRails/app/models/concerns/personal_best.rb
+++ b/WcaOnRails/app/models/concerns/personal_best.rb
@@ -7,12 +7,12 @@ module PersonalBest
 
   def rank_to_wcif(type)
     {
-      "eventId": eventId,
-      "best": best,
-      "worldRanking": worldRank,
-      "continentalRanking": continentRank,
-      "nationalRanking": countryRank,
-      "type": type,
+      eventId: eventId,
+      best: best,
+      worldRanking: worldRank,
+      continentalRanking: continentRank,
+      nationalRanking: countryRank,
+      type: type,
     }
   end
 

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -195,7 +195,7 @@ class Registration < ApplicationRecord
 
   def self.wcif_json_schema
     {
-      "type" => ["object", "null"], # Note: for now there may be WCIF persons without registration.
+      "type" => ["object", "null"], # NOTE: for now there may be WCIF persons without registration.
       "properties" => {
         "wcaRegistrationId" => { "type" => "integer" },
         "eventIds" => { "type" => "array", "items" => { "type" => "string", "enum" => Event.pluck(:id) } },

--- a/WcaOnRails/app/models/schedule_activity.rb
+++ b/WcaOnRails/app/models/schedule_activity.rb
@@ -178,11 +178,11 @@ class ScheduleActivity < ApplicationRecord
     parts.each do |p|
       case p[0]
       when "a"
-        parts_hash[:attempt_number] = p[1..-1].to_i
+        parts_hash[:attempt_number] = p[1..].to_i
       when "g"
-        parts_hash[:group_number] = p[1..-1].to_i
+        parts_hash[:group_number] = p[1..].to_i
       when "r"
-        parts_hash[:round_number] = p[1..-1].to_i
+        parts_hash[:round_number] = p[1..].to_i
       end
     end
     parts_hash

--- a/WcaOnRails/app/models/upload_json.rb
+++ b/WcaOnRails/app/models/upload_json.rb
@@ -8,9 +8,7 @@ class UploadJson
   validates :competition_id, presence: true
 
   validate do
-    if !results_json_str
-      errors.add(:results_file, "can't be blank")
-    else
+    if results_json_str
       begin
         # Parse the json first
         JSON::Validator.validate!(ResultsValidators::JSONSchemas::RESULT_JSON_SCHEMA, parsed_json)
@@ -22,6 +20,8 @@ class UploadJson
       rescue JSON::Schema::ValidationError => e
         errors.add(:results_file, "has errors: #{e.message}")
       end
+    else
+      errors.add(:results_file, "can't be blank")
     end
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -268,7 +268,7 @@ class User < ApplicationRecord
 
   before_validation :copy_data_from_persons
   def copy_data_from_persons
-    # Note: copy data from the person only if the WCA ID has already been claimed
+    # NOTE: copy data from the person only if the WCA ID has already been claimed
     # or the user claims this WCA ID.
     # Otherwise (when setting WCA ID directly) we want to validate
     # that the user details matches the person details instead.
@@ -1126,7 +1126,7 @@ class User < ApplicationRecord
     {
       "type" => "object",
       "properties" => {
-        "registrantId" => { "type" => ["integer", "null"] }, # Note: for now registrantId may be null if the person doesn't compete.
+        "registrantId" => { "type" => ["integer", "null"] }, # NOTE: for now registrantId may be null if the person doesn't compete.
         "name" => { "type" => "string" },
         "wcaUserId" => { "type" => "integer" },
         "wcaId" => { "type" => ["string", "null"] },

--- a/WcaOnRails/app/uploaders/avatar_uploader_base.rb
+++ b/WcaOnRails/app/uploaders/avatar_uploader_base.rb
@@ -55,7 +55,7 @@ class AvatarUploaderBase < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    # NOTE that we are storing avatars by wca_id. There are two consequences of this:
+    # NOTE: that we are storing avatars by wca_id. There are two consequences of this:
     #  - A user must have a wca_id to have an avatar (see validations in user.rb).
     #  - Changing the wca_id for a user is complicated, and not something we
     #    are bothering to handle very well.
@@ -78,7 +78,7 @@ class AvatarUploaderBase < CarrierWave::Uploader::Base
 
   # Add an allow list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_white_list # rubocop:disable Naming/InclusiveLanguage
+  def extension_white_list
     %w(jpg jpeg gif png)
   end
 

--- a/WcaOnRails/config/locales/locales.rb
+++ b/WcaOnRails/config/locales/locales.rb
@@ -3,121 +3,121 @@
 module Locales
   AVAILABLE = {
     # Ordered alphabetically by their local code, but with English first.
-    "en": {
-      "flag_id": "gb",
-      "name": "English",
+    en: {
+      flag_id: "gb",
+      name: "English",
     },
-    "cs": {
-      "flag_id": "cz",
-      "name": "Čeština",
+    cs: {
+      flag_id: "cz",
+      name: "Čeština",
     },
-    "da": {
-      "flag_id": "dk",
-      "name": "Dansk",
+    da: {
+      flag_id: "dk",
+      name: "Dansk",
     },
-    "de": {
-      "flag_id": "de",
-      "name": "Deutsch",
+    de: {
+      flag_id: "de",
+      name: "Deutsch",
     },
-    "eo": {
-      "flag_id": "eo",
-      "name": "Esperanto",
+    eo: {
+      flag_id: "eo",
+      name: "Esperanto",
     },
-    "es": {
-      "flag_id": "es",
-      "name": "Español",
+    es: {
+      flag_id: "es",
+      name: "Español",
     },
-    "fi": {
-      "flag_id": "fi",
-      "name": "Suomi",
+    fi: {
+      flag_id: "fi",
+      name: "Suomi",
     },
-    "fr": {
-      "flag_id": "fr",
-      "name": "Français",
+    fr: {
+      flag_id: "fr",
+      name: "Français",
     },
-    "hr": {
-      "flag_id": "hr",
-      "name": "Hrvatski",
+    hr: {
+      flag_id: "hr",
+      name: "Hrvatski",
     },
-    "hu": {
-      "flag_id": "hu",
-      "name": "Magyar",
+    hu: {
+      flag_id: "hu",
+      name: "Magyar",
     },
-    "id": {
-      "flag_id": "id",
-      "name": "Bahasa Indonesia",
+    id: {
+      flag_id: "id",
+      name: "Bahasa Indonesia",
     },
-    "it": {
-      "flag_id": "it",
-      "name": "Italiano",
+    it: {
+      flag_id: "it",
+      name: "Italiano",
     },
-    "ja": {
-      "flag_id": "jp",
-      "name": "日本語",
+    ja: {
+      flag_id: "jp",
+      name: "日本語",
     },
-    "kk": {
-      "flag_id": "kz",
-      "name": "Қазақша",
+    kk: {
+      flag_id: "kz",
+      name: "Қазақша",
     },
-    "ko": {
-      "flag_id": "kr",
-      "name": "한국어",
+    ko: {
+      flag_id: "kr",
+      name: "한국어",
     },
-    "nl": {
-      "flag_id": "nl",
-      "name": "Nederlands",
+    nl: {
+      flag_id: "nl",
+      name: "Nederlands",
     },
-    "pl": {
-      "flag_id": "pl",
-      "name": "Polski",
+    pl: {
+      flag_id: "pl",
+      name: "Polski",
     },
-    "pt": {
-      "flag_id": "pt",
-      "name": "Português Europeu",
+    pt: {
+      flag_id: "pt",
+      name: "Português Europeu",
     },
-    "pt-BR": {
-      "flag_id": "br",
-      "name": "Português Brasileiro",
+    'pt-BR': {
+      flag_id: "br",
+      name: "Português Brasileiro",
     },
-    "ro": {
-      "flag_id": "ro",
-      "name": "Română",
+    ro: {
+      flag_id: "ro",
+      name: "Română",
     },
-    "ru": {
-      "flag_id": "ru",
-      "name": "Русский",
+    ru: {
+      flag_id: "ru",
+      name: "Русский",
     },
-    "sk": {
-      "flag_id": "sk",
-      "name": "Slovenský",
+    sk: {
+      flag_id: "sk",
+      name: "Slovenský",
     },
-    "sl": {
-      "flag_id": "si",
-      "name": "Slovensko",
+    sl: {
+      flag_id: "si",
+      name: "Slovensko",
     },
-    "sv": {
-      "flag_id": "se",
-      "name": "Svenska",
+    sv: {
+      flag_id: "se",
+      name: "Svenska",
     },
-    "th": {
-      "flag_id": "th",
-      "name": "ภาษาไทย",
+    th: {
+      flag_id: "th",
+      name: "ภาษาไทย",
     },
-    "uk": {
-      "flag_id": "ua",
-      "name": "Українська",
+    uk: {
+      flag_id: "ua",
+      name: "Українська",
     },
-    "vi": {
-      "flag_id": "vn",
-      "name": "Tiếng Việt",
+    vi: {
+      flag_id: "vn",
+      name: "Tiếng Việt",
     },
-    "zh-CN": {
-      "flag_id": "cn",
-      "name": "简体中文",
+    'zh-CN': {
+      flag_id: "cn",
+      name: "简体中文",
     },
-    "zh-TW": {
-      "flag_id": "tw",
-      "name": "繁體中文",
+    'zh-TW': {
+      flag_id: "tw",
+      name: "繁體中文",
     },
   }.freeze
 end

--- a/WcaOnRails/lib/auxiliary_data_computation.rb
+++ b/WcaOnRails/lib/auxiliary_data_computation.rb
@@ -5,7 +5,7 @@ module AuxiliaryDataComputation
     self.compute_concise_results
     self.compute_rank_tables
 
-    self.delete_php_cache # Note: this should go away together with the PHP code.
+    self.delete_php_cache # NOTE: this should go away together with the PHP code.
   end
 
   ## Build 'concise results' tables.
@@ -87,7 +87,7 @@ module AuxiliaryDataComputation
             end
           end
           values = personal_rank.map do |person_id, rank_data|
-            # Note: continent_rank and country_rank may be not present because of a country change, in such case we default to 0.
+            # NOTE: continent_rank and country_rank may be not present because of a country change, in such case we default to 0.
             "('#{person_id}', '#{event_id}', #{rank_data[:best]}, #{rank_data[:world_rank]}, #{rank_data[:continent_rank] || 0}, #{rank_data[:country_rank] || 0})"
           end
           # Insert 500 rows at once to avoid running into too long query.

--- a/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
@@ -3,7 +3,7 @@
 module ResultsValidators
   class CompetitorLimitValidator < GenericValidator
     COMPETITOR_LIMIT_WARNING = "The number of persons in the competition (%{n_competitors}) is above the competitor limit (%{competitor_limit})."\
-      " The results of the competitors registered after the competitor limit was reached must be removed."
+                               " The results of the competitors registered after the competitor limit was reached must be removed."
 
     @@desc = "For competition with a competitor limit, this validator checks that this limit is respected."
 

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -5,7 +5,7 @@ module ResultsValidators
     NOT_333_MAIN_EVENT_WARNING = "The selected main event for this competition is %{main_event_id}. Please give WRT an explanation of how that event was treated as the main event of the competition."
     NO_MAIN_EVENT_WARNING = "There is no selected main event for this competition. Please let WRT know that this is correct."
     UNEXPECTED_RESULTS_ERROR = "Results are present for %{event_id}, however it is not listed as an official event."\
-      " Please remove the event from the results or contact the WCAT to request the event to be added to the WCA website."
+                               " Please remove the event from the results or contact the WCAT to request the event to be added to the WCA website."
     UNEXPECTED_ROUND_RESULTS_ERROR = "The round %{round_id} is present in the results but was not created on the events tab. Please include the round's information in the competition's manage events page."
     MISSING_RESULTS_WARNING = "There are no results for %{event_id}, but it is listed as an official event. If the event was held, please reupload your JSON with the results included. If the event was not held, leave a comment for the WRT."
     MISSING_ROUND_RESULTS_ERROR = "There are no results for round %{round_id} but it is listed in the events tab. If this round was not held, please remove the round in the competition's manage events page."

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -10,18 +10,18 @@ module ResultsValidators
     MET_CUTOFF_MISSING_RESULTS_ERROR = "[%{round_id}] %{person_name} met the cutoff but is missing results for the second phase of the round. The cutoff was %{cutoff}."
     DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR = "[%{round_id}] %{person_name} has at least one result for the second phase of the round but didn't meet the cutoff. The cutoff was %{cutoff}."
     WRONG_ATTEMPTS_FOR_CUTOFF_ERROR = "[%{round_id}] %{person_name} is missing at least one attempt for the cutoff phase."\
-    " Please edit the result to include the missing attempt(s) or update the round's information in the competition's Manage Events page."
+                                      " Please edit the result to include the missing attempt(s) or update the round's information in the competition's Manage Events page."
     MISMATCHED_RESULT_FORMAT_ERROR = "[%{round_id}] Results for %{person_name} are in the wrong format: expected %{expected_format}, but got %{format}."
     RESULT_OVER_TIME_LIMIT_ERROR = "[%{round_id}] At least one result for %{person_name} is over the time limit for the round, which is %{time_limit} per attempt. All solves over the time limit must be changed to DNF."
     RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR = "[%{round_ids}] The sum of results for %{person_name} is over the cumulative time limit, which was %{time_limit}."
     NO_ROUND_INFORMATION_WARNING = "[%{round_id}] There is no information about the cutoff and time limit for this round. These validations have been skipped. Please update the round's information in the competition's Manage Events page."
     UNDEF_TL_WARNING = "[%{round_id}] The time limit for this round is undefined, time limit validations have been skipped. This is expected only for competitions before 2013."
     SUSPICIOUS_DNF_WARNING = "[%{round_ids}] The round has a cumulative time limit, and extrapolating based on %{person_name}'s successful solves, they would have had very little time left for at least one of their DNFs."\
-    " Please ensure that every DNF and DNS is indeed correct. If the competitor did not start an attempt or did not have any remaining time before starting an attempt, it must be entered as DNS."
+                             " Please ensure that every DNF and DNS is indeed correct. If the competitor did not start an attempt or did not have any remaining time before starting an attempt, it must be entered as DNS."
 
     # Miscelaneous errors
     MISSING_CUMULATIVE_ROUND_ID_ERROR = "[%{original_round_id}] Unable to find the round \%{wcif_id}\ for the cumulative time limit specified in the WCIF."\
-    " Please go to the competition's Manage Events page and remove %{wcif_id} from the cumulative time limit for %{original_round_id}. WST knows about this bug (GitHub issue #3254)."
+                                        " Please go to the competition's Manage Events page and remove %{wcif_id} from the cumulative time limit for %{original_round_id}. WST knows about this bug (GitHub issue #3254)."
 
     @@desc = "This validator checks that all results respect the format, time limit, and cutoff information if available. It also looks for similar results within the round."
 

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -11,16 +11,16 @@ module ResultsValidators
     VERY_YOUNG_PERSON_WARNING = "%{name} seems to be less than 3 years old, please ensure it's correct."
     NOT_SO_YOUNG_PERSON_WARNING = "%{name} seems to be around 100 years old, please ensure it's correct."
     SAME_PERSON_NAME_WARNING = "There is already at least one person with the name '%{name}' in the WCA database (%{wca_ids})."\
-      " Please ensure that your '%{name}' is a different person. If not, please assign the correct WCA ID to the user account and regenerate the results JSON."
+                               " Please ensure that your '%{name}' is a different person. If not, please assign the correct WCA ID to the user account and regenerate the results JSON."
     NON_MATCHING_DOB_WARNING = "The birthdate '%{dob}' provided for %{name} (%{wca_id}) does not match the current record in the WCA database ('%{expected_dob}'). If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
     NON_MATCHING_GENDER_WARNING = "The gender '%{gender}' provided for %{name} (%{wca_id}) does not match the current record in the WCA database ('%{expected_gender}')."\
-    " If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
+                                  " If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
     EMPTY_GENDER_WARNING = "The gender for newcomer %{name} is empty. Valid gender values are 'female', 'male' and 'other'. Please leave a comment to the WRT about this."
     NON_MATCHING_NAME_WARNING = "The name '%{name}' provided for %{wca_id} does not match the current record in the WCA database ('%{expected_name}'). "
     NON_MATCHING_COUNTRY_WARNING = "The country '%{country}' provided for %{name} (%{wca_id}) does not match the current record in the WCA database ('%{expected_country}')."\
-    " If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
+                                   " If this is an error, fix it. Otherwise, leave a comment to the WRT about it."
     MULTIPLE_NEWCOMERS_WITH_SAME_NAME_WARNING = "There are multiple new competitors with the exact same name: %{name}. Please ensure that all results are correct for these competitors"\
-    " and that all results are correctly seperated by their corresponding id."
+                                                " and that all results are correctly seperated by their corresponding id."
     WRONG_PARENTHESIS_TYPE_ERROR = "The parenthesis character used in '%{name}' is an irregular character, please replace it with a regular parenthesis '(' or ')' and with appropriate spacing."
 
     @@desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -8,9 +8,9 @@ module ResultsValidators
     MISSING_SCRAMBLES_FOR_GROUP_ERROR = "[%{round_id}] Group %{group_id}: missing scrambles, detected only %{actual} instead of %{expected}."
     MISSING_SCRAMBLES_FOR_MULTI_ERROR = "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
     MULTIPLE_FMC_GROUPS_WARNING = "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused "\
-      "scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
+                                  "scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
     WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR = "[%{round_id}] This round has a different number of scramble sets than specified on the Manage Events tab. "\
-      "Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
+                                          "Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
 
     @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
 

--- a/WcaOnRails/spec/features/incident_management_spec.rb
+++ b/WcaOnRails/spec/features/incident_management_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.feature "Incident Management" do
-  let!(:incident1) { FactoryBot.create(:incident, title: "First incident", tags: ["a", "b"], incident_competitions_attributes: { "0": { competition_id: FactoryBot.create(:competition, :confirmed).id } }) }
+  let!(:incident1) { FactoryBot.create(:incident, title: "First incident", tags: ["a", "b"], incident_competitions_attributes: { '0': { competition_id: FactoryBot.create(:competition, :confirmed).id } }) }
   let!(:incident2) { FactoryBot.create(:incident, :resolved, title: "Second incident", tags: ["a", "c", "1a"]) }
   let!(:incident3) { FactoryBot.create(:incident, :resolved, title: "Custom title", tags: ["c"]) }
 

--- a/WcaOnRails/spec/helpers/competitions_helper_spec.rb
+++ b/WcaOnRails/spec/helpers/competitions_helper_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
-          "[Steven](#{person_url('2006YOYO03')}) finished third (9.99)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
+                           "[Steven](#{person_url('2006YOYO03')}) finished third (9.99)."
       end
 
       it "handles only 2 people in final" do
@@ -46,7 +46,7 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (9.99)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (9.99)."
       end
 
       it "handles only 1 person in final" do
@@ -63,8 +63,8 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
-          "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
+                           "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
       end
 
       it "handles ties in the podium" do
@@ -74,7 +74,7 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333"))
         expect(text).to eq "[Dan](#{person_url('2006YOYO01')}) and [Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
-          "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
+                           "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
       end
 
       it "handles tied third place" do
@@ -85,8 +85,8 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with an average of 9.99 seconds in the 3x3x3 Cube event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
-          "[John](#{person_url('2006YOYO03')}) and [Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (9.99) and " \
+                           "[John](#{person_url('2006YOYO03')}) and [Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 9.99 seconds)."
       end
     end
 
@@ -118,8 +118,8 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333bf"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with a single solve of 1:00.00 in the 3x3x3 Blindfolded event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (1:00.00) and " \
-          "[Steven](#{person_url('2006YOYO03')}) finished third (1:00.00)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (1:00.00) and " \
+                           "[Steven](#{person_url('2006YOYO03')}) finished third (1:00.00)."
       end
     end
 
@@ -151,8 +151,8 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333fm"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with a mean of 27.67 moves in the 3x3x3 Fewest Moves event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (27.67) and " \
-          "[Steven](#{person_url('2006YOYO03')}) finished third (27.67)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (27.67) and " \
+                           "[Steven](#{person_url('2006YOYO03')}) finished third (27.67)."
       end
 
       it "handles DNF averages in the podium" do
@@ -162,8 +162,8 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333fm"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with a mean of 27.67 moves in the 3x3x3 Fewest Moves event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (27.67) and " \
-          "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 24 moves)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (27.67) and " \
+                           "[Steven](#{person_url('2006YOYO03')}) finished third (with a single solve of 24 moves)."
       end
     end
 
@@ -199,8 +199,8 @@ RSpec.describe CompetitionsHelper do
 
         text = helper.winners(competition, Event.c_find("333mbf"))
         expect(text).to eq "[Jeremy](#{person_url('2006YOYO01')}) won with a result of 8/9 45:32 in the 3x3x3 Multi-Blind event. " \
-          "[Dan](#{person_url('2006YOYO02')}) finished second (8/9 45:32) and " \
-          "[Steven](#{person_url('2006YOYO03')}) finished third (8/9 45:32)."
+                           "[Dan](#{person_url('2006YOYO02')}) finished second (8/9 45:32) and " \
+                           "[Steven](#{person_url('2006YOYO03')}) finished third (8/9 45:32)."
       end
     end
   end

--- a/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
+++ b/WcaOnRails/spec/lib/auxiliary_data_computation_spec.rb
@@ -89,13 +89,13 @@ RSpec.describe "AuxiliaryDataComputation" do
       AuxiliaryDataComputation.compute_concise_results # Rank tables computation require concise results to be present.
       AuxiliaryDataComputation.compute_rank_tables
       %w(ranksSingle ranksAverage).each do |ranks_type|
-        # Note: this person hasn't got any results in Europe/France yet.
+        # NOTE: this person hasn't got any results in Europe/France yet.
         expect(rank_333(new_french, ranks_type)).to include(worldRank: 1, continentRank: 0, countryRank: 0)
-        # Note: the only change is the countryRank of new_canadian (previously american_1).
+        # NOTE: the only change is the countryRank of new_canadian (previously american_1).
         # Note: the continent is still USA, so continentRank shouldn't be affected.
         expect(rank_333(new_canadian, ranks_type)).to include(worldRank: 2, continentRank: 1, countryRank: 2)
         expect(rank_333(canadian, ranks_type)).to include(worldRank: 3, continentRank: 2, countryRank: 1)
-        # Note: this person stays 2nd in the country.
+        # NOTE: this person stays 2nd in the country.
         expect(rank_333(american_2, ranks_type)).to include(worldRank: 4, continentRank: 3, countryRank: 2)
       end
     end

--- a/WcaOnRails/spec/models/post_spec.rb
+++ b/WcaOnRails/spec/models/post_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Post do
       expect(Post.find(post.id).tags_array).to match_array %w(wdc)
 
       expect(post.update(tags: "wdc,test tag with spaces")).to eq false
-      expect(post).to be_invalid_with_errors("post_tags.tag": ["only allows English letters, numbers, hyphens, and '+'"])
+      expect(post).to be_invalid_with_errors('post_tags.tag': ["only allows English letters, numbers, hyphens, and '+'"])
 
       expect(Post.find(post.id).tags_array).to match_array %w(wdc)
     end

--- a/WcaOnRails/spec/models/upload_json_spec.rb
+++ b/WcaOnRails/spec/models/upload_json_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe UploadJson do
       "competitionId" => competition.id,
       "persons" => [
         {
-          "id": 1,
-          "name": "Sherlock Holmes",
-          "wcaId": "2020HOLM01",
-          "countryId": "GB",
-          "gender": "m",
-          "dob": "2000-01-01",
+          id: 1,
+          name: "Sherlock Holmes",
+          wcaId: "2020HOLM01",
+          countryId: "GB",
+          gender: "m",
+          dob: "2000-01-01",
         },
       ],
       "events" => [
@@ -50,7 +50,7 @@ RSpec.describe UploadJson do
                   "average" => 900,
                 },
               ],
-              "groups": [],
+              groups: [],
             },
           ],
         },

--- a/WcaOnRails/spec/requests/api_persons_spec.rb
+++ b/WcaOnRails/spec/requests/api_persons_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "API Persons" do
 
     context "when a query is given" do
       it "renders only people matching the query parameter" do
-        get api_v0_persons_path, params: { q: "#{person.wca_id.first(4)} #{person.name[1..-1]}" }
+        get api_v0_persons_path, params: { q: "#{person.wca_id.first(4)} #{person.name[1..]}" }
         expect(response).to be_successful
         json = JSON.parse(response.body)
         expect(json.length).to eq 1

--- a/WcaOnRails/spec/requests/incidents_spec.rb
+++ b/WcaOnRails/spec/requests/incidents_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "Incidents management", type: :request do
         {
           tags: "a,b",
           private_wrc_decision: "Private resolution",
-          incident_competitions_attributes: { "0": { competition_id: competition.id, comments: "some text" } },
+          incident_competitions_attributes: { '0': { competition_id: competition.id, comments: "some text" } },
         }
       }
 


### PR DESCRIPTION
Mostly just let RuboCop do its thing with `NewCops: enable`.

The main reason why we're introducing this now (instead of already doing it earlier) is that recently GitHub CI runners were upgraded, and now they have a feature to show linter offenses directly in a PR diff. So this makes life much easier for us when new style guidelines need to be applied.

Also, RuboCop is a sassy crybaby when new "Cops" are added and you haven't explicitly opted in or out. I want to get rid of the constant pain of having to rebase other people's PRs because RuboCops "Hey, look dis new stuff!!" messages are being intepreted as errors by OverCommit.