### PR TITLE
Move dumping functions to common DbDumpHelper

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -179,8 +179,8 @@ class Api::V0::ApiController < ApplicationController
   end
 
   def export_public
-    sql_perma_path = DatabaseController.rel_download_path DatabaseController::RESULTS_EXPORT_FOLDER, DatabaseController::RESULTS_EXPORT_SQL_PERMALINK
-    tsv_perma_path = DatabaseController.rel_download_path DatabaseController::RESULTS_EXPORT_FOLDER, DatabaseController::RESULTS_EXPORT_TSV_PERMALINK
+    sql_perma_path = DatabaseController.rel_download_path DbDumpHelper::RESULTS_EXPORT_FOLDER, DbDumpHelper::RESULTS_EXPORT_SQL_PERMALINK
+    tsv_perma_path = DatabaseController.rel_download_path DbDumpHelper::RESULTS_EXPORT_FOLDER, DbDumpHelper::RESULTS_EXPORT_TSV_PERMALINK
 
     timestamp = Timestamp.find_by(name: DumpPublicResultsDatabase::TIMESTAMP_NAME)
 

--- a/WcaOnRails/app/controllers/database_controller.rb
+++ b/WcaOnRails/app/controllers/database_controller.rb
@@ -1,40 +1,25 @@
 # frozen_string_literal: true
 
 class DatabaseController < ApplicationController
-  EXPORT_PUBLIC_FOLDER = Rails.root.join('public', 'export')
-
-  RESULTS_EXPORT_FOLDER = EXPORT_PUBLIC_FOLDER.join('results')
-  RESULTS_EXPORT_FILENAME = 'WCA_export'
-  RESULTS_EXPORT_SQL = "#{RESULTS_EXPORT_FILENAME}.sql".freeze
-  RESULTS_EXPORT_README = 'README.md'
-  RESULTS_EXPORT_METADATA = 'metadata.json'
-  RESULTS_EXPORT_SQL_PERMALINK = "#{RESULTS_EXPORT_SQL}.zip".freeze
-  RESULTS_EXPORT_TSV_PERMALINK = "#{RESULTS_EXPORT_FILENAME}.tsv.zip".freeze
-
-  DEVELOPER_EXPORT_FOLDER = EXPORT_PUBLIC_FOLDER.join('developer')
-  DEVELOPER_EXPORT_FILENAME = 'wca-developer-database-dump'
-  DEVELOPER_EXPORT_SQL = "#{DEVELOPER_EXPORT_FILENAME}.sql".freeze
-  DEVELOPER_EXPORT_SQL_PERMALINK = "#{DEVELOPER_EXPORT_FILENAME}.zip".freeze
-
   RESULTS_README_TEMPLATE = 'database/public_results_readme'
 
   def results_export
-    @sql_filename, @sql_filesize = _link_info RESULTS_EXPORT_SQL_PERMALINK
-    @tsv_filename, @tsv_filesize = _link_info RESULTS_EXPORT_TSV_PERMALINK
+    @sql_filename, @sql_filesize = _link_info DbDumpHelper::RESULTS_EXPORT_SQL_PERMALINK
+    @tsv_filename, @tsv_filesize = _link_info DbDumpHelper::RESULTS_EXPORT_TSV_PERMALINK
 
-    @sql_rel_path = DatabaseController.rel_download_path RESULTS_EXPORT_FOLDER, @sql_filename
-    @tsv_rel_path = DatabaseController.rel_download_path RESULTS_EXPORT_FOLDER, @tsv_filename
+    @sql_rel_path = DatabaseController.rel_download_path DbDumpHelper::RESULTS_EXPORT_FOLDER, @sql_filename
+    @tsv_rel_path = DatabaseController.rel_download_path DbDumpHelper::RESULTS_EXPORT_FOLDER, @tsv_filename
 
