### PR TITLE
Bug fixes to Qualification.js.

### DIFF
--- a/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Qualification.js
@@ -43,10 +43,11 @@ export default {
             newQualification.level = averageInput ? parseInt(averageInput.value) : 0;
           }
         } else {
+          // Set default values when resultType is newly set.
           newQualification.level = 0;
+          newQualification.type = "attemptResult";
         }
       }
-      console.log(newQualification);
       onChange(newQualification);
     };
 
@@ -96,7 +97,7 @@ export default {
       }
     }
 
-    let whenDateBlock = qualificationInput ? (
+    let whenDateBlock = qualification && qualification.type != "" ? (
       <div className="form-group">
         <label htmlFor="whenDate-input" className="col-sm-3 control-label">
           { I18n.t('qualification.deadline.description') }


### PR DESCRIPTION
-Set a default 'type' after resultType is newly set, so that fields below appear.
-Show the qualification deadline field for any 'type', not just ones with time inputs.
-Delete a stray Console.log.

Part of #2051.