### PR TITLE
fixes #8004 look at nested activities to determine next activity id

### DIFF
--- a/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
@@ -15,6 +15,14 @@ const currentElementsIds = {
   activity: 0,
 };
 
+function withNestedActivities(activities) {
+  if (activities.length === 0) return [];
+  return [
+    ...activities,
+    ...withNestedActivities(_.flatMap(activities, 'childActivities')),
+  ];
+}
+
 export function initElementsIds(venues) {
   // Explore the WCIF to get the highest ids.
   const maxId = (objects) => _.max(_.map(objects, 'id')) || 0;
@@ -38,14 +46,6 @@ export function newRoomId() {
 export function newActivityId() {
   currentElementsIds.activity += 1;
   return currentElementsIds.activity;
-}
-
-function withNestedActivities(activities) {
-  if (activities.length === 0) return [];
-  return [
-    ...activities,
-    ...withNestedActivities(_.flatMap(activities, 'childActivities')),
-  ];
 }
 
 export function convertVenueActivitiesToVenueTimezone(oldTZ, venueWcif) {

--- a/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
@@ -19,7 +19,7 @@ export function initElementsIds(venues) {
   // Explore the WCIF to get the highest ids.
   const maxId = (objects) => _.max(_.map(objects, 'id')) || 0;
   const rooms = _.flatMap(venues, 'rooms');
-  const activities = _.flatMap(rooms, 'activities');
+  const activities = _.flatMap(rooms, (room) => withNestedActivities(room.activities));
   currentElementsIds.venue = maxId(venues);
   currentElementsIds.room = maxId(rooms);
   currentElementsIds.activity = maxId(activities);


### PR DESCRIPTION
Addresses a bug where child activities were not considered when adding schedule activities.

This has been a massive paint point recently with more people using the wcif through competitiongroups and the activity fetched being wrong when new activites got added to the schedule.