### PR TITLE
Add more info to the competition API

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -102,6 +102,7 @@ gem 'sprockets-rails'
 gem 'fuzzy-string-match'
 gem 'sidekiq'
 gem 'sidekiq-cron'
+gem 'deep_merge', require: 'deep_merge/rails_compat'
 
 group :development, :test do
   gem 'spring'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     date (3.3.3)
     debug_inspector (1.0.0)
     declarative (0.0.20)
+    deep_merge (1.2.2)
     devise (4.9.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -775,6 +776,7 @@ DEPENDENCIES
   daemons
   database_cleaner
   datetimepicker-rails!
+  deep_merge
   devise
   devise-bootstrap-views
   devise-i18n

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -18,7 +18,8 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   COMPETITION_INFO_SERIALIZE_OPTIONS = {
-    only: %w[extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
+    only: %w[extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results
+             event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
     methods: %w[registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff? events_with_rounds schedule_wcif],
     include: %w[tabs],
   }.freeze

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -17,9 +17,16 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     paginate json: competitions
   end
 
+  COMPETITION_INFO_SERIALIZE_OPTIONS = {
+    only: %w[id name website start_date registration_open registration_close announced_at cancelled_at end_date competitor_limit extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
+    methods: %w[url website short_name city venue_address venue_details latitude_degrees longitude_degrees country_iso2 event_ids registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff? events_with_rounds schedule_wcif],
+    include: %w[delegates organizers tabs],
+  }.freeze
+
   def show
     competition = competition_from_params
-    render json: competition
+    json = competition.serializable_hash(COMPETITION_INFO_SERIALIZE_OPTIONS)
+    render json: json
   end
 
   def schedule

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -21,7 +21,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     only: %w[extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results
              event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent
              use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
-    methods: %w[registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff? events_with_rounds schedule_wcif],
+    methods: %w[registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff?],
     include: %w[tabs],
   }.freeze
 

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -27,9 +27,9 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
   def show
     competition = competition_from_params
+
     if stale?(competition)
-      json = competition.serializable_hash(COMPETITION_INFO_SERIALIZE_OPTIONS)
-      render json: json
+      render json: competition.as_json(COMPETITION_INFO_SERIALIZE_OPTIONS)
     end
   end
 

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -19,7 +19,8 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
   COMPETITION_INFO_SERIALIZE_OPTIONS = {
     only: %w[extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results
-             event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
+             event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent
+             use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
     methods: %w[registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff? events_with_rounds schedule_wcif],
     include: %w[tabs],
   }.freeze

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -18,9 +18,9 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   COMPETITION_INFO_SERIALIZE_OPTIONS = {
-    only: %w[id name website start_date registration_open registration_close announced_at cancelled_at end_date competitor_limit extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
-    methods: %w[url website short_name city venue_address venue_details latitude_degrees longitude_degrees country_iso2 event_ids registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff? events_with_rounds schedule_wcif],
-    include: %w[delegates organizers tabs],
+    only: %w[extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
+    methods: %w[registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff? events_with_rounds schedule_wcif],
+    include: %w[tabs],
   }.freeze
 
   def show

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -25,8 +25,10 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
   def show
     competition = competition_from_params
-    json = competition.serializable_hash(COMPETITION_INFO_SERIALIZE_OPTIONS)
-    render json: json
+    if stale?(competition)
+      json = competition.serializable_hash(COMPETITION_INFO_SERIALIZE_OPTIONS)
+      render json: json
+    end
   end
 
   def schedule

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -397,11 +397,8 @@ class Competition < ApplicationRecord
   end
 
   def events_with_rounds
-    includes_associations = [
-      { rounds: [:competition_event] },
-    ]
     competition_events
-      .includes(includes_associations)
+      .includes({ rounds: [:competition_event] })
       .sort_by { |ce| ce.event.rank }
       .map(&:to_wcif)
   end

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1915,7 +1915,10 @@ class Competition < ApplicationRecord
   }.freeze
 
   def serializable_hash(options = nil)
-    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}) { |_, h1, h2| h1 + h2 })
+    # This looks weird, but we need the 'deeper_merge' method to handle arrays inside hashes.
+    #   In turn, the 'deeper_merge' library has a quirk that even though it doesn't use the ! naming convention,
+    #   it tries to modify the source array in-place. This is not cool so we need to circumvent by duplicating.
+    json = super(DEFAULT_SERIALIZE_OPTIONS.deep_dup.deeper_merge(options || {}))
     # Fallback to the default 'serializable_hash' method, but always include our
     # custom 'class' attribute.
     # We can't put that in our DEFAULT_SERIALIZE_OPTIONS because the 'class'

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 class Competition < ApplicationRecord
@@ -379,6 +380,10 @@ class Competition < ApplicationRecord
     competitor_limit_enabled? && registrations.accepted_and_paid_pending_count >= competitor_limit
   end
 
+  def number_of_bookmarks
+    bookmarked_users.length
+  end
+
   def country
     Country.c_find(self.countryId)
   end
@@ -389,6 +394,16 @@ class Competition < ApplicationRecord
 
   def main_event_id=(event_id)
     super(event_id.blank? ? nil : event_id)
+  end
+
+  def events_with_rounds
+    includes_associations = [
+      { rounds: [:competition_event] },
+    ]
+    competition_events
+      .includes(includes_associations)
+      .sort_by { |ce| ce.event.rank }
+      .map(&:to_wcif)
   end
 
   # Enforce that the users marked as delegates for this competition are

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -380,7 +380,7 @@ class Competition < ApplicationRecord
   end
 
   def number_of_bookmarks
-    bookmarked_users.length
+    bookmarked_users.count
   end
 
   def country

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1915,7 +1915,7 @@ class Competition < ApplicationRecord
   }.freeze
 
   def serializable_hash(options = nil)
-    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {})) { |_, h1, h2| h1 + h2 }
+    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}) { |_, h1, h2| h1 + h2 })
     # Fallback to the default 'serializable_hash' method, but always include our
     # custom 'class' attribute.
     # We can't put that in our DEFAULT_SERIALIZE_OPTIONS because the 'class'

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -395,13 +395,6 @@ class Competition < ApplicationRecord
     super(event_id.blank? ? nil : event_id)
   end
 
