### PR TITLE
Include model information in the search cache key

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -97,7 +97,7 @@ class Api::V0::ApiController < ApplicationController
         return
       end
       concise_results_date = ComputeAuxiliaryData.end_date || Date.current
-      cache_key = ["search", concise_results_date.iso8601, query]
+      cache_key = ["search", *models, concise_results_date.iso8601, query]
       result = Rails.cache.fetch(cache_key) do
         models.flat_map { |model| model.search(query, params: params).limit(DEFAULT_API_RESULT_LIMIT) }
       end


### PR DESCRIPTION
(sidenote regarding the use of model classes as cache keys: Rails `ActiveRecord` classes respond to `to_param`, which simply yields the class name as string: `Competition.to_param --> "Competition"`. This matches the specification for cache keys at https://guides.rubyonrails.org/caching_with_rails.html#cache-keys)