### PR TITLE
enforced indented internal methods, and refactored affected files

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -169,6 +169,9 @@ Style/SignalException:
 Layout/SpaceAroundOperators:
   Enabled: false
 
+Layout/IndentationConsistency:
+  EnforcedStyle: indented_internal_methods
+
 Style/StringLiteralsInInterpolation:
   Enabled: false
 

--- a/WcaOnRails/app/controllers/accounts/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/accounts/registrations_controller.rb
@@ -8,18 +8,18 @@ class Accounts::RegistrationsController < Devise::RegistrationsController
 
   private
 
-  def check_captcha
-    return if verify_recaptcha
+    def check_captcha
+      return if verify_recaptcha
 
-    build_resource(sign_up_params)
-    resource.validate
+      build_resource(sign_up_params)
+      resource.validate
 
-    clean_up_passwords resource
-    set_minimum_password_length
+      clean_up_passwords resource
+      set_minimum_password_length
 
-    respond_with_navigational(resource) do
-      flash.now[:recaptcha_error] = flash[:recaptcha_error]
-      render :new
+      respond_with_navigational(resource) do
+        flash.now[:recaptcha_error] = flash[:recaptcha_error]
+        render :new
+      end
     end
-  end
 end

--- a/WcaOnRails/app/controllers/country_bands_controller.rb
+++ b/WcaOnRails/app/controllers/country_bands_controller.rb
@@ -51,20 +51,20 @@ class CountryBandsController < ApplicationController
 
   private
 
-  def id_from_params
-    Integer(params.require(:id))
-  rescue ArgumentError
-    nil
-  end
-
-  def set_instance_variables
-    @in_band = CountryBand.where(number: @number).map(&:country).sort_by(&:name).map(&:iso2)
-    # The list of unused countries should contain both unused countries and countries for the selected band.
-    # Therefore we can get the list of relevant countries by substracting all the
-    # other bands countries to the overall list of countries.
-    used_countries = CountryBand.where.not(number: @number).map(&:country)
-    @unused = (Country.real - used_countries).map do |c|
-      { name: c.name, iso2: c.iso2 }
+    def id_from_params
+      Integer(params.require(:id))
+    rescue ArgumentError
+      nil
     end
-  end
+
+    def set_instance_variables
+      @in_band = CountryBand.where(number: @number).map(&:country).sort_by(&:name).map(&:iso2)
+      # The list of unused countries should contain both unused countries and countries for the selected band.
+      # Therefore we can get the list of relevant countries by substracting all the
+      # other bands countries to the overall list of countries.
+      used_countries = CountryBand.where.not(number: @number).map(&:country)
+      @unused = (Country.real - used_countries).map do |c|
+        { name: c.name, iso2: c.iso2 }
+      end
+    end
 end

--- a/WcaOnRails/app/controllers/errors_controller.rb
+++ b/WcaOnRails/app/controllers/errors_controller.rb
@@ -12,15 +12,15 @@ class ErrorsController < ApplicationController
 
   private
 
-  def error_page(code)
-    supported_error_codes.fetch(code, "404")
-  end
+    def error_page(code)
+      supported_error_codes.fetch(code, "404")
+    end
 
-  def supported_error_codes
-    {
-      500 => "500",
-      501 => "500",
-      502 => "500",
-    }
-  end
+    def supported_error_codes
+      {
+        500 => "500",
+        501 => "500",
+        502 => "500",
+      }
+    end
 end

--- a/WcaOnRails/app/controllers/incidents_controller.rb
+++ b/WcaOnRails/app/controllers/incidents_controller.rb
@@ -106,19 +106,19 @@ class IncidentsController < ApplicationController
 
   private
 
-  def set_incident
-    @incident = Incident.find(params[:id])
-  end
+    def set_incident
+      @incident = Incident.find(params[:id])
+    end
 
-  def incident_params
-    params.require(:incident).permit(
-      :title,
-      :private_description,
-      :private_wrc_decision,
-      :public_summary,
-      :tags,
-      :digest_worthy,
-      incident_competitions_attributes: [:id, :competition_id, :comments, :_destroy],
-    )
-  end
+    def incident_params
+      params.require(:incident).permit(
+        :title,
+        :private_description,
+        :private_wrc_decision,
+        :public_summary,
+        :tags,
+        :digest_worthy,
+        incident_competitions_attributes: [:id, :competition_id, :comments, :_destroy],
+      )
+    end
 end

--- a/WcaOnRails/app/controllers/sessions_controller.rb
+++ b/WcaOnRails/app/controllers/sessions_controller.rb
@@ -45,55 +45,55 @@ class SessionsController < Devise::SessionsController
 
   private
 
-  def two_factor_enabled?
-    find_user&.two_factor_enabled?
-  end
-
-  def authenticate_with_two_factor
-    user = self.resource = find_user
-    if user_params[:otp_attempt].present? && session[:otp_user_id]
-      authenticate_via_otp(user)
-    elsif user && user.valid_password?(user_params[:password])
-      prompt_for_two_factor(user)
+    def two_factor_enabled?
+      find_user&.two_factor_enabled?
     end
