### PR TITLE
Add "Championship Type" and "Exempt from WCA Dues" columns to WFC export

### DIFF
--- a/WcaOnRails/app/controllers/wfc_controller.rb
+++ b/WcaOnRails/app/controllers/wfc_controller.rb
@@ -18,7 +18,7 @@ class WfcController < ApplicationController
     to = params.require(:to_date)
     @competitions = Competition
                     .select(select_attributes)
-                    .includes(:delegates)
+                    .includes(:delegates, :championships)
                     .left_joins(:competitors)
                     .group("Competitions.id")
                     .where("results_posted_at >= ? and results_posted_at <= ?", from, to)

--- a/WcaOnRails/app/models/championship.rb
+++ b/WcaOnRails/app/models/championship.rb
@@ -2,9 +2,12 @@
 
 class Championship < ApplicationRecord
   include Comparable
-  CHAMPIONSHIP_TYPES = [
+  MAJOR_CHAMPIONSHIP_TYPES = [
     "world",
     *Continent.real.map(&:id),
+  ].freeze
+  CHAMPIONSHIP_TYPES = [
+    *MAJOR_CHAMPIONSHIP_TYPES,
     *Country.real.map(&:iso2),
     *EligibleCountryIso2ForChampionship.championship_types,
   ].freeze

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1719,10 +1719,15 @@ class Competition < ApplicationRecord
     cal
   end
 
-  def exempt_from_wca_dues?
-    world_or_continental_championship = (championships.map(&:championship_type) & Championship::MAJOR_CHAMPIONSHIP_TYPES).any?
-    multi_country_fmc_competition = events.length == 1 && events[0].fewest_moves? && Country::FICTIVE_IDS.include?(countryId)
+  def world_or_continental_championship?
+    championships.map(&:championship_type).any? { |ct| Championship::MAJOR_CHAMPIONSHIP_TYPES.include?(ct) }
+  end
 
-    return world_or_continental_championship || multi_country_fmc_competition
+  def multi_country_fmc_competition?
+    events.length == 1 && events[0].fewest_moves? && Country::FICTIVE_IDS.include?(countryId)
+  end
+
+  def exempt_from_wca_dues?
+    world_or_continental_championship? || multi_country_fmc_competition?
   end
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1718,4 +1718,11 @@ class Competition < ApplicationRecord
     cal.publish
     cal
   end
+
+  def exempt_from_wca_dues?
+    world_or_continental_championship = (championships.map(&:championship_type) & Championship::MAJOR_CHAMPIONSHIP_TYPES).any?
+    multi_country_fmc_competition = events.length == 1 && events[0].fewest_moves? && Country::FICTIVE_IDS.include?(countryId)
+
+    return world_or_continental_championship || multi_country_fmc_competition
+  end
 end

--- a/WcaOnRails/app/views/wfc/competition_export.csv.erb
+++ b/WcaOnRails/app/views/wfc/competition_export.csv.erb
@@ -4,7 +4,7 @@
   "Start", "End", "Announced", "Posted",
   "Link on WCA", "Competitors", "Delegates",
   "Currency Code", "Base Registration Fee", "Currency Subunit",
-  "Championship Type"
+  "Championship Type", "Exempt from WCA Dues"
 ] %>
 <%= CSV.generate_line(headers, col_sep: "\t").html_safe -%>
 <% @competitions.each do |c| %>
@@ -13,6 +13,6 @@
     c.start_date, c.end_date, c.announced_at, c.results_posted_at,
     competition_url(c.id), c.num_competitors, c.delegates.map(&:name).sort.join(","),
     c.currency_code, c.base_entry_fee_lowest_denomination, Money::Currency.new(c.currency_code).subunit_to_unit,
-    c.championships.map(&:championship_type).sort.join(",")
+    c.championships.map(&:championship_type).sort.join(","), c.exempt_from_wca_dues?
   ], col_sep: "\t").html_safe -%>
 <% end %>

