### PR TITLE
More validations for advancement conditions

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1921,4 +1921,11 @@ class Competition < ApplicationRecord
     series_competitions
       .where.not(id: self.id)
   end
+
+  def find_round_for(event_id, round_type_id, format_id = nil)
+    rounds.find do |r|
+      r.event.id == event_id && r.round_type_id == round_type_id &&
+        (format_id.nil? || format_id == r.format_id)
+    end
+  end
 end

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -41,7 +41,17 @@ module Resultable
     end
 
     def round
-      Round.find_for(competitionId, eventId, roundTypeId, formatId)
+      # This method is actually relatively expensive, it's definitely fine to
+      # use it if you're dealing with a single result, but if you're manipulating
+      # a bunch of them please don't use it as you likely have another mean
+      # to get a 'round' for your set of results.
+      # Using a 'find' here is intentional to pass the `includes(:rounds)` to
+      # avoid the n+1 query on competition_events if we were directly using
+      # competition.find_round_for.
+      Competition
+        .includes(:rounds)
+        .find(competition_id)
+        .find_round_for(event_id, round_type_id, format_id)
     end
 
     validate :belongs_to_a_round

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -50,8 +50,8 @@ module Resultable
       # competition.find_round_for.
       Competition
         .includes(:rounds)
-        .find(competition_id)
-        .find_round_for(event_id, round_type_id, format_id)
+        .find_by_id(competition_id)
+        &.find_round_for(event_id, round_type_id, format_id)
     end
 
     validate :belongs_to_a_round

--- a/WcaOnRails/app/models/round.rb
+++ b/WcaOnRails/app/models/round.rb
@@ -238,18 +238,4 @@ class Round < ApplicationRecord
   def self.name_from_attributes(event, round_type)
     I18n.t("round.name", event_name: event.name, round_name: round_type.name)
   end
-
-  # Find a matching round the given (competition_id, event_id, round_type_id)
-  # tuple.
-  # Optionally take a format if we want a strict match.
-  def self.find_for(competition_id, event_id, round_type_id, format_id = nil)
-    Competition.find_by(id: competition_id)
-               &.competition_events
-               &.find { |ce| ce.event_id == event_id }
-               &.rounds
-               &.find do |r|
-                 r.round_type_id == round_type_id &&
-                   (format_id.nil? || format_id == r.format_id)
-               end
-  end
 end

--- a/WcaOnRails/lib/advancement_conditions/attempt_result_condition.rb
+++ b/WcaOnRails/lib/advancement_conditions/attempt_result_condition.rb
@@ -18,5 +18,13 @@ module AdvancementConditions
         I18n.t("advancement_condition#{".short" if short}.attempt_result.points", round_format: round_form, points: SolveTime.multibld_attempt_to_points(attempt_result))
       end
     end
+
+    def max_advancing(results)
+      return 0 if results.empty?
+      field = results.first.format.sort_by == "single" ? :best : :average
+      results.select do |r|
+        r.to_solve_time(field).complete? && r.send(field) < attempt_result
+      end.size
+    end
   end
 end

--- a/WcaOnRails/lib/advancement_conditions/percent_condition.rb
+++ b/WcaOnRails/lib/advancement_conditions/percent_condition.rb
@@ -11,5 +11,9 @@ module AdvancementConditions
     def to_s(round, short: false)
       I18n.t("advancement_condition#{".short" if short}.percent", percent: percent)
     end
+
+    def max_advancing(results)
+      results.size * percent / 100
+    end
   end
 end

--- a/WcaOnRails/lib/advancement_conditions/ranking_condition.rb
+++ b/WcaOnRails/lib/advancement_conditions/ranking_condition.rb
@@ -11,5 +11,9 @@ module AdvancementConditions
     def to_s(round, short: false)
       I18n.t("advancement_condition#{".short" if short}.ranking", ranking: ranking)
     end
+
+    def max_advancing(results)
+      ranking
+    end
   end
 end

--- a/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
+++ b/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
@@ -2,12 +2,22 @@
 
 module ResultsValidators
   class AdvancementConditionsValidator < GenericValidator
