### PR TITLE
Allow non-admins to close registration when the competitor limit is reached.

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -262,6 +262,17 @@ class CompetitionsController < ApplicationController
     redirect_to admin_edit_competition_path(comp)
   end
 
+  def orga_close_reg_when_full_limit
+    comp = competition_from_params
+    if comp.orga_can_close_reg_full_limit?
+      comp.update!(registration_close: Time.now)
+      flash[:success] = t('competitions.messages.orga_closed_reg_success')
+    else
+      flash[:danger] = t('competitions.messages.orga_closed_reg_failure')
+    end
+    redirect_to edit_competition_path(comp)
+  end
+
   def edit_events
     associations = CHECK_SCHEDULE_ASSOCIATIONS.merge(
       competition_events: {

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -616,7 +616,13 @@ class CompetitionsController < ApplicationController
     end
 
     if @competition&.confirmed? && !current_user.can_admin_competitions?
-      # If the competition is confirmed, non admins are not allowed to change anything.
+      # If the competition is confirmed, non admins are not allowed to change anything
+      # except closing registration as this can cause a large expense because of refunds,
+      if @competition&.registration_full? 
+        permitted_competition_params += [
+          :registration_close,
+        ]
+      end
     else
       permitted_competition_params += [
         :id,

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -39,7 +39,7 @@ class CompetitionsController < ApplicationController
     end
   end
 
-  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :edit_schedule, :payment_setup]
+  before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) }, only: [:edit, :update, :edit_events, :edit_schedule, :payment_setup, :orga_close_reg_when_full_limit]
 
   before_action -> { redirect_to_root_unless_user(:can_confirm_competition?, competition_from_params) }, only: [:update], if: :confirming?
 

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -616,13 +616,7 @@ class CompetitionsController < ApplicationController
     end
 
     if @competition&.confirmed? && !current_user.can_admin_competitions?
