### PR TITLE
Migrate CompetitionsMedia column lengths

### DIFF
--- a/WcaOnRails/db/migrate/20230822155348_change_media_submitter_email_column_length.rb
+++ b/WcaOnRails/db/migrate/20230822155348_change_media_submitter_email_column_length.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeMediaSubmitterEmailColumnLength < ActiveRecord::Migration[7.0]
+  def change
+    change_column :CompetitionsMedia, :submitterName, :string, limit: nil
+    change_column :CompetitionsMedia, :submitterEmail, :string, limit: nil
+  end
+end

--- a/WcaOnRails/db/schema.rb
+++ b/WcaOnRails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_07_182015) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_22_155348) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -89,9 +89,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_182015) do
     t.string "type", limit: 15, default: "", null: false
     t.string "text", limit: 100, default: "", null: false
     t.text "uri"
-    t.string "submitterName", limit: 50, default: "", null: false
+    t.string "submitterName", default: "", null: false
     t.text "submitterComment"
-    t.string "submitterEmail", limit: 45, default: "", null: false
+    t.string "submitterEmail", default: "", null: false
     t.timestamp "timestampSubmitted", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.timestamp "timestampDecided"
     t.string "status", limit: 10, default: "", null: false


### PR DESCRIPTION
To avoid those pesky CI fails during minor dependency updates because a fake email was "too long for the column"