### PR TITLE
Check if announced is null before ordering

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -72,7 +72,7 @@ class Competition < ApplicationRecord
       ).group(:id)
   }
   scope :order_by_date, -> { order(:start_date, :end_date) }
-  scope :order_by_announcement_date, -> { order(announced_at: :desc) }
+  scope :order_by_announcement_date, -> { where.not(announced_at: nil).order(announced_at: :desc) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :not_confirmed, -> { where(confirmed_at: nil) }
 


### PR DESCRIPTION
After clicking order by announcement, we are currently getting this error

![image](https://user-images.githubusercontent.com/10170850/231062319-a25a2355-9e89-4dd5-836b-f28c1f8b5a52.png)

This PR aims to fix it

The root cause of it was actually this line accessing a method on a nil string

https://github.com/thewca/worldcubeassociation.org/blob/63808dcf3487399d669f4f6a4bf1b8383cbe241e/WcaOnRails/app/views/competitions/_index_table.html.erb#L21