### PR TITLE
Fix registration comments for walk-in registrations

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -196,6 +196,8 @@ class RegistrationsController < ApplicationController
       user, locked_account_created = user_for_registration!(params[:registration_data])
       registration = @competition.registrations.find_or_initialize_by(user_id: user.id)
       raise I18n.t("registrations.add.errors.already_registered") unless registration.new_record?
+      registration_comment = params.dig(:registration_data, :comments)
+      registration.assign_attributes(comments: registration_comment) if registration_comment.present?
       registration.assign_attributes(accepted_at: Time.now, accepted_by: current_user.id)
       params[:registration_data][:event_ids]&.each do |event_id|
         competition_event = @competition.competition_events.find { |ce| ce.event_id == event_id }

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -277,7 +277,7 @@ class Registration < ApplicationRecord
 
   validate :forcing_competitors_to_add_comment, if: :is_competing?
   private def forcing_competitors_to_add_comment
-    if competition&.force_comment_in_registration.present? && comments.strip.empty?
+    if competition&.force_comment_in_registration.present? && !comments&.strip&.present?
       errors.add(:user_id, I18n.t('registrations.errors.cannot_register_without_comment'))
     end
   end

--- a/WcaOnRails/app/views/registrations/add.html.erb
+++ b/WcaOnRails/app/views/registrations/add.html.erb
@@ -27,6 +27,10 @@
       <%= f.input :wca_id, as: :wca_id,
                            input_html: { value: params.dig(:registration_data, :wca_id) },
                            label: t('activerecord.attributes.user.wca_id') %>
+      <% if @competition.force_comment_in_registration %>
+        <%= f.input :comments, input_html: { value: params.dig(:registration_data, :comments) },
+                               label: t('activerecord.attributes.registration.comments') %>
+      <% end %>
 
       <div class="form-group">
         <%= label_tag "events" do %>


### PR DESCRIPTION
Another one of those errors caused by enforcing comments on a blank/empty comment.
Refer to WST mail thread wonderfully named `Re:` from UTC 2023-05-20 04:18 for details.