### PR TITLE
[NFC]: fix our usage of serializable_hash

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/persons_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/persons_controller.rb
@@ -31,7 +31,7 @@ class Api::V0::PersonsController < Api::V0::ApiController
 
   private def person_to_json(person)
     {
-      person: person.serializable_hash.slice(:wca_id, :name, :url, :gender, :country_iso2, :delegate_status, :teams, :avatar),
+      person: person.serializable_hash(only: [:wca_id, :name, :url, :gender, :country_iso2, :delegate_status, :teams, :avatar]),
       competition_count: person.competitions.count,
       personal_records: person.ranksSingle.each_with_object({}) do |rank_single, ranks|
         event_id = rank_single.event.id

--- a/WcaOnRails/app/models/competition_series.rb
+++ b/WcaOnRails/app/models/competition_series.rb
@@ -40,13 +40,20 @@ class CompetitionSeries < ApplicationRecord
     end
   end
 
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["name", "short_name"],
+    include: ["competitions"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    {
-      id: wcif_id,
-      name: name,
-      short_name: short_name,
-      competitions: competitions.map(&:id),
-    }
+    options = DEFAULT_SERIALIZE_OPTIONS.merge(options || {})
+    include_competitions = options[:include]&.delete("competitions")
+    json = super(options)
+    json.merge!(id: wcif_id)
+    if include_competitions
+      json[:competitions] = competitions.ids
+    end
+    json
   end
 
   def to_wcif

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -9,10 +9,14 @@ module Resultable
   included do
     # NOTE: We use cached values instead of belongs_to to improve performances.
     belongs_to :competition, foreign_key: :competitionId
+    alias_attribute :competition_id, :competitionId
     belongs_to :round_type, foreign_key: :roundTypeId
+    alias_attribute :round_type_id, :roundTypeId
     # FIXME: shouldn't we take advantage of the fact that these are cached?
     belongs_to :event, foreign_key: :eventId
+    alias_attribute :event_id, :eventId
     belongs_to :format, foreign_key: :formatId
+    alias_attribute :format_id, :formatId
 
     # Forgetting to synchronize the results in WCA Live is a very common mistake,
     # so this error message is hinting the user to check that, even if it's

--- a/WcaOnRails/app/models/event.rb
+++ b/WcaOnRails/app/models/event.rb
@@ -71,16 +71,19 @@ class Event < ApplicationRecord
     ['333', '222', '444', '333oh', 'clock', 'mega', 'pyram', 'skewb', 'sq1'].include?(self.id)
   end
 
+  alias_method :can_change_time_limit, :can_change_time_limit?
+  alias_method :can_have_cutoff, :can_have_cutoff?
+  alias_method :is_timed_event, :timed_event?
+  alias_method :is_fewest_moves, :fewest_moves?
+  alias_method :is_multiple_blindfolded, :multiple_blindfolded?
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["id"],
+    methods: ["name", "can_change_time_limit", "can_have_cutoff", "is_timed_event",
+              "is_fewest_moves", "is_multiple_blindfolded", "format_ids"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    {
-      id: self.id,
-      name: self.name,
-      format_ids: self.formats.map(&:id),
-      can_change_time_limit: self.can_change_time_limit?,
-      can_have_cutoff: self.can_have_cutoff?,
-      is_timed_event: self.timed_event?,
-      is_fewest_moves: self.fewest_moves?,
-      is_multiple_blindfolded: self.multiple_blindfolded?,
-    }
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
   end
 end

--- a/WcaOnRails/app/models/format.rb
+++ b/WcaOnRails/app/models/format.rb
@@ -27,17 +27,13 @@ class Format < ApplicationRecord
     }[self.id]
   end
 
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["id", "sort_by", "sort_by_second", "expected_solve_count",
+           "trim_fastest_n", "trim_slowest_n"],
+    methods: ["name", "short_name", "allowed_first_phase_formats"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    {
-      id: self.id,
-      name: self.name,
-      short_name: self.short_name,
-      sort_by: self.sort_by,
-      sort_by_second: self.sort_by_second,
-      expected_solve_count: self.expected_solve_count,
-      trim_fastest_n: self.trim_fastest_n,
-      trim_slowest_n: self.trim_slowest_n,
-      allowed_first_phase_formats: self.allowed_first_phase_formats,
-    }
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
   end
 end

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -286,21 +286,24 @@ class Person < ApplicationRecord
     persons.order(:name)
   end
 
+  def url
+    Rails.application.routes.url_helpers.person_url(wca_id, host: EnvVars.ROOT_URL)
+  end
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["wca_id", "name", "gender"],
+    methods: ["url", "country_iso2"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    json = {
+    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+    json.merge!(
       class: self.class.to_s.downcase,
-      url: Rails.application.routes.url_helpers.person_url(self.wca_id, host: EnvVars.ROOT_URL),
-
       id: self.wca_id,
-      wca_id: self.wca_id,
-      name: self.name,
-
-      gender: self.gender,
-      country_iso2: self.country_iso2,
-    }
+    )
 
     # If there's a user for this Person, merge in all their data,
     # the Person's data takes priority, though.
-    (user || User.new).serializable_hash.merge(json)
+    (user || User.new).serializable_hash(options).merge(json)
   end
 end

--- a/WcaOnRails/app/models/post.rb
+++ b/WcaOnRails/app/models/post.rb
@@ -48,17 +48,21 @@ class Post < ApplicationRecord
     posts.order(created_at: :desc)
   end
 
+  def url
+    Rails.application.routes.url_helpers.post_path(slug)
+  end
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["id", "slug", "title", "sticky", "created_at"],
+    methods: ["url"],
+    include: ["author"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    json = {
+    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+    json.merge!(
       class: self.class.to_s.downcase,
-      id: id,
-      slug: slug,
-      url: Rails.application.routes.url_helpers.post_path(slug),
-      title: title,
-      author: author,
-      sticky: sticky?,
-      createdAt: created_at.iso8601,
-    }
+    )
     if options[:teaser_only]
       json[:teaser] = md(body_teaser)
     else

--- a/WcaOnRails/app/models/regional_organization.rb
+++ b/WcaOnRails/app/models/regional_organization.rb
@@ -31,12 +31,16 @@ class RegionalOrganization < ApplicationRecord
     start_date.nil?
   end
 
+  def logo_url
+    Rails.application.routes.url_helpers.rails_representation_url(logo.variant(resize: "500x300").processed) if logo.attached?
+  end
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["name", "website", "country"],
+    methods: ["logo_url"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    {
-      name: name,
-      website: website,
-      country: country,
-      logo: logo.attached? ? Rails.application.routes.url_helpers.rails_representation_url(logo.variant(resize: "500x300").processed) : nil,
-    }
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
   end
 end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -286,12 +286,12 @@ class Registration < ApplicationRecord
                                    .join(" + ")
   end
 
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["id", "competition_id", "user_id"],
+    methods: ["event_ids"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    {
-      id: id,
-      competition_id: competition_id,
-      user_id: user_id,
-      event_ids: events.map(&:id),
-    }
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
   end
 end

--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -46,24 +46,33 @@ class Result < ApplicationRecord
   scope :average_better_than, lambda { |time| where("average < ? AND average > 0", time) }
   scope :in_event, lambda { |event_id| where(eventId: event_id) }
 
+  alias_attribute :name, :personName
+  alias_attribute :wca_id, :personId
+
+  def attempts
+    [value1, value2, value3, value4, value5]
+  end
+
+  def country_iso2
+    country.iso2
+  end
+
+  def regional_single_record
+    regionalSingleRecord || ""
+  end
+
+  def regional_average_record
+    regionalAverageRecord || ""
+  end
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["id", "pos", "best", "best_index", "worst_index", "average"],
+    methods: ["name", "country_iso2", "competition_id", "event_id",
+              "round_type_id", "format_id", "wca_id", "attempts", "best_index",
+              "worst_index", "regional_single_record", "regional_average_record"],
+  }.freeze
+
   def serializable_hash(options = nil)
-    {
-      id: id,
-      name: personName,
-      country_iso2: country.iso2,
-      competition_id: competitionId,
-      pos: pos,
-      event_id: eventId,
-      round_type_id: roundTypeId,
-      format_id: formatId,
-      wca_id: personId,
-      attempts: [value1, value2, value3, value4, value5],
-      best: best,
-      best_index: best_index,
-      worst_index: worst_index,
-      average: average,
-      regional_single_record: regionalSingleRecord || "",
-      regional_average_record: regionalAverageRecord || "",
-    }
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
   end
 end

--- a/WcaOnRails/app/models/team_member.rb
+++ b/WcaOnRails/app/models/team_member.rb
@@ -11,6 +11,9 @@ class TeamMember < ApplicationRecord
   scope :current_leader, -> { self.current.merge(self.leader) }
 
   attr_accessor :current_user
+  delegate :friendly_id, to: :team
+  delegate :hidden?, to: :team
+  alias_attribute :leader, :team_leader
 
   def current_member?
     end_date.nil? || end_date > Date.today
@@ -41,4 +44,13 @@ class TeamMember < ApplicationRecord
   end
 
   validates :start_date, presence: true
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: [],
+    methods: ["friendly_id", "leader"],
+  }.freeze
+
+  def serializable_hash(options = nil)
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+  end
 end

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -255,8 +255,8 @@
           // code update, because we don't have access to the currency
           // "subunit_to_unit" from the js world.
           function UpdateDues(){
-            <% countryBand = CountryBand.where(iso2: @competition.serializable_hash[:country_iso2]).map(&:number)[0] %>
-            <% if !countryBand.nil? && countryBand > 0 %>
+            <% countryBand = CountryBand.where(iso2: @competition.country_iso2).map(&:number)[0] %>
+            <% if countryBand.present? && countryBand > 0 %>
               var bandFeeUSD = <%= CountryBand::BANDS[countryBand][:value] %>;
             <% else %>
               var bandFeeUSD = 0;

--- a/WcaOnRails/app/webpacker/components/PostsWidget.js
+++ b/WcaOnRails/app/webpacker/components/PostsWidget.js
@@ -66,7 +66,7 @@ function PostsList({
               {' '}
               on
               {' '}
-              {formattedTextForDate(post.createdAt, 'en')}
+              {formattedTextForDate(post.created_at, 'en')}
             </Card.Meta>
             <Card.Description dangerouslySetInnerHTML={{ __html: post.teaser }} />
           </Card.Content>

--- a/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
+++ b/WcaOnRails/app/webpacker/components/RegionalOrganizations/index.js
@@ -23,8 +23,8 @@ function ROOverview({
         {orgs.map((org) => (
           <div key={org.name} className="organization-box">
             <a target="_blank" rel="noreferrer" className="hide-new-window-icon" href={org.website}>
-              <img src={org.logo} alt="" />
-              <div className={`organization-info${org.logo ? ' hide-until-hover' : ''}`}>
+              <img src={org.logo_url} alt="" />
+              <div className={`organization-info${org.logo_url ? ' hide-until-hover' : ''}`}>
                 <div className="country">
                   {org.country}
                 </div>


### PR DESCRIPTION
This is a non functional change that aims to fix our usage of the [`serializable_hash`](https://apidock.com/rails/ActiveModel/Serialization/serializable_hash) method in rails.

At the time we (I?) implemented some of these, I don't think it had so many flexibility as now, and I do think we're using it wrong!
The original goal of this method of this method is to be able to override the default attributes and method which are exported when serializing an object to json, and it defaults to the attributes returned by the `attributes` method.
For instance depending on what part of the API you're in, you may not want to include everything of the model and its nested object.
Let's take a rough example from our codebase: when serializing a competition, we also include each organizers and all of the user's serializable attributes, its team, avatar, and so on.
While it may be desirable in some endpoints, there could be others where we would like to be more selective by doing something like this for instance:
`competition.serializable_hash(only: ["name"], methods: ["country_iso2"], include: { organizers: { only: ["id", "name"] })`
Which handpicks only the attributes needed by the endpoint consumer.

Our current approach totally ignores any given option, and just overrides the attributes to what we need, or at least what we needed in the first place.
I suggest an alternate implementation where we provide a default set of options (currently set to what is serialized now, so that no behavior from the website changes), which can be overridden as the caller see fits.

While I did not check for all instances where this could be useful, I do believe some endpoints consumes way more data than they need, and I actually expect this to be useful as we have more and more "react component to api endpoint" communication.
(I don't want to spoil anything but I have something coming which uses this :))

