### PR TITLE
Make `nil` be the default value for regional markers

### DIFF
--- a/WcaOnRails/app/models/result.rb
+++ b/WcaOnRails/app/models/result.rb
@@ -18,11 +18,12 @@ class Result < ApplicationRecord
   # we also need sure to query the correct competition as well through a custom scope.
   belongs_to :inbox_person, ->(res) { where(competitionId: res.competitionId) }, primary_key: :id, foreign_key: :personId, optional: true
 
-  # NOTE: both nil and "" exist in the database, we may consider cleaning that up.
-  MARKERS = [nil, "", "NR", "ER", "WR", "AfR", "AsR", "NAR", "OcR", "SAR"].freeze
+  MARKERS = [nil, "NR", "ER", "WR", "AfR", "AsR", "NAR", "OcR", "SAR"].freeze
 
   validates_inclusion_of :regionalSingleRecord, in: MARKERS
   validates_inclusion_of :regionalAverageRecord, in: MARKERS
+  alias_attribute :regional_single_record, :regionalSingleRecord
+  alias_attribute :regional_average_record, :regionalAverageRecord
 
   def country
     Country.c_find(self.countryId)
@@ -61,14 +62,6 @@ class Result < ApplicationRecord
 
   def country_iso2
     country.iso2
-  end
-
-  def regional_single_record
-    regionalSingleRecord || ""
-  end
-
-  def regional_average_record
-    regionalAverageRecord || ""
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/WcaOnRails/app/webpacker/components/Results/ResultForm/ResultForm.js
+++ b/WcaOnRails/app/webpacker/components/Results/ResultForm/ResultForm.js
@@ -29,8 +29,8 @@ const attemptsDataFromResult = (result) => ({
     getExpectedSolveCount(result.format_id),
     (index) => (result.attempts && result.attempts[index]) || 0,
   ),
-  markerBest: result.regional_single_record || '',
-  markerAvg: result.regional_average_record || '',
+  markerBest: result.regional_single_record,
+  markerAvg: result.regional_average_record,
 });
 
 const personDataFromResult = (result) => ({

--- a/WcaOnRails/app/webpacker/lib/helpers/competition-results.js
+++ b/WcaOnRails/app/webpacker/lib/helpers/competition-results.js
@@ -1,8 +1,9 @@
 /* eslint import/prefer-default-export: "off" */
 export function getRecordClass(record) {
+  if (!record) {
+    return '';
+  }
   switch (record) {
-    case '':
-      return '';
     case 'WR': // Intentional fallthrough
     case 'NR':
       return record;

--- a/WcaOnRails/app/webpacker/lib/wca-data.js.erb
+++ b/WcaOnRails/app/webpacker/lib/wca-data.js.erb
@@ -116,7 +116,7 @@ export function friendlyTimezoneName(id) {
 
 // ----- REGIONAL MARKERS -----
 
-export const regionalMarkers = <%= Result::MARKERS.compact %>;
+export const regionalMarkers = <%= Result::MARKERS.to_json.html_safe %>;
 
 // ----- VENUE ROOM COLORS -----
 

--- a/WcaOnRails/spec/factories/results.rb
+++ b/WcaOnRails/spec/factories/results.rb
@@ -126,7 +126,7 @@ FactoryBot.define do
     personId { person.wca_id }
     personName { person.name }
     countryId { person.countryId }
-    regionalSingleRecord { "" }
-    regionalAverageRecord { "" }
+    regionalSingleRecord { nil }
+    regionalAverageRecord { nil }
   end
 end


### PR DESCRIPTION
When implementing #6360 it seems I did found both occurrences in the db and picked `""` as the default, it turns out having `nil` as the default sounds better for the WRT so this PR intends to fix the current implementation.
This fixes the validation and form to make sure `nil` is the default value, and that `""` is not allowed anymore.
I'll update all existing `""` regional markers before this get merged so that all results in the db are in a "valid" state (as far as rails is concerned) using these queries:
```sql
update `Results` set `regionalSingleRecord`=null WHERE `regionalSingleRecord` ="";
update `Results` set `regionalAverageRecord`=null WHERE `regionalAverageRecord` ="";
```