### PR TITLE
Make order of competition form more intuitive

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -160,17 +160,6 @@
           <%= render "nearby_competitions" %>
         </div>
 
-        <%= f.input :information, input_html: { class: disable_form ? "" : "markdown-editor" } %>
-        <%= f.input :staff_delegate_ids, as: :user_ids, only_staff_delegates: true %>
-        <%= f.input :trainee_delegate_ids, as: :user_ids, only_trainee_delegates: true %>
-        <%= f.input :organizer_ids, as: :user_ids %>
-        <%= f.input :contact, hint: t('.contact_html', md: t('.supports_md_html')) %>
-
-        <hr>
-        <%= f.input :generate_website %>
-        <%= f.input :external_website %>
-        <hr>
-
         <div class="series">
           <%= f.simple_fields_for :competition_series, @competition.competition_series do |f2| %>
             <%= render "competition_series_fields", f: f2 %>
@@ -187,6 +176,22 @@
             </div>
           </div>
         </div>
+        <hr>
+
+        <%= f.input :information, input_html: { class: disable_form ? "" : "markdown-editor" } %>
+        <%= f.input :competitor_limit_enabled, collection: [ :true, :false ] %>
+        <div class="wca-competitor-limit-options">
+          <%= f.input :competitor_limit %>
+          <%= f.input :competitor_limit_reason %>
+        </div>
+        <%= f.input :delegate_ids, as: :user_ids, only_delegates: true %>
+        <%= f.input :trainee_delegate_ids, as: :user_ids, only_trainee_delegates: true %>
+        <%= f.input :organizer_ids, as: :user_ids %>
+        <%= f.input :contact, hint: t('.contact_html', md: t('.supports_md_html')) %>
+
+        <hr>
+        <%= f.input :generate_website %>
+        <%= f.input :external_website %>
         <hr>
 
         <div class="championships">

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -206,7 +206,7 @@
           <%= f.input :competitor_limit %>
           <%= f.input :competitor_limit_reason %>
         </div>
-        <%= f.input :delegate_ids, as: :user_ids, only_delegates: true %>
+        <%= f.input :staff_delegate_ids, as: :user_ids, only_staff_delegates: true %>
         <%= f.input :trainee_delegate_ids, as: :user_ids, only_trainee_delegates: true %>
         <%= f.input :organizer_ids, as: :user_ids %>
         <%= f.input :contact, hint: t('.contact_html', md: t('.supports_md_html')) %>

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -217,18 +217,6 @@
 
       <fieldset <%= disable_form && "disabled" %>>
 
-        <div class="wca-registration-options">
-          <%= f.input :enable_donations %>
-          <%= f.input :guests_enabled, as: :radio_buttons, collection: [ :true, :false ] %>
-        </div>
-
-        <%= f.input :guests_entry_fee_lowest_denomination, as: :money_amount, currency: @competition.currency_code, currency_selector: "#competition_currency_code" %>
-
-        <div class="guest-no-entry-fee-options">
-          <%= f.input :guest_entry_status, include_blank: false %>
-          <%= f.input :guests_per_registration_limit %>
-        </div>
-
         <div class="form-group">
           <div class="col-sm-offset-2 col-sm-9">
             <div id="registration-dates-picker" class="row datetimerange">
@@ -236,25 +224,6 @@
               <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime %>
             </div>
           </div>
-        </div>
-
-        <div class="colliding-competitions">
-          <div id="colliding-registration-start-competitions" class="adjacent-competitions">
-            <% @colliding_registration_start_competitions = [] # nasty hack to display the "loading" indicator without crashing %>
-            <%= render "colliding_registration_start_competitions" %>
-          </div>
-
-          <script>
-            $("#registration-dates-picker .datetimepicker").on("dp.change", function(e) {
-              window.wca.fetchCollidingRegistrationStartCompetitions();
-            });
-          </script>
-        </div>
-
-        <%= f.input :competitor_limit_enabled, collection: [ :true, :false ] %>
-        <div class="wca-competitor-limit-options">
-          <%= f.input :competitor_limit %>
-          <%= f.input :competitor_limit_reason %>
         </div>
 
         <% disable_money_input = !@competition.can_edit_registration_fees? %>
@@ -308,6 +277,31 @@
             $('input[name="competition[base_entry_fee_lowest_denomination]"]').on('change', UpdateDues).trigger('change'); //trigger() to display dues upon load
           });
         </script>
+
+        <div class="wca-registration-options">
+          <%= f.input :enable_donations %>
+          <%= f.input :guests_enabled, as: :radio_buttons, collection: [ :true, :false ] %>
+        </div>
+
+        <%= f.input :guests_entry_fee_lowest_denomination, as: :money_amount, currency: @competition.currency_code, currency_selector: "#competition_currency_code" %>
+
+        <div class="guest-no-entry-fee-options"> # Daniel
+          <%= f.input :guest_entry_status, include_blank: false %>
+          <%= f.input :guests_per_registration_limit %>
+        </div>
+
+        <div class="colliding-competitions">
+          <div id="colliding-registration-start-competitions" class="adjacent-competitions">
+            <% @colliding_registration_start_competitions = [] # nasty hack to display the "loading" indicator without crashing %>
+            <%= render "colliding_registration_start_competitions" %>
+          </div>
+
+          <script>
+            $("#registration-dates-picker .datetimepicker").on("dp.change", function(e) {
+              window.wca.fetchCollidingRegistrationStartCompetitions();
+            });
+          </script>
+        </div>
 
         <%= f.input :refund_policy_percent %>
         <%= f.input :refund_policy_limit_date, as: :datetime_picker %>

