### PR TITLE
Fix psychsheet rankings for tied averages

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1474,16 +1474,14 @@ class Competition < ApplicationRecord
       prev_sorted_registration = nil
       sorted_registrations = []
       registrations.each_with_index do |registration, i|
-        if sort_by == 'single'
-          rank = registration.single_rank
-        else
-          rank = registration.average_rank
-        end
-        if rank
-          tied_previous = registration.average_rank == prev_sorted_registration&.registration&.average_rank && registration.single_rank == prev_sorted_registration&.registration&.single_rank
-          pos = tied_previous ? prev_sorted_registration.pos : i + 1
-        else
-          # Hasn't competed in this event yet.
+        rank = sort_by == 'single' ? registration.single_rank : registration.average_rank
+        average_tied_previous = registration.average_rank == prev_sorted_registration&.registration&.average_rank
+        single_tied_previous = registration.single_rank == prev_sorted_registration&.registration&.single_rank
+        # Change position to previous if both single and average are tied with previous registration
+        tied_previous = single_tied_previous && average_tied_previous
+        pos = tied_previous ? prev_sorted_registration.pos : i + 1
+        # Hasn't competed in this event yet.
+        unless rank
           tied_previous = nil
           pos = nil
         end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1475,13 +1475,14 @@ class Competition < ApplicationRecord
       sorted_registrations = []
       registrations.each_with_index do |registration, i|
         rank = sort_by == 'single' ? registration.single_rank : registration.average_rank
-        average_tied_previous = registration.average_rank == prev_sorted_registration&.registration&.average_rank
-        single_tied_previous = registration.single_rank == prev_sorted_registration&.registration&.single_rank
-        # Change position to previous if both single and average are tied with previous registration
-        tied_previous = single_tied_previous && average_tied_previous
-        pos = tied_previous ? prev_sorted_registration.pos : i + 1
-        # Hasn't competed in this event yet.
-        unless rank
+        if rank
+          # Change position to previous if both single and average are tied with previous registration.
+          average_tied_previous = registration.average_rank == prev_sorted_registration&.registration&.average_rank
+          single_tied_previous = registration.single_rank == prev_sorted_registration&.registration&.single_rank
+          tied_previous = single_tied_previous && average_tied_previous
+          pos = tied_previous ? prev_sorted_registration.pos : i + 1
+        else
+          # Hasn't competed in this event yet.
           tied_previous = nil
           pos = nil
         end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1476,13 +1476,11 @@ class Competition < ApplicationRecord
       registrations.each_with_index do |registration, i|
         if sort_by == 'single'
           rank = registration.single_rank
-          prev_rank = prev_sorted_registration&.registration&.single_rank
         else
           rank = registration.average_rank
-          prev_rank = prev_sorted_registration&.registration&.average_rank
         end
         if rank
-          tied_previous = rank == prev_rank
+          tied_previous = registration.average_rank == prev_sorted_registration&.registration&.average_rank && registration.single_rank == prev_sorted_registration&.registration&.single_rank
           pos = tied_previous ? prev_sorted_registration.pos : i + 1
         else
           # Hasn't competed in this event yet.

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -651,10 +651,12 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
       FactoryBot.create :ranks_single, rank: 1, best: 1500, eventId: "444", personId: registration1.personId
 
       registration2 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
+      registration2.person.update!(name: "A")
       FactoryBot.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration2.personId
       FactoryBot.create :ranks_single, rank: 10, best: 1900, eventId: "444", personId: registration2.personId
 
       registration3 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
+      registration3.person.update!(name: "B")
       FactoryBot.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration3.personId
       FactoryBot.create :ranks_single, rank: 10, best: 1900, eventId: "444", personId: registration3.personId
 

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -646,17 +646,18 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
     end
 
     it "sorts 444 by single, and average, and handles ties" do
+      user_a = FactoryBot.create(:user, :wca_id, name: 'A')
+      user_b = FactoryBot.create(:user, :wca_id, name: 'B')
+
       registration1 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
       FactoryBot.create :ranks_average, rank: 1, best: 2000, eventId: "444", personId: registration1.personId
       FactoryBot.create :ranks_single, rank: 1, best: 1500, eventId: "444", personId: registration1.personId
 