-    @sql_perma_path = DatabaseController.rel_download_path RESULTS_EXPORT_FOLDER, RESULTS_EXPORT_SQL_PERMALINK
-    @tsv_perma_path = DatabaseController.rel_download_path RESULTS_EXPORT_FOLDER, RESULTS_EXPORT_TSV_PERMALINK
+    @sql_perma_path = DatabaseController.rel_download_path DbDumpHelper::RESULTS_EXPORT_FOLDER, DbDumpHelper::RESULTS_EXPORT_SQL_PERMALINK
+    @tsv_perma_path = DatabaseController.rel_download_path DbDumpHelper::RESULTS_EXPORT_FOLDER, DbDumpHelper::RESULTS_EXPORT_TSV_PERMALINK
   end
 
   def _link_info(permalink)
-    full_permalink = RESULTS_EXPORT_FOLDER.join(permalink)
+    full_permalink = DbDumpHelper::RESULTS_EXPORT_FOLDER.join(permalink)
 
     actual_filename = File.basename File.readlink(full_permalink)
     # Manually resolve the relative link to be independent of runtime environments
-    actual_file = RESULTS_EXPORT_FOLDER.join(actual_filename)
+    actual_file = DbDumpHelper::RESULTS_EXPORT_FOLDER.join(actual_filename)
 
     filesize_bytes = File.size? actual_file
 
@@ -42,12 +27,12 @@ class DatabaseController < ApplicationController
   end
 
   def developer_export
-    @rel_download_path = DatabaseController.rel_download_path DEVELOPER_EXPORT_FOLDER, DEVELOPER_EXPORT_SQL_PERMALINK
+    @rel_download_path = DatabaseController.rel_download_path DbDumpHelper::DEVELOPER_EXPORT_FOLDER, DbDumpHelper::DEVELOPER_EXPORT_SQL_PERMALINK
   end
 
   def self.rel_download_path(base_folder, file_name)
     file_path = base_folder.join file_name
-    relative_path = file_path.relative_path_from EXPORT_PUBLIC_FOLDER.parent
+    relative_path = file_path.relative_path_from DbDumpHelper::EXPORT_PUBLIC_FOLDER.parent
 
     # has to start with / or otherwise Rails resolves the controller action into the path
     "/#{relative_path}"

--- a/WcaOnRails/app/jobs/dump_developer_database.rb
+++ b/WcaOnRails/app/jobs/dump_developer_database.rb
@@ -10,10 +10,8 @@ class DumpDeveloperDatabase < SingletonApplicationJob
       running_on_dev_dump = Timestamp.exists?(name: DatabaseDumper::DEV_TIMESTAMP_NAME)
 
       unless running_on_dev_dump
-        Rake::Task["db:dump:development"].invoke
-
+        DbDumpHelper.dump_developer_db
         last_developer_db_dump.touch :date
-        Rake::Task["db:dump:development"].reenable
       end
     end
   end

--- a/WcaOnRails/app/jobs/dump_public_results_database.rb
+++ b/WcaOnRails/app/jobs/dump_public_results_database.rb
@@ -9,10 +9,8 @@ class DumpPublicResultsDatabase < SingletonApplicationJob
     # Create results database dump every day.
     last_public_results_dump = Timestamp.find_or_create_by(name: TIMESTAMP_NAME)
     if force_export || last_public_results_dump.not_after?(24.hours.ago)
-      Rake::Task["db:dump:public_results"].invoke
-
+      DbDumpHelper.dump_results_db
       last_public_results_dump.touch :date
-      Rake::Task["db:dump:public_results"].reenable
     end
   end
 end

--- a/WcaOnRails/app/views/database/results_export.html.erb
+++ b/WcaOnRails/app/views/database/results_export.html.erb
@@ -17,7 +17,7 @@
     <dd><%= t('.file_formats.tsv') %></dd>
   </dl>
 
-  <p><%= t('.hint_readme_html', readme_filename: content_tag('code', DatabaseController::RESULTS_EXPORT_README)) %></p>
+  <p><%= t('.hint_readme_html', readme_filename: content_tag('code', DbDumpHelper::RESULTS_EXPORT_README)) %></p>
 
   <pre><%= DatabaseController.render_readme(self, DateTime.now) %></pre>
 </div>

