### PR TITLE
Allow Banned Competitors to register for competitions after their ban expires

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -226,8 +226,8 @@ class Registration < ApplicationRecord
   private def user_can_register_for_competition
     if user&.cannot_register_for_competition_reasons.present?
       errors.add(:user_id, user.cannot_register_for_competition_reasons.to_sentence)
-    elsif user.banned?
-      ban_end = user.current_team_members.select(:name == "Banned Competitors").first.end_date
+    elsif user&.banned?
+      ban_end = user.current_team_members.select(:team == Team.banned).first.end_date
       if !ban_end.present? || competition.start_date < ban_end
         errors.add(:user_id, I18n.t('registrations.errors.banned_html').html_safe)
       end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -226,6 +226,8 @@ class Registration < ApplicationRecord
   private def user_can_register_for_competition
     if user&.cannot_register_for_competition_reasons.present?
       errors.add(:user_id, user.cannot_register_for_competition_reasons.to_sentence)
+    elsif user.banned? && competition.start_date < user.current_team_members.select(:name == "Banned Competitors").first.end_date
+      errors.add(:user_id, I18n.t('registrations.errors.banned_html').html_safe)
     end
   end
 

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -226,8 +226,11 @@ class Registration < ApplicationRecord
   private def user_can_register_for_competition
     if user&.cannot_register_for_competition_reasons.present?
       errors.add(:user_id, user.cannot_register_for_competition_reasons.to_sentence)
-    elsif user.banned? && competition.start_date < user.current_team_members.select(:name == "Banned Competitors").first.end_date
-      errors.add(:user_id, I18n.t('registrations.errors.banned_html').html_safe)
+    elsif user.banned?
+      ban_end = user.current_team_members.select(:name == "Banned Competitors").first.end_date
+      if !ban_end.present? || competition.start_date < ban_end
+        errors.add(:user_id, I18n.t('registrations.errors.banned_html').html_safe)
+      end
     end
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -923,7 +923,6 @@ class User < ApplicationRecord
       reasons << I18n.t('registrations.errors.need_gender') if gender.blank?
       reasons << I18n.t('registrations.errors.need_dob') if dob.blank?
       reasons << I18n.t('registrations.errors.need_country') if country_iso2.blank?
-      reasons << I18n.t('registrations.errors.banned_html').html_safe if banned?
     end
   end
 


### PR DESCRIPTION
Fixes #7591. 
I decided to remove the banned? check from `cannot_register_for_competition_reasons` as it's also used in the notification helper line 55 where it doesn't make sense. Instead I implemented a check directly in `user_can_register_for_competition`.
This ruby code looks pretty ugly, so I would love to get some suggestions on what is better!