### PR TITLE
switched type g from 'Third Round' to 'Semi Final'

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -133,8 +133,8 @@ en:
       name: "Final"
       cellName: "Final"
     "g":
-      name: "Third round"
-      cellName: "Third round"
+      name: "Semi Final"
+      cellName: "Semi Final"
     "h":
       name: "Qualification round"
       cellName: "Qualification round"

--- a/WcaOnRails/db/seeds/round_types.seeds.rb
+++ b/WcaOnRails/db/seeds/round_types.seeds.rb
@@ -10,6 +10,6 @@ sql = "INSERT INTO `RoundTypes` (`id`, `rank`, `name`, `cellName`, `final`) VALU
 ('d', 20, 'First round', 'First round', 0),
 ('e', 59, 'Second round', 'Second round', 0),
 ('f', 99, 'Final', 'Final', 1),
-('g', 70, 'Third round', 'Third round', 0),
+('g', 70, 'Semi Final', 'Semi Final', 0),
 ('h', 10, 'Qualification round', 'Qualification round', 0);"
 ActiveRecord::Base.connection.execute(sql)


### PR DESCRIPTION
If a third round out of four has a cut-off, the round would show up as "Third Round" instead of "Semi Final". This has been fixed to keep consistency with non-cut-off rounds