### PR TITLE
Remove Gen 2 Timer from Delegate Reports Template

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/_equipment_default.md
+++ b/WcaOnRails/app/views/delegate_reports/_equipment_default.md
@@ -1,4 +1,3 @@
-Gen 2 Timer: 0
 Gen 3 Pro Timer: 0
 Gen 4 Pro Timer: 0
 Gen 5 Pro Timer: 0


### PR DESCRIPTION
Gen 2 timers are no longer official timers.