### PR TITLE
fix: restore checkbox functionality for `/competitions`

### DIFF
--- a/WcaOnRails/app/views/competitions/_index_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_form.html.erb
@@ -114,14 +114,14 @@
 </div>
 
 <div id="registration-status" class="form-group registration-status-selector">
-  <%= check_box_tag("#{:show_registration_status}-checkbox", params[:show_registration_status], params[:show_registration_status] == "on") %>
-  <%= label_tag(name = "#{:show_registration_status}-checkbox",
+  <%= check_box_tag(:show_registration_status, params[:show_registration_status], params[:show_registration_status] == "on") %>
+  <%= label_tag(name = :show_registration_status,
                 content_or_options = t('competitions.index.show_registration_status')) %>
 </div>
 
 <div id="cancelled" class="form-group cancel-selector">
-  <%= check_box_tag("#{:show_cancelled}-checkbox", params[:show_cancelled], params[:show_cancelled] == "on") %>
-  <%= label_tag(name = "#{:show_cancelled}-checkbox",
+  <%= check_box_tag(:show_cancelled, params[:show_cancelled], params[:show_cancelled] == "on") %>
+  <%= label_tag(name = :show_cancelled,
                 content_or_options = t('competitions.index.show_cancelled')) %>
 </div>
 


### PR DESCRIPTION
Apparently, it's not safe to invent an arbitrary name for the checkboxes & labels, as was introduced in https://github.com/thewca/worldcubeassociation.org/pull/7304 - likely because the original name (as is) is used in a controller (?). Sorry for that.

Removed the expression around the names in quotation marks.

Fixes #7369 

Screenshots:
<img width="1197" alt="Bildschirmfoto 2022-11-08 um 15 10 09" src="https://user-images.githubusercontent.com/53974095/200586595-a034a329-fb3e-47f4-a04f-960567554188.png">
<img width="1212" alt="Bildschirmfoto 2022-11-08 um 15 09 49" src="https://user-images.githubusercontent.com/53974095/200586607-6237fbcd-6028-4499-8282-ae8d1961313a.png">

@Nevseros thanks Ekaterina for reporting the issue originally mentioned by [Sehoon Kim (김세훈)](https://forum.worldcubeassociation.org/u/Sehoon_Kim)
[(2022KIMS02)](https://www.worldcubeassociation.org/persons/2022KIMS02)