### PR TITLE
User badge css fix

### DIFF
--- a/WcaOnRails/app/webpacker/stylesheets/static_pages/teams_committees.scss
+++ b/WcaOnRails/app/webpacker/stylesheets/static_pages/teams_committees.scss
@@ -45,8 +45,27 @@
 
     /* On mobile, colour every other user badge a light shade of grey to separate them */
     @media (max-width: 525px) {
-      & > :nth-child(2n) {
+      &> :nth-child(2n) {
         background: #f2f2f2 !important;
+      }
+    }
+
+    .user-badge {
+
+      /* Make it fill width of screen on mobile */
+      @media (max-width: 525px) {
+        width: 100vw;
+        margin: 0 !important;
+        border: none !important;
+        border-radius: 0 !important;
+
+        .user-name {
+          background: none !important;
+        }
+
+        >.label {
+          border-radius: 0 !important;
+        }
       }
     }
   }

--- a/WcaOnRails/app/webpacker/stylesheets/user_badge.scss
+++ b/WcaOnRails/app/webpacker/stylesheets/user_badge.scss
@@ -3,7 +3,7 @@
 .user-badge {
   margin: 4px !important;
 
-  & > .label {
+  &>.label {
     // Same colour as the rest of the button, so that it blends without a border.
     // It should normally be hidden anyway, but for the users with multiple lines
     // of subtext, it shows a little.
@@ -63,21 +63,5 @@
 
   .user-avatar-rounded-left {
     border-radius: 0.3em 0 0 0.3em;
-  }
-
-  /* Make it fill width of screen on mobile */
-  @media (max-width: 525px) {
-    width: 100vw;
-    margin: 0 !important;
-    border: none !important;
-    border-radius: 0 !important;
-
-    .user-name {
-      background: none !important;
-    }
-
-    > .label {
-      border-radius: 0 !important;
-    }
   }
 }


### PR DESCRIPTION
Currently react component UserBadge is used in two places: Teams & Committees page & Delegates page. The property of user badge to make the width `100vw` is breaking Delegates UI in mobile view. Since that property is needed only in teams & committees page, I've moved those css to teams & committees page.

PS: This fix will help in [Delegates UI revamp](https://github.com/thewca/worldcubeassociation.org/pull/8209) as well.