### PR TITLE
Suppress React 18 import warning

### DIFF
--- a/WcaOnRails/config/webpack/webpack.config.js
+++ b/WcaOnRails/config/webpack/webpack.config.js
@@ -45,7 +45,8 @@ const customConfig = {
         },
       }
     }
-  }
+  },
+  ignoreWarnings: [/Module not found: Error: Can't resolve 'react-dom\/client'/],
 };
 
 module.exports = merge(webpackConfig, customConfig);


### PR DESCRIPTION
Yes, this is the officially recommended way as per https://github.com/reactjs/react-rails\#getting-warning-for-cant-resolve-react-domclient-in-react--18

Fixes https://github.com/thewca/worldcubeassociation.org/issues/7904