### PR TITLE
AdvancementConditionsValidator: take into account valid results

### DIFF
--- a/WcaOnRails/lib/advancement_conditions/percent_condition.rb
+++ b/WcaOnRails/lib/advancement_conditions/percent_condition.rb
@@ -13,7 +13,9 @@ module AdvancementConditions
     end
 
     def max_advancing(results)
-      results.size * percent / 100
+      valid_results = results.select { |r| r.best > 0 }.size
+      proceeds = results.size * percent / 100
+      [valid_results, proceeds].min
     end
   end
 end


### PR DESCRIPTION
Follow up for #7376: since it's been deployed we have been seeing a lot of "false positive" for the "not enough qualified warning", for instance messages like that:

> Round 333bf-f: according to the events data, at most 18 could have proceed, but only 13 competed in the round. Please leave a comment about that (or fix the events data if you applied a different advancement condition).

When actually only 13 people did have valid results.
This patch basically performs a min between the number of valid results and the theoretical number of people who could have qualified based on the percentage.