-      registration2 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
-      registration2.person.update!(name: "A")
+      registration2 = FactoryBot.create(:registration, :accepted, user: user_a, competition: competition, events: [Event.find("444")])
       FactoryBot.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration2.personId
       FactoryBot.create :ranks_single, rank: 10, best: 1900, eventId: "444", personId: registration2.personId
 
-      registration3 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
-      registration3.person.update!(name: "B")
+      registration3 = FactoryBot.create(:registration, :accepted, user: user_b, competition: competition, events: [Event.find("444")])
       FactoryBot.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration3.personId
       FactoryBot.create :ranks_single, rank: 10, best: 1900, eventId: "444", personId: registration3.personId
 

--- a/WcaOnRails/spec/controllers/registrations_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/registrations_controller_spec.rb
@@ -647,30 +647,38 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
 
     it "sorts 444 by single, and average, and handles ties" do
       registration1 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
-      FactoryBot.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration1.personId
-      FactoryBot.create :ranks_single, rank: 20, best: 2000, eventId: "444", personId: registration1.personId
+      FactoryBot.create :ranks_average, rank: 1, best: 2000, eventId: "444", personId: registration1.personId
+      FactoryBot.create :ranks_single, rank: 1, best: 1500, eventId: "444", personId: registration1.personId
 
       registration2 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
       FactoryBot.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration2.personId
       FactoryBot.create :ranks_single, rank: 10, best: 1900, eventId: "444", personId: registration2.personId
 
       registration3 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
-      FactoryBot.create :ranks_average, rank: 9, best: 3232, eventId: "444", personId: registration3.personId
+      FactoryBot.create :ranks_average, rank: 10, best: 4242, eventId: "444", personId: registration3.personId
+      FactoryBot.create :ranks_single, rank: 10, best: 1900, eventId: "444", personId: registration3.personId
 
       registration4 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
-      FactoryBot.create :ranks_average, rank: 11, best: 4545, eventId: "444", personId: registration4.personId
+      FactoryBot.create :ranks_average, rank: 20, best: 4545, eventId: "444", personId: registration4.personId
+      FactoryBot.create :ranks_single, rank: 30, best: 2500, eventId: "444", personId: registration4.personId
+
+      registration5 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
+      FactoryBot.create :ranks_average, rank: 20, best: 4545, eventId: "444", personId: registration5.personId
+      FactoryBot.create :ranks_single, rank: 31, best: 2600, eventId: "444", personId: registration5.personId
+
+      registration6 = FactoryBot.create(:registration, :accepted, competition: competition, events: [Event.find("444")])
 
       get :psych_sheet_event, params: { competition_id: competition.id, event_id: "444" }
       psych_sheet = assigns(:psych_sheet)
-      expect(psych_sheet.sorted_registrations.map { |sr| sr.registration.id }).to eq [registration3.id, registration2.id, registration1.id, registration4.id]
-      expect(psych_sheet.sorted_registrations.map(&:pos)).to eq [1, 2, 2, 4]
-      expect(psych_sheet.sorted_registrations.map(&:tied_previous)).to eq [false, false, true, false]
+      expect(psych_sheet.sorted_registrations.map { |sr| sr.registration.id }).to eq [registration1.id, registration2.id, registration3.id, registration4.id, registration5.id, registration6.id]
+      expect(psych_sheet.sorted_registrations.map(&:pos)).to eq [1, 2, 2, 4, 5, nil]
+      expect(psych_sheet.sorted_registrations.map(&:tied_previous)).to eq [false, false, true, false, false, nil]
 
       get :psych_sheet_event, params: { competition_id: competition.id, event_id: "444", sort_by: :single }
       psych_sheet = assigns(:psych_sheet)
-      expect(psych_sheet.sorted_registrations.map { |sr| sr.registration.id }).to eq [registration2.id, registration1.id, registration3.id, registration4.id]
-      expect(psych_sheet.sorted_registrations.map(&:pos)).to eq [1, 2, nil, nil]
-      expect(psych_sheet.sorted_registrations.map(&:tied_previous)).to eq [false, false, nil, nil]
+      expect(psych_sheet.sorted_registrations.map { |sr| sr.registration.id }).to eq [registration1.id, registration2.id, registration3.id, registration4.id, registration5.id, registration6.id]
+      expect(psych_sheet.sorted_registrations.map(&:pos)).to eq [1, 2, 2, 4, 5, nil]
+      expect(psych_sheet.sorted_registrations.map(&:tied_previous)).to eq [false, false, true, false, false, nil]
     end
 
     it "handles missing average" do

