### PR TITLE
Reinstate dummy version of Hungarian locale

### DIFF
--- a/WcaOnRails/config/locales/hu.yml
+++ b/WcaOnRails/config/locales/hu.yml
@@ -1,0 +1,5 @@
+hu:
+  users:
+    update_locale:
+      #original_hash: 4cde9bc
+      success: Frissített nyelv.

--- a/WcaOnRails/config/locales/locales.rb
+++ b/WcaOnRails/config/locales/locales.rb
@@ -43,6 +43,10 @@ module Locales
       flag_id: "hr",
       name: "Hrvatski",
     },
+    hu: {
+      flag_id: "hu",
+      name: "Magyar",
+    },
     id: {
       flag_id: "id",
       name: "Bahasa Indonesia",


### PR DESCRIPTION
We were requested to remove the locale for a complete makeover, but this messed with users and mailers who had their preferred_locale set to 'hu'. So we just keep a dummy version to not make the code crash (and to save us from manually removing preferred_locale in the database for users that had it set to HU) until the new version is submitted