### PR TITLE
Make sure competition form AJAX arrays are arrays

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -287,19 +287,19 @@ class CompetitionsController < ApplicationController
   end
 
   def get_nearby_competitions(competition)
-    nearby_competitions = competition.nearby_competitions_warning[0, 10]
+    nearby_competitions = competition.nearby_competitions_warning.to_a[0, 10]
     nearby_competitions.select!(&:confirmed?) unless current_user.can_view_hidden_competitions?
     nearby_competitions
   end
 
   def get_series_eligible_competitions(competition)
-    series_eligible_competitions = competition.series_eligible_competitions
+    series_eligible_competitions = competition.series_eligible_competitions.to_a
     series_eligible_competitions.select!(&:confirmed?) unless current_user.can_view_hidden_competitions?
     series_eligible_competitions
   end
 
   def get_colliding_registration_start_competitions(competition)
-    colliding_registration_start_competitions = competition.colliding_registration_start_competitions
+    colliding_registration_start_competitions = competition.colliding_registration_start_competitions.to_a
     colliding_registration_start_competitions.select!(&:confirmed?) unless current_user.can_view_hidden_competitions?
     colliding_registration_start_competitions
   end


### PR DESCRIPTION
The implementation behind `nearby_competitions_warning` and `series_eligible_competitions` makes it so that the Rails ActiveRecord query is "accidentally" fetched into an array before invoking the `sort_by`, while the implementation behind `colliding_registration_start_comps` can use a "real" SQL `ORDER BY`.

As a result, the former two invocations have a `select!` method (which is a pure Ruby method defined on arrays, and just a unhappy naming coincidence that has nothing to do with SQL `SELECT`) while the latter one does not.

This commit consistently squeezes the results into an array in any case. God knows why the tests for this sometimes fail and sometimes don't.

CC @FinnIckler 