### PR TITLE
Minor performance fixes to reduce server load during registration peaks

### DIFF
--- a/WcaOnRails/app/assets/javascripts/competitions.js
+++ b/WcaOnRails/app/assets/javascripts/competitions.js
@@ -90,7 +90,7 @@ onPage('competitions#index', function() {
     $form.trigger('submit.rails');
   }
 
-  $form.on('change', '#events, #region, #state, #display, #status, #delegate, #cancelled', submitForm)
+  $form.on('change', '#events, #region, #state, #display, #status, #delegate, #cancelled, #registration-status', submitForm)
        .on('click', '#clear-all-events, #select-all-events', submitForm)
        .on('input', '#search', window.wca.lodashDebounce(submitForm, window.wca.TEXT_INPUT_DEBOUNCE_MS))
        .on('dp.change','#from_date, #to_date', submitForm);

--- a/WcaOnRails/app/assets/stylesheets/competitions.scss
+++ b/WcaOnRails/app/assets/stylesheets/competitions.scss
@@ -185,6 +185,10 @@ $venue-map-wrapper-height: 400px;
   .cancel-selector {
     display: block;
   }
+
+  .registration-status-selector {
+    display: block;
+  }
 }
 
 .same-line {

--- a/WcaOnRails/app/controllers/cached_result.rb
+++ b/WcaOnRails/app/controllers/cached_result.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class CachedResult < ApplicationRecord
+  self.primary_key = "key_params"
+
+  def parsed_payload
+    JSON.parse(self.payload)
+  end
 end

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -103,6 +103,7 @@ class CompetitionsController < ApplicationController
     @by_announcement_selected = params[:state] == "by_announcement"
     @custom_selected = params[:state] == "custom"
     @show_cancelled = params[:show_cancelled] == "on"
+    @show_registration_status = params[:show_registration_status] == "on"
 
     @years = ["all years"] + Competition.non_future_years
 

--- a/WcaOnRails/app/controllers/results_controller.rb
+++ b/WcaOnRails/app/controllers/results_controller.rb
@@ -144,7 +144,7 @@ class ResultsController < ApplicationController
     # Default params
     params[:event_id] ||= "all events"
     params[:region] ||= "world"
-    params[:years] ||= "all years"
+    params[:years] = "all years" # FIXME: this is disabling years filters for now
     params[:show] ||= "mixed"
     params[:gender] ||= "All"
 

--- a/WcaOnRails/app/models/registration_competition_event.rb
+++ b/WcaOnRails/app/models/registration_competition_event.rb
@@ -7,4 +7,5 @@ class RegistrationCompetitionEvent < ApplicationRecord
   validates :competition_event, presence: true
 
   has_one :event, through: :competition_event
+  delegate :event, to: :competition_event, allow_nil: true
 end

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -113,9 +113,14 @@
                                  data: { data: User.where(id: params[:delegate]).to_json } %>
 </div>
 
+<div id="registration-status" class="form-group registration-status-selector">
+  <%= check_box_tag(:show_registration_status, params[:show_registration_status], params[:show_registration_status] == "on") %>
+  <%= label_tag(t('competitions.index.show_registration_status')) %>
+</div>
+
 <div id="cancelled" class="form-group cancel-selector">
   <%= check_box_tag(:show_cancelled, params[:show_cancelled], params[:show_cancelled] == "on") %>
-  <%= label_tag("Show cancelled competitions") %>
+  <%= label_tag(t('competitions.index.show_cancelled')) %>
 </div>
 
 <div id="display" class="form-group">

--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -19,8 +19,10 @@
           <%= ui_icon('hourglass half', title: t('competitions.index.tooltips.hourglass.in_progress'), data: { toggle: "tooltip" }) %>
         <% elsif @by_announcement_selected %>
           <%= ui_icon('hourglass start', title: t('competitions.index.tooltips.hourglass.announced_on', announcement_date: competition.announced_at.strftime(" %F %H:%M:%S")), data: { toggle: "tooltip" }) %>
-        <% else %>
+        <% elsif @show_registration_status %>
           <%= registration_status_icon(competition) %>
+        <% else %>
+          <%= ui_icon('hourglass start', title: t('competitions.index.tooltips.hourglass.starts_in', days: t('common.days', count:(competition.start_date - Date.today).to_i)), data: { toggle: "tooltip" }) %>
         <% end %>
         <%= wca_date_range(competition.start_date, competition.end_date) %>
       </span>

--- a/WcaOnRails/app/views/results/_results_selector.html.erb
+++ b/WcaOnRails/app/views/results/_results_selector.html.erb
@@ -86,15 +86,16 @@
   </div>
 </div>
 
-<% if show_rankings_options %>
-  <div class="form-group">
-    <%= label_tag(t("results.selector_elements.gender_selector.gender")) %>
-    <div id="gender" class="btn-group">
-      <%= link_to t("results.selector_elements.gender_selector.gender_all"), request.params.merge(gender: "All"), class: "btn btn-info" + (@gender == "All" ? " active" : "") %>
-      <%= link_to t("results.selector_elements.gender_selector.male"), request.params.merge(gender: "Male"), class: "btn btn-info" + (@gender == "Male" ? " active" : "") %>
-      <%= link_to t("results.selector_elements.gender_selector.female"), request.params.merge(gender: "Female"), class: "btn btn-info" + (@gender == "Female" ? " active" : "") %>
-    </div>
+<div class="form-group">
+  <%= label_tag(t("results.selector_elements.gender_selector.gender")) %>
+  <div id="gender" class="btn-group">
+    <%= link_to t("results.selector_elements.gender_selector.gender_all"), request.params.merge(gender: "All"), class: "btn btn-info" + (@gender == "All" ? " active" : "") %>
+    <%= link_to t("results.selector_elements.gender_selector.male"), request.params.merge(gender: "Male"), class: "btn btn-info" + (@gender == "Male" ? " active" : "") %>
+    <%= link_to t("results.selector_elements.gender_selector.female"), request.params.merge(gender: "Female"), class: "btn btn-info" + (@gender == "Female" ? " active" : "") %>
   </div>
+</div>
+
+<% if show_rankings_options %>
   <div class="form-group">
     <%= label_tag(t("results.selector_elements.show_selector.show")) %>
     <div id="show" class="btn-group">

--- a/WcaOnRails/app/views/results/rankings.html.erb
+++ b/WcaOnRails/app/views/results/rankings.html.erb
@@ -2,6 +2,7 @@
 
 <div class="container">
   <h1><%= yield(:title) %></h1>
+  <p><%= t("results.last_updated_html", timestamp: wca_local_time(@timestamp)) %></p>
 
   <div id="results-selector" class="results-select form-inline">
     <%= render 'results_selector', show_rankings_options: true %>

--- a/WcaOnRails/app/views/results/records.html.erb
+++ b/WcaOnRails/app/views/results/records.html.erb
@@ -2,6 +2,7 @@
 
 <div class="container">
   <h1><%= yield(:title) %></h1>
+  <p><%= t("results.last_updated_html", timestamp: wca_local_time(@timestamp)) %></p>
 
   <div id="results-selector" class="results-select form-inline">
     <%= render 'results_selector', show_records_options: true %>
@@ -11,7 +12,6 @@
   <% record_timestamp = Timestamp.find_by(name: "compute_auxiliary_data_end") %>
   <% cache_if record_timestamp.present?, ["records", *record_params, record_timestamp&.date, I18n.locale] do %>
     <%
-      @rows = ActiveRecord::Base.connection.exec_query(@query)
       comp_ids = @rows.map { |r| r["competitionId"] }.uniq
       unless @is_slim
         @competitions_by_id = Hash[Competition.where(id: comp_ids).map { |c| [c.id, c] }]

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1461,6 +1461,8 @@ en:
       #context: selecting a specific year ('year' is a number)
       past_from: "Past from %{year}"
       past_all: "Past from all years"
+      show_cancelled: "Show cancelled competitions"
+      show_registration_status: "Show registration status icon"
       #context: titles for the competitions list
       titles:
         in_progress: "Competitions in progress"
@@ -1479,6 +1481,7 @@ en:
           ended: "Ended %{days} ago"
           in_progress: "In progress!"
           posted: "Results are posted!"
+          starts_in: "Starts in %{days}"
           announced_on: "Announced on %{announcement_date}"
         #context: the "search" button
         search: "Name or city"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1740,6 +1740,7 @@ en:
       unknown_show: "Unknown show parameter, must be either \"N persons\", \"N results\", or \"by region\""
     records:
       title: "Records"
+    last_updated_html: "Last updated: %{timestamp}"
     selector_elements:
       events_selector:
         event: "Event"


### PR DESCRIPTION
- Disable registration status icons by default, add an option to show them if desired
- Load event models during registration via `CompetitionEvent` cache
- Cache Records page (Bonus: Gender filter)