### PR TITLE
Add administrative notes to registrations

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -786,6 +786,7 @@ class RegistrationsController < ApplicationController
         :deleted_at,
         :accepted_by,
         :deleted_by,
+        :administrative_notes,
       ]
       params[:registration].merge! case params[:registration][:status]
                                    when "accepted"

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -240,6 +240,10 @@ class Competition < ApplicationRecord
     persisted_events_id.length
   end
 
+  def has_administrative_notes?
+    registrations.any? { |registration| !registration.administrative_notes.blank? }
+  end
+
   NEARBY_DISTANCE_KM_WARNING = 250
   NEARBY_DISTANCE_KM_DANGER = 10
   NEARBY_DISTANCE_KM_INFO = 100

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -199,6 +199,7 @@ class Registration < ApplicationRecord
     authorized_fields = {
       "guests" => guests,
       "comments" => comments || '',
+      "administrative_notes" => administrative_notes || '',
     }
     {
       "wcaRegistrationId" => id,
@@ -222,6 +223,7 @@ class Registration < ApplicationRecord
         "status" => { "type" => "string", "enum" => %w(accepted deleted pending) },
         "guests" => { "type" => "integer" },
         "comments" => { "type" => "string" },
+        "administrative_notes" => { "type" => "string" },
       },
     }
   end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -199,7 +199,7 @@ class Registration < ApplicationRecord
     authorized_fields = {
       "guests" => guests,
       "comments" => comments || '',
-      "administrative_notes" => administrative_notes || '',
+      "administrativeNotes" => administrative_notes || '',
     }
     {
       "wcaRegistrationId" => id,
@@ -223,7 +223,7 @@ class Registration < ApplicationRecord
         "status" => { "type" => "string", "enum" => %w(accepted deleted pending) },
         "guests" => { "type" => "integer" },
         "comments" => { "type" => "string" },
-        "administrative_notes" => { "type" => "string" },
+        "administrativeNotes" => { "type" => "string" },
       },
     }
   end

--- a/WcaOnRails/app/views/registrations/edit.html.erb
+++ b/WcaOnRails/app/views/registrations/edit.html.erb
@@ -28,6 +28,8 @@
 
     <%= f.input :comments %>
 
+    <%= f.input :administrative_notes %>
+
     <%= f.input :status, as: :radio_buttons, collection: [:accepted, :pending, :deleted], checked: @registration.checked_status, include_blank: false %>
 
     <div class="form-group">

--- a/WcaOnRails/app/views/registrations/edit_registrations.html.erb
+++ b/WcaOnRails/app/views/registrations/edit_registrations.html.erb
@@ -84,6 +84,9 @@
             <th class="events" data-sortable="true"><%= t 'registrations.list.n_events' %></th>
             <th class="guests"><%= t 'activerecord.attributes.registration.guests' %></th>
             <th class="comments"><%= t 'activerecord.attributes.registration.comments' %></th>
+            <% if @competition.has_administrative_notes? %>
+              <th class="administrative-notes"><%= t 'activerecord.attributes.registration.administrative_notes' %></th>
+            <% end %>
             <% if @competition.using_stripe_payments? %>
               <th class="paid"><%= t 'activerecord.attributes.registration.paid_entry_fees' %></th>
             <% end %>
@@ -145,6 +148,13 @@
                   <%= registration.comments %>
                 </span>
               </td>
+              <% if @competition.has_administrative_notes? %>
+                <td class="administrative-notes">
+                  <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.administrative_notes %>">
+                    <%= registration.administrative_notes %>
+                  </span>
+                </td>
+              <% end %>
               <% if @competition.using_stripe_payments? %>
                 <td class="entry_fee">
                   <span data-toggle="tooltip" data-placement="left" data-container="body" title="<%= registration.last_payment_date %>">

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -639,7 +639,7 @@ en:
         comments: ""
         guests: ""
         status: ""
-        administrative_notes: ""
+        administrative_notes: "Additional notes kept as part of managing this registration. These can't be viewed by the competitor."
       vote:
         comment: ""
       competition_medium:

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -362,6 +362,7 @@ en:
         comments: "Comments"
         paid_entry_fees: "Paid"
         status: "Status"
+        administrative_notes: "Administrative notes"
         # We can remove the following 3 keys once https://github.com/thewca/worldcubeassociation.org/issues/275 is done! (spec will complain anyway)
         name: "Name"
         birthday: "Birthday"
@@ -638,6 +639,7 @@ en:
         comments: ""
         guests: ""
         status: ""
+        administrative_notes: ""
       vote:
         comment: ""
       competition_medium:

--- a/WcaOnRails/db/migrate/20230515103948_add_administrative_notes_to_registrations.rb
+++ b/WcaOnRails/db/migrate/20230515103948_add_administrative_notes_to_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdministrativeNotesToRegistrations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :registrations, :administrative_notes, :text
+  end
+end

