### PR TITLE
Invoke login-relevant mocks immediately in tests

### DIFF
--- a/WcaOnRails/spec/controllers/application_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/application_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ApplicationController do
   describe "GET #update_locale" do
-    let(:user) { FactoryBot.create(:user) }
+    let!(:user) { FactoryBot.create(:user) }
 
     it "updates the user preferred locale and the session locale" do
       sign_in user

--- a/WcaOnRails/spec/controllers/competition_tabs_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competition_tabs_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CompetitionTabsController, type: :controller do
-  let(:organizer) { FactoryBot.create :user }
+  let!(:organizer) { FactoryBot.create :user }
   let(:competition) { FactoryBot.create :competition, organizers: [organizer] }
 
   context "when signed in as organizer" do

--- a/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/delegate_reports_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DelegateReportsController do
   end
 
   context "logged in as THE delegate" do
-    let(:user) { comp.delegates.first }
+    let!(:user) { comp.delegates.first }
     before :each do
       sign_in user
     end
@@ -117,7 +117,7 @@ RSpec.describe DelegateReportsController do
   end
 
   context "logged in as THE trainee delegate" do
-    let(:user) { comp.trainee_delegates.first }
+    let!(:user) { comp.trainee_delegates.first }
     before :each do
       sign_in user
     end

--- a/WcaOnRails/spec/controllers/panel_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/panel_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PanelController do
   describe "signed in as senior delegate" do
-    let(:senior_delegate) { FactoryBot.create :senior_delegate }
+    let!(:senior_delegate) { FactoryBot.create :senior_delegate }
     before :each do
       sign_in senior_delegate
     end
@@ -21,7 +21,7 @@ RSpec.describe PanelController do
   end
 
   describe "signed in as board member" do
-    let(:board_member) { FactoryBot.create :user, :board_member }
+    let!(:board_member) { FactoryBot.create :user, :board_member }
     before :each do
       sign_in board_member
     end

--- a/WcaOnRails/spec/controllers/polls_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/polls_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe PollsController do
   end
 
   context "logged in as board member" do
-    let(:board_member) { FactoryBot.create :user, :board_member }
+    let!(:board_member) { FactoryBot.create :user, :board_member }
     before :each do
       sign_in board_member
     end

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe RegistrationsController do
   context "signed in as organizer" do
-    let(:organizer) { FactoryBot.create(:user) }
+    let!(:organizer) { FactoryBot.create(:user) }
     let(:competition) { FactoryBot.create(:competition, :registration_open, organizers: [organizer], events: Event.where(id: %w(222 333))) }
     let(:zzyzx_user) { FactoryBot.create :user, name: "Zzyzx" }
     let(:registration) { FactoryBot.create(:registration, competition: competition, user: zzyzx_user) }
@@ -544,7 +544,7 @@ RSpec.describe RegistrationsController do
   end
 
   context "competition not visible" do
-    let(:organizer) { FactoryBot.create :user }
+    let!(:organizer) { FactoryBot.create :user }
     let(:competition) { FactoryBot.create(:competition, :registration_open, events: Event.where(id: %w(333 444 333bf)), showAtAll: false, organizers: [organizer]) }
 
     it "404s when competition is not visible to public" do

--- a/WcaOnRails/spec/controllers/teams_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/teams_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe TeamsController do
     context 'when signed in as a team leader without rights to manage all teams' do
       let(:team_where_is_leader) { Team.wrc }
       let(:team_where_is_not_leader) { Team.wst }
-      let(:leader) do
+      let!(:leader) do
         user = FactoryBot.create(:user)
         FactoryBot.create(:team_member, team_id: team_where_is_leader.id, user_id: user.id, team_leader: true)
         user
@@ -91,7 +91,7 @@ RSpec.describe TeamsController do
 
   describe 'POST #update' do
     context 'when signed in as an admin' do
-      let(:admin) { FactoryBot.create :admin }
+      let!(:admin) { FactoryBot.create :admin }
       before :each do
         sign_in admin
       end

--- a/WcaOnRails/spec/controllers/users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/users_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe UsersController do
   end
 
   describe "approve wca id claim" do
