### PR TITLE
Remove currency deprecation warning

### DIFF
--- a/WcaOnRails/config/initializers/ruby_money.rb
+++ b/WcaOnRails/config/initializers/ruby_money.rb
@@ -4,3 +4,4 @@ Money.locale_backend = :i18n
 
 eu_bank = EuCentralBank.new
 Money.default_bank = eu_bank
+Money.default_currency = Money::Currency.new("USD")


### PR DESCRIPTION
This warning pops up quite often in development:
> [WARNING] The default currency will change from `USD` to `nil` in the next major release. Make sure to set it explicitly using `Money.default_currency=` to avoid potential issues

If we don't address this the website will break, so this commit explicitly sets the default currency.