### PR TITLE
Improve Error Handling and Logging

### DIFF
--- a/WcaOnRails/app/controllers/errors_controller.rb
+++ b/WcaOnRails/app/controllers/errors_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class ErrorsController < ApplicationController
+  layout "application"
+
+  def show
+    @exception = request.env["action_dispatch.exception"]
+    @status_code = ActionDispatch::ExceptionWrapper.new(request.env, @exception).status_code
+    @request_id = request.env["action_dispatch.request_id"]
+    render error_page(@status_code), status: @status_code
+  end
+
+  private
+
+  def error_page(code)
+    supported_error_codes.fetch(code, "404")
+  end
+
+  def supported_error_codes
+    {
+      500 => "500",
+      501 => "500",
+      502 => "500",
+    }
+  end
+end

--- a/WcaOnRails/app/views/errors/404.html.erb
+++ b/WcaOnRails/app/views/errors/404.html.erb
@@ -1,0 +1,7 @@
+<div class="dialog" style="display: flex; height: 80vh; justify-content: center; align-items:center">
+  <div>
+    <h1><%= t('wca.errors.error_pages.400_error') %></h1>
+    <p><%= t('wca.errors.error_pages.400_contact') %></p>
+    <p>Request ID: <%= @request_id %></p>
+  </div>
+</div>

--- a/WcaOnRails/app/views/errors/500.html.erb
+++ b/WcaOnRails/app/views/errors/500.html.erb
@@ -1,0 +1,7 @@
+<div class="dialog" style="display: flex; height: 80vh; justify-content: center; align-items:center">
+  <div>
+    <h1><%= t('wca.errors.error_pages.500_error') %></h1>
+    <p><%= t('wca.errors.error_pages.500_contact') %></p>
+    <p>Request ID: <%= @request_id %></p>
+  </div>
+</div>

--- a/WcaOnRails/config/environments/development.rb
+++ b/WcaOnRails/config/environments/development.rb
@@ -87,6 +87,12 @@ Rails.application.configure do
     Bullet.add_safelist type: :unused_eager_loading, class_name: "CompetitionEvent", association: :rounds
   end
 
+  # uncomment this if you want to test error pages in development
+  # config.consider_all_requests_local = false
+  # config.exceptions_app = ->(env) {
+  #   ErrorsController.action(:show).call(env)
+  # }
+
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/WcaOnRails/config/environments/production.rb
+++ b/WcaOnRails/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -135,6 +135,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Error pages for production
+  config.exceptions_app = ->(env) {
+    ErrorsController.action(:show).call(env)
+  }
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -809,6 +809,12 @@ en:
         form_error:
           one: "The form contains one error:"
           other: "The form contains %{count} errors:"
+      error_pages:
+        #context: The error pages in the case of 500s or 400s
+        500_error: "We're sorry, but something went wrong."
+        500_contact: "If you report this error to the Software Team please mention the Request ID"
+        400_error: "The page you were looking for doesn't exist."
+        400_contact: "If you think this is a mistake please contact the Software Team and include the Request ID"
     #context: Key used when an external OAuth app is willing to access a WCA user's data
     doorkeeper:
       applications:


### PR DESCRIPTION
This PR fixes #7658 and #17 by introducing Custom error pages for 400 and 500 errors. 
I also include a request id with every error which can be cross referenced with the logs on the server (or New Relic for easier searchability).
I also changed the log level from `:debug` to `:info` which should reduce our logs by 85%, save on disk space and improve performance.