-  end
 
-  def authenticate_via_otp(user)
-    if user.validate_and_consume_otp!(user_params[:otp_attempt]) ||
-       user.invalidate_otp_backup_code!(user_params[:otp_attempt])
-      # Remove any lingering user data from login
-      session.delete(:otp_user_id)
-      user.remember_me = 1 if user_params[:remember_me] == '1'
-      user.save!
-      sign_in(user, event: :authentication)
-    else
-      flash[:danger] = I18n.t("devise.sessions.new.2fa.errors.invalid_otp")
-      prompt_for_two_factor(user)
+    def authenticate_with_two_factor
+      user = self.resource = find_user
+      if user_params[:otp_attempt].present? && session[:otp_user_id]
+        authenticate_via_otp(user)
+      elsif user && user.valid_password?(user_params[:password])
+        prompt_for_two_factor(user)
+      end
     end
-  end
 
-  # Store the user's ID in the session for later retrieval and render the
-  # two factor code prompt
-  #
-  # The user must have 2FA enabled and have been authenticated with
-  # a valid login and password before calling this method!
-  def prompt_for_two_factor(user)
-    # Set @user for Devise views
-    @user = user
-
-    session[:otp_user_id] = user.id
-    render 'devise/sessions/2fa'
-  end
-
-  def user_params
-    params.require(:user).permit(:login, :password, :otp_attempt, :remember_me)
-  end
-
-  def find_user
-    if session[:otp_user_id]
-      User.find(session[:otp_user_id])
-    elsif user_params[:login]
-      User.find_first_by_auth_conditions(login: user_params[:login])
+    def authenticate_via_otp(user)
+      if user.validate_and_consume_otp!(user_params[:otp_attempt]) ||
+         user.invalidate_otp_backup_code!(user_params[:otp_attempt])
+        # Remove any lingering user data from login
+        session.delete(:otp_user_id)
+        user.remember_me = 1 if user_params[:remember_me] == '1'
+        user.save!
+        sign_in(user, event: :authentication)
+      else
+        flash[:danger] = I18n.t("devise.sessions.new.2fa.errors.invalid_otp")
+        prompt_for_two_factor(user)
+      end
     end
-  end
+
+    # Store the user's ID in the session for later retrieval and render the
+    # two factor code prompt
+    #
+    # The user must have 2FA enabled and have been authenticated with
+    # a valid login and password before calling this method!
+    def prompt_for_two_factor(user)
+      # Set @user for Devise views
+      @user = user
+
+      session[:otp_user_id] = user.id
+      render 'devise/sessions/2fa'
+    end
+
+    def user_params
+      params.require(:user).permit(:login, :password, :otp_attempt, :remember_me)
+    end
+
+    def find_user
+      if session[:otp_user_id]
+        User.find(session[:otp_user_id])
+      elsif user_params[:login]
+        User.find_first_by_auth_conditions(login: user_params[:login])
+      end
+    end
 end

--- a/WcaOnRails/app/inputs/date_picker_input.rb
+++ b/WcaOnRails/app/inputs/date_picker_input.rb
@@ -37,41 +37,41 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
 
   private
 
-  def input_button
-    template.content_tag :span, class: 'input-group-btn' do
-      template.content_tag :button, class: 'btn btn-default', type: 'button' do
-        template.content_tag :span, '', class: 'glyphicon glyphicon-calendar'
+    def input_button
+      template.content_tag :span, class: 'input-group-btn' do
+        template.content_tag :button, class: 'btn btn-default', type: 'button' do
+          template.content_tag :span, '', class: 'glyphicon glyphicon-calendar'
+        end
       end
     end
-  end
 
-  def utc_addon
-    ""
-  end
+    def utc_addon
+      ""
+    end
 
-  def set_html_options
-    input_html_options[:type] = 'text'
-    input_html_options[:autocomplete] = 'off'
-    input_html_options[:data] ||= {}
-    input_html_options[:data][:date_options] = date_options
-    input_html_options[:placeholder] = input_placeholder
-  end
+    def set_html_options
+      input_html_options[:type] = 'text'
+      input_html_options[:autocomplete] = 'off'
+      input_html_options[:data] ||= {}
+      input_html_options[:data][:date_options] = date_options
+      input_html_options[:placeholder] = input_placeholder
+    end
 
-  def set_value_html_option
-    return unless value.present?
-    input_html_options[:value] ||= value.is_a?(String) ? value : I18n.localize(value, format: self.class.display_pattern)
-  end
+    def set_value_html_option
+      return unless value.present?
+      input_html_options[:value] ||= value.is_a?(String) ? value : I18n.localize(value, format: self.class.display_pattern)
+    end
 
