### PR TITLE
Show time until registration open in bookmarked competitions

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -625,6 +625,7 @@ class CompetitionsController < ApplicationController
       @bookmarked_competitions = Competition.not_over
                                             .where(id: bookmarked_ids.uniq)
                                             .sort_by(&:start_date)
+      @show_registration_status = params[:show_registration_status] == "on"
     end
   end
 

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -35,7 +35,7 @@
       <tbody>
         <% competitions.each do |competition| %>
           <% registration = registrations_by_competition_id[competition.id] %>
-          <% opens_in_days = distance_of_time_in_words_to_now(competition.registration_open) %>
+          <% bookmarked && opens_in_days = distance_of_time_in_words_to_now(competition.registration_open) %>
           <% tr_classes = [ competition.confirmed? ? "confirmed" : "not-confirmed",
                           competition.showAtAll? ? "visible" : "not-visible",
                           competition.cancelled? ? "cancelled" : "",

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -16,6 +16,9 @@
     <table class="table competitions-table <%= past ? "table-striped" : "" %>">
       <thead>
         <tr>
+          <% if @show_registration_status && bookmarked %>
+            <th></th>
+          <% end %>
           <th><%= t 'competitions.adjacent_competitions.name' %></th>
           <th><%= t 'competitions.adjacent_competitions.location' %></th>
           <th><%= t 'competitions.adjacent_competitions.date' %></th>
@@ -23,12 +26,16 @@
           <th></th>
           <th></th>
           <th><%= "Delegates" if show_delegates %></th>
+          <% if bookmarked %>
+            <th></th>
+          <% end %>
           <th class="big-column"></th>
         </tr>
       </thead>
       <tbody>
         <% competitions.each do |competition| %>
           <% registration = registrations_by_competition_id[competition.id] %>
+          <% opens_in_days = distance_of_time_in_words_to_now(competition.registration_open) %>
           <% tr_classes = [ competition.confirmed? ? "confirmed" : "not-confirmed",
                           competition.showAtAll? ? "visible" : "not-visible",
                           competition.cancelled? ? "cancelled" : "",
@@ -36,6 +43,9 @@
           <tr class="<%= tr_classes %>"
               data-toggle="tooltip" data-placement="bottom" data-container="body"
               title="<%= competition_message_for_user(competition, current_user) unless past %>">
+            <% if @show_registration_status && bookmarked %>
+              <td><%= registration_status_icon(competition) %></td>
+            <% end %>
             <td>
               <%= link_to competition.display_name, competition_path(competition) %>
               <% if competition.championships.any? %>
@@ -78,6 +88,11 @@
                 <% end %>
               <% end %>
             </td>
+            <% if bookmarked && competition.registration_not_yet_opened? %>
+              <td>
+                  <%= t('registrations.will_open_html', days: opens_in_days, time: wca_local_time(competition.registration_open)) %>
+              </td>
+            <% end %>
             <td class="big-column"></td>
           </tr>
         <% end %>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -35,7 +35,6 @@
       <tbody>
         <% competitions.each do |competition| %>
           <% registration = registrations_by_competition_id[competition.id] %>
-          <% bookmarked && opens_in_days = distance_of_time_in_words_to_now(competition.registration_open) %>
           <% tr_classes = [ competition.confirmed? ? "confirmed" : "not-confirmed",
                           competition.showAtAll? ? "visible" : "not-visible",
                           competition.cancelled? ? "cancelled" : "",
@@ -88,11 +87,6 @@
                 <% end %>
               <% end %>
             </td>
-            <% if bookmarked && competition.registration_not_yet_opened? %>
-              <td>
-                  <%= t('registrations.will_open_html', days: opens_in_days, time: wca_local_time(competition.registration_open)) %>
-              </td>
-            <% end %>
             <td class="big-column"></td>
           </tr>
         <% end %>

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -26,9 +26,6 @@
           <th></th>
           <th></th>
           <th><%= "Delegates" if show_delegates %></th>
-          <% if bookmarked %>
-            <th></th>
-          <% end %>
           <th class="big-column"></th>
         </tr>
       </thead>

--- a/WcaOnRails/app/views/competitions/my_competitions.html.erb
+++ b/WcaOnRails/app/views/competitions/my_competitions.html.erb
@@ -49,7 +49,7 @@
   </h3>
 
   <%= t '.bookmarked_explanation' %>
-  <%= form_tag('/competitions/mine', method: :get, class: "competition-select form-inline #{@display}", id: "bookmarked-competitions-query-form") do %>
+  <%= form_tag(my_comps_path, method: :get, class: "competition-select form-inline #{@display}", id: "bookmarked-competitions-query-form") do %>
     <div id="registration-status" class="form-group registration-status-selector">
       <%= check_box_tag(:show_registration_status, params[:show_registration_status], params[:show_registration_status] == "on") %>
       <%= label_tag(name = :show_registration_status, content_or_options = t('competitions.index.show_registration_status')) %>
@@ -61,9 +61,9 @@
 
 <script>
 $(document).ready(function() {
+    var $form = $('#bookmarked-competitions-query-form');
     function submitForm() {
-      var $form = $('#bookmarked-competitions-query-form');
-      $form.trigger('submit');
+      $form.trigger('submit.rails');
     }
     $('#show_registration_status').on('change', submitForm);
 });

--- a/WcaOnRails/app/views/competitions/my_competitions.html.erb
+++ b/WcaOnRails/app/views/competitions/my_competitions.html.erb
@@ -49,7 +49,22 @@
   </h3>
 
   <%= t '.bookmarked_explanation' %>
-
+  <%= form_tag('/competitions/mine', method: :get, class: "competition-select form-inline #{@display}", id: "bookmarked-competitions-query-form") do %>
+    <div id="registration-status" class="form-group registration-status-selector">
+      <%= check_box_tag(:show_registration_status, params[:show_registration_status], params[:show_registration_status] == "on") %>
+      <%= label_tag(name = :show_registration_status, content_or_options = t('competitions.index.show_registration_status')) %>
+    </div>
+  <% end %>
   <%= render "my_competitions_table", competitions: @bookmarked_competitions, registrations_by_competition_id: @registered_for_by_competition_id, past: false, bookmarked: true %>
 
 </div>
+
+<script>
+$(document).ready(function() {
+    function submitForm() {
+      var $form = $('#bookmarked-competitions-query-form');
+      $form.trigger('submit');
+    }
+    $('#show_registration_status').on('change', submitForm);
+});
+</script>


### PR DESCRIPTION
Issue #7561 

Now bookmarked competitions looks like this:
![image](https://github.com/thewca/worldcubeassociation.org/assets/94986692/f6f2c9e5-ac62-46e8-9e84-b94bbae2ca13)

Or if you turned off showing registration status icon:
![image](https://github.com/thewca/worldcubeassociation.org/assets/94986692/3c2aee87-e804-4b36-b31a-eb02a42e4c20)
