### PR TITLE
Add support for non-competing staff.

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -390,8 +390,8 @@ class RegistrationsController < ApplicationController
       registration_attributes = registration_attributes.except(:accepted_at, :accepted_by, :deleted_at, :deleted_by)
     end
     # If a person was previously registered as a non-competing staff, and then later decides to
-    # register for the competition, clear that field.
-    @registration.non_competing_staff = false
+    # register for the competition, switch their registration status to competing.
+    @registration.is_competing = true
     if current_user.can_edit_registration?(@registration) && @registration.update(registration_attributes)
       if !was_accepted && @registration.accepted?
         mailer = RegistrationsMailer.notify_registrant_of_accepted_registration(@registration)

--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -389,6 +389,9 @@ class RegistrationsController < ApplicationController
     if @registration.checked_status == new_status
       registration_attributes = registration_attributes.except(:accepted_at, :accepted_by, :deleted_at, :deleted_by)
     end
+    # If a person was previously registered as a non-competing staff, and then later decides to
+    # register for the competition, clear that field.
+    @registration.non_competing_staff = false
     if current_user.can_edit_registration?(@registration) && @registration.update(registration_attributes)
       if !was_accepted && @registration.accepted?
         mailer = RegistrationsMailer.notify_registrant_of_accepted_registration(@registration)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1751,15 +1751,13 @@ class Competition < ApplicationRecord
       local_assignments = []
       registration = registrations.find { |reg| reg.user_id == wcif_person["wcaUserId"] }
       # If no registration is found, assume that this is a non-competing staff member being added.
-      if !registration
-        registration = registrations.create(
-          competition: self,
-          user_id: wcif_person["wcaUserId"],
-          created_at: DateTime,
-          updated_at: DateTime,
-          non_competing_staff: true,
-        )
-      end
+      registration ||= registrations.create(
+        competition: self,
+        user_id: wcif_person["wcaUserId"],
+        created_at: DateTime,
+        updated_at: DateTime,
+        non_competing_staff: true,
+      )
       # NOTE: person doesn't necessarily have corresponding registration (e.g. registratinless organizer/delegate).
       if wcif_person["roles"]
         roles = wcif_person["roles"] - ["delegate", "trainee-delegate", "organizer"] # These three are added on the fly.

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1756,7 +1756,7 @@ class Competition < ApplicationRecord
         user_id: wcif_person["wcaUserId"],
         created_at: DateTime,
         updated_at: DateTime,
-        non_competing_staff: true,
+        is_competing: false,
       )
       # NOTE: person doesn't necessarily have corresponding registration (e.g. registratinless organizer/delegate).
       if wcif_person["roles"]

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1750,7 +1750,15 @@ class Competition < ApplicationRecord
     wcif_persons.each do |wcif_person|
       local_assignments = []
       registration = registrations.find { |reg| reg.user_id == wcif_person["wcaUserId"] }
-      next unless registration
+      # If no registration is found, assume that this is a non-competing staff member being added.
+      if not registration
+        registration = registrations.create(
+          competition: self,
+          user_id: wcif_person["wcaUserId"],
+          created_at: DateTime.now(),
+          updated_at: DateTime.now(),
+          non_competing_staff: true)
+      end
       # NOTE: person doesn't necessarily have corresponding registration (e.g. registratinless organizer/delegate).
       if wcif_person["roles"]
         roles = wcif_person["roles"] - ["delegate", "trainee-delegate", "organizer"] # These three are added on the fly.

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1751,13 +1751,14 @@ class Competition < ApplicationRecord
       local_assignments = []
       registration = registrations.find { |reg| reg.user_id == wcif_person["wcaUserId"] }
       # If no registration is found, assume that this is a non-competing staff member being added.
-      if not registration
+      if !registration
         registration = registrations.create(
           competition: self,
           user_id: wcif_person["wcaUserId"],
-          created_at: DateTime.now(),
-          updated_at: DateTime.now(),
-          non_competing_staff: true)
+          created_at: DateTime,
+          updated_at: DateTime,
+          non_competing_staff: true,
+        )
       end
       # NOTE: person doesn't necessarily have corresponding registration (e.g. registratinless organizer/delegate).
       if wcif_person["roles"]

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -45,7 +45,7 @@
   <% end %>
 
   <%= form_for @competition, url: competition_registrations_do_actions_for_selected_path(@competition), remote: true do |f| %>
-    <% [:pending, :accepted, :deleted, :non_competing_staff].each do |status| %>
+    <% [:pending, :accepted, :deleted, :non_competing].each do |status| %>
       <% if :pending == status %>
         <h2><%= t 'registrations.list.waiting_list' %></h2>
       <% elsif :accepted == status %>
@@ -53,7 +53,7 @@
       <% elsif :deleted == status %>
         <h2><%= t 'registrations.list.deleted_registrations' %></h2>
       <% else %>
-        <h2><%= t 'registrations.list.non_competing_staff' %></h2>
+        <h2><%= t 'registrations.list.non_competing' %></h2>
       <% end %>
       <% registrations = @registrations.public_send(status) %>
       <%= wca_table table_class: "registrations-table #{status}",

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -45,13 +45,15 @@
   <% end %>
 
   <%= form_for @competition, url: competition_registrations_do_actions_for_selected_path(@competition), remote: true do |f| %>
-    <% [:pending, :accepted, :deleted].each do |status| %>
+    <% [:pending, :accepted, :deleted, :non_competing_staff].each do |status| %>
       <% if :pending == status %>
         <h2><%= t 'registrations.list.waiting_list' %></h2>
       <% elsif :accepted == status %>
         <h2><%= t 'registrations.list.approved_registrations' %></h2>
-      <% else %>
+      <% elsif :deleted == status %>
         <h2><%= t 'registrations.list.deleted_registrations' %></h2>
+      <% else %>
+        <h2><%= t 'registrations.list.non_competing_staff' %></h2>
       <% end %>
       <% registrations = @registrations.public_send(status) %>
       <%= wca_table table_class: "registrations-table #{status}",

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1226,6 +1226,7 @@ en:
       waiting_list: "Waiting List"
       approved_registrations: "Approved registrations"
       deleted_registrations: "Deleted registrations"
+      non_competing_staff: "Non-competing staff"
       not_paid: "Not paid"
       registered:
         without_stripe: "Registered on"

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1226,7 +1226,7 @@ en:
       waiting_list: "Waiting List"
       approved_registrations: "Approved registrations"
       deleted_registrations: "Deleted registrations"
-      non_competing_staff: "Non-competing staff"
+      non_competing: "Non-competing registrations"
       not_paid: "Not paid"
       registered:
         without_stripe: "Registered on"

--- a/WcaOnRails/db/migrate/20221224215047_add_non_competing_staff_to_registration.rb
+++ b/WcaOnRails/db/migrate/20221224215047_add_non_competing_staff_to_registration.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddNonCompetingStaffToRegistration < ActiveRecord::Migration[7.0]
-  def change
-    add_column :registrations, :non_competing_staff, :boolean, default: false
-  end
-end

--- a/WcaOnRails/db/migrate/20221224215047_add_non_competing_staff_to_registration.rb
+++ b/WcaOnRails/db/migrate/20221224215047_add_non_competing_staff_to_registration.rb
@@ -1,0 +1,5 @@
+class AddNonCompetingStaffToRegistration < ActiveRecord::Migration[7.0]
+  def change
+    add_column :registrations, :non_competing_staff, :boolean, default: false
+  end
+end

--- a/WcaOnRails/db/migrate/20221224215047_add_non_competing_staff_to_registration.rb
+++ b/WcaOnRails/db/migrate/20221224215047_add_non_competing_staff_to_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNonCompetingStaffToRegistration < ActiveRecord::Migration[7.0]
   def change
     add_column :registrations, :non_competing_staff, :boolean, default: false

