### PR TITLE
Split every localization into its own pack that can be dynamically loaded

### DIFF
--- a/WcaOnRails/.eslintrc.json
+++ b/WcaOnRails/.eslintrc.json
@@ -13,7 +13,7 @@
         "SharedArrayBuffer": "readonly",
         "_": true
     },
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true

--- a/WcaOnRails/.eslintrc.json
+++ b/WcaOnRails/.eslintrc.json
@@ -13,6 +13,7 @@
         "SharedArrayBuffer": "readonly",
         "_": true
     },
+    "parser": "babel-eslint",
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true

--- a/WcaOnRails/.eslintrc.json
+++ b/WcaOnRails/.eslintrc.json
@@ -18,7 +18,8 @@
             "jsx": true
         },
         "ecmaVersion": 2018,
-        "sourceType": "module"
+        "sourceType": "module",
+        "allowImportExportEverywhere": true
     },
     "plugins": [
         "react",

--- a/WcaOnRails/app/webpacker/lib/edit-events.js
+++ b/WcaOnRails/app/webpacker/lib/edit-events.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 /* eslint import/no-named-as-default: "off" */
 /* eslint import/no-named-as-default-member: "off" */
+/* eslint import/no-cycle: "off" */
 import EditEvents from '../components/EditEvents';
 import { events } from './wca-data.js.erb';
 

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -44,8 +44,9 @@ window.I18n.tArray = tArray;
 export default window.I18n;
 
 function loadTranslations(i18n, locale) {
-  const translations = import(`../rails_translations/${locale}.json`)
-  i18n.store(translations);
+  import(`../rails_translations/${locale}.json`).then((translations) => {
+    i18n.store(translations);
+  })
 }
 
 // store the actual translations.

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -46,11 +46,7 @@ export default window.I18n;
 function loadTranslations(i18n, locale) {
   import(`../rails_translations/${locale}.json`).then((translations) => {
     i18n.store(translations);
-  }).catch((err) => {
-    if (err) {
-      console.error(`Could not load translations because of ${err}, if this is test this is intended`);
-    }
-  });
+  })
 }
 
 // store the actual translations.

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -1,7 +1,5 @@
 import { I18n } from 'i18n-js';
 
-const i18nFileContext = require.context('rails_translations');
-
 const DEFAULT_LOCALE = 'en';
 
 /**
@@ -46,7 +44,7 @@ window.I18n.tArray = tArray;
 export default window.I18n;
 
 function loadTranslations(i18n, locale) {
-  const translations = i18nFileContext(`./${locale}.json`);
+  const translations = import(`../rails_translations/${locale}.json`)
   i18n.store(translations);
 }
 

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -46,7 +46,7 @@ export default window.I18n;
 function loadTranslations(i18n, locale) {
   import(`../rails_translations/${locale}.json`).then((translations) => {
     i18n.store(translations);
-  })
+  });
 }
 
 // store the actual translations.

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -47,7 +47,7 @@ function loadTranslations(i18n, locale) {
   import(`../rails_translations/${locale}.json`).then((translations) => {
     i18n.store(translations);
   }).catch((err) => {
-    if(err) {
+    if (err) {
       console.error(`Could not load translations because of ${err}, if this is test this is intended`);
     }
   });

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -44,7 +44,7 @@ window.I18n.tArray = tArray;
 export default window.I18n;
 
 function loadTranslations(i18n, locale) {
-  import(`../rails_translations/${locale}.json`).then((translations) => {
+  import(`rails_translations/${locale}.json`).then((translations) => {
     i18n.store(translations);
   });
 }

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -46,6 +46,10 @@ export default window.I18n;
 function loadTranslations(i18n, locale) {
   import(`../rails_translations/${locale}.json`).then((translations) => {
     i18n.store(translations);
+  }).catch((err) => {
+    if(err){
+      console.error(`Could not load translations because of ${err}, if this is test this is intended`)
+    }
   });
 }
 

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -47,8 +47,8 @@ function loadTranslations(i18n, locale) {
   import(`../rails_translations/${locale}.json`).then((translations) => {
     i18n.store(translations);
   }).catch((err) => {
-    if(err){
-      console.error(`Could not load translations because of ${err}, if this is test this is intended`)
+    if(err) {
+      console.error(`Could not load translations because of ${err}, if this is test this is intended`);
     }
   });
 }

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@babel/core": "^7.22.5",
+    "@babel/eslint-parser": "^7.22.5",
     "@babel/plugin-proposal-class-properties": "^7.17.12",
     "@babel/plugin-proposal-decorators": "^7.22.5",
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -48,6 +48,15 @@
     json5 "^2.2.2"
     semver "^6.3.0"
 
+"@babel/eslint-parser@^7.22.5":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.22.6.tgz#fa75b578a6392d92243eb8fb9c4e7ece8ad7c583"
+  integrity sha512-KAom7E7d6bAh5/PflF3luynWlDLOIqfX+ZJcL0LRs6/6rtXJmJxPiWuIGfxNPtcWdtQ5lSSJbKbQlz/c/R60Ng==
+  dependencies:
+    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
+    "@nicolo-ribaudo/semver-v6" "^6.3.3"
+    eslint-visitor-keys "^2.1.0"
+
 "@babel/generator@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.5.tgz#1e7bf768688acfb05cf30b2369ef855e82d984f7"
@@ -1542,6 +1551,18 @@
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
+
+"@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
+  version "5.1.1-v1"
+  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
+  integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
+  dependencies:
+    eslint-scope "5.1.1"
+
+"@nicolo-ribaudo/semver-v6@^6.3.3":
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz#ea6d23ade78a325f7a52750aab1526b02b628c29"
+  integrity sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3440,6 +3461,11 @@ eslint-scope@^7.2.0:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
+
+eslint-visitor-keys@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   version "3.4.1"


### PR DESCRIPTION
I recently noticed that we are loading an 1.6MB js file that contains all the localizations on each page. 1.6MB is huge in web terms and while it will be cached  by the browser on subsequent loads, this change will still reduce a good amount of traffic.
This brings the average translation pack to less than 50kb. 