### PR TITLE
Fix error response for Results Admin API

### DIFF
--- a/WcaOnRails/app/controllers/admin/results_controller.rb
+++ b/WcaOnRails/app/controllers/admin/results_controller.rb
@@ -59,7 +59,7 @@ module Admin
         validator.validate(competition_ids: [result.competitionId])
         json[:messages] = ["Result inserted!"].concat(validator.infos.map(&:to_s))
       else
-        json[:errors] = result.errors.map { |key, msg| "#{key}: #{msg}" }
+        json[:errors] = result.errors.map(&:full_message)
       end
       render json: json
     end
@@ -89,7 +89,7 @@ module Admin
         }
       else
         render json: {
-          errors: result.errors.map { |key, msg| "#{key}: #{msg}" },
+          errors: result.errors.map(&:full_message),
         }
       end
     end


### PR DESCRIPTION
as per problem reported by WRT via email.
The `errors` object was refactored in Rails 6.1 and we migrated _almost_ every place except this one :sweat_smile: https://code.lulalala.com/2020/0531-1013.html