### PR TITLE
Fixed dues value fetching bug

### DIFF
--- a/WcaOnRails/app/views/competitions/_competition_form.html.erb
+++ b/WcaOnRails/app/views/competitions/_competition_form.html.erb
@@ -252,7 +252,7 @@
             var compLimit = compLimitEnabled ? $("#competition_competitor_limit").val() : null;
             var currencyCode = $("#competition_currency_code").val();
             var countryId = $("#competition_countryId").val();
-            var entryFee = $("#base_entry_fee_lowest_denomination_input_field").val();
+            var entryFee = $("#competition_base_entry_fee_lowest_denomination").val();
             window.wca.cancelPendingAjaxAndAjax('calculate_dues', {
               url: '<%= calculate_dues_path %>',
               data: {


### PR DESCRIPTION
There was an issue because of which `$("#base_entry_fee_lowest_denomination_input_field").val()` was returning the value as given in the input, ie, $300.00, and hence `to_i` returned 0. This change will remove the currency and decimal and make it in the lowest denomination 30000.