### PR TITLE
Bug fix: event selectability hint not hiding properly

### DIFF
--- a/WcaOnRails/app/assets/javascripts/registrations.js
+++ b/WcaOnRails/app/assets/javascripts/registrations.js
@@ -69,7 +69,7 @@ onPage('registrations#add, registrations#do_add', function() {
   });
 });
 
-onPage('registrations#create', function() {
+onPage('registrations#create, registrations#register', function() {
   // Hide the hint when the user selects an event
   // or selects all events
   $('.associated-events input[type="checkbox"], .select-all-events').click(function() {


### PR DESCRIPTION
The select hint wasn't hiding when it should.