### PR TITLE
Fix RO apply link

### DIFF
--- a/WcaOnRails/app/views/regional_organizations/index.html.erb
+++ b/WcaOnRails/app/views/regional_organizations/index.html.erb
@@ -4,4 +4,5 @@
   <%= react_component("RegionalOrganizations/index", {
     orgs: @acknowledged_regional_organizations,
   }) %>
+  <%= t('regional_organizations.application_instructions.description_html') %>
 </div>

--- a/WcaOnRails/app/views/regional_organizations/index.html.erb
+++ b/WcaOnRails/app/views/regional_organizations/index.html.erb
@@ -4,5 +4,4 @@
   <%= react_component("RegionalOrganizations/index", {
     orgs: @acknowledged_regional_organizations,
   }) %>
-  <%= t('regional_organizations.application_instructions.description_html') %>
 </div>

--- a/WcaOnRails/app/webpacker/components/I18nHTMLTranslate.js
+++ b/WcaOnRails/app/webpacker/components/I18nHTMLTranslate.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { sanitize } from 'dompurify';
+
+import I18n from '../lib/i18n';
+
+function I18nHTMLTranslate({
+  i18nKey,
+}) {
+  return (
+    <div name="I18nHTMLTranslate" dangerouslySetInnerHTML={{ __html: sanitize(I18n.t(i18nKey)) }} />
+  );
+}
+
+export default I18nHTMLTranslate;

--- a/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
+++ b/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
@@ -50,7 +50,6 @@ function ROOverview({
       </ol>
 
       <h3>{I18n.t('regional_organizations.application_instructions.title')}</h3>
-      <p>{I18n.t('regional_organizations.application_instructions.description_html')}</p>
     </>
   );
 }

--- a/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
+++ b/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
@@ -50,6 +50,7 @@ function ROOverview({
       </ol>
 
       <h3>{I18n.t('regional_organizations.application_instructions.title')}</h3>
+      <p dangerouslySetInnerHTML={{ __html: I18n.t('regional_organizations.application_instructions.description_html') }} />
     </>
   );
 }

--- a/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
+++ b/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { sanitize } from 'dompurify';
 import I18n from '../../lib/i18n';
 
 function ROOverview({
@@ -50,7 +51,7 @@ function ROOverview({
       </ol>
 
       <h3>{I18n.t('regional_organizations.application_instructions.title')}</h3>
-      <p dangerouslySetInnerHTML={{ __html: I18n.t('regional_organizations.application_instructions.description_html') }} />
+      <p dangerouslySetInnerHTML={{ __html: sanitize(I18n.t('regional_organizations.application_instructions.description_html')) }} />
     </>
   );
 }

--- a/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
+++ b/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { sanitize } from 'dompurify';
 import I18n from '../../lib/i18n';
+import I18nHTMLTranslate from '../I18nHTMLTranslate';
 
 function ROOverview({
   orgs,
@@ -51,7 +51,7 @@ function ROOverview({
       </ol>
 
       <h3>{I18n.t('regional_organizations.application_instructions.title')}</h3>
-      <p dangerouslySetInnerHTML={{ __html: sanitize(I18n.t('regional_organizations.application_instructions.description_html')) }} />
+      <p><I18nHTMLTranslate i18nKey="regional_organizations.application_instructions.description_html" /></p>
     </>
   );
 }

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -154,6 +154,10 @@ ignore:
 <%
   require './lib/custom_wca_i18n_scanner.rb'
   I18n::Tasks.add_scanner 'CustomWcaI18nScanner', only: %w(*.erb)
+
+  I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+    only: %w(*.js),
+    patterns: [['<I18nHTMLTranslate\si18nKey=%{key}\s/>', '%{key}']]
 %>
 # <%#= I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
 #        only: %w(*.html.haml *.html.slim),

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -157,7 +157,7 @@ ignore:
 
   I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
     only: %w(*.js),
-    patterns: [['<I18nHTMLTranslate\si18nKey=%{key}\s/>', '%{key}']]
+    patterns: [['I18nHTMLTranslate\si18nKey=%{key}', '%{key}']]
 %>
 # <%#= I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
 #        only: %w(*.html.haml *.html.slim),

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -157,7 +157,7 @@ ignore:
 
   I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
     only: %w(*.js),
-    patterns: [['I18nHTMLTranslate\si18nKey=%{key}', '%{key}']]
+    patterns: [['I18nHTMLTranslate\s+i18nKey=%{key}', '%{key}']]
 %>
 # <%#= I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
 #        only: %w(*.html.haml *.html.slim),

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -30,6 +30,7 @@
     "core-js": "^3.22.8",
     "css-loader": "^6.7.1",
     "css-minimizer-webpack-plugin": "^4.0.0",
+    "dompurify": "^2.3.9",
     "easymde": "^2.16.1",
     "expose-loader": "^4.0.0",
     "file-loader": "^6.2.0",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -2660,6 +2660,11 @@ domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.9.tgz#a4be5e7278338d6db09922dffcf6182cd099d70a"
+  integrity sha512-3zOnuTwup4lPV/GfGS6UzG4ub9nhSYagR/5tB3AvDEwqyy5dtyCM2dVjwGDCnrPerXifBKTYh/UWCGKK7ydhhw==
+
 domutils@1.5:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"


### PR DESCRIPTION
#7041 

In React, HTML written in locales break because JSX expressions automatically add double quotes to the translated sentences. This is fixed by moving the apply link to ruby views, but makes the link also appear in the case where there are no regional organizations, which on a second thought, makes sense too.

Case I'm talking about:

![image](https://user-images.githubusercontent.com/58278719/178329509-c3ad3bcb-3b69-49d4-bb77-18664209b156.png)
