### PR TITLE
Refactor ResultsValidators to bundle data loading

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -29,6 +29,8 @@ class Competition < ApplicationRecord
   has_many :bookmarked_users, through: :bookmarked_competitions, source: :user
   belongs_to :competition_series, optional: true
   has_many :series_competitions, -> { readonly }, through: :competition_series, source: :competitions
+  has_many :inbox_results, dependent: :delete_all
+  has_many :inbox_persons, dependent: :delete_all
 
   accepts_nested_attributes_for :competition_events, allow_destroy: true
   accepts_nested_attributes_for :championships, allow_destroy: true
@@ -574,7 +576,9 @@ class Competition < ApplicationRecord
              'bookmarked_competitions',
              'bookmarked_users',
              'competition_series',
-             'series_competitions'
+             'series_competitions',
+             'inbox_results',
+             'inbox_persons'
           # Do nothing as they shouldn't be cloned.
         when 'organizers'
           clone.organizers = organizers

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -29,8 +29,8 @@ class Competition < ApplicationRecord
   has_many :bookmarked_users, through: :bookmarked_competitions, source: :user
   belongs_to :competition_series, optional: true
   has_many :series_competitions, -> { readonly }, through: :competition_series, source: :competitions
-  has_many :inbox_results, dependent: :delete_all
-  has_many :inbox_persons, dependent: :delete_all
+  has_many :inbox_results, foreign_key: "competitionId", dependent: :delete_all
+  has_many :inbox_persons, foreign_key: "competitionId", dependent: :delete_all
 
   accepts_nested_attributes_for :competition_events, allow_destroy: true
   accepts_nested_attributes_for :championships, allow_destroy: true

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -23,11 +23,6 @@ module Resultable
     # outside the scope of the WCA website.
     validates_numericality_of :pos, message: "The position is not a valid number. Did you clear all the empty rows and synchronized WCA Live?"
 
-    # Order by event, then roundTypeId, then average if exists, then best if exists
-    scope :sorted_for_competitions,
-          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).order(:competitionId).sorted }
-    scope :sorted, -> { order(:eventId, :roundTypeId).order(Arel.sql("IF(formatId IN ('a','m') AND average>0, average, 2147483647), IF(best>0, best, 2147483647)")) }
-
     # Define cached stuff with the same name as the associations for validation
     def round_type
       RoundType.c_find(roundTypeId)

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -25,8 +25,8 @@ module Resultable
 
     # Order by event, then roundTypeId, then average if exists, then best if exists
     scope :sorted_for_competitions,
-          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).merge(Result.sorted) }
-    scope :sorted, -> { order(:competitionId, :eventId, :roundTypeId).order("IF(formatId IN ('a','m') AND average>0, average, 2147483647), IF(best>0, best, 2147483647)") }
+          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).order(:competitionId).merge(Result.sorted) }
+    scope :sorted, -> { order(:eventId, :roundTypeId).order(Arel.sql("IF(formatId IN ('a','m') AND average>0, average, 2147483647), IF(best>0, best, 2147483647)")) }
 
     # Define cached stuff with the same name as the associations for validation
     def round_type

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -25,7 +25,8 @@ module Resultable
 
     # Order by event, then roundTypeId, then average if exists, then best if exists
     scope :sorted_for_competitions,
-          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).order(:competitionId, :eventId, :roundTypeId).order(Arel.sql("if(formatId in ('a','m') and average>0, average, 2147483647), if(best>0, best, 2147483647)")) }
+          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).merge(Result.sorted) }
+    scope :sorted, -> { order(:competitionId, :eventId, :roundTypeId).order("IF(formatId IN ('a','m') AND average>0, average, 2147483647), IF(best>0, best, 2147483647)") }
 
     # Define cached stuff with the same name as the associations for validation
     def round_type

--- a/WcaOnRails/app/models/concerns/resultable.rb
+++ b/WcaOnRails/app/models/concerns/resultable.rb
@@ -25,7 +25,7 @@ module Resultable
 
     # Order by event, then roundTypeId, then average if exists, then best if exists
     scope :sorted_for_competitions,
-          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).order(:competitionId).merge(Result.sorted) }
+          ->(competition_ids) { includes(:format).where(competitionId: competition_ids).order(:competitionId).sorted }
     scope :sorted, -> { order(:eventId, :roundTypeId).order(Arel.sql("IF(formatId IN ('a','m') AND average>0, average, 2147483647), IF(best>0, best, 2147483647)")) }
 
     # Define cached stuff with the same name as the associations for validation

--- a/WcaOnRails/app/models/inbox_person.rb
+++ b/WcaOnRails/app/models/inbox_person.rb
@@ -4,6 +4,7 @@ class InboxPerson < ApplicationRecord
   self.table_name = "InboxPersons"
 
   alias_attribute :wca_id, :wcaId
+  alias_attribute :ref_id, :id
 
   validates :name, presence: true
   validates :dob, presence: true

--- a/WcaOnRails/app/models/inbox_person.rb
+++ b/WcaOnRails/app/models/inbox_person.rb
@@ -3,8 +3,11 @@
 class InboxPerson < ApplicationRecord
   self.table_name = "InboxPersons"
 
+  belongs_to :person, -> { current }, foreign_key: "wcaId", primary_key: "wca_id", optional: true
+
   alias_attribute :wca_id, :wcaId
   alias_attribute :ref_id, :id