-  def events_with_rounds
-    competition_events
-      .includes({ rounds: [:competition_event] })
-      .sort_by { |ce| ce.event.rank }
-      .map(&:to_wcif)
-  end
-
   # Enforce that the users marked as delegates for this competition are
   # actually delegates. Note: just because someone (legally) delegated a
   # competition in the past does not mean that they are still a delegate,

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1915,7 +1915,7 @@ class Competition < ApplicationRecord
   }.freeze
 
   def serializable_hash(options = nil)
-    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+    json = super(DEFAULT_SERIALIZE_OPTIONS.deep_merge(options || {}))
     # Fallback to the default 'serializable_hash' method, but always include our
     # custom 'class' attribute.
     # We can't put that in our DEFAULT_SERIALIZE_OPTIONS because the 'class'

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1915,7 +1915,7 @@ class Competition < ApplicationRecord
   }.freeze
 
   def serializable_hash(options = nil)
-    json = super(DEFAULT_SERIALIZE_OPTIONS.deep_merge(options || {}))
+    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {})) { |_, h1, h2| h1 + h2 }
     # Fallback to the default 'serializable_hash' method, but always include our
     # custom 'class' attribute.
     # We can't put that in our DEFAULT_SERIALIZE_OPTIONS because the 'class'

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 class Competition < ApplicationRecord


### PR DESCRIPTION
To Render the WCA-Registrations Frontend we need some more info as part of the competition API. I also added a `stale?` check because this route will be used much more heavily on the Frontend and we don't want to recompute it if not needed.

I chose to keep it under it's current route as this change is compatible with the current response, but I can add a new path if it makes more sense.