### PR TITLE
Update node installation in Dockerfile

### DIFF
--- a/WcaOnRails/Dockerfile
+++ b/WcaOnRails/Dockerfile
@@ -4,11 +4,20 @@ EXPOSE 3000
 ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y curl gnupg
-
 # Add PPA needed to install nodejs.
-# From: https://github.com/nodesource/distributions
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+# From: https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
+RUN apt-get update \
+apt-get install -y ca-certificates curl gnupg \
+mkdir -p /etc/apt/keyrings \
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+
+RUN NODE_MAJOR=16 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update && apt-get install -y curl gnupg wget nodejs
+
+# The Latest Ruby image doesn't come with libffi7 anymore
+RUN wget http://es.archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi7_3.3-4_amd64.deb
+RUN dpkg -i libffi7_3.3-4_amd64.deb
 
 # Add PPA needed to install yarn.
 # From: https://yarnpkg.com/en/docs/install#debian-stable

--- a/WcaOnRails/Dockerfile
+++ b/WcaOnRails/Dockerfile
@@ -9,15 +9,9 @@ WORKDIR /app
 RUN apt-get update \
 apt-get install -y ca-certificates curl gnupg \
 mkdir -p /etc/apt/keyrings \
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
 RUN NODE_MAJOR=16 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-
-RUN apt-get update && apt-get install -y curl gnupg wget nodejs
-
-# The Latest Ruby image doesn't come with libffi7 anymore
-RUN wget http://es.archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi7_3.3-4_amd64.deb
-RUN dpkg -i libffi7_3.3-4_amd64.deb
 
 # Add PPA needed to install yarn.
 # From: https://yarnpkg.com/en/docs/install#debian-stable


### PR DESCRIPTION
Node has deprecated its installation scripts in favour of installing via packages. See https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions.