### PR TITLE
Equipment funding form change

### DIFF
--- a/WcaOnRails/app/views/panel/index.html.erb
+++ b/WcaOnRails/app/views/panel/index.html.erb
@@ -35,7 +35,7 @@
         <%= link_to "Travel Reimbursement Form", "https://docs.google.com/forms/d/12tz2I_EeBORm14kQO6ZB5TOp321YbXkIXvrxUNIHxN0/viewform" %>
       </li>
       <li>
-        <%= link_to "Equipment Funding Form", "https://docs.google.com/forms/d/e/1FAIpQLSeglibvXYG6Z2CzIPbxu2LTpAuXkJPK-vi4GuOnBFx1756ufA/viewform" %>
+        <%= link_to "Equipment Funding Form", "https://docs.google.com/forms/d/e/1FAIpQLSebkWMyG2kRzR3cDm3jXFVMFCwd5u4XI6Yt35givu0SOidpHg/viewform" %>
       </li>
       <li>
         <%= link_to "Bands for WCA Dues", country_bands_path %>


### PR DESCRIPTION
This PR is based upon an update to the WCA Equipment Funding Policy which the WCA Board approved recently. We (@thewca/financial-committee ) have created a new form for the same.