### PR TITLE
Add Correct Cache Control for the cached wcif response

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -109,7 +109,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     id = params[:competition_id] || params[:id]
 
     cache_key = "wcif/#{id}"
-    expires_in 5.minutes, :public => true
+    expires_in 5.minutes, public: true
     render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
       competition = competition_from_params
       competition.to_wcif

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -109,6 +109,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     id = params[:competition_id] || params[:id]
 
     cache_key = "wcif/#{id}"
+    expires_in 5.minutes, :public => true
     render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
       competition = competition_from_params
       competition.to_wcif


### PR DESCRIPTION
Fixes #7630 by adding `expires_in 5.minutes, :public => true` to the route