### PR TITLE
Implement a posting results "check-in"

### DIFF
--- a/WcaOnRails/app/controllers/admin/results_controller.rb
+++ b/WcaOnRails/app/controllers/admin/results_controller.rb
@@ -4,6 +4,61 @@ module Admin
   class ResultsController < AdminController
     # NOTE: authentication is performed by admin controller
 
+    def posting_index
+      respond_to do |format|
+        format.html do
+          render :posting_index
+        end
+        format.json do
+          @pending_competitions = Competition.pending_posting
+          user_attributes = {
+            only: ["id", "name"],
+            methods: [],
+            include: [],
+          }
+          render json: {
+            current_user: current_user.as_json(user_attributes),
+            competitions: @pending_competitions.as_json(
+              only: ["id", "name"],
+              methods: ["city", "country_iso2"],
+              include: { posting_user: user_attributes },
+            ),
+          }
+        end
+      end
+    end
+
+    def start_posting
+      # The purpose of this action is to allow an admin to "lock" and start
+      # posting competitions. This is an informative lock that relies on
+      # WRT members common sense though, nothing should actually prevent
+      # posting from happening.
+      # If posting is possible, the idea is to:
+      #   - get all pending competitions
+      #   - filter out those who are already being posted (by the same member)
+      #   - intersect with the competitions in the parameters
+      #   - either lock them and reply ok, or there is none to lock and reply
+      #   it was a no-op.
+      @other_posting = Competition.where.not(posting_user: [nil, current_user]).any?
+      if @other_posting
+        return render json: { error: "Someone is already posting!" }
+      end
+      @updated_competitions = Competition.pending_posting.where(posting_user: nil).where(id: params[:competition_ids])
+      if @updated_competitions.empty?
+        return render json: { error: "No competitions to lock." }
+      end
+
+      json = { error: "Something went wrong." }
+      if @updated_competitions.update(posting_user: current_user)
+        @updated_competitions.each do |c|
+          CompetitionsMailer.posting_results(c, current_user).deliver_now
+        end
+        json = { message: "Competitions successfully locked, go on posting!" }
+      end
+
+      render json: json
+    end
+
     def new
       competition = Competition.find(params[:competition_id])
       round = Round.find(params[:round_id])

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -255,7 +255,9 @@ class CompetitionsController < ApplicationController
     end
 
     ActiveRecord::Base.transaction do
-      comp.update!(results_posted_at: Time.now, results_posted_by: current_user.id)
+      # It's important to clearout the 'posting_by' here to make sure
+      # another WRT member can start posting other results.
+      comp.update!(results_posted_at: Time.now, results_posted_by: current_user.id, posting_by: nil)
       comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
       comp.registrations.accepted.each { |registration| registration.user.maybe_assign_wca_id_by_results(comp) }
     end

--- a/WcaOnRails/app/mailers/competitions_mailer.rb
+++ b/WcaOnRails/app/mailers/competitions_mailer.rb
@@ -161,6 +161,16 @@ class CompetitionsMailer < ApplicationMailer
     @competition.uploaded_jsons.delete_all
   end
 
+  def posting_results(competition, poster)
+    @competition = competition
+    @poster = poster
+    mail(
+      from: "results@worldcubeassociation.org",
+      to: "results@worldcubeassociation.org",
+      subject: "Results for #{competition.name}",
+    )
+  end
+
   def registration_reminder(competition, user, registered_but_not_accepted)
     @competition = competition
     @user = user

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -29,6 +29,7 @@ class Competition < ApplicationRecord
   has_many :bookmarked_users, through: :bookmarked_competitions, source: :user
   belongs_to :competition_series, optional: true
   has_many :series_competitions, -> { readonly }, through: :competition_series, source: :competitions
+  belongs_to :posting_user, optional: true, foreign_key: 'posting_by', class_name: "User"
   has_many :inbox_results, foreign_key: "competitionId", dependent: :delete_all
   has_many :inbox_persons, foreign_key: "competitionId", dependent: :delete_all
 