--- a/WcaOnRails/app/views/wfc/competition_export.csv.erb
+++ b/WcaOnRails/app/views/wfc/competition_export.csv.erb
@@ -3,7 +3,8 @@
   "Id", "Name", "Country", "Continent",
   "Start", "End", "Announced", "Posted",
   "Link on WCA", "Competitors", "Delegates",
-  "Currency Code", "Base Registration Fee", "Currency Subunit"
+  "Currency Code", "Base Registration Fee", "Currency Subunit",
+  "Championship Type"
 ] %>
 <%= CSV.generate_line(headers, col_sep: "\t").html_safe -%>
 <% @competitions.each do |c| %>
@@ -12,5 +13,6 @@
     c.start_date, c.end_date, c.announced_at, c.results_posted_at,
     competition_url(c.id), c.num_competitors, c.delegates.map(&:name).sort.join(","),
     c.currency_code, c.base_entry_fee_lowest_denomination, Money::Currency.new(c.currency_code).subunit_to_unit,
+    c.championships.map(&:championship_type).sort.join(",")
   ], col_sep: "\t").html_safe -%>
 <% end %>

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -1098,4 +1098,49 @@ RSpec.describe Competition do
     expect(competition).not_to be_valid
     expect(competition.errors.messages[:organizer_ids].first).to match "Need a country"
   end
+
+  describe "exempt_from_wca_dues" do
+    let(:four_by_four) { Event.find "444" }
+    let(:fmc) { Event.find "333fm" }
+
+    it "is false when competition has no championships" do
+      competition = FactoryBot.create(:competition, events: [four_by_four], championship_types: [], countryId: "CA")
+      expect(competition.exempt_from_wca_dues?).to eq false
+    end
+
+    it "is false when competition is a national championship" do
+      competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["CA"], countryId: "CA")
+      expect(competition.exempt_from_wca_dues?).to eq false
+    end
+
+    it "is false when 333fm is the only event and competition is in a single country" do
+      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "CA" )
+      expect(competition.exempt_from_wca_dues?).to eq false
+    end
+
+    it "is true when 333fm is the only event and competition is in multiple countries" do
+      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XN" )
+      expect(competition.exempt_from_wca_dues?).to eq true
+    end
+
+    it "is true when 333fm is the only event and competition is in multiple continents" do
+      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XW" )
+      expect(competition.exempt_from_wca_dues?).to eq true
+    end
+
+    it "is true when competition is a national championship and a world championship" do
+      competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["AU", "world"], countryId: "AU")
+      expect(competition.exempt_from_wca_dues?).to eq true
+    end
+
+    it "is true when competition is a continental championship" do
+      competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["_North America"], countryId: "CA")
+      expect(competition.exempt_from_wca_dues?).to eq true
+    end
+
+    it "is true when competition is a world championship" do
+      competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["world"], countryId: "KR")
+      expect(competition.exempt_from_wca_dues?).to eq true
+    end
+  end
 end

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -1099,7 +1099,7 @@ RSpec.describe Competition do
     expect(competition.errors.messages[:organizer_ids].first).to match "Need a country"
   end
 
-  describe "exempt_from_wca_dues" do
+  describe "is exempt from dues" do
     let(:four_by_four) { Event.find "444" }
     let(:fmc) { Event.find "333fm" }
 

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -1114,17 +1114,17 @@ RSpec.describe Competition do
     end
 
     it "is false when 333fm is the only event and competition is in a single country" do
-      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "CA" )
+      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "CA")
       expect(competition.exempt_from_wca_dues?).to eq false
     end
 
     it "is true when 333fm is the only event and competition is in multiple countries" do
-      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XN" )
+      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XN")
       expect(competition.exempt_from_wca_dues?).to eq true
     end
 
     it "is true when 333fm is the only event and competition is in multiple continents" do
-      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XW" )
+      competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XW")
       expect(competition.exempt_from_wca_dues?).to eq true
     end
 


### PR DESCRIPTION
- Added the "Championship Type" column to the WFC export (closes #7053)
- Figured it would be more useful to export a boolean indicating if a competition is exempt from WCA Dues, so I added an "Exempt from WCA Dues" column too