### PR TITLE
Fix failure during docker compose up

### DIFF
--- a/WcaOnRails/db/seeds/development/competitions.seeds.rb
+++ b/WcaOnRails/db/seeds/development/competitions.seeds.rb
@@ -93,8 +93,8 @@ after "development:users" do
             eventId: event.id,
             roundTypeId: roundTypeId,
             formatId: round_format.id,
-            regionalSingleRecord: k == 0 ? "WR" : "",
-            regionalAverageRecord: k == 0 ? "WR" : "",
+            regionalSingleRecord: k == 0 ? "WR" : nil,
+            regionalAverageRecord: k == 0 ? "WR" : nil,
           )
           round_format.expected_solve_count.times do |v|
             result.send("value#{v+1}=", random_wca_value)


### PR DESCRIPTION
I just ran a `docker compose up` on a fresh repo and ran into a failure: I believe it's linked to #7929.

Interestingly there was also some changes to `Gemfile.lock`: the new diff looks good (as in: it's ordered alphabetically), but I don't how it ended up the way it is now on master.