-  def value
-    object.send(attribute_name) if object.respond_to? attribute_name
-  end
+    def value
+      object.send(attribute_name) if object.respond_to? attribute_name
+    end
 
-  def date_options
-    custom_options = input_html_options[:data][:date_options] || {}
-    self.class.date_options_base.merge!(custom_options)
-  end
+    def date_options
+      custom_options = input_html_options[:data][:date_options] || {}
+      self.class.date_options_base.merge!(custom_options)
+    end
 
-  def input_placeholder
-    I18n.t('common.date_placeholder')
-  end
+    def input_placeholder
+      I18n.t('common.date_placeholder')
+    end
 end

--- a/WcaOnRails/app/inputs/datetime_picker_input.rb
+++ b/WcaOnRails/app/inputs/datetime_picker_input.rb
@@ -11,11 +11,11 @@ class DatetimePickerInput < DatePickerInput
 
   private
 
-  def utc_addon
-    template.content_tag :span, "UTC", class: "input-group-addon"
-  end
+    def utc_addon
+      template.content_tag :span, "UTC", class: "input-group-addon"
+    end
 
-  def input_placeholder
-    I18n.t('common.datetime_placeholder')
-  end
+    def input_placeholder
+      I18n.t('common.datetime_placeholder')
+    end
 end

--- a/WcaOnRails/app/inputs/time_picker_input.rb
+++ b/WcaOnRails/app/inputs/time_picker_input.rb
@@ -3,15 +3,15 @@
 class TimePickerInput < DatePickerInput
   private
 
-  def display_pattern
-    I18n.t('timepicker.dformat', default: '%R')
-  end
+    def display_pattern
+      I18n.t('timepicker.dformat', default: '%R')
+    end
 
-  def picker_pattern
-    I18n.t('timepicker.pformat', default: 'HH:mm')
-  end
+    def picker_pattern
+      I18n.t('timepicker.pformat', default: 'HH:mm')
+    end
 
-  def date_options
-    date_options_base
-  end
+    def date_options
+      date_options_base
+    end
 end

--- a/WcaOnRails/app/jobs/submit_report_nag_job.rb
+++ b/WcaOnRails/app/jobs/submit_report_nag_job.rb
@@ -31,13 +31,13 @@ class SubmitReportNagJob < SingletonApplicationJob
 
   private
 
-  def send_nag(competition)
-    competition.delegate_report.update(nag_sent_at: Time.now)
-    CompetitionsMailer.submit_report_nag(competition).deliver_now
-  end
+    def send_nag(competition)
+      competition.delegate_report.update(nag_sent_at: Time.now)
+      CompetitionsMailer.submit_report_nag(competition).deliver_now
+    end
 
-  def send_reminder(competition)
-    competition.delegate_report.update(reminder_sent_at: Time.now)
-    CompetitionsMailer.submit_report_reminder(competition).deliver_now
-  end
+    def send_reminder(competition)
+      competition.delegate_report.update(reminder_sent_at: Time.now)
+      CompetitionsMailer.submit_report_reminder(competition).deliver_now
+    end
 end

--- a/WcaOnRails/lib/results_validators/competitions_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitions_results_validator.rb
@@ -74,15 +74,15 @@ module ResultsValidators
 
     private
 
-    def merge(other_validators)
-      unless other_validators.respond_to?(:each)
-        other_validators = [other_validators]
+      def merge(other_validators)
+        unless other_validators.respond_to?(:each)
+          other_validators = [other_validators]
+        end
+        other_validators.each do |v|
+          @errors.concat(v.errors)
+          @warnings.concat(v.warnings)
+          @infos.concat(v.infos)
+        end
       end
-      other_validators.each do |v|
-        @errors.concat(v.errors)
-        @warnings.concat(v.warnings)
-        @infos.concat(v.infos)
-      end
-    end
   end
 end

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -51,71 +51,71 @@ module ResultsValidators
 
     private
 
