### PR TITLE
Make the password reset link clickable.

### DIFF
--- a/WcaOnRails/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/WcaOnRails/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -11,7 +11,7 @@
 </p>
 
 <p>
-  <%= edit_password_url(@resource, :reset_password_token => @token, locale: I18n.locale) %>
+  <a href="<%= edit_password_url(@resource, :reset_password_token => @token, locale: I18n.locale) %>" target="_blank" rel="noopener noreferrer"/><%= edit_password_url(@resource, :reset_password_token => @token, locale: I18n.locale) %></a>
 </p>
 
 <p>


### PR DESCRIPTION
Currently this is how the email message appears on my inbox. No clickable link. I've to select the particular text then copy and paste it into a browser. This journey is not feasible in mobile phone.

<img width="856" alt="Screenshot 2023-04-13 at 21 56 35" src="https://user-images.githubusercontent.com/2534060/231800443-a9a53dc1-3476-455e-a3e7-586b93965cd2.png">
