### PR TITLE
Move rubocop config to the rails folder

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -53,6 +53,7 @@ PreCommit:
 
   RuboCop:
     enabled: true
+    command: ['bundle', 'exec', 'rubocop', '--config', './WcaOnRails/.rubocop.yml']
     on_warn: fail # Treat all warnings as failures
 
   IllegalStrings:

--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -5,11 +5,11 @@ AllCops:
   DisplayCopNames: true
   NewCops: enable
   Exclude:
-    - 'WcaOnRails/node_modules/**/*'
-    - 'WcaOnRails/bin/**/*'
-    - 'WcaOnRails/vendor/**/*'
+    - 'node_modules/**/*'
+    - 'bin/**/*'
+    - 'vendor/**/*'
     # This file is provided as-is by Discourse
-    - 'WcaOnRails/lib/single_sign_on.rb'
+    - 'lib/single_sign_on.rb'
 
 Bundler/OrderedGems:
   Enabled: false
@@ -201,7 +201,7 @@ Layout/EmptyLineAfterGuardClause:
 
 Lint/EmptyFile:
   Exclude:
-    - 'WcaOnRails/db/seeds.rb'
+    - 'db/seeds.rb'
 
 # We have too many event IDs and Comp Years with numbers in them
 Naming/VariableNumber:
@@ -211,11 +211,11 @@ Naming/VariableNumber:
 # we have no choice but to follow their conventions until they update
 Naming/InclusiveLanguage:
   Exclude:
-    - 'WcaOnRails/config/**/*'
+    - 'config/**/*'
 
 Style/OpenStructUse:
   Exclude:
-    - 'WcaOnRails/spec/lib/middlewares/warden_user_logger_spec.rb'
+    - 'spec/lib/middlewares/warden_user_logger_spec.rb'
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: never

--- a/WcaOnRails/.rubocop_todo.yml
+++ b/WcaOnRails/.rubocop_todo.yml
@@ -14,11 +14,11 @@
 # SupportedStyles: snake_case, camelCase
 Naming/MethodName:
   Exclude:
-    - 'WcaOnRails/app/controllers/users_controller.rb'
-    - 'WcaOnRails/app/models/light_result.rb'
-    - 'WcaOnRails/app/models/event.rb'
-    - 'WcaOnRails/app/models/round_type.rb'
-    - 'WcaOnRails/db/migrate/20160109070723_convert_process_links_format_to_markdown.rb'
+    - 'app/controllers/users_controller.rb'
+    - 'app/models/light_result.rb'
+    - 'app/models/event.rb'
+    - 'app/models/round_type.rb'
+    - 'db/migrate/20160109070723_convert_process_links_format_to_markdown.rb'
 
 # Offense count: 16
 # Configuration parameters: EnforcedStyle, SupportedStyles.
@@ -36,19 +36,19 @@ Lint/AmbiguousBlockAssociation:
 
 Metrics/CyclomaticComplexity:
   Exclude:
-    - 'WcaOnRails/app/controllers/competitions_controller.rb'
-    - 'WcaOnRails/app/controllers/registrations_controller.rb'
-    - 'WcaOnRails/app/jobs/sync_mailing_lists_job.rb'
-    - 'WcaOnRails/app/models/competition.rb'
-    - 'WcaOnRails/lib/results_validators/*.rb'
+    - 'app/controllers/competitions_controller.rb'
+    - 'app/controllers/registrations_controller.rb'
+    - 'app/jobs/sync_mailing_lists_job.rb'
+    - 'app/models/competition.rb'
+    - 'lib/results_validators/*.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
-    - 'WcaOnRails/app/controllers/competitions_controller.rb'
-    - 'WcaOnRails/app/controllers/registrations_controller.rb'
-    - 'WcaOnRails/app/jobs/sync_mailing_lists_job.rb'
-    - 'WcaOnRails/app/models/competition.rb'
-    - 'WcaOnRails/lib/results_validators/*.rb'
+    - 'app/controllers/competitions_controller.rb'
+    - 'app/controllers/registrations_controller.rb'
+    - 'app/jobs/sync_mailing_lists_job.rb'
+    - 'app/models/competition.rb'
+    - 'lib/results_validators/*.rb'
 
 Lint/StructNewOverride:
   Enabled: false


### PR DESCRIPTION
This should allow some IDEs to detect it when only opening the rails portions of the codebase without having to manually copy over the files