### PR TITLE
Add Conditional GET to public wcif endpoint

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -109,11 +109,12 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     id = params[:competition_id] || params[:id]
     cache_key = "wcif/#{id}"
     expires_in 5.minutes, public: true
-    render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
-      competition = competition_from_params
-      fresh_when(:etag => competition, :last_modfied => competition.updated_at, :public => true)
-      competition.to_wcif
-    }
+    if stale?(last_modified: competition.updated_at, public: true)
+      render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
+        competition = competition_from_params
+        competition.to_wcif
+      }
+    end
   end
 
   def update_wcif

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -108,10 +108,10 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   def show_wcif_public
     id = params[:competition_id] || params[:id]
     cache_key = "wcif/#{id}"
+    competition = competition_from_params
     expires_in 5.minutes, public: true
     if stale?(last_modified: competition.updated_at, public: true)
       render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
-        competition = competition_from_params
         competition.to_wcif
       }
     end

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -110,7 +110,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     cache_key = "wcif/#{id}"
     competition = competition_from_params
     expires_in 5.minutes, public: true
-    if stale?(last_modified: competition.updated_at, public: true)
+    if stale?(competition, public: true)
       render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
         competition.to_wcif
       }

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -107,11 +107,11 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
   def show_wcif_public
     id = params[:competition_id] || params[:id]
-
     cache_key = "wcif/#{id}"
     expires_in 5.minutes, public: true
     render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
       competition = competition_from_params
+      fresh_when(:etag => competition, :last_modfied => competition.updated_at, :public => true)
       competition.to_wcif
     }
   end


### PR DESCRIPTION
We have seen some crawling on public wcif endpoints kill our servers over the last ~2 weeks and this would be one version to remedy this: 
Additionally to caching the endpoint for repeated request from multiple users, we can add a conditional get request to cache multiple requests for the same user, even if they are more than 5 minutes old.

Other solutions we could think about: 
- using a json serializer that caches automatically on last_modified like https://github.com/codenoble/cache-crispies instead of checking manually
- blocking certain user-agents from this route
- redirecting routes to use api.worldcubeassociation.org if they are not (so cloudfront can do the caching)
- precomputing wcif for every competition and updating on patch
- ???