### PR TITLE
Send competition inquires to contact email if a pure, valid email address is found

### DIFF
--- a/WcaOnRails/app/models/website_contact.rb
+++ b/WcaOnRails/app/models/website_contact.rb
@@ -20,10 +20,13 @@ class WebsiteContact < ContactForm
 
   def to_email
     if inquiry == "competition"
-      Competition.find_by_id(competition_id)&.managers&.map(&:email)
-    else
-      "contact@worldcubeassociation.org"
+      competition = Competition.find_by_id(competition_id)
+      if competition.present?
+        return ValidateEmail.valid?(competition.contact) ? competition.contact : competition.managers.map(&:email)
+      end
     end
+
+    "contact@worldcubeassociation.org"
   end
 
   def subject

--- a/WcaOnRails/spec/factories/contacts.rb
+++ b/WcaOnRails/spec/factories/contacts.rb
@@ -7,4 +7,30 @@ FactoryBot.define do
     f.to_email { "to@example.com" }
     f.subject { "Subject" }
   end
+
+  factory :website_contact do
+    name { "Jon" }
+    your_email { "jon@example.com" }
+
+    transient do
+      competition_contact { nil }
+      competition_managers { [] }
+    end
+
+    trait :specific_competition_inquiry do
+      inquiry { "competition" }
+    end
+
+    trait :general_competitions_inquiry do
+      inquiry { "competitions_in_general" }
+    end
+
+    trait :with_invalid_competition_id do
+      competition_id { "FooBar1900" }
+    end
+
+    trait :with_competition do
+      competition_id { FactoryBot.create(:competition, :announced, contact: competition_contact, delegates: competition_managers).id }
+    end
+  end
 end

--- a/WcaOnRails/spec/factories/contacts.rb
+++ b/WcaOnRails/spec/factories/contacts.rb
@@ -11,18 +11,11 @@ FactoryBot.define do
   factory :website_contact do
     name { "Jon" }
     your_email { "jon@example.com" }
+    inquiry { "different" }
 
     transient do
       competition_contact { nil }
-      competition_managers { [] }
-    end
-
-    trait :specific_competition_inquiry do
-      inquiry { "competition" }
-    end
-
-    trait :general_competitions_inquiry do
-      inquiry { "competitions_in_general" }
+      competition_delegates { [] }
     end
 
     trait :with_invalid_competition_id do
@@ -30,7 +23,7 @@ FactoryBot.define do
     end
 
     trait :with_competition do
-      competition_id { FactoryBot.create(:competition, :announced, contact: competition_contact, delegates: competition_managers).id }
+      competition_id { FactoryBot.create(:competition, :announced, contact: competition_contact, delegates: competition_delegates).id }
     end
   end
 end

--- a/WcaOnRails/spec/models/website_contact_spec.rb
+++ b/WcaOnRails/spec/models/website_contact_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WebsiteContact do
+  context "to email" do
+    let(:competition_managers) { [FactoryBot.create(:delegate), FactoryBot.create(:delegate)] }
+
+    it "sends inquires not regarding a specific competition to the general WCA contact email" do
+      form = FactoryBot.build(:website_contact, :general_competitions_inquiry)
+      expect(form.inquiry).not_to eq "competition"
+      expect(form.to_email).to eq "contact@worldcubeassociation.org"
+    end
+
+    it "sends competition inquires to the general WCA contact email when competition id is nil" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry)
+      expect(form.competition_id).to be_nil
+      expect(form.to_email).to eq "contact@worldcubeassociation.org"
+    end
+
+    it "sends competition inquires to the general WCA contact email when competition id is not found" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_invalid_competition_id)
+      expect(form.competition_id).not_to be_nil
+      expect(form.to_email).to eq "contact@worldcubeassociation.org"
+    end
+
+    it "sends competition inquires to competition contact email when a pure, valid email address is provided for contact" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "unit-test@speedcubingcanada.org")
+      expect(form.to_email).to eq "unit-test@speedcubingcanada.org"
+    end
+
+    it "sends competition inquires to competition managers when nothing is provided for contact" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers)
+      expect(form.to_email).to eq competition_managers.map(&:email)
+    end
+
+    it "sends competition inquires to competition managers when an invalid email address is provided for contact" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "not an em@il address")
+      expect(form.to_email).to eq competition_managers.map(&:email)
+    end
+
+    it "sends competition inquires to competition managers when a markdown email address is provided for contact" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "[Speedcubing Canada](mailto:unit-test@speedcubingcanada.org)")
+      expect(form.to_email).to eq competition_managers.map(&:email)
+    end
+
+    it "sends competition inquires to competition managers when a markdown website is provided for contact" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "[Speedcubing Canada](unit-test.speedcubingcanada.org)")
+      expect(form.to_email).to eq competition_managers.map(&:email)
+    end
+
+    it "sends competition inquires to competition managers when a website is provided for contact" do
+      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "unit-test.speedcubingcanada.org")
+      expect(form.to_email).to eq competition_managers.map(&:email)
+    end    
+  end
+end

