### PR TITLE
Use <span> instead of <div> as root element of I18nHTMLTranslate

### DIFF
--- a/WcaOnRails/app/webpacker/components/I18nHTMLTranslate.js
+++ b/WcaOnRails/app/webpacker/components/I18nHTMLTranslate.js
@@ -3,11 +3,20 @@ import { sanitize } from 'dompurify';
 
 import I18n from '../lib/i18n';
 
+/**
+ * @param {string} i18nKey
+ * @returns {JSX.Element}
+ * @constructor
+ */
 function I18nHTMLTranslate({
   i18nKey,
 }) {
   return (
-    <div name="I18nHTMLTranslate" dangerouslySetInnerHTML={{ __html: sanitize(I18n.t(i18nKey)) }} />
+    <span
+      name="I18nHTMLTranslate"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: sanitize(I18n.t(i18nKey)) }}
+    />
   );
 }
 


### PR DESCRIPTION
Use `<span>` instead of `<div>` as root element of React `I18nHTMLTranslate` component.

Allows this component to be used inside `<p>` elements as the primary reason for this.