-    let(:delegate) { FactoryBot.create(:delegate) }
+    let!(:delegate) { FactoryBot.create(:delegate) }
     let(:person) { FactoryBot.create(:person) }
     let(:user) { FactoryBot.create :user, unconfirmed_wca_id: person.wca_id, delegate_to_handle_wca_id_claim: delegate, dob_verification: person.dob }
 
@@ -109,8 +109,8 @@ RSpec.describe UsersController do
   end
 
   describe "editing user data" do
-    let(:user) { FactoryBot.create(:user) }
-    let(:delegate) { FactoryBot.create(:delegate) }
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:delegate) { FactoryBot.create(:delegate) }
 
     context "recently authenticated" do
       it "user can change email" do
@@ -183,7 +183,7 @@ RSpec.describe UsersController do
     end
 
     context "when the delegate status of a user is changed by a senior delegate" do
-      let(:user_who_makes_the_change) { FactoryBot.create(:senior_delegate) }
+      let!(:user_who_makes_the_change) { FactoryBot.create(:senior_delegate) }
       let(:user_senior_delegate) { FactoryBot.create(:senior_delegate) }
       let(:user_whose_delegate_status_changes) { FactoryBot.create(:delegate, delegate_status: "candidate_delegate", senior_delegate: user_senior_delegate) }
 
@@ -226,7 +226,7 @@ RSpec.describe UsersController do
     end
 
     context 'signed in' do
-      let(:admin) { FactoryBot.create :admin, cookies_acknowledged: false }
+      let!(:admin) { FactoryBot.create :admin, cookies_acknowledged: false }
 
       before :each do
         sign_in admin

--- a/WcaOnRails/spec/controllers/votes_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/votes_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe VotesController do
   end
 
   context "logged in as delegate" do
-    let(:delegate) { FactoryBot.create :delegate }
+    let!(:delegate) { FactoryBot.create :delegate }
     before :each do
       sign_in delegate
     end
@@ -54,7 +54,7 @@ RSpec.describe VotesController do
   end
 
   context "logged in as staff member" do
-    let(:staff_member) { FactoryBot.create :user, :wrt_member }
+    let!(:staff_member) { FactoryBot.create :user, :wrt_member }
     before :each do
       sign_in staff_member
     end

--- a/WcaOnRails/spec/features/competition_events_spec.rb
+++ b/WcaOnRails/spec/features/competition_events_spec.rb
@@ -132,7 +132,7 @@ RSpec.feature "Competition events management" do
   end
 
   context "confirmed competition" do
-    let(:competition) { FactoryBot.create(:competition, :confirmed, event_ids: ["222", "444"]) }
+    let!(:competition) { FactoryBot.create(:competition, :confirmed, event_ids: ["222", "444"]) }
 
     scenario "delegate cannot add events", js: true do
       sign_in competition.delegates.first
@@ -214,7 +214,7 @@ RSpec.feature "Competition events management" do
   end
 
   context "competition with results posted" do
-    let(:competition) { FactoryBot.create :competition, :confirmed, :visible, :results_posted, event_ids: Event.where(id: '333') }
+    let!(:competition) { FactoryBot.create :competition, :confirmed, :visible, :results_posted, event_ids: Event.where(id: '333') }
     let(:competition_event) { competition.competition_events.find_by_event_id("333") }
 
     scenario "delegate cannot update events", js: true, retry: 3 do

--- a/WcaOnRails/spec/features/competition_manage_schedule_spec.rb
+++ b/WcaOnRails/spec/features/competition_manage_schedule_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Competition events management" do
   end
 
   context "unconfirmed competition without schedule" do
-    let(:competition) { FactoryBot.create(:competition, :with_delegate, :registration_open, event_ids: ["333", "444"], with_rounds: true) }
+    let!(:competition) { FactoryBot.create(:competition, :with_delegate, :registration_open, event_ids: ["333", "444"], with_rounds: true) }
     background do
       sign_in competition.delegates.first
       visit "/competitions/#{competition.id}/schedule/edit"
@@ -31,7 +31,7 @@ RSpec.feature "Competition events management" do
   end
 
   context "unconfirmed competition with schedule" do
