### PR TITLE
Expose results in a bulk API route

### DIFF
--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -260,6 +260,7 @@ Rails.application.routes.draw do
       get '/persons/:wca_id/competitions' => "persons#competitions", as: :person_competitions
       get '/geocoding/search' => 'geocoding#get_location_from_query', as: :geocoding_search
       get '/countries' => 'api#countries'
+      get '/results' => 'api#results'
       resources :competitions, only: [:index, :show] do
         get '/wcif' => 'competitions#show_wcif'
         get '/wcif/public' => 'competitions#show_wcif_public'


### PR DESCRIPTION
I may want to do bulk analysis on results from a number of competitions without importing the wca database. This API endpoint *should not* be too burdensome on the server.