### PR TITLE
Update the API help page to clarify usage

### DIFF
--- a/WcaOnRails/app/views/api/v0/api/help.html.erb
+++ b/WcaOnRails/app/views/api/v0/api/help.html.erb
@@ -5,26 +5,24 @@
 
   <h2>OAuth</h2>
   <p>
-    Go to <%= link_to oauth_applications_path, oauth_applications_path %> to
-    manage your OAuth applications.
+    <%= t('api.manage_oauth_html', oauth_link: link_to(oauth_applications_path, oauth_applications_path)) %>
   </p>
   <p>
-    Here is an example, using curl, of obtaining an access token using an Application ID, Client Secret, your WCA email, and your password:
+    <%= t('api.token_request_intro') %>
   </p>
-<pre><code>curl <%= oauth_token_url %> -X POST -F grant_type=password -F client_id=APP_ID -F client_secret=APP_SECRET -F username=YOUR_EMAIL -F password=YOUR_PASSWORD
+<pre><code>> curl <%= oauth_token_url %> -X POST -F grant_type=password -F client_id=<%= t('api.app_id_placeholder') %> -F client_secret=<%= t('api.app_secret_placeholder') %> -F username=<%= t('api.user_email_placeholder') %> -F password=<%= t('api.user_password_placeholder') %>
 
 {"access_token":"1d6c95446cab947224286b7bec4382d898c664c7a3cafb16d3d110a3044cf4dc","token_type":"bearer","expires_in":7200,"created_at":1430788134}
 </code></pre>
   <p>
-    An OAuth access token can be used, until it expires, to make authorized API requests. For example, to access information about your account:
+    <%= t('api.user_info_request_intro') %>
   </p>
-<pre><code>
-> curl -H "Authorization: Bearer 1d6c95446cab947224286b7bec4382d898c664c7a3cafb16d3d110a3044cf4dc" <%= api_v0_me_url %>
+<pre><code>> curl -H "Authorization: Bearer 1d6c95446cab947224286b7bec4382d898c664c7a3cafb16d3d110a3044cf4dc" <%= api_v0_me_url %>
 
 {"me":{"id":1,"email":"wca@worldcubeassociation.org","created_at":"2015-05-05T00:57:11.788Z","updated_at":"2015-05-05T00:57:12.072Z"}}
 </code></pre>
 
-  <h2>Legal TNoodle version</h2>
+  <h2><%= t('api.legal_tnoodle_api_header') %></h2>
   <%= link_to api_v0_scramble_program_path, api_v0_scramble_program_path %>
 
 </div>

--- a/WcaOnRails/app/views/api/v0/api/help.html.erb
+++ b/WcaOnRails/app/views/api/v0/api/help.html.erb
@@ -10,7 +10,7 @@
   <p>
     <%= t('api.token_request_intro') %>
   </p>
-<pre><code>> curl <%= oauth_token_url %> -X POST -F grant_type=password -F client_id=<%= t('api.app_id_placeholder') %> -F client_secret=<%= t('api.app_secret_placeholder') %> -F username=<%= t('api.user_email_placeholder') %> -F password=<%= t('api.user_password_placeholder') %>
+<pre><code>> curl <%= oauth_token_url %> -X POST -F grant_type=password -F client_id=APP_ID -F client_secret=APP_SECRET -F username=<%= t('api.user_email_placeholder') %> -F password=<%= t('api.user_password_placeholder') %>
 
 {"access_token":"1d6c95446cab947224286b7bec4382d898c664c7a3cafb16d3d110a3044cf4dc","token_type":"bearer","expires_in":7200,"created_at":1430788134}
 </code></pre>

--- a/WcaOnRails/app/views/api/v0/api/help.html.erb
+++ b/WcaOnRails/app/views/api/v0/api/help.html.erb
@@ -8,9 +8,19 @@
     Go to <%= link_to oauth_applications_path, oauth_applications_path %> to
     manage your OAuth applications.
   </p>
-<pre><code>> curl <%= oauth_token_url %> -X POST -F grant_type=password -F username=software_team -F password=wca
+  <p>
+    Here is an example, using curl, of obtaining an access token using an Application ID, Client Secret, your WCA email, and your password:
+  </p>
+<pre><code>curl <%= oauth_token_url %> -X POST -F grant_type=password -F client_id=APP_ID -F client_secret=APP_SECRET -F username=YOUR_EMAIL -F password=YOUR_PASSWORD
+
 {"access_token":"1d6c95446cab947224286b7bec4382d898c664c7a3cafb16d3d110a3044cf4dc","token_type":"bearer","expires_in":7200,"created_at":1430788134}
+</code></pre>
+  <p>
+    An OAuth access token can be used, until it expires, to make authorized API requests. For example, to access information about your account:
+  </p>
+<pre><code>
 > curl -H "Authorization: Bearer 1d6c95446cab947224286b7bec4382d898c664c7a3cafb16d3d110a3044cf4dc" <%= api_v0_me_url %>
+
 {"me":{"id":1,"email":"wca@worldcubeassociation.org","created_at":"2015-05-05T00:57:11.788Z","updated_at":"2015-05-05T00:57:12.072Z"}}
 </code></pre>
 

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -2544,8 +2544,6 @@ en:
   api:
     manage_oauth_html: 'Go to %{oauth_link} to manage your OAuth applications.'
     token_request_intro: 'Here is an example, using curl, of obtaining an access token using an Application ID, Client Secret, your WCA email, and your password:'
-    app_id_placeholder: 'APP_ID'
-    app_secret_placeholder: 'APP_SECRET'
     user_email_placeholder: 'YOUR_EMAIL'
     user_password_placeholder: 'YOUR_PASSWORD'
     user_info_request_intro: 'An OAuth access token can be used, until it expires, to make authorized API requests. For example, to access information about your account:'

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -2540,3 +2540,14 @@ en:
   footer:
     privacy: Privacy
     disclaimer: Disclaimer
+  #context: Key used when describing the API
+  api:
+    manage_oauth_html: 'Go to %{oauth_link} to manage your OAuth applications.'
+    token_request_intro: 'Here is an example, using curl, of obtaining an access token using an Application ID, Client Secret, your WCA email, and your password:'
+    app_id_placeholder: 'APP_ID'
+    app_secret_placeholder: 'APP_SECRET'
+    user_email_placeholder: 'YOUR_EMAIL'
+    user_password_placeholder: 'YOUR_PASSWORD'
+    user_info_request_intro: 'An OAuth access token can be used, until it expires, to make authorized API requests. For example, to access information about your account:'
+    legal_tnoodle_api_header: 'Legal TNoodle version'
+


### PR DESCRIPTION
Update the API help page to clarify the need for client_id and client_secret parameters, and that the username should typically be a user's email. I assume the software_team/wca username and password are more useful for members of the WCA admin team who are more likely to already know how to use the API. The aim of this PR is to make the API more accessible to members of the public who are interesting in exploring its capabilities.