### PR TITLE
Have registrations export generate wcif_status instead of single-letter

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -129,7 +129,7 @@ class RegistrationsController < ApplicationController
     end
     registration_rows = CSV.read(file.path, headers: true, header_converters: :symbol, skip_blanks: true, converters: ->(string) { string&.strip })
                            .map(&:to_hash)
-                           .select { |registration_row| registration_row[:status] == "a" }
+                           .select { |registration_row| registration_row[:status] == "a" || registration_row[:status] == "accepted" }
     if competition.competitor_limit_enabled? && registration_rows.length > competition.competitor_limit
       raise I18n.t("registrations.import.errors.over_competitor_limit",
                    accepted_count: registration_rows.length,

--- a/WcaOnRails/app/views/registrations/export.csv.erb
+++ b/WcaOnRails/app/views/registrations/export.csv.erb
@@ -3,7 +3,7 @@
 <%= CSV.generate_line(headers).html_safe -%>
 <% @registrations.each do |registration| %>
 <%= CSV.generate_line([
-  registration.wcif_status
+  registration.wcif_status,
   registration.name,
   registration.country.id,
   registration.wca_id,

--- a/WcaOnRails/app/views/registrations/export.csv.erb
+++ b/WcaOnRails/app/views/registrations/export.csv.erb
@@ -3,7 +3,7 @@
 <%= CSV.generate_line(headers).html_safe -%>
 <% @registrations.each do |registration| %>
 <%= CSV.generate_line([
-  registration.pending? ? "p" : "a",
+  registration.wcif_status
   registration.name,
   registration.country.id,
   registration.wca_id,

--- a/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "registrations/export.csv.erb" do
     assign(:registrations, competition.registrations)
     render
 
-    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\na,Bob,USA,,1990-01-01,m,1,0,bob@bob.com,1,\"\"\n"
+    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\naccepted,Bob,USA,,1990-01-01,m,1,0,bob@bob.com,1,\"\"\n"
   end
 
   it "renders null (missing) gender as empty string" do
@@ -39,6 +39,6 @@ RSpec.describe "registrations/export.csv.erb" do
     assign(:registrations, competition.registrations)
     render
 
-    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\na,Bob,USA,,1990-01-01,,1,0,bob@bob.com,1,\"\"\n"
+    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\naccepted,Bob,USA,,1990-01-01,,1,0,bob@bob.com,1,\"\"\n"
   end
 end


### PR DESCRIPTION
Still need to test locally - but I think if we just return the WCIF status in the endpoint we improve the CSV export considerably.

# Manual tests:
- [x] Exporting registrations in different states returns the WCIF states in the CSV
- [ ] Importing registrations with different WCIF states adds only accepted registrations (existing behaviour)
- [ ] Importing registrations with "a" states adds them as registrations (backwards compatibility)
