### PR TITLE
Hide registration edit fields if external website is used

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -354,8 +354,10 @@
         <%= f.input :on_the_spot_registration, collection: [ :true, :false ] %>
         <%= f.input :on_the_spot_entry_fee_lowest_denomination, as: :money_amount, currency: @competition.currency_code, currency_selector: "#competition_currency_code" %>
 
-        <%= f.input :allow_registration_edits, collection: [ :true, :false ] %>
-        <%= f.input :allow_registration_self_delete_after_acceptance, collection: [ :true, :false ] %>
+        <div class="wca-registration-options">
+          <%= f.input :allow_registration_edits, collection: [ :true, :false ] %>
+          <%= f.input :allow_registration_self_delete_after_acceptance, collection: [ :true, :false ] %>
+        </div>
 
         <%= f.input :extra_registration_requirements, input_html: { class: disable_form ? "" : "markdown-editor" } %>
 


### PR DESCRIPTION
Allowing competitors to edit the registration doesn't make sense if an external system is used.
This commit just hides the fields altogether, which relies on our database default. (i.e. sets them to `false`)

The selection caused confusion to a Japanese Delegate because they use their own third party registration system over here. So they were not sure what to select, and I figured hiding the selection altogether would make the most sense.