-      # If the competition is confirmed, non admins are not allowed to change anything
-      # except closing registration as this can cause a large expense because of refunds,
-      if @competition&.registration_full?
-        permitted_competition_params += [
-          :registration_close,
-        ]
-      end
+      # If the competition is confirmed, non admins are not allowed to change anything.
     else
       permitted_competition_params += [
         :id,

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -618,7 +618,7 @@ class CompetitionsController < ApplicationController
     if @competition&.confirmed? && !current_user.can_admin_competitions?
       # If the competition is confirmed, non admins are not allowed to change anything
       # except closing registration as this can cause a large expense because of refunds,
-      if @competition&.registration_full? 
+      if @competition&.registration_full?
         permitted_competition_params += [
           :registration_close,
         ]

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1250,6 +1250,10 @@ class Competition < ApplicationRecord
     confirmed? && announced? && !cancelled?
   end
 
+  def orga_can_close_reg_full_limit?
+    registration_full? && registration_opened?
+  end
+
   def display_name(short: false)
     data = short ? cellName : name
     if cancelled?

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -215,11 +215,11 @@
           <% end %>
         </div>
 
-      <% disable_registration_close = !@competition.registration_full? %>
+      <% disable_registration_close = !(@competition.registration_full? || !disable_form) %>
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-9">
           <div id="registration-dates-picker" class="row datetimerange">
-            <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime, disabled: true %>
+            <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime, disabled: disable_form %>
             <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime, disabled: disable_registration_close %>
           </div>
         </div>

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -215,6 +215,16 @@
           <% end %>
         </div>
 
+      <% disable_registration_close = !@competition.registration_full? %>
+      <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-9">
+          <div id="registration-dates-picker" class="row datetimerange">
+            <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime, disabled: true %>
+            <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime, disabled: disable_registration_close %>
+          </div>
+        </div>
+      </div>
+
       <fieldset <%= disable_form && "disabled" %>>
 
         <div class="wca-registration-options">
@@ -227,15 +237,6 @@
         <div class="guest-no-entry-fee-options">
           <%= f.input :guest_entry_status, include_blank: false %>
           <%= f.input :guests_per_registration_limit %>
-        </div>
-
-        <div class="form-group">
-          <div class="col-sm-offset-2 col-sm-9">
-            <div id="registration-dates-picker" class="row datetimerange">
-              <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime %>
-              <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime %>
-            </div>
-          </div>
         </div>
 
         <div class="colliding-competitions">

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -215,16 +215,6 @@
           <% end %>
         </div>
 
-      <% disable_registration_close = !(@competition.registration_full? || !disable_form) %>
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-9">
-          <div id="registration-dates-picker" class="row datetimerange">
-            <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime, disabled: disable_form %>
-            <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime, disabled: disable_registration_close %>
-          </div>
-        </div>
-      </div>
-
       <fieldset <%= disable_form && "disabled" %>>
 
         <div class="wca-registration-options">
@@ -237,6 +227,15 @@
         <div class="guest-no-entry-fee-options">
           <%= f.input :guest_entry_status, include_blank: false %>
           <%= f.input :guests_per_registration_limit %>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-9">
+            <div id="registration-dates-picker" class="row datetimerange">
+              <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime %>
+              <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime %>
+            </div>
+          </div>
         </div>
 
         <div class="colliding-competitions">

--- a/WcaOnRails/app/views/competitions/edit.html.erb
+++ b/WcaOnRails/app/views/competitions/edit.html.erb
@@ -54,6 +54,19 @@
       </li>
     </ul>
     <hr>
+  <% else %>
+    <ul>
+      <li>
+        <%= button_to competition_orga_close_reg_when_full_limit_path, class: 'btn btn-danger', disabled: !@competition.orga_can_close_reg_full_limit?, method: :post, data: { confirm: t('competitions.orga_close_reg_confirm') } do %>
+          <%= t 'competitions.orga_close_reg' %>
+        <% end %>
+        <% if !@competition.registration_full? && !@competition.registration_past?%>
+          <%= t 'competitions.note_reg_not_full_orga_close_reg' %>
+        <% elsif @competition.registration_past?%>
+          <%= t 'competitions.note_reg_closed_orga_close_reg' %>
+        <% end %>
+      </li>
+    </ul>
   <% end %>
 
   <%= render 'competition_form' %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1350,6 +1350,8 @@ en:
       stripe_connected: "You have now successfully connected your Stripe account and can now receive registration payments for this competition."
       stripe_not_connected: "There was a problem and we could not connect your Stripe account."
       championship_exists: "There is already a %{championship_type} in %{year}"
+      orga_closed_reg_success: "Sucessfully closed registration."
+      orga_closed_reg_failure: "Cannot close registration."
     #context: on the "My competitions" page
     my_competitions:
       title: "My competitions"
@@ -1643,6 +1645,10 @@ en:
     results_posted_by_html: "Posted by %{poster_name} on %{date_time}"
     cancel_mistake: "Made a mistake?"
     note_before_cancel: "Note: only confirmed competitions can be cancelled."
+    orga_close_reg: "Close registration."
+    orga_close_reg_confirm: "Are you sure you want to close registration? You cannot undo this."
+    note_reg_not_full_orga_close_reg: "Note: you can only close registration once the competitor limit has been reached."
+    note_reg_closed_orga_close_reg: "Note: registration is already closed."
     show:
       general_info: "General info"
       events: "Events"

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -129,6 +129,7 @@ Rails.application.routes.draw do
   post 'competitions/:id/post_announcement' => 'competitions#post_announcement', as: :competition_post_announcement
   post 'competitions/:id/cancel' => 'competitions#cancel_competition', as: :competition_cancel
   post 'competitions/:id/post_results' => 'competitions#post_results', as: :competition_post_results
+  post 'competitions/:id/orga_close_reg_when_full_limit' => 'competitions#orga_close_reg_when_full_limit', as: :competition_orga_close_reg_when_full_limit
 
   get 'panel' => 'panel#index'
   get 'panel/delegate-crash-course', to: redirect('/edudoc/delegate-crash-course/delegate_crash_course.pdf', status: 302)

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -901,18 +901,18 @@ RSpec.describe CompetitionsController do
       before :each do
         sign_in orga
       end
-      
+
       it "can close registration with full limit" do
-        comp_with_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit:1)
+        comp_with_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit: 1)
         comp_with_full_reg.organizers << orga