-    def check_main_event(competition, results)
-      if competition.main_event
-        if competition.main_event_id != "333"
-          @warnings << ValidationWarning.new(:events, competition.id,
-                                             NOT_333_MAIN_EVENT_WARNING,
-                                             main_event_id: competition.main_event_id)
-        end
-      else
-        @warnings << ValidationWarning.new(:events, competition.id,
-                                           NO_MAIN_EVENT_WARNING)
-      end
-    end
-
-    def check_events_match(competition, results)
-      # Check for missing/unexpected events.
-      # As events must be validated by WCAT, any missing or unexpected event should lead to an error.
-      expected = competition.events.map(&:id)
-      real = results.map(&:eventId).uniq
-
-      (real - expected).each do |event_id|
-        @errors << ValidationError.new(:events, competition.id,
-                                       UNEXPECTED_RESULTS_ERROR,
-                                       event_id: event_id)
-      end
-
-      (expected - real).each do |event_id|
-        @warnings << ValidationWarning.new(:events, competition.id,
-                                           MISSING_RESULTS_WARNING,
-                                           event_id: event_id)
-      end
-    end
-
-    def check_rounds_match(competition, results)
-      # Check that rounds match what was declared.
-      # This function automatically casts cutoff rounds to regular rounds if everyone has met the cutoff.
-
-      expected_rounds_by_ids = competition.competition_events.map(&:rounds).flatten.to_h { |r| ["#{r.event.id}-#{r.round_type_id}", r] }
-
-      expected = expected_rounds_by_ids.keys
-      real = results.map { |r| "#{r.eventId}-#{r.roundTypeId}" }.uniq
-      unexpected = real - expected
-      missing = expected - real
-
-      missing.each do |round_id|
-        event_id, round_type_id = round_id.split("-")
-        equivalent_round_id = "#{event_id}-#{RoundType.toggle_cutoff(round_type_id)}"
-        if unexpected.include?(equivalent_round_id)
-          unexpected.delete(equivalent_round_id)
-          round = expected_rounds_by_ids[round_id]
-          unless round.round_type.combined?
-            @errors << ValidationError.new(:rounds, competition.id,
-                                           UNEXPECTED_COMBINED_ROUND_ERROR,
-                                           round_name: round.name)
+      def check_main_event(competition, results)
+        if competition.main_event
+          if competition.main_event_id != "333"
+            @warnings << ValidationWarning.new(:events, competition.id,
+                                               NOT_333_MAIN_EVENT_WARNING,
+                                               main_event_id: competition.main_event_id)
           end
         else
+          @warnings << ValidationWarning.new(:events, competition.id,
+                                             NO_MAIN_EVENT_WARNING)
+        end
+      end
+
+      def check_events_match(competition, results)
+        # Check for missing/unexpected events.
+        # As events must be validated by WCAT, any missing or unexpected event should lead to an error.
+        expected = competition.events.map(&:id)
+        real = results.map(&:eventId).uniq
+
+        (real - expected).each do |event_id|
+          @errors << ValidationError.new(:events, competition.id,
+                                         UNEXPECTED_RESULTS_ERROR,
+                                         event_id: event_id)
+        end
+
+        (expected - real).each do |event_id|
+          @warnings << ValidationWarning.new(:events, competition.id,
+                                             MISSING_RESULTS_WARNING,
+                                             event_id: event_id)
+        end
+      end
+
+      def check_rounds_match(competition, results)
+        # Check that rounds match what was declared.
+        # This function automatically casts cutoff rounds to regular rounds if everyone has met the cutoff.
+
+        expected_rounds_by_ids = competition.competition_events.map(&:rounds).flatten.to_h { |r| ["#{r.event.id}-#{r.round_type_id}", r] }
+
+        expected = expected_rounds_by_ids.keys
+        real = results.map { |r| "#{r.eventId}-#{r.roundTypeId}" }.uniq
+        unexpected = real - expected
+        missing = expected - real
+
+        missing.each do |round_id|
+          event_id, round_type_id = round_id.split("-")
+          equivalent_round_id = "#{event_id}-#{RoundType.toggle_cutoff(round_type_id)}"
+          if unexpected.include?(equivalent_round_id)
+            unexpected.delete(equivalent_round_id)
+            round = expected_rounds_by_ids[round_id]
+            unless round.round_type.combined?
+              @errors << ValidationError.new(:rounds, competition.id,
+                                             UNEXPECTED_COMBINED_ROUND_ERROR,
+                                             round_name: round.name)
+            end
+          else
+            @errors << ValidationError.new(:rounds, competition.id,
+                                           MISSING_ROUND_RESULTS_ERROR,
+                                           round_id: round_id)
+          end
+        end
+        unexpected.each do |round_id|
           @errors << ValidationError.new(:rounds, competition.id,
-                                         MISSING_ROUND_RESULTS_ERROR,
+                                         UNEXPECTED_ROUND_RESULTS_ERROR,
                                          round_id: round_id)
         end
       end
-      unexpected.each do |round_id|
-        @errors << ValidationError.new(:rounds, competition.id,
-                                       UNEXPECTED_ROUND_RESULTS_ERROR,
-                                       round_id: round_id)
-      end
-    end
   end
 end

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -46,36 +46,36 @@ module ResultsValidators
 
     private
 
-    def reset_state
-      @errors = []
-      @warnings = []
-      @infos = []
-    end
+      def reset_state
+        @errors = []
+        @warnings = []
+        @infos = []
+      end
 
     protected
 
