### PR TITLE
Add base registration fee and more registration data to WCIF

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1572,6 +1572,7 @@ class Competition < ApplicationRecord
       "events" => events_wcif,
       "schedule" => schedule_wcif,
       "competitorLimit" => competitor_limit_enabled? ? competitor_limit : nil,
+      "baseRegistrationFee" => base_entry_fee_lowest_denomination,
       "extensions" => wcif_extensions.map(&:to_wcif),
     }
   end
@@ -1796,6 +1797,7 @@ class Competition < ApplicationRecord
           },
         },
         "competitorLimit" => { "type" => ["integer", "null"] },
+        "baseRegistrationFee" => { "type" => ["integer", "null"] },
         "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
     }

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -207,9 +207,9 @@ class Registration < ApplicationRecord
         "status" => { "type" => "string", "enum" => %w(accepted deleted pending) },
         "guests" => { "type" => "integer" },
         "comments" => { "type" => "string" },
-        "createdAt" => { "type" => ["xTime", "null"]},
+        "createdAt" => { "type" => ["xTime", "null"] },
         "paidEntryFees" => { "type" => ["integer", "null"] },
-        "lastPaymentTime" => { "type" => ["xTime", "null"]},
+        "lastPaymentTime" => { "type" => ["xTime", "null"] },
       },
     }
   end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -181,6 +181,9 @@ class Registration < ApplicationRecord
     authorized_fields = {
       "guests" => guests,
       "comments" => comments || '',
+      "createdAt" => created_at,
+      "paidEntryFees" => paid_entry_fees,
+      "lastPaymentTime" => last_payment_date, # Despite the name of the original field, this is a timestamp
     }
     {
       "wcaRegistrationId" => id,
@@ -204,6 +207,9 @@ class Registration < ApplicationRecord
         "status" => { "type" => "string", "enum" => %w(accepted deleted pending) },
         "guests" => { "type" => "integer" },
         "comments" => { "type" => "string" },
+        "createdAt" => { "type" => ["xTime", "null"]},
+        "paidEntryFees" => { "type" => ["integer", "null"] },
+        "lastPaymentTime" => { "type" => ["xTime", "null"]},
       },
     }
   end

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Competition WCIF" do
       event_ids: %w(333 444 333fm 333mbf),
       with_schedule: true,
       competitor_limit: 50,
+      base_entry_fee_lowest_denomination: 1000,
     )
   }
   let(:partner_competition) { FactoryBot.create(:competition, id: "PartnerComp2014", series_base: competition, series_distance_days: 3) }
@@ -259,6 +260,7 @@ RSpec.describe "Competition WCIF" do
           ],
         },
         "competitorLimit" => 50,
+        "baseRegistrationFee" => 1000,
         "extensions" => [],
       )
     end


### PR DESCRIPTION
This allows for accessing more data through the API to organisers. I personally plan to use some of these fields to set up automatic registration acceptance through the API. 