### PR TITLE
Change "Top X" to "Up to Top X" On Events Tab

### DIFF
--- a/WcaOnRails/app/webpacker/components/EditEvents/AdvancementCondition.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/AdvancementCondition.js
@@ -19,10 +19,10 @@ export default {
 
       switch(advancementCondition.type) {
         case "ranking":
-          return `Top ${advancementCondition.level}`;
+          return `Up to top ${advancementCondition.level}`;
           break;
         case "percent":
-          return `Top ${advancementCondition.level}%`;
+          return `Up to top ${advancementCondition.level}%`;
           break;
         case "attemptResult":
           return matchResult(advancementCondition.level, wcifEvent.id, { short: true });

--- a/WcaOnRails/app/webpacker/components/EditEvents/AdvancementCondition.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/AdvancementCondition.js
@@ -19,10 +19,10 @@ export default {
 
       switch(advancementCondition.type) {
         case "ranking":
-          return `Up to top ${advancementCondition.level}`;
+          return `Top ${advancementCondition.level}`;
           break;
         case "percent":
-          return `Up to top ${advancementCondition.level}%`;
+          return `Top ${advancementCondition.level}%`;
           break;
         case "attemptResult":
           return matchResult(advancementCondition.level, wcifEvent.id, { short: true });

--- a/WcaOnRails/app/webpacker/components/EditEvents/AdvancementCondition.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/AdvancementCondition.js
@@ -19,10 +19,10 @@ export default {
 
       switch(advancementCondition.type) {
         case "ranking":
-          return `Top ${advancementCondition.level}`;
+          return `Up to Top ${advancementCondition.level}`;
           break;
         case "percent":
-          return `Top ${advancementCondition.level}%`;
+          return `Up to Top ${advancementCondition.level}%`;
           break;
         case "attemptResult":
           return matchResult(advancementCondition.level, wcifEvent.id, { short: true });


### PR DESCRIPTION
#7853, changed former wording of "Top X" to "Up to Top X" on the events tab on any given competition's website.