### PR TITLE
Bump shakapacker to v7.0.3

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -84,7 +84,7 @@ gem 'i18n-country-translations', github: 'thewca/i18n-country-translations'
 gem 'http_accept_language'
 gem 'twitter_cldr'
 # version explicitly specified because Shakapacker wants to keep Gemfile and package.json in sync
-gem 'shakapacker', '7.0.1'
+gem 'shakapacker', '7.0.3'
 gem 'json-schema'
 gem 'translighterate'
 gem 'enum_help'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -637,7 +637,7 @@ GEM
     seedbank (0.5.0)
       rake (>= 10.0)
     semantic_range (3.0.0)
-    shakapacker (7.0.1)
+    shakapacker (7.0.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -820,7 +820,7 @@ DEPENDENCIES
   sdoc
   seedbank
   selectize-rails!
-  shakapacker (= 7.0.1)
+  shakapacker (= 7.0.3)
   simple_form
   simplecov
   simplecov-lcov

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -69,7 +69,7 @@
     "sass": "^1.66.1",
     "sass-loader": "^13.3.2",
     "semantic-ui-react": "^2.1.4",
-    "shakapacker": "7.0.1",
+    "shakapacker": "7.0.3",
     "style-loader": "^3.3.3",
     "terser-webpack-plugin": "^5.3.9",
     "webpack": "^5.88.2",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -6840,10 +6840,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-7.0.1.tgz#6a796e8780c0a3e8e1adb2e75b1b2b827cf9e1d0"
-  integrity sha512-6lZrKcDGjTlPyEI6swEHVDwokDVhTqwzaeILpyR2rj/Ml+dasu2dBr9/wo57nnf8OPxDr/tZQanjXHHDuXVkbg==
+shakapacker@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-7.0.3.tgz#e67fca4e74c3ef380e1acf53a1d51ab4784ca01c"
+  integrity sha512-2kwNP8kadkmGOqb7Bp/iNzF3bV31zni8b35Uzst2DZHjnFcnDbW96MERXHc7lS3p3AmKJVbUBmHAFCPsLT9tcw==
   dependencies:
     glob "^7.2.0"
     js-yaml "^4.1.0"


### PR DESCRIPTION
Manual bump because Dependabot cannot figure out that both need to be updated together across dependency ecosystems (across Bundler AND Yarn)