### PR TITLE
Fixes #6782 - Add validators for obvious person name issues

### DIFF
--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -115,20 +115,20 @@ module ResultsValidators
             duplicate_newcomer_names << p.name
           end
           # Look for obvious person name issues
-          splitted_name = p.name.split
-          if splitted_name.any? { |n| n.downcase == n }
+          splt_name = p.name.split
+          if splt_name.any? { |n| n.downcase == n }
             @warnings << ValidationWarning.new(:persons, competition_id,
                                                LOWERCASE_NAME_WARNING,
                                                name: p.name)
           end
-          if splitted_name.length > 2
-            if splitted_name[0, splitted_name.length-2].any? { |n| n.length == 1 }
+          if splt_name.length > 2
+            if splt_name[0, splt_name.length-1].any? { |n| n.length == 1 }
               @warnings << ValidationWarning.new(:persons, competition_id,
                                                  MISSING_ABBREVIATION_PERIOD_WARNING,
                                                  name: p.name)
             end
           end
-          if p.name[0, 2].include?(" ") || p.name[0, 2].include?(".") || p.name.reverse[0, 2].include?(" ") || p.name.reverse[0, 2].include?(".")
+          if [' ', '.'].include?(p.name[1]) || p.name[-2] == (" ") || p.name[-1] == "." && p.name[-3] == " " 
             @errors << ValidationError.new(:persons, competition_id,
                                            SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR,
                                            name: p.name)

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -128,7 +128,7 @@ module ResultsValidators
                                                  name: p.name)
             end
           end
-          if [' ', '.'].include?(p.name[1]) || p.name[-2] == (" ") || p.name[-1] == "." && p.name[-3] == " " 
+          if [' ', '.'].include?(p.name[1]) || (p.name[-2] == (" ")) || ((p.name[-1] == ".") && (p.name[-3] == " "))
             @errors << ValidationError.new(:persons, competition_id,
                                            SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR,
                                            name: p.name)

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -128,7 +128,7 @@ module ResultsValidators
                                                  name: p.name)
             end
           end
-          if [' ', '.'].include?(p.name[1]) || ((name[-2] == " ") && !['I', 'V'].include?(name[-1])) || ((p.name[-1] == ".") && (p.name[-3] == " "))
+          if [' ', '.'].include?(p.name[1]) || ((p.name[-2] == " ") && !['I', 'V'].include?(p.name[-1])) || ((p.name[-1] == ".") && (p.name[-3] == " "))
             @warning << ValidationWarning.new(:persons, competition_id,
                                               SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING,
                                               name: p.name)

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -117,13 +117,13 @@ module ResultsValidators
           end
           # Look for obvious person name issues
           splitted_name = p.name.split
-          if splitted_name.any?( |n| n.downcase == n)
+          if splitted_name.any? { |n| n.downcase == n}
             @warnings << ValidationWarning.new(:persons, competition_id,
                                            LOWERCASE_NAME_WARNING,
                                            name: p.name)
           end
           if splitted_name.length > 2
-            if splitted_name[0,splitted_name.length-2].any?( |n| n.length == 1)
+            if splitted_name[0,splitted_name.length-2].any? { |n| n.length == 1}
               @warnings << ValidationWarning.new(:persons, competition_id,
                                                   MISSING_ABBREVIATION_PERIOD_WARNING,
                                                   name: p.name)

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -123,7 +123,7 @@ module ResultsValidators
                                            name: p.name)
           end
           if splitted_name.length > 2
-            if splitted_name[0,splitted_name.length-2].any( |n| n.length == 1)
+            if splitted_name[0,splitted_name.length-2].any?( |n| n.length == 1)
               @warnings << ValidationWarning.new(:persons, competition_id,
                                                   MISSING_ABBREVIATION_PERIOD_WARNING,
                                                   name: p.name)

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -24,7 +24,7 @@ module ResultsValidators
     WRONG_PARENTHESIS_TYPE_ERROR = "The parenthesis character used in '%{name}' is an irregular character, please replace it with a regular parenthesis '(' or ')' and with appropriate spacing."
     LOWERCASE_NAME_WARNING = "'%{name}' has a lowercase name, please ensure the correct spelling."
     MISSING_ABBREVIATION_PERIOD_WARNING = "'%{name}' is missing an abbreviation period from a single letter middle name, please ensure the correct spelling."
