### PR TITLE
Fix validators descriptions

### DIFF
--- a/WcaOnRails/app/views/admin/_validator_form.html.erb
+++ b/WcaOnRails/app/views/admin/_validator_form.html.erb
@@ -41,7 +41,7 @@
             <% ResultsValidators::Utils::ALL_VALIDATORS.each do |validator| %>
               <tr>
                 <td><%= validator.class_name %></td>
-                <td><%= validator.new.description %></td>
+                <td><%= validator.description %></td>
                 <td></td> <!-- Extra column for .table-greedy-last-column -->
               </tr>
             <% end %>

--- a/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
+++ b/WcaOnRails/lib/results_validators/advancement_conditions_validator.rb
@@ -23,7 +23,7 @@ module ResultsValidators
     # They are not taken into account in advancement conditions.
     IGNORE_ROUND_TYPES = ["0", "h", "b"].freeze
 
-    @@desc = "This validator checks that advancement between rounds is correct according to the regulations."
+    @desc = "This validator checks that advancement between rounds is correct according to the regulations."
 
     def self.has_automated_fix?
       false

--- a/WcaOnRails/lib/results_validators/competitions_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitions_results_validator.rb
@@ -2,7 +2,7 @@
 
 module ResultsValidators
   class CompetitionsResultsValidator < GenericValidator
-    @@desc = "This validator is an aggregate of an arbitrary set of other validators, running on an arbitrary set of competitions."
+    @desc = "This validator is an aggregate of an arbitrary set of other validators, running on an arbitrary set of competitions."
 
     def self.has_automated_fix?
       false

--- a/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
+++ b/WcaOnRails/lib/results_validators/competitor_limit_validator.rb
@@ -5,7 +5,7 @@ module ResultsValidators
     COMPETITOR_LIMIT_WARNING = "The number of persons in the competition (%{n_competitors}) is above the competitor limit (%{competitor_limit}). " \
                                "The results of the competitors registered after the competitor limit was reached must be removed."
 
-    @@desc = "For competition with a competitor limit, this validator checks that this limit is respected."
+    @desc = "For competition with a competitor limit, this validator checks that this limit is respected."
 
     def self.has_automated_fix?
       false

--- a/WcaOnRails/lib/results_validators/events_rounds_validator.rb
+++ b/WcaOnRails/lib/results_validators/events_rounds_validator.rb
@@ -13,7 +13,7 @@ module ResultsValidators
     MISSING_ROUND_RESULTS_ERROR = "There are no results for round %{round_id} but it is listed in the events tab. If this round was not held, please remove the round in the competition's manage events page."
     UNEXPECTED_COMBINED_ROUND_ERROR = "No cutoff was announced for '%{round_name}', but it has been detected as a cutoff round in the results. Please update the round's information in the competition's manage events page."
 
-    @@desc = "This validator checks that all events and rounds match between what has been announced and what is present in the results. It also check for a main event and emit a warning if there is none (and if 3x3 is not in the results)."
+    @desc = "This validator checks that all events and rounds match between what has been announced and what is present in the results. It also check for a main event and emit a warning if there is none (and if 3x3 is not in the results)."
 
     def self.has_automated_fix?
       false

--- a/WcaOnRails/lib/results_validators/generic_validator.rb
+++ b/WcaOnRails/lib/results_validators/generic_validator.rb
@@ -4,7 +4,7 @@ module ResultsValidators
   class GenericValidator
     attr_reader :errors, :warnings, :infos, :apply_fixes
 
-    @@desc = "Please override that class variable with a proper description when you inherit the class."
+    @desc = "Please override that class variable with a proper description when you inherit the class."
 
     def initialize(apply_fixes: false)
       @apply_fixes = apply_fixes
@@ -52,8 +52,8 @@ module ResultsValidators
       raise NotImplementedError
     end
 
-    def description
-      @@desc
+    def self.description
+      @desc
     end
 
     def self.class_name

--- a/WcaOnRails/lib/results_validators/individual_results_validator.rb
+++ b/WcaOnRails/lib/results_validators/individual_results_validator.rb
@@ -23,7 +23,7 @@ module ResultsValidators
     MISSING_CUMULATIVE_ROUND_ID_ERROR = "[%{original_round_id}] Unable to find the round %{wcif_id} for the cumulative time limit specified in the WCIF. " \
                                         "Please go to the competition's Manage Events page and remove %{wcif_id} from the cumulative time limit for %{original_round_id}. WST knows about this bug (GitHub issue #3254)."
 
-    @@desc = "This validator checks that all results respect the format, time limit, and cutoff information if available. It also looks for similar results within the round."
+    @desc = "This validator checks that all results respect the format, time limit, and cutoff information if available. It also looks for similar results within the round."
 
     def self.has_automated_fix?
       false

--- a/WcaOnRails/lib/results_validators/persons_validator.rb
+++ b/WcaOnRails/lib/results_validators/persons_validator.rb
@@ -29,7 +29,7 @@ module ResultsValidators
     SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING = "'%{name}' has a single letter as first or last name. Please fix the name or confirm that this is indeed the competitor's correct name according to an official document."
     SINGLE_NAME_WARNING = "'%{name}' has only one name. Please confirm that this is indeed the competitor's full name according to an official document."
 
-    @@desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."
+    @desc = "This validator checks that Persons data make sense with regard to the competition results and the WCA database."
 
     def self.has_automated_fix?
       false

--- a/WcaOnRails/lib/results_validators/positions_validator.rb
+++ b/WcaOnRails/lib/results_validators/positions_validator.rb
@@ -5,7 +5,7 @@ module ResultsValidators
     WRONG_POSITION_IN_RESULTS_ERROR = "[%{round_id}] %{person_name} is in the wrong position: expected %{expected_pos}, but got %{pos}."
     POSITION_FIXED_INFO = "[%{round_id}] Automatically fixed the position of %{person_name} from %{pos} to %{expected_pos}."
 
-    @@desc = "This validator checks that positions stored in results are correct with regard to the actual results."
+    @desc = "This validator checks that positions stored in results are correct with regard to the actual results."
 
     def self.has_automated_fix?
       true

--- a/WcaOnRails/lib/results_validators/scrambles_validator.rb
+++ b/WcaOnRails/lib/results_validators/scrambles_validator.rb
@@ -12,7 +12,7 @@ module ResultsValidators
     WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR = "[%{round_id}] This round has a different number of scramble sets than specified on the Manage Events tab. " \
                                           "Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
 
-    @@desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
+    @desc = "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
 
     def self.has_automated_fix?
       false


### PR DESCRIPTION
This changes validators to use class instance variables for their description (which are *not* shared in the inheritance tree).