-    let(:competition) { FactoryBot.create(:competition, :with_delegate, :registration_open, :with_valid_schedule, event_ids: ["333", "444"]) }
+    let!(:competition) { FactoryBot.create(:competition, :with_delegate, :registration_open, :with_valid_schedule, event_ids: ["333", "444"]) }
     background do
       sign_in competition.delegates.first
       visit "/competitions/#{competition.id}/schedule/edit"

--- a/WcaOnRails/spec/features/competition_management_spec.rb
+++ b/WcaOnRails/spec/features/competition_management_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.feature "Competition management" do
   context "when signed in as admin" do
-    let(:admin) { FactoryBot.create :admin }
+    let!(:admin) { FactoryBot.create :admin }
     before :each do
       sign_in admin
     end
@@ -135,7 +135,7 @@ RSpec.feature "Competition management" do
   end
 
   context "when signed in as delegate" do
-    let(:delegate) { FactoryBot.create(:delegate) }
+    let!(:delegate) { FactoryBot.create(:delegate) }
     let(:cloned_delegate) { FactoryBot.create(:delegate) }
     let(:competition_to_clone) { FactoryBot.create :competition, cityName: 'Melbourne, Victoria', countryId: "Australia", delegates: [cloned_delegate], showAtAll: true }
 

--- a/WcaOnRails/spec/features/cookie_law_spec.rb
+++ b/WcaOnRails/spec/features/cookie_law_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "cookie law" do
   end
 
   context "signed in" do
-    let(:admin) { FactoryBot.create(:admin, cookies_acknowledged: false) }
+    let!(:admin) { FactoryBot.create(:admin, cookies_acknowledged: false) }
     background do
       sign_in admin
     end

--- a/WcaOnRails/spec/features/create_competition_tabs_spec.rb
+++ b/WcaOnRails/spec/features/create_competition_tabs_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.feature "create competition tabs" do
-  let(:organizer) { FactoryBot.create :user }
+  let!(:organizer) { FactoryBot.create :user }
   let(:competition) { FactoryBot.create :competition, organizers: [organizer] }
 
   it "creating a new tab" do

--- a/WcaOnRails/spec/features/delegate_report_spec.rb
+++ b/WcaOnRails/spec/features/delegate_report_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.feature "Registration management" do
-  let(:delegate) { FactoryBot.create :delegate, name: "Jeremy on Bart" }
+  let!(:delegate) { FactoryBot.create :delegate, name: "Jeremy on Bart" }
   let(:competition) { FactoryBot.create :competition, :with_valid_submitted_results, delegates: [delegate], name: "Submit Report 2017" }
   let!(:delegate_report) { FactoryBot.create :delegate_report, competition: competition, schedule_url: "http://example.com" }
   let!(:wrc_members) { FactoryBot.create_list :user, 3, :wrc_member }

--- a/WcaOnRails/spec/features/edit_user_spec.rb
+++ b/WcaOnRails/spec/features/edit_user_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.feature "Edit user" do
-  let(:admin) { FactoryBot.create(:admin) }
+  let!(:admin) { FactoryBot.create(:admin) }
   let(:existing_user) { FactoryBot.create(:user_with_wca_id) }
   let(:new_person) { FactoryBot.create(:person) }
   let(:new_user) do

--- a/WcaOnRails/spec/features/incident_management_spec.rb
+++ b/WcaOnRails/spec/features/incident_management_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Incident Management" do
   let!(:incident3) { FactoryBot.create(:incident, :resolved, title: "Custom title", tags: ["c"]) }
 
   context "when signed in as a WRC member" do
-    let(:wrc_member) { FactoryBot.create(:user, :wrc_member) }
+    let!(:wrc_member) { FactoryBot.create(:user, :wrc_member) }
     before(:each) do
       sign_in wrc_member
     end
@@ -77,7 +77,7 @@ RSpec.feature "Incident Management" do
   end
 
   context "when signed in as a Delegate" do
-    let(:delegate) { FactoryBot.create(:delegate) }
+    let!(:delegate) { FactoryBot.create(:delegate) }
     before(:each) do
       sign_in delegate
     end
@@ -111,7 +111,7 @@ RSpec.feature "Incident Management" do
   end
 
   context "when signed in as a User" do
