### PR TITLE
Truncate admin notes like comments in registrations table

### DIFF
--- a/WcaOnRails/app/assets/stylesheets/registrations.scss
+++ b/WcaOnRails/app/assets/stylesheets/registrations.scss
@@ -4,7 +4,8 @@ table.registrations-table {
   td {
     white-space: nowrap;
     &.comments,
-    &.guests {
+    &.guests,
+    &.administrative-notes {
       max-width: 50px;
       overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
Currently, if you have a lengthy administrative note (which they often are), the table will be extended horizontally by the width of the comment, causing horizontal scrolling.