+  alias_attribute :wca_person, :person
 
   validates :name, presence: true
   validates :dob, presence: true

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -12,6 +12,8 @@ class Person < ApplicationRecord
 
   enum gender: (User::ALLOWABLE_GENDERS.to_h { |g| [g, g.to_s] })
 
+  alias_attribute :ref_id, :wca_id
+
   scope :current, -> { where(subId: 1) }
 
   scope :in_region, lambda { |region_id|

--- a/WcaOnRails/app/models/person.rb
+++ b/WcaOnRails/app/models/person.rb
@@ -149,6 +149,10 @@ class Person < ApplicationRecord
     [most_frequent_delegate, most_recent_delegate].uniq
   end
 
+  def wca_person
+    self
+  end
+
   def sub_ids
     Person.where(wca_id: wca_id).map(&:subId)
   end

--- a/WcaOnRails/app/models/result_validation_form.rb
+++ b/WcaOnRails/app/models/result_validation_form.rb
@@ -79,8 +79,8 @@ class ResultValidationForm
 
   def build_validator
     ResultsValidators::CompetitionsResultsValidator.new(
+      validators,
       check_real_results: true,
-      validators: validators,
       apply_fixes: apply_fixes,
     )
   end

--- a/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
+++ b/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
@@ -29,7 +29,7 @@ module ResultsValidators
       false
     end
 
-    protected def competition_associations
+    def competition_associations
       {
         rounds: [],
       }

--- a/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
+++ b/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
@@ -35,7 +35,7 @@ module ResultsValidators
       }
     end
 
-    protected def run_validation(validator_data)
+    def run_validation(validator_data)
       ordered_round_type_ids = RoundType.order(:rank).all.map(&:id)
 
       validator_data.each do |competition_data|

--- a/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
+++ b/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
@@ -29,50 +29,49 @@ module ResultsValidators
       false
     end
 
-    def validate(competition_ids: [], model: Result, results: nil)
-      reset_state
-      # Get all results if not provided
-      results ||= model.sorted_for_competitions(competition_ids)
+    protected def competition_associations
+      {
+        rounds: [],
+      }
+    end
 
-      results_by_competition_id = results.group_by(&:competitionId)
+    protected def run_validation(validator_data)
+      ordered_round_type_ids = RoundType.order(:rank).all.map(&:id)
 
-      competitions_start_dates = Competition.where(id: results_by_competition_id.keys).select(:id, :start_date).to_h do |c|
-        [c.id, c.start_date]
-      end
+      validator_data.each do |competition_data|
+        competition = competition_data.competition
+        comp_start_date = competition.start_date
 
-      results_by_competition_id.each do |competition_id, results_for_comp|
-        competition = Competition.includes(:rounds).find(competition_id)
-        comp_start_date = competitions_start_dates[competition_id]
-        results_by_event_id = results_for_comp.group_by(&:eventId)
+        results_by_event_id = competition_data.results.group_by(&:eventId)
         results_by_event_id.each do |event_id, results_for_event|
-          results_by_event_id[event_id] = results_for_event.group_by(&:roundTypeId)
-        end
-        ordered_round_type_ids = RoundType.order(:rank).all.map(&:id)
-        results_by_event_id.each do |event_id, results_by_round_type_id|
+          results_by_round_type_id = results_for_event.group_by(&:roundTypeId)
+
           round_types_in_results = results_by_round_type_id.keys.reject do |round_type_id|
             IGNORE_ROUND_TYPES.include?(round_type_id)
           end
+
           remaining_number_of_rounds = round_types_in_results.size
           previous_round_type_id = nil
+
           (ordered_round_type_ids & round_types_in_results).each do |round_type_id|
             remaining_number_of_rounds -= 1
             number_of_people_in_round = results_by_round_type_id[round_type_id].size
             round_id = "#{event_id}-#{round_type_id}"
             if number_of_people_in_round <= 7 && remaining_number_of_rounds > 0
               # https://www.worldcubeassociation.org/regulations/#9m3: Rounds with 7 or fewer competitors must not have subsequent rounds.
