### PR TITLE
Implement correct handling for Stripe API sub-hundred 'special case' currencies

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -476,10 +476,14 @@ class RegistrationsController < ApplicationController
           render json: { error: { message: t("registrations.payment_form.alerts.amount_too_low") } }
           return
         end
+
+        currency_iso = registration.outstanding_entry_fees.currency.iso_code
+        stripe_amount = StripeCharge.amount_to_stripe(amount, currency_iso)
+
         payment_intent_args = {
           payment_method: params[:payment_method_id],
-          amount: amount,
-          currency: registration.outstanding_entry_fees.currency.iso_code,
+          amount: stripe_amount,
+          currency: currency_iso,
           confirmation_method: "manual",
           confirm: true,
           receipt_email: user.email,
@@ -582,10 +586,13 @@ class RegistrationsController < ApplicationController
       return
     end
 
+    currency_iso = registration.competition.currency_code
+    stripe_amount = StripeCharge.amount_to_stripe(refund_amount, currency_iso)
+
     refund = Stripe::Refund.create(
       {
         charge: payment.stripe_charge_id,
-        amount: refund_amount,
+        amount: stripe_amount,
       },
       stripe_account: registration.competition.connected_stripe_account_id,
     )

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -515,7 +515,7 @@ class RegistrationsController < ApplicationController
           stripe_account: registration.competition.connected_stripe_account_id,
         )
       end
-    rescue Stripe::CardError => e
+    rescue Stripe::StripeError => e
       # Log and display error to client
       stripe_charge.update!(status: "failure", error: e.message)
       render json: { error: { message: e.message } }

--- a/WcaOnRails/app/models/stripe_charge.rb
+++ b/WcaOnRails/app/models/stripe_charge.rb
@@ -7,4 +7,29 @@ class StripeCharge < ApplicationRecord
     success: "success",
     failure: "failure",
   }
+
+  # as per https://stripe.com/docs/currencies#special-cases
+  ZERO_DECIMAL_CURRENCIES = %w[HUF TWD UGX].freeze
+
+  # Stripe has a small handful of fancy snowflake currencies
+  # that need to be submitted as multiples of 100. The details are documented
+  # at https://stripe.com/docs/currencies#special-cases
+  def self.amount_to_stripe(amount_lowest_denomination, iso_currency)
+    if ZERO_DECIMAL_CURRENCIES.include?(iso_currency)
+      amount_times_hundred = amount_lowest_denomination * 100
+
+      # Stripe API rejects payments that are below the hundreds sub-unit.
+      # In practice this should never happen because the inflation on those currencies
+      # makes it absolutely impractical for Delegates to charge 0.45 HUF for example.
+      # If this error is actually ever thrown, talk to the Delegates of the competition in question.
+      if amount_times_hundred % 100 != 0
+        raise "Trying to charge an amount of #{amount_lowest_denomination} #{iso_currency}, which is smaller than what the Stripe API accepts for sub-hundred currencies"
+      end
+
+      return amount_times_hundred
+    end
+
+    # Stripe API will be happy as-is.
+    amount_lowest_denomination
+  end
 end

--- a/WcaOnRails/app/models/stripe_charge.rb
+++ b/WcaOnRails/app/models/stripe_charge.rb
@@ -8,12 +8,16 @@ class StripeCharge < ApplicationRecord
     failure: "failure",
   }
 
-  # as per https://stripe.com/docs/currencies#special-cases
-  ZERO_DECIMAL_CURRENCIES = %w[HUF TWD UGX].freeze
+  # sub-hundred units special cases per https://stripe.com/docs/currencies#special-cases
+  # that are not compatible with the subunits from our RubyMoney gem.
+  # In other words, `Money::Currency.find(iso_code).subunit_to_unit`
+  # is not what the Stripe API expects in these cases.
+  # Note that TWD from the Stripe docs is not listed here because it is implemented with cents in RubyMoney.
+  ZERO_DECIMAL_CURRENCIES = %w[HUF UGX].freeze
 
   # Stripe has a small handful of fancy snowflake currencies
-  # that need to be submitted as multiples of 100. The details are documented
-  # at https://stripe.com/docs/currencies#special-cases
+  # that need to be submitted as multiples of 100 even though they technically have subunits.
+  # The details are documented at https://stripe.com/docs/currencies#special-cases
   def self.amount_to_stripe(amount_lowest_denomination, iso_currency)
     if ZERO_DECIMAL_CURRENCIES.include?(iso_currency)
       amount_times_hundred = amount_lowest_denomination * 100

--- a/WcaOnRails/app/models/stripe_charge.rb
+++ b/WcaOnRails/app/models/stripe_charge.rb
@@ -15,10 +15,10 @@ class StripeCharge < ApplicationRecord
   # Note that TWD from the Stripe docs is not listed here because it is implemented with cents in RubyMoney.
   ZERO_DECIMAL_CURRENCIES = %w[HUF UGX].freeze
 