--- a/WcaOnRails/lib/db_dump_helper.rb
+++ b/WcaOnRails/lib/db_dump_helper.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module DbDumpHelper
+  EXPORT_PUBLIC_FOLDER = Rails.root.join('public', 'export')
+
+  RESULTS_EXPORT_FOLDER = EXPORT_PUBLIC_FOLDER.join('results')
+  RESULTS_EXPORT_FILENAME = 'WCA_export'
+  RESULTS_EXPORT_SQL = "#{RESULTS_EXPORT_FILENAME}.sql".freeze
+  RESULTS_EXPORT_README = 'README.md'
+  RESULTS_EXPORT_METADATA = 'metadata.json'
+  RESULTS_EXPORT_SQL_PERMALINK = "#{RESULTS_EXPORT_SQL}.zip".freeze
+  RESULTS_EXPORT_TSV_PERMALINK = "#{RESULTS_EXPORT_FILENAME}.tsv.zip".freeze
+
+  DEVELOPER_EXPORT_FOLDER = EXPORT_PUBLIC_FOLDER.join('developer')
+  DEVELOPER_EXPORT_FILENAME = 'wca-developer-database-dump'
+  DEVELOPER_EXPORT_SQL = "#{DEVELOPER_EXPORT_FILENAME}.sql".freeze
+  DEVELOPER_EXPORT_SQL_PERMALINK = "#{DEVELOPER_EXPORT_FILENAME}.zip".freeze
+
+  def self.dump_developer_db
+    Dir.mktmpdir do |dir|
+      FileUtils.cd dir do
+        DatabaseDumper.development_dump(DEVELOPER_EXPORT_SQL)
+
+        self.zip_and_permalink(DEVELOPER_EXPORT_FOLDER, DEVELOPER_EXPORT_SQL_PERMALINK, nil, DEVELOPER_EXPORT_SQL)
+      end
+    end
+  end
+
+  def self.dump_results_db
+    Dir.mktmpdir do |dir|
+      FileUtils.cd dir do
+        export_timestamp = DateTime.now
+
+        tsv_folder_name = "TSV_export"
+        FileUtils.mkpath tsv_folder_name
+
+        DatabaseDumper.public_results_dump(RESULTS_EXPORT_SQL, tsv_folder_name)
+
+        metadata = {
+          'export_format_version' => DatabaseDumper::PUBLIC_RESULTS_VERSION,
+          'export_date' => export_timestamp,
+        }
+        File.write(RESULTS_EXPORT_METADATA, JSON.dump(metadata))
+
+        readme_template = DatabaseController.render_readme(ActionController::Base.new, export_timestamp)
+        File.write(RESULTS_EXPORT_README, readme_template)
+
+        # Remove old exports to save storage space
+        FileUtils.rm_r RESULTS_EXPORT_FOLDER, force: true, secure: true
+
+        sql_zip_filename = "WCA_export#{export_timestamp.strftime('%j')}_#{export_timestamp.strftime('%Y%m%dT%H%M%SZ')}.sql.zip"
+        sql_zip_contents = [RESULTS_EXPORT_METADATA, RESULTS_EXPORT_README, RESULTS_EXPORT_SQL]
+
+        self.zip_and_permalink(RESULTS_EXPORT_FOLDER, sql_zip_filename, RESULTS_EXPORT_SQL_PERMALINK, *sql_zip_contents)
+
+        tsv_zip_filename = "WCA_export#{export_timestamp.strftime('%j')}_#{export_timestamp.strftime('%Y%m%dT%H%M%SZ')}.tsv.zip"
+        tsv_files = Dir.glob("#{tsv_folder_name}/*.tsv").map do |tsv|
+          FileUtils.mv(tsv, '.')
+          File.basename tsv
+        end
+
+        tsv_zip_contents = [RESULTS_EXPORT_METADATA, RESULTS_EXPORT_README] | tsv_files
+        self.zip_and_permalink(RESULTS_EXPORT_FOLDER, tsv_zip_filename, RESULTS_EXPORT_TSV_PERMALINK, *tsv_zip_contents)
+      end
+    end
+  end
+
+  def self.zip_and_permalink(root_folder, zip_filename, permalink_filename = nil, *zip_contents)
+    zip_file_list = zip_contents.join(" ")
+
+    LogTask.log_task "Zipping #{zip_contents.length} file entries to '#{zip_filename}'" do
+      system("zip #{zip_filename} #{zip_file_list}") || raise("Error running `zip`")
+    end
+
+    public_zip_path = root_folder.join(zip_filename)
+
+    LogTask.log_task "Moving zipped file to '#{public_zip_path}'" do
+      FileUtils.mkpath(File.dirname(public_zip_path))
+      FileUtils.mv(zip_filename, public_zip_path)
+
+      if permalink_filename.present?
+        permalink_zip_path = root_folder.join(permalink_filename)
+
+        # Writing a RELATIVE link, so that we can do readlink in dev and prod and not care about stuff like Docker
+        FileUtils.ln_s(zip_filename, permalink_zip_path, force: true)
+      end
+    end
+  end
+end