-    def get_rounds_info(competition, round_ids_from_results)
-      # Get rounds information from the competition, and detect a legitimate situation
-      # where a round_id may be missing in the competition rounds: if it was a
-      # cutoff round and everyone made the cutoff!
-      # See additional comment here: https://github.com/thewca/worldcubeassociation.org/pull/4357#discussion_r307312177
-      rounds_information = competition.competition_events.flat_map(&:rounds).to_h do |r|
-        ["#{r.event.id}-#{r.round_type_id}", r]
-      end
-      # Now try to "cast" a declared cutoff round to an existing non-cutoff round
-      missing_round_ids = round_ids_from_results - rounds_information.keys
-      extra_round_ids = rounds_information.keys - round_ids_from_results
-      missing_round_ids.each do |round_id|
-        event_id, round_type_id = round_id.split("-")
-        equivalent_round_id = "#{event_id}-#{RoundType.toggle_cutoff(round_type_id)}"
-        if extra_round_ids.delete(equivalent_round_id)
-          equivalent_round = rounds_information[equivalent_round_id]
-          if equivalent_round.round_type.combined?
-            rounds_information[round_id] = rounds_information.delete(equivalent_round_id)
+      def get_rounds_info(competition, round_ids_from_results)
+        # Get rounds information from the competition, and detect a legitimate situation
+        # where a round_id may be missing in the competition rounds: if it was a
+        # cutoff round and everyone made the cutoff!
+        # See additional comment here: https://github.com/thewca/worldcubeassociation.org/pull/4357#discussion_r307312177
+        rounds_information = competition.competition_events.flat_map(&:rounds).to_h do |r|
+          ["#{r.event.id}-#{r.round_type_id}", r]
+        end
+        # Now try to "cast" a declared cutoff round to an existing non-cutoff round
+        missing_round_ids = round_ids_from_results - rounds_information.keys
+        extra_round_ids = rounds_information.keys - round_ids_from_results
+        missing_round_ids.each do |round_id|
+          event_id, round_type_id = round_id.split("-")
+          equivalent_round_id = "#{event_id}-#{RoundType.toggle_cutoff(round_type_id)}"
+          if extra_round_ids.delete(equivalent_round_id)
+            equivalent_round = rounds_information[equivalent_round_id]
+            if equivalent_round.round_type.combined?
+              rounds_information[round_id] = rounds_information.delete(equivalent_round_id)
+            end
           end
         end
+        rounds_information
       end
-      rounds_information
-    end
   end
 end

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -134,184 +134,184 @@ module ResultsValidators
 
     private
 
-    def check_multi_time_limit(context, competition_id, round_id, completed_solves)
-      _, result, = context
-      completed_solves.each do |solve_time|
-        time_limit_seconds = [3600, solve_time.attempted * 600].min
-        if solve_time.time_seconds > time_limit_seconds
+      def check_multi_time_limit(context, competition_id, round_id, completed_solves)
+        _, result, = context
+        completed_solves.each do |solve_time|
+          time_limit_seconds = [3600, solve_time.attempted * 600].min
+          if solve_time.time_seconds > time_limit_seconds
+            @warnings << ValidationWarning.new(:results, competition_id,
+                                               MBF_RESULT_OVER_TIME_LIMIT_WARNING,
+                                               round_id: round_id,
+                                               result: solve_time.clock_format,
+                                               person_name: result.personName)
+          end
+        end
+      end
+
+      def check_similar_results(context, index, results_for_round)
+        competition_id, result, round_id, = context
+        similar = results_similar_to(result, index, results_for_round)
+        similar.each do |r|
           @warnings << ValidationWarning.new(:results, competition_id,
-                                             MBF_RESULT_OVER_TIME_LIMIT_WARNING,
+                                             SIMILAR_RESULTS_WARNING,
                                              round_id: round_id,
-                                             result: solve_time.clock_format,
+                                             person_name: result.personName,
+                                             similar_person_name: r.personName)
+        end
+      end
+
+      def check_result_after_dns(context, all_solve_times)
+        # Now let's try to find a DNS result followed by a non-DNS result
+        first_index = all_solve_times.find_index(SolveTime::DNS)
+        # Just use '5' here to get all of them
+        if first_index && all_solve_times[first_index, 5].select(&:complete?).any?
+          competition_id, result, round_id, = context
+          @warnings << ValidationWarning.new(:results, competition_id,
+                                             RESULT_AFTER_DNS_WARNING,
+                                             round_id: round_id,
                                              person_name: result.personName)
         end
       end
-    end
 