--- a/WcaOnRails/spec/models/website_contact_spec.rb
+++ b/WcaOnRails/spec/models/website_contact_spec.rb
@@ -3,55 +3,93 @@
 require "rails_helper"
 
 RSpec.describe WebsiteContact do
-  context "to email" do
-    let(:competition_managers) { [FactoryBot.create(:delegate), FactoryBot.create(:delegate)] }
+  let(:delegates) { [FactoryBot.create(:delegate), FactoryBot.create(:delegate)] }
 
+  context "to email" do
     it "sends inquires not regarding a specific competition to the general WCA contact email" do
-      form = FactoryBot.build(:website_contact, :general_competitions_inquiry)
+      form = FactoryBot.build(:website_contact)
       expect(form.inquiry).not_to eq "competition"
       expect(form.to_email).to eq "contact@worldcubeassociation.org"
     end
 
     it "sends competition inquires to the general WCA contact email when competition id is nil" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry)
+      form = FactoryBot.build(:website_contact, inquiry: "competition")
       expect(form.competition_id).to be_nil
       expect(form.to_email).to eq "contact@worldcubeassociation.org"
     end
 
     it "sends competition inquires to the general WCA contact email when competition id is not found" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_invalid_competition_id)
+      form = FactoryBot.build(:website_contact, :with_invalid_competition_id, inquiry: "competition")
       expect(form.competition_id).not_to be_nil
       expect(form.to_email).to eq "contact@worldcubeassociation.org"
     end
 
     it "sends competition inquires to competition contact email when a pure, valid email address is provided for contact" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "unit-test@speedcubingcanada.org")
+      form = FactoryBot.build(:website_contact, :with_competition, inquiry: "competition", competition_delegates: delegates, competition_contact: "unit-test@speedcubingcanada.org")
       expect(form.to_email).to eq "unit-test@speedcubingcanada.org"
     end
 
     it "sends competition inquires to competition managers when nothing is provided for contact" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers)
-      expect(form.to_email).to eq competition_managers.map(&:email)
+      form = FactoryBot.build(:website_contact, :with_competition, inquiry: "competition", competition_delegates: delegates)
+      expect(form.to_email).to eq delegates.map(&:email)
     end
 
     it "sends competition inquires to competition managers when an invalid email address is provided for contact" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "not an em@il address")
-      expect(form.to_email).to eq competition_managers.map(&:email)
+      form = FactoryBot.build(:website_contact, :with_competition, inquiry: "competition", competition_delegates: delegates, competition_contact: "not an em@il address")
+      expect(form.to_email).to eq delegates.map(&:email)
     end
 
     it "sends competition inquires to competition managers when a markdown email address is provided for contact" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "[Speedcubing Canada](mailto:unit-test@speedcubingcanada.org)")
