### PR TITLE
Add WCA Live to Nav Bar (#7724)

### DIFF
--- a/WcaOnRails/app/views/layouts/_navigation.html.erb
+++ b/WcaOnRails/app/views/layouts/_navigation.html.erb
@@ -55,8 +55,6 @@
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="https://live.worldcubeassociation.org"><%= ui_icon('sort numeric down') %>WCA Live</a></li>
-          <li class="divider"></li>
           <li><a href="<%= rankings_path("333", "single") %>"><%= ui_icon('signal', class: 'fa-rotate-90') %> <%= t '.rankings' %></a></li>
           <li><a href="<%= records_path %>"><%= ui_icon('trophy') %> <%= t '.records' %></a></li>
           <li><a href="<%= persons_path %>"><%= ui_icon('users') %> <%= t '.persons' %></a></li>
@@ -147,6 +145,11 @@
         <a href="https://forum.worldcubeassociation.org/" target="_blank" class="top-nav hide-new-window-icon">
           <%= ui_icon('comments') %>
           <span class="visible-lg-inline visible-xs-inline"><%= t '.forum' %></span>
+        </a>
+      </li>
+      <li>
+        <a href="https://live.worldcubeassociation.org/" target="_blank" class="top-nav hide-new-window-icon">
+          <%= ui_icon('sort numeric down') %> WCA Live
         </a>
       </li>
     </ul>


### PR DESCRIPTION
Removed WCA Live from "Results" dropdown to its own separate header.

Here is a screenshot of the corrected Navbar with this commit: 

![Screenshot 2023-09-25 174726](https://github.com/thewca/worldcubeassociation.org/assets/77213551/770d206f-8e5c-44a5-863d-b886f51bfa4a)
