### PR TITLE
Fix test choke due to race condition in EditEventsSpec

### DIFF
--- a/WcaOnRails/spec/features/competition_events_spec.rb
+++ b/WcaOnRails/spec/features/competition_events_spec.rb
@@ -205,7 +205,11 @@ RSpec.feature "Competition events management" do
           click_button "Yes"
         end
 
-        save_events_react(wait_for_completion: false)
+        # The alert that is expected here implies the 400 error message
+        #   (which is displayed in an alert in our current frontend)
+        accept_alert do
+          save_events_react(wait_for_completion: false)
+        end
 
         expect(competition.reload.events.map(&:id)).to match_array %w(222 444)
       end


### PR DESCRIPTION
The fact that we had previously set `wait_for_completion` to `false` meant that the test terminated faster than the WCIF `PATCH` in the background. When the test terminates, it clears its data from the test DB, and then the still-ongoing WCIF update in the background was trying to reload an entity that doesn't exist.

By using `accept_modal` in Capybara, we explicitly expect that a "some error occured during the PATCH" modal pops up, and only continue the test when the server in hte background is done.