### PR TITLE
Do not error when posting WCIF with unchanged competitor limit

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1687,6 +1687,8 @@ class Competition < ApplicationRecord
   end
 
   def set_wcif_competitor_limit!(wcif_competitor_limit, current_user)
+    return if wcif_competitor_limit == self.competitor_limit
+
     if confirmed? && !current_user.can_admin_competitions?
       raise WcaExceptions::BadApiParameter.new("Cannot edit the competitor limit because the competition has been confirmed by WCAT")
     end

--- a/WcaOnRails/spec/models/competition_wcif_spec.rb
+++ b/WcaOnRails/spec/models/competition_wcif_spec.rb
@@ -313,6 +313,17 @@ RSpec.describe "Competition WCIF" do
       # Adding a competitor limit should error
       expect { competition.set_wcif_competitor_limit!(competitor_limit_wcif, delegate) }.to raise_error(WcaExceptions::BadApiParameter)
     end
+
+    it "does not error when the limit is unchanged" do
+      competitor_limit_wcif = 50
+
+      # Manually confirm the competition
+      competition.confirmed_at = "2013-06-01"
+      competition.save!
+
+      competition.set_wcif_competitor_limit!(competitor_limit_wcif, delegate)
+      expect(competition.to_wcif["competitorLimit"]).to eq(competitor_limit_wcif)
+    end
   end
 
   describe "#set_wcif_events!" do


### PR DESCRIPTION
This is causing WCA Live synchronization to fail.

I can't run locally right now, so I'm relying on CI.