### PR TITLE
Searchable incidents

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -115,11 +115,15 @@ class Api::V0::ApiController < ApplicationController
     search(Regulation)
   end
 
+  def incidents_search
+    search(Incident)
+  end
+
   def omni_search
     # We intentionally exclude Post, as our autocomplete ui isn't very useful with
     # them yet.
     params[:persons_table] = true
-    search(Competition, User, Regulation)
+    search(Competition, User, Regulation, Incident)
   end
 
   def show_user(user)

--- a/WcaOnRails/app/controllers/search_results_controller.rb
+++ b/WcaOnRails/app/controllers/search_results_controller.rb
@@ -11,6 +11,7 @@ class SearchResultsController < ApplicationController
       @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)
       @posts = Post.search(@omni_query).page(params[:posts_page]).per(SEARCH_RESULT_LIMIT)
       @regulations = Kaminari.paginate_array(Regulation.search(@omni_query)).page(params[:regulations_page]).per(SEARCH_RESULT_LIMIT)
+      @incidents = Incident.search(@omni_query).page(params[:incidents_page]).per(SEARCH_RESULT_LIMIT)
     end
   end
 end

--- a/WcaOnRails/app/models/incident.rb
+++ b/WcaOnRails/app/models/incident.rb
@@ -38,4 +38,35 @@ class Incident < ApplicationRecord
       errors.add(:digest_sent_at, "can't be set if incident is not resolved.")
     end
   end
+
+  def url
+    Rails.application.routes.url_helpers.incident_url(self)
+  end
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    only: ["id", "title", "public_summary"],
+    methods: ["url"],
+  }.freeze
+
+  def serializable_hash(options = nil)
+    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+    json.merge!(
+      class: self.class.to_s.downcase,
+    )
+  end
+
+  def self.search(query, params: {})
+    incidents = Incident
+    query&.split&.each do |part|
+      like_query = %w(public_summary title).map { |col| "#{col} LIKE :part" }.join(" OR ")
+      incidents = incidents.where(like_query, part: "%#{part}%")
+    end
+    if params[:tags]
+      incidents = incidents.where(incident_tags: IncidentTag.where(tag: params[:tags].split(",")))
+    end
+    if params[:competitions]
+      incidents = incidents.where(incident_competitions: IncidentCompetition.where(competition_id: params[:competitions].split(",")))
+    end
+    incidents.order(created_at: :desc)
+  end
 end

--- a/WcaOnRails/app/views/search_results/index.html.erb
+++ b/WcaOnRails/app/views/search_results/index.html.erb
@@ -95,6 +95,21 @@
       <%= paginate @regulations, param_name: :regulations_page, params: { anchor: "regulations-and-guidelines" } %>
     <% end %>
 
+    <% if @incidents.present? %>
+      <h2><%= anchorable t('.incidents') %></h2>
+      <% @incidents.each do |incident| %>
+        <div>
+          <%= link_to incident.url do %>
+            <h4><%= wca_highlight(incident.title, query_parts) %></h4>
+          <% end %>
+          <blockquote>
+            <%= wca_highlight(md(incident.public_summary), query_parts) %>
+          </blockquote>
+        </div>
+      <% end %>
+      <%= paginate @incidents, param_name: :incidents_page, params: { anchor: "competitions" } %>
+    <% end %>
+
     <% if @competitions.empty? %>
       <h2><%= t '.not_found.competitions' %> <%= wca_highlight(@omni_query, @omni_query) %></h2>
     <% end %>
@@ -106,6 +121,9 @@
     <% end %>
     <% if @regulations.empty? %>
       <h2><%= t '.not_found.regulations_and_guidelines' %> <%= wca_highlight(@omni_query, @omni_query) %></h2>
+    <% end %>
+    <% if @incidents.empty? %>
+      <h2><%= t '.not_found.incidents' %> <%= wca_highlight(@omni_query, @omni_query) %></h2>
     <% end %>
   <% end %>
 </div>