--- a/WcaOnRails/db/migrate/20221224215048_add_is_competing_to_registration.rb
+++ b/WcaOnRails/db/migrate/20221224215048_add_is_competing_to_registration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsCompetingToRegistration < ActiveRecord::Migration[7.0]
+  def change
+    add_column :registrations, :is_competing, :boolean, default: true
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1189,6 +1189,7 @@ CREATE TABLE `registrations` (
   `deleted_at` datetime DEFAULT NULL,
   `deleted_by` int(11) DEFAULT NULL,
   `roles` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `non_competing_staff` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1795,4 +1796,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20221123090104'),
 ('20221123121220'),
 ('20230119115432'),
-('20230204111111');
+('20230204111111'),
+('20221224215047');

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -2,7 +2,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8mb4 */;
+/*!50503 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -11,26 +11,26 @@
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 DROP TABLE IF EXISTS `Competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Competitions` (
   `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `cityName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `information` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `year` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `month` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `day` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `endMonth` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `endDay` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `year` smallint unsigned NOT NULL DEFAULT '0',
+  `month` smallint unsigned NOT NULL DEFAULT '0',
+  `day` smallint unsigned NOT NULL DEFAULT '0',
+  `endMonth` smallint unsigned NOT NULL DEFAULT '0',
+  `endDay` smallint unsigned NOT NULL DEFAULT '0',
   `venue` varchar(240) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `venueAddress` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `venueDetails` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `external_website` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `showAtAll` tinyint(1) NOT NULL DEFAULT '0',
-  `latitude` int(11) DEFAULT NULL,
-  `longitude` int(11) DEFAULT NULL,
+  `latitude` int DEFAULT NULL,
+  `longitude` int DEFAULT NULL,
   `contact` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `registration_open` datetime DEFAULT NULL,
@@ -41,22 +41,22 @@ CREATE TABLE `Competitions` (
   `results_nag_sent_at` datetime DEFAULT NULL,
   `generate_website` tinyint(1) DEFAULT NULL,
   `announced_at` datetime DEFAULT NULL,
-  `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
+  `base_entry_fee_lowest_denomination` int DEFAULT NULL,
   `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
-  `endYear` smallint(6) NOT NULL DEFAULT '0',
+  `endYear` smallint NOT NULL DEFAULT '0',
   `connected_stripe_account_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
   `competitor_limit_enabled` tinyint(1) DEFAULT NULL,
-  `competitor_limit` int(11) DEFAULT NULL,
+  `competitor_limit` int DEFAULT NULL,
   `competitor_limit_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `extra_registration_requirements` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `on_the_spot_registration` tinyint(1) DEFAULT NULL,
-  `on_the_spot_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
-  `refund_policy_percent` int(11) DEFAULT NULL,
+  `on_the_spot_entry_fee_lowest_denomination` int DEFAULT NULL,
+  `refund_policy_percent` int DEFAULT NULL,
   `refund_policy_limit_date` datetime DEFAULT NULL,
-  `guests_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
+  `guests_entry_fee_lowest_denomination` int DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `results_submitted_at` datetime DEFAULT NULL,
@@ -70,21 +70,21 @@ CREATE TABLE `Competitions` (
   `event_restrictions` tinyint(1) DEFAULT NULL,
   `event_restrictions_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `registration_reminder_sent_at` datetime DEFAULT NULL,
-  `announced_by` int(11) DEFAULT NULL,
-  `results_posted_by` int(11) DEFAULT NULL,
+  `announced_by` int DEFAULT NULL,
+  `results_posted_by` int DEFAULT NULL,
   `main_event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cancelled_at` datetime DEFAULT NULL,
-  `cancelled_by` int(11) DEFAULT NULL,
+  `cancelled_by` int DEFAULT NULL,
   `waiting_list_deadline_date` datetime DEFAULT NULL,
   `event_change_deadline_date` datetime DEFAULT NULL,
   `guest_entry_status` int NOT NULL DEFAULT '0',
   `allow_registration_edits` tinyint(1) NOT NULL DEFAULT '0',
   `allow_registration_self_delete_after_acceptance` tinyint(1) NOT NULL DEFAULT '0',
-  `competition_series_id` int(11) DEFAULT NULL,
+  `competition_series_id` int DEFAULT NULL,
   `use_wca_live_for_scoretaking` tinyint(1) NOT NULL DEFAULT '0',
   `allow_registration_without_qualification` tinyint(1) DEFAULT '0',
-  `guests_per_registration_limit` int(11) DEFAULT NULL,
-  `events_per_registration_limit` int(11) DEFAULT NULL,
+  `guests_per_registration_limit` int DEFAULT NULL,
+  `events_per_registration_limit` int DEFAULT NULL,
   `force_comment_in_registration` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
@@ -96,9 +96,9 @@ CREATE TABLE `Competitions` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `CompetitionsMedia`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `CompetitionsMedia` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `type` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `text` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -110,56 +110,56 @@ CREATE TABLE `CompetitionsMedia` (
   `timestampDecided` timestamp NULL DEFAULT NULL,
   `status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11866 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ConciseAverageResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ConciseAverageResults` (
-  `id` int(11) NOT NULL DEFAULT '0',
-  `average` int(11) NOT NULL DEFAULT '0',
-  `valueAndId` bigint(22) DEFAULT NULL,
+  `id` int NOT NULL DEFAULT '0',
+  `average` int NOT NULL DEFAULT '0',
+  `valueAndId` bigint DEFAULT NULL,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `year` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `month` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `day` smallint(5) unsigned NOT NULL DEFAULT '0'
+  `year` smallint unsigned NOT NULL DEFAULT '0',
+  `month` smallint unsigned NOT NULL DEFAULT '0',
+  `day` smallint unsigned NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ConciseSingleResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ConciseSingleResults` (
-  `id` int(11) NOT NULL DEFAULT '0',
-  `best` int(11) NOT NULL DEFAULT '0',
-  `valueAndId` bigint(22) DEFAULT NULL,
+  `id` int NOT NULL DEFAULT '0',
+  `best` int NOT NULL DEFAULT '0',
+  `valueAndId` bigint DEFAULT NULL,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `year` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `month` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `day` smallint(5) unsigned NOT NULL DEFAULT '0'
+  `year` smallint unsigned NOT NULL DEFAULT '0',
+  `month` smallint unsigned NOT NULL DEFAULT '0',
+  `day` smallint unsigned NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Continents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Continents` (
   `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `recordName` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `latitude` int(11) NOT NULL DEFAULT '0',
-  `longitude` int(11) NOT NULL DEFAULT '0',
-  `zoom` tinyint(4) NOT NULL DEFAULT '0',
+  `latitude` int NOT NULL DEFAULT '0',
+  `longitude` int NOT NULL DEFAULT '0',
+  `zoom` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Countries`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Countries` (
   `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -172,11 +172,11 @@ CREATE TABLE `Countries` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Events` (
   `id` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(54) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `rank` int(11) NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   `format` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
@@ -184,21 +184,21 @@ CREATE TABLE `Events` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Formats` (
   `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sort_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `sort_by_second` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `expected_solve_count` int(11) NOT NULL,
-  `trim_fastest_n` int(11) NOT NULL,
-  `trim_slowest_n` int(11) NOT NULL,
+  `expected_solve_count` int NOT NULL,
+  `trim_fastest_n` int NOT NULL,
+  `trim_slowest_n` int NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `InboxPersons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `InboxPersons` (
   `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `wcaId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -215,22 +215,22 @@ CREATE TABLE `InboxPersons` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `InboxResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `InboxResults` (
   `personId` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `pos` smallint(6) NOT NULL DEFAULT '0',
+  `pos` smallint NOT NULL DEFAULT '0',
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `value1` int(11) NOT NULL DEFAULT '0',
-  `value2` int(11) NOT NULL DEFAULT '0',
-  `value3` int(11) NOT NULL DEFAULT '0',
-  `value4` int(11) NOT NULL DEFAULT '0',
-  `value5` int(11) NOT NULL DEFAULT '0',
-  `best` int(11) NOT NULL DEFAULT '0',
-  `average` int(11) NOT NULL DEFAULT '0',
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `value1` int NOT NULL DEFAULT '0',
+  `value2` int NOT NULL DEFAULT '0',
+  `value3` int NOT NULL DEFAULT '0',
+  `value4` int NOT NULL DEFAULT '0',
+  `value5` int NOT NULL DEFAULT '0',
+  `best` int NOT NULL DEFAULT '0',
+  `average` int NOT NULL DEFAULT '0',
+  `id` bigint NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`),
   KEY `InboxResults_fk_tournament` (`competitionId`),
   KEY `InboxResults_fk_event` (`eventId`),
@@ -240,65 +240,65 @@ CREATE TABLE `InboxResults` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Persons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Persons` (
   `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `subId` tinyint(6) NOT NULL DEFAULT '1',
+  `subId` tinyint NOT NULL DEFAULT '1',
   `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
-  `year` smallint(6) NOT NULL DEFAULT '0',
-  `month` tinyint(4) NOT NULL DEFAULT '0',
-  `day` tinyint(4) NOT NULL DEFAULT '0',
+  `year` smallint NOT NULL DEFAULT '0',
+  `month` tinyint NOT NULL DEFAULT '0',
+  `day` tinyint NOT NULL DEFAULT '0',
   `comments` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `rails_id` int(11) NOT NULL AUTO_INCREMENT,
-  `incorrect_wca_id_claim_count` int(11) NOT NULL DEFAULT '0',
+  `rails_id` int NOT NULL AUTO_INCREMENT,
+  `incorrect_wca_id_claim_count` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`rails_id`),
   UNIQUE KEY `index_Persons_on_id_and_subId` (`id`,`subId`),
   KEY `Persons_fk_country` (`countryId`),
   KEY `Persons_id` (`id`),
   KEY `Persons_name` (`name`),
   FULLTEXT KEY `index_Persons_on_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=183889 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksAverage`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `RanksAverage` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `best` int(11) NOT NULL DEFAULT '0',
-  `worldRank` int(11) NOT NULL DEFAULT '0',
-  `continentRank` int(11) NOT NULL DEFAULT '0',
-  `countryRank` int(11) NOT NULL DEFAULT '0',
+  `best` int NOT NULL DEFAULT '0',
+  `worldRank` int NOT NULL DEFAULT '0',
+  `continentRank` int NOT NULL DEFAULT '0',
+  `countryRank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=764698935 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksSingle`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `RanksSingle` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `best` int(11) NOT NULL DEFAULT '0',
-  `worldRank` int(11) NOT NULL DEFAULT '0',
-  `continentRank` int(11) NOT NULL DEFAULT '0',
-  `countryRank` int(11) NOT NULL DEFAULT '0',
+  `best` int NOT NULL DEFAULT '0',
+  `worldRank` int NOT NULL DEFAULT '0',
+  `continentRank` int NOT NULL DEFAULT '0',
+  `countryRank` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=898055726 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Results`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Results` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `pos` smallint(6) NOT NULL DEFAULT '0',
+  `id` int NOT NULL AUTO_INCREMENT,
+  `pos` smallint NOT NULL DEFAULT '0',
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `personName` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -306,13 +306,13 @@ CREATE TABLE `Results` (
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `value1` int(11) NOT NULL DEFAULT '0',
-  `value2` int(11) NOT NULL DEFAULT '0',
-  `value3` int(11) NOT NULL DEFAULT '0',
-  `value4` int(11) NOT NULL DEFAULT '0',
-  `value5` int(11) NOT NULL DEFAULT '0',
-  `best` int(11) NOT NULL DEFAULT '0',
-  `average` int(11) NOT NULL DEFAULT '0',
+  `value1` int NOT NULL DEFAULT '0',
+  `value2` int NOT NULL DEFAULT '0',
+  `value3` int NOT NULL DEFAULT '0',
+  `value4` int NOT NULL DEFAULT '0',
+  `value5` int NOT NULL DEFAULT '0',
+  `best` int NOT NULL DEFAULT '0',
+  `average` int NOT NULL DEFAULT '0',
   `regionalSingleRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `regionalAverageRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -335,14 +335,14 @@ CREATE TABLE `Results` (
   KEY `index_Results_on_eventId_and_value5` (`eventId`,`value5`),
   KEY `index_Results_on_regionalSingleRecord_and_eventId` (`regionalSingleRecord`,`eventId`),
   KEY `index_Results_on_regionalAverageRecord_and_eventId` (`regionalAverageRecord`,`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB AUTO_INCREMENT=4618749 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RoundTypes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `RoundTypes` (
   `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `rank` int(11) NOT NULL DEFAULT '0',
+  `rank` int NOT NULL DEFAULT '0',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `final` tinyint(1) NOT NULL,
@@ -351,29 +351,29 @@ CREATE TABLE `RoundTypes` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Scrambles`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `Scrambles` (
-  `scrambleId` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `scrambleId` int unsigned NOT NULL AUTO_INCREMENT,
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `groupId` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `isExtra` tinyint(1) NOT NULL,
-  `scrambleNum` int(11) NOT NULL,
+  `scrambleNum` int NOT NULL,
   `scramble` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`scrambleId`),
   KEY `competitionId` (`competitionId`,`eventId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2464231 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_attachments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `active_storage_attachments` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `record_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `record_id` bigint(20) NOT NULL,
-  `blob_id` bigint(20) NOT NULL,
+  `record_id` bigint NOT NULL,
+  `blob_id` bigint NOT NULL,
   `created_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_attachments_uniqueness` (`record_type`,`record_id`,`name`,`blob_id`),
@@ -383,27 +383,27 @@ CREATE TABLE `active_storage_attachments` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_blobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `active_storage_blobs` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `key` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `filename` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `content_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `byte_size` bigint(20) NOT NULL,
+  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `byte_size` bigint NOT NULL,
   `checksum` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
-  `service_name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `service_name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_blobs_on_key` (`key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_variant_records`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `active_storage_variant_records` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `blob_id` bigint(20) NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `blob_id` bigint NOT NULL,
   `variation_digest` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_variant_records_uniqueness` (`blob_id`,`variation_digest`),
@@ -412,9 +412,9 @@ CREATE TABLE `active_storage_variant_records` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ar_internal_metadata` (
-  `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `key` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
   `value` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -423,95 +423,95 @@ CREATE TABLE `ar_internal_metadata` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_forums`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `archive_phpbb3_forums` (
-  `forum_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `left_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `right_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_parents` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_desc` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_desc_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT '7',
-  `forum_desc_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_image` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `forum_rules_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT '7',
-  `forum_rules_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_topics_per_page` tinyint(4) NOT NULL DEFAULT '0',
-  `forum_type` tinyint(4) NOT NULL DEFAULT '0',
-  `forum_status` tinyint(4) NOT NULL DEFAULT '0',
-  `forum_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `forum_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `forum_flags` tinyint(4) NOT NULL DEFAULT '32',
-  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `prune_next` int(11) unsigned NOT NULL DEFAULT '0',
-  `prune_days` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `forum_options` int(20) unsigned NOT NULL DEFAULT '0',
-  `forum_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_topics_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_topics_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_topics_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `enable_shadow_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `prune_shadow_days` mediumint(8) unsigned NOT NULL DEFAULT '7',
-  `prune_shadow_freq` mediumint(8) unsigned NOT NULL DEFAULT '1',
-  `prune_shadow_next` int(11) NOT NULL DEFAULT '0',
+  `forum_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `left_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `right_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_parents` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+  `forum_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_desc` text CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+  `forum_desc_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_desc_options` int unsigned NOT NULL DEFAULT '7',
+  `forum_desc_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_link` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_style` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_image` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_rules` text CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+  `forum_rules_link` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_rules_options` int unsigned NOT NULL DEFAULT '7',
+  `forum_rules_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_topics_per_page` tinyint NOT NULL DEFAULT '0',
+  `forum_type` tinyint NOT NULL DEFAULT '0',
+  `forum_status` tinyint NOT NULL DEFAULT '0',
+  `forum_last_post_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_last_poster_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_last_post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_last_post_time` int unsigned NOT NULL DEFAULT '0',
+  `forum_last_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `forum_flags` tinyint NOT NULL DEFAULT '32',
+  `display_on_index` tinyint unsigned NOT NULL DEFAULT '1',
+  `enable_indexing` tinyint unsigned NOT NULL DEFAULT '1',
+  `enable_icons` tinyint unsigned NOT NULL DEFAULT '1',
+  `enable_prune` tinyint unsigned NOT NULL DEFAULT '0',
+  `prune_next` int unsigned NOT NULL DEFAULT '0',
+  `prune_days` mediumint unsigned NOT NULL DEFAULT '0',
+  `prune_viewed` mediumint unsigned NOT NULL DEFAULT '0',
+  `prune_freq` mediumint unsigned NOT NULL DEFAULT '0',
+  `display_subforum_list` tinyint unsigned NOT NULL DEFAULT '1',
+  `forum_options` int unsigned NOT NULL DEFAULT '0',
+  `forum_posts_approved` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_posts_unapproved` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_posts_softdeleted` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_topics_approved` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_topics_unapproved` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_topics_softdeleted` mediumint unsigned NOT NULL DEFAULT '0',
+  `enable_shadow_prune` tinyint unsigned NOT NULL DEFAULT '0',
+  `prune_shadow_days` mediumint unsigned NOT NULL DEFAULT '7',
+  `prune_shadow_freq` mediumint unsigned NOT NULL DEFAULT '1',
+  `prune_shadow_next` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`forum_id`),
   KEY `left_right_id` (`left_id`,`right_id`),
   KEY `forum_lastpost_id` (`forum_last_post_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_posts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `archive_phpbb3_posts` (
-  `post_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poster_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `post_username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `post_text` mediumtext CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `post_checksum` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `post_edit_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_edit_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_edit_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `post_visibility` tinyint(3) NOT NULL DEFAULT '0',
-  `post_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `post_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `post_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `post_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `forum_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `poster_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `icon_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `poster_ip` varchar(40) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `post_time` int unsigned NOT NULL DEFAULT '0',
+  `post_reported` tinyint unsigned NOT NULL DEFAULT '0',
+  `enable_bbcode` tinyint unsigned NOT NULL DEFAULT '1',
+  `enable_smilies` tinyint unsigned NOT NULL DEFAULT '1',
+  `enable_magic_url` tinyint unsigned NOT NULL DEFAULT '1',
+  `enable_sig` tinyint unsigned NOT NULL DEFAULT '1',
+  `post_username` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `post_text` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  `post_checksum` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `post_attachment` tinyint unsigned NOT NULL DEFAULT '0',
+  `bbcode_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `post_postcount` tinyint unsigned NOT NULL DEFAULT '1',
+  `post_edit_time` int unsigned NOT NULL DEFAULT '0',
+  `post_edit_reason` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `post_edit_user` mediumint unsigned NOT NULL DEFAULT '0',
+  `post_edit_count` smallint unsigned NOT NULL DEFAULT '0',
+  `post_edit_locked` tinyint unsigned NOT NULL DEFAULT '0',
+  `post_visibility` tinyint NOT NULL DEFAULT '0',
+  `post_delete_time` int unsigned NOT NULL DEFAULT '0',
+  `post_delete_reason` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `post_delete_user` mediumint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`post_id`),
   KEY `forum_id` (`forum_id`),
   KEY `topic_id` (`topic_id`),
@@ -522,51 +522,51 @@ CREATE TABLE `archive_phpbb3_posts` (
   KEY `post_visibility` (`post_visibility`),
   FULLTEXT KEY `post_subject` (`post_subject`),
   FULLTEXT KEY `post_content` (`post_text`,`post_subject`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_topics`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `archive_phpbb3_topics` (
-  `topic_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `topic_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `topic_poster` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_views` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_status` tinyint(3) NOT NULL DEFAULT '0',
-  `topic_type` tinyint(3) NOT NULL DEFAULT '0',
-  `topic_first_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_first_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
-  `topic_first_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_moved_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `poll_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `poll_start` int(11) unsigned NOT NULL DEFAULT '0',
-  `poll_length` int(11) unsigned NOT NULL DEFAULT '0',
-  `poll_max_options` tinyint(4) NOT NULL DEFAULT '1',
-  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT '0',
-  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `topic_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `forum_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `icon_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_attachment` tinyint unsigned NOT NULL DEFAULT '0',
+  `topic_reported` tinyint unsigned NOT NULL DEFAULT '0',
+  `topic_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_poster` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_time` int unsigned NOT NULL DEFAULT '0',
+  `topic_time_limit` int unsigned NOT NULL DEFAULT '0',
+  `topic_views` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_status` tinyint NOT NULL DEFAULT '0',
+  `topic_type` tinyint NOT NULL DEFAULT '0',
+  `topic_first_post_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_first_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `topic_last_post_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_last_poster_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_last_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `topic_last_post_time` int unsigned NOT NULL DEFAULT '0',
+  `topic_last_view_time` int unsigned NOT NULL DEFAULT '0',
+  `topic_moved_id` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_bumped` tinyint unsigned NOT NULL DEFAULT '0',
+  `topic_bumper` mediumint unsigned NOT NULL DEFAULT '0',
+  `poll_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `poll_start` int unsigned NOT NULL DEFAULT '0',
+  `poll_length` int unsigned NOT NULL DEFAULT '0',
+  `poll_max_options` tinyint NOT NULL DEFAULT '1',
+  `poll_last_vote` int unsigned NOT NULL DEFAULT '0',
+  `poll_vote_change` tinyint unsigned NOT NULL DEFAULT '0',
   `poll_vote_name` tinyint(1) NOT NULL DEFAULT '0',
-  `topic_visibility` tinyint(3) NOT NULL DEFAULT '0',
-  `topic_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `topic_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `topic_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `topic_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_visibility` tinyint NOT NULL DEFAULT '0',
+  `topic_delete_time` int unsigned NOT NULL DEFAULT '0',
+  `topic_delete_reason` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `topic_delete_user` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_posts_approved` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_posts_unapproved` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_posts_softdeleted` mediumint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`topic_id`),
   KEY `forum_id` (`forum_id`),
   KEY `forum_id_type` (`forum_id`,`topic_type`),
@@ -574,106 +574,106 @@ CREATE TABLE `archive_phpbb3_topics` (
   KEY `fid_time_moved` (`forum_id`,`topic_last_post_time`,`topic_moved_id`),
   KEY `topic_visibility` (`topic_visibility`),
   KEY `forum_vis_last` (`forum_id`,`topic_visibility`,`topic_last_post_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `archive_phpbb3_users` (
-  `user_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
-  `user_type` tinyint(2) NOT NULL DEFAULT '0',
-  `group_id` mediumint(8) unsigned NOT NULL DEFAULT '3',
-  `user_permissions` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_regdate` int(11) unsigned NOT NULL DEFAULT '0',
-  `username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `username_clean` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_passchg` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_email` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_email_hash` bigint(20) NOT NULL DEFAULT '0',
-  `user_birthday` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_lastmark` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_lastpage` varchar(200) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_last_confirm_key` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_last_search` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_warnings` tinyint(4) NOT NULL DEFAULT '0',
-  `user_last_warning` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_login_attempts` tinyint(4) NOT NULL DEFAULT '0',
-  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT '0',
-  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_posts` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_lang` varchar(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_timezone` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_dateformat` varchar(64) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
-  `user_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_rank` mediumint(8) unsigned NOT NULL DEFAULT '0',
-  `user_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_new_privmsg` int(4) NOT NULL DEFAULT '0',
-  `user_unread_privmsg` int(4) NOT NULL DEFAULT '0',
-  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `user_full_folder` int(11) NOT NULL DEFAULT '-3',
-  `user_emailtime` int(11) unsigned NOT NULL DEFAULT '0',
-  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_topic_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_topic_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd',
-  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_post_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
-  `user_post_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'a',
-  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT '0',
-  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_notify_type` tinyint(4) NOT NULL DEFAULT '0',
-  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_options` int(11) unsigned NOT NULL DEFAULT '230271',
-  `user_avatar` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_avatar_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT '0',
-  `user_sig` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
-  `user_sig_bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_sig_bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_jabber` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_actkey` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_newpasswd` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_form_salt` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
-  `user_new` tinyint(1) unsigned NOT NULL DEFAULT '1',
-  `user_reminded` tinyint(4) NOT NULL DEFAULT '0',
-  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
+  `user_type` tinyint NOT NULL DEFAULT '0',
+  `group_id` mediumint unsigned NOT NULL DEFAULT '3',
+  `user_permissions` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+  `user_perm_from` mediumint unsigned NOT NULL DEFAULT '0',
+  `user_ip` varchar(40) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_regdate` int unsigned NOT NULL DEFAULT '0',
+  `username` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `username_clean` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_passchg` int unsigned NOT NULL DEFAULT '0',
+  `user_email` varchar(100) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_email_hash` bigint NOT NULL DEFAULT '0',
+  `user_birthday` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_lastvisit` int unsigned NOT NULL DEFAULT '0',
+  `user_lastmark` int unsigned NOT NULL DEFAULT '0',
+  `user_lastpost_time` int unsigned NOT NULL DEFAULT '0',
+  `user_lastpage` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_last_search` int unsigned NOT NULL DEFAULT '0',
+  `user_warnings` tinyint NOT NULL DEFAULT '0',
+  `user_last_warning` int unsigned NOT NULL DEFAULT '0',
+  `user_login_attempts` tinyint NOT NULL DEFAULT '0',
+  `user_inactive_reason` tinyint NOT NULL DEFAULT '0',
+  `user_inactive_time` int unsigned NOT NULL DEFAULT '0',
+  `user_posts` mediumint unsigned NOT NULL DEFAULT '0',
+  `user_lang` varchar(30) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 'd M Y H:i',
+  `user_style` mediumint unsigned NOT NULL DEFAULT '0',
+  `user_rank` mediumint unsigned NOT NULL DEFAULT '0',
+  `user_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_new_privmsg` int NOT NULL DEFAULT '0',
+  `user_unread_privmsg` int NOT NULL DEFAULT '0',
+  `user_last_privmsg` int unsigned NOT NULL DEFAULT '0',
+  `user_message_rules` tinyint unsigned NOT NULL DEFAULT '0',
+  `user_full_folder` int NOT NULL DEFAULT '-3',
+  `user_emailtime` int unsigned NOT NULL DEFAULT '0',
+  `user_topic_show_days` smallint unsigned NOT NULL DEFAULT '0',
+  `user_topic_sortby_type` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint unsigned NOT NULL DEFAULT '0',
+  `user_post_sortby_type` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 'a',
+  `user_notify` tinyint unsigned NOT NULL DEFAULT '0',
+  `user_notify_pm` tinyint unsigned NOT NULL DEFAULT '1',
+  `user_notify_type` tinyint NOT NULL DEFAULT '0',
+  `user_allow_pm` tinyint unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewonline` tinyint unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewemail` tinyint unsigned NOT NULL DEFAULT '1',
+  `user_allow_massemail` tinyint unsigned NOT NULL DEFAULT '1',
+  `user_options` int unsigned NOT NULL DEFAULT '230271',
+  `user_avatar` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_avatar_width` smallint unsigned NOT NULL DEFAULT '0',
+  `user_avatar_height` smallint unsigned NOT NULL DEFAULT '0',
+  `user_sig` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+  `user_new` tinyint unsigned NOT NULL DEFAULT '1',
+  `user_reminded` tinyint NOT NULL DEFAULT '0',
+  `user_reminded_time` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username_clean` (`username_clean`),
   KEY `user_birthday` (`user_birthday`),
   KEY `user_email_hash` (`user_email_hash`),
   KEY `user_type` (`user_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_registrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `archive_registrations` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `birthYear` smallint(6) unsigned NOT NULL DEFAULT '0',
-  `birthMonth` tinyint(4) unsigned NOT NULL DEFAULT '0',
-  `birthDay` tinyint(4) unsigned NOT NULL DEFAULT '0',
+  `birthYear` smallint unsigned NOT NULL DEFAULT '0',
+  `birthMonth` tinyint unsigned NOT NULL DEFAULT '0',
+  `birthDay` tinyint unsigned NOT NULL DEFAULT '0',
   `email` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `guests_old` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `user_id` int(11) DEFAULT NULL,
+  `user_id` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `guests` int(11) NOT NULL DEFAULT '0',
+  `guests` int NOT NULL DEFAULT '0',
   `accepted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competitionId_and_user_id` (`competitionId`,`user_id`)
@@ -681,35 +681,35 @@ CREATE TABLE `archive_registrations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `assignments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `assignments` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `registration_id` bigint(20) DEFAULT NULL,
-  `schedule_activity_id` bigint(20) DEFAULT NULL,
-  `station_number` int(11) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `registration_id` bigint DEFAULT NULL,
+  `schedule_activity_id` bigint DEFAULT NULL,
+  `station_number` int DEFAULT NULL,
   `assignment_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_assignments_on_registration_id` (`registration_id`),
   KEY `index_assignments_on_schedule_activity_id` (`schedule_activity_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4025401 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `bookmarked_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `bookmarked_competitions` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `user_id` int(11) NOT NULL,
+  `user_id` int NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_bookmarked_competitions_on_competition_id` (`competition_id`),
   KEY `index_bookmarked_competitions_on_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=85297 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `cached_results`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cached_results` (
-  `key_params` varchar(191) NOT NULL,
+  `key_params` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `payload` json DEFAULT NULL,
   `created_at` datetime(6) NOT NULL,
   `updated_at` datetime(6) NOT NULL,
@@ -718,23 +718,23 @@ CREATE TABLE `cached_results` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `championships`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `championships` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_championships_on_competition_id_and_championship_type` (`competition_id`,`championship_type`),
   KEY `index_championships_on_championship_type` (`championship_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=617 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_delegates`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `competition_delegates` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `delegate_id` int(11) DEFAULT NULL,
+  `delegate_id` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
@@ -742,29 +742,29 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=19371 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `competition_events` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
+  `fee_lowest_denomination` int NOT NULL DEFAULT '0',
   `qualification` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=91298 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_organizers`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `competition_organizers` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `organizer_id` int(11) DEFAULT NULL,
+  `organizer_id` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
@@ -772,44 +772,44 @@ CREATE TABLE `competition_organizers` (
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=20945 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_series`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `competition_series` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `wcif_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `short_name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=68 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_tabs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `competition_tabs` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `display_order` int(11) DEFAULT NULL,
+  `display_order` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_tabs_on_display_order_and_competition_id` (`display_order`,`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=25828 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_venues`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `competition_venues` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wcif_id` int(11) NOT NULL,
+  `wcif_id` int NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `latitude_microdegrees` int(11) NOT NULL,
-  `longitude_microdegrees` int(11) NOT NULL,
+  `latitude_microdegrees` int NOT NULL,
+  `longitude_microdegrees` int NOT NULL,
   `timezone_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -817,15 +817,15 @@ CREATE TABLE `competition_venues` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_venues_on_competition_id_and_wcif_id` (`competition_id`,`wcif_id`),
   KEY `index_competition_venues_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=4828 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `completed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `completed_jobs` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `attempts` int(11) NOT NULL DEFAULT '0',
+  `id` int NOT NULL AUTO_INCREMENT,
+  `priority` int NOT NULL DEFAULT '0',
+  `attempts` int NOT NULL DEFAULT '0',
   `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -837,23 +837,23 @@ CREATE TABLE `completed_jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `country_bands`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `country_bands` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `number` int(11) NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `number` int NOT NULL,
   `iso2` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_country_bands_on_iso2` (`iso2`),
   KEY `index_country_bands_on_number` (`number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=123 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delayed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `delayed_jobs` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `priority` int(11) NOT NULL DEFAULT '0',
-  `attempts` int(11) NOT NULL DEFAULT '0',
+  `id` int NOT NULL AUTO_INCREMENT,
+  `priority` int NOT NULL DEFAULT '0',
+  `attempts` int NOT NULL DEFAULT '0',
   `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
@@ -869,9 +869,9 @@ CREATE TABLE `delayed_jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delegate_reports`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `delegate_reports` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `equipment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `venue` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
@@ -880,7 +880,7 @@ CREATE TABLE `delegate_reports` (
   `incidents` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `discussion_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `posted_by_user_id` int(11) DEFAULT NULL,
+  `posted_by_user_id` int DEFAULT NULL,
   `posted_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -889,55 +889,55 @@ CREATE TABLE `delegate_reports` (
   `wrc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wdc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
   `wdc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `wrc_primary_user_id` int(11) DEFAULT NULL,
-  `wrc_secondary_user_id` int(11) DEFAULT NULL,
+  `wrc_primary_user_id` int DEFAULT NULL,
+  `wrc_secondary_user_id` int DEFAULT NULL,
   `reminder_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=10542 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `eligible_country_iso2s_for_championship`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eligible_country_iso2s_for_championship` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `eligible_country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_eligible_iso2s_for_championship_on_type_and_country_iso2` (`championship_type`,`eligible_country_iso2`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `incident_competitions` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `incident_id` bigint(20) NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `incident_id` bigint NOT NULL,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `comments` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_competitions_on_incident_id_and_competition_id` (`incident_id`,`competition_id`),
   KEY `index_incident_competitions_on_incident_id` (`incident_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=132 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `incident_tags` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `incident_id` bigint(20) NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `incident_id` bigint NOT NULL,
   `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_tags_on_incident_id_and_tag` (`incident_id`,`tag`),
   KEY `index_incident_tags_on_incident_id` (`incident_id`),
   KEY `index_incident_tags_on_tag` (`tag`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=154 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incidents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `incidents` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `title` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `private_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `private_wrc_decision` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
@@ -948,11 +948,11 @@ CREATE TABLE `incidents` (
   `digest_worthy` tinyint(1) DEFAULT '0',
   `digest_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=81 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `linkings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `linkings` (
   `wca_id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `wca_ids` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -961,13 +961,13 @@ CREATE TABLE `linkings` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `locations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `locations` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) NOT NULL,
-  `latitude_microdegrees` int(11) DEFAULT NULL,
-  `longitude_microdegrees` int(11) DEFAULT NULL,
-  `notification_radius_km` int(11) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `latitude_microdegrees` int DEFAULT NULL,
+  `longitude_microdegrees` int DEFAULT NULL,
+  `notification_radius_km` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
@@ -975,31 +975,31 @@ CREATE TABLE `locations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_grants`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oauth_access_grants` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `resource_owner_id` int(11) NOT NULL,
-  `application_id` int(11) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `resource_owner_id` int NOT NULL,
+  `application_id` int NOT NULL,
   `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `expires_in` int(11) NOT NULL,
+  `expires_in` int NOT NULL,
   `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_grants_on_token` (`token`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_tokens`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oauth_access_tokens` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `resource_owner_id` int(11) DEFAULT NULL,
-  `application_id` int(11) DEFAULT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `resource_owner_id` int DEFAULT NULL,
+  `application_id` int DEFAULT NULL,
   `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `refresh_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `expires_in` int(11) DEFAULT NULL,
+  `expires_in` int DEFAULT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1007,13 +1007,13 @@ CREATE TABLE `oauth_access_tokens` (
   UNIQUE KEY `index_oauth_access_tokens_on_token` (`token`),
   UNIQUE KEY `index_oauth_access_tokens_on_refresh_token` (`refresh_token`),
   KEY `index_oauth_access_tokens_on_resource_owner_id` (`resource_owner_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=303 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_applications`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `oauth_applications` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `uid` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1021,31 +1021,31 @@ CREATE TABLE `oauth_applications` (
   `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `owner_id` int(11) DEFAULT NULL,
+  `owner_id` int DEFAULT NULL,
   `owner_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `dangerously_allow_any_redirect_uri` tinyint(1) NOT NULL DEFAULT '0',
   `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `poll_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `poll_options` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `description` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `poll_id` int(11) NOT NULL,
+  `poll_id` int NOT NULL,
   PRIMARY KEY (`id`),
   KEY `poll_id` (`poll_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `polls`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `polls` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `question` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `multiple` tinyint(1) NOT NULL,
   `deadline` datetime NOT NULL,
@@ -1058,27 +1058,27 @@ CREATE TABLE `polls` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `post_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `post_tags` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `post_id` int(11) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `post_id` int NOT NULL,
   `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_post_tags_on_post_id_and_tag` (`post_id`,`tag`),
   KEY `index_post_tags_on_post_id` (`post_id`),
   KEY `index_post_tags_on_tag` (`tag`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=22433 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `posts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `posts` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `slug` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sticky` tinyint(1) NOT NULL DEFAULT '0',
-  `author_id` int(11) DEFAULT NULL,
+  `author_id` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `show_on_homepage` tinyint(1) NOT NULL DEFAULT '1',
@@ -1088,15 +1088,15 @@ CREATE TABLE `posts` (
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`sticky`,`created_at`),
   KEY `index_posts_on_world_readable_and_created_at` (`created_at`),
   KEY `idx_show_wr_sticky_created_at` (`show_on_homepage`,`sticky`,`created_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14092 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `preferred_formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `preferred_formats` (
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `format_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `ranking` int(11) NOT NULL,
+  `ranking` int NOT NULL,
   UNIQUE KEY `index_preferred_formats_on_event_id_and_format_id` (`event_id`,`format_id`),
   KEY `fk_rails_c3e0098ed3` (`format_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1104,8 +1104,8 @@ CREATE TABLE `preferred_formats` (
 DROP TABLE IF EXISTS `rails_persons`;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 SET @saved_cs_client     = @@character_set_client;
-SET character_set_client = utf8;
-/*!50001 CREATE VIEW `rails_persons` AS SELECT
+/*!50503 SET character_set_client = utf8mb4 */;
+/*!50001 CREATE VIEW `rails_persons` AS SELECT 
  1 AS `id`,
  1 AS `wca_id`,
  1 AS `subId`,
@@ -1120,9 +1120,9 @@ SET character_set_client = utf8;
 SET character_set_client = @saved_cs_client;
 DROP TABLE IF EXISTS `regional_organizations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `regional_organizations` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `country` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `website` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1140,33 +1140,33 @@ CREATE TABLE `regional_organizations` (
   PRIMARY KEY (`id`),
   KEY `index_regional_organizations_on_name` (`name`),
   KEY `index_regional_organizations_on_country` (`country`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=47 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `registration_competition_events` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `registration_id` int(11) DEFAULT NULL,
-  `competition_event_id` int(11) DEFAULT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `registration_id` int DEFAULT NULL,
+  `competition_event_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_registration_competition_events_on_reg_id_and_comp_event_id` (`registration_id`,`competition_event_id`),
   KEY `index_reg_events_reg_id_comp_event_id` (`registration_id`,`competition_event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2962567 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_payments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `registration_payments` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `registration_id` int(11) DEFAULT NULL,
-  `amount_lowest_denomination` int(11) DEFAULT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `registration_id` int DEFAULT NULL,
+  `amount_lowest_denomination` int DEFAULT NULL,
   `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `refunded_registration_payment_id` int(11) DEFAULT NULL,
-  `user_id` int(11) DEFAULT NULL,
+  `refunded_registration_payment_id` int DEFAULT NULL,
+  `user_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_registration_payments_on_stripe_charge_id` (`stripe_charge_id`),
   KEY `idx_reg_payments_on_refunded_registration_payment_id` (`refunded_registration_payment_id`)
@@ -1174,52 +1174,53 @@ CREATE TABLE `registration_payments` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `registrations` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `user_id` int(11) DEFAULT NULL,
+  `user_id` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `guests` int(11) NOT NULL DEFAULT '0',
+  `guests` int NOT NULL DEFAULT '0',
   `accepted_at` datetime DEFAULT NULL,
-  `accepted_by` int(11) DEFAULT NULL,
+  `accepted_by` int DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
-  `deleted_by` int(11) DEFAULT NULL,
+  `deleted_by` int DEFAULT NULL,
   `roles` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `non_competing_staff` tinyint(1) DEFAULT '0',
+  `is_competing` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=612217 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `rounds`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `rounds` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `competition_event_id` int(11) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `competition_event_id` int NOT NULL,
   `format_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `number` int(11) NOT NULL,
+  `number` int NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `time_limit` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `cutoff` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `advancement_condition` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `scramble_set_count` int(11) NOT NULL DEFAULT '1',
+  `scramble_set_count` int NOT NULL DEFAULT '1',
   `round_results` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `total_number_of_rounds` int(11) NOT NULL,
-  `old_type` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `total_number_of_rounds` int NOT NULL,
+  `old_type` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=798685 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_check_categories`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `sanity_check_categories` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_check_categories_on_name` (`name`)
@@ -1227,10 +1228,10 @@ CREATE TABLE `sanity_check_categories` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_check_exclusions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `sanity_check_exclusions` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `sanity_check_id` bigint(20) NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `sanity_check_id` bigint NOT NULL,
   `exclusion` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
@@ -1240,10 +1241,10 @@ CREATE TABLE `sanity_check_exclusions` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_checks`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `sanity_checks` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `sanity_check_category_id` bigint(20) NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `sanity_check_category_id` bigint NOT NULL,
   `topic` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1255,39 +1256,39 @@ CREATE TABLE `sanity_checks` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schedule_activities`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `schedule_activities` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `holder_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `holder_id` bigint(20) NOT NULL,
-  `wcif_id` int(11) NOT NULL,
+  `holder_id` bigint NOT NULL,
+  `wcif_id` int NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `activity_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_time` datetime NOT NULL,
   `end_time` datetime NOT NULL,
-  `scramble_set_id` int(11) DEFAULT NULL,
+  `scramble_set_id` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_activities_on_their_id_within_holder` (`holder_type`,`holder_id`,`wcif_id`),
   KEY `index_schedule_activities_on_holder_type_and_holder_id` (`holder_type`,`holder_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=281582 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `schema_migrations` (
-  `version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `version` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `starburst_announcement_views`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `starburst_announcement_views` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) DEFAULT NULL,
-  `announcement_id` int(11) DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` int DEFAULT NULL,
+  `announcement_id` int DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
@@ -1296,25 +1297,25 @@ CREATE TABLE `starburst_announcement_views` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `starburst_announcements`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `starburst_announcements` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `start_delivering_at` datetime DEFAULT NULL,
   `stop_delivering_at` datetime DEFAULT NULL,
-  `limit_to_users` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `limit_to_users` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `category` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `category` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `stripe_charges`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `stripe_charges` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `status` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1327,11 +1328,11 @@ CREATE TABLE `stripe_charges` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `team_members`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `team_members` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `team_id` int(11) NOT NULL,
-  `user_id` int(11) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `team_id` int NOT NULL,
+  `user_id` int NOT NULL,
   `start_date` date NOT NULL,
   `end_date` date DEFAULT NULL,
   `team_leader` tinyint(1) NOT NULL DEFAULT '0',
@@ -1339,13 +1340,13 @@ CREATE TABLE `team_members` (
   `updated_at` datetime NOT NULL,
   `team_senior_member` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=604 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `teams`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `teams` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `friendly_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1353,11 +1354,11 @@ CREATE TABLE `teams` (
   `hidden` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_teams_on_friendly_id` (`friendly_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `timestamps`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `timestamps` (
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `date` datetime DEFAULT NULL,
@@ -1366,9 +1367,9 @@ CREATE TABLE `timestamps` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `uploaded_jsons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `uploaded_jsons` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `json_str` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
@@ -1377,26 +1378,26 @@ CREATE TABLE `uploaded_jsons` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `user_preferred_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `user_preferred_events` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) DEFAULT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int DEFAULT NULL,
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_user_preferred_events_on_user_id_and_event_id` (`user_id`,`event_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=274288 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `users` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `encrypted_password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `reset_password_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `reset_password_sent_at` datetime DEFAULT NULL,
   `remember_created_at` datetime DEFAULT NULL,
-  `sign_in_count` int(11) NOT NULL DEFAULT '0',
+  `sign_in_count` int NOT NULL DEFAULT '0',
   `current_sign_in_at` datetime DEFAULT NULL,
   `last_sign_in_at` datetime DEFAULT NULL,
   `current_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1409,21 +1410,21 @@ CREATE TABLE `users` (
   `updated_at` datetime DEFAULT NULL,
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_status` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `senior_delegate_id` int(11) DEFAULT NULL,
+  `senior_delegate_id` int DEFAULT NULL,
   `region` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wca_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `pending_avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `saved_avatar_crop_x` int(11) DEFAULT NULL,
-  `saved_avatar_crop_y` int(11) DEFAULT NULL,
-  `saved_avatar_crop_w` int(11) DEFAULT NULL,
-  `saved_avatar_crop_h` int(11) DEFAULT NULL,
-  `saved_pending_avatar_crop_x` int(11) DEFAULT NULL,
-  `saved_pending_avatar_crop_y` int(11) DEFAULT NULL,
-  `saved_pending_avatar_crop_w` int(11) DEFAULT NULL,
-  `saved_pending_avatar_crop_h` int(11) DEFAULT NULL,
+  `saved_avatar_crop_x` int DEFAULT NULL,
+  `saved_avatar_crop_y` int DEFAULT NULL,
+  `saved_avatar_crop_w` int DEFAULT NULL,
+  `saved_avatar_crop_h` int DEFAULT NULL,
+  `saved_pending_avatar_crop_x` int DEFAULT NULL,
+  `saved_pending_avatar_crop_y` int DEFAULT NULL,
+  `saved_pending_avatar_crop_w` int DEFAULT NULL,
+  `saved_pending_avatar_crop_h` int DEFAULT NULL,
   `unconfirmed_wca_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `delegate_id_to_handle_wca_id_claim` int(11) DEFAULT NULL,
+  `delegate_id_to_handle_wca_id_claim` int DEFAULT NULL,
   `dob` date DEFAULT NULL,
   `gender` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `country_iso2` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1435,7 +1436,7 @@ CREATE TABLE `users` (
   `encrypted_otp_secret` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `encrypted_otp_secret_iv` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `encrypted_otp_secret_salt` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `consumed_timestep` int(11) DEFAULT NULL,
+  `consumed_timestep` int DEFAULT NULL,
   `otp_required_for_login` tinyint(1) DEFAULT '0',
   `otp_backup_codes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `session_validity_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1448,15 +1449,15 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=331914 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `venue_rooms`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `venue_rooms` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `competition_venue_id` bigint(20) NOT NULL,
-  `wcif_id` int(11) NOT NULL,
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `competition_venue_id` bigint NOT NULL,
+  `wcif_id` int NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1464,35 +1465,35 @@ CREATE TABLE `venue_rooms` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_venue_rooms_on_competition_venue_id_and_wcif_id` (`competition_venue_id`,`wcif_id`),
   KEY `index_venue_rooms_on_competition_venue_id` (`competition_venue_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5901 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `vote_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `vote_options` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `vote_id` int(11) NOT NULL,
-  `poll_option_id` int(11) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `vote_id` int NOT NULL,
+  `poll_option_id` int NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `votes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `votes` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) NOT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
   `comment` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `poll_id` int(11) DEFAULT NULL,
+  `poll_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_votes_on_user_id` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `wcif_extensions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `wcif_extensions` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint NOT NULL AUTO_INCREMENT,
   `extendable_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `extendable_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `extension_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1500,7 +1501,7 @@ CREATE TABLE `wcif_extensions` (
   `data` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_wcif_extensions_on_extendable_type_and_extendable_id` (`extendable_type`,`extendable_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=183 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 /*!50001 SET @saved_cs_client          = @@character_set_client */;
@@ -1510,6 +1511,7 @@ CREATE TABLE `wcif_extensions` (
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments`,`Persons`.`incorrect_wca_id_claim_count` AS `incorrect_wca_id_claim_count` from `Persons` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -1795,6 +1797,9 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20221121111430'),
 ('20221123090104'),
 ('20221123121220'),
+('20221224215047'),
+('20221224215048'),
 ('20230119115432'),
-('20230204111111'),
-('20221224215047');
+('20230204111111');
+
+

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -2,7 +2,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!50503 SET NAMES utf8mb4 */;
+/*!40101 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -11,26 +11,26 @@
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 DROP TABLE IF EXISTS `Competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Competitions` (
   `id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `cityName` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `information` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `year` smallint unsigned NOT NULL DEFAULT '0',
-  `month` smallint unsigned NOT NULL DEFAULT '0',
-  `day` smallint unsigned NOT NULL DEFAULT '0',
-  `endMonth` smallint unsigned NOT NULL DEFAULT '0',
-  `endDay` smallint unsigned NOT NULL DEFAULT '0',
+  `year` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `month` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `day` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `endMonth` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `endDay` smallint(5) unsigned NOT NULL DEFAULT '0',
   `venue` varchar(240) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `venueAddress` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `venueDetails` varchar(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `external_website` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `showAtAll` tinyint(1) NOT NULL DEFAULT '0',
-  `latitude` int DEFAULT NULL,
-  `longitude` int DEFAULT NULL,
+  `latitude` int(11) DEFAULT NULL,
+  `longitude` int(11) DEFAULT NULL,
   `contact` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `registration_open` datetime DEFAULT NULL,
@@ -41,22 +41,22 @@ CREATE TABLE `Competitions` (
   `results_nag_sent_at` datetime DEFAULT NULL,
   `generate_website` tinyint(1) DEFAULT NULL,
   `announced_at` datetime DEFAULT NULL,
-  `base_entry_fee_lowest_denomination` int DEFAULT NULL,
+  `base_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'USD',
-  `endYear` smallint NOT NULL DEFAULT '0',
+  `endYear` smallint(6) NOT NULL DEFAULT '0',
   `connected_stripe_account_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `end_date` date DEFAULT NULL,
   `enable_donations` tinyint(1) DEFAULT NULL,
   `competitor_limit_enabled` tinyint(1) DEFAULT NULL,
-  `competitor_limit` int DEFAULT NULL,
+  `competitor_limit` int(11) DEFAULT NULL,
   `competitor_limit_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `extra_registration_requirements` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `on_the_spot_registration` tinyint(1) DEFAULT NULL,
-  `on_the_spot_entry_fee_lowest_denomination` int DEFAULT NULL,
-  `refund_policy_percent` int DEFAULT NULL,
+  `on_the_spot_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
+  `refund_policy_percent` int(11) DEFAULT NULL,
   `refund_policy_limit_date` datetime DEFAULT NULL,
-  `guests_entry_fee_lowest_denomination` int DEFAULT NULL,
+  `guests_entry_fee_lowest_denomination` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   `results_submitted_at` datetime DEFAULT NULL,
@@ -70,21 +70,21 @@ CREATE TABLE `Competitions` (
   `event_restrictions` tinyint(1) DEFAULT NULL,
   `event_restrictions_reason` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `registration_reminder_sent_at` datetime DEFAULT NULL,
-  `announced_by` int DEFAULT NULL,
-  `results_posted_by` int DEFAULT NULL,
+  `announced_by` int(11) DEFAULT NULL,
+  `results_posted_by` int(11) DEFAULT NULL,
   `main_event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `cancelled_at` datetime DEFAULT NULL,
-  `cancelled_by` int DEFAULT NULL,
+  `cancelled_by` int(11) DEFAULT NULL,
   `waiting_list_deadline_date` datetime DEFAULT NULL,
   `event_change_deadline_date` datetime DEFAULT NULL,
   `guest_entry_status` int NOT NULL DEFAULT '0',
   `allow_registration_edits` tinyint(1) NOT NULL DEFAULT '0',
   `allow_registration_self_delete_after_acceptance` tinyint(1) NOT NULL DEFAULT '0',
-  `competition_series_id` int DEFAULT NULL,
+  `competition_series_id` int(11) DEFAULT NULL,
   `use_wca_live_for_scoretaking` tinyint(1) NOT NULL DEFAULT '0',
   `allow_registration_without_qualification` tinyint(1) DEFAULT '0',
-  `guests_per_registration_limit` int DEFAULT NULL,
-  `events_per_registration_limit` int DEFAULT NULL,
+  `guests_per_registration_limit` int(11) DEFAULT NULL,
+  `events_per_registration_limit` int(11) DEFAULT NULL,
   `force_comment_in_registration` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `year_month_day` (`year`,`month`,`day`),
@@ -96,9 +96,9 @@ CREATE TABLE `Competitions` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `CompetitionsMedia`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `CompetitionsMedia` (
-  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `type` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `text` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -110,56 +110,56 @@ CREATE TABLE `CompetitionsMedia` (
   `timestampDecided` timestamp NULL DEFAULT NULL,
   `status` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=11866 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ConciseAverageResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ConciseAverageResults` (
-  `id` int NOT NULL DEFAULT '0',
-  `average` int NOT NULL DEFAULT '0',
-  `valueAndId` bigint DEFAULT NULL,
+  `id` int(11) NOT NULL DEFAULT '0',
+  `average` int(11) NOT NULL DEFAULT '0',
+  `valueAndId` bigint(22) DEFAULT NULL,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `year` smallint unsigned NOT NULL DEFAULT '0',
-  `month` smallint unsigned NOT NULL DEFAULT '0',
-  `day` smallint unsigned NOT NULL DEFAULT '0'
+  `year` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `month` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `day` smallint(5) unsigned NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ConciseSingleResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ConciseSingleResults` (
-  `id` int NOT NULL DEFAULT '0',
-  `best` int NOT NULL DEFAULT '0',
-  `valueAndId` bigint DEFAULT NULL,
+  `id` int(11) NOT NULL DEFAULT '0',
+  `best` int(11) NOT NULL DEFAULT '0',
+  `valueAndId` bigint(22) DEFAULT NULL,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `continentId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `year` smallint unsigned NOT NULL DEFAULT '0',
-  `month` smallint unsigned NOT NULL DEFAULT '0',
-  `day` smallint unsigned NOT NULL DEFAULT '0'
+  `year` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `month` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `day` smallint(5) unsigned NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Continents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Continents` (
   `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `recordName` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `latitude` int NOT NULL DEFAULT '0',
-  `longitude` int NOT NULL DEFAULT '0',
-  `zoom` tinyint NOT NULL DEFAULT '0',
+  `latitude` int(11) NOT NULL DEFAULT '0',
+  `longitude` int(11) NOT NULL DEFAULT '0',
+  `zoom` tinyint(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Countries`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Countries` (
   `id` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -172,11 +172,11 @@ CREATE TABLE `Countries` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Events` (
   `id` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(54) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `rank` int NOT NULL DEFAULT '0',
+  `rank` int(11) NOT NULL DEFAULT '0',
   `format` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
@@ -184,21 +184,21 @@ CREATE TABLE `Events` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Formats` (
   `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sort_by` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `sort_by_second` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `expected_solve_count` int NOT NULL,
-  `trim_fastest_n` int NOT NULL,
-  `trim_slowest_n` int NOT NULL,
+  `expected_solve_count` int(11) NOT NULL,
+  `trim_fastest_n` int(11) NOT NULL,
+  `trim_slowest_n` int(11) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `InboxPersons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxPersons` (
   `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `wcaId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -215,22 +215,22 @@ CREATE TABLE `InboxPersons` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `InboxResults`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `InboxResults` (
   `personId` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `pos` smallint NOT NULL DEFAULT '0',
+  `pos` smallint(6) NOT NULL DEFAULT '0',
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `value1` int NOT NULL DEFAULT '0',
-  `value2` int NOT NULL DEFAULT '0',
-  `value3` int NOT NULL DEFAULT '0',
-  `value4` int NOT NULL DEFAULT '0',
-  `value5` int NOT NULL DEFAULT '0',
-  `best` int NOT NULL DEFAULT '0',
-  `average` int NOT NULL DEFAULT '0',
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `value1` int(11) NOT NULL DEFAULT '0',
+  `value2` int(11) NOT NULL DEFAULT '0',
+  `value3` int(11) NOT NULL DEFAULT '0',
+  `value4` int(11) NOT NULL DEFAULT '0',
+  `value5` int(11) NOT NULL DEFAULT '0',
+  `best` int(11) NOT NULL DEFAULT '0',
+  `average` int(11) NOT NULL DEFAULT '0',
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`),
   KEY `InboxResults_fk_tournament` (`competitionId`),
   KEY `InboxResults_fk_event` (`eventId`),
@@ -240,65 +240,65 @@ CREATE TABLE `InboxResults` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Persons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Persons` (
   `id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `subId` tinyint NOT NULL DEFAULT '1',
+  `subId` tinyint(6) NOT NULL DEFAULT '1',
   `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `gender` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '',
-  `year` smallint NOT NULL DEFAULT '0',
-  `month` tinyint NOT NULL DEFAULT '0',
-  `day` tinyint NOT NULL DEFAULT '0',
+  `year` smallint(6) NOT NULL DEFAULT '0',
+  `month` tinyint(4) NOT NULL DEFAULT '0',
+  `day` tinyint(4) NOT NULL DEFAULT '0',
   `comments` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `rails_id` int NOT NULL AUTO_INCREMENT,
-  `incorrect_wca_id_claim_count` int NOT NULL DEFAULT '0',
+  `rails_id` int(11) NOT NULL AUTO_INCREMENT,
+  `incorrect_wca_id_claim_count` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`rails_id`),
   UNIQUE KEY `index_Persons_on_id_and_subId` (`id`,`subId`),
   KEY `Persons_fk_country` (`countryId`),
   KEY `Persons_id` (`id`),
   KEY `Persons_name` (`name`),
   FULLTEXT KEY `index_Persons_on_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=183889 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksAverage`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksAverage` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `best` int NOT NULL DEFAULT '0',
-  `worldRank` int NOT NULL DEFAULT '0',
-  `continentRank` int NOT NULL DEFAULT '0',
-  `countryRank` int NOT NULL DEFAULT '0',
+  `best` int(11) NOT NULL DEFAULT '0',
+  `worldRank` int(11) NOT NULL DEFAULT '0',
+  `continentRank` int(11) NOT NULL DEFAULT '0',
+  `countryRank` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=764698935 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RanksSingle`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RanksSingle` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `best` int NOT NULL DEFAULT '0',
-  `worldRank` int NOT NULL DEFAULT '0',
-  `continentRank` int NOT NULL DEFAULT '0',
-  `countryRank` int NOT NULL DEFAULT '0',
+  `best` int(11) NOT NULL DEFAULT '0',
+  `worldRank` int(11) NOT NULL DEFAULT '0',
+  `continentRank` int(11) NOT NULL DEFAULT '0',
+  `countryRank` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `fk_persons` (`personId`),
   KEY `fk_events` (`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=898055726 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Results`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Results` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `pos` smallint NOT NULL DEFAULT '0',
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `pos` smallint(6) NOT NULL DEFAULT '0',
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `personName` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -306,13 +306,13 @@ CREATE TABLE `Results` (
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `formatId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `value1` int NOT NULL DEFAULT '0',
-  `value2` int NOT NULL DEFAULT '0',
-  `value3` int NOT NULL DEFAULT '0',
-  `value4` int NOT NULL DEFAULT '0',
-  `value5` int NOT NULL DEFAULT '0',
-  `best` int NOT NULL DEFAULT '0',
-  `average` int NOT NULL DEFAULT '0',
+  `value1` int(11) NOT NULL DEFAULT '0',
+  `value2` int(11) NOT NULL DEFAULT '0',
+  `value3` int(11) NOT NULL DEFAULT '0',
+  `value4` int(11) NOT NULL DEFAULT '0',
+  `value5` int(11) NOT NULL DEFAULT '0',
+  `best` int(11) NOT NULL DEFAULT '0',
+  `average` int(11) NOT NULL DEFAULT '0',
   `regionalSingleRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `regionalAverageRecord` char(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -335,14 +335,14 @@ CREATE TABLE `Results` (
   KEY `index_Results_on_eventId_and_value5` (`eventId`,`value5`),
   KEY `index_Results_on_regionalSingleRecord_and_eventId` (`regionalSingleRecord`,`eventId`),
   KEY `index_Results_on_regionalAverageRecord_and_eventId` (`regionalAverageRecord`,`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=4618749 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci PACK_KEYS=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `RoundTypes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `RoundTypes` (
   `id` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `rank` int NOT NULL DEFAULT '0',
+  `rank` int(11) NOT NULL DEFAULT '0',
   `name` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `cellName` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `final` tinyint(1) NOT NULL,
@@ -351,29 +351,29 @@ CREATE TABLE `RoundTypes` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `Scrambles`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `Scrambles` (
-  `scrambleId` int unsigned NOT NULL AUTO_INCREMENT,
+  `scrambleId` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `eventId` varchar(6) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `roundTypeId` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `groupId` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `isExtra` tinyint(1) NOT NULL,
-  `scrambleNum` int NOT NULL,
+  `scrambleNum` int(11) NOT NULL,
   `scramble` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`scrambleId`),
   KEY `competitionId` (`competitionId`,`eventId`)
-) ENGINE=InnoDB AUTO_INCREMENT=2464231 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_attachments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_attachments` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `record_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `record_id` bigint NOT NULL,
-  `blob_id` bigint NOT NULL,
+  `record_id` bigint(20) NOT NULL,
+  `blob_id` bigint(20) NOT NULL,
   `created_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_attachments_uniqueness` (`record_type`,`record_id`,`name`,`blob_id`),
@@ -383,27 +383,27 @@ CREATE TABLE `active_storage_attachments` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_blobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_blobs` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `key` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `filename` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `content_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `byte_size` bigint NOT NULL,
+  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `byte_size` bigint(20) NOT NULL,
   `checksum` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
-  `service_name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `service_name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_blobs_on_key` (`key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `active_storage_variant_records`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `active_storage_variant_records` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `blob_id` bigint NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `blob_id` bigint(20) NOT NULL,
   `variation_digest` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_active_storage_variant_records_uniqueness` (`blob_id`,`variation_digest`),
@@ -412,9 +412,9 @@ CREATE TABLE `active_storage_variant_records` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `ar_internal_metadata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ar_internal_metadata` (
-  `key` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  `key` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `value` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -423,95 +423,95 @@ CREATE TABLE `ar_internal_metadata` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_forums`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_phpbb3_forums` (
-  `forum_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
-  `parent_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `left_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `right_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_parents` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
-  `forum_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_desc` text CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
-  `forum_desc_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_desc_options` int unsigned NOT NULL DEFAULT '7',
-  `forum_desc_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_link` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_style` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_image` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_rules` text CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
-  `forum_rules_link` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_rules_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_rules_options` int unsigned NOT NULL DEFAULT '7',
-  `forum_rules_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_topics_per_page` tinyint NOT NULL DEFAULT '0',
-  `forum_type` tinyint NOT NULL DEFAULT '0',
-  `forum_status` tinyint NOT NULL DEFAULT '0',
-  `forum_last_post_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_last_poster_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_last_post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_last_post_time` int unsigned NOT NULL DEFAULT '0',
-  `forum_last_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_last_poster_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `forum_flags` tinyint NOT NULL DEFAULT '32',
-  `display_on_index` tinyint unsigned NOT NULL DEFAULT '1',
-  `enable_indexing` tinyint unsigned NOT NULL DEFAULT '1',
-  `enable_icons` tinyint unsigned NOT NULL DEFAULT '1',
-  `enable_prune` tinyint unsigned NOT NULL DEFAULT '0',
-  `prune_next` int unsigned NOT NULL DEFAULT '0',
-  `prune_days` mediumint unsigned NOT NULL DEFAULT '0',
-  `prune_viewed` mediumint unsigned NOT NULL DEFAULT '0',
-  `prune_freq` mediumint unsigned NOT NULL DEFAULT '0',
-  `display_subforum_list` tinyint unsigned NOT NULL DEFAULT '1',
-  `forum_options` int unsigned NOT NULL DEFAULT '0',
-  `forum_posts_approved` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_posts_unapproved` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_posts_softdeleted` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_topics_approved` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_topics_unapproved` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_topics_softdeleted` mediumint unsigned NOT NULL DEFAULT '0',
-  `enable_shadow_prune` tinyint unsigned NOT NULL DEFAULT '0',
-  `prune_shadow_days` mediumint unsigned NOT NULL DEFAULT '7',
-  `prune_shadow_freq` mediumint unsigned NOT NULL DEFAULT '1',
-  `prune_shadow_next` int NOT NULL DEFAULT '0',
+  `forum_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_parents` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `forum_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `forum_desc_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT '7',
+  `forum_desc_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_image` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules` text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `forum_rules_link` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT '7',
+  `forum_rules_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_topics_per_page` tinyint(4) NOT NULL DEFAULT '0',
+  `forum_type` tinyint(4) NOT NULL DEFAULT '0',
+  `forum_status` tinyint(4) NOT NULL DEFAULT '0',
+  `forum_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `forum_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `forum_flags` tinyint(4) NOT NULL DEFAULT '32',
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `prune_next` int(11) unsigned NOT NULL DEFAULT '0',
+  `prune_days` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `forum_options` int(20) unsigned NOT NULL DEFAULT '0',
+  `forum_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_topics_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_topics_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_topics_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `enable_shadow_prune` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `prune_shadow_days` mediumint(8) unsigned NOT NULL DEFAULT '7',
+  `prune_shadow_freq` mediumint(8) unsigned NOT NULL DEFAULT '1',
+  `prune_shadow_next` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`forum_id`),
   KEY `left_right_id` (`left_id`,`right_id`),
   KEY `forum_lastpost_id` (`forum_last_post_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_posts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_phpbb3_posts` (
-  `post_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
-  `topic_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `forum_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `poster_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `icon_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `poster_ip` varchar(40) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `post_time` int unsigned NOT NULL DEFAULT '0',
-  `post_reported` tinyint unsigned NOT NULL DEFAULT '0',
-  `enable_bbcode` tinyint unsigned NOT NULL DEFAULT '1',
-  `enable_smilies` tinyint unsigned NOT NULL DEFAULT '1',
-  `enable_magic_url` tinyint unsigned NOT NULL DEFAULT '1',
-  `enable_sig` tinyint unsigned NOT NULL DEFAULT '1',
-  `post_username` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
-  `post_text` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  `post_checksum` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `post_attachment` tinyint unsigned NOT NULL DEFAULT '0',
-  `bbcode_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `bbcode_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `post_postcount` tinyint unsigned NOT NULL DEFAULT '1',
-  `post_edit_time` int unsigned NOT NULL DEFAULT '0',
-  `post_edit_reason` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `post_edit_user` mediumint unsigned NOT NULL DEFAULT '0',
-  `post_edit_count` smallint unsigned NOT NULL DEFAULT '0',
-  `post_edit_locked` tinyint unsigned NOT NULL DEFAULT '0',
-  `post_visibility` tinyint NOT NULL DEFAULT '0',
-  `post_delete_time` int unsigned NOT NULL DEFAULT '0',
-  `post_delete_reason` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `post_delete_user` mediumint unsigned NOT NULL DEFAULT '0',
+  `post_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `poster_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `post_username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `post_text` mediumtext CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  `post_checksum` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `post_edit_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `post_edit_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_edit_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `post_visibility` tinyint(3) NOT NULL DEFAULT '0',
+  `post_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `post_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `post_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`post_id`),
   KEY `forum_id` (`forum_id`),
   KEY `topic_id` (`topic_id`),
@@ -522,51 +522,51 @@ CREATE TABLE `archive_phpbb3_posts` (
   KEY `post_visibility` (`post_visibility`),
   FULLTEXT KEY `post_subject` (`post_subject`),
   FULLTEXT KEY `post_content` (`post_text`,`post_subject`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_topics`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_phpbb3_topics` (
-  `topic_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
-  `forum_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `icon_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_attachment` tinyint unsigned NOT NULL DEFAULT '0',
-  `topic_reported` tinyint unsigned NOT NULL DEFAULT '0',
-  `topic_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
-  `topic_poster` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_time` int unsigned NOT NULL DEFAULT '0',
-  `topic_time_limit` int unsigned NOT NULL DEFAULT '0',
-  `topic_views` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_status` tinyint NOT NULL DEFAULT '0',
-  `topic_type` tinyint NOT NULL DEFAULT '0',
-  `topic_first_post_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_first_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
-  `topic_first_poster_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `topic_last_post_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_last_poster_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_last_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `topic_last_poster_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `topic_last_post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `topic_last_post_time` int unsigned NOT NULL DEFAULT '0',
-  `topic_last_view_time` int unsigned NOT NULL DEFAULT '0',
-  `topic_moved_id` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_bumped` tinyint unsigned NOT NULL DEFAULT '0',
-  `topic_bumper` mediumint unsigned NOT NULL DEFAULT '0',
-  `poll_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `poll_start` int unsigned NOT NULL DEFAULT '0',
-  `poll_length` int unsigned NOT NULL DEFAULT '0',
-  `poll_max_options` tinyint NOT NULL DEFAULT '1',
-  `poll_last_vote` int unsigned NOT NULL DEFAULT '0',
-  `poll_vote_change` tinyint unsigned NOT NULL DEFAULT '0',
+  `topic_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `topic_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `topic_poster` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_views` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_status` tinyint(3) NOT NULL DEFAULT '0',
+  `topic_type` tinyint(3) NOT NULL DEFAULT '0',
+  `topic_first_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_first_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_last_poster_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_moved_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `poll_title` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `poll_start` int(11) unsigned NOT NULL DEFAULT '0',
+  `poll_length` int(11) unsigned NOT NULL DEFAULT '0',
+  `poll_max_options` tinyint(4) NOT NULL DEFAULT '1',
+  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT '0',
+  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `poll_vote_name` tinyint(1) NOT NULL DEFAULT '0',
-  `topic_visibility` tinyint NOT NULL DEFAULT '0',
-  `topic_delete_time` int unsigned NOT NULL DEFAULT '0',
-  `topic_delete_reason` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `topic_delete_user` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_posts_approved` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_posts_unapproved` mediumint unsigned NOT NULL DEFAULT '0',
-  `topic_posts_softdeleted` mediumint unsigned NOT NULL DEFAULT '0',
+  `topic_visibility` tinyint(3) NOT NULL DEFAULT '0',
+  `topic_delete_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `topic_delete_reason` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `topic_delete_user` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `topic_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`topic_id`),
   KEY `forum_id` (`forum_id`),
   KEY `forum_id_type` (`forum_id`,`topic_type`),
@@ -574,106 +574,106 @@ CREATE TABLE `archive_phpbb3_topics` (
   KEY `fid_time_moved` (`forum_id`,`topic_last_post_time`,`topic_moved_id`),
   KEY `topic_visibility` (`topic_visibility`),
   KEY `forum_vis_last` (`forum_id`,`topic_visibility`,`topic_last_post_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_phpbb3_users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_phpbb3_users` (
-  `user_id` mediumint unsigned NOT NULL AUTO_INCREMENT,
-  `user_type` tinyint NOT NULL DEFAULT '0',
-  `group_id` mediumint unsigned NOT NULL DEFAULT '3',
-  `user_permissions` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
-  `user_perm_from` mediumint unsigned NOT NULL DEFAULT '0',
-  `user_ip` varchar(40) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_regdate` int unsigned NOT NULL DEFAULT '0',
-  `username` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `username_clean` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_password` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_passchg` int unsigned NOT NULL DEFAULT '0',
-  `user_email` varchar(100) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_email_hash` bigint NOT NULL DEFAULT '0',
-  `user_birthday` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_lastvisit` int unsigned NOT NULL DEFAULT '0',
-  `user_lastmark` int unsigned NOT NULL DEFAULT '0',
-  `user_lastpost_time` int unsigned NOT NULL DEFAULT '0',
-  `user_lastpage` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_last_confirm_key` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_last_search` int unsigned NOT NULL DEFAULT '0',
-  `user_warnings` tinyint NOT NULL DEFAULT '0',
-  `user_last_warning` int unsigned NOT NULL DEFAULT '0',
-  `user_login_attempts` tinyint NOT NULL DEFAULT '0',
-  `user_inactive_reason` tinyint NOT NULL DEFAULT '0',
-  `user_inactive_time` int unsigned NOT NULL DEFAULT '0',
-  `user_posts` mediumint unsigned NOT NULL DEFAULT '0',
-  `user_lang` varchar(30) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_timezone` varchar(100) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_dateformat` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 'd M Y H:i',
-  `user_style` mediumint unsigned NOT NULL DEFAULT '0',
-  `user_rank` mediumint unsigned NOT NULL DEFAULT '0',
-  `user_colour` varchar(6) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_new_privmsg` int NOT NULL DEFAULT '0',
-  `user_unread_privmsg` int NOT NULL DEFAULT '0',
-  `user_last_privmsg` int unsigned NOT NULL DEFAULT '0',
-  `user_message_rules` tinyint unsigned NOT NULL DEFAULT '0',
-  `user_full_folder` int NOT NULL DEFAULT '-3',
-  `user_emailtime` int unsigned NOT NULL DEFAULT '0',
-  `user_topic_show_days` smallint unsigned NOT NULL DEFAULT '0',
-  `user_topic_sortby_type` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 't',
-  `user_topic_sortby_dir` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 'd',
-  `user_post_show_days` smallint unsigned NOT NULL DEFAULT '0',
-  `user_post_sortby_type` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 't',
-  `user_post_sortby_dir` varchar(1) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT 'a',
-  `user_notify` tinyint unsigned NOT NULL DEFAULT '0',
-  `user_notify_pm` tinyint unsigned NOT NULL DEFAULT '1',
-  `user_notify_type` tinyint NOT NULL DEFAULT '0',
-  `user_allow_pm` tinyint unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewonline` tinyint unsigned NOT NULL DEFAULT '1',
-  `user_allow_viewemail` tinyint unsigned NOT NULL DEFAULT '1',
-  `user_allow_massemail` tinyint unsigned NOT NULL DEFAULT '1',
-  `user_options` int unsigned NOT NULL DEFAULT '230271',
-  `user_avatar` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_avatar_type` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_avatar_width` smallint unsigned NOT NULL DEFAULT '0',
-  `user_avatar_height` smallint unsigned NOT NULL DEFAULT '0',
-  `user_sig` mediumtext CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
-  `user_sig_bbcode_uid` varchar(8) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_sig_bbcode_bitfield` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_jabber` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_actkey` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_newpasswd` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_form_salt` varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL DEFAULT '',
-  `user_new` tinyint unsigned NOT NULL DEFAULT '1',
-  `user_reminded` tinyint NOT NULL DEFAULT '0',
-  `user_reminded_time` int unsigned NOT NULL DEFAULT '0',
+  `user_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_type` tinyint(2) NOT NULL DEFAULT '0',
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT '3',
+  `user_permissions` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `user_ip` varchar(40) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_regdate` int(11) unsigned NOT NULL DEFAULT '0',
+  `username` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `username_clean` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_password` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_passchg` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_email` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_email_hash` bigint(20) NOT NULL DEFAULT '0',
+  `user_birthday` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_lastmark` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_lastpage` varchar(200) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_last_search` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_warnings` tinyint(4) NOT NULL DEFAULT '0',
+  `user_last_warning` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_login_attempts` tinyint(4) NOT NULL DEFAULT '0',
+  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT '0',
+  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_posts` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `user_lang` varchar(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd M Y H:i',
+  `user_style` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `user_rank` mediumint(8) unsigned NOT NULL DEFAULT '0',
+  `user_colour` varchar(6) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_new_privmsg` int(4) NOT NULL DEFAULT '0',
+  `user_unread_privmsg` int(4) NOT NULL DEFAULT '0',
+  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `user_full_folder` int(11) NOT NULL DEFAULT '-3',
+  `user_emailtime` int(11) unsigned NOT NULL DEFAULT '0',
+  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_topic_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_post_sortby_type` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT 'a',
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_notify_type` tinyint(4) NOT NULL DEFAULT '0',
+  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_options` int(11) unsigned NOT NULL DEFAULT '230271',
+  `user_avatar` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT '0',
+  `user_sig` mediumtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `user_new` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `user_reminded` tinyint(4) NOT NULL DEFAULT '0',
+  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `username_clean` (`username_clean`),
   KEY `user_birthday` (`user_birthday`),
   KEY `user_email_hash` (`user_email_hash`),
   KEY `user_type` (`user_type`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `archive_registrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `archive_registrations` (
-  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `competitionId` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `personId` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `countryId` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `gender` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `birthYear` smallint unsigned NOT NULL DEFAULT '0',
-  `birthMonth` tinyint unsigned NOT NULL DEFAULT '0',
-  `birthDay` tinyint unsigned NOT NULL DEFAULT '0',
+  `birthYear` smallint(6) unsigned NOT NULL DEFAULT '0',
+  `birthMonth` tinyint(4) unsigned NOT NULL DEFAULT '0',
+  `birthDay` tinyint(4) unsigned NOT NULL DEFAULT '0',
   `email` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `guests_old` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `user_id` int DEFAULT NULL,
+  `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `guests` int NOT NULL DEFAULT '0',
+  `guests` int(11) NOT NULL DEFAULT '0',
   `accepted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competitionId_and_user_id` (`competitionId`,`user_id`)
@@ -681,35 +681,35 @@ CREATE TABLE `archive_registrations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `assignments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `assignments` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `registration_id` bigint DEFAULT NULL,
-  `schedule_activity_id` bigint DEFAULT NULL,
-  `station_number` int DEFAULT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `registration_id` bigint(20) DEFAULT NULL,
+  `schedule_activity_id` bigint(20) DEFAULT NULL,
+  `station_number` int(11) DEFAULT NULL,
   `assignment_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_assignments_on_registration_id` (`registration_id`),
   KEY `index_assignments_on_schedule_activity_id` (`schedule_activity_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4025401 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `bookmarked_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `bookmarked_competitions` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `user_id` int NOT NULL,
+  `user_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_bookmarked_competitions_on_competition_id` (`competition_id`),
   KEY `index_bookmarked_competitions_on_user_id` (`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=85297 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `cached_results`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `cached_results` (
-  `key_params` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `key_params` varchar(191) NOT NULL,
   `payload` json DEFAULT NULL,
   `created_at` datetime(6) NOT NULL,
   `updated_at` datetime(6) NOT NULL,
@@ -718,23 +718,23 @@ CREATE TABLE `cached_results` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `championships`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `championships` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_championships_on_competition_id_and_championship_type` (`competition_id`,`championship_type`),
   KEY `index_championships_on_championship_type` (`championship_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=617 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_delegates`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_delegates` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `delegate_id` int DEFAULT NULL,
+  `delegate_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
@@ -742,29 +742,29 @@ CREATE TABLE `competition_delegates` (
   UNIQUE KEY `index_competition_delegates_on_competition_id_and_delegate_id` (`competition_id`,`delegate_id`),
   KEY `index_competition_delegates_on_competition_id` (`competition_id`),
   KEY `index_competition_delegates_on_delegate_id` (`delegate_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=19371 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_events` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `fee_lowest_denomination` int NOT NULL DEFAULT '0',
+  `fee_lowest_denomination` int(11) NOT NULL DEFAULT '0',
   `qualification` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_events_on_competition_id_and_event_id` (`competition_id`,`event_id`),
   KEY `fk_rails_ba6cfdafb1` (`event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=91298 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_organizers`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_organizers` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `organizer_id` int DEFAULT NULL,
+  `organizer_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `receive_registration_emails` tinyint(1) NOT NULL DEFAULT '0',
@@ -772,44 +772,44 @@ CREATE TABLE `competition_organizers` (
   UNIQUE KEY `idx_competition_organizers_on_competition_id_and_organizer_id` (`competition_id`,`organizer_id`),
   KEY `index_competition_organizers_on_competition_id` (`competition_id`),
   KEY `index_competition_organizers_on_organizer_id` (`organizer_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=20945 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_series`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_series` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `wcif_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `short_name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=68 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_tabs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_tabs` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `content` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `display_order` int DEFAULT NULL,
+  `display_order` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_tabs_on_display_order_and_competition_id` (`display_order`,`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=25828 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `competition_venues`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `competition_venues` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `wcif_id` int NOT NULL,
+  `wcif_id` int(11) NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `latitude_microdegrees` int NOT NULL,
-  `longitude_microdegrees` int NOT NULL,
+  `latitude_microdegrees` int(11) NOT NULL,
+  `longitude_microdegrees` int(11) NOT NULL,
   `timezone_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -817,15 +817,15 @@ CREATE TABLE `competition_venues` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_competition_venues_on_competition_id_and_wcif_id` (`competition_id`,`wcif_id`),
   KEY `index_competition_venues_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4828 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `completed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `completed_jobs` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `priority` int NOT NULL DEFAULT '0',
-  `attempts` int NOT NULL DEFAULT '0',
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `priority` int(11) NOT NULL DEFAULT '0',
+  `attempts` int(11) NOT NULL DEFAULT '0',
   `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
   `queue` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -837,23 +837,23 @@ CREATE TABLE `completed_jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `country_bands`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `country_bands` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `number` int NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `number` int(11) NOT NULL,
   `iso2` varchar(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_country_bands_on_iso2` (`iso2`),
   KEY `index_country_bands_on_number` (`number`)
-) ENGINE=InnoDB AUTO_INCREMENT=123 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delayed_jobs`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `delayed_jobs` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `priority` int NOT NULL DEFAULT '0',
-  `attempts` int NOT NULL DEFAULT '0',
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `priority` int(11) NOT NULL DEFAULT '0',
+  `attempts` int(11) NOT NULL DEFAULT '0',
   `handler` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `last_error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `run_at` datetime DEFAULT NULL,
@@ -869,9 +869,9 @@ CREATE TABLE `delayed_jobs` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `delegate_reports`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `delegate_reports` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `equipment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `venue` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
@@ -880,7 +880,7 @@ CREATE TABLE `delegate_reports` (
   `incidents` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `remarks` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `discussion_url` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `posted_by_user_id` int DEFAULT NULL,
+  `posted_by_user_id` int(11) DEFAULT NULL,
   `posted_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -889,55 +889,55 @@ CREATE TABLE `delegate_reports` (
   `wrc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wdc_feedback_requested` tinyint(1) NOT NULL DEFAULT '0',
   `wdc_incidents` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `wrc_primary_user_id` int DEFAULT NULL,
-  `wrc_secondary_user_id` int DEFAULT NULL,
+  `wrc_primary_user_id` int(11) DEFAULT NULL,
+  `wrc_secondary_user_id` int(11) DEFAULT NULL,
   `reminder_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_delegate_reports_on_competition_id` (`competition_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10542 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `eligible_country_iso2s_for_championship`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `eligible_country_iso2s_for_championship` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `championship_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `eligible_country_iso2` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_eligible_iso2s_for_championship_on_type_and_country_iso2` (`championship_type`,`eligible_country_iso2`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_competitions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `incident_competitions` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `incident_id` bigint NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `incident_id` bigint(20) NOT NULL,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `comments` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_competitions_on_incident_id_and_competition_id` (`incident_id`,`competition_id`),
   KEY `index_incident_competitions_on_incident_id` (`incident_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=132 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incident_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `incident_tags` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `incident_id` bigint NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `incident_id` bigint(20) NOT NULL,
   `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_incident_tags_on_incident_id_and_tag` (`incident_id`,`tag`),
   KEY `index_incident_tags_on_incident_id` (`incident_id`),
   KEY `index_incident_tags_on_tag` (`tag`)
-) ENGINE=InnoDB AUTO_INCREMENT=154 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `incidents`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `incidents` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `title` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `private_description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `private_wrc_decision` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
@@ -948,11 +948,11 @@ CREATE TABLE `incidents` (
   `digest_worthy` tinyint(1) DEFAULT '0',
   `digest_sent_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=81 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `linkings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `linkings` (
   `wca_id` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `wca_ids` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -961,13 +961,13 @@ CREATE TABLE `linkings` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `locations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `locations` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `user_id` int NOT NULL,
-  `latitude_microdegrees` int DEFAULT NULL,
-  `longitude_microdegrees` int DEFAULT NULL,
-  `notification_radius_km` int DEFAULT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `latitude_microdegrees` int(11) DEFAULT NULL,
+  `longitude_microdegrees` int(11) DEFAULT NULL,
+  `notification_radius_km` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
@@ -975,31 +975,31 @@ CREATE TABLE `locations` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_grants`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `oauth_access_grants` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `resource_owner_id` int NOT NULL,
-  `application_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `resource_owner_id` int(11) NOT NULL,
+  `application_id` int(11) NOT NULL,
   `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `expires_in` int NOT NULL,
+  `expires_in` int(11) NOT NULL,
   `redirect_uri` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `created_at` datetime NOT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_access_grants_on_token` (`token`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_access_tokens`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `oauth_access_tokens` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `resource_owner_id` int DEFAULT NULL,
-  `application_id` int DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `resource_owner_id` int(11) DEFAULT NULL,
+  `application_id` int(11) DEFAULT NULL,
   `token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `refresh_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `expires_in` int DEFAULT NULL,
+  `expires_in` int(11) DEFAULT NULL,
   `revoked_at` datetime DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1007,13 +1007,13 @@ CREATE TABLE `oauth_access_tokens` (
   UNIQUE KEY `index_oauth_access_tokens_on_token` (`token`),
   UNIQUE KEY `index_oauth_access_tokens_on_refresh_token` (`refresh_token`),
   KEY `index_oauth_access_tokens_on_resource_owner_id` (`resource_owner_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=303 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `oauth_applications`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `oauth_applications` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `uid` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1021,31 +1021,31 @@ CREATE TABLE `oauth_applications` (
   `scopes` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
-  `owner_id` int DEFAULT NULL,
+  `owner_id` int(11) DEFAULT NULL,
   `owner_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `dangerously_allow_any_redirect_uri` tinyint(1) NOT NULL DEFAULT '0',
   `confidential` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_oauth_applications_on_uid` (`uid`),
   KEY `index_oauth_applications_on_owner_id_and_owner_type` (`owner_id`,`owner_type`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `poll_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `poll_options` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `description` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `poll_id` int NOT NULL,
+  `poll_id` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `poll_id` (`poll_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `polls`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `polls` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `question` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `multiple` tinyint(1) NOT NULL,
   `deadline` datetime NOT NULL,
@@ -1058,27 +1058,27 @@ CREATE TABLE `polls` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `post_tags`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `post_tags` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `post_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `post_id` int(11) NOT NULL,
   `tag` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_post_tags_on_post_id_and_tag` (`post_id`,`tag`),
   KEY `index_post_tags_on_post_id` (`post_id`),
   KEY `index_post_tags_on_tag` (`tag`)
-) ENGINE=InnoDB AUTO_INCREMENT=22433 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `posts`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `posts` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `slug` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `sticky` tinyint(1) NOT NULL DEFAULT '0',
-  `author_id` int DEFAULT NULL,
+  `author_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `show_on_homepage` tinyint(1) NOT NULL DEFAULT '1',
@@ -1088,15 +1088,15 @@ CREATE TABLE `posts` (
   KEY `index_posts_on_world_readable_and_sticky_and_created_at` (`sticky`,`created_at`),
   KEY `index_posts_on_world_readable_and_created_at` (`created_at`),
   KEY `idx_show_wr_sticky_created_at` (`show_on_homepage`,`sticky`,`created_at`)
-) ENGINE=InnoDB AUTO_INCREMENT=14092 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `preferred_formats`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `preferred_formats` (
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `format_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `ranking` int NOT NULL,
+  `ranking` int(11) NOT NULL,
   UNIQUE KEY `index_preferred_formats_on_event_id_and_format_id` (`event_id`,`format_id`),
   KEY `fk_rails_c3e0098ed3` (`format_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1104,8 +1104,8 @@ CREATE TABLE `preferred_formats` (
 DROP TABLE IF EXISTS `rails_persons`;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 SET @saved_cs_client     = @@character_set_client;
-/*!50503 SET character_set_client = utf8mb4 */;
-/*!50001 CREATE VIEW `rails_persons` AS SELECT 
+SET character_set_client = utf8;
+/*!50001 CREATE VIEW `rails_persons` AS SELECT
  1 AS `id`,
  1 AS `wca_id`,
  1 AS `subId`,
@@ -1120,9 +1120,9 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = @saved_cs_client;
 DROP TABLE IF EXISTS `regional_organizations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `regional_organizations` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `country` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `website` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1140,33 +1140,33 @@ CREATE TABLE `regional_organizations` (
   PRIMARY KEY (`id`),
   KEY `index_regional_organizations_on_name` (`name`),
   KEY `index_regional_organizations_on_country` (`country`)
-) ENGINE=InnoDB AUTO_INCREMENT=47 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_competition_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registration_competition_events` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `registration_id` int DEFAULT NULL,
-  `competition_event_id` int DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `registration_id` int(11) DEFAULT NULL,
+  `competition_event_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_registration_competition_events_on_reg_id_and_comp_event_id` (`registration_id`,`competition_event_id`),
   KEY `index_reg_events_reg_id_comp_event_id` (`registration_id`,`competition_event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2962567 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registration_payments`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registration_payments` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `registration_id` int DEFAULT NULL,
-  `amount_lowest_denomination` int DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `registration_id` int(11) DEFAULT NULL,
+  `amount_lowest_denomination` int(11) DEFAULT NULL,
   `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `refunded_registration_payment_id` int DEFAULT NULL,
-  `user_id` int DEFAULT NULL,
+  `refunded_registration_payment_id` int(11) DEFAULT NULL,
+  `user_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_registration_payments_on_stripe_charge_id` (`stripe_charge_id`),
   KEY `idx_reg_payments_on_refunded_registration_payment_id` (`refunded_registration_payment_id`)
@@ -1174,53 +1174,52 @@ CREATE TABLE `registration_payments` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registrations` (
-  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `ip` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `user_id` int DEFAULT NULL,
+  `user_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `guests` int NOT NULL DEFAULT '0',
+  `guests` int(11) NOT NULL DEFAULT '0',
   `accepted_at` datetime DEFAULT NULL,
-  `accepted_by` int DEFAULT NULL,
+  `accepted_by` int(11) DEFAULT NULL,
   `deleted_at` datetime DEFAULT NULL,
-  `deleted_by` int DEFAULT NULL,
+  `deleted_by` int(11) DEFAULT NULL,
   `roles` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `non_competing_staff` tinyint(1) DEFAULT '0',
   `is_competing` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=612217 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `rounds`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `rounds` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `competition_event_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `competition_event_id` int(11) NOT NULL,
   `format_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `number` int NOT NULL,
+  `number` int(11) NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `time_limit` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `cutoff` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `advancement_condition` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `scramble_set_count` int NOT NULL DEFAULT '1',
+  `scramble_set_count` int(11) NOT NULL DEFAULT '1',
   `round_results` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `total_number_of_rounds` int NOT NULL,
-  `old_type` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `total_number_of_rounds` int(11) NOT NULL,
+  `old_type` varchar(1) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_rounds_on_competition_event_id_and_number` (`competition_event_id`,`number`)
-) ENGINE=InnoDB AUTO_INCREMENT=798685 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_check_categories`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sanity_check_categories` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_sanity_check_categories_on_name` (`name`)
@@ -1228,10 +1227,10 @@ CREATE TABLE `sanity_check_categories` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_check_exclusions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sanity_check_exclusions` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `sanity_check_id` bigint NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `sanity_check_id` bigint(20) NOT NULL,
   `exclusion` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
@@ -1241,10 +1240,10 @@ CREATE TABLE `sanity_check_exclusions` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `sanity_checks`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sanity_checks` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `sanity_check_category_id` bigint NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `sanity_check_category_id` bigint(20) NOT NULL,
   `topic` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `comments` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1256,39 +1255,39 @@ CREATE TABLE `sanity_checks` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schedule_activities`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schedule_activities` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `holder_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `holder_id` bigint NOT NULL,
-  `wcif_id` int NOT NULL,
+  `holder_id` bigint(20) NOT NULL,
+  `wcif_id` int(11) NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `activity_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `start_time` datetime NOT NULL,
   `end_time` datetime NOT NULL,
-  `scramble_set_id` int DEFAULT NULL,
+  `scramble_set_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_activities_on_their_id_within_holder` (`holder_type`,`holder_id`,`wcif_id`),
   KEY `index_schedule_activities_on_holder_type_and_holder_id` (`holder_type`,`holder_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=281582 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `schema_migrations`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_migrations` (
-  `version` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+  `version` varchar(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   UNIQUE KEY `unique_schema_migrations` (`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `starburst_announcement_views`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `starburst_announcement_views` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `user_id` int DEFAULT NULL,
-  `announcement_id` int DEFAULT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `announcement_id` int(11) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`),
@@ -1297,25 +1296,25 @@ CREATE TABLE `starburst_announcement_views` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `starburst_announcements`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `starburst_announcements` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `start_delivering_at` datetime DEFAULT NULL,
   `stop_delivering_at` datetime DEFAULT NULL,
-  `limit_to_users` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `limit_to_users` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
-  `category` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `category` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `stripe_charges`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `stripe_charges` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `status` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1328,11 +1327,11 @@ CREATE TABLE `stripe_charges` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `team_members`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `team_members` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `team_id` int NOT NULL,
-  `user_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `team_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
   `start_date` date NOT NULL,
   `end_date` date DEFAULT NULL,
   `team_leader` tinyint(1) NOT NULL DEFAULT '0',
@@ -1340,13 +1339,13 @@ CREATE TABLE `team_members` (
   `updated_at` datetime NOT NULL,
   `team_senior_member` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=604 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `teams`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `teams` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `friendly_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1354,11 +1353,11 @@ CREATE TABLE `teams` (
   `hidden` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `index_teams_on_friendly_id` (`friendly_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `timestamps`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `timestamps` (
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `date` datetime DEFAULT NULL,
@@ -1367,9 +1366,9 @@ CREATE TABLE `timestamps` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `uploaded_jsons`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `uploaded_jsons` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `competition_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `json_str` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
@@ -1378,26 +1377,26 @@ CREATE TABLE `uploaded_jsons` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `user_preferred_events`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `user_preferred_events` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `user_id` int DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
   `event_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_user_preferred_events_on_user_id_and_event_id` (`user_id`,`event_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=274288 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
-  `id` int NOT NULL AUTO_INCREMENT,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `email` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `encrypted_password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `reset_password_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `reset_password_sent_at` datetime DEFAULT NULL,
   `remember_created_at` datetime DEFAULT NULL,
-  `sign_in_count` int NOT NULL DEFAULT '0',
+  `sign_in_count` int(11) NOT NULL DEFAULT '0',
   `current_sign_in_at` datetime DEFAULT NULL,
   `last_sign_in_at` datetime DEFAULT NULL,
   `current_sign_in_ip` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1410,21 +1409,21 @@ CREATE TABLE `users` (
   `updated_at` datetime DEFAULT NULL,
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `delegate_status` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `senior_delegate_id` int DEFAULT NULL,
+  `senior_delegate_id` int(11) DEFAULT NULL,
   `region` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `wca_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `pending_avatar` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `saved_avatar_crop_x` int DEFAULT NULL,
-  `saved_avatar_crop_y` int DEFAULT NULL,
-  `saved_avatar_crop_w` int DEFAULT NULL,
-  `saved_avatar_crop_h` int DEFAULT NULL,
-  `saved_pending_avatar_crop_x` int DEFAULT NULL,
-  `saved_pending_avatar_crop_y` int DEFAULT NULL,
-  `saved_pending_avatar_crop_w` int DEFAULT NULL,
-  `saved_pending_avatar_crop_h` int DEFAULT NULL,
+  `saved_avatar_crop_x` int(11) DEFAULT NULL,
+  `saved_avatar_crop_y` int(11) DEFAULT NULL,
+  `saved_avatar_crop_w` int(11) DEFAULT NULL,
+  `saved_avatar_crop_h` int(11) DEFAULT NULL,
+  `saved_pending_avatar_crop_x` int(11) DEFAULT NULL,
+  `saved_pending_avatar_crop_y` int(11) DEFAULT NULL,
+  `saved_pending_avatar_crop_w` int(11) DEFAULT NULL,
+  `saved_pending_avatar_crop_h` int(11) DEFAULT NULL,
   `unconfirmed_wca_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `delegate_id_to_handle_wca_id_claim` int DEFAULT NULL,
+  `delegate_id_to_handle_wca_id_claim` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
   `gender` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `country_iso2` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1436,7 +1435,7 @@ CREATE TABLE `users` (
   `encrypted_otp_secret` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `encrypted_otp_secret_iv` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `encrypted_otp_secret_salt` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `consumed_timestep` int DEFAULT NULL,
+  `consumed_timestep` int(11) DEFAULT NULL,
   `otp_required_for_login` tinyint(1) DEFAULT '0',
   `otp_backup_codes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `session_validity_token` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1449,15 +1448,15 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_wca_id` (`wca_id`),
   KEY `index_users_on_senior_delegate_id` (`senior_delegate_id`),
   KEY `index_users_on_delegate_id_to_handle_wca_id_claim` (`delegate_id_to_handle_wca_id_claim`)
-) ENGINE=InnoDB AUTO_INCREMENT=331914 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `venue_rooms`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `venue_rooms` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `competition_venue_id` bigint NOT NULL,
-  `wcif_id` int NOT NULL,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `competition_venue_id` bigint(20) NOT NULL,
+  `wcif_id` int(11) NOT NULL,
   `name` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1465,35 +1464,35 @@ CREATE TABLE `venue_rooms` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_venue_rooms_on_competition_venue_id_and_wcif_id` (`competition_venue_id`,`wcif_id`),
   KEY `index_venue_rooms_on_competition_venue_id` (`competition_venue_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5901 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `vote_options`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `vote_options` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `vote_id` int NOT NULL,
-  `poll_option_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `vote_id` int(11) NOT NULL,
+  `poll_option_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `votes`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `votes` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `user_id` int NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
   `comment` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `poll_id` int DEFAULT NULL,
+  `poll_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_votes_on_user_id` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `wcif_extensions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `wcif_extensions` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `extendable_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `extendable_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `extension_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1501,7 +1500,7 @@ CREATE TABLE `wcif_extensions` (
   `data` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `index_wcif_extensions_on_extendable_type_and_extendable_id` (`extendable_type`,`extendable_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=183 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!50001 DROP VIEW IF EXISTS `rails_persons`*/;
 /*!50001 SET @saved_cs_client          = @@character_set_client */;
@@ -1511,7 +1510,6 @@ CREATE TABLE `wcif_extensions` (
 /*!50001 SET character_set_results     = utf8mb4 */;
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `rails_persons` AS select `Persons`.`rails_id` AS `id`,`Persons`.`id` AS `wca_id`,`Persons`.`subId` AS `subId`,`Persons`.`name` AS `name`,`Persons`.`countryId` AS `countryId`,`Persons`.`gender` AS `gender`,`Persons`.`year` AS `year`,`Persons`.`month` AS `month`,`Persons`.`day` AS `day`,`Persons`.`comments` AS `comments`,`Persons`.`incorrect_wca_id_claim_count` AS `incorrect_wca_id_claim_count` from `Persons` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -1797,9 +1795,6 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20221121111430'),
 ('20221123090104'),
 ('20221123121220'),
-('20221224215047'),
-('20221224215048'),
 ('20230119115432'),
-('20230204111111');
-
-
+('20230204111111'),
+('20221224215048');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -587,7 +587,7 @@ module DatabaseDumper
           updated_at
           user_id
           roles
-          non_competing_staff
+          is_competing
         ),
         db_default: %w(ip),
         fake_values: {

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -587,6 +587,7 @@ module DatabaseDumper
           updated_at
           user_id
           roles
+          non_competing_staff
         ),
         db_default: %w(ip),
         fake_values: {

--- a/WcaOnRails/spec/models/registration_spec.rb
+++ b/WcaOnRails/spec/models/registration_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe Registration do
     expect(registration).to be_invalid_with_errors(registration_competition_events: ["must register for at least one event"])
   end
 
+  it "allows zero events for non competing staff" do
+    registration.registration_competition_events = []
+    registration.non_competing_staff = true
+    expect(registration).to be_valid
+  end
+
   it "requires events be offered by competition" do
     registration.registration_competition_events.build(competition_event_id: 1234)
     expect(registration).to be_invalid_with_errors(

--- a/WcaOnRails/spec/models/registration_spec.rb
+++ b/WcaOnRails/spec/models/registration_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Registration do
 
   it "allows zero events for non competing staff" do
     registration.registration_competition_events = []
-    registration.non_competing_staff = true
+    registration.is_competing = false
     expect(registration).to be_valid
   end
 


### PR DESCRIPTION
When persons are included in the WCIF patch who are not registered, they are now assumed to be non-competing staff, rather than silently being ignored. This allows them to have an entry in Registrations without having to sign up for events, which in turn allows them to be assigned to tasks like judging. Because they are not marked as "accepted", they do not appear in the registrations table or psych sheet.

This doesn't add a UI for adding non-competing staff; this is left up to tools that assign tasks like Groupifier, and an in-development tool for CubingUSA Nationals.

Non-competing staff also appear in a separate table on the edit registrations page.

Fixes #7491.