### PR TITLE
Update _organization_default.md

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/_organization_default.md
+++ b/WcaOnRails/app/views/delegate_reports/_organization_default.md
@@ -1,14 +1,14 @@
-* **Organization team:** [Who are the persons in the organisation team? Was this their first organised competition or do they have previous experience? How did they do their job with the tasks before the competition? How did they do during the competition? Are you likely going to work with the organiser(s) again?]
+* **Organization team:** [Who were the persons in the organisation team? Was this their first organised competition, or did they have previous experience? How did they do their job with the tasks before the competition? How did they do during the competition? Are you likely going to work with the organiser(s) again?]
 
-* **Delegates:** [If you are not the closest living Delegate: Why are you in charge of this competition? Were there other listed Delegates besides you? Were there other unlisted Delegates present? Did you coordinate everything well with the organisers before and during the weekend? Did you carry out any of the organisation tasks?]
+* **Delegates:** [If you were not the closest-living Delegate: Why were you in charge of this competition? Were there other listed Delegates besides you? Were there other unlisted Delegates present? Did you coordinate everything well with the organisers before and during the weekend? Did you carry out any of the organisation tasks?]
 
 * **Schedule:** [Did you fall behind or run ahead of schedule? What were the reasons for deviations? Did you start/end the competition day(s) on time?]
 
-* **Judging system:** [Running VS Fixed/Seated? Did you have dedicated staff? Were there pre-computed assignments (i.e. Groupifier)?]
+* **Judging system:** [Running VS Fixed/Seated? Did you have dedicated staff? Were there pre-computed assignments (e.g., Groupifier)?]
 
 * **Scrambling:** [How many scramblers did you generally assign? Did you have troubles with the scrambling of any particular puzzles? Did you use scrambler signatures? Did you use printed scrambles or display device(s)? If printed, who prepared the print-outs? If display, who was in charge of changing scrambles with password access?]
 
-* **Score-taking:** [Did you catch up with score-taking or were there significant delays between the event happening and the times being entered? When did you perform score checks?]
+* **Score-taking:** [Did you catch up with score-taking, or were there significant delays between the event happening and the times being entered? When did you perform score checks?]
 
 * **Software:** [Which programs did you use to help you with managing the competition? What software was used to create the Scorecards? If custom, is the source code freely available? If custom, why did you decide to use the program instead of WCA-recommended alternatives?]
 
@@ -16,7 +16,7 @@
 
 * **Prizes:** [Did you give out any form of certificates or prizes to the winners? If so, what?]
 
-* **Delegate expenses:** [Which costs were paid for the listed Delegate(s)? Who were they paid by and where did the money come from?]
+* **Delegate expenses:** [Which costs were paid for the listed Delegate(s)? Who were they paid by, and where did the money come from?]
 
 * **Sponsors:** [Were there any companies sponsoring the competition? If so, what form of sponsorship did you get (money, cubes, other)? What did you have to do in return?]
 


### PR DESCRIPTION
Grammar fixes:
* "Closest living Delegate" without the hyphen suggested that the interpretation is the "closest Delegate who is alive" as opposed to the "the Delegate who is located the closest".
* A few sentences of the same section were written in present tense although the rest of the document was in past tense.
* One instance of "i.e." should have been "e.g." since Groupifier is not the only way to generate groups. 
* Three instances of "or" or "and" were used to begin an independent clause without a preceding comma.