### PR TITLE
Fixed order of team members

### DIFF
--- a/WcaOnRails/app/webpacker/components/StaticPages/TeamsCommittees.js
+++ b/WcaOnRails/app/webpacker/components/StaticPages/TeamsCommittees.js
@@ -41,8 +41,8 @@ function Team({ team }) {
       <div className="team-members">
         {team.current_members
           .sort((a, b) => a.name.localeCompare(b.name))
-          .sort((a) => (a.senior_member ? -1 : 1))
-          .sort((a) => (a.leader ? -1 : 1))
+          .sort((a, b) => (b.senior_member - a.senior_member))
+          .sort((a, b) => (b.leader - a.leader))
           .map((user) => (
             <div key={team.id.toString() + user.id.toString()}>
               <UserBadge

--- a/WcaOnRails/app/webpacker/components/UserBadge.js
+++ b/WcaOnRails/app/webpacker/components/UserBadge.js
@@ -82,14 +82,14 @@ function UserBadge({
                 {user.name}
                 <Icon name="user circle outline" />
               </b>
-              <p className="user-badge-subtext">{subtext}</p>
+              <div className="user-badge-subtext">{subtext}</div>
             </Button>
           )}
         />
       ) : (
         <div className="user-name ui button user-name-no-link">
           <b>{user.name}</b>
-          <p className="user-badge-subtext">{subtext}</p>
+          <div className="user-badge-subtext">{subtext}</div>
         </div>
       )}
     </Button>


### PR DESCRIPTION
Apparently slight differences in the way V8 and SpiderMonkey have implemented `Array.prototype.sort` meant that in Firefox the members of teams on `/teams-committees` were being shown out of order. This fixes the ambiguity.

Also changed `p` to `div` to fix console error.