--- a/WcaOnRails/lib/tasks/db.rake
+++ b/WcaOnRails/lib/tasks/db.rake
@@ -39,77 +39,11 @@ namespace :db do
   namespace :dump do
     desc 'Generates a dump of our database with sensitive information stripped, safe for public viewing.'
     task development: :environment do
-      Dir.mktmpdir do |dir|
-        FileUtils.cd dir do
-          DatabaseDumper.development_dump(DatabaseController::DEVELOPER_EXPORT_SQL)
-
-          LogTask.log_task "Zipping '#{DatabaseController::DEVELOPER_EXPORT_SQL}' to '#{DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK}'" do
-            system("zip #{DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK} #{DatabaseController::DEVELOPER_EXPORT_SQL}") || raise("Error running `zip`")
-          end
-
-          public_zip_path = DatabaseController::DEVELOPER_EXPORT_FOLDER.join(DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK)
-
-          LogTask.log_task "Moving zipped file to '#{public_zip_path}'" do
-            FileUtils.mkpath(File.dirname(public_zip_path))
-            FileUtils.mv(DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK, public_zip_path)
-          end
-        end
-      end
+      DbDumpHelper.dump_developer_db
     end
 
     task public_results: :environment do
-      Dir.mktmpdir do |dir|
-        FileUtils.cd dir do
-          export_timestamp = DateTime.now
-
-          tsv_folder_name = "TSV_export"
-          FileUtils.mkpath tsv_folder_name
-
-          DatabaseDumper.public_results_dump(DatabaseController::RESULTS_EXPORT_SQL, tsv_folder_name)
-
-          metadata = {
-            'export_format_version' => DatabaseDumper::PUBLIC_RESULTS_VERSION,
-            'export_date' => export_timestamp,
-          }
-          File.write(DatabaseController::RESULTS_EXPORT_METADATA, JSON.dump(metadata))
-
-          readme_template = DatabaseController.render_readme(ActionController::Base.new, export_timestamp)
-          File.write(DatabaseController::RESULTS_EXPORT_README, readme_template)
-
-          # Remove old exports to save storage space
-          FileUtils.rm_r DatabaseController::RESULTS_EXPORT_FOLDER, force: true, secure: true
-
-          def zip_and_permalink(zip_filename, permalink_filename, *additional_files)
-            zip_contents = [DatabaseController::RESULTS_EXPORT_METADATA, DatabaseController::RESULTS_EXPORT_README] | additional_files
-            zip_filelist = zip_contents.join(" ")
-
-            LogTask.log_task "Zipping metadata and #{additional_files.length} additional files to '#{zip_filename}'" do
-              system("zip #{zip_filename} #{zip_filelist}") || raise("Error running `zip`")
-            end
-
-            public_zip_path = DatabaseController::RESULTS_EXPORT_FOLDER.join(zip_filename)
-            permalink_zip_path = DatabaseController::RESULTS_EXPORT_FOLDER.join(permalink_filename)
-
-            LogTask.log_task "Moving zipped file to '#{public_zip_path}'" do
-              FileUtils.mkpath(File.dirname(public_zip_path))
-              FileUtils.mv(zip_filename, public_zip_path)
-              # Writing a RELATIVE link, so that we can do readlink in dev and prod and not care about stuff like Docker
-              FileUtils.ln_s(zip_filename, permalink_zip_path, force: true)
-            end
-          end
-
-          sql_zip_filename = "WCA_export#{export_timestamp.strftime('%j')}_#{export_timestamp.strftime('%Y%m%dT%H%M%SZ')}.sql.zip"
-          zip_and_permalink(sql_zip_filename, DatabaseController::RESULTS_EXPORT_SQL_PERMALINK, DatabaseController::RESULTS_EXPORT_SQL)
-
-          tsv_zip_filename = "WCA_export#{export_timestamp.strftime('%j')}_#{export_timestamp.strftime('%Y%m%dT%H%M%SZ')}.tsv.zip"
-          tsv_files = Dir.glob("#{tsv_folder_name}/*.tsv").map do |tsv|
-            FileUtils.mv(tsv, '.')
-            File.basename tsv
-          end
-
-          zip_and_permalink(tsv_zip_filename, DatabaseController::RESULTS_EXPORT_TSV_PERMALINK, *tsv_files)
-        end
-      end
+      DbDumpHelper.dump_results_db
     end
   end
 