-    SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING = "'%{name}' has a single letter as first or last name. If this is an abbreviation, please fix the name."
+    SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING = "'%{name}' has a single letter as first or last name, please fix the name."
 
     @@desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."
 
@@ -128,7 +128,7 @@ module ResultsValidators
                                                  name: p.name)
             end
           end
-          if [' ', '.'].include?(p.name[1]) || (p.name[-2] == " ") || ((p.name[-1] == ".") && (p.name[-3] == " "))
+          if [' ', '.'].include?(p.name[1]) || ((name[-2] == " ") && !['I', 'V'].include?(name[-1])) || ((p.name[-1] == ".") && (p.name[-3] == " "))
             @warning << ValidationWarning.new(:persons, competition_id,
                                               SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING,
                                               name: p.name)

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -26,7 +26,6 @@ module ResultsValidators
     MISSING_ABBREVIATION_PERIOD_WARNING = "'%{name}' is missing an abbreviation period from a single letter middle name, please ensure the correct spelling."
     SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR = "'%{name}' has a single letter abbreviation as first or last name, please fix the name."
 
-
     @@desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."
 
     def self.has_automated_fix?
@@ -117,22 +116,22 @@ module ResultsValidators
           end
           # Look for obvious person name issues
           splitted_name = p.name.split
-          if splitted_name.any? { |n| n.downcase == n}
+          if splitted_name.any? { |n| n.downcase == n }
             @warnings << ValidationWarning.new(:persons, competition_id,
-                                           LOWERCASE_NAME_WARNING,
-                                           name: p.name)
+                                               LOWERCASE_NAME_WARNING,
+                                               name: p.name)
           end
           if splitted_name.length > 2
-            if splitted_name[0,splitted_name.length-2].any? { |n| n.length == 1}
+            if splitted_name[0, splitted_name.length-2].any? { |n| n.length == 1 }
               @warnings << ValidationWarning.new(:persons, competition_id,
-                                                  MISSING_ABBREVIATION_PERIOD_WARNING,
-                                                  name: p.name)
+                                                 MISSING_ABBREVIATION_PERIOD_WARNING,
+                                                 name: p.name)
             end
           end
-          if p.name[0,2].include?(" ") or p.name[0,2].include?(".") or p.name.reverse[0,2].include?(" ") or p.name.reverse[0,2].include?(".")
+          if p.name[0, 2].include?(" ") || p.name[0, 2].include?(".") || p.name.reverse[0, 2].include?(" ") || p.name.reverse[0, 2].include?(".")
             @errors << ValidationError.new(:persons, competition_id,
-                                                SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR,
-                                                name: p.name)
+                                           SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR,
+                                           name: p.name)
           end
         end
         duplicate_newcomer_names.each do |name|

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -24,7 +24,7 @@ module ResultsValidators
     WRONG_PARENTHESIS_TYPE_ERROR = "The parenthesis character used in '%{name}' is an irregular character, please replace it with a regular parenthesis '(' or ')' and with appropriate spacing."
     LOWERCASE_NAME_WARNING = "'%{name}' has a lowercase name, please ensure the correct spelling."
     MISSING_ABBREVIATION_PERIOD_WARNING = "'%{name}' is missing an abbreviation period from a single letter middle name, please ensure the correct spelling."
-    SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR = "'%{name}' has a single letter abbreviation as first or last name, please fix the name."
+    SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING = "'%{name}' has a single letter as first or last name. If this is an abbreviation, please fix the name."
 
     @@desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."
 
@@ -128,10 +128,10 @@ module ResultsValidators
                                                  name: p.name)
             end
           end
