### PR TITLE
Restructure Stripe journal: Record all transactions

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -467,8 +467,9 @@ class RegistrationsController < ApplicationController
       return
     end
     intent = nil
-    stripe_charge = nil
+    stripe_transaction = nil
     competition = registration.competition
+    account_id = competition.connected_stripe_account_id
     registration_metadata = {
       competition: competition.name,
       registration_url: edit_registration_url(registration),
@@ -481,7 +482,7 @@ class RegistrationsController < ApplicationController
         end
 
         currency_iso = registration.outstanding_entry_fees.currency.iso_code
-        stripe_amount = StripeCharge.amount_to_stripe(amount, currency_iso)
+        stripe_amount = StripeTransaction.amount_to_stripe(amount, currency_iso)
 
         payment_intent_args = {
           payment_method: params[:payment_method_id],
@@ -494,55 +495,56 @@ class RegistrationsController < ApplicationController
           metadata: registration_metadata,
         }
         # Log the payment attempt
-        stripe_charge = StripeCharge.create!(
-          metadata: payment_intent_args.to_json,
-          stripe_charge_id: nil,
+        stripe_transaction = StripeTransaction.create!(
+          parameters: payment_intent_args,
+          api_type: "PaymentIntent",
+          stripe_id: nil,
           status: "unknown",
+          account_id: account_id,
         )
         # Create the PaymentIntent, overriding the stripe_account for the request
         # by the connected stripe account for the competition.
         intent = Stripe::PaymentIntent.create(
           payment_intent_args,
-          stripe_account: registration.competition.connected_stripe_account_id,
+          stripe_account: account_id,
         )
       elsif params[:payment_intent_id]
-        stripe_charge = StripeCharge.find_by(stripe_charge_id: params[:payment_intent_id])
-        # We should definitely find a StripeCharge for this PI, so show an error if we don't.
-        unless stripe_charge
+        stripe_transaction = StripeTransaction.find_by(type: 'PaymentIntent', stripe_id: params[:payment_intent_id])
+        # We should definitely find a StripeTransaction for this PI, so show an error if we don't.
+        unless stripe_transaction
           render json: { error: { message: t("registrations.payment_form.errors.intent_not_found") } }
           return
         end
         intent = Stripe::PaymentIntent.confirm(
           params[:payment_intent_id],
           {},
-          stripe_account: registration.competition.connected_stripe_account_id,
+          stripe_account: account_id,
         )
       end
     rescue Stripe::StripeError => e
       # Log and display error to client
-      stripe_charge.update!(status: "failure", error: e.message)
+      stripe_transaction.update!(status: "failure", error: e.message)
       render json: { error: { message: e.message } }
       return
     end
-    status, response = generate_payment_response!(registration, intent, stripe_charge)
+    status, response = generate_payment_response!(registration, intent, stripe_transaction)
     render json: response, status: status
   end
 
-  private def generate_payment_response!(registration, intent, stripe_charge)
+  private def generate_payment_response!(registration, intent, stripe_transaction)
     if intent && intent.status == "requires_action" &&
        intent.next_action.type == "use_stripe_sdk"
       # For now, since we don't have a charge, we'll keep the intent id as the charge id
       # to be able to match the log entry to an actual Stripe action.
-      stripe_charge.update!(
+      stripe_transaction.update!(
         status: "payment_intent_registered",
-        stripe_charge_id: intent.id,
+        stripe_id: intent.id,
       )
       # Tell the client to handle the action
       [200, { requires_action: true, payment_intent_client_secret: intent.client_secret }]
-    elsif intent&.status == "succeeded"
-      # FIXME: what if intent.charges.total_count is not 1?!
+    elsif intent.status == "succeeded"
       intent.charges.data.each do |charge|
-        ruby_amount = StripeCharge.amount_to_ruby(charge.amount, charge.currency)
+        ruby_amount = StripeTransaction.amount_to_ruby(charge.amount, charge.currency)
 
         registration.record_payment(
           ruby_amount,
@@ -550,11 +552,11 @@ class RegistrationsController < ApplicationController
           charge.id,
           current_user.id,
         )
-        stripe_charge.update!(
-          status: "success",
-          stripe_charge_id: charge.id,
-        )
       end
+      stripe_transaction.update!(
+        status: "success",
+        stripe_id: intent.id,
+      )
       # The payment didn’t need any additional actions and is completed!
       # Handle post-payment fulfillment
       [200, { success: true }]
@@ -592,7 +594,7 @@ class RegistrationsController < ApplicationController
     end
 
     currency_iso = registration.competition.currency_code
-    stripe_amount = StripeCharge.amount_to_stripe(refund_amount, currency_iso)
+    stripe_amount = StripeTransaction.amount_to_stripe(refund_amount, currency_iso)
 
     refund = Stripe::Refund.create(
       {
@@ -604,7 +606,7 @@ class RegistrationsController < ApplicationController
 
     # Should be the same as `refund_amount`, but by double-converting from the Stripe object
     # we can also double-check that they're on the same page as we are (to be _really_ sure!)
-    ruby_amount = StripeCharge.amount_to_ruby(refund.amount, refund.currency)
+    ruby_amount = StripeTransaction.amount_to_ruby(refund.amount, refund.currency)
 
     registration.record_refund(
       ruby_amount,

--- a/WcaOnRails/app/controllers/server_status_controller.rb
+++ b/WcaOnRails/app/controllers/server_status_controller.rb
@@ -93,7 +93,7 @@ class StripeChargesCheck < StatusCheck
   end
 
   protected def _status_description
-    unknown_stripe_charges_count = StripeCharge.where(status: "unknown").count
+    unknown_stripe_charges_count = StripeTransaction.where(status: "unknown").count
 
     if unknown_stripe_charges_count == 0
       [:success, nil]

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -150,26 +150,31 @@ class Registration < ApplicationRecord
     (competition.registration_opened? || !(new_or_deleted?)) || (competition.user_can_pre_register?(user))
   end
 
-  def record_payment(amount, currency_code, stripe_charge_id, user_id)
+  def record_payment(
+    amount_lowest_denomination,
+    currency_code,
+    receipt,
+    user_id
+  )
     registration_payments.create!(
-      amount_lowest_denomination: amount,
+      amount_lowest_denomination: amount_lowest_denomination,
       currency_code: currency_code,
-      stripe_charge_id: stripe_charge_id,
+      receipt: receipt,
       user_id: user_id,
     )
   end
 
   def record_refund(
-    amount,
+    amount_lowest_denomination,
     currency_code,
-    stripe_refund_id,
+    receipt,
     refunded_registration_payment_id,
     user_id
   )
     registration_payments.create!(
-      amount_lowest_denomination: amount * -1,
+      amount_lowest_denomination: amount_lowest_denomination.abs * -1,
       currency_code: currency_code,
-      stripe_charge_id: stripe_refund_id,
+      receipt: receipt,
       refunded_registration_payment_id: refunded_registration_payment_id,
       user_id: user_id,
     )

--- a/WcaOnRails/app/models/registration_payment.rb
+++ b/WcaOnRails/app/models/registration_payment.rb
@@ -4,6 +4,8 @@ class RegistrationPayment < ApplicationRecord
   belongs_to :registration
   belongs_to :user
 
+  belongs_to :receipt, polymorphic: true
+
   monetize :amount_lowest_denomination,
            as: "amount",
            allow_nil: true,

--- a/WcaOnRails/app/models/registration_payment.rb
+++ b/WcaOnRails/app/models/registration_payment.rb
@@ -4,7 +4,7 @@ class RegistrationPayment < ApplicationRecord
   belongs_to :registration
   belongs_to :user
 
-  belongs_to :receipt, polymorphic: true
+  belongs_to :receipt, polymorphic: true, optional: true
 
   monetize :amount_lowest_denomination,
            as: "amount",
@@ -12,6 +12,6 @@ class RegistrationPayment < ApplicationRecord
            with_model_currency: :currency_code
 
   def amount_available_for_refund
-    amount_lowest_denomination + RegistrationPayment.where(refunded_registration_payment_id: id).sum("amount_lowest_denomination")
+    amount_lowest_denomination + RegistrationPayment.where(refunded_registration_payment_id: id).sum(:amount_lowest_denomination)
   end
 end

--- a/WcaOnRails/app/models/stripe_charge.rb
+++ b/WcaOnRails/app/models/stripe_charge.rb
@@ -8,6 +8,8 @@ class StripeCharge < ApplicationRecord
     failure: "failure",
   }
 
+  has_one :registration_payment, as: :receipt
+
   # sub-hundred units special cases per https://stripe.com/docs/currencies#special-cases
   # that are not compatible with the subunits from our RubyMoney gem.
   # In other words, `Money::Currency.find(iso_code).subunit_to_unit`

--- a/WcaOnRails/app/models/stripe_transaction.rb
+++ b/WcaOnRails/app/models/stripe_transaction.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class StripeCharge < ApplicationRecord
+class StripeTransaction < ApplicationRecord
   enum status: {
     unknown: "unknown",
     payment_intent_registered: "payment_intent_registered",
@@ -9,6 +9,11 @@ class StripeCharge < ApplicationRecord
   }
 
   has_one :registration_payment, as: :receipt
+  belongs_to :parent_transaction, class_name: "StripeTransaction", optional: true
+
+  # We don't need the native JSON type on DB level, so we serialize in Ruby.
+  # Also saves us from some pains because JSON columns are highly inconsistent among MySQL and MariaDB.
+  serialize :parameters, JSON
 
   # sub-hundred units special cases per https://stripe.com/docs/currencies#special-cases
   # that are not compatible with the subunits from our RubyMoney gem.

--- a/WcaOnRails/app/models/stripe_transaction.rb
+++ b/WcaOnRails/app/models/stripe_transaction.rb
@@ -8,6 +8,13 @@ class StripeTransaction < ApplicationRecord
     failure: "failure",
   }
 
+  # Actual values are according to Stripe API documentation as of 2023-03-12.
+  enum api_type: {
+    payment_intent: "payment_intent",
+    charge: "charge",
+    refund: "refund",
+  }
+
   has_one :registration_payment, as: :receipt
   belongs_to :parent_transaction, class_name: "StripeTransaction", optional: true
 
@@ -61,5 +68,17 @@ class StripeTransaction < ApplicationRecord
 
     # Stripe and ruby-money agree. All good.
     amount_stripe_denomination
+  end
+
+  def self.create_receipt(api_transaction, parameters, status, account_id)
+    StripeTransaction.create!(
+      api_type: api_transaction.object,
+      parameters: parameters,
+      stripe_id: api_transaction.id,
+      amount_stripe_denomination: api_transaction.amount,
+      currency_code: api_transaction.currency,
+      status: status,
+      account_id: account_id,
+    )
   end
 end

--- a/WcaOnRails/db/migrate/20230311165116_add_receipt_to_registration_payments.rb
+++ b/WcaOnRails/db/migrate/20230311165116_add_receipt_to_registration_payments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReceiptToRegistrationPayments < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :registration_payments, :receipt, polymorphic: true, index: true, after: :currency_code
+  end
+end

--- a/WcaOnRails/db/migrate/20230311183558_restructure_stripe_charges_table.rb
+++ b/WcaOnRails/db/migrate/20230311183558_restructure_stripe_charges_table.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RestructureStripeChargesTable < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :stripe_charges, :stripe_transactions
+
+    change_table :stripe_transactions do |t|
+      t.string :api_type, after: :id
+      t.rename :stripe_charge_id, :stripe_id
+      t.rename :metadata, :parameters
+      t.integer :amount_stripe_denomination, after: :stripe_id, null: true
+      t.string :currency_code, after: :amount_stripe_denomination, null: true
+      t.references :parent_transaction, foreign_key: { to_table: :stripe_transactions }
+      t.string :account_id, after: :error
+    end
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1162,6 +1162,8 @@ CREATE TABLE `registration_payments` (
   `registration_id` int(11) DEFAULT NULL,
   `amount_lowest_denomination` int(11) DEFAULT NULL,
   `currency_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `receipt_id` bigint DEFAULT NULL,
+  `receipt_type` varchar(191) DEFAULT NULL,
   `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
@@ -1169,7 +1171,8 @@ CREATE TABLE `registration_payments` (
   `user_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `index_registration_payments_on_stripe_charge_id` (`stripe_charge_id`),
-  KEY `idx_reg_payments_on_refunded_registration_payment_id` (`refunded_registration_payment_id`)
+  KEY `idx_reg_payments_on_refunded_registration_payment_id` (`refunded_registration_payment_id`),
+  KEY `index_registration_payments_on_receipt` (`receipt_type`, `receipt_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `registrations`;
@@ -1798,4 +1801,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20230119115432'),
 ('20230204111111'),
 ('20221224215048'),
-('20230303093411');
+('20230303093411'),
+('20230311165116');

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1313,19 +1313,25 @@ CREATE TABLE `starburst_announcements` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-DROP TABLE IF EXISTS `stripe_charges`;
+DROP TABLE IF EXISTS `stripe_transactions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `stripe_charges` (
+CREATE TABLE `stripe_transactions` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `metadata` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `stripe_charge_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `api_type` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `stripe_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `parameters` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `amount_stripe_denomination` int(11) DEFAULT NULL,
+  `currency_code` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `status` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `account_id` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
+  `parent_transaction_id` bigint(20) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `index_stripe_charges_on_status` (`status`)
+  KEY `index_stripe_transactions_on_status` (`status`),
+  CONSTRAINT `fk_rails_6ad225b020` FOREIGN KEY (`parent_transaction_id`) REFERENCES `stripe_transactions` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `team_members`;
@@ -1798,8 +1804,9 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20221121111430'),
 ('20221123090104'),
 ('20221123121220'),
+('20221224215048'),
 ('20230119115432'),
 ('20230204111111'),
-('20221224215048'),
 ('20230303093411'),
-('20230311165116');
+('20230311165116'),
+('20230311183558');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -771,7 +771,7 @@ module DatabaseDumper
         ),
       ),
     }.freeze,
-    "stripe_charges" => :skip_all_rows,
+    "stripe_transactions" => :skip_all_rows,
     "uploaded_jsons" => :skip_all_rows,
     "bookmarked_competitions" => {
       where_clause: JOIN_WHERE_VISIBLE_COMP,

--- a/WcaOnRails/lib/tasks/backfill_stripe_transactions.rb
+++ b/WcaOnRails/lib/tasks/backfill_stripe_transactions.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+@stripe_obj_cache = {}
+
+def retrieve_stripe_obj(stripe_id, &block)
+  @stripe_obj_cache[stripe_id] ||= block.call
+end
+
+def process_parameters_old(transaction)
+  # Older transactions stored different metadata.
+  arguments, account_details = transaction.parameters
+
+  transaction.amount_stripe_denomination = arguments['amount']
+  transaction.currency_code = arguments['currency']
+
+  metadata = arguments['metadata']
+  stripe_account_id = account_details['stripe_account']
+
+  try_match_reg_payments(transaction, metadata, stripe_account_id)
+end
+
+def process_parameters_recent(transaction)
+  metadata = transaction.parameters['metadata']
+
+  # newer Stripe Charges don't store their account ID in our manual metadata anymore (somebody changed the format at some point)
+  # so we have to resort to the competition instead and hope that it still has a Stripe account attached.
+  competition_name = metadata['competition']
+  competition = Competition.find_by(name: competition_name)
+
+  stripe_account_id = competition&.connected_stripe_account_id
+
+  return puts "Cannot re-construct Stripe account ID for transaction ##{transaction.id}. Skipping…" if stripe_account_id.nil?
+
+  try_match_reg_payments(transaction, metadata, stripe_account_id)
+end
+
+def try_match_reg_payments(transaction, metadata, stripe_account_id)
+  wca_id = metadata[:wca_id]
+  competition_name = metadata[:competition]
+
+  person = Person.find_by(wca_id: wca_id)
+  competition = Competition.find_by(name: competition_name)
+
+  if person && competition
+    registration = Registration.find_by(competition_id: competition.id, user_id: person.user.id)
+
+    comp_stripe_account = competition.connected_stripe_account_id
+
+    if comp_stripe_account.nil?
+      puts "WARNING: There is no Stripe account associated with #{competition.id} anymore."
+    elsif comp_stripe_account != stripe_account_id
+      puts "WARNING: The competition's Stripe account (#{comp_stripe_account}) is different from the metadata's Stripe account (#{account_details[:stripe_account]})."
+    end
+
+    # We run into this loop if a StripeTransaction was NOT able to match the RegistrationPayment based on the stripe_id alone.
+    # This most likely happens because we have historical records where the stripe_id column in the transactions table is set to 0 or NULL.
+    registration.registration_payments.each do |rev_eng_payment|
+      payment_stripe_id = rev_eng_payment.stripe_charge_id
+
+      if payment_stripe_id.present?
+        is_charge_payment = payment_stripe_id.start_with?('ch_')
+        is_refund_payment = payment_stripe_id.start_with?('re_')
+
+        if is_charge_payment
+          stripe_obj = retrieve_stripe_obj(payment_stripe_id) { Stripe::Charge.retrieve(payment_stripe_id, stripe_account_id) }
+        elsif is_refund_payment
+          stripe_obj = retrieve_stripe_obj(payment_stripe_id) { Stripe::Refund.retrieve(payment_stripe_id, stripe_account_id) }
+        else
+          puts "The stripe_charge_id for registration payment ##{rev_eng_payment.id} has an unknown prefix type: #{payment_stripe_id}. Skipping…"
+          next
+        end
+
+        # Historical records did not use the Ruby<->Stripe conversion routine (because that was only recently added)
+        # so we can compare the amounts directly without worrying about denominations. We only have to worry about negative amounts for refund
+        rev_eng_stripe_amount = rev_eng_payment.amount_lowest_denomination.abs * (is_refund_payment ? -1 : 1)
+
+        if stripe_obj.amount == rev_eng_stripe_amount && stripe_obj.currency.lower == rev_eng_payment.currency_code.lower
+          # It's a match!
+          transaction.stripe_id = payment_stripe_id
+          transaction.account_id = stripe_account_id
+
+          transaction.amount_stripe_denomination = stripe_obj.amount
+          transaction.currency_code = stripe_obj.currency
+
+          # Store the receipt
+          rev_eng_payment.receipt = transaction
+          rev_eng_payment.save(validation: false)
+        end
+      else
+        puts "The registration payment ##{rev_eng_payment.id} does not have an attached Stripe charge ID"
+      end
+    end
+  else
+    puts "Competition named '#{competition_name}' not found" if competition.nil?
+    puts "Person '#{wca_id}' not found" if person.nil?
+  end
+end
+
+namespace :stripe_transactions do
+  desc "Fill in the new columns for old charges that have already been recorded in the system"
+  task backfill_registrations: [:environment] do
+    StripeTransaction.find_each do |transaction|
+      if transaction.stripe_charge_id.present? && transaction.stripe_charge_id != 0
+        unless transaction.registration_payment.present?
+          reg_payment = RegistrationPayment.find_by(stripe_charge_id: transaction.stripe_charge_id)
+
+          if reg_payment.present?
+            reg_payment.receipt = transaction
+            # We need to run this without validations because there are some _very_ old Stripe transactions in our system,
+            # that didn't even record a `user_id` (because it was not part of the table structure back then). This makes
+            # Rails freak out because nowadays, upon saving, user_id is required.
+            reg_payment.save(validate: false)
+          else
+            puts "Stripe transaction without matching RegistrationPayment: #{transaction.stripe_charge_id}"
+          end
+        end
+      elsif transaction.parameters.is_a? Array
+        process_parameters_old(transaction)
+      elsif transaction.parameters.is_a? Hash
+        # Newer transactions store the Stripe API args directly as metadata.
+        process_parameters_recent(transaction)
+      end
+
+      if transaction.stripe_id&.start_with?('pi_')
+        transaction.api_type = 'payment_intent'
+      elsif transaction.stripe_id&.start_with?('ch_')
+        transaction.api_type = 'charge'
+      elsif transaction.stripe_id&.start_with?('re_')
+        transaction.api_type = 'refund'
+      end
+
+      transaction.save
+    end
+  end
+end

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -832,7 +832,7 @@ RSpec.describe RegistrationsController do
         it 'issues a full refund' do
           post :refund_payment, params: { id: registration.id, payment_id: @payment.id, payment: { refund_amount: competition.base_entry_fee.cents } }
           expect(response).to redirect_to edit_registration_path(registration)
-          refund = Stripe::Refund.retrieve(registration.reload.registration_payments.last.stripe_charge_id, stripe_account: competition.connected_stripe_account_id)
+          refund = Stripe::Refund.retrieve(registration.reload.registration_payments.last.receipt.stripe_id, stripe_account: competition.connected_stripe_account_id)
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee
           expect(refund.amount).to eq competition.base_entry_fee.cents
@@ -846,7 +846,7 @@ RSpec.describe RegistrationsController do
           refund_amount = competition.base_entry_fee.cents / 2
           post :refund_payment, params: { id: registration.id, payment_id: @payment.id, payment: { refund_amount: refund_amount } }
           expect(response).to redirect_to edit_registration_path(registration)
-          refund = Stripe::Refund.retrieve(registration.reload.registration_payments.last.stripe_charge_id, stripe_account: competition.connected_stripe_account_id)
+          refund = Stripe::Refund.retrieve(registration.reload.registration_payments.last.receipt.stripe_id, stripe_account: competition.connected_stripe_account_id)
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee / 2
           expect(refund.amount).to eq competition.base_entry_fee.cents / 2

--- a/WcaOnRails/spec/controllers/server_status_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/server_status_controller_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe "StripeChargesCheck" do
   end
 
   it "warns about stripe charges with status unknown" do
-    StripeCharge.create!(
-      metadata: "",
+    StripeTransaction.create!(
+      parameters: {},
       status: "unknown",
     )
 

--- a/WcaOnRails/spec/models/stripe_transaction_spec.rb
+++ b/WcaOnRails/spec/models/stripe_transaction_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 
 # The currency amounts are all roughly equivalent to USD $15
 # at the time of writing these tests.
-RSpec.describe StripeCharge do
+RSpec.describe StripeTransaction do
   it "handles HUF as a special currency" do
     six_thousand_huf = Money.from_amount(6_000, 'HUF')
     expect(six_thousand_huf.cents).to eq(6_000)
 
-    stripe_amount = StripeCharge.amount_to_stripe(six_thousand_huf.cents, six_thousand_huf.currency.iso_code)
+    stripe_amount = StripeTransaction.amount_to_stripe(six_thousand_huf.cents, six_thousand_huf.currency.iso_code)
     expect(stripe_amount).to eq(600_000)
 
-    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, six_thousand_huf.currency.iso_code)
+    ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, six_thousand_huf.currency.iso_code)
     expect(ruby_amount).to eq(six_thousand_huf.cents)
   end
 
@@ -20,10 +20,10 @@ RSpec.describe StripeCharge do
     sixty_thousand_ugx = Money.from_amount(60_000, 'UGX')
     expect(sixty_thousand_ugx.cents).to eq(60_000)
 
-    stripe_amount = StripeCharge.amount_to_stripe(sixty_thousand_ugx.cents, sixty_thousand_ugx.currency.iso_code)
+    stripe_amount = StripeTransaction.amount_to_stripe(sixty_thousand_ugx.cents, sixty_thousand_ugx.currency.iso_code)
     expect(stripe_amount).to eq(6_000_000)
 
-    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, sixty_thousand_ugx.currency.iso_code)
+    ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, sixty_thousand_ugx.currency.iso_code)
     expect(ruby_amount).to eq(sixty_thousand_ugx.cents)
   end
 
@@ -31,13 +31,13 @@ RSpec.describe StripeCharge do
     expect do
       # Funnily enough, our RubyMoney gem doesn't even support HUF sub-units, but Stripe still insists on
       # *not* charging sub-units in the lowest two decimal places. So we manually insert a fraction to check for the error.
-      StripeCharge.amount_to_stripe(6000.45, 'HUF')
+      StripeTransaction.amount_to_stripe(6000.45, 'HUF')
     end.to raise_error(RuntimeError)
 
     expect do
       # When Stripe returns something that is not cleanly divisible into cents (which, according to its own API docs,
       # it never should…) we throw an error and complain as a safeguard.
-      StripeCharge.amount_to_ruby(6045, 'HUF')
+      StripeTransaction.amount_to_ruby(6045, 'HUF')
     end.to raise_error(RuntimeError)
   end
 
@@ -45,10 +45,10 @@ RSpec.describe StripeCharge do
     fifteen_usd = Money.from_amount(15, 'USD')
     expect(fifteen_usd.cents).to eq(1_500)
 
-    stripe_amount = StripeCharge.amount_to_stripe(fifteen_usd.cents, fifteen_usd.currency.iso_code)
+    stripe_amount = StripeTransaction.amount_to_stripe(fifteen_usd.cents, fifteen_usd.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
 
-    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, fifteen_usd.currency.iso_code)
+    ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, fifteen_usd.currency.iso_code)
     expect(ruby_amount).to eq(fifteen_usd.cents)
   end
 
@@ -56,10 +56,10 @@ RSpec.describe StripeCharge do
     fifteen_eur = Money.from_amount(15, 'EUR')
     expect(fifteen_eur.cents).to eq(1_500)
 
-    stripe_amount = StripeCharge.amount_to_stripe(fifteen_eur.cents, fifteen_eur.currency.iso_code)
+    stripe_amount = StripeTransaction.amount_to_stripe(fifteen_eur.cents, fifteen_eur.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
 
-    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, fifteen_eur.currency.iso_code)
+    ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, fifteen_eur.currency.iso_code)
     expect(ruby_amount).to eq(fifteen_eur.cents)
   end
 
@@ -67,10 +67,10 @@ RSpec.describe StripeCharge do
     two_thousand_yen = Money.from_amount(2_000, 'JPY')
     expect(two_thousand_yen.cents).to eq(2_000)
 
-    stripe_amount = StripeCharge.amount_to_stripe(two_thousand_yen.cents, two_thousand_yen.currency.iso_code)
+    stripe_amount = StripeTransaction.amount_to_stripe(two_thousand_yen.cents, two_thousand_yen.currency.iso_code)
     expect(stripe_amount).to eq(2_000)
 
-    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, two_thousand_yen.currency.iso_code)
+    ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, two_thousand_yen.currency.iso_code)
     expect(ruby_amount).to eq(two_thousand_yen.cents)
   end
 
@@ -80,10 +80,10 @@ RSpec.describe StripeCharge do
     five_hundred_twd = Money.from_amount(500, 'TWD')
     expect(five_hundred_twd.cents).to eq(50_000)
 
-    stripe_amount = StripeCharge.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
+    stripe_amount = StripeTransaction.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
     expect(stripe_amount).to eq(50_000)
 
-    ruby_amount = StripeCharge.amount_to_ruby(stripe_amount, five_hundred_twd.currency.iso_code)
+    ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, five_hundred_twd.currency.iso_code)
     expect(ruby_amount).to eq(five_hundred_twd.cents)
   end
 end


### PR DESCRIPTION
Stripe has an onthology of payment objects, namely `PaymentIntent`, `Charge` and `Refund` (among others, but these are the ones relevant to us.)

Until now, we used to create a PaymentIntent and then handle the charge manually. We only log the Stripe `Charge` ID in the registration payment but the code is highly inconsistent with the rest. Sometimes, IDs for `PaymentIntent` and `Charge` are written into the same Stripe journal row, overriding each other upon update call. If a refund is made, that refund possibly conflicts with the entries in the Stripe logs because we don't journal it at all... Apart from writing it into a column in `registration_payments` that is thought to be for `Charge` IDs.

This PR aims to simplify working with the Stripe integration by:
- Renaming `StripeCharge` to `StripeTransaction`, which is supposed to be a general name for payment-related events going on with Stripe.
- Logging _everything_, no matter whether it's a `PaymentIntent`, a `Charge` or a `Refund`. Everything we send/communicate with the Stripe API, we also very precisely insert it into our journal.
- Referring the `RegistrationPayment` to the corresponding Stripe transaction not through an overloaded `stripe_charge_id` column (which half of the time isn't even containing proper `Charge` IDs) but rather through a polymorphic `receipt` association. So a receipt for a `RegistrationPayment` could really be anything (makes integrating other payment gateways much easier in the future!) and we just set the value to the corresponding `StripeTransaction` from our journal upon payment success.

Note that this PR primarily renames stuff. There is no substantial change in the payment logic (that comes in a second PR after this one has been merged) and the only non-renaming changes are a bit of backwards compatibility with old charges that are already in the system that may not have had the same journaling as the one introduced in this PR.