### PR TITLE
Remove edit-result link from the cached table

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -324,4 +324,9 @@ module CompetitionsHelper
 
     CompetitionSeries.new(competitions: [form_competition, competition])
   end
+
+  def result_cache_key(competition, view, is_admin: false)
+    results_updated_at = competition.results.order('updated_at desc').limit(1).pluck(:updated_at).first
+    [competition.id, view, results_updated_at&.iso8601 || "", I18n.locale, is_admin]
+  end
 end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1303,11 +1303,6 @@ class Competition < ApplicationRecord
     [cityName, country&.name].compact.join(', ')
   end
 
-  def result_cache_key(view)
-    results_updated_at = results.order('updated_at desc').limit(1).pluck(:updated_at).first
-    [id, view, results_updated_at&.iso8601 || "", I18n.locale]
-  end
-
   def events_with_podium_results
     light_results_from_relation(
       results.podium.order(:pos),

--- a/WcaOnRails/app/views/competitions/show_results_by_person.html.erb
+++ b/WcaOnRails/app/views/competitions/show_results_by_person.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, @competition.name) %>
 
 <%= render layout: 'results_nav' do %>
-  <% cache @competition.result_cache_key("by_person") do %>
+  <% cache result_cache_key(@competition, "by_person", is_admin: current_user&.can_admin_results? || false) do %>
     <% @competition.person_ids_with_results.each do |personId, results| %>
       <h3>
         <% first_result = results.first %>


### PR DESCRIPTION
The results table "per-person" is cached, but the "is admin" part isn't in the cache key, and therefore if an admin view the results first the cached version has the edit link for everyone.

It doesn't mean they can actually edit a result, but it's definitely a bit confusing!

As far as I know we don't actually use this link in the WRT anyway: the proper fix would have been to adjust the cache key but we can simply remove the link :)