### PR TITLE
Fix DB seeds for use with Docker Ruby image

### DIFF
--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -78,7 +78,7 @@ after "development:users" do
           total_number_of_rounds: round_types.length,
           time_limit: event.can_change_time_limit? ? TimeLimit.new : nil,
           cutoff: nil,
-          advancement_condition: is_final ? nil : RankingCondition.new(16),
+          advancement_condition: is_final ? nil : AdvancementConditions::RankingCondition.new(16),
           scramble_set_count: rand(1..4),
           round_results: [],
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       done &&
       echo "MySQL is ready!" &&
       if ! [[ "`mysqlshow --user=root --host=wca_db wca_development`" =~ "Tables" ]] ;
-        then echo "Populating development db, this will take a while" && bin/rake db:load:development ;
+        then echo "Populating development db, this will take a while" && bin/rake db:reset ;
       fi &&
       bin/rails server -b 0.0.0.0'
     depends_on:


### PR DESCRIPTION
(Kinda) fixes #7403 

For some :tm: reason (didn't want to dig any deeper) the classloader inside the Ruby Docker env wants fully qualified constants in the `lib` folder. This is a bit odd because on a "real" Ruby env on my dev machine it works fine, and in both cases the invocation happens through Rake, so normally they _should_ behave the same. Oh well...

I also switched the DB warmup to use our seeds, because loading the Dev Dump just takes soooo long these days.
People who want to use the dev data can SSH into the container and trigger the loading process via the usual `db:load:development` task themselves.