### PR TITLE
Do not show year when sorting competitions by announcement date

### DIFF
--- a/WcaOnRails/app/views/competitions/_index_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_index_table.html.erb
@@ -1,7 +1,7 @@
 <ul class="list-group">
   <li class="list-group-item"><strong><%= "#{title} (#{competitions.count})" %></strong></li>
   <% competitions.each_with_index do |competition, index| %>
-    <% if index > 0 && competition.year != competitions[index - 1].year && params[:event_ids].empty? %>
+    <% if index > 0 && competition.year != competitions[index - 1].year && params[:event_ids].empty? && !@by_announcement_selected %>
       <li class="list-group-item break"><%= competition.year %></li>
     <% end %>
     <% li_classes = ["list-group-item"] %>


### PR DESCRIPTION
https://github.com/thewca/worldcubeassociation.org/issues/7366

Currently, the competitions displaying in the US are split pretty evenly between 2022 and 2023. As a result, when displaying competitions by Announcement Date, a few lines appear and then the year on its own line. The year is redundant since it already shows the date and year in the first column.
This screen shot is from a few weeks back, and now as more competitions are being announced for 2023, the year is cluttering the UI even more.
<img width="857" alt="Screen Shot 2022-10-17 at 9 36 11 AM" src="https://user-images.githubusercontent.com/25484201/204148716-1be81d61-cf76-46ac-819c-0ab5a4b2140a.png">

After the changes, the year no longer appears in this mode.
<img width="856" alt="Screen Shot 2022-10-17 at 9 34 49 AM" src="https://user-images.githubusercontent.com/25484201/204148727-2ecbe68c-2ce9-423e-a8be-e89d910d50a7.png">
