### PR TITLE
API route to return countries

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -209,4 +209,8 @@ class Api::V0::ApiController < ApplicationController
 
     @current_api_user = User.find_by_id(doorkeeper_token&.resource_owner_id)
   end
+
+  def countries
+    render json: Country.all
+  end
 end

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -259,6 +259,7 @@ Rails.application.routes.draw do
       get '/persons/:wca_id/results' => "persons#results", as: :person_results
       get '/persons/:wca_id/competitions' => "persons#competitions", as: :person_competitions
       get '/geocoding/search' => 'geocoding#get_location_from_query', as: :geocoding_search
+      get '/countries' => 'api#countries'
       resources :competitions, only: [:index, :show] do
         get '/wcif' => 'competitions#show_wcif'
         get '/wcif/public' => 'competitions#show_wcif_public'


### PR DESCRIPTION
I want to do some calculations involving people's continental records and don't want to import the database.

Added:
```
GET /api/v0/countries

[
{
  "id": "Afghanistan",
  "name": "Afghanistan",
  "continentId": "_Asia",
  "iso2": "AF"
},
{
  "id": "Albania",
  "name": "Albania",
  "continentId": "_Europe",
  "iso2": "AL"
},  
...
]

```