### PR TITLE
Fix DbDumper grep misinterpreting mysql output as RegExp

### DIFF
--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -1110,7 +1110,7 @@ module DatabaseDumper
   end
 
   def self.filter_out_mysql_warning(dest_filename = nil)
-    "2>&1 | grep -v \"[Warning] Using a password on the command line interface can be insecure.\"#{dest_filename.present? ? " > #{dest_filename}" : ''} || true"
+    "2>&1 | grep -v \"\\[Warning\\] Using a password on the command line interface can be insecure.\"#{dest_filename.present? ? " > #{dest_filename}" : ''} || true"
   end
 end
 


### PR DESCRIPTION
_Really_ fixes https://github.com/thewca/worldcubeassociation.org/issues/7903 this time around.

Fun fact: This bug was in our code for at least three years, we just never noticed it because we never wrote the output of any `mysql` command to a public file directly (the old PHP TSV export was completely custom).

`grep` interpreted the square brackets as RegExp group by default. Mask them, and we're good.