### PR TITLE
Add registration eligibility to competitions on the competition list (Fixes #7036)

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -268,4 +268,33 @@ module CompetitionsHelper
   def cached_pdf_name(competition, colors)
     "#{pdf_name(competition)}_#{competition.updated_at.iso8601}_#{colors}"
   end
+
+  def registration_status_icon(competition)
+    icon = ""
+    title = ""
+    icon_class = ""
+
+    if competition.registration_not_yet_opened?
+      icon = "clock"
+      title = "Registraion opens in #{(competition.start_date - Date.today).to_i} days"
+      icon_class = "blue"
+    elsif competition.registration_past?
+      icon = "times circle"
+      title = "Registration closed"
+      icon_class = "red"
+    elsif competition.registration_full?
+      icon = "exclamation circle"
+      title = "Registration full, waiting list open"
+      icon_class = "orange"
+    else
+      icon = "check circle"
+      title = "Registration open"
+      icon_class = "green"
+    end
+
+    ui_icon(icon,
+            title: title,
+            class: icon_class,
+            data: { toggle: "tooltip" })
+  end
 end

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -276,18 +276,18 @@ module CompetitionsHelper
 
     if competition.registration_not_yet_opened?
       icon = "clock"
-      title = I18n.t('competitions.index.tooltips.registration.opens_in', days: t('common.days', count: (Date.today - competition.end_date).to_i))
+      title = I18n.t('competitions.index.tooltips.registration.opens_in', duration: distance_of_time_in_words_to_now(competition.registration_open))
       icon_class = "blue"
     elsif competition.registration_past?
-      icon = "times circle"
+      icon = "user times"
       title = I18n.t('competitions.index.tooltips.registration.closed')
       icon_class = "red"
     elsif competition.registration_full?
-      icon = "exclamation circle"
+      icon = "user"
       title = I18n.t('competitions.index.tooltips.registration.full')
       icon_class = "orange"
     else
-      icon = "check circle"
+      icon = "user plus"
       title = I18n.t('competitions.index.tooltips.registration.open')
       icon_class = "green"
     end

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -283,7 +283,7 @@ module CompetitionsHelper
       title = I18n.t('competitions.index.tooltips.registration.closed', days: t('common.days', count: (competition.start_date - Date.today).to_i))
       icon_class = "red"
     elsif competition.registration_full?
-      icon = "user"
+      icon = "user clock"
       title = I18n.t('competitions.index.tooltips.registration.full')
       icon_class = "orange"
     else

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -276,19 +276,19 @@ module CompetitionsHelper
 
     if competition.registration_not_yet_opened?
       icon = "clock"
-      title = "Registraion opens in #{(competition.start_date - Date.today).to_i} days"
+      title = I18n.t('competitions.index.tooltips.registration.opens_in', days: t('common.days', count: (Date.today - competition.end_date).to_i))
       icon_class = "blue"
     elsif competition.registration_past?
       icon = "times circle"
-      title = "Registration closed"
+      title = I18n.t('competitions.index.tooltips.registration.closed')
       icon_class = "red"
     elsif competition.registration_full?
       icon = "exclamation circle"
-      title = "Registration full, waiting list open"
+      title = I18n.t('competitions.index.tooltips.registration.full')
       icon_class = "orange"
     else
       icon = "check circle"
-      title = "Registration open"
+      title = I18n.t('competitions.index.tooltips.registration.open')
       icon_class = "green"
     end
 

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -280,7 +280,7 @@ module CompetitionsHelper
       icon_class = "blue"
     elsif competition.registration_past?
       icon = "user times"
-      title = I18n.t('competitions.index.tooltips.registration.closed')
+      title = I18n.t('competitions.index.tooltips.registration.closed', days: t('common.days', count: (competition.start_date - Date.today).to_i))
       icon_class = "red"
     elsif competition.registration_full?
       icon = "user"

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -8,6 +8,9 @@
     <% li_classes << (competition.is_probably_over? ? "past" : "not-past") %>
     <% li_classes << "cancelled" if competition.cancelled? %>
     <li class="<%= li_classes.join(' ') %>">
+      <span>
+        <%= registration_status_icon(competition) %>
+      </span>
       <span class="date">
         <% if competition.is_probably_over? %>
           <% if competition.results_posted? %>

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -9,7 +9,6 @@
     <% li_classes << "cancelled" if competition.cancelled? %>
     <li class="<%= li_classes.join(' ') %>">
       <span class="date">
-        <%= registration_status_icon(competition) %>
         <% if competition.is_probably_over? %>
           <% if competition.results_posted? %>
             <%= ui_icon('check circle', title: t('competitions.index.tooltips.hourglass.posted'), class: "results-posted-indicator", data: { toggle: "tooltip" }) %>
@@ -21,7 +20,7 @@
         <% elsif @by_announcement_selected %>
           <%= ui_icon('hourglass start', title: t('competitions.index.tooltips.hourglass.announced_on', announcement_date: competition.announced_at.strftime(" %F %H:%M:%S")), data: { toggle: "tooltip" }) %>
         <% else %>
-          <%= ui_icon('hourglass start', title: t('competitions.index.tooltips.hourglass.starts_in', days: t('common.days', count:(competition.start_date - Date.today).to_i)), data: { toggle: "tooltip" }) %>
+          <%= registration_status_icon(competition) %>
         <% end %>
         <%= wca_date_range(competition.start_date, competition.end_date) %>
       </span>

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -8,10 +8,8 @@
     <% li_classes << (competition.is_probably_over? ? "past" : "not-past") %>
     <% li_classes << "cancelled" if competition.cancelled? %>
     <li class="<%= li_classes.join(' ') %>">
-      <span>
-        <%= registration_status_icon(competition) %>
-      </span>
       <span class="date">
+        <%= registration_status_icon(competition) %>
         <% if competition.is_probably_over? %>
           <% if competition.results_posted? %>
             <%= ui_icon('check circle', title: t('competitions.index.tooltips.hourglass.posted'), class: "results-posted-indicator", data: { toggle: "tooltip" }) %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1463,7 +1463,7 @@ en:
           opens_in: "Registration will open in %{duration}"
           closed: "Registration has closed. Competition starts in %{days}"
           open: "Registration is open!"
-          full: "Competitor limit reached, the waiting list is now in effect"
+          full: "Competitor limit reached, new registrations will go to the waiting list"
       no_comp_found: "No competitions found."
       no_comp_match: "We didn't find any competitions with %{events}! Try searching for fewer events."
     #context: on the "My competitions" page

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1463,7 +1463,7 @@ en:
         registration:
           opens_in: "Registration will open in %{days}"
           closed: "Registration has closed"
-          open: "Registraion is open!"
+          open: "Registration is open!"
           full: "Competitor limit reached, the waiting list is now in effect"
       no_comp_found: "No competitions found."
       no_comp_match: "We didn't find any competitions with %{events}! Try searching for fewer events."

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1453,7 +1453,6 @@ en:
           ended: "Ended %{days} ago"
           in_progress: "In progress!"
           posted: "Results are posted!"
-          starts_in: "Starts in %{days}"
           announced_on: "Announced on %{announcement_date}"
         #context: the "search" button
         search: "Name or city"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1461,7 +1461,7 @@ en:
         recent: "Last %{count} days"
         #context: the registration status icon
         registration:
-          opens_in: "Registration will open in %{days}"
+          opens_in: "Registration will open in %{duration}"
           closed: "Registration has closed"
           open: "Registration is open!"
           full: "Competitor limit reached, the waiting list is now in effect"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1461,7 +1461,7 @@ en:
         #context: the registration status icon
         registration:
           opens_in: "Registration will open in %{duration}"
-          closed: "Registration has closed"
+          closed: "Registration has closed. Competition starts in %{days}"
           open: "Registration is open!"
           full: "Competitor limit reached, the waiting list is now in effect"
       no_comp_found: "No competitions found."

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1459,6 +1459,12 @@ en:
         search: "Name or city"
         #context: the "recent" button
         recent: "Last %{count} days"
+        #context: the registration status icon
+        registration:
+          opens_in: "Registration will open in %{days}"
+          closed: "Registration has closed"
+          open: "Registraion is open!"
+          full: "Competitor limit reached, the waiting list is now in effect"
       no_comp_found: "No competitions found."
       no_comp_match: "We didn't find any competitions with %{events}! Try searching for fewer events."
     #context: on the "My competitions" page


### PR DESCRIPTION
This PR aims to add icons showing the current status of a competition's registration on the competitions list, in response to issue #7036.

In it's current state it does not currently integrate with the translations, but I thought it would be worth making a draft to see if this is the correct direction to head in
<img width="403" alt="image" src="https://user-images.githubusercontent.com/26287997/180028245-5fb8b603-ac00-45d5-8e3a-5811df1ccd9f.png">
