### PR TITLE
Add rewrite for legacy PHP export permalink

### DIFF
--- a/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
+++ b/chef/site-cookbooks/wca/templates/worldcubeassociation.org.conf.erb
@@ -55,6 +55,10 @@ server {
     return 302 /admin/;
   }
 
+  location /results/misc {
+    rewrite ^/results/misc/(.*\.zip)$ /export/results/$1 break;
+  }
+
   # Redirect competitions.php to /competitions
   location /results/competitions.php {
     set $rails_args "";

--- a/docker/nginx-dev.conf
+++ b/docker/nginx-dev.conf
@@ -34,6 +34,9 @@ server {
     return 302 /admin/;
   }
 
+  location /results/misc {
+    rewrite ^/results/misc/(.*\.zip)$ /export/results/$1 break;
+  }
 
   location /results/rankings {
     try_files $uri @app;


### PR DESCRIPTION
Makes the old permalinks available under the new Rails-driven export.