-    let(:user) { FactoryBot.create(:user) }
+    let!(:user) { FactoryBot.create(:user) }
     before(:each) do
       sign_in user
     end

--- a/WcaOnRails/spec/features/manage_team_spec.rb
+++ b/WcaOnRails/spec/features/manage_team_spec.rb
@@ -6,7 +6,9 @@ RSpec.feature "Manage team" do
   let!(:results_team) { Team.find_by_friendly_id("wrt") }
   let!(:results_team_member) { FactoryBot.create(:user, :wrt_member) }
 
-  before(:each) { sign_in FactoryBot.create(:admin) }
+  before(:each) do
+    sign_in FactoryBot.create(:admin)
+  end
 
   it 'remove member from team' do
     visit "/teams/#{results_team.id}/edit"

--- a/WcaOnRails/spec/features/media_spec.rb
+++ b/WcaOnRails/spec/features/media_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Media" do
   context "when signed in as regular user" do
     let(:competition) { FactoryBot.create(:competition) }
-    let(:user) { FactoryBot.create(:user) }
+    let!(:user) { FactoryBot.create(:user) }
 
     before :each do
       sign_in user

--- a/WcaOnRails/spec/features/register_for_competition_spec.rb
+++ b/WcaOnRails/spec/features/register_for_competition_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.feature "Registering for a competition" do
-  let(:user) { FactoryBot.create :user }
-  let(:delegate) { FactoryBot.create :delegate }
+  let!(:user) { FactoryBot.create :user }
+  let!(:delegate) { FactoryBot.create :delegate }
   let(:competition) { FactoryBot.create :competition, :registration_open, delegates: [delegate], showAtAll: true }
 
   context "signed in as user" do

--- a/WcaOnRails/spec/features/registration_management_spec.rb
+++ b/WcaOnRails/spec/features/registration_management_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.feature "Registration management" do
-  let(:delegate) { FactoryBot.create :delegate }
+  let!(:delegate) { FactoryBot.create :delegate }
   let(:competition) { FactoryBot.create :competition, :registration_open, delegates: [delegate] }
 
   let!(:user1) { FactoryBot.create :user, name: "Johnny Bravo" }

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "API Competitions" do
   end
 
   describe "GET #show_wcif" do
-    let(:competition) { FactoryBot.create(:competition, :visible) }
+    let!(:competition) { FactoryBot.create(:competition, :visible) }
 
     context "when not signed in" do
       it "does not allow access" do
@@ -184,7 +184,7 @@ RSpec.describe "API Competitions" do
     end
 
     describe "events" do
-      let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
+      let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
 
       context "when signed in as a board member" do
         sign_in { FactoryBot.create :user, :board_member }
@@ -244,7 +244,7 @@ RSpec.describe "API Competitions" do
         before { sign_in competition.delegates.first }
 
         context "confirmed competition" do
-          let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :confirmed, event_ids: %w(222 333)) }
+          let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible, :confirmed, event_ids: %w(222 333)) }
 
           it "allows adding rounds to an event" do
             competition.competition_events.find_by_event_id("333").rounds.delete_all
@@ -458,7 +458,7 @@ RSpec.describe "API Competitions" do
     end
 
     describe "extensions" do
-      let(:competition) { FactoryBot.create(:competition, :with_organizer, :visible) }
+      let!(:competition) { FactoryBot.create(:competition, :with_organizer, :visible) }
       context "when signed in as a competition manager" do
         before { sign_in competition.organizers.first }
 
@@ -477,7 +477,7 @@ RSpec.describe "API Competitions" do
     end
 
     describe "OAuth user" do
-      let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
+      let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
 
       context "as a competition manager" do
         let(:scopes) { Doorkeeper::OAuth::Scopes.new }
@@ -511,7 +511,7 @@ RSpec.describe "API Competitions" do
       end
 
       context "as a normal user" do
-        let(:user) { FactoryBot.create :user }
+        let!(:user) { FactoryBot.create :user }
         let(:scopes) { Doorkeeper::OAuth::Scopes.new }
 
         before :each do
@@ -531,7 +531,7 @@ RSpec.describe "API Competitions" do
     end
 
     describe "CSRF" do
