### PR TITLE
Add QiYi Display to default Delegate Report Text

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/_equipment_default.md
+++ b/WcaOnRails/app/views/delegate_reports/_equipment_default.md
@@ -5,3 +5,4 @@ Gen 5 Pro Timer: 0
 
 Gen 2 Display: 0
 Gen 3 Display: 0
+QiYi Display: 0


### PR DESCRIPTION
QiYi Displays are being increasingly used. This adds it as a default option to save time for Delegates when completing the report.