### PR TITLE
Modify lowercase name person validator

### DIFF
--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -121,7 +121,7 @@ module ResultsValidators
             roman_readable = p.name
           end
           split_name = roman_readable.split
-          if split_name.any? { |n| n.downcase == n }
+          if if split_name.first.downcase == split_name.first || split_name.last.downcase == split_name.last
             @warnings << ValidationWarning.new(:persons, competition_id,
                                                LOWERCASE_NAME_WARNING,
                                                name: p.name)

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -121,7 +121,7 @@ module ResultsValidators
             roman_readable = p.name
           end
           split_name = roman_readable.split
-          if if split_name.first.downcase == split_name.first || split_name.last.downcase == split_name.last
+          if split_name.first.downcase == split_name.first || split_name.last.downcase == split_name.last
             @warnings << ValidationWarning.new(:persons, competition_id,
                                                LOWERCASE_NAME_WARNING,
                                                name: p.name)

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe PV do
         res_single_letter = FactoryBot.create(:inbox_result,
                                               competition: competition1,
                                               eventId: "333oh")
-        res_single_letter.person.update(name: "A. B. Doe")
+        res_single_letter.person.update(name: "A. B. van der Doe")
         res_same_name1 = FactoryBot.create(:inbox_result,
                                            competition: competition1,
                                            eventId: "333oh")

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe PV do
         res_lowercase2 = FactoryBot.create(:inbox_result,
                                            competition: competition1,
                                            eventId: "333oh")
-        res_lowercase2.person.update(name: "İlis хocavənd V")
+        res_lowercase2.person.update(name: "ilis Xocavənd")
         res_missing_period = FactoryBot.create(:inbox_result,
                                                competition: competition1,
                                                eventId: "333oh")


### PR DESCRIPTION
Changed the lowercase name warning to only catch lowercase first or last names. In some regions, having lowercase middle parts like 'van' or 'de' in names is much more common than I thought before creating the warning in #7039. This is why the warning can appear unreasonably often and ignoring middle names makes sense.