### PR TITLE
Migrate Analytics to GA4

### DIFF
--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -64,7 +64,18 @@
   <%= auto_discovery_link_tag(:rss, rss_url(format: :xml)) %>
   <% if EnvVars.WCA_LIVE_SITE? %>
     <script data-ad-client="ca-pub-8682718775826560" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <!-- Google tag (gtag.js) -->
+    <!-- Legacy GA property still active for transitioning numbers -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-41256017-1', 'auto');
+      ga("set", "anonymizeIp", true);
+      ga('send', 'pageview');
+    </script>
+    <!-- New Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-QB1H9R123K"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/WcaOnRails/app/views/layouts/application.html.erb
+++ b/WcaOnRails/app/views/layouts/application.html.erb
@@ -64,15 +64,13 @@
   <%= auto_discovery_link_tag(:rss, rss_url(format: :xml)) %>
   <% if EnvVars.WCA_LIVE_SITE? %>
     <script data-ad-client="ca-pub-8682718775826560" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-QB1H9R123K"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-41256017-1', 'auto');
-      ga("set", "anonymizeIp", true);
-      ga('send', 'pageview');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-QB1H9R123K', { 'anonymize_ip': true });
     </script>
   <% end %>
 </head>


### PR DESCRIPTION
As per https://support.google.com/analytics/answer/9304153?sjid=4362531488141620959-EU#add-tag&zippy=%2Cadd-the-google-tag-directly-to-your-web-pages