-    def check_similar_results(context, index, results_for_round)
-      competition_id, result, round_id, = context
-      similar = results_similar_to(result, index, results_for_round)
-      similar.each do |r|
-        @warnings << ValidationWarning.new(:results, competition_id,
-                                           SIMILAR_RESULTS_WARNING,
+      def check_format_matches(context)
+        competition_id, result, round_id, round_info = context
+        # FIXME: maybe that can be part of the separate
+        # "check consistency of roundTypeIds and formatIds" across a given round
+        # Check that the result's format matches the round format
+        unless round_info.format.id == result.formatId
+          @errors << ValidationError.new(:results, competition_id,
+                                         MISMATCHED_RESULT_FORMAT_ERROR,
+                                         round_id: round_id,
+                                         person_name: result.personName,
+                                         expected_format: round_info.format.name,
+                                         format: Format.c_find(result.formatId).name)
+        end
+      end
+
+      def check_results_for_cutoff(context, cutoff)
+        competition_id, result, round_id, round = context
+        number_of_attempts = cutoff.number_of_attempts
+        cutoff_result = SolveTime.new(round.event.id, :single, cutoff.attempt_result)
+        solve_times = result.solve_times
+        # Compare through SolveTime so we don't need to care about DNF/DNS
+        maybe_qualifying_results = solve_times[0, number_of_attempts]
+        # Get the remaining attempt according to the expected solve count given the format
+        other_results = solve_times[number_of_attempts, round.format.expected_solve_count - number_of_attempts]
+
+        if maybe_qualifying_results.select(&:skipped?).any?
+          # There are at least one skipped results among those in the first phase.
+          @errors << ValidationError.new(:results, competition_id,
+                                         WRONG_ATTEMPTS_FOR_CUTOFF_ERROR,
+                                         round_id: round_id,
+                                         person_name: result.personName)
+        end
+
+        qualifying_results = maybe_qualifying_results.select { |solve_time| solve_time < cutoff_result }
+        skipped, unskipped = other_results.partition(&:skipped?)
+        if qualifying_results.any?
+          # Meets the cutoff, no result should be SKIPPED
+          if skipped.any?
+            @errors << ValidationError.new(:results, competition_id,
+                                           MET_CUTOFF_MISSING_RESULTS_ERROR,
                                            round_id: round_id,
                                            person_name: result.personName,
-                                           similar_person_name: r.personName)
-      end
-    end
-
-    def check_result_after_dns(context, all_solve_times)
-      # Now let's try to find a DNS result followed by a non-DNS result
-      first_index = all_solve_times.find_index(SolveTime::DNS)
-      # Just use '5' here to get all of them
-      if first_index && all_solve_times[first_index, 5].select(&:complete?).any?
-        competition_id, result, round_id, = context
-        @warnings << ValidationWarning.new(:results, competition_id,
-                                           RESULT_AFTER_DNS_WARNING,
+                                           cutoff: cutoff.to_s(round))
+          end
+        else
+          # Doesn't meet the cutoff, all results should be SKIPPED
+          if unskipped.any?
+            @errors << ValidationError.new(:results, competition_id,
+                                           DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR,
                                            round_id: round_id,
-                                           person_name: result.personName)
-      end
-    end
-
-    def check_format_matches(context)
-      competition_id, result, round_id, round_info = context
-      # FIXME: maybe that can be part of the separate
-      # "check consistency of roundTypeIds and formatIds" across a given round
-      # Check that the result's format matches the round format
-      unless round_info.format.id == result.formatId
-        @errors << ValidationError.new(:results, competition_id,
-                                       MISMATCHED_RESULT_FORMAT_ERROR,
-                                       round_id: round_id,
-                                       person_name: result.personName,
-                                       expected_format: round_info.format.name,
-                                       format: Format.c_find(result.formatId).name)
-      end
-    end
-
-    def check_results_for_cutoff(context, cutoff)
-      competition_id, result, round_id, round = context
-      number_of_attempts = cutoff.number_of_attempts
-      cutoff_result = SolveTime.new(round.event.id, :single, cutoff.attempt_result)
-      solve_times = result.solve_times
-      # Compare through SolveTime so we don't need to care about DNF/DNS
-      maybe_qualifying_results = solve_times[0, number_of_attempts]
-      # Get the remaining attempt according to the expected solve count given the format
-      other_results = solve_times[number_of_attempts, round.format.expected_solve_count - number_of_attempts]
-
-      if maybe_qualifying_results.select(&:skipped?).any?
-        # There are at least one skipped results among those in the first phase.
-        @errors << ValidationError.new(:results, competition_id,
-                                       WRONG_ATTEMPTS_FOR_CUTOFF_ERROR,
-                                       round_id: round_id,
-                                       person_name: result.personName)
+                                           person_name: result.personName,
+                                           cutoff: cutoff.to_s(round))
+          end
+        end
       end
 
