### PR TITLE
Push cronjobs to non-concurrent queue via Sidekiq capsule

### DIFF
--- a/WcaOnRails/config/initializers/sidekiq.rb
+++ b/WcaOnRails/config/initializers/sidekiq.rb
@@ -3,6 +3,9 @@
 Sidekiq.configure_server do |config|
   config.redis = { url: EnvConfig.SIDEKIQ_REDIS_URL }
 
+  # Run all queues except cronjobs in the default runner
+  config.queues = %w[critical default mailers]
+
   # Our cronjobs generally react allergic to concurrency because we never designed them with idempotency in mind.
   # Instead of redesigning our whole zoo of cronjobs, pipe them through a linear execution worker.
   config.capsule("cronjobs") do |cap|

--- a/WcaOnRails/config/initializers/sidekiq.rb
+++ b/WcaOnRails/config/initializers/sidekiq.rb
@@ -2,6 +2,13 @@
 
 Sidekiq.configure_server do |config|
   config.redis = { url: EnvConfig.SIDEKIQ_REDIS_URL }
+
+  # Our cronjobs generally react allergic to concurrency because we never designed them with idempotency in mind.
+  # Instead of redesigning our whole zoo of cronjobs, pipe them through a linear execution worker.
+  config.capsule("cronjobs") do |cap|
+    cap.concurrency = 1
+    cap.queues = [WcaCronjob::QUEUE_NAME]
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
Matches how there was only one single worker in the DelayedJob Supervisor setup.
Hope this solves some of the problems WRT has been facing.