### PR TITLE
Add Gsuite credentials copy to bootstrap script

### DIFF
--- a/scripts/wca-bootstrap.sh
+++ b/scripts/wca-bootstrap.sh
@@ -82,6 +82,7 @@ fi
 if [ "$environment" != "development" ]; then
   echo "Downloading secret chef key from S3"
   aws s3 cp s3://wca-backups/latest/my_secret_key $repo_root/secrets/my_secret_key
+  aws s3 cp s3://wca-backups/latest/application_default_credentials.json $repo_root/secrets/application_default_credentials.json
 fi
 
 # Install chef client


### PR DESCRIPTION
We missed this as part of making the server bootstrapping process stateless.
