### PR TITLE
Fix dockerfile being run on single line

### DIFF
--- a/WcaOnRails/Dockerfile
+++ b/WcaOnRails/Dockerfile
@@ -3,13 +3,14 @@ EXPOSE 3000
 
 ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /app
+ARG NODE_MAJOR=16
 
 # Add PPA needed to install nodejs.
 # From: https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
 RUN apt-get update && apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
-RUN NODE_MAJOR=16 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Add PPA needed to install yarn.
 # From: https://yarnpkg.com/en/docs/install#debian-stable

--- a/WcaOnRails/Dockerfile
+++ b/WcaOnRails/Dockerfile
@@ -6,10 +6,8 @@ WORKDIR /app
 
 # Add PPA needed to install nodejs.
 # From: https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
-RUN apt-get update \
-apt-get install -y ca-certificates curl gnupg \
-mkdir -p /etc/apt/keyrings \
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN apt-get update && apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
 RUN NODE_MAJOR=16 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 


### PR DESCRIPTION
Not sure why this worked on my machine, but we should not run all of these on a single line as it causes apt-get to error out.
I've also moved the NODE_MAJOR Version to ARG