### PR TITLE
Expose webpacker ports on host machine in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
   wca_webpacker:
     <<: *app
     container_name: "webpacker"
-    expose:
-      - "3035"
+    ports:
+      - "3035:3035"
     environment:
       DATABASE_HOST: wca_db
       SHAKAPACKER_DEV_SERVER_HOST: 0.0.0.0


### PR DESCRIPTION
This should allow the hot module reloading from webpacker to communicate with the docker version of webpacker (and prevent all of the errors below showing up in my console)

![image](https://github.com/thewca/worldcubeassociation.org/assets/26287997/db898f78-f98a-42f4-b259-4579eff5d578)
