### PR TITLE
Include non-competing staff in the public WCIF export

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1771,7 +1771,8 @@ class Competition < ApplicationRecord
     wcif_persons.each do |wcif_person|
       local_assignments = []
       registration = registrations.find { |reg| reg.user_id == wcif_person["wcaUserId"] }
-      # If no registration is found, assume that this is a non-competing staff member being added.
+      # If no registration is found, and the Registration is marked as non-competing, add this person as a non-competing staff member.
+      next unless registration || !wcif_person["registration"] || wcif_person["registration"]["is_competing"] != false
       registration ||= registrations.create(
         competition: self,
         user_id: wcif_person["wcaUserId"],

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1645,7 +1645,7 @@ class Competition < ApplicationRecord
                                 .includes(includes_associations)
                                 .to_enum
                                 .with_index(1)
-                                .select { |r, registrant_id| authorized || r.accepted? || !r.is_competing? }
+                                .select { |r, registrant_id| authorized || r.wcif_status == "accepted" }
                                 .map do |r, registrant_id|
                                   managers.delete(r.user)
                                   r.user.to_wcif(self, r, registrant_id, authorized: authorized)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1642,7 +1642,7 @@ class Competition < ApplicationRecord
                                 .includes(includes_associations)
                                 .to_enum
                                 .with_index(1)
-                                .select { |r, registrant_id| authorized || r.accepted? }
+                                .select { |r, registrant_id| authorized || r.accepted? || !r.is_competing? }
                                 .map do |r, registrant_id|
                                   managers.delete(r.user)
                                   r.user.to_wcif(self, r, registrant_id, authorized: authorized)

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -211,6 +211,7 @@ class Registration < ApplicationRecord
                   else
                     'pending'
                   end,
+      "isCompeting" => is_competing?,
     }.merge(authorized ? authorized_fields : {})
   end
 
@@ -224,6 +225,7 @@ class Registration < ApplicationRecord
         "guests" => { "type" => "integer" },
         "comments" => { "type" => "string" },
         "administrativeNotes" => { "type" => "string" },
+        "isCompeting" => { "type" => "boolean" },
       },
     }
   end

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -204,12 +204,10 @@ class Registration < ApplicationRecord
     {
       "wcaRegistrationId" => id,
       "eventIds" => events.map(&:id).sort,
-      "status" => if accepted?
+      "status" => if accepted? || !is_competing?
                     'accepted'
                   elsif deleted?
                     'deleted'
-                  elsif !is_competing?
-                    'noncompeting'
                   else
                     'pending'
                   end,
@@ -222,7 +220,7 @@ class Registration < ApplicationRecord
       "properties" => {
         "wcaRegistrationId" => { "type" => "integer" },
         "eventIds" => { "type" => "array", "items" => { "type" => "string", "enum" => Event.pluck(:id) } },
-        "status" => { "type" => "string", "enum" => %w(accepted deleted pending noncompeting) },
+        "status" => { "type" => "string", "enum" => %w(accepted deleted pending) },
         "guests" => { "type" => "integer" },
         "comments" => { "type" => "string" },
         "administrativeNotes" => { "type" => "string" },

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -208,6 +208,8 @@ class Registration < ApplicationRecord
                     'accepted'
                   elsif deleted?
                     'deleted'
+                  elsif !is_competing?
+                    'noncompeting'
                   else
                     'pending'
                   end,
@@ -220,7 +222,7 @@ class Registration < ApplicationRecord
       "properties" => {
         "wcaRegistrationId" => { "type" => "integer" },
         "eventIds" => { "type" => "array", "items" => { "type" => "string", "enum" => Event.pluck(:id) } },
-        "status" => { "type" => "string", "enum" => %w(accepted deleted pending) },
+        "status" => { "type" => "string", "enum" => %w(accepted deleted pending noncompeting) },
         "guests" => { "type" => "integer" },
         "comments" => { "type" => "string" },
         "administrativeNotes" => { "type" => "string" },

--- a/WcaOnRails/app/models/registration.rb
+++ b/WcaOnRails/app/models/registration.rb
@@ -195,6 +195,17 @@ class Registration < ApplicationRecord
     Hash.new(index: index, length: pending_registrations.length)
   end
 
+  def wcif_status
+    # Non-competing staff are treated as accepted.
+    if accepted? || !is_competing?
+      'accepted'
+    elsif deleted?
+      'deleted'
+    else
+      'pending'
+    end
+  end
+
   def to_wcif(authorized: false)
     authorized_fields = {
       "guests" => guests,
@@ -204,13 +215,7 @@ class Registration < ApplicationRecord
     {
       "wcaRegistrationId" => id,
       "eventIds" => events.map(&:id).sort,
-      "status" => if accepted? || !is_competing?
-                    'accepted'
-                  elsif deleted?
-                    'deleted'
-                  else
-                    'pending'
-                  end,
+      "status" => wcif_status,
       "isCompeting" => is_competing?,
     }.merge(authorized ? authorized_fields : {})
   end


### PR DESCRIPTION
This will allow tools like competitiongroups.com to show non-competing staff members' assignments.

Depends on thewca/wcif#15.