--- a/WcaOnRails/app/webpacker/components/Persons/NewPersonForm/NewPersonForm.js
+++ b/WcaOnRails/app/webpacker/components/Persons/NewPersonForm/NewPersonForm.js
@@ -40,7 +40,7 @@ function NewPersonForm({
   const fetchIds = useCallback((params) => {
     setErrors({});
     fetchJsonOrError(`${adminGenerateIds}?${new URLSearchParams(params)}`)
-      .then((data) => {
+      .then(({ data }) => {
         if (data.semiId !== undefined) {
           setSemiId(data.semiId);
         }

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/PersonForm.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/PersonForm.js
@@ -22,7 +22,8 @@ function PersonForm({ personData, setPersonData }) {
   // Create a function to get person data from the API.
   const fetchDataForWcaId = (id) => {
     setWcaIdError(null);
-    fetchJsonOrError(personApiUrl(id)).then(({ person }) => {
+    fetchJsonOrError(personApiUrl(id)).then(({ data }) => {
+      const { person } = data;
       setPersonData({
         wcaId: person.wca_id,
         name: person.name,

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/RoundForm.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/RoundForm.js
@@ -49,7 +49,7 @@ function RoundForm({ roundData, setRoundData }) {
 
   const fetchDataForCompetition = (id) => {
     setCompetitionIdError(null);
-    fetchJsonOrError(competitionEventsDataUrl(id)).then((data) => {
+    fetchJsonOrError(competitionEventsDataUrl(id)).then(({ data }) => {
       setLocalRoundData(data);
     }).catch((err) => setCompetitionIdError(err.message));
   };

--- a/WcaOnRails/app/webpacker/components/SearchWidget/IncidentItem.js
+++ b/WcaOnRails/app/webpacker/components/SearchWidget/IncidentItem.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import I18n from '../../lib/i18n';
+
+function IncidentItem({
+  item,
+}) {
+  return (
+    <div className="omnisearch-item-incident">
+      {I18n.t('incidents_log.incident')}
+      {' '}
+      {item.title}
+    </div>
+  );
+}
+
+export default IncidentItem;

--- a/WcaOnRails/app/webpacker/components/SearchWidget/OmnisearchInput.js
+++ b/WcaOnRails/app/webpacker/components/SearchWidget/OmnisearchInput.js
@@ -4,6 +4,7 @@ import React, {
 import { Dropdown } from 'semantic-ui-react';
 
 import CompetitionItem from './CompetitionItem';
+import IncidentItem from './IncidentItem';
 import RegulationItem from './RegulationItem';
 import UserItem from './UserItem';
 import TextItem from './TextItem';
@@ -18,6 +19,7 @@ const classToComponent = {
   competition: CompetitionItem,
   regulation: RegulationItem,
   text: TextItem,
+  incident: IncidentItem,
 };
 
 function ItemFor({ item }) {
@@ -43,7 +45,7 @@ const itemToOption = (item) => ({
   value: item.id,
   // 'text' is used by the search method from the component, we need to put
   // the text with a potential match here!
-  text: [item.id, item.name, item.content_html, item.search].join(' '),
+  text: [item.id, item.name, item.title, item.content_html, item.search, item.public_summary].join(' '),
   content: <ItemFor item={item} />,
 });
 

--- a/WcaOnRails/app/webpacker/components/SearchWidget/OmnisearchInput.js
+++ b/WcaOnRails/app/webpacker/components/SearchWidget/OmnisearchInput.js
@@ -104,7 +104,7 @@ function OmnisearchInput({
       // FUI's dropdown will automatically remove selected items from the
       // options left for selection.
       fetchJsonOrError(url(debouncedSearch))
-        .then((data) => setResults(data.result.map(itemToOption)))
+        .then(({ data }) => setResults(data.result.map(itemToOption)))
         .finally(() => setLoading(false));
     }
   }, [debouncedSearch, url]);

--- a/WcaOnRails/app/webpacker/lib/hooks/useLoadedData.js
+++ b/WcaOnRails/app/webpacker/lib/hooks/useLoadedData.js
@@ -7,14 +7,16 @@ import { fetchJsonOrError } from '../requests/fetchWithAuthenticityToken';
 // const { data, loading, error, sync } = useLoadedData(`path/to/resource`);
 const useLoadedData = (url) => {
   const [data, setData] = useState(null);
+  const [headers, setHeaders] = useState(new Headers());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const sync = useCallback(() => {
     setLoading(true);
     setError(null);
-    fetchJsonOrError(url).then((loaded) => {
-      setData(loaded);
+    fetchJsonOrError(url).then((response) => {
+      setData(response.data);
+      setHeaders(response.headers);
     }).catch((err) => {
       setError(err.message);
     }).finally(() => setLoading(false));
@@ -24,6 +26,7 @@ const useLoadedData = (url) => {
 
   return {
     data,
+    headers,
     loading,
     error,
     sync,

--- a/WcaOnRails/app/webpacker/lib/hooks/useSaveAction.js
+++ b/WcaOnRails/app/webpacker/lib/hooks/useSaveAction.js
@@ -24,7 +24,7 @@ const useSaveAction = () => {
       method: 'PATCH',
       body: JSON.stringify(data),
       ...options,
-    }).then(onSuccess).catch(onError).finally(() => setSaving(false));
+    }).then((response) => onSuccess(response.data)).catch(onError).finally(() => setSaving(false));
   }, [setSaving]);
 
   return {

--- a/WcaOnRails/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
+++ b/WcaOnRails/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
@@ -17,6 +17,6 @@ export function fetchJsonOrError(url, fetchOptions = {}) {
         if (!response.ok) {
           throw new Error(`${response.status}: ${response.statusText}\n${json.error}`);
         }
-        return json;
+        return { data: json, headers: response.headers };
       }));
 }

--- a/WcaOnRails/config/i18n.yml
+++ b/WcaOnRails/config/i18n.yml
@@ -42,4 +42,5 @@ translations:
       - "*.enums.*"
       - "*.regional_organizations.*"
       - "*.qualification.*"
+      - "*.incidents_log.*"
       - "*.logo.*"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -2298,6 +2298,7 @@ en:
       competitions: "Competitions"
       people: "People"
       advanced_search: "Advanced search"
+      incidents: "Incidents"
       posts: "Posts"
       regulations_and_guidelines: "Regulations and Guidelines"
       #context: Used in the homepage's omnisearch
@@ -2308,11 +2309,13 @@ en:
         competitions: "No competitions found for"
         people: "No people found for"
         posts: "No posts found for"
+        incidents: "No incidents found for"
         regulations_and_guidelines: "No Regulations or Guidelines found for"
   #context: Incident log
   incidents_log:
     #context: disclaimer displayed to inform incidents are only in English
     i18n_disclaimer: "Please note the incidents section is only available in English, the content below is not translated."
+    incident: "Incident:"
   #context: About the regulations
   about_regulations:
     title: "About the Regulations"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -247,6 +247,7 @@ Rails.application.routes.draw do
       get '/search/competitions' => 'api#competitions_search'
       get '/search/users' => 'api#users_search'
       get '/search/regulations' => 'api#regulations_search'
+      get '/search/incidents' => 'api#incidents_search'
       get '/users/:id' => 'api#show_user_by_id', constraints: { id: /\d+/ }
       get '/users/:wca_id' => 'api#show_user_by_wca_id'
       get '/delegates' => 'api#delegates'


### PR DESCRIPTION
This is a placeholder for implementing searchable incidents, and it's mainly meant for @kr-matthews.

I have *not* had the time to do the incident index controller method, nor the pagination, nor exploiting it through a dummy react component, nor the additional search fields (ie: tags, competition ids).

It's actually pretty much mergeable as-is (if there was an issue "make incidents searchable in omnisearch"), so I figured I would give you a rough idea of how a very basic implementation would look.

I'll complete that PR with the additional features you need asap ;)

I've also taken notes as I was implementing it about what was going on in my mind, hopefully it may be useful:
```
## Implementing searchable incidents

At this point I now that for most models it's just a matter of implementing a static "search" method, and if we have this quite naturally my first approach would be to integrate it into our omnisearch.
ATM my plan is to:
  - implement a basic search method that use a `q` parameter to search into the public content
  - serialize with an "incident" class, and deal with it in omnisearch

If that works well, I'll go ahead with implementing an index page that rely on "search" + pagination, then add some seach parameters (competitions, tags).

While implementing the search I figured out which attributes I wanted to search in (title, public_summary), and chained some `LIKE %something%` based on the query's parts (it's actually done like this for posts for instance).
When implementing the search, I noticed the search api relies on the default serializable_hash for incidents, which is not suitable as it contains private fields.
I went ahead and implemented a default set of options for serializable_hash.

While implementing the index search "view" page I noticed the use of present? then empty? is a bit weird as it could just be a "if any?"; "else", but I resisted the temptation to rewrite the whole page.
I implemented the search in our homepage omnisearch, then realized that on the "search results" page it's a different omni search: given basically no one uses this one and it's bound to disappear, I did not bother touching this.

When implementing tag search I considered two approaches:
1:
> incidents = incidents.where(incident_tags: IncidentTag.where(tag: tags))
2:
> incidents = incidents.where(id: IncidentTag.where(tag: tags).pluck(:incident_id))

2 unfortunately fires two sql queries, and 1 just works as expected so I kept this one.
I took the same approach for competitions.


```