### PR TITLE
Rename REDIS_URL to CACHE_URL to not confilict with Sidekiq

### DIFF
--- a/WcaOnRails/config/environments/development.rb
+++ b/WcaOnRails/config/environments/development.rb
@@ -23,8 +23,8 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
     # If the Developer is not running through Docker, Redis caching is disabled
-    redis_url = EnvVars.REDIS_URL
-    config.cache_store = redis_url.empty? ? :memory_store : :redis_cache_store, { url: redis_url }
+    cache_url = EnvVars.CACHE_URL
+    config.cache_store = cache_url.empty? ? :memory_store : :redis_cache_store, { url: cache_url }
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}",
     }

--- a/WcaOnRails/config/environments/production.rb
+++ b/WcaOnRails/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: EnvVars.REDIS_URL }
+  config.cache_store = :redis_cache_store, { url: EnvVars.CACHE_URL }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/WcaOnRails/env_vars.rb
+++ b/WcaOnRails/env_vars.rb
@@ -5,7 +5,7 @@ EnvVars = SuperConfig.new do
     mandatory :SECRET_KEY_BASE, :string
     mandatory :DATABASE_HOST, :string
     mandatory :DATABASE_PASSWORD, :string
-    mandatory :REDIS_URL, :string
+    mandatory :CACHE_URL, :string
     mandatory :SMTP_USERNAME, :string
     mandatory :SMTP_PASSWORD, :string
   end
@@ -43,7 +43,7 @@ EnvVars = SuperConfig.new do
   optional :NEW_RELIC_LICENSE_KEY, :string, ''
   optional :CDN_AVATARS_DISTRIBUTION_ID, :string, ''
   optional :STRIPE_WEBHOOK_SECRET, :string, ''
-  optional :REDIS_URL, :string, ''
+  optional :CACHE_URL, :string, ''
   optional :STAGING_PASSWORD, :string, ''
 
   mandatory :GOOGLE_MAPS_API_KEY, :string

--- a/chef/site-cookbooks/wca/recipes/default.rb
+++ b/chef/site-cookbooks/wca/recipes/default.rb
@@ -280,7 +280,7 @@ elsif node.chef_environment == "staging"
   redis[:host] = "redis-main-staging-001.iebvzt.0001.usw2.cache.amazonaws.com"
 end
 
-redis_url = "redis://#{redis[:host]}:#{redis[:port]}"
+cache_url = "redis://#{redis[:host]}:#{redis[:port]}"
 
 #### Rails secrets
 # Don't be confused by the name of this file! This is used by both our staging
@@ -293,7 +293,7 @@ template "#{rails_root}/.env.production" do
   group username
   variables({
               secrets: secrets,
-              redis_url: redis_url,
+              cache_url: cache_url,
               db_host: db["host"],
               read_replica_host: read_replica
             })

--- a/chef/site-cookbooks/wca/templates/env.production.erb
+++ b/chef/site-cookbooks/wca/templates/env.production.erb
@@ -10,7 +10,7 @@ SECRET_KEY_BASE=<%= @secrets['secret_key_base'] %>
 DATABASE_HOST=<%= @db_host %>
 DATABASE_PASSWORD=<%= @secrets['mysql_password'] %>
 READ_REPLICA_HOST=<%= @read_replica_host %>
-REDIS_URL=<%= @redis_url %>
+CACHE_URL=<%= @cache_url %>
 SMTP_USERNAME=<%= @secrets['SMTP_USERNAME'] %>
 SMTP_PASSWORD=<%= @secrets['SMTP_PASSWORD'] %>
 RECAPTCHA_PUBLIC_KEY=<%= @secrets['RECAPTCHA_PUBLIC_KEY'] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       RAILS_ENV: development
       DATABASE_HOST: wca_db
       SHAKAPACKER_DEV_SERVER_HOST: wca_webpacker
-      REDIS_URL: redis://wca_redis:6379/0
+      CACHE_URL: redis://wca_redis:6379/0
     tty: true
     # First, install Ruby and Node dependencies
     # Next, load the database if it does not exist yet


### PR DESCRIPTION
As we want to use a different Node in the Redis Cluster for Sidekiq, we need to rename the Environment Variable for the Redis node that is there for caching