-    REGULATION_9M_ERROR = "Event %{event_id} has more than four rounds, which is not permitted as per Regulation 9m."
+    # PV: There used to be an error for regulation 9M, but now all results
+    # must belong to a round, and rails validations make sure the total
+    # number of rounds is <= 4, and that each round number is unique.
     REGULATION_9M1_ERROR = "Round %{round_id} has 99 or fewer competitors but has more than two subsequent rounds, which is not permitted as per Regulation 9m1."
     REGULATION_9M2_ERROR = "Round %{round_id} has 15 or fewer competitors but has more than one subsequent round, which is not permitted as per Regulation 9m2."
     REGULATION_9M3_ERROR = "Round %{round_id} has 7 or fewer competitors but has at least one subsequent round, which is not permitted as per Regulation 9m3."
     REGULATION_9P1_ERROR = "Round %{round_id}: Fewer than 25%% of competitors were eliminated, which is not permitted as per Regulation 9p1."
     OLD_REGULATION_9P_ERROR = "Round %{round_id}: There must be at least one competitor eliminated, which is required as per Regulation 9p (competitions before April 2010)."
+    ROUND_9P1_ERROR = "Round %{round_id}: according to the advancement condition (%{condition}), fewer than 25%% of competitors would be eliminated," \
+                      "which is not permitted as per Regulation 9p1. Please update the round information in the manage events page."
+    TOO_MANY_QUALIFIED_WARNING = "Round %{round_id}: more competitors qualified than what the advancement condition planned (%{actual} instead of %{expected}, " \
+                                 "the condition was: %{condition}). Please update the round information in the manage events page."
+    NOT_ENOUGH_QUALIFIED_WARNING = "Round %{round_id}: according to the events data, at most %{expected} could have proceed, but only %{actual} competed in the round. " \
+                                   "Please leave a comment about that (or fix the events data if you applied a different advancement condition)."
+    COMPETED_NOT_QUALIFIED_ERROR = "Round %{round_id}: %{ids} competed but did not meet the attempt result advancement condition (%{condition}). " \
+                                   "Please make sure the advancement condition reflects what was used during the competition, and remove the results if needed."
 
     # These are the old "(combined) qualification" and "b-final" rounds.
     # They are not taken into account in advancement conditions.
@@ -31,6 +41,7 @@ module ResultsValidators
       end
 
       results_by_competition_id.each do |competition_id, results_for_comp|
+        competition = Competition.includes(:rounds).find(competition_id)
         comp_start_date = competitions_start_dates[competition_id]
         results_by_event_id = results_for_comp.group_by(&:eventId)
         results_by_event_id.each do |event_id, results_for_event|
@@ -42,14 +53,7 @@ module ResultsValidators
             IGNORE_ROUND_TYPES.include?(round_type_id)
           end
           remaining_number_of_rounds = round_types_in_results.size
-          if remaining_number_of_rounds > 4
-            # https://www.worldcubeassociation.org/regulations/#9m: Events must have at most four rounds.
-            # Should not happen as we already have a validation to create rounds, but who knows...
-            @errors << ValidationError.new(:rounds, competition_id,
-                                           REGULATION_9M_ERROR,
-                                           event_id: event_id)
-          end
-          number_of_people_in_previous_round = nil
+          previous_round_type_id = nil
           (ordered_round_type_ids & round_types_in_results).each do |round_type_id|
             remaining_number_of_rounds -= 1
             number_of_people_in_round = results_by_round_type_id[round_type_id].size
@@ -75,7 +79,30 @@ module ResultsValidators
 
             # Check for the number of qualified competitors (only if we are not
             # in a first round).
