### PR TITLE
Add Organizers column to WFC export

### DIFF
--- a/WcaOnRails/app/controllers/wfc_controller.rb
+++ b/WcaOnRails/app/controllers/wfc_controller.rb
@@ -18,7 +18,7 @@ class WfcController < ApplicationController
     to = params.require(:to_date)
     @competitions = Competition
                     .select(select_attributes)
-                    .includes(:delegates, :championships, :organizers)
+                    .includes(:delegates, :championships, :organizers, :events)
                     .left_joins(:competitors)
                     .group("Competitions.id")
                     .where("results_posted_at >= ? and results_posted_at <= ?", from, to)

--- a/WcaOnRails/app/controllers/wfc_controller.rb
+++ b/WcaOnRails/app/controllers/wfc_controller.rb
@@ -18,7 +18,7 @@ class WfcController < ApplicationController
     to = params.require(:to_date)
     @competitions = Competition
                     .select(select_attributes)
-                    .includes(:delegates, :championships)
+                    .includes(:delegates, :championships, :organizers)
                     .left_joins(:competitors)
                     .group("Competitions.id")
                     .where("results_posted_at >= ? and results_posted_at <= ?", from, to)

--- a/WcaOnRails/app/views/wfc/competition_export.csv.erb
+++ b/WcaOnRails/app/views/wfc/competition_export.csv.erb
@@ -4,7 +4,7 @@
   "Start", "End", "Announced", "Posted",
   "Link on WCA", "Competitors", "Delegates",
   "Currency Code", "Base Registration Fee", "Currency Subunit",
-  "Championship Type", "Exempt from WCA Dues"
+  "Championship Type", "Exempt from WCA Dues", "Organizers"
 ] %>
 <%= CSV.generate_line(headers, col_sep: "\t").html_safe -%>
 <% @competitions.each do |c| %>
@@ -13,6 +13,6 @@
     c.start_date, c.end_date, c.announced_at, c.results_posted_at,
     competition_url(c.id), c.num_competitors, c.delegates.map(&:name).sort.join(","),
     c.currency_code, c.base_entry_fee_lowest_denomination, Money::Currency.new(c.currency_code).subunit_to_unit,
-    c.championships.map(&:championship_type).sort.join(","), c.exempt_from_wca_dues?
+    c.championships.map(&:championship_type).sort.join(","), c.exempt_from_wca_dues?, c.organizers.map(&:name).sort.join(",")
   ], col_sep: "\t").html_safe -%>
 <% end %>


### PR DESCRIPTION
Adds an Organizers column to the WFC export. The row values are comma separated, alphabetically sorted lists of names (similar to the Delegates column).

As per an email discussion I had with the WFC, this is needed to implement rules like: "if Speedcubing Canada is listed as an Organizer on the WCA website, send the WCA Dues invoice to Speedcubing Canada".

Bonus fix: query optimization that should've been added in #7060 since `competition.multi_country_fmc_competition?` accesses `competition.events`.