### PR TITLE
Fix Series associations in form preloading

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -319,6 +319,13 @@ module CompetitionsHelper
     if (series = competition.competition_series)
       form_competition.competition_series = series
 
+      # Hack around Rails reverse has_one associations
+      # because our form_competition is not the actual persisted competition
+      new_competitions = series.competitions | [form_competition]
+      competition_ids = new_competitions.map(&:id).join(',')
+
+      series.competition_ids = competition_ids
+
       return series
     end
 

--- a/WcaOnRails/app/views/competitions/_competition_series_fields.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_series_fields.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   <% end %>
 
-  <% if @competition.persisted? %>
+  <% if f.object&.persisted? %>
     <%# i18n-tasks-use t('simple_form.hints.competition.competition_series.wcif_id') %>
     <%# i18n-tasks-use t('activerecord.attributes.competition_series.wcif_id') %>
     <%= f.input :wcif_id %>
@@ -17,7 +17,7 @@
   <%# i18n-tasks-use t('activerecord.attributes.competition_series.name') %>
   <%= f.input :name %>
 
-  <% if @competition.persisted? %>
+  <% if f.object&.persisted? %>
     <%# i18n-tasks-use t('simple_form.hints.competition.competition_series.short_name') %>
     <%# i18n-tasks-use t('activerecord.attributes.competition_series.short_name') %>
     <%= f.input :short_name %>


### PR DESCRIPTION
This concerns a bug reported by Japanese Delegate Ryutaro Miyazaki via email.
Series with more than two competitions would break depending on the order that you load them in.

Bonus: This also automates assigning an ID and nickname to a newly created (not yet persisted) Series.