@@ -122,20 +56,20 @@ namespace :db do
 
       Dir.mktmpdir do |dir|
         FileUtils.cd dir do
-          dev_db_dump_url = "https://www.worldcubeassociation.org/export/developer/#{DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK}"
+          dev_db_dump_url = "https://www.worldcubeassociation.org/export/developer/#{DbDumpHelper::DEVELOPER_EXPORT_SQL_PERMALINK}"
 
           LogTask.log_task("Downloading #{dev_db_dump_url}") do
-            system("curl -o #{DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK} #{dev_db_dump_url}") || raise("Error while running `curl`")
+            system("curl -o #{DbDumpHelper::DEVELOPER_EXPORT_SQL_PERMALINK} #{dev_db_dump_url}") || raise("Error while running `curl`")
           end
-          LogTask.log_task("Unzipping #{DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK}") do
-            system("unzip #{DatabaseController::DEVELOPER_EXPORT_SQL_PERMALINK}") || raise("Error while running `unzip`")
+          LogTask.log_task("Unzipping #{DbDumpHelper::DEVELOPER_EXPORT_SQL_PERMALINK}") do
+            system("unzip #{DbDumpHelper::DEVELOPER_EXPORT_SQL_PERMALINK}") || raise("Error while running `unzip`")
           end
 
           config = ActiveRecord::Base.connection_db_config
-          LogTask.log_task "Clobbering contents of '#{config.database}' with #{DatabaseController::DEVELOPER_EXPORT_SQL}" do
+          LogTask.log_task "Clobbering contents of '#{config.database}' with #{DbDumpHelper::DEVELOPER_EXPORT_SQL}" do
             DatabaseDumper.mysql("DROP DATABASE IF EXISTS #{config.database}")
             DatabaseDumper.mysql("CREATE DATABASE #{config.database}")
-            DatabaseDumper.mysql("SOURCE #{DatabaseController::DEVELOPER_EXPORT_SQL}", config.database)
+            DatabaseDumper.mysql("SOURCE #{DbDumpHelper::DEVELOPER_EXPORT_SQL}", config.database)
           end
 
           default_password = 'wca'


### PR DESCRIPTION
Because invoking Rake tasks from within the Rails application code ain't cool.

Essentially, everything that happened within the Rake task body is now moved to a separate module function. The Rake task directly calls that module's function, so literally nothing changed there.

The hourly cronjobs can also call the module under `libs`, instead of having to rely on Rake.