### PR TITLE
Dynamically select calendar text color based on background

### DIFF
--- a/WcaOnRails/app/webpacker/lib/show-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/show-schedule.js
@@ -17,7 +17,7 @@ const HEX_BASE = 16;
  *
  * @param {string} hexColor HEX color code to convert to RGB
  *
- * @returns {Array<int>} RBG values, defaults to `[0, 0, 0]` if `hexColor` cannot be parsed
+ * @returns {Array<number>} RBG values, defaults to `[0, 0, 0]` if `hexColor` cannot be parsed
  */
 const hexToRgb = (hexColor) => {
   if (/#[0-9A-Fa-f]{6}/.test(hexColor)) {

--- a/WcaOnRails/app/webpacker/lib/show-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/show-schedule.js
@@ -16,6 +16,10 @@ const HEX_CHANNEL_REGEX = /^#(?<r>[0-9A-Fa-f]{2})(?<g>[0-9A-Fa-f]{2})(?<b>[0-9A-
 /**
  * Convert a HEX color code to RGB values.
  *
+ * @example
+ * // returns [255, 255, 255]
+ * getTextColor('#ffffff');
+ *
  * @param {string} hexColor HEX color code to convert to RGB
  *
  * @returns {Array<number>} RBG values, defaults to `[0, 0, 0]` if `hexColor` cannot be parsed
@@ -40,6 +44,10 @@ const BLACK = '#000000';
 /**
  * Compute appropriate text color (black or white) based on how "light" or "dark"
  * the background color of a calendar item is.
+ *
+ * @example
+ * // returns #000000 (black given white background color)
+ * getTextColor('#ffffff');
  *
  * @param {string} backgroundColor Calendar item's background color (in HEX)
  *

--- a/WcaOnRails/app/webpacker/lib/show-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/show-schedule.js
@@ -11,6 +11,7 @@ window.wca.registerVenueData = (id, venueData) => {
 };
 
 const HEX_BASE = 16;
+const HEX_CHANNEL_REGEX = /^#(?<r>[0-9A-Fa-f]{2})(?<g>[0-9A-Fa-f]{2})(?<b>[0-9A-Fa-f]{2})$/;
 
 /**
  * Convert a HEX color code to RGB values.
@@ -20,11 +21,13 @@ const HEX_BASE = 16;
  * @returns {Array<number>} RBG values, defaults to `[0, 0, 0]` if `hexColor` cannot be parsed
  */
 const hexToRgb = (hexColor) => {
-  if (/#[0-9A-Fa-f]{6}/.test(hexColor)) {
+  const match = hexColor.match(HEX_CHANNEL_REGEX);
+
+  if (match !== null) {
     return [
-      parseInt(hexColor.slice(1, 3), HEX_BASE),
-      parseInt(hexColor.slice(3, 5), HEX_BASE),
-      parseInt(hexColor.slice(5, 7), HEX_BASE),
+      parseInt(match.groups.r, HEX_BASE),
+      parseInt(match.groups.g, HEX_BASE),
+      parseInt(match.groups.b, HEX_BASE),
     ];
   }
 

--- a/WcaOnRails/app/webpacker/lib/show-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/show-schedule.js
@@ -10,6 +10,44 @@ window.wca.registerVenueData = (id, venueData) => {
   dataByVenueId[id] = venueData;
 };
 
+const HEX_BASE = 16;
+
+/**
+ * Convert a HEX color code to RGB values.
+ *
+ * @param {string} hexColor HEX color code to convert to RGB
+ *
+ * @returns {Array<int>} RBG values, defaults to `[0, 0, 0]` if `hexColor` cannot be parsed
+ */
+const hexToRgb = (hexColor) => {
+  if (/#[0-9A-Fa-f]{6}/.test(hexColor)) {
+    return [
+      parseInt(hexColor.slice(1, 3), HEX_BASE),
+      parseInt(hexColor.slice(3, 5), HEX_BASE),
+      parseInt(hexColor.slice(5, 7), HEX_BASE),
+    ];
+  }
+
+  return [0, 0, 0];
+};
+
+const WHITE = '#ffffff';
+const BLACK = '#000000';
+
+/**
+ * Compute appropriate text color (black or white) based on how "light" or "dark"
+ * the background color of a calendar item is.
+ *
+ * @param {string} backgroundColor Calendar item's background color (in HEX)
+ *
+ * @returns {string} white for "dark" backgrounds, black for "light" backgrounds
+ */
+const getTextColor = (backgroundColor) => {
+  const [red, green, blue] = hexToRgb(backgroundColor);
+  // formula from https://stackoverflow.com/a/3943023
+  return (red * 0.299 + green * 0.587 + blue * 0.114) > 186 ? BLACK : WHITE;
+};
+
 const getCalendarElemId = (venueId) => `#calendar-venue-${venueId}`;
 const getScheduleElemId = (venueId) => `#schedule-venue-${venueId}`;
 
@@ -44,6 +82,8 @@ const fetchCalendarEvents = (venueId, start, end, timezone, callback) => {
   callback(calendarEvents);
 };
 
+const GREY = '#666666';
+
 const initFullCalendar = ($elem, calendarParams) => {
   const venueData = dataByVenueId[calendarParams.venueId];
   const options = {
@@ -51,8 +91,9 @@ const initFullCalendar = ($elem, calendarParams) => {
     eventDataTransform: (eventData) => {
       const ev = eventData;
       if (ev.activityDetails.event_id.startsWith('other')) {
-        ev.color = '#666';
+        ev.color = GREY;
       }
+      ev.textColor = getTextColor(ev.color);
       return ev;
     },
     eventRender: (event, element) => {


### PR DESCRIPTION
Closes #7549 and closes #7276.

Converts background HEX color code to RGB, then computes overall intensity (how "light" or "dark" the color is) to determine if we should use white or black for the text color. 

Note: as per https://stackoverflow.com/a/3943023, there are _some_ cases where this _could_ break W3C rules. I'm an advocate for web accessibility, but I think competition organizers are capable of selecting background colors that provide sufficient contrast against `#ffffff` and `#000000`. If this is really a concern and we're ok with a bulkier solution, we can find a library that handles the color intensity computation.

White background:

![image](https://user-images.githubusercontent.com/48423418/213837264-396ed52e-8c0c-43cb-8606-38836f777bac.png)

Yellow background:

![image](https://user-images.githubusercontent.com/48423418/213837456-6ab25fba-9dc4-4aa1-93d6-4769b92ae60c.png)

Cream background (color used in #7549):

![image](https://user-images.githubusercontent.com/48423418/213838195-72c88784-b829-4c12-85f6-7effc06a5408.png)
