### PR TITLE
Increase Unicorn timeout

### DIFF
--- a/WcaOnRails/config/unicorn.rb
+++ b/WcaOnRails/config/unicorn.rb
@@ -25,7 +25,7 @@ end
 listen "/tmp/unicorn.wca.sock"
 pid "#{dir}/pids/unicorn.pid"
 
-timeout 30
+timeout 60
 
 preload_app true
 


### PR DESCRIPTION
Saving WCIF for large competitions may take longer than 30s, ideally we would optimise the request itself, but for now we need to make sure the server doesn't close the connection too soon.