--- a/WcaOnRails/spec/views/registrations/psych_sheet_event.html.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/psych_sheet_event.html.erb_spec.rb
@@ -11,19 +11,27 @@ RSpec.describe "registrations/psych_sheet_event", clean_db_with_truncation: true
     FactoryBot.create(:ranks_average, eventId: "333", rank: 1, best: "500", personId: the_best.wca_id)
     FactoryBot.create(:ranks_single, eventId: "333", rank: 1, best: "450", personId: the_best.wca_id)
 
-    tied_first = FactoryBot.create(:user, :wca_id, name: "Tied But Better")
+    tied_first = FactoryBot.create(:user, :wca_id, name: "Tied First")
     FactoryBot.create(:ranks_average, eventId: "333", rank: 10, best: "2000", personId: tied_first.wca_id)
     FactoryBot.create(:ranks_single, eventId: "333", rank: 10, best: "1500", personId: tied_first.wca_id)
 
-    tied_second = FactoryBot.create(:user, :wca_id, name: "Tied But Worse")
+    tied_second = FactoryBot.create(:user, :wca_id, name: "Tied Second")
     FactoryBot.create(:ranks_average, eventId: "333", rank: 10, best: "2000", personId: tied_second.wca_id)
-    FactoryBot.create(:ranks_single, eventId: "333", rank: 20, best: "1899", personId: tied_second.wca_id)
+    FactoryBot.create(:ranks_single, eventId: "333", rank: 10, best: "1500", personId: tied_second.wca_id)
+
+    tied_average_first = FactoryBot.create(:user, :wca_id, name: "Tied but Better")
+    FactoryBot.create(:ranks_average, eventId: "333", rank: 20, best: "3000", personId: tied_average_first.wca_id)
+    FactoryBot.create(:ranks_single, eventId: "333", rank: 30, best: "2500", personId: tied_average_first.wca_id)
+
+    tied_average_second = FactoryBot.create(:user, :wca_id, name: "Tied but Worse")
+    FactoryBot.create(:ranks_average, eventId: "333", rank: 20, best: "3000", personId: tied_average_second.wca_id)
+    FactoryBot.create(:ranks_single, eventId: "333", rank: 31, best: "2600", personId: tied_average_second.wca_id)
 
     # Two guys who have never competed before.
     newcomer1 = FactoryBot.create(:user, name: "Newcomer I")
     newcomer2 = FactoryBot.create(:user, name: "Newcomer II")
 
-    [the_best, tied_first, tied_second, newcomer1, newcomer2].each do |user|
+    [the_best, tied_first, tied_second, tied_average_first, tied_average_second, newcomer1, newcomer2].each do |user|
       FactoryBot.create(:registration, :accepted, user: user, competition: competition, events: [event])
     end
 
@@ -35,11 +43,13 @@ RSpec.describe "registrations/psych_sheet_event", clean_db_with_truncation: true
     render
 
     [
-      { pos: 1,   name: "Best Guy",         average: "5.00",  single: "4.50" },
-      { pos: 2,   name: "Tied But Better",  average: "20.00", single: "15.00" },
-      { pos: 2,   name: "Tied But Worse",   average: "20.00", single: "18.99" },
-      { pos: "",  name: "Newcomer I",       average: "",      single: "" },
-      { pos: "",  name: "Newcomer II",      average: "",      single: "" },
+      { pos: 1, name: "Best Guy", average: "5.00", single: "4.50" },
+      { pos: 2, name: "Tied First", average: "20.00", single: "15.00" },
+      { pos: 2, name: "Tied Second", average: "20.00", single: "15.00" },
+      { pos: 4, name: "Tied but Better", average: "30.00", single: "25.00" },
+      { pos: 5, name: "Tied but Worse", average: "30.00", single: "26.00" },
+      { pos: "", name: "Newcomer I", average: "", single: "" },
+      { pos: "", name: "Newcomer II", average: "", single: "" },
     ].each_with_index do |criteria, i|
       criteria.each do |td_class, value|
         expect(rendered).to have_css(".wca-results tbody tr:nth-child(#{i + 1}) td.#{td_class}", text: value)


### PR DESCRIPTION
Fixes #7738 

After changes psychsheet looks like this:
![image](https://github.com/thewca/worldcubeassociation.org/assets/94986692/350bffa2-6f51-43a3-b594-6e2bf5cc9ac2)
