### PR TITLE
Update Regulation Translation Index

### DIFF
--- a/WcaOnRails/app/views/regulations/translations/index.html.erb
+++ b/WcaOnRails/app/views/regulations/translations/index.html.erb
@@ -11,9 +11,21 @@
   <% current_translations = [
     {
       version: "2022-06-01",
+      language: "简体中文",
+      language_english: "Chinese",
+      url: "./chinese",
+    },
+    {
+      version: "2022-06-01",
       language: "Português Brasileiro",
       language_english: "Portuguese, Brazil",
       url: "./portuguese-brazilian",
+    },
+    {
+      version: "2022-06-01",
+      language: "Русский",
+      language_english: "Russian",
+      url: "./russian",
     },
     {
       version: "2022-06-01",
@@ -37,12 +49,6 @@
     },
     {
       version: "2022-01-01",
-      language: "Русский",
-      language_english: "Russian",
-      url: "./russian",
-    },
-    {
-      version: "2022-01-01",
       language: "Svenska",
       language_english: "Swedish",
       url: "./swedish",
@@ -52,12 +58,6 @@
       language: "Italiano",
       language_english: "Italian",
       url: "./italian",
-    },
-    {
-      version: "2022-01-01",
-      language: "简体中文",
-      language_english: "Chinese",
-      url: "./chinese",
     },
     {
       version: "2021-05-01",


### PR DESCRIPTION
Great appreciate if we could get a redeploy after merge this one!

Update of regulation translation to June 01, 2022
[Chinese](https://github.com/thewca/wca-regulations-translations/pull/126) and [Russian](https://github.com/thewca/wca-regulations-translations/pull/127)