-            if number_of_people_in_previous_round
+            if previous_round_type_id
+              # Get the actual Round from the website: they are populated for all
+              # competitions and we can check both what actually happens and what
+              # was set to happen.
+              previous_round = competition.find_round_for(event_id, previous_round_type_id)
+              previous_results = results_by_round_type_id[previous_round_type_id]
+              number_of_people_in_previous_round = previous_results.size
+              condition = previous_round.advancement_condition
+
+              # Check that no one proceeded if they shouldn't have
+              if condition.instance_of? AdvancementConditions::AttemptResultCondition
+                current_persons = results_by_round_type_id[round_type_id].map(&:wca_id)
+                people_over_condition = previous_results.filter do |r|
+                  current_persons.include?(r.wca_id) && r.send(r.format.sort_by) > condition.attempt_result
+                end.map(&:wca_id)
+                if people_over_condition.any?
+                  @errors << ValidationError.new(:rounds, competition_id,
+                                                 COMPETED_NOT_QUALIFIED_ERROR,
+                                                 round_id: round_id,
+                                                 ids: people_over_condition.join(","),
+                                                 condition: condition.to_s(previous_round))
+                end
+              end
+
               # Article 9p, since July 20, 2006 until April 13, 2010
               if Date.new(2006, 7, 20) <= comp_start_date &&
                  comp_start_date <= Date.new(2010, 4, 13)
@@ -85,16 +112,43 @@ module ResultsValidators
                                                  round_id: round_id)
                 end
               else
+                max_advancing = 3 * number_of_people_in_previous_round / 4
                 # Article 9p1, since April 14, 2010
                 # https://www.worldcubeassociation.org/regulations/#9p1: At least 25% of competitors must be eliminated between consecutive rounds of the same event.
-                if number_of_people_in_round > 3 * number_of_people_in_previous_round / 4
+                if number_of_people_in_round > max_advancing
                   @errors << ValidationError.new(:rounds, competition_id,
                                                  REGULATION_9P1_ERROR,
                                                  round_id: round_id)
                 end
+                if condition
+                  theoritical_number_of_people = condition.max_advancing(previous_results)
+                  if number_of_people_in_round > theoritical_number_of_people
+                    @warnings << ValidationWarning.new(:rounds, competition_id,
+                                                       TOO_MANY_QUALIFIED_WARNING,
+                                                       round_id: round_id,
+                                                       actual: number_of_people_in_round,
+                                                       expected: theoritical_number_of_people,
+                                                       condition: condition.to_s(previous_round))
+                  end
+                  if theoritical_number_of_people > max_advancing
+                    @errors << ValidationError.new(:rounds, competition_id,
+                                                   ROUND_9P1_ERROR,
+                                                   round_id: round_id,
+                                                   condition: condition.to_s(previous_round))
+                  end
+                  # This comes from https://github.com/thewca/worldcubeassociation.org/issues/5587
+                  if theoritical_number_of_people - number_of_people_in_round >= 3 &&
+                     (number_of_people_in_round / theoritical_number_of_people) <= 0.8
+                    @warnings << ValidationWarning.new(:rounds, competition_id,
+                                                       NOT_ENOUGH_QUALIFIED_WARNING,
+                                                       round_id: round_id,
+                                                       expected: theoritical_number_of_people,
+                                                       actual: number_of_people_in_round)
+                  end
+                end
               end
             end
-            number_of_people_in_previous_round = number_of_people_in_round
+            previous_round_type_id = round_type_id
           end
         end
       end

--- a/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ACV do
   context "on InboxResult and Result" do
     let!(:competition1) { FactoryBot.create(:competition, starts: Date.new(2010, 3, 1), event_ids: ["333oh"]) }
     let!(:competition2) { FactoryBot.create(:competition, :past, event_ids: ["222"]) }
+    let!(:competition3) { FactoryBot.create(:competition, :past, event_ids: ["333"]) }
 
     # The idea behind this variable is the following: the validator can be applied
     # on either a particular model for given competition ids, or on a set of results.
@@ -23,18 +24,20 @@ RSpec.describe ACV do
     }
 
     it "doesn't complain when it's fine" do
+      (1..4).each { |i| FactoryBot.create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 4, number: i) }
+      (1..2).each { |i| FactoryBot.create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: i) }
       [Result, InboxResult].each do |model|
         result_kind = model.model_name.singular.to_sym
         # Using a single fake person for all the results for better performance.
         fake_person = build_person(result_kind, competition1)
         # Collecting all the results and using bulk import for better performance.
         results = []
