### PR TITLE
Registration import issue of country fixed

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -222,7 +222,7 @@ class RegistrationsController < ApplicationController
     registration_row[:email]&.downcase!
     person_details = {
       name: registration_row[:name],
-      country_iso2: Country.c_find(registration_row[:country]).iso2,
+      country_iso2: Country.find_by(name: registration_row[:country]).iso2,
       gender: registration_row[:gender],
       dob: registration_row[:birth_date],
     }


### PR DESCRIPTION
WST received an email where the import was failing. The reason for failing was they were sending the country name in country column, but we were considering it as country ID and hence we were not getting country object for Country since we were using c_find.