### PR TITLE
Bump Shakapacker to v7.1.0

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -85,7 +85,7 @@ gem 'i18n-country-translations', github: 'thewca/i18n-country-translations'
 gem 'http_accept_language'
 gem 'twitter_cldr'
 # version explicitly specified because Shakapacker wants to keep Gemfile and package.json in sync
-gem 'shakapacker', '7.0.3'
+gem 'shakapacker', '7.1.0'
 gem 'json-schema'
 gem 'translighterate'
 gem 'enum_help'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -499,7 +499,7 @@ GEM
     rack (2.2.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
-    rack-proxy (0.7.6)
+    rack-proxy (0.7.7)
       rack
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -643,7 +643,7 @@ GEM
     seedbank (0.5.0)
       rake (>= 10.0)
     semantic_range (3.0.0)
-    shakapacker (7.0.3)
+    shakapacker (7.1.0)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -837,7 +837,7 @@ DEPENDENCIES
   sdoc
   seedbank
   selectize-rails!
-  shakapacker (= 7.0.3)
+  shakapacker (= 7.1.0)
   sidekiq
   sidekiq-cron
   simple_form

--- a/WcaOnRails/config/webpack/webpack.config.js
+++ b/WcaOnRails/config/webpack/webpack.config.js
@@ -1,7 +1,5 @@
-const { generateWebpackConfig, merge } = require('shakapacker');
+const { generateWebpackConfig } = require('shakapacker');
 const webpack = require('webpack');
-
-const webpackConfig = generateWebpackConfig();
 
 const customConfig = {
   resolve: {
@@ -51,4 +49,4 @@ const customConfig = {
   ignoreWarnings: [/Module not found: Error: Can't resolve 'react-dom\/client'/],
 };
 
-module.exports = merge(webpackConfig, customConfig);
+module.exports = generateWebpackConfig(customConfig);

--- a/WcaOnRails/package.json
+++ b/WcaOnRails/package.json
@@ -69,7 +69,7 @@
     "sass": "^1.68.0",
     "sass-loader": "^13.3.2",
     "semantic-ui-react": "^2.1.4",
-    "shakapacker": "7.0.3",
+    "shakapacker": "7.1.0",
     "style-loader": "^3.3.3",
     "terser-webpack-plugin": "^5.3.9",
     "webpack": "^5.88.2",

--- a/WcaOnRails/yarn.lock
+++ b/WcaOnRails/yarn.lock
@@ -6909,10 +6909,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-7.0.3.tgz#e67fca4e74c3ef380e1acf53a1d51ab4784ca01c"
-  integrity sha512-2kwNP8kadkmGOqb7Bp/iNzF3bV31zni8b35Uzst2DZHjnFcnDbW96MERXHc7lS3p3AmKJVbUBmHAFCPsLT9tcw==
+shakapacker@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-7.1.0.tgz#95bd37db60702ffa21f9ea29a88f438de3db25b2"
+  integrity sha512-xKfF4LKrFQdMLYeIi/uBV6pfkPTO4lgCAIMx3W5+MHW61ENOXu4WeQ50qVR9u5hV6XXzi7AiS7C6dWO2GFnYAg==
   dependencies:
     glob "^7.2.0"
     js-yaml "^4.1.0"


### PR DESCRIPTION
Another month has gone by without Dependabot learning that these two _have_ to be updated in conjunction.

Supersedes https://github.com/thewca/worldcubeassociation.org/pull/8398
Supersedes https://github.com/thewca/worldcubeassociation.org/pull/8379