### PR TITLE
Use content_or_options in label_tag to bypass humanize method [competitions page / translation]

### DIFF
--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -114,14 +114,14 @@
 </div>
 
 <div id="registration-status" class="form-group registration-status-selector">
-  <%= check_box_tag(:show_registration_status, params[:show_registration_status], params[:show_registration_status] == "on") %>
-  <%= label_tag(name = t('competitions.index.show_registration_status'),
+  <%= check_box_tag("#{:show_registration_status}-checkbox", params[:show_registration_status], params[:show_registration_status] == "on") %>
+  <%= label_tag(name = "#{:show_registration_status}-checkbox",
                 content_or_options = t('competitions.index.show_registration_status')) %>
 </div>
 
 <div id="cancelled" class="form-group cancel-selector">
-  <%= check_box_tag(:show_cancelled, params[:show_cancelled], params[:show_cancelled] == "on") %>
-  <%= label_tag(name = t('competitions.index.show_cancelled'),
+  <%= check_box_tag("#{:show_cancelled}-checkbox", params[:show_cancelled], params[:show_cancelled] == "on") %>
+  <%= label_tag(name = "#{:show_cancelled}-checkbox",
                 content_or_options = t('competitions.index.show_cancelled')) %>
 </div>
 

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -115,12 +115,14 @@
 
 <div id="registration-status" class="form-group registration-status-selector">
   <%= check_box_tag(:show_registration_status, params[:show_registration_status], params[:show_registration_status] == "on") %>
-  <%= t 'competitions.index.show_registration_status' %>
+  <%= label_tag(name = t('competitions.index.show_registration_status'),
+                content_or_options = t('competitions.index.show_registration_status')) %>
 </div>
 
 <div id="cancelled" class="form-group cancel-selector">
   <%= check_box_tag(:show_cancelled, params[:show_cancelled], params[:show_cancelled] == "on") %>
-  <%= t 'competitions.index.show_cancelled' %>
+  <%= label_tag(name = t('competitions.index.show_cancelled'),
+                content_or_options = t('competitions.index.show_cancelled')) %>
 </div>
 
 <div id="display" class="form-group">

--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -115,12 +115,12 @@
 
 <div id="registration-status" class="form-group registration-status-selector">
   <%= check_box_tag(:show_registration_status, params[:show_registration_status], params[:show_registration_status] == "on") %>
-  <%= label_tag(t('competitions.index.show_registration_status')) %>
+  <%= t 'competitions.index.show_registration_status' %>
 </div>
 
 <div id="cancelled" class="form-group cancel-selector">
   <%= check_box_tag(:show_cancelled, params[:show_cancelled], params[:show_cancelled] == "on") %>
-  <%= label_tag(t('competitions.index.show_cancelled')) %>
+  <%= t 'competitions.index.show_cancelled' %>
 </div>
 
 <div id="display" class="form-group">


### PR DESCRIPTION
Summarizing the original problem described in https://github.com/thewca/worldcubeassociation.org/issues/7299: When passing only one parameter inside a `label_tag`, this automatically calls the `humanize` method. For the German translation of two keys at the competitions page, this leads to unwanted behavior: we would like to have several words capitalized, not only the first one at the beginning of the translated key.

This PR now explicitly instructs the `label_tag` to write the content exactly as specified in the locales/*.yml file and bypasses the humanize method. From what I can tell, this should not cause trouble for non-German translations, because we usually expect the text to appear exactly as translated with the i18n keys and don't expect `humanize` to take care of underscores or capital letters. As this seems to be the first time this needs to be introduced for this repository (the search only leads to the issue quoted above), I made it explicit in the fix by writing keyword arguments instead of positional arguments only.

Result in local docker build:
<img width="623" alt="Bildschirmfoto 2022-10-21 um 00 13 56" src="https://user-images.githubusercontent.com/53974095/197069159-28cfb471-16da-47b1-a2cb-13e08af5042b.png">


Fixes https://github.com/thewca/worldcubeassociation.org/issues/7299