### PR TITLE
Check DB dump schedules before actually enqueueing them

### DIFF
--- a/WcaOnRails/app/jobs/dump_public_results_database.rb
+++ b/WcaOnRails/app/jobs/dump_public_results_database.rb
@@ -8,10 +8,15 @@ class DumpPublicResultsDatabase < ApplicationJob
 
   queue_as :default
 
-  def perform(force_export: false)
+  before_enqueue do |job|
     # Create results database dump every day.
-    if force_export || self.class.start_timestamp.not_after?(1.day.ago.end_of_hour)
-      DbDumpHelper.dump_results_db
-    end
+    should_export = self.class.start_timestamp.not_after?(1.day.ago.end_of_hour)
+    force_export = job.arguments.last&.fetch(:force_export, false)
+
+    throw :abort unless should_export || force_export
+  end
+
+  def perform
+    DbDumpHelper.dump_results_db
   end
 end


### PR DESCRIPTION
Otherwise, the three seconds it took to check that the dump shouldn't run will affect future decisions about whether the dump should run.