### PR TITLE
Remove .lvimrc

### DIFF
--- a/.lvimrc
+++ b/.lvimrc
@@ -1,2 +1,0 @@
-set expandtab
-set shiftwidth=2 tabstop=2 softtabstop=2


### PR DESCRIPTION
This is a trivial config file for LunarVim I believe - doesn't need to be in the main repo, lvim users should have their own config.