### PR TITLE
switched dev and results export timing

### DIFF
--- a/WcaOnRails/config/schedule.yml
+++ b/WcaOnRails/config/schedule.yml
@@ -20,12 +20,12 @@ submit_report_nag:
 
 dump_developer_database:
   class: "DumpDeveloperDatabase"
-  cron: "0 0 */3 * *"
+  cron: "0 0 * * *"
   queue: wca_jobs
 
 dump_public_results_database:
   class: "DumpPublicResultsDatabase"
-  cron: "0 0 * * *"
+  cron: "0 0 */3 * *"
   queue: wca_jobs
 
 unstick_posts:


### PR DESCRIPTION
Dev export should run every day, while results export should run every 3 days. These schedles were switched in schedule.yml