--- a/WcaOnRails/db/structure.sql
+++ b/WcaOnRails/db/structure.sql
@@ -1193,6 +1193,7 @@ CREATE TABLE `registrations` (
   `deleted_by` int(11) DEFAULT NULL,
   `roles` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `is_competing` tinyint(1) DEFAULT '1',
+  `administrative_notes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_registrations_on_competition_id_and_user_id` (`competition_id`,`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1854,4 +1855,5 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20230311183558'),
 ('20230312182740'),
 ('20230315170143'),
+('20230515103948'),
 ('20230517135741');

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -603,6 +603,7 @@ module DatabaseDumper
         db_default: %w(ip),
         fake_values: {
           "comments" => "''", # Can't use :db_default here because comments does not have a default value.
+          "administrative_notes" => "''", # Can't use :db_default here because administrative_notes does not have a default value.
         },
       ),
     }.freeze,

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -352,6 +352,13 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
       expect(registration.reload.comments).to eq "new comment"
       expect(flash[:success]).to eq "Updated registration"
     end
+
+    it "cannot edit administrative notes on registration" do
+      registration = FactoryBot.create :registration, :pending, competition: competition, user_id: user.id
+
+      patch :update, params: { id: registration.id, registration: { administrative_notes: "admin notes" } }
+      expect(registration.reload.administrative_notes).to eq ""
+    end
   end
 
   context "signed in as competitor" do

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -205,6 +205,11 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
       expect(flash[:danger]).to include I18n.t('registrations.errors.undelete_banned')
     end
 
+    it "can edit administrative notes on registration" do
+      patch :update, params: { id: registration.id, registration: { administrative_notes: "admin notes" } }
+      expect(registration.reload.administrative_notes).to eq "admin notes"
+    end
+
     describe "with views" do
       render_views
       it "does not update registration that changed" do
@@ -481,6 +486,13 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
       registration = FactoryBot.create :registration, :accepted, competition: competition, user_id: user.id
       get :edit, params: { id: registration.id }
       expect(response).to redirect_to root_path
+    end
+
+    it "cannot edit administrative notes on registration" do
+      registration = FactoryBot.create :registration, :pending, competition: competition, user_id: user.id
+
+      patch :update, params: { id: registration.id, registration: { administrative_notes: "admin notes" } }
+      expect(registration.reload.administrative_notes).to eq ""
     end
 
     it "cannot edit someone else's registration" do

--- a/WcaOnRails/spec/factories/registrations.rb
+++ b/WcaOnRails/spec/factories/registrations.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     association :user, factory: [:user, :wca_id]
     guests { 10 }
     comments { "" }
+    administrative_notes { "" }
     transient do
       events { competition.events }
     end

--- a/WcaOnRails/spec/views/registrations/edit_registrations.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/edit_registrations.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "registrations/edit_registrations" do
     assign(:registrations, competition.registrations)
 
     render
-    expect(rendered).to match(/Administrative Notes/)
+    expect(rendered).to match(/Administrative notes/)
     expect(rendered).to match(/😎/)
   end
 
@@ -23,6 +23,6 @@ RSpec.describe "registrations/edit_registrations" do
     assign(:registrations, competition.registrations)
 
     render
-    expect(rendered).not_to match(/Administrative Notes/)
+    expect(rendered).not_to match(/Administrative notes/)
   end
 end

--- a/WcaOnRails/spec/views/registrations/edit_registrations.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/edit_registrations.html.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "registrations/edit_registrations" do
+  it "shows administrative notes when a registration has them" do
+    competition = FactoryBot.create(:competition, :registration_open)
+    FactoryBot.create(:registration, competition: competition, administrative_notes: "😎")
+
+    assign(:competition, competition)
+    assign(:registrations, competition.registrations)
+
+    render
+    expect(rendered).to match(/Administrative Notes/)
+    expect(rendered).to match(/😎/)
+  end
+
+  it "hides administrative notes when no registrations have them" do
+    competition = FactoryBot.create(:competition, :registration_open)
+    FactoryBot.create(:registration, competition: competition)
+
+    assign(:competition, competition)
+    assign(:registrations, competition.registrations)
+
+    render
+    expect(rendered).not_to match(/Administrative Notes/)
+  end
+end

--- a/WcaOnRails/spec/views/registrations/register.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/register.html.erb_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "registrations/register" do
 
   def setup(payment_status)
     competition = FactoryBot.create(:competition, :stripe_connected, :visible, :registration_open)
-    registration = FactoryBot.create(:registration, payment_status, competition: competition)
+    registration = FactoryBot.create(:registration, payment_status, competition: competition, administrative_notes: "👽")
     allow(view).to receive(:current_user) { registration.user }
     assign(:competition, competition)
     assign(:registration, registration)
@@ -64,5 +64,17 @@ RSpec.describe "registrations/register" do
   it "renders unpaid registrations and ask for payment" do
     setup :unpaid
     expect(rendered).to match(/Pay now!/)
+  end
+
+  it "only shows fields that are editable by a competitor" do
+    setup :paid
+    expect(rendered).to match(/Events/)
+    expect(rendered).to match(/Guests/)
+    expect(rendered).to match(/Comments/)
+
+    expect(rendered).not_to match(/Administrative [Nn]otes/)
+    expect(rendered).not_to match(/👽/)
+
+    expect(rendered).not_to match(/Status/)
   end
 end


### PR DESCRIPTION
Fixes #7628

Adds the ability to add administrative notes when editing a competitor's registration:

<img width="509" alt="Screenshot 2023-05-15 at 10 59 53 PM" src="https://github.com/thewca/worldcubeassociation.org/assets/24919355/30c32a02-12b4-451e-b66e-f94891e0db0c">

Once >=1 registration has admin notes, they show up on `/edit/registrations`:

| No registrations have admin notes | >=1 has admin notes |
| --- | --- |
| <img width="1386" alt="Screenshot 2023-05-15 at 11 00 47 PM" src="https://github.com/thewca/worldcubeassociation.org/assets/24919355/686b01b1-f9f9-4235-8ac6-81f7af6db49b"> | <img width="1386" alt="Screenshot 2023-05-15 at 11 00 29 PM" src="https://github.com/thewca/worldcubeassociation.org/assets/24919355/1dcd72b3-5be4-4f43-ae94-3be3c7608149"> |

This also adds `administrative_notes` to the non-public WCIF.

**Help requested:** For whatever reason, when I try to run the DB migration, I keep getting really large diffs in the generated structure.sql. It'll replace things like `int(11)` with `int`. I'm running things locally using `docker-compose up`. Has anyone run into this type of thing before?