### PR TITLE
Issue #6811 - Clarify event selectability in competition registration form

### DIFF
--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -69,15 +69,11 @@ onPage('registrations#add, registrations#do_add', function() {
   });
 });
 
-function hideEventSelectaqbilityHint() {
-  // opacity:0 rather than display:none to avoid DOM shifting
-  $('.associated-events .select-hint').css('opacity', '0');
-}
-
 onPage('registrations#create', function() {
   // Hide the hint when the user selects an event
   // or selects all events
   $('.associated-events input[type="checkbox"], .select-all-events').click(function() {
-    hideEventSelectaqbilityHint();
+    // opacity:0 rather than display:none to avoid DOM shifting
+    $('.associated-events .select-hint').css('opacity', '0');
   });
 });

--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -74,6 +74,6 @@ onPage('registrations#create', function() {
   // or selects all events
   $('.associated-events input[type="checkbox"], .select-all-events').click(function() {
     // opacity:0 rather than display:none to avoid DOM shifting
-    $('.associated-events .select-hint').css('opacity', '0');
+    $('.associated-events .select-hint').css('visibility', 'hidden');
   });
 });

--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -24,7 +24,7 @@ onPage('registrations#edit_registrations', function() {
   showHideActions();
 
   $('button[value=delete-selected]').on("click", function(e) {
-    var $selectedRows = $registrationsTable.find("tr.selected");
+    const $selectedRows = $registrationsTable.find("tr.selected");
     if(!confirm("Delete the " + $selectedRows.length + " selected registrations?")) {
       e.preventDefault();
     }
@@ -38,24 +38,24 @@ onPage('registrations#index', function() {
 });
 
 function comparePaymentDate(a, b) {
-  var elemA = $(a);
-  var elemB = $(b);
-  var paidA = elemA.data("paidDate");
-  var paidB = elemB.data("paidDate");
+  const elemA = $(a);
+  const elemB = $(b);
+  const paidA = elemA.data("paidDate");
+  const paidB = elemB.data("paidDate");
   if (paidA !== "" && paidB !== "") {
     // Both have paid, compare their last payment dates
     return paidA.localeCompare(paidB);
-  } else if (paidA === "" && paidB === "") {
+  }
+  if (paidA === "" && paidB === "") {
     // None have paid, compare their registration dates
     return elemA.data("registeredAt").localeCompare(elemB.data("registeredAt"));
-  } else {
-    return paidA === "" ? 1 : -1;
   }
+  return paidA === "" ? 1 : -1;
 }
 
 function compareHtmlContent(a, b) {
-  var first = $('<p>' + a + '</p>').text().trim();
-  var second = $('<p>' + b + '</p>').text().trim();
+  const first = $('<p>' + a + '</p>').text().trim();
+  const second = $('<p>' + b + '</p>').text().trim();
   return first.localeCompare(second);
 }
 
@@ -66,5 +66,18 @@ onPage('registrations#add, registrations#do_add', function() {
   });
   $('#select-all-events').on('click', function() {
     $('#events input[type="checkbox"]').prop('checked', true);
+  });
+});
+
+function hideEventSelectaqbilityHint() {
+  // opacity:0 rather than display:none to avoid DOM shifting
+  $('.associated-events .select-hint').css('opacity', '0');
+}
+
+onPage('registrations#create', function() {
+  // Hide the hint when the user selects an event
+  // or selects all events
+  $('.associated-events input[type="checkbox"], .select-all-events').click(function() {
+    hideEventSelectaqbilityHint();
   });
 });

--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -24,7 +24,7 @@ onPage('registrations#edit_registrations', function() {
   showHideActions();
 
   $('button[value=delete-selected]').on("click", function(e) {
-    const $selectedRows = $registrationsTable.find("tr.selected");
+    var $selectedRows = $registrationsTable.find("tr.selected");
     if(!confirm("Delete the " + $selectedRows.length + " selected registrations?")) {
       e.preventDefault();
     }
@@ -38,24 +38,24 @@ onPage('registrations#index', function() {
 });
 
 function comparePaymentDate(a, b) {
-  const elemA = $(a);
-  const elemB = $(b);
-  const paidA = elemA.data("paidDate");
-  const paidB = elemB.data("paidDate");
+  var elemA = $(a);
+  var elemB = $(b);
+  var paidA = elemA.data("paidDate");
+  var paidB = elemB.data("paidDate");
   if (paidA !== "" && paidB !== "") {
     // Both have paid, compare their last payment dates
     return paidA.localeCompare(paidB);
-  }
-  if (paidA === "" && paidB === "") {
+  } else if (paidA === "" && paidB === "") {
     // None have paid, compare their registration dates
     return elemA.data("registeredAt").localeCompare(elemB.data("registeredAt"));
+  } else {
+    return paidA === "" ? 1 : -1;
   }
-  return paidA === "" ? 1 : -1;
 }
 
 function compareHtmlContent(a, b) {
-  const first = $('<p>' + a + '</p>').text().trim();
-  const second = $('<p>' + b + '</p>').text().trim();
+  var first = $('<p>' + a + '</p>').text().trim();
+  var second = $('<p>' + b + '</p>').text().trim();
   return first.localeCompare(second);
 }
 

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -413,6 +413,11 @@ textarea {
 
 // _associated_events_picker.html.erb specific styles
 .form-horizontal {
+  .select-hint {
+    @extend .help-block;
+    margin-bottom: 0;
+  }
+
   .associated-events-label {
     @extend .col-sm-2, .control-label;
   }

--- a/WcaOnRails/app/assets/stylesheets/wca.scss
+++ b/WcaOnRails/app/assets/stylesheets/wca.scss
@@ -422,6 +422,10 @@ textarea {
     @extend .col-sm-2, .control-label;
   }
 
+  .associated-events-label.has-top-hint {
+    padding-top: calc(18px + 1em);
+  }
+
   .associated-events {
     @extend .col-sm-9;
   }

--- a/WcaOnRails/app/views/registrations/_register_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_register_form.html.erb
@@ -1,9 +1,9 @@
 <% disabled = !current_user.can_edit_registration?(@registration) %>
 <% url = @registration.new_record? ? competition_registrations_path(@competition)
-                                   : registration_path(@registration) %>
+           : registration_path(@registration) %>
 <%= horizontal_simple_form_for @registration, url: url, html: { class: 'are-you-sure no-submit-on-enter' } do |f| %>
   <%= render "shared/associated_events_picker", form_builder: f, disabled: disabled,
-              events_association_name: :registration_competition_events, allowed_events: @competition.events, selected_events: @selected_events, hint: notify_of_preferred_events(@registration) %>
+             events_association_name: :registration_competition_events, allowed_events: @competition.events, selected_events: @selected_events, hint: notify_of_preferred_events(@registration), show_select_hint: true %>
 
   <% if @competition.guests_enabled? %>
     <%= f.input :guests, disabled: disabled %>

--- a/WcaOnRails/app/views/registrations/_register_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_register_form.html.erb
@@ -1,6 +1,6 @@
 <% disabled = !current_user.can_edit_registration?(@registration) %>
 <% url = @registration.new_record? ? competition_registrations_path(@competition)
-           : registration_path(@registration) %>
+                                   : registration_path(@registration) %>
 <%= horizontal_simple_form_for @registration, url: url, html: { class: 'are-you-sure no-submit-on-enter' } do |f| %>
   <%= render "shared/associated_events_picker", form_builder: f, disabled: disabled,
              events_association_name: :registration_competition_events, allowed_events: @competition.events, selected_events: @selected_events, hint: notify_of_preferred_events(@registration), show_select_hint: true %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -4,8 +4,9 @@ Variables:
  - disabled
  - events_association_name -> name of the associated events relation
  - allowed_events -> a relation or an Array of Event objects that should be shown (all by default)
- - selected_events -> a relation or an Array of Event objects that whould be marked as selected
+ - selected_events -> a relation or an Array of Event objects that would be marked as selected
  - hint -> a hint to be displayed under the picker
+ - show_select_hint -> should the hint to show that the event buttons are selectable be shown (issue #6811)
 
 Note: form_builder.object is the object having associated events.
 %>
@@ -13,6 +14,7 @@ Note: form_builder.object is the object having associated events.
 <%
   disabled ||= false
   hint ||= false
+  show_select_hint ||= false
   allowed_events ||= Event.official
 
   label = I18n.t("activerecord.attributes.#{form_builder.object.class.name.underscore}.#{events_association_name}")
@@ -31,6 +33,10 @@ Note: form_builder.object is the object having associated events.
     <% end %>
   <% end %>
   <div id="<%= events_association_name %>" class="associated-events">
+    <% if show_select_hint && (selected_events.length == 0) %>
+      <div class="select-hint"><%= t 'competitions.index.select_hint' %></div>
+    <% end %>
+
     <%= form_builder.simple_fields_for events_association_name, all_events do |f| %>
       <span class="event-checkbox <%= "disabled" if disabled %>">
         <% event = f.object.event %>

--- a/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
+++ b/WcaOnRails/app/views/shared/_associated_events_picker.html.erb
@@ -21,10 +21,14 @@ Note: form_builder.object is the object having associated events.
   using_competition_events = events_association_name == :registration_competition_events
   all_events = form_builder.object.events_to_associated_events(allowed_events)
   errors = form_builder.object.errors.messages[events_association_name] || []
+
+  # Only show the hint when it's allowed and there are no events already selected.
+  # Note that the visibility of the hint is also controlled in JS when you select any event.
+  show_select_hint = show_select_hint && (selected_events.length < 1) && (errors.length < 1)
 %>
 
 <div class="form-group <%= "has-error" unless errors.empty? %>">
-  <%= label_tag events_association_name, class: "associated-events-label" do %>
+  <%= label_tag events_association_name, class: "associated-events-label#{" has-top-hint" if show_select_hint}" do %>
     <%= label %> (<span class="events-selected-count"></span>)
     <% unless disabled %>
       <br />
@@ -33,7 +37,7 @@ Note: form_builder.object is the object having associated events.
     <% end %>
   <% end %>
   <div id="<%= events_association_name %>" class="associated-events">
-    <% if show_select_hint && (selected_events.length == 0) %>
+    <% if show_select_hint %>
       <div class="select-hint"><%= t 'competitions.index.select_hint' %></div>
     <% end %>
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1421,6 +1421,7 @@ en:
       all_events: "All"
       all_years: "All Years"
       clear: "Clear"
+      select_hint: "Please select events"
       list: "List"
       map: "Map"
       region: "Region"


### PR DESCRIPTION
Clarify event selectability in competition registration form.

Adds a hint above the cube icons when no events are selected at first only on registration forms.