### PR TITLE
Downcase the locale in the assets

### DIFF
--- a/WcaOnRails/app/helpers/application_helper.rb
+++ b/WcaOnRails/app/helpers/application_helper.rb
@@ -252,7 +252,7 @@ module ApplicationHelper
     add_to_js_assets('fullcalendar/fullcalendar_wca')
     add_to_css_assets('fullcalendar_wca')
     if I18n.locale != :en
-      add_to_js_assets("fullcalendar/locales/#{I18n.locale}.js")
+      add_to_js_assets("fullcalendar/locales/#{I18n.locale.downcase}.js")
     end
   end
 end


### PR DESCRIPTION
Fixes #7206.

It was looking for `pt-BR.js` instead of `pt-br.js` for fullcalendar's locales.
No idea how it even worked before, maybe rails 6 was more tolerant with the case?