-  # Stripe has a small handful of fancy snowflake currencies
-  # that need to be submitted as multiples of 100 even though they technically have subunits.
-  # The details are documented at https://stripe.com/docs/currencies#special-cases
   def self.amount_to_stripe(amount_lowest_denomination, iso_currency)
+    # Stripe has a small handful of fancy snowflake currencies
+    # that need to be submitted as multiples of 100 even though they technically have subunits.
+    # The details are documented at https://stripe.com/docs/currencies#special-cases
     if ZERO_DECIMAL_CURRENCIES.include?(iso_currency)
       amount_times_hundred = amount_lowest_denomination * 100
 

--- a/WcaOnRails/spec/models/stripe_charge_spec.rb
+++ b/WcaOnRails/spec/models/stripe_charge_spec.rb
@@ -12,13 +12,6 @@ RSpec.describe StripeCharge do
     expect(stripe_amount).to eq(600_000)
   end
 
-  it "handles TWD as a special currency" do
-    five_hundred_twd = Money.new(500, 'TWD')
-
-    stripe_amount = StripeCharge.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
-    expect(stripe_amount).to eq(50_000)
-  end
-
   it "handles UGX as a special currency" do
     sixty_thousand_ugx = Money.new(60_000, 'UGX')
 

--- a/WcaOnRails/spec/models/stripe_charge_spec.rb
+++ b/WcaOnRails/spec/models/stripe_charge_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The currency amounts are all roughly equivalent to USD $15
+# at the time of writing these tests.
+RSpec.describe StripeCharge do
+  it "handles HUF as a special currency" do
+    six_thousand_huf = Money.new(6_000, 'HUF')
+
+    stripe_amount = StripeCharge.amount_to_stripe(six_thousand_huf.cents, six_thousand_huf.currency.iso_code)
+    expect(stripe_amount).to eq(600_000)
+  end
+
+  it "handles TWD as a special currency" do
+    five_hundred_twd = Money.new(500, 'TWD')
+
+    stripe_amount = StripeCharge.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
+    expect(stripe_amount).to eq(50_000)
+  end
+
+  it "handles UGX as a special currency" do
+    sixty_thousand_ugx = Money.new(60_000, 'UGX')
+
+    stripe_amount = StripeCharge.amount_to_stripe(sixty_thousand_ugx.cents, sixty_thousand_ugx.currency.iso_code)
+    expect(stripe_amount).to eq(6_000_000)
+  end
+
+  it "throws exception when sub-hundred currency not divisible" do
+    expect {
+      StripeCharge.amount_to_stripe(6000.45, 'HUF')
+    }.to raise_error(RuntimeError)
+  end
+
+  it "handles USD as a normal currency" do
+    fifteen_usd = Money.new(1_500, 'USD')
+
+    stripe_amount = StripeCharge.amount_to_stripe(fifteen_usd.cents, fifteen_usd.currency.iso_code)
+    expect(stripe_amount).to eq(1_500)
+  end
+
+  it "handles EUR as a normal currency" do
+    fifteen_eur = Money.new(1_500, 'EUR')
+
+    stripe_amount = StripeCharge.amount_to_stripe(fifteen_eur.cents, fifteen_eur.currency.iso_code)
+    expect(stripe_amount).to eq(1_500)
+  end
+
+  it "handles JPY as a normal currency" do
+    two_thousand_yen = Money.new(2_000, 'JPY')
+
+    stripe_amount = StripeCharge.amount_to_stripe(two_thousand_yen.cents, two_thousand_yen.currency.iso_code)
+    expect(stripe_amount).to eq(2_000)
+  end
+end

--- a/WcaOnRails/spec/models/stripe_charge_spec.rb
+++ b/WcaOnRails/spec/models/stripe_charge_spec.rb
@@ -7,6 +7,7 @@ require 'rails_helper'
 RSpec.describe StripeCharge do
   it "handles HUF as a special currency" do
     six_thousand_huf = Money.from_amount(6_000, 'HUF')
+    expect(six_thousand_huf.cents).to eq(6_000)
 
     stripe_amount = StripeCharge.amount_to_stripe(six_thousand_huf.cents, six_thousand_huf.currency.iso_code)
     expect(stripe_amount).to eq(600_000)
@@ -14,6 +15,7 @@ RSpec.describe StripeCharge do
 
   it "handles UGX as a special currency" do
     sixty_thousand_ugx = Money.from_amount(60_000, 'UGX')
+    expect(sixty_thousand_ugx.cents).to eq(60_000)
 
     stripe_amount = StripeCharge.amount_to_stripe(sixty_thousand_ugx.cents, sixty_thousand_ugx.currency.iso_code)
     expect(stripe_amount).to eq(6_000_000)
