### PR TITLE
Add workflows for Building and Deploying Docker Images

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -1,0 +1,52 @@
+name: Deploy Image on GitHub Release
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.CI_CD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_CD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build and Push Sidekiq image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./WcaOnRails
+          push: true
+          file: Dockerfile.sidekiq
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:sidekiq-production
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:sidekiq-staging
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+        # this will trigger the deployment pipeline for prod
+      - name: Build and push Prod Image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./WcaOnRails
+          push: true
+          file: Dockerfile
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:latest
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:staging
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:${{ github.event.release.tag_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+        # Replace the old sidekiq image with the new one
+      - name: Deploy Sidekiq
+        run: |
+          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-auxiliary-services --force-new-deployment
+        # There is no pipeline for staging so we manually force to update the image
+      - name: Deploy staging
+        run: |
+          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-staging --force-new-deployment

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -42,6 +42,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:${{ github.event.release.tag_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_TAG=$GITHUB_SHA
         # Replace the old sidekiq image with the new one
       - name: Deploy Sidekiq
         run: |

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -2,6 +2,7 @@ name: Deploy Image on GitHub Release
 on:
   release:
     types: [created]
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -39,7 +40,6 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:latest
             ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:staging
-            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:${{ github.event.release.tag_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/staging-deployment-from-prs.yml
+++ b/.github/workflows/staging-deployment-from-prs.yml
@@ -63,6 +63,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:staging
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_TAG=$GITHUB_SHA
       - name: Deploy staging if triggered
         if: steps.trigger-deployment.outputs.triggered == 'true'
         run: |

--- a/.github/workflows/staging-deployment-from-prs.yml
+++ b/.github/workflows/staging-deployment-from-prs.yml
@@ -1,0 +1,69 @@
+name: Deployment to Staging
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger deployment on comment
+        id: trigger-deployment
+        uses: shanegenschaw/pull-request-comment-trigger@v2.1.0
+        with:
+          trigger: '@thewca-bot deploy staging'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get ref from pr
+        id: comment-branch
+        uses: xt0rted/pull-request-comment-branch@v2
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.CI_CD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_CD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+      - name: Build Sidekiq if triggered
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+        uses: docker/build-push-action@v4
+        with:
+          context: ./WcaOnRails
+          push: true
+          file: Dockerfile.sidekiq
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:sidekiq-staging
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build Rails if triggered
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+        uses: docker/build-push-action@v4
+        with:
+          context: ./WcaOnRails
+          push: true
+          file: Dockerfile
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:staging
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Deploy staging if triggered
+        if: steps.trigger-deployment.outputs.triggered == 'true'
+        run: |
+          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-staging --force-new-deployment


### PR DESCRIPTION
In Preparation for #8314 I added two new workflows.
On Release:
- Builds new Images and marks them as latest for staging and prod
- Pushing an image triggers the deployment pipeline for prod
- Sidekiq image is updated and deployed
- Staging image is updated and deployed

On PR Comment:
- Allows deploying PRs to staging by writing '@thewca-bot deploy staging' 
- Replaces Main and Sidekiq Staging images if triggered

We could think of another way of deploying staging images, but I think this could work well. This almost makes the deploy repository redundant, depending on if we want to add a separate workflow for updating documents.