### PR TITLE
Fix translations status page

### DIFF
--- a/WcaOnRails/app/views/static_pages/merch.html.erb
+++ b/WcaOnRails/app/views/static_pages/merch.html.erb
@@ -24,7 +24,7 @@
     <%= t('merch.title') %>
   </h1>
 
-  <% t('merch.paragraphs').each do |paragraph| %>
+  <% t('merch.paragraphs').values.each do |paragraph| %>
     <p><%= paragraph %></p>
   <% end %>
 

--- a/WcaOnRails/config/i18n-tasks.yml.erb
+++ b/WcaOnRails/config/i18n-tasks.yml.erb
@@ -112,6 +112,7 @@ ignore_unused:
   - 'wca.doorkeeper.scopes.*'
   - 'contact.*.info'
   - 'organizer_guidelines.*'
+  - 'merch.paragraphs.*'
   # Mark all events/continents/countries/delegate_statuses as used.
   # FYI if a language doesn't translate one of them, it will appear in the missing keys, as long as it exists in English
   - 'events.*'

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -2584,9 +2584,9 @@ en:
   merch:
       title: 'WCA Merchandise'
       paragraphs:
-        - 'The WCA has exclusive merchandise available to purchase! From T-Shirts, Hoodies, Stickers, Stackmats, Backpacks, and more! Our designs are constantly updated including the classic WCA logo, official World Championship merchandise, and World Record designs.'
-        - 'Buying WCA Merch through our stores is one of the best ways for you to support the WCA - a non-profit, volunteer run organization. We use all profits from the merchandise to further fund championships, equipment and other WCA related activities.'
-        - 'You can buy our merchandise all over the world -- with direct stores in Europe, America and India and more to come soon!'
+        '1': 'The WCA has exclusive merchandise available to purchase! From T-Shirts, Hoodies, Stickers, Stackmats, Backpacks, and more! Our designs are constantly updated including the classic WCA logo, official World Championship merchandise, and World Record designs.'
+        '2': 'Buying WCA Merch through our stores is one of the best ways for you to support the WCA - a non-profit, volunteer run organization. We use all profits from the merchandise to further fund championships, equipment and other WCA related activities.'
+        '3': 'You can buy our merchandise all over the world -- with direct stores in Europe, America and India and more to come soon!'
   database:
     results_export:
       heading: "WCA Results Export"


### PR DESCRIPTION
We generally assume the translation YAML is maps and not lists, even for enumerations. Currently there is a list and this crashes the translations page and Internationalize doesn't handle it either.