### PR TITLE
Added queue status for delayed jobs

### DIFF
--- a/WcaOnRails/app/jobs/timed_application_job.rb
+++ b/WcaOnRails/app/jobs/timed_application_job.rb
@@ -3,6 +3,10 @@
 module TimedApplicationJob
   extend ActiveSupport::Concern
 
+  def queued_timestamp
+    Timestamp.find_or_create_by!(name: "#{self.name.underscore}_queued")
+  end
+
   def start_timestamp
     Timestamp.find_or_create_by!(name: "#{self.name.underscore}_start")
   end
@@ -11,12 +15,20 @@ module TimedApplicationJob
     Timestamp.find_or_create_by!(name: "#{self.name.underscore}_end")
   end
 
+  def queued_date
+    queued_timestamp.date
+  end
+
   def start_date
     start_timestamp.date
   end
 
   def end_date
     end_timestamp.date
+  end
+
+  def in_queue?
+    queued_date.present? && start_date.nil?
   end
 
   def in_progress?
@@ -29,11 +41,14 @@ module TimedApplicationJob
 
   included do
     after_enqueue do |job|
-      # Reset the end timestamp so the job is no longer considered finished.
+      # When queued, clears the start and end timestamps, and updates the queued timestamp.
+      job.class.queued_timestamp.touch :date
+      job.class.start_timestamp.update! date: nil
       job.class.end_timestamp.update! date: nil
     end
 
     around_perform do |job, block|
+      # When performing, updates the start timestamp.
       job.class.start_timestamp.touch :date
       job.class.end_timestamp.update! date: nil
       block.call

--- a/WcaOnRails/app/views/admin/_delayed_job_runner.html.erb
+++ b/WcaOnRails/app/views/admin/_delayed_job_runner.html.erb
@@ -8,8 +8,13 @@
 <% if job.respond_to?(:reason_not_to_run) && job.reason_not_to_run %>
   <%= alert :warning, job.reason_not_to_run %>
 <% else %>
-  <% if job.in_progress? %>
-    <%= alert :info, "The job is running. Thanks for checking =)" %>
+  <% if job.in_queue? %>
+    <%= alert :info, "The job is still in queue." %>
+  <% elsif job.in_progress? %>
+    <%= alert :info do %>
+      The job started <%= time_ago_in_words job.start_date %> ago
+      and is still running. Thanks for checking =)
+    <% end %>
   <% elsif job < TimedApplicationJob %>
     <% if job.finished? %>
       <%= alert :success do %>


### PR DESCRIPTION
Recently, WRT faced a case where they started CAD, and took around 15 minutes to complete. But the UI said it started just 4 minutes ago even though the button was clicked 15 minutes ago. From the code, I understood that the job stays in queue initially for sometime, and for some reasons the queue was huge during that time.

This PR is to show the queue status if the job is queued. This will be helpful for WRT to get an idea if the job actually started, or is it still in queue.