--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -178,6 +178,28 @@
         </div>
         <hr>
 
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-9">
+            <div id="registration-dates-picker" class="row datetimerange">
+              <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime %>
+              <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime %>
+            </div>
+          </div>
+        </div>
+
+        <div class="colliding-competitions">
+          <div id="colliding-registration-start-competitions" class="adjacent-competitions">
+            <% @colliding_registration_start_competitions = [] # nasty hack to display the "loading" indicator without crashing %>
+            <%= render "colliding_registration_start_competitions" %>
+          </div>
+
+          <script>
+            $("#registration-dates-picker .datetimepicker").on("dp.change", function(e) {
+              window.wca.fetchCollidingRegistrationStartCompetitions();
+            });
+          </script>
+        </div>
+
         <%= f.input :information, input_html: { class: disable_form ? "" : "markdown-editor" } %>
         <%= f.input :competitor_limit_enabled, collection: [ :true, :false ] %>
         <div class="wca-competitor-limit-options">
@@ -221,15 +243,6 @@
         </div>
 
       <fieldset <%= disable_form && "disabled" %>>
-
-        <div class="form-group">
-          <div class="col-sm-offset-2 col-sm-9">
-            <div id="registration-dates-picker" class="row datetimerange">
-              <%= f.input :registration_open, as: :datetime_picker, wrapper: :ranged_datetime %>
-              <%= f.input :registration_close, as: :datetime_picker, wrapper: :ranged_datetime %>
-            </div>
-          </div>
-        </div>
 
         <% disable_money_input = !@competition.can_edit_registration_fees? %>
         <%= f.input :currency_code, collection: Money::Currency.table.values, label_method: lambda { |c| "#{c[:name]} (#{c[:iso_code]})" }, value_method: lambda { |c| c[:iso_code] }, disabled: disable_money_input  %>
@@ -293,19 +306,6 @@
         <div class="guest-no-entry-fee-options"> # Daniel
           <%= f.input :guest_entry_status, include_blank: false %>
           <%= f.input :guests_per_registration_limit %>
-        </div>
-
-        <div class="colliding-competitions">
-          <div id="colliding-registration-start-competitions" class="adjacent-competitions">
-            <% @colliding_registration_start_competitions = [] # nasty hack to display the "loading" indicator without crashing %>
-            <%= render "colliding_registration_start_competitions" %>
-          </div>
-
-          <script>
-            $("#registration-dates-picker .datetimepicker").on("dp.change", function(e) {
-              window.wca.fetchCollidingRegistrationStartCompetitions();
-            });
-          </script>
         </div>
 
         <%= f.input :refund_policy_percent %>

--- a/WcaOnRails/app/views/competitions/_competition_info.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_info.html.erb
@@ -124,6 +124,15 @@
     <% end %>
 
     <% unless competition.results_posted? %>
+      <% if competition.competitor_limit_enabled %>
+        <dl class="dl-horizontal">
+          <dt><%= t '.competitor_limit' %></dt>
+          <dd>
+            <%= competition.competitor_limit %>
+          </dd>
+        </dl>
+      <% end %>
+
       <dl class="dl-horizontal">
         <dt><%= t '.number_of_bookmarks' %></dt>
         <dd>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1397,6 +1397,7 @@ en:
       part_of_a_series: "This competition is part of a Competition Series."
       part_of_a_series_list: "This competition is part of the %{name} Competition Series. Other competitions in this Series are:"
       series_registration_warning_html: "Note: You can submit a registration for all competitions in a Series, but only one of those registrations can be confirmed and accepted. <b>You will only be allowed to compete in one of the Series competitions!</b>"
+      competitor_limit: "Competitor limit"
       competitor_limit_is: "There is a competitor limit of %{competitor_limit} competitors."
       no_competitor_limit: "There is no competitor limit."
       entry_fee_is: "The base registration fee for this competition is %{base_entry_fee}."


### PR DESCRIPTION
Per request of some WCAT members, I have made the form order more intuitive. As well, I have added more clear display of the competitor limit as it was in the past according to Wilson.

Additionally when reordering, I noticed some bug (not caused but this PR) that I think was introduced from https://github.com/thewca/worldcubeassociation.org/pull/7163. The first table (from competitions/:id/edit/admin) which has the label "Nearby competitions (within 5 days and 10 km)" actually has content for (NEARBY_DAYS_WARNING, NEARBY_DISTANCE_KM_WARNING), which is 180 days and 250km currently. I couldn't figure out where the variables are actually be called to some function, just something that seemed rather hacky that I couldn't update without breaking a lot of other stuff.