### PR TITLE
Add Get Permissions and Me route

### DIFF
--- a/WcaOnRails/app/controllers/api/internal/v1/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/internal/v1/api_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Api::Internal::V1::ApiController < ApplicationController
+  prepend_before_action :validate_token
+
+  def validate_token
+    service_token = request.headers["X-WCA-Service-Token"]
+    unless service_token.present?
+      return render json: { error: "Missing Authentication" }, status: :forbidden
+    end
+    response = Vault.with_retries(Vault::HTTPConnectionError) do
+      Vault.logical.write("identity/oidc/introspect", data: { token: service_token })
+    end
+    unless response.data.present? && response.data[:active]
+      render json: { error: "Authentication Expired or Token Invalid" }, status: :forbidden
+    end
+  end
+end

--- a/WcaOnRails/app/controllers/api/internal/v1/permissions_controller.rb
+++ b/WcaOnRails/app/controllers/api/internal/v1/permissions_controller.rb
@@ -1,0 +1,18 @@
+class Api::Internal::V1::PermissionsController < Api::Internal::V1::ApiController
+  def index
+    user_id = params.require(:user_id)
+    user = User.find(user_id)
+    render json: {
+      can_attend_competitions: {
+        scope: user.cannot_register_for_competition_reasons.empty? ? "*" : [],
+        until: user.banned? ? user.current_team_members.select(:team == Team.banned).first.end_date : nil
+      },
+      can_organize_competitions: {
+        scope: user.can_create_competitions? ? "*" : [],
+      },
+      can_administer_competitions: {
+        scope: user.can_admin_competitions? ? "*" : (user.delegated_competitions + user.organized_competitions).pluck("id"),
+      },
+    }
+  end
+end

--- a/WcaOnRails/app/controllers/api/v0/users_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/users_controller.rb
@@ -1,0 +1,32 @@
+class Api::V0::PersonsController < Api::V0::ApiController
+  def me
+    if current_user
+      if stale?(current_user)
+        render json: { user: current_user }
+      end
+    else
+      render status: :unauthorized, json: { error: "Please log in" }
+    end
+  end
+
+  def permissions
+    if current_user
+      if stale?(current_user)
+        render json: {
+          can_attend_competitions: {
+            scope: current_user.cannot_register_for_competition_reasons.empty? ? "*" : [],
+            until: user.banned? ? user.current_team_members.select(:team == Team.banned).first.end_date : nil
+          },
+          can_organize_competitions: {
+            scope: current_user.can_create_competitions? ? "*" : [],
+          },
+          can_administer_competitions: {
+            scope: current_user.can_admin_competitions? ? "*" : (current_user.delegated_competitions + current_user.organized_competitions).pluck("id"),
+          },
+        }
+      end
+    else
+      render status: :unauthorized, json: { error: "Please log in" }
+    end
+  end
+end


### PR DESCRIPTION
For wca-registrations we will need some new user related routes. This PR adds 2 public and one internal route.

Public Routes:
- Returns all information about the current user so we can display it in the frontend
- Returns the current users permissions so we can display the correct elements in the frontend

Private Routes:
- Returns the permissions of any user so we can validate if a user is allowed to perform an action on a microservice

Private Routes are secured using [Vault's Identity tokens ](https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#generate-a-signed-id-token), this way only services that are connected to vault and have the correct permissions to generate tokens can use the internal routes.

See an example on how you use it on the other side [here](https://github.com/thewca/wca-registration/pull/247). 

I have not added these routes to the routes.rb yet, as where we will mount them still needs to be discussed. I have cautiously added a /api/internal/v1 route for now.

Should I add tests for this?