### PR TITLE
Add check-in and multi cube submission as custom calendar activities

### DIFF
--- a/WcaOnRails/app/models/schedule_activity.rb
+++ b/WcaOnRails/app/models/schedule_activity.rb
@@ -3,7 +3,7 @@
 class ScheduleActivity < ApplicationRecord
   # See https://docs.google.com/document/d/1hnzAZizTH0XyGkSYe-PxFL5xpKVWl_cvSdTzlT_kAs8/edit#heading=h.14uuu58hnua
   VALID_ACTIVITY_CODE_BASE = (Event.official.map(&:id) + %w(other)).freeze
-  VALID_OTHER_ACTIVITY_CODE = %w(registration breakfast lunch dinner awards unofficial misc tutorial).freeze
+  VALID_OTHER_ACTIVITY_CODE = %w(registration checkin breakfast lunch dinner awards unofficial misc tutorial).freeze
   belongs_to :holder, polymorphic: true
   has_many :child_activities, class_name: "ScheduleActivity", as: :holder, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
@@ -60,7 +60,7 @@ class ScheduleActivity < ApplicationRecord
     parts = ScheduleActivity.parse_activity_code(activity_code)
     if parts[:event_id] == "other"
       # TODO/NOTE: should we fix the name for event with predefined activity codes? (ie: those below but 'misc' and 'unofficial')
-      # VALID_OTHER_ACTIVITY_CODE = %w(registration breakfast lunch dinner awards unofficial misc).freeze
+      # VALID_OTHER_ACTIVITY_CODE = %w(registration checkin breakfast lunch dinner awards unofficial misc).freeze
       name
     else
       inferred_name = Event.c_find(parts[:event_id]).name

--- a/WcaOnRails/app/models/schedule_activity.rb
+++ b/WcaOnRails/app/models/schedule_activity.rb
@@ -3,7 +3,7 @@
 class ScheduleActivity < ApplicationRecord
   # See https://docs.google.com/document/d/1hnzAZizTH0XyGkSYe-PxFL5xpKVWl_cvSdTzlT_kAs8/edit#heading=h.14uuu58hnua
   VALID_ACTIVITY_CODE_BASE = (Event.official.map(&:id) + %w(other)).freeze
-  VALID_OTHER_ACTIVITY_CODE = %w(registration checkin breakfast lunch dinner awards unofficial misc tutorial).freeze
+  VALID_OTHER_ACTIVITY_CODE = %w(registration checkin multi breakfast lunch dinner awards unofficial misc tutorial).freeze
   belongs_to :holder, polymorphic: true
   has_many :child_activities, class_name: "ScheduleActivity", as: :holder, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
@@ -60,7 +60,7 @@ class ScheduleActivity < ApplicationRecord
     parts = ScheduleActivity.parse_activity_code(activity_code)
     if parts[:event_id] == "other"
       # TODO/NOTE: should we fix the name for event with predefined activity codes? (ie: those below but 'misc' and 'unofficial')
-      # VALID_OTHER_ACTIVITY_CODE = %w(registration checkin breakfast lunch dinner awards unofficial misc).freeze
+      # VALID_OTHER_ACTIVITY_CODE = %w(registration checkin multi breakfast lunch dinner awards unofficial misc).freeze
       name
     else
       inferred_name = Event.c_find(parts[:event_id]).name

--- a/WcaOnRails/app/webpacker/components/SchedulesEditor/CustomActivity.js
+++ b/WcaOnRails/app/webpacker/components/SchedulesEditor/CustomActivity.js
@@ -9,7 +9,8 @@ import {
 import { scheduleElementSelector } from '../../lib/helpers/edit-schedule';
 
 export const commonActivityCodes = {
-  'other-registration': 'Registration',
+  'other-registration': 'On-site registration',
+  'other-checkin': 'Check-in',
   'other-tutorial': 'Tutorial for new competitors',
   'other-breakfast': 'Breakfast',
   'other-lunch': 'Lunch',

--- a/WcaOnRails/app/webpacker/components/SchedulesEditor/CustomActivity.js
+++ b/WcaOnRails/app/webpacker/components/SchedulesEditor/CustomActivity.js
@@ -12,6 +12,7 @@ export const commonActivityCodes = {
   'other-registration': 'On-site registration',
   'other-checkin': 'Check-in',
   'other-tutorial': 'Tutorial for new competitors',
+  'other-multi': 'Cube submission for 3x3x3 Multi-Blind',
   'other-breakfast': 'Breakfast',
   'other-lunch': 'Lunch',
   'other-dinner': 'Dinner',

--- a/WcaOnRails/app/webpacker/lib/helpers/fullcalendar.js
+++ b/WcaOnRails/app/webpacker/lib/helpers/fullcalendar.js
@@ -64,7 +64,7 @@ const fullCalendarHandlers = {
       }
       $menu.removeClass('hide-element');
       $menu.position({ my: 'left top', of: jsEvent });
-      // avoid it being immediately hiddent by our window click listener
+      // avoid it being immediately hidden by our window click listener
       jsEvent.stopPropagation();
     } else {
       $menu.addClass('hide-element');
@@ -81,8 +81,8 @@ const fullCalendarHandlers = {
   onSizeChanged: eventModifiedInCalendar,
   onTimeframeSelected: (showModalAction, start, end) => {
     const eventProps = {
-      title: commonActivityCodes['other-registration'],
-      activityCode: 'other-registration',
+      title: commonActivityCodes['other-checkin'],
+      activityCode: 'other-checkin',
       start,
       end,
     };
@@ -96,7 +96,7 @@ export default function generate(eventFetcher, showModalAction, scheduleWcif, ad
 
   const localOptions = {
     // Having only one view for edition enable us to have a "static" list of event
-    // If we had more, we would need a function to fetch them everytime
+    // If we had more, we would need a function to fetch them every time
     events: eventFetcher,
     editable: true,
     droppable: true,


### PR DESCRIPTION
The validation logic assumes the activity code stars with `other` and has a single `-`, so I used `other-checkin` and `other-multi`.
Also changed the registration text to include "On-site".