-        FactoryBot.create_list(:registration, 1, :accepted, :newcomer, competition: comp_with_full_reg) 
+        FactoryBot.create_list(:registration, 1, :accepted, :newcomer, competition: comp_with_full_reg)
         patch :orga_close_reg_when_full_limit, params: { id: comp_with_full_reg }
         expect(response).to redirect_to edit_competition_path(comp_with_full_reg)
         expect(comp_with_full_reg.reload.registration_past?).to eq true
       end
 
       it "cannot close registration non full limit" do
-        comp_without_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit:100)
+        comp_without_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit: 100)
         comp_without_full_reg.organizers << orga
         FactoryBot.create_list(:registration, 2, :pending, :newcomer, competition: comp_without_full_reg)
         FactoryBot.create_list(:registration, 3, :accepted, :newcomer, competition: comp_without_full_reg)

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -903,23 +903,34 @@ RSpec.describe CompetitionsController do
       end
 
       it "can close registration with full limit" do
-        comp_with_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit: 1)
+        comp_with_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit_enabled: true, competitor_limit: 1, competitor_limit_reason: "we have a tiny venue")
         comp_with_full_reg.organizers << orga
-        FactoryBot.create_list(:registration, 1, :accepted, :newcomer, competition: comp_with_full_reg)
+        FactoryBot.create(:registration, :accepted, :newcomer, competition: comp_with_full_reg) 
         patch :orga_close_reg_when_full_limit, params: { id: comp_with_full_reg }
         expect(response).to redirect_to edit_competition_path(comp_with_full_reg)
-        expect(comp_with_full_reg.reload.registration_past?).to eq true
+        expect(comp_with_full_reg.reload.registration_close).to be < Time.now
       end
 
       it "cannot close registration non full limit" do
-        comp_without_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit: 100)
+        comp_without_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit_enabled: true, competitor_limit: 100, competitor_limit_reason: "venue size")
         comp_without_full_reg.organizers << orga
-        FactoryBot.create_list(:registration, 2, :pending, :newcomer, competition: comp_without_full_reg)
-        FactoryBot.create_list(:registration, 3, :accepted, :newcomer, competition: comp_without_full_reg)
-        # expect(comp_without_full_reg.reload.registration_past?).to eq false
+        FactoryBot.create(:registration, :pending, :newcomer, competition: comp_without_full_reg)
+        FactoryBot.create(:registration, :accepted, :newcomer, competition: comp_without_full_reg)
         patch :orga_close_reg_when_full_limit, params: { id: comp_without_full_reg }
         expect(response).to redirect_to edit_competition_path(comp_without_full_reg)
-        expect(comp_without_full_reg.reload.registration_past?).to eq false
+        expect(comp_without_full_reg.reload.registration_close).to be > Time.now
+      end
+    end
+
+    context 'regular user trying to close registration via button' do
+      sign_in { FactoryBot.create :user }
+      it 'does not allow regular user to use organiser reg close button' do
+        comp_with_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit_enabled: true, competitor_limit: 1, competitor_limit_reason: "we have a tiny venue")
+        FactoryBot.create(:registration, :accepted, :newcomer, competition: comp_with_full_reg)
+        expect {
+          patch :orga_close_reg_when_full_limit, params: { id: comp_with_full_reg }
+        }.to raise_error(ActionController::RoutingError)
+        expect(comp_with_full_reg.reload.registration_close).to be > Time.now
       end
     end
   end

--- a/WcaOnRails/spec/controllers/competitions_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/competitions_controller_spec.rb
@@ -905,7 +905,7 @@ RSpec.describe CompetitionsController do
       it "can close registration with full limit" do
         comp_with_full_reg = FactoryBot.create(:competition, :registration_open, competitor_limit_enabled: true, competitor_limit: 1, competitor_limit_reason: "we have a tiny venue")
         comp_with_full_reg.organizers << orga
-        FactoryBot.create(:registration, :accepted, :newcomer, competition: comp_with_full_reg) 
+        FactoryBot.create(:registration, :accepted, :newcomer, competition: comp_with_full_reg)
         patch :orga_close_reg_when_full_limit, params: { id: comp_with_full_reg }
         expect(response).to redirect_to edit_competition_path(comp_with_full_reg)
         expect(comp_with_full_reg.reload.registration_close).to be < Time.now


### PR DESCRIPTION
Giving refunds can be a big expense to organisers, if a waiting list gets too large before WCAT can action the closure. This PR should fix that issue.

Fixes #6818