@@ -77,6 +78,7 @@ class Competition < ApplicationRecord
   scope :order_by_announcement_date, -> { where.not(announced_at: nil).order(announced_at: :desc) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :not_confirmed, -> { where(confirmed_at: nil) }
+  scope :pending_posting, -> { where.not(results_submitted_at: nil).where(results_posted_at: nil) }
 
   enum guest_entry_status: {
     unclear: 0,
@@ -150,6 +152,7 @@ class Competition < ApplicationRecord
     announced_by
     cancelled_by
     results_posted_by
+    posting_by
     main_event_id
     waiting_list_deadline_date
     event_change_deadline_date
@@ -579,6 +582,7 @@ class Competition < ApplicationRecord
              'bookmarked_users',
              'competition_series',
              'series_competitions',
+             'posting_user',
              'inbox_results',
              'inbox_persons'
           # Do nothing as they shouldn't be cloned.

--- a/WcaOnRails/app/views/admin/_nav.html.erb
+++ b/WcaOnRails/app/views/admin/_nav.html.erb
@@ -7,6 +7,7 @@
         { text: "List competitions", path: competitions_view, fa_icon: "list" },
         { text: "Delegates", path: delegates_stats_path, fa_icon: "sitemap" },
         { text: "Edit teams", path: teams_path, fa_icon: "users" },
+        { text: "Posting Dashboard", path: posting_index_path, fa_icon: "user lock" },
         { text: "Run validators", path: admin_check_results_path, fa_icon: "check double" },
         { text: "Create newcomers", path: admin_finish_unfinished_persons_path, fa_icon: "user plus" },
         { text: "Check records", path: admin_check_regional_records_path, fa_icon: "trophy" },

--- a/WcaOnRails/app/views/admin/results/posting_index.html.erb
+++ b/WcaOnRails/app/views/admin/results/posting_index.html.erb
@@ -1,0 +1,5 @@
+<% provide(:title, "Result posting check-in") %>
+
+<div class="container">
+  <%= react_component("PostingCompetitions/index") %>
+</div>

--- a/WcaOnRails/app/views/competitions_mailer/posting_results.erb
+++ b/WcaOnRails/app/views/competitions_mailer/posting_results.erb
@@ -1,0 +1,7 @@
+<p>Results Team,</p>
+
+<p>
+  <%= @poster.name %> is posting results for <%= @competition.name %>.
+  <br />
+  Remember to check <%= link_to "the dashboard", posting_index_url %> if you want to start posting results.
+</p>

--- a/WcaOnRails/app/webpacker/components/PostingCompetitions/index.js
+++ b/WcaOnRails/app/webpacker/components/PostingCompetitions/index.js
@@ -1,0 +1,218 @@
+import React, { useState, useCallback, useEffect } from 'react';
+
+import {
+  Button, Checkbox, Header, Segment, Table,
+} from 'semantic-ui-react';
+import _ from 'lodash';
+import useLoadedData from '../../lib/hooks/useLoadedData';
+import useSaveAction from '../../lib/hooks/useSaveAction';
+import Loading from '../Requests/Loading';
+import Errored from '../Requests/Errored';
+import CountryFlag from '../wca/CountryFlag';
+import {
+  adminCheckUploadedResults,
+  adminPostingCompetitionsUrl,
+  adminImportResultsUrl,
+  adminStartPostingUrl,
+  competitionUrl,
+} from '../../lib/requests/routes.js.erb';
+
+function stateReducer(accumulated, current) {
+  return { ...accumulated, [current.id]: current.posting_user !== undefined };
+}
+
+function checkboxesStateFromData(competitions) {
+  return competitions.reduce(stateReducer, {});
+}
+
+function findUserId(competitions) {
+  const ids = competitions.map((c) => (c.posting_user ? c.posting_user.id : null));
+  return ids.filter(Boolean)[0];
+}
+
+function PostingCompetitionsIndex({
+  competitions,
+  currentUser,
+  save,
+  saving,
+  setMessage,
+  sync,
+}) {
+  const initialState = checkboxesStateFromData(competitions);
+  const [checkboxes, setCheckboxes] = useState(initialState);
+
+  const updater = useCallback((competitionId, value) => {
+    setCheckboxes((prevState) => ({ ...prevState, [competitionId]: value }));
+  }, [setCheckboxes]);
+  const postingUserId = findUserId(competitions);
+
+  const someoneElsePosting = postingUserId && postingUserId !== currentUser.id;
+  // We want to deactivate the form if:
+  //   - it's saving
+  //   - someone else is posting!
+  const globalDisable = saving || someoneElsePosting;
+
+  useEffect(() => {
+    if (someoneElsePosting) {
+      setMessage({ color: 'orange', text: 'Someone else is posting' });
+    }
+  }, [someoneElsePosting, setMessage]);
+
+  const handleResponse = useCallback((json) => {
+    if (json.error) {
+      setMessage({ color: 'red', text: json.error });
+    } else {
+      setMessage({ color: 'green', text: json.message });
+      sync();
+    }
+  }, [sync, setMessage]);
+
+  const startPostingAction = useCallback(() => {
+    const checkedCompetitions = Object.entries(checkboxes).filter(([, value]) => value);
+    const competitionIds = checkedCompetitions.map(([key]) => key);
+    save(adminStartPostingUrl, { competition_ids: competitionIds }, handleResponse, { method: 'POST' });
+  }, [checkboxes, handleResponse, save]);
+
+  return (
+    <>
+      {competitions.length === 0 && (
+        <Table.Row>
+          <Table.Cell colSpan={3}>
+            No competitions are awaiting to be posted
+          </Table.Cell>
+        </Table.Row>
+      )}
+      {competitions.map((c) => (
+        <Table.Row key={c.id}>
+          <Table.Cell>
+            <Header as="h5" floated="left">
+              {c.name}
+              <Header.Subheader>
+                {c.city}
+                {' '}
+                <CountryFlag iso2={c.country_iso2} />
+              </Header.Subheader>
+            </Header>
+            <Button.Group floated="right">
+              <Button
+                target="blank"
+                primary
+                href={competitionUrl(c.id)}
+              >
+                Competition page
+              </Button>
+              {/* Only display these if we can post. */}
+              {!someoneElsePosting && initialState[c.id] && (
+                <>
+                  <Button
+                    target="blank"
+                    color="olive"
+                    href={adminCheckUploadedResults(c.id)}
+                  >
+                    Check uploaded results
+                  </Button>
+                  <Button
+                    target="blank"
+                    color="green"
+                    href={adminImportResultsUrl(c.id)}
+                  >
+                    Import the results
+                  </Button>
+                </>
+              )}
+            </Button.Group>
+          </Table.Cell>
+          <Table.Cell>
+            <Checkbox
+              checked={checkboxes[c.id]}
+              onChange={(e, data) => updater(c.id, data.checked)}
+              disabled={globalDisable || initialState[c.id]}
+            />
+          </Table.Cell>
+          <Table.Cell>
+            {c.posting_user && (
+              <span>{c.posting_user.name}</span>
+            )}
+          </Table.Cell>
+        </Table.Row>
+      ))}
+      <Table.Row>
+        <Table.Cell />
+        <Table.Cell colSpan={2}>
+          <Button
+            positive
+            // We can't start posting if we're not allowed to, or if we didn't
+            // perform any change to the initial state.
+            disabled={globalDisable || _.isEqual(checkboxes, initialState)}
+            onClick={startPostingAction}
+          >
+            Start posting
+          </Button>
+        </Table.Cell>
+      </Table.Row>
+    </>
+  );
+}
+
+function PostingCompetitionsTable() {
+  const {
+    data, loading, error, sync,
+  } = useLoadedData(adminPostingCompetitionsUrl);
+  const { save, saving } = useSaveAction();
+  const [message, setMessage] = useState(null);
+
+  return (
+    <>
+      <Table celled>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              Competition
+              {' '}
+              <Button
+                icon="sync"
+                color="teal"
+                onClick={() => { setMessage(null); sync(); }}
+              />
+            </Table.HeaderCell>
+            <Table.HeaderCell>Posting</Table.HeaderCell>
+            <Table.HeaderCell>Poster</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {error && (
+            <Table.Row>
+              <Table.Cell colSpan={3}>
+                <Errored componentName="PostingCompetitionsIndex" />
+              </Table.Cell>
+            </Table.Row>
+          )}
+          {loading && (
+            <Table.Row>
+              <Table.Cell colSpan={3}>
+                <Loading />
+              </Table.Cell>
+            </Table.Row>
+          )}
+          {!loading && data && (
+            <PostingCompetitionsIndex
+              competitions={data.competitions}
+              currentUser={data.current_user}
+              save={save}
+              saving={saving}
+              sync={sync}
+              setMessage={setMessage}
+            />
+          )}
+        </Table.Body>
+      </Table>
+      {message && (
+        <Segment color={message.color} inverted>
+          {message.text}
+        </Segment>
+      )}
+    </>
+  );
+}
+
+export default PostingCompetitionsTable;

--- a/WcaOnRails/app/webpacker/lib/requests/routes.js.erb
+++ b/WcaOnRails/app/webpacker/lib/requests/routes.js.erb
@@ -75,3 +75,11 @@ export const adminGenerateIds = `<%= CGI.unescape(Rails.application.routes.url_h
 export const personApiUrl = (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_person_path("${wcaId}"))%>`;
 
 export const geocodingApiUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_geocoding_search_path) %>`;
+
+export const adminPostingCompetitionsUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.posting_index_path(format: "json")) %>`;
+
+export const adminStartPostingUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.start_posting_path) %>`;
+
+export const adminImportResultsUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_import_results_path("${competitionId}")) %>`;
+
+export const adminCheckUploadedResults = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_upload_results_edit_path("${competitionId}"))%>`;

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -275,6 +275,11 @@ Rails.application.routes.draw do
   get '/sso-discourse' => 'users#sso_discourse'
   get '/redirect/wac-survey' => 'users#wac_survey'
 
+  scope 'admin' do
+    get '/posting-index' => 'admin/results#posting_index'
+    post '/start-posting' => 'admin/results#start_posting'
+  end
+
   namespace :api do
     get '/', to: redirect('/api/v0', status: 302)
     namespace :v0 do

--- a/WcaOnRails/db/migrate/20230921143204_add_posting_by_to_competition.rb
+++ b/WcaOnRails/db/migrate/20230921143204_add_posting_by_to_competition.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPostingByToCompetition < ActiveRecord::Migration[7.0]
+  def change
+    add_column :Competitions, :posting_by, :integer, null: true, default: nil
+  end
+end

--- a/WcaOnRails/db/schema.rb
+++ b/WcaOnRails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_144154) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_21_143204) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_144154) do
     t.integer "guests_per_registration_limit"
     t.integer "events_per_registration_limit"
     t.boolean "force_comment_in_registration"
+    t.integer "posting_by"
     t.index ["cancelled_at"], name: "index_Competitions_on_cancelled_at"
     t.index ["countryId"], name: "index_Competitions_on_countryId"
     t.index ["end_date"], name: "index_Competitions_on_end_date"

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -95,6 +95,7 @@ module DatabaseDumper
           event_restrictions_reason
           announced_by
           results_posted_by
+          posting_by
           main_event_id
           cancelled_at
           cancelled_by


### PR DESCRIPTION
The WRT has a bunch of new members, and the risk of two (or more) members posting results at the same time has increased.
The current workflow is to send a "posting" email in the results thread, but it's definitely error prone and may or may not reflect what's being done on the website depending on the mail clients/internet.

The idea behind this PR is to introduce some kind of "posting results" index, which would list the competition pending posting from a WRT members, let WRT member declare they are posting one or more competitions (aka "taking the  lock"), let other members visiting the page know that someone is posting (and who).

As far as the WRT is concerned I think this contains just what we need, but I'll let other members chime in if needed.

Screenshot of a list of competitions needing posting:
![initial](https://user-images.githubusercontent.com/1007485/190230314-403a035f-5849-4ab8-b64d-c83b66747c68.png)

This is the view when taking the lock on one competitions:
![locked](https://user-images.githubusercontent.com/1007485/190230387-14670a71-0a12-47b5-b41a-b18606071ace.png)

It sends a mail in the results email thread of that competition:
![mail](https://user-images.githubusercontent.com/1007485/190230578-9ee1eaef-4f06-45ea-87bd-645b6c0c277d.png)

This is the same view but from another WRT member:
![someone_posting](https://user-images.githubusercontent.com/1007485/190230427-4eb47e8a-b61a-4800-a59f-10b9204ef9f6.png)

Clicking "post the competition" on the competition admin page clear the lock for that competition, and it looks like this:
![unlocked](https://user-images.githubusercontent.com/1007485/190230524-2a2b7bf3-7efd-4eff-ba11-cd13a516bbdf.png)

It's worth noting that the person posting one competition can add more competitions to those currently being posted (since we can post multiple competitions at the same time), however the form would be totally disabled if another member is posting at least one competition.

If nothing more urgent requires it, do you think it would be possible to deploy these changes to staging so that the WRT can take a look at how it looks "in real time"?