### PR TITLE
Throttle Sidekiq mailer threads

### DIFF
--- a/WcaOnRails/config/initializers/sidekiq.rb
+++ b/WcaOnRails/config/initializers/sidekiq.rb
@@ -5,6 +5,9 @@ Sidekiq.configure_server do |config|
 
   # Run all queues except cronjobs in the default runner
   config.queues = %w[critical default mailers]
+  # Three queues, three threads. We don't want to steal too much resources from Rails,
+  #   especially regarding the DB connection pool which is limited to 5 resources by default
+  config.concurrency = 3
 
   # Our cronjobs generally react allergic to concurrency because we never designed them with idempotency in mind.
   # Instead of redesigning our whole zoo of cronjobs, pipe them through a linear execution worker.


### PR DESCRIPTION
Because otherwise they eat 5 by default, and cronjobs have 1 (linear execution), which is 5+1=6 and that's more than the Rails default for DB pooling :sweat_smile: 