### PR TITLE
Registration error fixes

### DIFF
--- a/WcaOnRails/app/views/registrations/_register_form.html.erb
+++ b/WcaOnRails/app/views/registrations/_register_form.html.erb
@@ -36,6 +36,7 @@
       <div class="col-sm-offset-2 col-sm-10">
         <% if @registration.new_or_deleted? %>
           <%= f.submit t('registrations.register'), class: "btn btn-success" %>
+          <p>Do not refresh or resubmit the form after clicking "Register" - this will break the registration flow.</p>
         <% else %>
           <%= f.hidden_field :status, value: @registration.checked_status %>
           <% if current_user.can_delete_registration?(@registration) %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1277,7 +1277,7 @@ en:
     waiting_list: "Your registration is pending. For approval, you may need to pay a registration fee. Check the competition website for details."
     accepted: "Your registration has been accepted!"
     entry_fees_fully_paid: "You have paid %{paid}, which fully covers the registration fees."
-    will_pay_here: "You will pay them here after submitting your registration"
+    will_pay_here: "You will be redirected to the payment page after submitting your registration."
     wont_pay_here: "Please check competition's information for instruction about how to pay"
     not_qualified: "Not qualified"
     refund_form:


### PR DESCRIPTION
**Disclaimer: I'm not sure this is worth spending time on. It feels fairly complex relative to the benefit it brings, and our time is likely better spent on just implementing more fundamental reg fixes. If someone sees an easy way to merge this with high confidence, though, it might be worth it.** 

This PR does 2 things:
1. Adds a basic text notice telling users not to refresh after registration is submitted
2. Adds error handling for a Duplicate Record Exists error which continues the registration flow if a record already exists.

I'm very uncertain on the implementation of change (2). A few notes:
- Error handling was chosen instead of checking if the record already existed in the DB, to prevent multiple calls to the DB under periods of already high load.
- I've opted to allow registration emails to be sent again in the case of form resubmission. This is a crude solution, but I figured the trade off of more emails vs 
- I have no idea how to implement tests that check whether this fix actually works, or if it introduces other errors.