-      qualifying_results = maybe_qualifying_results.select { |solve_time| solve_time < cutoff_result }
-      skipped, unskipped = other_results.partition(&:skipped?)
-      if qualifying_results.any?
-        # Meets the cutoff, no result should be SKIPPED
-        if skipped.any?
+      def check_cumulative_across_rounds(context, rounds_by_ids, results_by_round_id)
+        competition_id, result, round_id, round_info = context
+        time_limit_for_round = round_info.time_limit
+        cumulative_wcif_round_ids = time_limit_for_round.cumulative_round_ids
+        # Handle both cumulative for a single round or multiple round by doing the following:
+        #  - gather all solve times for all the rounds (necessitate to map round's WCIF id to "our" round ids)
+        #  - check the sum is below the limit
+        #  - check for any suspicious DNF result
+
+        # Match wcif round ids to "our" ids
+        cumulative_round_ids = cumulative_wcif_round_ids.map do |wcif_id|
+          parsed_wcif_id = Round.parse_wcif_id(wcif_id)
+          # Get the actual round_id from our expected rounds by id
+
+          actual_round_id = rounds_by_ids.find do |id, round|
+            round.event.id == parsed_wcif_id[:event_id] && round.number == parsed_wcif_id[:round_number]
+          end
+          unless actual_round_id
+            # FIXME: this needs to be removed when https://github.com/thewca/worldcubeassociation.org/issues/3254 is fixed.
+            @errors << ValidationError.new(:results, competition_id,
+                                           MISSING_CUMULATIVE_ROUND_ID_ERROR,
+                                           wcif_id: wcif_id, original_round_id: round_id)
+          end
+          actual_round_id&.at(0)
+        end.compact
+
+        # Get all solve times for all cumulative rounds for the current person
+        all_results_for_cumulative_rounds = cumulative_round_ids.map do |id|
+          # NOTE: since we proceed with all checks even if some expected rounds
+          # do not exist, we may have *expected* cumulative rounds that may
+          # not exist in results.
+          results_by_round_id[id]&.find { |r| r.personId == result.personId }
+        end.compact.map(&:solve_times).flatten
+        completed_solves_for_rounds = all_results_for_cumulative_rounds.select(&:complete?)
+        number_of_dnf_solves = all_results_for_cumulative_rounds.select(&:dnf?).size
+        sum_of_times_for_rounds = completed_solves_for_rounds.sum(&:time_centiseconds)
+
+        # Check the sum is below the limit
+        unless sum_of_times_for_rounds < time_limit_for_round.centiseconds
           @errors << ValidationError.new(:results, competition_id,
-                                         MET_CUTOFF_MISSING_RESULTS_ERROR,
-                                         round_id: round_id,
+                                         RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR,
+                                         round_ids: cumulative_round_ids.join(","),
                                          person_name: result.personName,
-                                         cutoff: cutoff.to_s(round))
+                                         time_limit: time_limit_for_round.to_s(round_info))
         end
-      else
-        # Doesn't meet the cutoff, all results should be SKIPPED
-        if unskipped.any?
-          @errors << ValidationError.new(:results, competition_id,
-                                         DIDNT_MEET_CUTOFF_HAS_RESULTS_ERROR,
-                                         round_id: round_id,
-                                         person_name: result.personName,
-                                         cutoff: cutoff.to_s(round))
-        end
-      end
-    end
 
-    def check_cumulative_across_rounds(context, rounds_by_ids, results_by_round_id)
-      competition_id, result, round_id, round_info = context
-      time_limit_for_round = round_info.time_limit
-      cumulative_wcif_round_ids = time_limit_for_round.cumulative_round_ids
-      # Handle both cumulative for a single round or multiple round by doing the following:
-      #  - gather all solve times for all the rounds (necessitate to map round's WCIF id to "our" round ids)
-      #  - check the sum is below the limit
-      #  - check for any suspicious DNF result
+        # Avoid any silly dividing by 0 on the next check.
+        return if completed_solves_for_rounds.empty?
 