-          if [' ', '.'].include?(p.name[1]) || (p.name[-2] == (" ")) || ((p.name[-1] == ".") && (p.name[-3] == " "))
-            @errors << ValidationError.new(:persons, competition_id,
-                                           SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR,
-                                           name: p.name)
+          if [' ', '.'].include?(p.name[1]) || (p.name[-2] == " ") || ((p.name[-1] == ".") && (p.name[-3] == " "))
+            @warning << ValidationWarning.new(:persons, competition_id,
+                                              SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING,
+                                              name: p.name)
           end
         end
         duplicate_newcomer_names.each do |name|

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -129,9 +129,9 @@ module ResultsValidators
             end
           end
           if [' ', '.'].include?(p.name[1]) || ((p.name[-2] == " ") && !['I', 'V'].include?(p.name[-1])) || ((p.name[-1] == ".") && (p.name[-3] == " "))
-            @warning << ValidationWarning.new(:persons, competition_id,
-                                              SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING,
-                                              name: p.name)
+            @warnings << ValidationWarning.new(:persons, competition_id,
+                                               SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING,
+                                               name: p.name)
           end
         end
         duplicate_newcomer_names.each do |name|

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -133,9 +133,9 @@ module ResultsValidators
                                                  name: p.name)
             end
           end
-          non_word_after_first_letter = [' ', '.'].include?(p.name[1])
-          space_before_last_letter = (p.name[-2] == " ") && !['I', 'V'].include?(p.name[-1]) # Numerical suffixes I and V have to be excluded to pass unit tests
-          abbreviated_last_name = (p.name[-1] == ".") && (p.name[-3] == " ")
+          non_word_after_first_letter = [' ', '.'].include?(roman_readable[1])
+          space_before_last_letter = (roman_readable[-2] == " ") && !['I', 'V'].include?(roman_readable[-1]) # Roman numerals I and V are allowed as suffixes
+          abbreviated_last_name = (roman_readable[-1] == ".") && (roman_readable[-3] == " ")
           if non_word_after_first_letter || space_before_last_letter || abbreviated_last_name
             @warnings << ValidationWarning.new(:persons, competition_id,
                                                SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING,

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -157,14 +157,18 @@ RSpec.describe PV do
                                                 competition: competition1,
                                                 eventId: "333oh")
         res_bad_parenthesis.person.update(name: "Bad Parenthesis Guy（test）")
