### PR TITLE
Exclude Trainee Delegates from WFC Export

### DIFF
--- a/WcaOnRails/app/views/wfc/competition_export.csv.erb
+++ b/WcaOnRails/app/views/wfc/competition_export.csv.erb
@@ -11,7 +11,7 @@
   <%= CSV.generate_line([
     c.id, c.name, c.country.iso2, c.continent.id,
     c.start_date, c.end_date, c.announced_at, c.results_posted_at,
-    competition_url(c.id), c.num_competitors, c.delegates.map(&:name).sort.join(","),
+    competition_url(c.id), c.num_competitors, c.delegates.reject(&:trainee_delegate?).map(&:name).sort.join(","),
     c.currency_code, c.base_entry_fee_lowest_denomination, Money::Currency.new(c.currency_code).subunit_to_unit,
     c.championships.map(&:championship_type).sort.join(","), c.exempt_from_wca_dues?, c.organizers.map(&:name).sort.join(",")
   ], col_sep: "\t").html_safe -%>

--- a/WcaOnRails/spec/factories/competitions.rb
+++ b/WcaOnRails/spec/factories/competitions.rb
@@ -69,6 +69,10 @@ FactoryBot.define do
       delegates { [FactoryBot.create(:trainee_delegate)] }
     end
 
+    trait :with_delegates_and_trainee_delegate do
+      delegates { [FactoryBot.create(:delegate), FactoryBot.create(:trainee_delegate), FactoryBot.create(:delegate)] }
+    end
+
     trait :with_organizer do
       organizers { [FactoryBot.create(:user)] }
     end

--- a/WcaOnRails/spec/views/wfc/competition_export.csv.erb_spec.rb
+++ b/WcaOnRails/spec/views/wfc/competition_export.csv.erb_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "csv"
+require "rails_helper"
+
+RSpec.describe "wfc/competition_export.csv.erb" do
+  it "renders valid csv headers" do
+    expected_headers = [
+      "Id", "Name", "Country", "Continent",
+      "Start", "End", "Announced", "Posted",
+      "Link on WCA", "Competitors", "Delegates",
+      "Currency Code", "Base Registration Fee", "Currency Subunit",
+      "Championship Type", "Exempt from WCA Dues", "Organizers"
+    ]
+
+    assign(:competitions, [])
+    render
+
+    headers = CSV.parse(rendered, col_sep: "\t")[0]
+    expect(headers).to eq expected_headers
+  end
+
+  it "filters out trainee delegates" do
+    competition = FactoryBot.create :competition, :with_valid_submitted_results, :with_delegates_and_trainee_delegate
+    competition.define_singleton_method(:num_competitors) do # mock count(distinct ...) from controller
+      10
+    end
+
+    assign(:competitions, [competition])
+    render
+
+    delegates_without_trainees = competition.delegates.reject(&:trainee_delegate?)
+    expect(delegates_without_trainees.length).to_not eq competition.delegates.length
+
+    table = CSV.parse(rendered, headers: true, col_sep: "\t")
+    expect(table[0]["Delegates"]).to eq delegates_without_trainees.map(&:name).sort.join(",")
+  end
+end


### PR DESCRIPTION
Fixes #7493. Back at it with the WFC export ;)

@danieljames-dj's [suggestion](https://github.com/thewca/worldcubeassociation.org/issues/7493#issuecomment-1365623663) didn't quite work:
```
     NoMethodError:
       undefined method `reject' for :delegates:Symbol

                           .includes(:delegates.reject{|delegate| !delegate.trainee_delegate}, :championships, :organizers, :events)
                                               ^^^^^^^
```

Thus, I filtered in the view instead of the controller (we do other operations like sorting at this level too). If there's a more elegant way to do this during the query, I'd be grateful for the pointers :)


