### PR TITLE
Add more detailed calendar export

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1864,11 +1864,13 @@ class Competition < ApplicationRecord
 
   def to_ics
     cal = Icalendar::Calendar.new
-    cal.event do |e|
-      e.dtstart = Icalendar::Values::Date.new(self.start_date)
-      e.dtend = Icalendar::Values::Date.new(self.end_date)
-      e.summary = self.name
-      e.url = self.website
+    wcif_ids = rounds.to_h { |r| [r.wcif_id, r.to_string_map] }
+    all_activities.each do |activity|
+      event = Icalendar::Event.new
+      event.dtstart = Icalendar::Values::DateTime.new(activity.start_time)
+      event.dtend = Icalendar::Values::DateTime.new(activity.end_time)
+      event.summary = activity.localized_name(wcif_ids)
+      cal.add_event(event)
     end
     cal.publish
     cal

--- a/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_schedule_tab.html.erb
@@ -31,6 +31,15 @@
         <%= t("competitions.schedule.venue_information_html", venue_name: link_to_google_maps_place(venue.name, venue.latitude_degrees, venue.longitude_degrees)) %>
         <br />
         <%= t("competitions.schedule.timezone_message", timezone: venue.timezone_id) %>
+        <br />
+        <%= t("competitions.competition_info.add_to_calendar") %>
+        <%= link_to(ui_icon("calendar plus"), competition_path(competition, format: :ics),
+            title: t("competitions.competition_info.add_to_calendar"),
+            data: {
+              toggle: "tooltip",
+              placement: "top",
+              container: "body",
+            }) %>
         <% if competition.competition_venues.size > 1 %>
           <br />
           <%= t("competitions.schedule.multiple_venues_available") %>

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -1295,4 +1295,14 @@ RSpec.describe Competition do
       expect(competition).to be_invalid_with_errors(guests_per_registration_limit: ["must be less than or equal to 100"])
     end
   end
+
+  context "has valid schedule" do
+    let(:competition) { FactoryBot.create :competition, :with_valid_schedule }
+
+    it "ics export includes all rounds" do
+      competition.rounds.map(&:name).each do |r|
+        expect(competition.to_ics.events.map { |e| e.summary.to_s }).to include(r)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is in regards to issue #7404
It creates seperate events for each round and attempt of each event. It also includes extra events such as lunch or registration. It also adds another export button in the schedule tab to make it more obvious and usefull.
An improvement would be allowing selecting certain events when exporting.
