### PR TITLE
Edited results announcement and added new translation string

### DIFF
--- a/WcaOnRails/app/views/results/rankings.html.erb
+++ b/WcaOnRails/app/views/results/rankings.html.erb
@@ -8,8 +8,6 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
   <p><%= t("results.last_updated_html", timestamp: wca_local_time(ranking_timestamp)) %></p>
-
-  <%# Note: When removing this announcement and its translation string, also remove results.heading_disabled_functions from i18n files. %>
   <p><i><%= t('results.filters_fixes_underway') %></i></p>
 
   <div id="results-selector" class="results-select form-inline">

--- a/WcaOnRails/app/views/results/rankings.html.erb
+++ b/WcaOnRails/app/views/results/rankings.html.erb
@@ -8,7 +8,9 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
   <p><%= t("results.last_updated_html", timestamp: wca_local_time(ranking_timestamp)) %></p>
-  <p><i><%= t('results.heading_disabled_functions') %></i></p>
+
+  <%# Note: When removing this announcement and its translation string, also remove results.heading_disabled_functions from i18n files. %>
+  <p><i><%= t('results.filters_fixes_underway') %></i></p>
 
   <div id="results-selector" class="results-select form-inline">
     <%= render 'results_selector', show_rankings_options: true %>

--- a/WcaOnRails/app/views/results/records.html.erb
+++ b/WcaOnRails/app/views/results/records.html.erb
@@ -8,8 +8,6 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
   <p><%= t("results.last_updated_html", timestamp: wca_local_time(record_timestamp)) %></p>
-
-  <%# Note: When removing this announcement and its translation string, also remove results.heading_disabled_functions from i18n files. %>
   <p><i><%= t('results.filters_fixes_underway') %></i></p>
 
   <div id="results-selector" class="results-select form-inline">

--- a/WcaOnRails/app/views/results/records.html.erb
+++ b/WcaOnRails/app/views/results/records.html.erb
@@ -8,7 +8,9 @@
 <div class="container">
   <h1><%= yield(:title) %></h1>
   <p><%= t("results.last_updated_html", timestamp: wca_local_time(record_timestamp)) %></p>
-  <p><i><%= t('results.heading_disabled_functions') %></i></p>
+
+  <%# Note: When removing this announcement and its translation string, also remove results.heading_disabled_functions from i18n files. %>
+  <p><i><%= t('results.filters_fixes_underway') %></i></p>
 
   <div id="results-selector" class="results-select form-inline">
     <%= render 'results_selector', show_records_options: true %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1801,6 +1801,7 @@ en:
       title: "Records"
     last_updated_html: "Last updated: %{timestamp}"
     heading_disabled_functions: "Please note that some filters (such as past years) are temporarily disabled. If you have experience in SQL optimisations, please contact the WST!"
+    filters_fixes_underway: "Please note that some filters (such as past years) are temporarily disabled. The Software Team is working to restore these filters - we are sorry for the inconvenience."
     tooltip_no_years: "Our database is too large to compute historical data"
     tooltip_no_quantities: "Our database is too large to compute long rankings"
     selector_elements:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1800,7 +1800,6 @@ en:
     records:
       title: "Records"
     last_updated_html: "Last updated: %{timestamp}"
-    heading_disabled_functions: "Please note that some filters (such as past years) are temporarily disabled. If you have experience in SQL optimisations, please contact the WST!"
     filters_fixes_underway: "Please note that some filters (such as past years) are temporarily disabled. The Software Team is working to restore these filters - we are sorry for the inconvenience."
     tooltip_no_years: "Our database is too large to compute historical data"
     tooltip_no_quantities: "Our database is too large to compute long rankings"


### PR DESCRIPTION
(Update to #7777)

Updates the notice regarding disabled filters on [records](https://www.worldcubeassociation.org/results/records) and [rankings](https://www.worldcubeassociation.org/results/rankings/333/single) pages.

* Wording needs review
* I opted not to remove the translation string for the previous announcement - would rather remove it all together when the announcement is removed entirely. I've added a comment remind to remove both translation strings when (when!) the announcements are removed.