-              @errors << ValidationError.new(:rounds, competition_id,
+              @errors << ValidationError.new(:rounds, competition.id,
                                              REGULATION_9M3_ERROR,
                                              round_id: round_id)
             end
             if number_of_people_in_round <= 15 && remaining_number_of_rounds > 1
               # https://www.worldcubeassociation.org/regulations/#9m2: Rounds with 15 or fewer competitors must have at most one subsequent round.
-              @errors << ValidationError.new(:rounds, competition_id,
+              @errors << ValidationError.new(:rounds, competition.id,
                                              REGULATION_9M2_ERROR,
                                              round_id: round_id)
             end
             if number_of_people_in_round <= 99 && remaining_number_of_rounds > 2
               # https://www.worldcubeassociation.org/regulations/#9m1: Rounds with 99 or fewer competitors must have at most one subsequent round.
-              @errors << ValidationError.new(:rounds, competition_id,
+              @errors << ValidationError.new(:rounds, competition.id,
                                              REGULATION_9M1_ERROR,
                                              round_id: round_id)
             end
@@ -96,7 +95,7 @@ module ResultsValidators
                   current_persons.include?(r.wca_id) && r.send(sort_by_column) > condition.attempt_result
                 end.map(&:wca_id)
                 if people_over_condition.any?
-                  @errors << ValidationError.new(:rounds, competition_id,
+                  @errors << ValidationError.new(:rounds, competition.id,
                                                  COMPETED_NOT_QUALIFIED_ERROR,
                                                  round_id: round_id,
                                                  ids: people_over_condition.join(","),
@@ -108,7 +107,7 @@ module ResultsValidators
               if Date.new(2006, 7, 20) <= comp_start_date &&
                  comp_start_date <= Date.new(2010, 4, 13)
                 if number_of_people_in_round >= number_of_people_in_previous_round
-                  @errors << ValidationError.new(:rounds, competition_id,
+                  @errors << ValidationError.new(:rounds, competition.id,
                                                  OLD_REGULATION_9P_ERROR,
                                                  round_id: round_id)
                 end
@@ -117,43 +116,43 @@ module ResultsValidators
                 # Article 9p1, since April 14, 2010
                 # https://www.worldcubeassociation.org/regulations/#9p1: At least 25% of competitors must be eliminated between consecutive rounds of the same event.
                 if number_of_people_in_round > max_advancing
-                  @errors << ValidationError.new(:rounds, competition_id,
+                  @errors << ValidationError.new(:rounds, competition.id,
                                                  REGULATION_9P1_ERROR,
                                                  round_id: round_id)
                 end
                 if condition
-                  theoritical_number_of_people = condition.max_advancing(previous_results)
-                  if number_of_people_in_round > theoritical_number_of_people
-                    @warnings << ValidationWarning.new(:rounds, competition_id,
+                  theoretical_number_of_people = condition.max_advancing(previous_results)
+                  if number_of_people_in_round > theoretical_number_of_people
+                    @warnings << ValidationWarning.new(:rounds, competition.id,
                                                        TOO_MANY_QUALIFIED_WARNING,
                                                        round_id: round_id,
                                                        actual: number_of_people_in_round,
-                                                       expected: theoritical_number_of_people,
+                                                       expected: theoretical_number_of_people,
                                                        condition: condition.to_s(previous_round))
                   end
-                  if theoritical_number_of_people > max_advancing
-                    @errors << ValidationError.new(:rounds, competition_id,
+                  if theoretical_number_of_people > max_advancing
+                    @errors << ValidationError.new(:rounds, competition.id,
                                                    ROUND_9P1_ERROR,
                                                    round_id: round_id,
                                                    condition: condition.to_s(previous_round))
                   end
                   # This comes from https://github.com/thewca/worldcubeassociation.org/issues/5587
-                  if theoritical_number_of_people - number_of_people_in_round >= 3 &&
-                     (number_of_people_in_round / theoritical_number_of_people) <= 0.8
-                    @warnings << ValidationWarning.new(:rounds, competition_id,
+                  if theoretical_number_of_people - number_of_people_in_round >= 3 &&
+                     (number_of_people_in_round / theoretical_number_of_people) <= 0.8
+                    @warnings << ValidationWarning.new(:rounds, competition.id,
                                                        NOT_ENOUGH_QUALIFIED_WARNING,
                                                        round_id: round_id,
-                                                       expected: theoritical_number_of_people,
+                                                       expected: theoretical_number_of_people,
                                                        actual: number_of_people_in_round)
                   end
                 end
               end
             end
+
             previous_round_type_id = round_type_id
           end
         end
       end
-      self
     end
   end
 end

--- a/WcaOnRails/lib/results_validators/competitions_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitions_results_validator.rb
@@ -37,17 +37,12 @@ module ResultsValidators
       @persons_by_id ||= @persons.index_by { |person| person.ref_id }
     end
 
-    protected def competition_associations
+    def competition_associations
       @validators.map(&:competition_associations)
                  .inject(:deep_merge)
     end
 
-    protected def competition_where_filters
-      @validators.map(&:competition_where_filters)
-                 .inject(:deep_merge)
-    end
-
-    protected def include_persons?
+    def include_persons?
       true
     end
 

--- a/WcaOnRails/lib/results_validators/competitions_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitions_results_validator.rb
@@ -46,6 +46,15 @@ module ResultsValidators
       true
     end
 
+    protected def validate_competitions(competition_ids, check_real_results: true)
+      competition_ids.each do |competition_id|
+        validator_data = ValidatorData.from_competition(self, competition_id, check_real_results: check_real_results)
+
+        # Intentionally run after every competition to avoid loading all competitions into memory at once.
+        run_validation([validator_data])
+      end
+    end
+
     # The concept: this aggregate of validators should be applicable on any association
     # of competitions/validators (eg: run all validations on a given competition,
     # validate the competitor limit for a given set of competitions).

--- a/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
@@ -11,13 +11,7 @@ module ResultsValidators
       false
     end
 
-    protected def competition_where_filters
-      {
-        competitor_limit_enabled: true,
-      }
-    end
-
-    protected def include_persons?
+    def include_persons?
       true
     end
 
@@ -28,7 +22,7 @@ module ResultsValidators
         competitor_limit = competition.competitor_limit
         total_competitors = competition_data.persons.count
 
-        if total_competitors > competitor_limit
+        if competition.competitor_limit_enabled && total_competitors > competitor_limit
           @warnings << ValidationWarning.new(:persons, competition.id,
                                              COMPETITOR_LIMIT_WARNING,
                                              n_competitors: total_competitors,

--- a/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
@@ -15,7 +15,7 @@ module ResultsValidators
       true
     end
 
-    protected def run_validation(validator_data)
+    def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
 

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -19,7 +19,7 @@ module ResultsValidators
       false
     end
 
-    protected def competition_associations
+    def competition_associations
       {
         events: [],
         competition_events: {

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -28,7 +28,7 @@ module ResultsValidators
       }
     end
 
-    protected def run_validation(validator_data)
+    def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
         results_for_comp = competition_data.results

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -78,6 +78,14 @@ module ResultsValidators
       }
     end
 
+    def competition_associations
+      {}
+    end
+
+    def include_persons?
+      false
+    end
+
     private
 
       def reset_state
@@ -87,18 +95,6 @@ module ResultsValidators
       end
 
     protected
-
-      def competition_associations
-        {}
-      end
-
-      def competition_where_filters
-        {}
-      end
-
-      def include_persons?
-        false
-      end
 
       def get_rounds_info(competition, round_ids_from_results)
         # Get rounds information from the competition, and detect a legitimate situation

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -46,6 +46,10 @@ module ResultsValidators
       self
     end
 
+    def run_validation(validator_data)
+      raise NotImplementedError
+    end
+
     def description
       @@desc
     end
@@ -90,10 +94,6 @@ module ResultsValidators
         validator_data = ValidatorData.from_results(self, results)
 
         run_validation(validator_data)
-      end
-
-      def run_validation(validator_data)
-        raise NotImplementedError
       end
 
       def get_rounds_info(competition, round_ids_from_results)

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -23,24 +23,6 @@ module ResultsValidators
       @infos.any?
     end
 
-    def validate_competitions(competition_ids, check_real_results: true)
-      validator_data = competition_ids.map do |competition_id|
-        ValidatorData.from_competition(self, competition_id, check_real_results: check_real_results)
-      end
-
-      run_validation(validator_data)
-    end
-
-    def validate_results(results)
-      validator_data = ValidatorData.from_results(self, results)
-
-      run_validation(validator_data)
-    end
-
-    protected def run_validation(validator_data)
-      raise NotImplementedError
-    end
-
     # User must provide either:
     #   - 'competition_ids' and 'model' (Result | InboxResult)
     #   - 'results'
@@ -95,6 +77,24 @@ module ResultsValidators
       end
 
     protected
+
+      def validate_competitions(competition_ids, check_real_results: true)
+        validator_data = competition_ids.map do |competition_id|
+          ValidatorData.from_competition(self, competition_id, check_real_results: check_real_results)
+        end
+
+        run_validation(validator_data)
+      end
+
+      def validate_results(results)
+        validator_data = ValidatorData.from_results(self, results)
+
+        run_validation(validator_data)
+      end
+
+      def run_validation(validator_data)
+        raise NotImplementedError
+      end
 
       def get_rounds_info(competition, round_ids_from_results)
         # Get rounds information from the competition, and detect a legitimate situation

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -30,7 +30,9 @@ module ResultsValidators
       self.reset_state
 
       if results.present?
-        self.validate_results(results)
+        validator_data = ValidatorData.from_results(self, results)
+
+        run_validation(validator_data)
       end
 
       if competition_ids.present?
@@ -38,9 +40,9 @@ module ResultsValidators
           competition_ids = [competition_ids]
         end
 
-        real_results = model == Result
+        check_real_results = model == Result
 
-        self.validate_competitions(competition_ids, check_real_results: real_results)
+        self.validate_competitions(competition_ids, check_real_results)
       end
 
       self
@@ -82,16 +84,8 @@ module ResultsValidators
 
     protected
 
-      def validate_competitions(competition_ids, check_real_results: true)
-        validator_data = competition_ids.map do |competition_id|
-          ValidatorData.from_competition(self, competition_id, check_real_results: check_real_results)
-        end
-
-        run_validation(validator_data)
-      end
-
-      def validate_results(results)
-        validator_data = ValidatorData.from_results(self, results)
+      def validate_competitions(competition_ids, check_real_results)
+        validator_data = ValidatorData.from_competitions(self, competition_ids, check_real_results)
 
         run_validation(validator_data)
       end

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -42,7 +42,7 @@ module ResultsValidators
       }
     end
 
-    protected def run_validation(validator_data)
+    def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
 

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -29,15 +29,8 @@ module ResultsValidators
       false
     end
 
-    def validate(competition_ids: [], model: Result, results: nil)
-      reset_state
-      # Get all results if not provided
-      results ||= model.sorted_for_competitions(competition_ids)
-      results_by_round_id_by_competition_id = results.group_by(&:competitionId).transform_values do |results_for_comp|
-        results_for_comp.group_by { |r| "#{r.eventId}-#{r.roundTypeId}" }
-      end.to_h
-
-      associations = {
+    protected def competition_associations
+      {
         events: [],
         competition_events: {
           rounds: {
@@ -47,20 +40,23 @@ module ResultsValidators
           },
         },
       }
+    end
 
-      # eagerload all competitions informations with all appropriate associations.
-      competitions = Competition.includes(associations).where(id: results_by_round_id_by_competition_id.keys).to_h do |c|
-        [c.id, c]
-      end
-      results_by_round_id_by_competition_id.each do |competition_id, results_by_round_id|
-        rounds_info_by_round_id = get_rounds_info(competitions[competition_id], results_by_round_id.keys)
+    protected def run_validation(validator_data)
+      validator_data.each do |competition_data|
+        competition = competition_data.competition
+
+        results_for_comp = competition_data.results
+        results_by_round_id = results_for_comp.group_by { |r| "#{r.eventId}-#{r.roundTypeId}" }
+
+        rounds_info_by_round_id = get_rounds_info(competition, results_by_round_id.keys)
         results_by_round_id.each do |round_id, results_for_round|
           # get cutoff and timelimit
           round_info = rounds_info_by_round_id[round_id]
 
           unless round_info
             # This situation may happen with "old" competitions
-            @warnings << ValidationWarning.new(:results, competition_id,
+            @warnings << ValidationWarning.new(:results, competition.id,
                                                NO_ROUND_INFORMATION_WARNING,
                                                round_id: round_id)
             next
@@ -73,7 +69,7 @@ module ResultsValidators
             # were possibly not enforced at the discretion of the WCA Delegate.
             # In which case we let the TL undefined, and no errors should be
             # generated.
-            @warnings << ValidationWarning.new(:results, competition_id,
+            @warnings << ValidationWarning.new(:results, competition.id,
                                                UNDEF_TL_WARNING,
                                                round_id: round_id)
           end
@@ -81,7 +77,7 @@ module ResultsValidators
           cutoff_for_round = round_info.cutoff
 
           results_for_round.each_with_index do |result, index|
-            context = [competition_id, result, round_id, round_info]
+            context = [competition.id, result, round_id, round_info]
             all_solve_times = result.solve_times
 
             # Check for possible similar results
@@ -99,7 +95,7 @@ module ResultsValidators
             next if round_info.has_undef_tl?
 
             # Checks for time limits if it can be user-specified
-            if !["333mbf", "333fm"].include?(result.eventId)
+            unless %w[333mbf 333fm].include?(result.eventId)
               cumulative_wcif_round_ids = time_limit_for_round.cumulative_round_ids
 
               check_result_after_dns(context, all_solve_times)
@@ -109,7 +105,7 @@ module ResultsValidators
                 # easy case: each completed result (not DNS, DNF, or SKIPPED) must be below the time limit.
                 results_over_time_limit = completed_solves.reject { |t| t.time_centiseconds < time_limit_for_round.centiseconds }
                 if results_over_time_limit&.any?
-                  @errors << ValidationError.new(:results, competition_id,
+                  @errors << ValidationError.new(:results, competition.id,
                                                  RESULT_OVER_TIME_LIMIT_ERROR,
                                                  round_id: round_id,
                                                  person_name: result.personName,
@@ -121,7 +117,7 @@ module ResultsValidators
               end
             end
 
-            check_multi_time_limit(context, competition_id, round_id, completed_solves) if result.eventId == "333mbf"
+            check_multi_time_limit(context, competition.id, round_id, completed_solves) if result.eventId == "333mbf"
           end
         end
       end
@@ -129,7 +125,6 @@ module ResultsValidators
       # Cleanup possible duplicate errors and warnings from cumulative time limits
       @errors.uniq!
       @warnings.uniq!
-      self
     end
 
     private

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -29,7 +29,7 @@ module ResultsValidators
       false
     end
 
-    protected def competition_associations
+    def competition_associations
       {
         events: [],
         competition_events: {

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -160,10 +160,11 @@ module ResultsValidators
                                              MULTIPLE_NEWCOMERS_WITH_SAME_NAME_WARNING,
                                              name: name)
         end
-        existing_person_by_wca_id = Person.current.where(wca_id: with_wca_id.map(&:wca_id)).to_h { |p| [p.wca_id, p] }
         with_wca_id.each do |p|
-          existing_person = existing_person_by_wca_id[p.wca_id]
-          if existing_person
+          # We have to "convert" to the actual `Person` model first, which is reasonable given that we're only using entries that have a WCA ID.
+          existing_person = p.wca_person
+
+          if existing_person.present?
             # WRT wants to show warnings for wrong person information.
             # (If I get this right, we do not actually update existing persons from InboxPerson)
             unless p.dob == existing_person.dob

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -39,7 +39,7 @@ module ResultsValidators
       true
     end
 
-    protected def run_validation(validator_data)
+    def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
         results_for_comp = competition_data.results

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -35,7 +35,7 @@ module ResultsValidators
       false
     end
 
-    protected def include_persons?
+    def include_persons?
       true
     end
 

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -11,7 +11,7 @@ module ResultsValidators
       true
     end
 
-    protected def run_validation(validator_data)
+    def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
         results_for_comp = competition_data.results

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -23,7 +23,7 @@ module ResultsValidators
           number_of_tied = 0
           results_for_round.each do |result|
             # Check for position in round
-            # The scope "InboxResult.sorted_for_competitions" already sorts by average then best,
+            # The validator data already sorts by average then best via ValidatorData#load_data,
             # so we simply need to check that the position stored matched the expected one
 
             # Unless we find two exact same results, we increase the expected position

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -11,17 +11,17 @@ module ResultsValidators
       true
     end
 
-    def validate(competition_ids: [], model: Result, results: nil)
-      reset_state
-      # Get all results if not provided
-      results ||= model.sorted_for_competitions(competition_ids)
-      results.group_by(&:competitionId).each do |competition_id, results_for_comp|
+    protected def run_validation(validator_data)
+      validator_data.each do |competition_data|
+        competition = competition_data.competition
+        results_for_comp = competition_data.results
+
         results_for_comp.group_by { |r| "#{r.eventId}-#{r.roundTypeId}" }.each do |round_id, results_for_round|
           expected_pos = 0
           last_result = nil
           # Number of tied competitors, *without* counting the first one
           number_of_tied = 0
-          results_for_round.each_with_index do |result, index|
+          results_for_round.each do |result|
             # Check for position in round
             # The scope "InboxResult.sorted_for_competitions" already sorts by average then best,
             # so we simply need to check that the position stored matched the expected one
@@ -29,7 +29,7 @@ module ResultsValidators
             # Unless we find two exact same results, we increase the expected position
             tied = false
             if last_result
-              if ["a", "m"].include?(result.formatId)
+              if %w[a m].include?(result.formatId)
                 # If the ranking is based on average, look at both average and best.
                 tied = result.average == last_result.average && result.best == last_result.best
               else
@@ -48,7 +48,7 @@ module ResultsValidators
 
             if expected_pos != result.pos
               if @apply_fixes
-                @infos << ValidationInfo.new(:results, competition_id,
+                @infos << ValidationInfo.new(:results, competition.id,
                                              POSITION_FIXED_INFO,
                                              round_id: round_id,
                                              person_name: result.personName,
@@ -56,7 +56,7 @@ module ResultsValidators
                                              pos: result.pos)
                 result.update!(pos: expected_pos)
               else
-                @errors << ValidationError.new(:results, competition_id,
+                @errors << ValidationError.new(:results, competition.id,
                                                WRONG_POSITION_IN_RESULTS_ERROR,
                                                round_id: round_id,
                                                person_name: result.personName,
@@ -67,7 +67,6 @@ module ResultsValidators
           end
         end
       end
-      self
     end
   end
 end

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -18,7 +18,7 @@ module ResultsValidators
       false
     end
 
-    protected def competition_associations
+    def competition_associations
       {
         events: [],
         scrambles: [],
@@ -38,7 +38,7 @@ module ResultsValidators
         # Get actual round ids from results
         rounds_ids = results_for_comp.map { |r| "#{r.eventId}-#{r.roundTypeId}" }.uniq
 
-        unless scrambles.any?
+        if results_for_comp.any? && !scrambles.any?
           @errors << ValidationError.new(:scrambles, competition.id,
                                          MISSING_SCRAMBLES_FOR_COMPETITION_ERROR,
                                          competition_id: competition.id)

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -18,53 +18,49 @@ module ResultsValidators
       false
     end
 
-    def validate(competition_ids: [], model: Result, results: nil)
-      reset_state
-      # Get all results if not provided
-      results ||= model.sorted_for_competitions(competition_ids)
-
-      associations = {
+    protected def competition_associations
+      {
         events: [],
+        scrambles: [],
         competition_events: {
           rounds: [:competition_event],
         },
       }
+    end
 
-      results_by_competition_id = results.group_by(&:competitionId)
+    protected def run_validation(validator_data)
+      validator_data.each do |competition_data|
+        competition = competition_data.competition
+        results_for_comp = competition_data.results
 
-      scrambles = Scramble.where(competitionId: results_by_competition_id.keys).group_by(&:competitionId)
+        scrambles = competition.scrambles
 
-      competitions = Competition.includes(associations).where(id: results_by_competition_id.keys).to_h do |c|
-        [c.id, c]
-      end
-
-      results_by_competition_id.each do |competition_id, results_for_comp|
         # Get actual round ids from results
         rounds_ids = results_for_comp.map { |r| "#{r.eventId}-#{r.roundTypeId}" }.uniq
 
-        unless scrambles[competition_id]&.any?
-          @errors << ValidationError.new(:scrambles, competition_id,
+        unless scrambles.any?
+          @errors << ValidationError.new(:scrambles, competition.id,
                                          MISSING_SCRAMBLES_FOR_COMPETITION_ERROR,
-                                         competition_id: competition_id)
+                                         competition_id: competition.id)
           next
         end
 
         # Group scramble by round_id
-        scrambles_by_round_id = scrambles[competition_id].group_by { |s| "#{s.eventId}-#{s.roundTypeId}" }
+        scrambles_by_round_id = scrambles.group_by { |s| "#{s.eventId}-#{s.roundTypeId}" }
         detected_scrambles_rounds_ids = scrambles_by_round_id.keys
         (rounds_ids - detected_scrambles_rounds_ids).each do |round_id|
-          @errors << ValidationError.new(:scrambles, competition_id,
+          @errors << ValidationError.new(:scrambles, competition.id,
                                          MISSING_SCRAMBLES_FOR_ROUND_ERROR,
                                          round_id: round_id)
         end
 
         (detected_scrambles_rounds_ids - rounds_ids).each do |round_id|
-          @errors << ValidationError.new(:scrambles, competition_id,
+          @errors << ValidationError.new(:scrambles, competition.id,
                                          UNEXPECTED_SCRAMBLES_FOR_ROUND_ERROR,
                                          round_id: round_id)
         end
 
-        rounds_info_by_ids = get_rounds_info(competitions[competition_id], rounds_ids)
+        rounds_info_by_ids = get_rounds_info(competition, rounds_ids)
 
         # For existing rounds and scrambles matching expected rounds in the WCA website,
         # check that the number of scrambles match at least the number of expected scrambles.
@@ -77,7 +73,7 @@ module ResultsValidators
             # filter out extra scrambles
             actual_number_of_scrambles = scrambles_for_group.reject(&:isExtra).size
             if actual_number_of_scrambles < expected_number_of_scrambles
-              errors_for_round << ValidationError.new(:scrambles, competition_id,
+              errors_for_round << ValidationError.new(:scrambles, competition.id,
                                                       MISSING_SCRAMBLES_FOR_GROUP_ERROR,
                                                       round_id: round_id, group_id: group_id,
                                                       actual: actual_number_of_scrambles,
@@ -86,18 +82,18 @@ module ResultsValidators
           end
           # Check if the number of groups match the number of scramble sets specified.
           if scrambles_by_group_id.size != rounds_info_by_ids[round_id].scramble_set_count
-            errors_for_round << ValidationError.new(:scrambles, competition_id,
+            errors_for_round << ValidationError.new(:scrambles, competition.id,
                                                     WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR,
                                                     round_id: round_id)
           end
           if round_id.start_with?("333fm") && scrambles_by_group_id.size > 1
-            @warnings << ValidationWarning.new(:scrambles, competition_id,
+            @warnings << ValidationWarning.new(:scrambles, competition.id,
                                                MULTIPLE_FMC_GROUPS_WARNING,
                                                round_id: round_id)
           end
           if round_id.start_with?("333mbf")
             unless errors_for_round.size < scrambles_by_group_id.keys.size
-              @errors << ValidationError.new(:scrambles, competition_id,
+              @errors << ValidationError.new(:scrambles, competition.id,
                                              MISSING_SCRAMBLES_FOR_MULTI_ERROR,
                                              round_id: round_id)
             end
@@ -106,7 +102,6 @@ module ResultsValidators
           end
         end
       end
-      self
     end
   end
 end

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -28,7 +28,7 @@ module ResultsValidators
       }
     end
 
-    protected def run_validation(validator_data)
+    def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
         results_for_comp = competition_data.results

--- a/WcaOnRails/lib/results_validators/validator_data.rb
+++ b/WcaOnRails/lib/results_validators/validator_data.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class ValidatorData
+    include ActiveModel::Model
+
+    attr_reader :competition, :results
+    attr_accessor :persons
+
+    def self.from_competition(validator, competition_id, check_real_results: true)
+      associations = self.load_associations(validator)
+
+      results_assoc = check_real_results ? :results : :inbox_results
+      associations.deep_merge!({ results_assoc => [] })
+
+      model_competition = self.load_competition(validator, competition_id, associations)
+      model_results = model_competition.send(results_assoc).sorted
+
+      self.load_data(validator, model_competition, model_results, check_real_results: check_real_results)
+    end
+
+    def self.from_results(validator, results)
+      results.group_by(&:competitionId)
+             .map do |competition_id, comp_results|
+        # TODO: A bit hacky to check this, but fair given the assumptions of the previous default `validate` method.
+        check_real_results = comp_results.any? { |r| r.is_a? Result }
+
+        model_competition = self.load_competition(validator, competition_id, check_real_results: check_real_results)
+
+        self.load_data(validator, model_competition, comp_results, check_real_results: check_real_results)
+      end
+    end
+
+    private
+
+    def load_associations(validator, check_real_results: false)
+      associations = validator.competition_associations
+
+      if validator.include_persons?
+        persons_assoc = check_real_results ? :competitors : :inbox_persons
+        associations.deep_merge!({ persons_assoc => [] })
+      end
+
+      associations
+    end
+
+    def load_competition(validator, competition_id, associations = nil, check_real_results: false)
+      associations ||= self.load_associations(validator, check_real_results: check_real_results)
+
+      where_filters = validator.competition_where_filters
+
+      Competition.includes(**associations)
+                 .where(**where_filters)
+                 .find(competition_id)
+    end
+
+    def load_data(validator, competition, results, check_real_results: false)
+      data = self.new(
+        competition: competition,
+        results: results,
+      )
+
+      if validator.include_persons?
+        data.persons = check_real_results ? competition.competitors : competition.inbox_persons
+      end
+
+      data
+    end
+  end
+end

--- a/WcaOnRails/lib/results_validators/validator_data.rb
+++ b/WcaOnRails/lib/results_validators/validator_data.rb
@@ -45,7 +45,9 @@ module ResultsValidators
 
       if validator.include_persons?
         persons_assoc = check_real_results ? :competitors : :inbox_persons
-        associations.deep_merge!({ persons_assoc => [] })
+        assoc_models = check_real_results ? [] : [:person]
+
+        associations.deep_merge!({ persons_assoc => assoc_models })
       end
 
       associations

--- a/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ACV do
                                   round_id: "333-f", actual: 9, expected: 4,
                                   condition: first_round2.advancement_condition.to_s(first_round2)),
       ]
-      acv = ACV.new.validate(competition_ids: [competition2, competition3], model: Result)
+      acv = ACV.new.validate(competition_ids: [competition2.id, competition3.id], model: Result)
       expect(acv.warnings).to match_array(expected_warnings)
       expect(acv.errors).to match_array(expected_errors)
     end

--- a/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ACV do
       [InboxResult, Result].flat_map { |model|
         [
           { competition_ids: [competition1.id, competition2.id], model: model },
-          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+          { results: model.where(competition_id: [competition1.id, competition2.id]), model: model },
         ]
       }
     }

--- a/WcaOnRails/spec/lib/results_validators/competitor_limit_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/competitor_limit_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CLV do
       [InboxResult, Result].flat_map { |model|
         [
           { competition_ids: [competition1.id, competition2.id], model: model },
-          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+          { results: model.where(competition_id: [competition1.id, competition2.id]), model: model },
         ]
       }
     }

--- a/WcaOnRails/spec/lib/results_validators/events_rounds_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/events_rounds_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ERV do
       [InboxResult, Result].flat_map { |model|
         [
           { competition_ids: [competition1.id, competition2.id], model: model },
-          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+          { results: model.where(competition_id: [competition1.id, competition2.id]), model: model },
         ]
       }
     }

--- a/WcaOnRails/spec/lib/results_validators/individual_results_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/individual_results_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe IRV do
       [InboxResult, Result].flat_map { |model|
         [
           { competition_ids: [competition1.id, competition2.id], model: model },
-          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+          { results: model.where(competition_id: [competition1.id, competition2.id]), model: model },
         ]
       }
     }

--- a/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/persons_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PV do
       [InboxResult, Result].flat_map { |model|
         [
           { competition_ids: [competition1.id, competition2.id], model: model },
-          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+          { results: model.where(competition_id: [competition1.id, competition2.id]), model: model },
         ]
       }
     }
@@ -108,7 +108,7 @@ RSpec.describe PV do
         ]
         validator_args = [
           { competition_ids: [competition1.id, competition2.id], model: InboxResult },
-          { results: InboxResult.sorted_for_competitions([competition1.id, competition2.id]), model: InboxResult },
+          { results: InboxResult.where(competition_id: [competition1.id, competition2.id]), model: InboxResult },
         ]
         validator_args.each do |arg|
           pv = PV.new.validate(**arg)
@@ -255,7 +255,7 @@ RSpec.describe PV do
         ]
         validator_args = [
           { competition_ids: [competition1.id, competition2.id], model: InboxResult },
-          { results: InboxResult.sorted_for_competitions([competition1.id, competition2.id]), model: InboxResult },
+          { results: InboxResult.where(competition_id: [competition1.id, competition2.id]), model: InboxResult },
         ]
         validator_args.each do |arg|
           pv = PV.new.validate(**arg)

--- a/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/positions_validator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ResultsValidators::PositionsValidator do
       [InboxResult, Result].flat_map { |model|
         [
           { competition_ids: [competition1.id, competition2.id], model: model },
-          { results: model.sorted_for_competitions([competition1.id, competition2.id]), model: model },
+          { results: model.where(competition_id: [competition1.id, competition2.id]), model: model },
         ]
       }
     }

--- a/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
+++ b/WcaOnRails/spec/lib/results_validators/scrambles_validator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SV do
       [InboxResult, Result].flat_map { |model|
         [
           { competition_ids: [competition1.id, competition2.id, competition3.id], model: model },
-          { results: model.sorted_for_competitions([competition1.id, competition2.id, competition3.id]), model: model },
+          { results: model.where(competition_id: [competition1.id, competition2.id, competition3.id]), model: model },
         ]
       }
     }


### PR DESCRIPTION
## Problem situation
With the perspective PHP refactor in #7643 we are facing the possibility of running `ResultsValidator`s on **A LOT** of competitions at once. This is problematic because right now, all validators are loading data pretty much "as they please". This leads to a high amount of potentially inefficient SQL queries.

## Suggested solution
Every `ResultsValidator` "announces" which data it needs by virtue of an `.includes` specification on the `Competitions` table. When the validator is run, all of this data is bundled into one central (newly introduced!) `ValidatorData` object. This object can also be shared across multiple validators when they are bundled via `CompetitionsResultsValidator`.

## Benefits
- The individual validators don't have to worry about the several different "entry points" to validation (pass competition ID plus model VS. pass `Resultable` rows) anymore. `GenericValidator` handles the entry point and bundles the different variants into `ValidatorData` which is then passed down.
- The individual validators also don't have to worry about `reset_state` and similar anymore.
- The combined validator can now efficiently batch Competitions if required.

## Remarks
- There are additional abstractions on `Persons` and `InboxPersons` now, because there are special cases depending on whether you're actually checking the real results or not. Both models now have a `ref_id` (which is the actual WCA ID in case of `Person`s and the DB increment ID in case of `InboxPerson`s)
- One small piece of logic in the `PersonsValidator` changed: Both "types" of persons now have a `wca_person` shorthand which yields the actual `Person` model (in case of `Person`, just returns `self` and in case of `InboxPerson` tries to load via `wca_id` foreign key if present). This avoids an additional SQL query just for one validator.
- The batching in `CompetitonsResultsValidator` is not yet used, because in the current codebase we only use it for validating single competitions. The aforementioned PR will use the feature after a rebase.