-      # Match wcif round ids to "our" ids
-      cumulative_round_ids = cumulative_wcif_round_ids.map do |wcif_id|
-        parsed_wcif_id = Round.parse_wcif_id(wcif_id)
-        # Get the actual round_id from our expected rounds by id
-
-        actual_round_id = rounds_by_ids.find do |id, round|
-          round.event.id == parsed_wcif_id[:event_id] && round.number == parsed_wcif_id[:round_number]
-        end
-        unless actual_round_id
-          # FIXME: this needs to be removed when https://github.com/thewca/worldcubeassociation.org/issues/3254 is fixed.
-          @errors << ValidationError.new(:results, competition_id,
-                                         MISSING_CUMULATIVE_ROUND_ID_ERROR,
-                                         wcif_id: wcif_id, original_round_id: round_id)
-        end
-        actual_round_id&.at(0)
-      end.compact
-
-      # Get all solve times for all cumulative rounds for the current person
-      all_results_for_cumulative_rounds = cumulative_round_ids.map do |id|
-        # NOTE: since we proceed with all checks even if some expected rounds
-        # do not exist, we may have *expected* cumulative rounds that may
-        # not exist in results.
-        results_by_round_id[id]&.find { |r| r.personId == result.personId }
-      end.compact.map(&:solve_times).flatten
-      completed_solves_for_rounds = all_results_for_cumulative_rounds.select(&:complete?)
-      number_of_dnf_solves = all_results_for_cumulative_rounds.select(&:dnf?).size
-      sum_of_times_for_rounds = completed_solves_for_rounds.sum(&:time_centiseconds)
-
-      # Check the sum is below the limit
-      unless sum_of_times_for_rounds < time_limit_for_round.centiseconds
-        @errors << ValidationError.new(:results, competition_id,
-                                       RESULTS_OVER_CUMULATIVE_TIME_LIMIT_ERROR,
-                                       round_ids: cumulative_round_ids.join(","),
-                                       person_name: result.personName,
-                                       time_limit: time_limit_for_round.to_s(round_info))
-      end
-
-      # Avoid any silly dividing by 0 on the next check.
-      return if completed_solves_for_rounds.empty?
-
-      # Check for any suspicious DNF
-      # Compute avg time per solve for the competitor
-      avg_per_solve = sum_of_times_for_rounds.to_f / completed_solves_for_rounds.size
-      # We want to issue a warning if the estimated time for all solves + DNFs goes roughly over the cumulative time limit by at least 20% (estimation tolerance to reduce false positive).
-      if (number_of_dnf_solves + completed_solves_for_rounds.size) * avg_per_solve >= 1.2 * time_limit_for_round.centiseconds
-        @warnings << ValidationWarning.new(:results, competition_id,
-                                           SUSPICIOUS_DNF_WARNING,
-                                           round_ids: cumulative_round_ids.join(","),
-                                           person_name: result.personName)
-      end
-    end
-
-    def results_similar_to(reference, reference_index, results)
-      # We do this programatically, but the original check_results.php used to do a big SQL query:
-      # https://github.com/thewca/worldcubeassociation.org/blob/b1ee87b318ff6e4f8658a711c19fd23a3ae51b9c/webroot/results/admin/check_results.php#L321-L353
-
-      similar_results = []
-      # Note that we don't want to treat a particular result as looking
-      # similar to itself, so we don't allow for results with matching ids.
-      # Further more, if a result A is similar to a result B, we don't want to
-      # return both (A, B) and (B, A) as matching pairs, it's sufficient to just
-      # return (A, B), which is why we require A.id < B.id.
-      results.each_with_index do |r, index|
-        next if index >= reference_index
-        # We attribute 1 point for each identical solve_time, we then just have to count the points.
-        score = r.solve_times.zip(reference.solve_times).count do |solve_time, reference_solve_time|
-          solve_time.complete? && solve_time == reference_solve_time
-        end
-        # We have at least 3 matching values, consider this similar
-        if score > 2
-          similar_results << r
+        # Check for any suspicious DNF
+        # Compute avg time per solve for the competitor
+        avg_per_solve = sum_of_times_for_rounds.to_f / completed_solves_for_rounds.size
+        # We want to issue a warning if the estimated time for all solves + DNFs goes roughly over the cumulative time limit by at least 20% (estimation tolerance to reduce false positive).
+        if (number_of_dnf_solves + completed_solves_for_rounds.size) * avg_per_solve >= 1.2 * time_limit_for_round.centiseconds
+          @warnings << ValidationWarning.new(:results, competition_id,
+                                             SUSPICIOUS_DNF_WARNING,
+                                             round_ids: cumulative_round_ids.join(","),
+                                             person_name: result.personName)
         end
       end
-      similar_results
-    end
+
+      def results_similar_to(reference, reference_index, results)
+        # We do this programatically, but the original check_results.php used to do a big SQL query:
+        # https://github.com/thewca/worldcubeassociation.org/blob/b1ee87b318ff6e4f8658a711c19fd23a3ae51b9c/webroot/results/admin/check_results.php#L321-L353
+
+        similar_results = []
+        # Note that we don't want to treat a particular result as looking
+        # similar to itself, so we don't allow for results with matching ids.
+        # Further more, if a result A is similar to a result B, we don't want to
+        # return both (A, B) and (B, A) as matching pairs, it's sufficient to just
+        # return (A, B), which is why we require A.id < B.id.
+        results.each_with_index do |r, index|
+          next if index >= reference_index
+          # We attribute 1 point for each identical solve_time, we then just have to count the points.
+          score = r.solve_times.zip(reference.solve_times).count do |solve_time, reference_solve_time|
+            solve_time.complete? && solve_time == reference_solve_time
+          end
+          # We have at least 3 matching values, consider this similar
+          if score > 2
+            similar_results << r
+          end
+        end
+        similar_results
+      end
   end
 end

--- a/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -178,11 +178,11 @@ RSpec.describe ACV do
 
   private
 
-  def build_person(result_kind, competition)
-    if result_kind == :result
-      FactoryBot.build(:person)
-    else
-      FactoryBot.build(:inbox_person, competitionId: competition.id)
+    def build_person(result_kind, competition)
+      if result_kind == :result
+        FactoryBot.build(:person)
+      else
+        FactoryBot.build(:inbox_person, competitionId: competition.id)
+      end
     end
-  end
 end


### PR DESCRIPTION
It is Ruby/Rails convention to indent function definitions under `private` and `protected` delcarations - see [line 433/434](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/validations.rb) in the Rails core code. 

Currently rubocop does not allow indentation under `private`/`protected` declarations.

This PR
* changes rubocop to not only allow but enforce indentation under `private`/`protected` declarations
* makes the necessary indentations on all files that would now fail Rubocop validation as a result of this change