### PR TITLE
Fix etag not updating on wcif patch when only associations have changed

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -108,7 +108,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   def show_wcif_public
     id = params[:competition_id] || params[:id]
     cache_key = "wcif/#{id}"
-    competition = competition_from_params(associations: { registrations: [:assignments]})
+    competition = competition_from_params(associations: { registrations: [:assignments] })
     expires_in 5.minutes, public: true
     if stale?(competition, public: true)
       render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -108,7 +108,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   def show_wcif_public
     id = params[:competition_id] || params[:id]
     cache_key = "wcif/#{id}"
-    competition = competition_from_params
+    competition = competition_from_params(associations: { registrations: [:assignments]})
     expires_in 5.minutes, public: true
     if stale?(competition, public: true)
       render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {


### PR DESCRIPTION
While we fixed setting the last modified in #8126, there is still the issue that the browser does not update the wcif correctly in some cases. If two wcifs have the same etag (because associations are not considered when computing the etag), the browser will still use their cached version even if the last-modfied header is updated. We tested this and documented this in #8160. 
This PR closes #8160 by adding assignments to the competition associations, I am not 100% if this is enough or it needs even deeper nesting (like `:schedule_activity`). Would love some input on this @gregorbg 

Another solution would be to set the etag computation to
```
if stale?(etag: [competition, competition.updated_at], last_modified: competition.updated_at, public: true)
      render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
        competition.to_wcif
      }
    end
```
This kinda feels silly, but TIL that Ruby does not use the updated_at in its hash function for computing these, maybe it's not in there because it doesn't end up in the wcif? Just giving rails the competition object is definitely a bit too automagic for my taste