### PR TITLE
Fix trailing space before period on About page

### DIFF
--- a/WcaOnRails/app/webpacker/components/StaticPages/About.js
+++ b/WcaOnRails/app/webpacker/components/StaticPages/About.js
@@ -117,11 +117,9 @@ function About({ currentBoardMembers }) {
         <I18nHTMLTranslate
           i18nKey="about.structure.operations_html"
           options={{
-            committees_and_teams: `
-                <a href="/teams-committees">
-                    ${I18n.t('about.structure.teams_committees')}
-                </a>
-            `,
+            committees_and_teams: `<a href="/teams-committees">${I18n.t(
+              'about.structure.teams_committees',
+            )}</a>`,
           }}
         />
       </p>


### PR DESCRIPTION
Blink and you'll miss it 👀 

Before:

![image](https://user-images.githubusercontent.com/48423418/218331686-500fb27f-b673-4c2b-bc33-5589a64d549b.png)

After:

![image](https://user-images.githubusercontent.com/48423418/218331689-2745ecdb-8a23-4ac8-b883-b5b8f497f0d4.png)

I used https://prettier.io/playground/ to safely format these few lines.