-        res_lowercase = FactoryBot.create(:inbox_result,
+        res_lowercase1 = FactoryBot.create(:inbox_result,
                                           competition: competition1,
                                           eventId: "333oh")
-        res_lowercase.person.update(name: "First Middle last")
+        res_lowercase1.person.update(name: "First Middle last")
+        res_lowercase2 = FactoryBot.create(:inbox_result,
+                                           competition: competition1,
+                                           eventId: "333oh")
+        res_lowercase2.person.update(name: "İlis хocavənd V")
         res_missing_period = FactoryBot.create(:inbox_result,
                                                competition: competition1,
                                                eventId: "333oh")
-        res_missing_period.person.update(name: "First A B. Last")
+        res_missing_period.person.update(name: "First A B. Last (最初)")
         res_single_letter = FactoryBot.create(:inbox_result,
                                               competition: competition1,
                                               eventId: "333oh")
@@ -219,7 +223,10 @@ RSpec.describe PV do
                                     name: res_same_name1.person.name),
           RV::ValidationWarning.new(:persons, competition1.id,
                                     PV::LOWERCASE_NAME_WARNING,
-                                    name: res_lowercase.person.name),
+                                    name: res_lowercase1.person.name),
+          RV::ValidationWarning.new(:persons, competition1.id,
+                                    PV::LOWERCASE_NAME_WARNING,
+                                    name: res_lowercase2.person.name),
           RV::ValidationWarning.new(:persons, competition1.id,
                                     PV::MISSING_ABBREVIATION_PERIOD_WARNING,
                                     name: res_missing_period.person.name),

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -158,8 +158,8 @@ RSpec.describe PV do
                                                 eventId: "333oh")
         res_bad_parenthesis.person.update(name: "Bad Parenthesis Guy（test）")
         res_lowercase1 = FactoryBot.create(:inbox_result,
-                                          competition: competition1,
-                                          eventId: "333oh")
+                                           competition: competition1,
+                                           eventId: "333oh")
         res_lowercase1.person.update(name: "First Middle last")
         res_lowercase2 = FactoryBot.create(:inbox_result,
                                            competition: competition1,

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -156,16 +156,16 @@ RSpec.describe PV do
         res_bad_parenthesis.person.update(name: "Bad Parenthesis Guy（test）")
         res_lowercase = FactoryBot.create(:inbox_result,
                                           competition: competition1,
-                                          eventId:"333oh")
+                                          eventId: "333oh")
         res_lowercase.person.update(name: "First Middle last")
         res_missing_period = FactoryBot.create(:inbox_result,
                                                competition: competition1,
-                                               eventId:"333oh")
+                                               eventId: "333oh")
         res_missing_period.person.update(name: "First A B. Last")
         res_single_letter = FactoryBot.create(:inbox_result,
                                               competition: competition1,
-                                              eventId:"333oh")
-        res_single_letter.person.update(name: "A. B. Last")     
+                                              eventId: "333oh")
+        res_single_letter.person.update(name: "A. B. Last")
         res_same_name1 = FactoryBot.create(:inbox_result,
                                            competition: competition1,
                                            eventId: "333oh")

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -154,6 +154,18 @@ RSpec.describe PV do
                                                 competition: competition1,
                                                 eventId: "333oh")
         res_bad_parenthesis.person.update(name: "Bad Parenthesis Guy（test）")
+        res_lowercase = FactoryBot.create(:inbox_result,
+                                          competition: competition1,
+                                          eventId:"333oh")
+        res_lowercase.person.update(name: "First Middle last")
+        res_missing_period = FactoryBot.create(:inbox_result,
+                                               competition: competition1,
+                                               eventId:"333oh")
+        res_missing_period.person.update(name: "First A B. Last")
+        res_single_letter = FactoryBot.create(:inbox_result,
+                                              competition: competition1,
+                                              eventId:"333oh")
+        res_single_letter.person.update(name: "A. B. Last")     
         res_same_name1 = FactoryBot.create(:inbox_result,
                                            competition: competition1,
                                            eventId: "333oh")
@@ -185,6 +197,9 @@ RSpec.describe PV do
           RV::ValidationError.new(:persons, competition1.id,
                                   PV::WRONG_PARENTHESIS_TYPE_ERROR,
                                   name: res_bad_parenthesis.person.name),
