### PR TITLE
Fix against changed numeric key export in i18n-js

### DIFF
--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -20,10 +20,10 @@ function tArray(scope, options) {
     const maybeNumericKeys = resKeys.map(Number);
     maybeNumericKeys.sort();
 
-    // Our i18n export library changed behavior in a minor version bump (sigh…) to maintain numeric keys as JS objects
-    // even when the keys clearly indicate index ordering, implying an array.
-    // We need to circumvent this behavior because we rely on external tools for our translators which require the YML
-    // to contain string keys (instead of changing the YML itself to a "proper" array)
+    // Our i18n export library changed behavior in a minor version bump (sigh…) to maintain numeric
+    // keys as JS objects even when the keys clearly indicate index ordering, implying an array.
+    // We need to circumvent this behavior because we rely on external tools for our translators,
+    // which require the YML to contain string keys (instead "proper" YML arrays)
     const isPseudoArray = maybeNumericKeys.every((key, idx) => key === (idx + 1));
 
     if (isPseudoArray) {

--- a/WcaOnRails/app/webpacker/lib/i18n.js
+++ b/WcaOnRails/app/webpacker/lib/i18n.js
@@ -13,13 +13,31 @@ const DEFAULT_LOCALE = 'en';
  */
 function tArray(scope, options) {
   let res = window.I18n.t(scope, options);
-  if (typeof res !== 'object' || !Array.isArray(res)) {
+
+  if (typeof res === 'object') {
+    const resKeys = Object.keys(res);
+
+    const maybeNumericKeys = resKeys.map(Number);
+    maybeNumericKeys.sort();
+
+    // Our i18n export library changed behavior in a minor version bump (sigh…) to maintain numeric keys as JS objects
+    // even when the keys clearly indicate index ordering, implying an array.
+    // We need to circumvent this behavior because we rely on external tools for our translators which require the YML
+    // to contain string keys (instead of changing the YML itself to a "proper" array)
+    const isPseudoArray = maybeNumericKeys.every((key, idx) => key === (idx + 1));
+
+    if (isPseudoArray) {
+      res = maybeNumericKeys.map((key) => res[key.toString()]);
+    }
+  }
+
+  if (!Array.isArray(res)) {
     // throw errors in same style as I18n.t:
     // return a valid result, just the error message not the content.
     return [`Expected Array from: ${scope}`];
   }
-  res = res.filter(Boolean);
-  return res;
+
+  return res.filter(Boolean);
 }
 
 window.I18n = window.I18n || new I18n();


### PR DESCRIPTION
Our translation YML (the source _Ruby_ object) looks like this:

```yml
avatar_guidelines:
  '1': "All avatars should be pictures of real persons."
  '2': "The person shown must be your current self."
  '3': "If there is more than one person on the avatar, it should be clear who of them is you."
  '4': "Your head, but not necessarily the full face, should be visible."
  '5': "The avatar should not include overlay texts or unnatural filters, including borders."
  '6': "The avatar must be submitted in correct orientation."
  '7': "The avatar must not contain offensive content (e.g. offensive gestures)."
```

This is supposed to represent an array of objects, but the numbering is using stringified keys, mostly because of historic reasons. This clashes with changes introduced in https://github.com/fnando/i18n/pull/74, which leads to the JS export creating an _Object_.

Note that this is technically correct and the i18n library is not to blame here. Our broken legacy processes are.
However, we do rely on certain assumptions of translations being arrays when reading them in React during runtime. So we need to patch this behavior on our side.

NOTE: Of course, the "proper" patch would be to convert all instances in all of our translated YML files to "real" YML arrays. But this would be a ton of work and most notably it would prompt all of our translators to "please submit a new translation" when in reality, there is nothing to do.