-        results += FactoryBot.build_list(result_kind, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 16, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 8, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 5, competition: competition2, eventId: "222", roundTypeId: "f", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 16, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 8, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 5, competition: competition2, eventId: "222", roundTypeId: "f", person: fake_person)
         model.import(results)
       end
 
@@ -46,13 +49,15 @@ RSpec.describe ACV do
     end
 
     it "ignores b-final" do
+      FactoryBot.create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 2, number: 0, old_type: "b")
+      (1..2).each { |i| FactoryBot.create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 2, number: i) }
       # Using a single fake person for all the results for better performance.
       fake_person = build_person(:result, competition1)
       # Collecting all the results and using bulk import for better performance.
       results = []
-      results += FactoryBot.build_list(:result, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person, skip_round_creation: true)
-      results += FactoryBot.build_list(:result, 8, competition: competition1, eventId: "333oh", roundTypeId: "b", person: fake_person, skip_round_creation: true)
-      results += FactoryBot.build_list(:result, 32, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person, skip_round_creation: true)
+      results += FactoryBot.build_list(:result, 100, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person)
+      results += FactoryBot.build_list(:result, 8, competition: competition1, eventId: "333oh", roundTypeId: "b", person: fake_person)
+      results += FactoryBot.build_list(:result, 32, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person)
       Result.import(results, validate: false)
 
       validator_args.each do |arg|
@@ -65,26 +70,84 @@ RSpec.describe ACV do
     end
 
     # Triggers:
-    # REGULATION_9M_ERROR
+    # ROUND_9P1_ERROR
+    # TOO_MANY_QUALIFIED_WARNING
+    # NOT_ENOUGH_QUALIFIED_WARNING
+    # COMPETED_NOT_QUALIFIED_ERROR
+    it "validates round's advancement condition" do
+      first_round = FactoryBot.create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 1)
+      first_round.update(advancement_condition: AdvancementConditions::AttemptResultCondition.new(1700))
+      FactoryBot.create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 2)
+
+      first_round2 = FactoryBot.create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 1)
+      first_round2.update(advancement_condition: AdvancementConditions::RankingCondition.new(4))
+      FactoryBot.create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 2)
+
+      expected_errors = []
+      # We create 20 competitors:
+      #   - for 2x2 this would actually let 17/20 people proceed, which breaks 9P1.
+      #   - for second round we let a valid number of competitors proceed, which
+      #   trigger the warning about letting less competitor proceed than expected.
+      #   - for 3x3 we set a ranking condition arbitrarily low, and we let more
+      #   competitors proceed than expected.
+      (1..20).each do |i|
+        fake_person = FactoryBot.create(:person)
+        value = i * 100
+        FactoryBot.create(:result, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person, best: value, average: value)
+        FactoryBot.create(:result, competition: competition3, eventId: "333", roundTypeId: "1", person: fake_person, best: value, average: value)
+        if i < 10
+          FactoryBot.create(:result, competition: competition2, eventId: "222", roundTypeId: "f", person: fake_person, best: value, average: value)
+          FactoryBot.create(:result, competition: competition3, eventId: "333", roundTypeId: "f", person: fake_person, best: value, average: value)
+        end
+        if i == 20
+          # Create a single attempt result over the attempt result condition.
+          FactoryBot.create(:result, competition: competition2, eventId: "222", roundTypeId: "f", person: fake_person, best: 1800, average: 1800)
+          expected_errors << RV::ValidationError.new(:rounds, competition2.id,
+                                                     ACV::COMPETED_NOT_QUALIFIED_ERROR,
+                                                     round_id: "222-f",
+                                                     ids: fake_person.wca_id,
+                                                     condition: first_round.advancement_condition.to_s(first_round))
+        end
+      end
+      expected_errors << RV::ValidationError.new(:rounds, competition2.id,
+                                                 ACV::ROUND_9P1_ERROR,
+                                                 round_id: "222-f",
+                                                 condition: first_round.advancement_condition.to_s(first_round))
+      expected_warnings = [
+        RV::ValidationWarning.new(:rounds, competition2.id,
+                                  ACV::NOT_ENOUGH_QUALIFIED_WARNING,
+                                  round_id: "222-f", expected: 16, actual: 10),
+        RV::ValidationWarning.new(:rounds, competition3.id,
+                                  ACV::TOO_MANY_QUALIFIED_WARNING,
+                                  round_id: "333-f", actual: 9, expected: 4,
+                                  condition: first_round2.advancement_condition.to_s(first_round2)),
+      ]
+      acv = ACV.new.validate(competition_ids: [competition2, competition3], model: Result)
+      expect(acv.warnings).to match_array(expected_warnings)
+      expect(acv.errors).to match_array(expected_errors)
+    end
+
+    # Triggers:
     # REGULATION_9M1_ERROR
     # REGULATION_9M2_ERROR
     # REGULATION_9M3_ERROR
     # REGULATION_9P1_ERROR
     # OLD_REGULATION_9P_ERROR
     it "complains when it should" do
