### PR TITLE
Add lib-yaml-dev dependecy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ This repository contains all of the code that runs on [worldcubeassociation.org]
   Feel free to take a look at our [chef recipe](https://github.com/thewca/worldcubeassociation.org/blob/master/chef/site-cookbooks/wca/recipes/default.rb#L6-L23)
   for the accurate versions we use and how we install them.
   Please note that other versions may work, but it is not guaranteed.
-  3. `bundle install && bin/yarn`
-  4. `bin/rake db:load:development` - Download and import the [developer's database export](https://github.com/thewca/worldcubeassociation.org/wiki/Developer-database-export). Depending on your computer it may take a long time. Alternatively you can run `bin/rake db:reset` which will create the database and seed it with random data (it's way faster, but less representative of our website content).
-  5. `bin/rails server` - Run rails. The server will be accessible at localhost:3000
+  3. Install `libyaml` using your package manager of choice, eg. [Mac](https://formulae.brew.sh/formula/libyaml) or [Ubuntu](https://launchpad.net/ubuntu/+source/libyaml)
+  4. `bundle install && bin/yarn`
+  5. `bin/rake db:load:development` - Download and import the [developer's database export](https://github.com/thewca/worldcubeassociation.org/wiki/Developer-database-export). Depending on your computer it may take a long time. Alternatively you can run `bin/rake db:reset` which will create the database and seed it with random data (it's way faster, but less representative of our website content).
+  6. `bin/rails server` - Run rails. The server will be accessible at localhost:3000
 - Run tests.
   1. `RAILS_ENV=test bin/rake db:reset` - Set up test database.
   2. `RAILS_ENV=test bin/rake assets:precompile` - Compile some assets needed for tests to run.

--- a/WcaOnRails/Dockerfile
+++ b/WcaOnRails/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
   nodejs \
   mariadb-client \
   libssl-dev \
-  libyaml-dev \ 
+  libyaml-dev \
   tzdata
 
 RUN gem update --system && gem install bundler

--- a/WcaOnRails/Dockerfile
+++ b/WcaOnRails/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
   nodejs \
   mariadb-client \
   libssl-dev \
+  libyaml-dev \ 
   tzdata
 
 RUN gem update --system && gem install bundler

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -142,6 +142,7 @@ package 'fonts-thai-tlwg'
 # Install native dependencies for gems
 package 'libghc-zlib-dev'
 package 'libsqlite3-dev'
+package 'libyaml-dev' #newly required by Psych 5.0
 package 'g++'
 package 'libmysqlclient-dev'
 package 'imagemagick'


### PR DESCRIPTION
With the recent upgrade to Version 5 of Psych we need lib-yaml as a dependency as it doesn't come with it's own bindings anymore. I added it both to chef and to Docker setups, additionally I added a reference to installing it in the readme if you are running the ruby portion of the website only (we already had some questions about an error in slack)