### PR TITLE
Allow updating the competitor limit within the WCIF

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1683,8 +1683,8 @@ class Competition < ApplicationRecord
   end
 
   def set_wcif_competitor_limit!(wcif_competitor_limit, current_user)
-    unless current_user.can_admin_competitions? || !confirmed?
-      raise WcaExceptions::BadApiParameter.new("Cannot edit the competitor limit")
+    if confirmed? && !current_user.can_admin_competitions?
+      raise WcaExceptions::BadApiParameter.new("Cannot edit the competitor limit because the competition has been confirmed by WCAT")
     end
 
     unless competitor_limit_enabled?

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe "Competition WCIF" do
       event_ids: %w(333 444 333fm 333mbf),
       with_schedule: true,
       competitor_limit: 50,
+      registration_open: "2013-12-01",
+      registration_close: "2013-12-31",
     )
   }
   let(:partner_competition) { FactoryBot.create(:competition, id: "PartnerComp2014", series_base: competition, series_distance_days: 3) }
@@ -267,6 +269,49 @@ RSpec.describe "Competition WCIF" do
       expect {
         JSON::Validator.validate!(Competition.wcif_json_schema, competition.to_wcif)
       }.to_not raise_error
+    end
+  end
+
+  describe "#set_wcif_competitor_limit!" do
+    let(:competitor_limit_wcif) { competition.to_wcif["competitorLimit"] }
+
+    it "Can set a new competitor limit" do
+      competitor_limit_wcif = 120
+
+      competition.set_wcif_competitor_limit!(competitor_limit_wcif, delegate)
+
+      expect(competition.competitor_limit_enabled?).to eq(true)
+      expect(competition.to_wcif["competitorLimit"]).to eq(competitor_limit_wcif)
+    end
+
+    it "Cannot set a new competitor limit after a competition is confirmed" do
+      competitor_limit_wcif = 120
+
+      # Manually confirm the competition
+      competition.confirmed_at = "2013-06-01"
+      competition.save!
+
+      expect { competition.set_wcif_competitor_limit!(competitor_limit_wcif, delegate) }.to raise_error(WcaExceptions::BadApiParameter)
+    end
+
+    it "Cannot add a competitor limit when competitor limits are not enabled" do
+      competitor_limit_wcif = 120
+
+      # Disable competitor limits for this competition manually.
+      competition.competitor_limit_enabled = false
+      competition.competitor_limit = nil
+      competition.competitor_limit_reason = nil
+      competition.save!
+
+      # Adding a competitor limit should error
+      expect { competition.set_wcif_competitor_limit!(competitor_limit_wcif, delegate) }.to raise_error(WcaExceptions::BadApiParameter)
+    end
+
+    it "Cannot remove a competitor limit" do
+      competitor_limit_wcif = nil
+
+      # Adding a competitor limit should error
+      expect { competition.set_wcif_competitor_limit!(competitor_limit_wcif, delegate) }.to raise_error(WcaExceptions::BadApiParameter)
     end
   end
 


### PR DESCRIPTION
This PR adds support for updating a competition's `competitor_limit` by passing a patch request into the WCIF. It also includes automated tests.

Note that this only supports updating the competitor limit from one number to another. Because having a competitor limit requires adding a `competitor_limit_reason` that is not part of the WCIF, this does not support adding or removing a competitor limit (ex. passing in `competitorLimit: null`).

### Motivation

As part of a [competition schedule generator](https://competition-scheduler.netlify.app/) I'm working on, I want to be able to update the competitor limit.

(I acknowledge the `competitor_limit_reason` stuff is semi-clunky; I'm happy to send a separate POST to `/competitions/<competition_id>` and close the PR if that is preferable)