### PR TITLE
Add Conditional GET Support

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -30,6 +30,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   def results
     competition = competition_from_params
     render json: competition.results
+    fresh_when(last_modified: competition.updated_at)
   end
 
   def event_results
@@ -52,13 +53,13 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
           name: round&.name || "#{event.name} #{round_type.name}",
           results: results.sort_by { |r| [r.pos, r.personName] },
         }
-    end
-    render json: {
-      id: event.id,
-      # Also include the (localized) name here, we don't have i18n in js yet.
-      name: event.name,
-      rounds: rounds,
-    }
+      end
+      render json: {
+        id: event.id,
+        # Also include the (localized) name here, we don't have i18n in js yet.
+        name: event.name,
+        rounds: rounds,
+      }
     end
   end
 

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -448,7 +448,7 @@ class CompetitionsController < ApplicationController
       },
     }
     @competition = competition_from_params(includes: associations)
-    if stale?(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
+    if stale?(etag: [@competition, current_user, I18n.locale], last_modified: @competition.updated_at)
       respond_to do |format|
         format.html
         format.pdf do
@@ -485,22 +485,22 @@ class CompetitionsController < ApplicationController
 
   def show_podiums
     @competition = competition_from_params
-    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
+    fresh_when(etag: [@competition, current_user, I18n.locale], last_modified: @competition.updated_at)
   end
 
   def show_all_results
     @competition = competition_from_params
-    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
+    fresh_when(etag: [@competition, current_user, I18n.locale], last_modified: @competition.updated_at)
   end
 
   def show_results_by_person
     @competition = competition_from_params
-    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
+    fresh_when(etag: [@competition, current_user, I18n.locale], last_modified: @competition.updated_at)
   end
 
   def show_scrambles
     @competition = competition_from_params
-    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
+    fresh_when(etag: [@competition, current_user, I18n.locale], last_modified: @competition.updated_at)
   end
 
   def embedable_map

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -448,7 +448,7 @@ class CompetitionsController < ApplicationController
       },
     }
     @competition = competition_from_params(includes: associations)
-    if stale?(@competition)
+    if stale?(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
       respond_to do |format|
         format.html
         format.pdf do
@@ -485,26 +485,22 @@ class CompetitionsController < ApplicationController
 
   def show_podiums
     @competition = competition_from_params
-    if stale?(@competition)
-    end
+    fresh_when(:etag => @competiton)
   end
 
   def show_all_results
     @competition = competition_from_params
-    if stale?(@competition)
-    end
+    fresh_when(@competiton)
   end
 
   def show_results_by_person
     @competition = competition_from_params
-    if stale?(@competition)
-    end
+    fresh_when(@competiton)
   end
 
   def show_scrambles
     @competition = competition_from_params
-    if stale?(@competition)
-    end
+    fresh_when(@competiton)
   end
 
   def embedable_map

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -485,22 +485,22 @@ class CompetitionsController < ApplicationController
 
   def show_podiums
     @competition = competition_from_params
-    fresh_when(:etag => @competiton)
+    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
   end
 
   def show_all_results
     @competition = competition_from_params
-    fresh_when(@competiton)
+    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
   end
 
   def show_results_by_person
     @competition = competition_from_params
-    fresh_when(@competiton)
+    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
   end
 
   def show_scrambles
     @competition = competition_from_params
-    fresh_when(@competiton)
+    fresh_when(:etag => [@competition, current_user, I18n.locale], :last_modified => @competition.updated_at)
   end
 
   def embedable_map

--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -29,7 +29,7 @@ class PersonsController < ApplicationController
   def show
     @person = Person.current.includes(:user, :ranksSingle, :ranksAverage, :competitions).find_by_wca_id!(params[:id])
 
-    if stale?(@person)
+    if stale?(:etag => [@person, current_user, I18n.locale])
       @previous_persons = Person.where(wca_id: params[:id]).where.not(subId: 1).order(:subId)
       @ranks_single = @person.ranksSingle.select { |r| r.event.official? }
       @ranks_average = @person.ranksAverage.select { |r| r.event.official? }

--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -28,13 +28,16 @@ class PersonsController < ApplicationController
 
   def show
     @person = Person.current.includes(:user, :ranksSingle, :ranksAverage, :competitions).find_by_wca_id!(params[:id])
-    @previous_persons = Person.where(wca_id: params[:id]).where.not(subId: 1).order(:subId)
-    @ranks_single = @person.ranksSingle.select { |r| r.event.official? }
-    @ranks_average = @person.ranksAverage.select { |r| r.event.official? }
-    @medals = @person.medals
-    @records = @person.records
-    @results = @person.results.includes(:competition, :event, :format, :round_type).order("Events.rank, Competitions.start_date DESC, Competitions.id, RoundTypes.rank DESC")
-    @championship_podiums = @person.championship_podiums
-    params[:event] ||= @results.first.event.id
+
+    if stale?(@person)
+      @previous_persons = Person.where(wca_id: params[:id]).where.not(subId: 1).order(:subId)
+      @ranks_single = @person.ranksSingle.select { |r| r.event.official? }
+      @ranks_average = @person.ranksAverage.select { |r| r.event.official? }
+      @medals = @person.medals
+      @records = @person.records
+      @results = @person.results.includes(:competition, :event, :format, :round_type).order("Events.rank, Competitions.start_date DESC, Competitions.id, RoundTypes.rank DESC")
+      @championship_podiums = @person.championship_podiums
+      params[:event] ||= @results.first.event.id
+    end
   end
 end

--- a/WcaOnRails/app/controllers/persons_controller.rb
+++ b/WcaOnRails/app/controllers/persons_controller.rb
@@ -29,7 +29,7 @@ class PersonsController < ApplicationController
   def show
     @person = Person.current.includes(:user, :ranksSingle, :ranksAverage, :competitions).find_by_wca_id!(params[:id])
 
-    if stale?(:etag => [@person, current_user, I18n.locale])
+    if stale?(etag: [@person, current_user, I18n.locale])
       @previous_persons = Person.where(wca_id: params[:id]).where.not(subId: 1).order(:subId)
       @ranks_single = @person.ranksSingle.select { |r| r.event.official? }
       @ranks_average = @person.ranksAverage.select { |r| r.event.official? }


### PR DESCRIPTION
Conditional GETs are a feature of the HTTP specification that provide a way for web servers to tell browsers that the response to a GET request hasn't changed since the last request and can be safely pulled from the browser cache. 
Rails supports these out of the box, read about it [here](https://guides.rubyonrails.org/caching_with_rails.html#conditional-get-support).

This PR adds Conditional GET checks for Persons and Competitions, which is going to save traffic for instances where the user revisits these pages without them having changed. The user and the Locale is included in the etag so wrong content is not served when a user changes permissions, logs into a different account or changes locale.

We will get even more benefits from this when we get I18n out of Ruby 