### PR TITLE
Add Guidelines for Disciplinary Incidents document to the Delegate Panel

### DIFF
--- a/WcaOnRails/app/views/panel/index.html.erb
+++ b/WcaOnRails/app/views/panel/index.html.erb
@@ -25,6 +25,9 @@
         <%= link_to "Delegate Crash course", panel_delegate_crash_course_path %>
       </li>
       <li>
+        <%= link_to "Guidelines for Disciplinary Incidents", "/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.pdf" %>
+      </li>
+      <li>
         <%= link_to "Delegates", delegates_stats_path %>
       </li>
       <li>


### PR DESCRIPTION
WDC recently added a "Guidelines for Disciplinary Incidents" doc, as an educational resource for delegates to reference when handling behavioral incidents that may involve WDC. This commit adds a link to that document to the Panel, so that it can be easily accessed by delegates.

The PR adding this document can be found [here on the wca-documents repo](https://github.com/thewca/wca-documents/pull/357). There is usually some delay between the PR being merged and the file going live on the WCA website, so the link added in this PR may be dead for a few more hours, but should eventually resolve to the document. When [this link](https://www.worldcubeassociation.org/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.pdf) resolves to the document, the file should be live.