### PR TITLE
Close unclosed label tag

### DIFF
--- a/WcaOnRails/app/views/devise/sessions/new.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/new.html.erb
@@ -33,6 +33,7 @@
               <label>
                 <%= f.check_box :remember_me, tabindex: "3" %>
                 <%= f.label :remember_me %>
+              </label>
             </div>
             <% end %>
           <%= f.submit t('devise.sessions.new.sign_in'), class: "btn btn-primary", tabindex: "3" %>


### PR DESCRIPTION
Close a label tag that I assume was never closed due to a typo, unless `f.label` does something weird, which I don't think it does.

Now interestingly I couldn't test this at all, because as far as I can tell, this page is never used. I don't know if maybe `/new.*.erb` routes are another built-in path in Rails, but searching everywhere for `sessions/new` didn't yield anything, only some comments in `WcaOnRails/config/initializers/devise.rb`. I wonder if this page was used at one point and then replaced, but someone forgot to delete it?

Or of course I just don't know how to search for the usage of Rails views :P

The comments: (WcaOnRails/config/initializers/devise.rb:213)
```
    # ==> Scopes configuration
    # Turn scoped views on. Before rendering "sessions/new", it will first check for
    # "users/sessions/new". It's turned off by default because it's slower if you
    # are using only default views.
    # config.scoped_views = false
```