### PR TITLE
Create assign-pr-to-author.yml

### DIFF
--- a/.github/workflows/assign-pr-to-author.yml
+++ b/.github/workflows/assign-pr-to-author.yml
@@ -1,0 +1,26 @@
+name: Assign PR to Author
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Assign PR to Author
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const issue_number = context.payload.pull_request.number;
+            github.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              assignees: [author]
+            });
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/assign-pr-to-author.yml
+++ b/.github/workflows/assign-pr-to-author.yml
@@ -1,26 +1,14 @@
-name: Assign PR to Author
+name: Auto Author Assign
 
 on:
-  pull_request:
-    types:
-      - opened
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
 
 jobs:
-  assign:
+  assign-author:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Assign PR to Author
-        uses: actions/github-script@v4
-        with:
-          script: |
-            const author = context.payload.pull_request.user.login;
-            const issue_number = context.payload.pull_request.number;
-            github.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue_number,
-              assignees: [author]
-            });
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: toshimaru/auto-author-assign@v1.6.2


### PR DESCRIPTION
For project management, it would be good if the author of a PR was also the assignee. ChatGPT generated this action, which seems reasonable to me.