-      expect(form.to_email).to eq competition_managers.map(&:email)
+      form = FactoryBot.build(:website_contact, :with_competition, inquiry: "competition", competition_delegates: delegates, competition_contact: "[Speedcubing Canada](mailto:unit-test@speedcubingcanada.org)")
+      expect(form.to_email).to eq delegates.map(&:email)
     end
 
     it "sends competition inquires to competition managers when a markdown website is provided for contact" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "[Speedcubing Canada](unit-test.speedcubingcanada.org)")
-      expect(form.to_email).to eq competition_managers.map(&:email)
+      form = FactoryBot.build(:website_contact, :with_competition, inquiry: "competition", competition_delegates: delegates, competition_contact: "[Speedcubing Canada](unit-test.speedcubingcanada.org)")
+      expect(form.to_email).to eq delegates.map(&:email)
     end
 
     it "sends competition inquires to competition managers when a website is provided for contact" do
-      form = FactoryBot.build(:website_contact, :specific_competition_inquiry, :with_competition, competition_managers: competition_managers, competition_contact: "unit-test.speedcubingcanada.org")
-      expect(form.to_email).to eq competition_managers.map(&:email)
-    end    
+      form = FactoryBot.build(:website_contact, :with_competition, inquiry: "competition", competition_delegates: delegates, competition_contact: "unit-test.speedcubingcanada.org")
+      expect(form.to_email).to eq delegates.map(&:email)
+    end
+  end
+
+  context "subject" do
+    it "builds subject line for specific competition inquiry" do
+      form = FactoryBot.build(:website_contact, :with_competition, inquiry: "competition", competition_delegates: delegates)
+      competition_name = Competition.find_by_id(form.competition_id).name
+      expect(form.subject).to start_with("[WCA Website] Comment for #{competition_name} by #{form.name} on")
+    end
+
+    it "builds subject line for general competition inquiry" do
+      form = FactoryBot.build(:website_contact, inquiry: "competitions_in_general")
+      expect(form.subject).to start_with("[WCA Website] General Competition Comment by #{form.name} on")
+    end
+
+    it "builds subject line for wca id or profile inquiry" do
+      form = FactoryBot.build(:website_contact, inquiry: "wca_id_or_profile")
+      expect(form.subject).to start_with("[WCA Website] WCA ID or WCA Profile Comment by #{form.name} on")
+    end
+
+    it "builds subject line for media inquiry" do
+      form = FactoryBot.build(:website_contact, inquiry: "media")
+      expect(form.subject).to start_with("[WCA Website] Media Comment by #{form.name} on")
+    end
+
+    it "builds subject line for software inquiry" do
+      form = FactoryBot.build(:website_contact, inquiry: "software")
+      expect(form.subject).to start_with("[WCA Website] Software Comment by #{form.name} on")
+    end
+
+    it "builds subject line for other inquiry" do
+      form = FactoryBot.build(:website_contact, inquiry: "different")
+      expect(form.subject).to start_with("[WCA Website] Other Comment by #{form.name} on")
+    end
+
+    it "raises error for invalid inquiry type" do
+      form = FactoryBot.build(:website_contact, inquiry: "foo_bar")
+      expect { form.subject }.to raise_error("Invalid inquiry type: `foo_bar`")
+    end
   end
 end


### PR DESCRIPTION
Closes #7531.

The `WebsiteContact` [form](https://www.worldcubeassociation.org/contact/website) will now direct specific competition inquires to the competition's `contact` field if it is a **"pure", valid email address**.

For example, inquires regarding [Pickering A 2023](https://www.worldcubeassociation.org/competitions/PickeringA2023) should get directed to the email address provided via the `contact` field. 

There are some edge cases to consider, which are covered in the tests for the `to_email` method. For example:
- If no `contact` is provided, fallback to the competition managers' emails (real example: [Music City Speedsolving 2023](https://www.worldcubeassociation.org/competitions/MusicCitySpeedsolving2023))
- If a website is provided for `contact`, fallback to the competition managers' emails (real example: [Brisbane Summer 2023](https://www.worldcubeassociation.org/competitions/BrisbaneSummer2023))

I wrote some bonus tests for the `subject` method too.