+      (1..4).each { |i| FactoryBot.create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 4, number: i) }
+      (1..2).each { |i| FactoryBot.create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: i) }
       [Result, InboxResult].each do |model|
         result_kind = model.model_name.singular.to_sym
         # Using a single fake person for all the results for better performance.
         fake_person = build_person(result_kind, competition1)
         # Collecting all the results and using bulk import for better performance.
         results = []
-        results += FactoryBot.build_list(result_kind, 99, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 15, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 4, competition: competition1, eventId: "333oh", roundTypeId: "c", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 4, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person, skip_round_creation: true)
-        results += FactoryBot.build_list(result_kind, 7, competition: competition2, eventId: "222", roundTypeId: "2", person: fake_person, skip_round_creation: true)
+        results += FactoryBot.build_list(result_kind, 99, competition: competition1, eventId: "333oh", roundTypeId: "1", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 15, competition: competition1, eventId: "333oh", roundTypeId: "2", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "3", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 7, competition: competition1, eventId: "333oh", roundTypeId: "f", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 8, competition: competition2, eventId: "222", roundTypeId: "1", person: fake_person)
+        results += FactoryBot.build_list(result_kind, 7, competition: competition2, eventId: "222", roundTypeId: "f", person: fake_person)
         model.import(results, validate: false)
       end
       expected_errors = [
@@ -92,29 +155,17 @@ RSpec.describe ACV do
                                 ACV::REGULATION_9M1_ERROR,
                                 round_id: "333oh-1"),
         RV::ValidationError.new(:rounds, competition1.id,
-                                ACV::REGULATION_9M1_ERROR,
-                                round_id: "333oh-2"),
-        RV::ValidationError.new(:rounds, competition1.id,
                                 ACV::REGULATION_9M2_ERROR,
                                 round_id: "333oh-2"),
         RV::ValidationError.new(:rounds, competition1.id,
-                                ACV::REGULATION_9M2_ERROR,
-                                round_id: "333oh-3"),
-        RV::ValidationError.new(:rounds, competition1.id,
                                 ACV::REGULATION_9M3_ERROR,
                                 round_id: "333oh-3"),
-        RV::ValidationError.new(:rounds, competition1.id,
-                                ACV::REGULATION_9M3_ERROR,
-                                round_id: "333oh-c"),
-        RV::ValidationError.new(:rounds, competition1.id,
-                                ACV::REGULATION_9M_ERROR,
-                                event_id: "333oh"),
         RV::ValidationError.new(:rounds, competition1.id,
                                 ACV::OLD_REGULATION_9P_ERROR,
                                 round_id: "333oh-f"),
         RV::ValidationError.new(:rounds, competition2.id,
                                 ACV::REGULATION_9P1_ERROR,
-                                round_id: "222-2"),
+                                round_id: "222-f"),
       ]
 
       validator_args.each do |arg|


### PR DESCRIPTION
Fixes #5587.

This implements a couple more errors and warning regarding the advancement conditions declared in the events/round data, here is a WIP list:
  - [x] error when the announced advancement condition would let more than 75% qualify.
  - [x] error when more people qualified than what was initially planned.
  - [x] error when using an attempt result qualification and people over that result qualify
  - [x] warning when an unusual number of competitors is missing compared to the expected number of qualified competitors.
  - [x] tests

This is just a draft for now, I hope to finish this soon!