### PR TITLE
Add non-trivial password to Staging

### DIFF
--- a/WcaOnRails/app/views/devise/sessions/new.html.erb
+++ b/WcaOnRails/app/views/devise/sessions/new.html.erb
@@ -20,10 +20,11 @@
             <% if Timestamp.find_by_name(DatabaseDumper::DEV_TIMESTAMP_NAME) %>
               <p class="help-block">
                 Hint! It looks like you are using the
-                <a href="https://github.com/thewca/worldcubeassociation.org/wiki/Developer-database-export" target="_blank">developer export</a>,
-                every user's
-                password is "wca". You can find email addresses to log in
-                with over on
+                <a href="https://github.com/thewca/worldcubeassociation.org/wiki/Developer-database-export" target="_blank">developer export</a>
+                <% unless DbDumpHelper.use_staging_password? %>
+                  , every user's password is "wca"
+                <% end %>
+                . You can find email addresses to log in with over on
                 <%= link_to "the delegates page", delegates_path %>.
               </p>
             <% end %>

--- a/WcaOnRails/env_vars.rb
+++ b/WcaOnRails/env_vars.rb
@@ -44,6 +44,7 @@ EnvVars = SuperConfig.new do
   optional :CDN_AVATARS_DISTRIBUTION_ID, :string, ''
   optional :STRIPE_WEBHOOK_SECRET, :string, ''
   optional :REDIS_URL, :string, ''
+  optional :STAGING_PASSWORD, :string, ''
 
   mandatory :GOOGLE_MAPS_API_KEY, :string
   mandatory :GITHUB_CREATE_PR_ACCESS_TOKEN, :string

--- a/WcaOnRails/lib/db_dump_helper.rb
+++ b/WcaOnRails/lib/db_dump_helper.rb
@@ -16,6 +16,8 @@ module DbDumpHelper
   DEVELOPER_EXPORT_SQL = "#{DEVELOPER_EXPORT_FILENAME}.sql".freeze
   DEVELOPER_EXPORT_SQL_PERMALINK = "#{DEVELOPER_EXPORT_FILENAME}.zip".freeze
 
+  DEFAULT_DEV_PASSWORD = 'wca'
+
   def self.dump_developer_db
     Dir.mktmpdir do |dir|
       FileUtils.cd dir do
@@ -85,5 +87,9 @@ module DbDumpHelper
         FileUtils.ln_s(zip_filename, permalink_zip_path, force: true)
       end
     end
+  end
+
+  def self.use_staging_password?
+    Rails.env.production? && !EnvVars.WCA_LIVE_SITE?
   end
 end

--- a/WcaOnRails/lib/tasks/db.rake
+++ b/WcaOnRails/lib/tasks/db.rake
@@ -72,9 +72,10 @@ namespace :db do
             DatabaseDumper.mysql("SOURCE #{DbDumpHelper::DEVELOPER_EXPORT_SQL}", config.database)
           end
 
-          default_password = 'wca'
-          default_encrypted_password = User.new(password: default_password).encrypted_password
-          LogTask.log_task "Setting all user passwords to '#{default_password}'" do
+          dummy_password = DbDumpHelper.use_staging_password? ? EnvVars.STAGING_PASSWORD : DbDumpHelper::DEFAULT_DEV_PASSWORD
+
+          default_encrypted_password = User.new(password: dummy_password).encrypted_password
+          LogTask.log_task "Setting all user passwords to '#{dummy_password}'" do
             User.update_all encrypted_password: default_encrypted_password
           end
 

--- a/chef/data_bags/secrets/production.json
+++ b/chef/data_bags/secrets/production.json
@@ -195,5 +195,12 @@
     "auth_tag": "8FIPNuPAxq+pHWhu9ApkQQ==\n",
     "version": 3,
     "cipher": "aes-256-gcm"
+  },
+  "STAGING_PASSWORD": {
+    "encrypted_data": "2NTOdWpa3+xi305WQp9baV83+6S96C8PMdjBIrOZ5kba4crk2flR\n",
+    "iv": "mMIbPey9y7F8XyxP\n",
+    "auth_tag": "bHPXjdBTVEQFcrdkhne4AQ==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   }
 }

--- a/chef/data_bags/secrets/staging.json
+++ b/chef/data_bags/secrets/staging.json
@@ -181,5 +181,12 @@
     "auth_tag": "UnYbYt3R/PeDLcSjygZ7Zw==\n",
     "version": 3,
     "cipher": "aes-256-gcm"
+  },
+   "STAGING_PASSWORD": {
+    "encrypted_data": "IdT+mp57nnVlxI1DgjTFYV1MRJHAI6mNlIgmPhjD0zXcTdfdTguO\n",
+    "iv": "vYfFks+BKpSim5ZA\n",
+    "auth_tag": "T8rUtsYg2v8/gPIX0/Ojxw==\n",
+    "version": 3,
+    "cipher": "aes-256-gcm"
   }
 }

--- a/chef/site-cookbooks/wca/templates/env.production.erb
+++ b/chef/site-cookbooks/wca/templates/env.production.erb
@@ -133,3 +133,10 @@ SURVEY_SECRET=<%=
     "production" => @secrets['SURVEY_SECRET'],
   }[node.chef_environment]
 %>
+STAGING_PASSWORD=<%=
+  {
+    "development" => "wca",
+    "staging" => @secrets['STAGING_PASSWORD'],
+    "production" => @secrets['STAGING_PASSWORD'],
+  }[node.chef_environment]
+%>


### PR DESCRIPTION
With the exponential growth of cubing, we unfortunately also experience an exponential growth of idiots who abuse the fact that the password `wca` grants you unlimited access on staging.

We have seen unfortunate and despicable incidents in the past couple of weeks which force us to enact better security measures. The first "quick fix" that I could come up with during the Worlds preparation trouble was to introduce a non-trivial password. We might consider other additional approaches when things settle down after US Nats and Worlds, but I think this will do for now.

The import code is configured to still use `wca` as a password for local imports of the dev dump.