### PR TITLE
Don't validate form when captcha failed

### DIFF
--- a/WcaOnRails/app/controllers/accounts/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/accounts/registrations_controller.rb
@@ -11,7 +11,7 @@ class Accounts::RegistrationsController < Devise::RegistrationsController
   def check_captcha
     return if verify_recaptcha
     self.resource = resource_class.new sign_up_params
-    resource.validate
+    # resource.validate
     set_minimum_password_length
     respond_with_navigational(resource) do
       flash.now[:recaptcha_error] = flash[:recaptcha_error]


### PR DESCRIPTION
As discussed on slack this prevents the server validating inputs in forms that use recaptcha when the captcha is not successful.