### PR TITLE
Stripe hotifx: Add conversion back from Stripe denomination to RubyMoney

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -542,8 +542,10 @@ class RegistrationsController < ApplicationController
     elsif intent&.status == "succeeded"
       # FIXME: what if intent.charges.total_count is not 1?!
       intent.charges.data.each do |charge|
+        ruby_amount = StripeCharge.amount_to_ruby(charge.amount, charge.currency)
+
         registration.record_payment(
-          charge.amount,
+          ruby_amount,
           charge.currency,
           charge.id,
           current_user.id,
@@ -600,8 +602,12 @@ class RegistrationsController < ApplicationController
       stripe_account: registration.competition.connected_stripe_account_id,
     )
 
+    # Should be the same as `refund_amount`, but by double-converting from the Stripe object
+    # we can also double-check that they're on the same page as we are (to be _really_ sure!)
+    ruby_amount = StripeCharge.amount_to_ruby(refund.amount, refund.currency)
+
     registration.record_refund(
-      refund.amount,
+      ruby_amount,
       refund.currency,
       refund.id,
       payment.id,

--- a/WcaOnRails/spec/models/stripe_charge_spec.rb
+++ b/WcaOnRails/spec/models/stripe_charge_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe StripeCharge do
 
     stripe_amount = StripeCharge.amount_to_stripe(six_thousand_huf.cents, six_thousand_huf.currency.iso_code)
     expect(stripe_amount).to eq(600_000)
+
+    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, six_thousand_huf.currency.iso_code)
+    expect(ruby_amount).to eq(six_thousand_huf.cents)
   end
 
   it "handles UGX as a special currency" do
@@ -19,6 +22,9 @@ RSpec.describe StripeCharge do
 
     stripe_amount = StripeCharge.amount_to_stripe(sixty_thousand_ugx.cents, sixty_thousand_ugx.currency.iso_code)
     expect(stripe_amount).to eq(6_000_000)
+
+    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, sixty_thousand_ugx.currency.iso_code)
+    expect(ruby_amount).to eq(sixty_thousand_ugx.cents)
   end
 
   it "throws exception when sub-hundred currency not divisible" do
@@ -26,6 +32,12 @@ RSpec.describe StripeCharge do
       # Funnily enough, our RubyMoney gem doesn't even support HUF sub-units, but Stripe still insists on
       # *not* charging sub-units in the lowest two decimal places. So we manually insert a fraction to check for the error.
       StripeCharge.amount_to_stripe(6000.45, 'HUF')
+    end.to raise_error(RuntimeError)
+
+    expect do
+      # When Stripe returns something that is not cleanly divisible into cents (which, according to its own API docs,
+      # it never should…) we throw an error and complain as a safeguard.
+      StripeCharge.amount_to_ruby(6045, 'HUF')
     end.to raise_error(RuntimeError)
   end
 
@@ -35,6 +47,9 @@ RSpec.describe StripeCharge do
 
     stripe_amount = StripeCharge.amount_to_stripe(fifteen_usd.cents, fifteen_usd.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
+
+    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, fifteen_usd.currency.iso_code)
+    expect(ruby_amount).to eq(fifteen_usd.cents)
   end
 
   it "handles EUR as a normal currency" do
@@ -43,6 +58,9 @@ RSpec.describe StripeCharge do
 
     stripe_amount = StripeCharge.amount_to_stripe(fifteen_eur.cents, fifteen_eur.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
+
+    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, fifteen_eur.currency.iso_code)
+    expect(ruby_amount).to eq(fifteen_eur.cents)
   end
 
   it "handles JPY as a normal currency" do
@@ -51,6 +69,9 @@ RSpec.describe StripeCharge do
 
     stripe_amount = StripeCharge.amount_to_stripe(two_thousand_yen.cents, two_thousand_yen.currency.iso_code)
     expect(stripe_amount).to eq(2_000)
+
+    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, two_thousand_yen.currency.iso_code)
+    expect(ruby_amount).to eq(two_thousand_yen.cents)
   end
 
   it "handles TWD as a normal currency" do
@@ -61,5 +82,8 @@ RSpec.describe StripeCharge do
 
     stripe_amount = StripeCharge.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
     expect(stripe_amount).to eq(50_000)
+
+    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, five_hundred_twd.currency.iso_code)
+    expect(ruby_amount).to eq(five_hundred_twd.cents)
   end
 end


### PR DESCRIPTION
We forgot/overlooked this when #7364 was merged. This adds back a reverse operation, so that 'special currencies' (see other PR for what that means) are correctly converted _back_ when inserting them into the Rails/Ruby world.