### PR TITLE
Improves email validation regexp

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "uri"
 require "fileutils"
 
 class User < ApplicationRecord
@@ -94,8 +95,7 @@ class User < ApplicationRecord
 
   # Very simple (and permissive) regexp, the goal is just to avoid silly typo
   # like "aaa@bbb,com", or forgetting the '@'.
-  EMAIL_RE = /[\w.%+-]+@[\w.-]+\.\w+/
-  validates :email, format: { with: EMAIL_RE }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   # Virtual attribute for authenticating by WCA ID or email.
   attr_accessor :login

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe User, type: :model do
 
     user = FactoryBot.build(:user, email: "aabbb.com")
     expect(user).to be_invalid_with_errors(email: ["is invalid"])
+
+    user = FactoryBot.build(:user, email: "john@gmail..com")
+    expect(user).to be_invalid_with_errors(email: ["is invalid"])
   end
 
   it "can confirm a user who has never competed before" do


### PR DESCRIPTION
Fixes #7832

Just a side note:

Email is not recomended to validate with regular expressions. See links:

- https://davidcel.is/articles/stop-validating-email-addresses-with-regex/
- https://stackoverflow.com/a/48170419

But it's still good to avoid smtp errors. I personally use the following trick:

- take the domain part
- check does this domain has MX-records
- if it has no MX-records there is no a chance the email could be delivered.

But the problem is that this particular case won't be handled correctly with ruby DNS  implementation

```ruby
irb(main):001:0> require "resolv"
=> true
irb(main):002:0> Resolv::DNS.open { |dns| dns.getresources "gmail..com", Resolv::DNS::Resource::IN::MX }
=> 
[#<Resolv::DNS::Resource::IN::MX:0x00007f162140f5b8 @exchange=#<Resolv::DNS::Name: alt1.gmail-smtp-in.l.google.com.>, @preference=10, @ttl=827>,
 #<Resolv::DNS::Resource::IN::MX:0x00007f162140ea50 @exchange=#<Resolv::DNS::Name: alt3.gmail-smtp-in.l.google.com.>, @preference=30, @ttl=827>,
 #<Resolv::DNS::Resource::IN::MX:0x00007f162140e0a0 @exchange=#<Resolv::DNS::Name: alt4.gmail-smtp-in.l.google.com.>, @preference=40, @ttl=827>,
 #<Resolv::DNS::Resource::IN::MX:0x00007f162140d628 @exchange=#<Resolv::DNS::Name: alt2.gmail-smtp-in.l.google.com.>, @preference=20, @ttl=827>,
 #<Resolv::DNS::Resource::IN::MX:0x00007f162140cc78 @exchange=#<Resolv::DNS::Name: gmail-smtp-in.l.google.com.>, @preference=5, @ttl=827>]
``` 
[Resolv::DNS#getresources](https://ruby-doc.org/3.2.2/stdlibs/resolv/Resolv/DNS.html#method-i-getresources) is not too strict :man_shrugging: 