@@ -29,6 +31,7 @@ RSpec.describe StripeCharge do
 
   it "handles USD as a normal currency" do
     fifteen_usd = Money.from_amount(15, 'USD')
+    expect(fifteen_usd.cents).to eq(1_500)
 
     stripe_amount = StripeCharge.amount_to_stripe(fifteen_usd.cents, fifteen_usd.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
@@ -36,6 +39,7 @@ RSpec.describe StripeCharge do
 
   it "handles EUR as a normal currency" do
     fifteen_eur = Money.from_amount(15, 'EUR')
+    expect(fifteen_eur.cents).to eq(1_500)
 
     stripe_amount = StripeCharge.amount_to_stripe(fifteen_eur.cents, fifteen_eur.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
@@ -43,6 +47,7 @@ RSpec.describe StripeCharge do
 
   it "handles JPY as a normal currency" do
     two_thousand_yen = Money.from_amount(2_000, 'JPY')
+    expect(two_thousand_yen.cents).to eq(2_000)
 
     stripe_amount = StripeCharge.amount_to_stripe(two_thousand_yen.cents, two_thousand_yen.currency.iso_code)
     expect(stripe_amount).to eq(2_000)
@@ -52,6 +57,7 @@ RSpec.describe StripeCharge do
     # TWD is one of the fancy-snowflake sub-hundred currecies in the Stripe API
     # but it is also the only one that actually has subunits in the RubyMoney gem so it needs no special treatment.
     five_hundred_twd = Money.from_amount(500, 'TWD')
+    expect(five_hundred_twd.cents).to eq(50_000)
 
     stripe_amount = StripeCharge.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
     expect(stripe_amount).to eq(50_000)

--- a/WcaOnRails/spec/models/stripe_charge_spec.rb
+++ b/WcaOnRails/spec/models/stripe_charge_spec.rb
@@ -6,43 +6,54 @@ require 'rails_helper'
 # at the time of writing these tests.
 RSpec.describe StripeCharge do
   it "handles HUF as a special currency" do
-    six_thousand_huf = Money.new(6_000, 'HUF')
+    six_thousand_huf = Money.from_amount(6_000, 'HUF')
 
     stripe_amount = StripeCharge.amount_to_stripe(six_thousand_huf.cents, six_thousand_huf.currency.iso_code)
     expect(stripe_amount).to eq(600_000)
   end
 
   it "handles UGX as a special currency" do
-    sixty_thousand_ugx = Money.new(60_000, 'UGX')
+    sixty_thousand_ugx = Money.from_amount(60_000, 'UGX')
 
     stripe_amount = StripeCharge.amount_to_stripe(sixty_thousand_ugx.cents, sixty_thousand_ugx.currency.iso_code)
     expect(stripe_amount).to eq(6_000_000)
   end
 
   it "throws exception when sub-hundred currency not divisible" do
-    expect {
+    expect do
+      # Funnily enough, our RubyMoney gem doesn't even support HUF sub-units, but Stripe still insists on
+      # *not* charging sub-units in the lowest two decimal places. So we manually insert a fraction to check for the error.
       StripeCharge.amount_to_stripe(6000.45, 'HUF')
-    }.to raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
 
   it "handles USD as a normal currency" do
-    fifteen_usd = Money.new(1_500, 'USD')
+    fifteen_usd = Money.from_amount(15, 'USD')
 
     stripe_amount = StripeCharge.amount_to_stripe(fifteen_usd.cents, fifteen_usd.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
   end
 
   it "handles EUR as a normal currency" do
-    fifteen_eur = Money.new(1_500, 'EUR')
+    fifteen_eur = Money.from_amount(15, 'EUR')
 
     stripe_amount = StripeCharge.amount_to_stripe(fifteen_eur.cents, fifteen_eur.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
   end
 
   it "handles JPY as a normal currency" do
-    two_thousand_yen = Money.new(2_000, 'JPY')
+    two_thousand_yen = Money.from_amount(2_000, 'JPY')
 
     stripe_amount = StripeCharge.amount_to_stripe(two_thousand_yen.cents, two_thousand_yen.currency.iso_code)
     expect(stripe_amount).to eq(2_000)
+  end
+
+  it "handles TWD as a normal currency" do
+    # TWD is one of the fancy-snowflake sub-hundred currecies in the Stripe API
+    # but it is also the only one that actually has subunits in the RubyMoney gem so it needs no special treatment.
+    five_hundred_twd = Money.from_amount(500, 'TWD')
+
+    stripe_amount = StripeCharge.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
+    expect(stripe_amount).to eq(50_000)
   end
 end


### PR DESCRIPTION
Fixes #7363 

See also https://stripe.com/docs/currencies#special-cases. As part of this PR, I have opened up the error reporting in the payments handler to catch all Stripe API-related errors and not just card errors, in the hopes that we can detect/diagnose problems in the future more easily.