### PR TITLE
Update US city validator to include US territories

### DIFF
--- a/WcaOnRails/lib/country_city_validators/us_city_validator.rb
+++ b/WcaOnRails/lib/country_city_validators/us_city_validator.rb
@@ -54,9 +54,17 @@ module CountryCityValidators
     Wyoming
   ).to_set
 
+  US_TERRITORIES = %w(
+    American\ Samoa
+    Guam
+    Northern\ Mariana\ Islands
+    Puerto\ Rico
+    U.S.\ Virgin\ Islands
+  ).to_set
+
   class UsCityValidator < CityCommaRegionValidator
     def initialize
-      super(type_of_region: "state", valid_regions: US_STATES)
+      super(type_of_region: "state", valid_regions: (US_STATES | US_TERRITORIES))
     end
 
     def self.country_iso_2


### PR DESCRIPTION
This should resolve issue #7599 with the city name being in the format "San Juan, Puerto Rico"