### PR TITLE
Revert banned competitor registration error handling

### DIFF
--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -224,13 +224,9 @@ class Registration < ApplicationRecord
   # change doesn't lead to an invalid state.
   validate :user_can_register_for_competition, on: :create
   private def user_can_register_for_competition
-    if user&.cannot_register_for_competition_reasons.present?
+    cannot_register_reasons = user&.cannot_register_for_competition_reasons(competition)
+    if cannot_register_reasons.present?
       errors.add(:user_id, user.cannot_register_for_competition_reasons.to_sentence)
-    elsif user&.banned?
-      ban_end = user.current_team_members.select(:team == Team.banned).first.end_date
-      if !ban_end.present? || competition.start_date < ban_end
-        errors.add(:user_id, I18n.t('registrations.errors.banned_html').html_safe)
-      end
     end
   end
 

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -226,7 +226,7 @@ class Registration < ApplicationRecord
   private def user_can_register_for_competition
     cannot_register_reasons = user&.cannot_register_for_competition_reasons(competition)
     if cannot_register_reasons.present?
-      errors.add(:user_id, user.cannot_register_for_competition_reasons.to_sentence)
+      errors.add(:user_id, cannot_register_reasons.to_sentence)
     end
   end
 

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -700,7 +700,7 @@ class User < ApplicationRecord
     current_teams.include?(Team.banned)
   end
 
-  def banned_at_date(date)
+  def banned_at_date?(date)
     if banned?
       ban_end = current_team_members.select(:team == Team.banned).first.end_date
       !ban_end.present? || date < ban_end
@@ -927,7 +927,7 @@ class User < ApplicationRecord
 
   # Note this is very similar to the cannot_be_assigned_to_user_reasons method in person.rb.
   # The competition parameter is there when you want to check if a (potentially banned)
-  # user wants to register for a competition you need the competition date for
+  # competitor wants to register for a specific competition, not competitions in general
   def cannot_register_for_competition_reasons(competition = nil)
     [].tap do |reasons|
       reasons << I18n.t('registrations.errors.need_name') if name.blank?

--- a/WcaOnRails/app/views/registrations/register.html.erb
+++ b/WcaOnRails/app/views/registrations/register.html.erb
@@ -31,7 +31,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <% user_may_register = current_user.cannot_register_for_competition_reasons.length == 0 %>
+    <% user_may_register = current_user.cannot_register_for_competition_reasons(@competition).length == 0 %>
     <% if @registration.show_details?(current_user) %>
       <p><%= t 'registrations.greeting', name: current_user.name %></p>
     <% end %>
@@ -51,7 +51,7 @@
           <%= t 'registrations.please_fix_profile_html', comp: @competition.name,
                 profile: link_to(t('registrations.profile'), profile_edit_path) %>
           <ul>
-            <% current_user.cannot_register_for_competition_reasons.each do |reason| %>
+            <% current_user.cannot_register_for_competition_reasons(@competition).each do |reason| %>
               <li><%= reason %></li>
             <% end %>
           </ul>

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -3589,7 +3589,7 @@ glob@^7.1.1, glob@^7.1.3, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.3, glob@^8.1.0:
+glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -3589,7 +3589,7 @@ glob@^7.1.1, glob@^7.1.3, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.1.0:
+glob@^8.0.3, glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==


### PR DESCRIPTION
I didn't know that banned competitors don't even get the registration form shown, but an immediate error. This reverts the behavior (and I think it's also the cleaner implementation).