+          RV::ValidationError.new(:persons, competition1.id,
+                                  PV::SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR,
+                                  name: res_single_letter.person.name),
         ]
         expected_warnings = [
           RV::ValidationWarning.new(:persons, competition1.id,
@@ -202,6 +217,12 @@ RSpec.describe PV do
           RV::ValidationWarning.new(:persons, competition1.id,
                                     PV::MULTIPLE_NEWCOMERS_WITH_SAME_NAME_WARNING,
                                     name: res_same_name1.person.name),
+          RV::ValidationWarning.new(:persons, competition1.id,
+                                    PV::LOWERCASE_NAME_WARNING,
+                                    name: res_lowercase.person.name),
+          RV::ValidationWarning.new(:persons, competition1.id,
+                                    PV::MISSING_ABBREVIATION_PERIOD_WARNING,
+                                    name: res_missing_period.person.name),
         ]
         validator_args = [
           { competition_ids: [competition1.id, competition2.id], model: InboxResult },

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe PV do
         res_lowercase1 = FactoryBot.create(:inbox_result,
                                            competition: competition1,
                                            eventId: "333oh")
-        res_lowercase1.person.update(name: "First Middle last")
+        res_lowercase1.person.update(name: "Yamada taro (山田太郎)")
         res_lowercase2 = FactoryBot.create(:inbox_result,
                                            competition: competition1,
                                            eventId: "333oh")
@@ -168,11 +168,11 @@ RSpec.describe PV do
         res_missing_period = FactoryBot.create(:inbox_result,
                                                competition: competition1,
                                                eventId: "333oh")
-        res_missing_period.person.update(name: "First A B. Last (最初)")
+        res_missing_period.person.update(name: "Missing A Period")
         res_single_letter = FactoryBot.create(:inbox_result,
                                               competition: competition1,
                                               eventId: "333oh")
-        res_single_letter.person.update(name: "A. B. Last")
+        res_single_letter.person.update(name: "A. B. Doe")
         res_same_name1 = FactoryBot.create(:inbox_result,
                                            competition: competition1,
                                            eventId: "333oh")

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe PV do
       # PERSON_WITHOUT_RESULTS_ERROR
       # WRONG_WCA_ID_ERROR
       # WRONG_PARENTHESIS_FORMAT_ERROR
+      # SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR
       # DOB_0101_WARNING
       # VERY_YOUNG_PERSON_WARNING
       # NOT_SO_YOUNG_PERSON_WARNING
@@ -128,6 +129,8 @@ RSpec.describe PV do
       # WHITESPACE_IN_NAME_ERROR
       # WRONG_PARENTHESIS_TYPE_ERROR
       # MULTIPLE_NEWCOMERS_WITH_SAME_NAME_WARNING
+      # LOWERCASE_NAME_WARNING
+      # MISSING_ABBREVIATION_PERIOD_WARNING
       it "validates person data" do
         FactoryBot.create(:inbox_result, competition: competition2, eventId: "222")
         res1 = FactoryBot.create(:inbox_result, competition: competition2, eventId: "222")

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -121,7 +121,6 @@ RSpec.describe PV do
       # PERSON_WITHOUT_RESULTS_ERROR
       # WRONG_WCA_ID_ERROR
       # WRONG_PARENTHESIS_FORMAT_ERROR
-      # SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR
       # DOB_0101_WARNING
       # VERY_YOUNG_PERSON_WARNING
       # NOT_SO_YOUNG_PERSON_WARNING
@@ -131,6 +130,7 @@ RSpec.describe PV do
       # MULTIPLE_NEWCOMERS_WITH_SAME_NAME_WARNING
       # LOWERCASE_NAME_WARNING
       # MISSING_ABBREVIATION_PERIOD_WARNING
+      # SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING
       it "validates person data" do
         FactoryBot.create(:inbox_result, competition: competition2, eventId: "222")
         res1 = FactoryBot.create(:inbox_result, competition: competition2, eventId: "222")
@@ -200,9 +200,6 @@ RSpec.describe PV do
           RV::ValidationError.new(:persons, competition1.id,
                                   PV::WRONG_PARENTHESIS_TYPE_ERROR,
                                   name: res_bad_parenthesis.person.name),
-          RV::ValidationError.new(:persons, competition1.id,
-                                  PV::SINGLE_LETTER_FIRST_OR_LAST_NAME_ERROR,
-                                  name: res_single_letter.person.name),
         ]
         expected_warnings = [
           RV::ValidationWarning.new(:persons, competition1.id,
@@ -226,6 +223,9 @@ RSpec.describe PV do
           RV::ValidationWarning.new(:persons, competition1.id,
                                     PV::MISSING_ABBREVIATION_PERIOD_WARNING,
                                     name: res_missing_period.person.name),
+          RV::ValidationWarning.new(:persons, competition1.id,
+                                    PV::SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING,
+                                    name: res_single_letter.person.name),
         ]
         validator_args = [
           { competition_ids: [competition1.id, competition2.id], model: InboxResult },


### PR DESCRIPTION
Add a warning for 
- lowercase names
- single letter middle names / abbreviations without a period
- single letter first and last names (with or without a period)

Update unit tests to include the new cases.