### PR TITLE
Added competition tooltip for case where registration is deleted

### DIFF
--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -7,7 +7,14 @@ module CompetitionsHelper
     if competition.cancelled?
       messages << t('competitions.messages.cancelled')
     elsif registration
-      messages << (registration.accepted? ? t('competitions.messages.tooltip_registered') : t('competitions.messages.tooltip_waiting_list'))
+      # Display a tooltip on a user's bookmarked competition based on their registration status.
+      if registration.accepted?
+        messages << t('competitions.messages.tooltip_registered')
+      elsif registration.deleted?
+        messages << t('competitions.messages.tooltip_deleted')
+      else # If not delted or accepted, assume user is on the waiting list
+        messages << t('competitions.messages.tooltip_waiting_list')
+      end
     end
     visible = competition.showAtAll?
     messages << if competition.confirmed?

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1362,6 +1362,7 @@ en:
       reg_opens_too_early: "Registration is set to start in less than the required 48 hours."
       tooltip_registered: "You are registered."
       tooltip_waiting_list: "You are currently on the waiting list."
+      tooltip_deleted: "Unfortunately your registration has been deleted. Please check your email for details, or contact the organiser."
       confirmed_visible: "This competition is confirmed and visible"
       confirmed_not_visible: "This competition is confirmed but not visible"
       not_confirmed_visible: "This competition is not confirmed but visible"


### PR DESCRIPTION
Fixes #7656. A third case for deleted registration was necessary - made this a secondary `if` statement for better readability. 