### PR TITLE
Dont show cancelled comps in my past comps table

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -587,6 +587,9 @@ class CompetitionsController < ApplicationController
     if current_user.person
       competition_ids.concat(current_user.person.competitions.pluck(:competitionId))
     end
+    # An organiser might still have duties to perform for a cancelled competition until the date of the competition has passed. 
+    # For example, mailing all competitors about the cancellation. 
+    # In general ensuring ease of access until it is certain that they won't need to frequently visit the page anymore.
     competitions = Competition.includes(:delegate_report, :delegates)
                               .where(id: competition_ids.uniq).where("cancelled_at is null or end_date >= curdate()")
                               .sort_by { |comp| comp.start_date || (Date.today + 20.year) }.reverse

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -588,7 +588,7 @@ class CompetitionsController < ApplicationController
       competition_ids.concat(current_user.person.competitions.pluck(:competitionId))
     end
     competitions = Competition.includes(:delegate_report, :delegates)
-                              .where(id: competition_ids.uniq)
+                              .where(id: competition_ids.uniq).where("cancelled_at is null or end_date >= curdate()")
                               .sort_by { |comp| comp.start_date || (Date.today + 20.year) }.reverse
     @past_competitions, @not_past_competitions = competitions.partition(&:is_probably_over?)
     bookmarked_ids = current_user.competitions_bookmarked.pluck(:competition_id)

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -587,8 +587,8 @@ class CompetitionsController < ApplicationController
     if current_user.person
       competition_ids.concat(current_user.person.competitions.pluck(:competitionId))
     end
-    # An organiser might still have duties to perform for a cancelled competition until the date of the competition has passed. 
-    # For example, mailing all competitors about the cancellation. 
+    # An organiser might still have duties to perform for a cancelled competition until the date of the competition has passed.
+    # For example, mailing all competitors about the cancellation.
     # In general ensuring ease of access until it is certain that they won't need to frequently visit the page anymore.
     competitions = Competition.includes(:delegate_report, :delegates)
                               .where(id: competition_ids.uniq).where("cancelled_at is null or end_date >= curdate()")


### PR DESCRIPTION
From the original email, this solves https://github.com/thewca/worldcubeassociation.org/issues/7597