### PR TITLE
Prepend competition series fields with "Series"

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -350,8 +350,8 @@ en:
       championship:
         championship_type: "Championship type"
       competition_series:
-        wcif_id: "ID"
-        name: "Name"
+        wcif_id: "Series ID"
+        name: "Series name"
         short_name: "Series nickname"
         competition_ids: "All competitions"
       #context: a registration to a competition


### PR DESCRIPTION
Changes "ID" to "Series ID" and "Name" to "Series name". Closes #7559 (for English only).

Example with incorrect competition _series_ name:

![series name](https://user-images.githubusercontent.com/48423418/215878547-5c1957b0-d2cb-458e-8e3e-1b4cb0d66cae.jpg)

I don't think there's a great way to unit test this. (I could be wrong - please let me know!)