-      let(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
+      let!(:competition) { FactoryBot.create(:competition, :with_delegate, :with_organizer, :visible) }
 
       # CSRF protection is always disabled for tests, enable it for this these requests.
       around(:each) do |example|

--- a/WcaOnRails/spec/requests/competitions_spec.rb
+++ b/WcaOnRails/spec/requests/competitions_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "competitions" do
-  let(:competition) { FactoryBot.create(:competition, :with_delegate, :visible, :with_valid_schedule) }
+  let!(:competition) { FactoryBot.create(:competition, :with_delegate, :visible, :with_valid_schedule) }
 
   describe "PATCH #update_competition" do
     context "when signed in as admin" do

--- a/WcaOnRails/spec/requests/incidents_spec.rb
+++ b/WcaOnRails/spec/requests/incidents_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Incidents management", type: :request do
     }
   }
 
-  let(:wrc_member) { FactoryBot.create(:user, :wrc_member) }
+  let!(:wrc_member) { FactoryBot.create(:user, :wrc_member) }
 
   describe "GET #show" do
     let!(:pending_incident) { FactoryBot.create(:incident) }

--- a/WcaOnRails/spec/requests/media_spec.rb
+++ b/WcaOnRails/spec/requests/media_spec.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples "must sign in" do |action, expect_success|
   end
 
   context "when signed in as regular user" do
-    let(:user) { FactoryBot.create :user }
+    let!(:user) { FactoryBot.create :user }
 
     before :each do
       sign_in user

--- a/WcaOnRails/spec/requests/regional_organizations_spec.rb
+++ b/WcaOnRails/spec/requests/regional_organizations_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe "Regional Organizations management", type: :request do
     }
   }
 
-  let(:board_member) { FactoryBot.create(:user, :board_member) }
-  let(:user) { FactoryBot.create(:user) }
+  let!(:board_member) { FactoryBot.create(:user, :board_member) }
+  let!(:user) { FactoryBot.create(:user) }
 
   describe "GET #index" do
     context "when logged in as a user" do

--- a/WcaOnRails/spec/requests/results_submission_spec.rb
+++ b/WcaOnRails/spec/requests/results_submission_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ResultsSubmissionController, type: :request do
   end
 
   context "logged in as THE delegate" do
-    let(:user) { comp.delegates.first }
+    let!(:user) { comp.delegates.first }
     let(:submission_message) { "Hello, here are the results" }
 
     before :each do

--- a/WcaOnRails/spec/requests/users_spec.rb
+++ b/WcaOnRails/spec/requests/users_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "users" do
   end
 
   context "user without 2FA" do
-    let(:user) { FactoryBot.create(:user) }
+    let!(:user) { FactoryBot.create(:user) }
     before { sign_in user }
 
     context "recently authenticated" do
@@ -129,7 +129,7 @@ RSpec.describe "users" do
   end
 
   context "user with 2FA" do
-    let(:user) { FactoryBot.create(:user, :with_2fa) }
+    let!(:user) { FactoryBot.create(:user, :with_2fa) }
     before { sign_in user }
     context "recently authenticated" do
       before { post users_authenticate_sensitive_path, params: { 'user[otp_attempt]': user.current_otp } }


### PR DESCRIPTION
We're continuing to suffer from cases where perfectly valid test scenarios "mysteriously" fail. Examples include (but are not limited to):
```
cookie law signed in remembers acknowledgement without cookies
Failure/Error: expect(page).to have_selector(CookieBannerHelper::ACKNOWLEDGE_SELECTOR)

Competition management when signed in as admin change guest entry fee to non-zero
Failure/Error: editing_user = User.find(editing_user_id)

Incident Management when signed in as a WRC member list of incidents filters by tag
Failure/Error: fill_in "Email or WCA ID", with: user.email
```

Upon investigation, it seems that almost all of these failures boil down to the backend doing a lookup by ID, but failing to find the ID in the database. Without going to deep into the inner workings of `RSpec`, I believe this has to do with the lazy instantiation mechanisms (`let(:variable)` vs `let!(:variable)`).

As an attempted remedy, I went through our entire test suite and changed all `let` invocations that memoize login-relevant information to be eager instead of lazy. In some places, this may not be strictly necessary, but at least it's consistent now :smile: 