### PR TITLE
Add 2021-05-01, 2022-01-01, and 2022-06-01 Regulations to the History

### DIFF
--- a/WcaOnRails/app/views/regulations/history/index.html.erb
+++ b/WcaOnRails/app/views/regulations/history/index.html.erb
@@ -5,7 +5,13 @@
   <p>Until 2011, the Regulations were maintained by Ron van Bruchem and the WCA Board. Since then, the <%= mail_to "wrc@worldcubeassociation.org", "WCA Regulations Committee" %> is in charge of them.<br />For the 2013 release, the Regulations were split into two documents: the Regulations and the Guidelines.</p>
   <p>Here are all past and current versions of the Regulations.</p>
   <ul>
-    <li><%= link_to "2021-05-01", "https://www.worldcubeassociation.org/regulations/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-08-01...official-2021-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2021" %>)</li>
+    <li><%= link_to "2023-02-01", "./official/2023-02-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2022-06-01...official-2023-02-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-february-2023" %>)</li>
+    <li><%= link_to "2022-06-01", "./official/2022-06-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2022-01-01...official-2022-06-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-june-2022" %>)
+      <ul>
+        <li><%= link_to "2022-01-01", "./official/2022-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2021-05-01...official-2022-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2022" %>)</li>
+      </ul>
+    </li>
+    <li><%= link_to "2021-05-01", "./official/2021-05-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-08-01...official-2021-05-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-may-2021" %>)
     <li><%= link_to "2020-08-01", "./official/2020-08-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2020-01-01...official-2020-08-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-august-2020" %>)
       <ul>
         <li><%= link_to "2020-01-01", "./official/2020-01-01/" %> (<%= link_to "Changes", "https://github.com/thewca/wca-regulations/compare/official-2019-05-01...official-2020-01-01#files_bucket" %>, <%= link_to "Summarized Changes", "https://www.worldcubeassociation.org/posts/wca-regulations-january-2020" %>)</li>


### PR DESCRIPTION
**!!! Do not merge before 2023-02-01 Regulations and Guidelines are released !!!**

@thewca/wrc-team please review in case there's something wrong.