### PR TITLE
Allow WRT to choose between replica and main database when generating Tokens

### DIFF
--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -367,9 +367,14 @@ class AdminController < ApplicationController
     role_credentials = Aws::InstanceProfileCredentials.new
     token_generator = Aws::RDS::AuthTokenGenerator.new credentials: role_credentials
 
-    @token = token_generator.auth_token({
+    @main_token = token_generator.auth_token({
                                           region: EnvConfig.DATABASE_AWS_REGION,
                                           endpoint: "#{EnvConfig.DATABASE_HOST}:3306",
+                                          user_name: EnvConfig.DATABASE_WRT_USER,
+                                        })
+    @replica_token = token_generator.auth_token({
+                                          region: EnvConfig.DATABASE_AWS_REGION,
+                                          endpoint: "#{EnvConfig.READ_REPLICA_HOST}:3306",
                                           user_name: EnvConfig.DATABASE_WRT_USER,
                                         })
   end

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -380,7 +380,7 @@ class AdminController < ApplicationController
                                  })
     end
 
-    @default_token = :main
+    @default_token = @db_tokens[:main]
   end
 
   def check_regional_records

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -380,7 +380,10 @@ class AdminController < ApplicationController
                                  })
     end
 
-    @default_token = @db_tokens[:main]
+    @db_server_indices = {
+      main: 1,
+      replica: 2,
+    }
   end
 
   def check_regional_records

--- a/WcaOnRails/app/controllers/admin_controller.rb
+++ b/WcaOnRails/app/controllers/admin_controller.rb
@@ -364,19 +364,23 @@ class AdminController < ApplicationController
   end
 
   def generate_db_token
+    @db_endpoints = {
+      main: EnvConfig.DATABASE_HOST,
+      replica: EnvConfig.READ_REPLICA_HOST,
+    }
+
     role_credentials = Aws::InstanceProfileCredentials.new
     token_generator = Aws::RDS::AuthTokenGenerator.new credentials: role_credentials
 
-    @main_token = token_generator.auth_token({
-                                          region: EnvConfig.DATABASE_AWS_REGION,
-                                          endpoint: "#{EnvConfig.DATABASE_HOST}:3306",
-                                          user_name: EnvConfig.DATABASE_WRT_USER,
-                                        })
-    @replica_token = token_generator.auth_token({
-                                          region: EnvConfig.DATABASE_AWS_REGION,
-                                          endpoint: "#{EnvConfig.READ_REPLICA_HOST}:3306",
-                                          user_name: EnvConfig.DATABASE_WRT_USER,
-                                        })
+    @db_tokens = @db_endpoints.transform_values do |url|
+      token_generator.auth_token({
+                                   region: EnvConfig.DATABASE_AWS_REGION,
+                                   endpoint: "#{url}:3306",
+                                   user_name: EnvConfig.DATABASE_WRT_USER,
+                                 })
+    end
+
+    @default_token = :main
   end
 
   def check_regional_records

--- a/WcaOnRails/app/views/admin/generate_db_token.html.erb
+++ b/WcaOnRails/app/views/admin/generate_db_token.html.erb
@@ -9,36 +9,46 @@
       This token is valid for 15 minutes
     </p>
 
-    <pre class="token" data-value="main">
-      <code><%= @main_token %></code>
-    </pre>
-    <pre class="token" data-value="replica" style="display: none">
-      <code><%= @replica_token %></code>
-    </pre>
+    <% @db_tokens.each do |key, token| %>
+      <% pre_selected = key == @default_token %>
+
+      <pre class="token" data-value="<%= key %>" data-wrt-selected="<%= pre_selected %>" style="display: <%= pre_selected ? 'block' : 'none' %>">
+        <code><%= token %></code>
+      </pre>
+    <% end %>
 
     <label for="dbs">Choose a database:</label>
 
     <select id="dbs">
-      <option value="main"><%= EnvConfig.DATABASE_HOST %></option>
-      <option value="replica"><%= EnvConfig.READ_REPLICA_HOST %></option>
+      <% @db_endpoints.each do |key, url| %>
+        <option value="<%= key %>"><%= url %></option>
+      <% end %>
     </select>
-    <br />
+
     <br />
 
-    <label class="btn btn-primary" onclick="navigator.clipboard.writeText('<%= @token %>');">
+    <label id="clipboard" class="btn btn-primary">
       Copy to clipboard
     </label>
 
     <script>
-      document.getElementById("dbs").addEventListener("change", handleDataBaseOptions)
-      function handleDataBaseOptions(event){
+      document.getElementById("dbs").addEventListener("change", handleDataBaseOptions);
+
+      function handleDataBaseOptions(event) {
         document.querySelectorAll('.token').forEach((el) => {
-          if(el.getAttribute('data-value') === event.target.value){
-            el.style.display = 'block'
-          }else{
-            el.style.display = 'none'
-          }
-        })
+          const isSelectedBox = el.getAttribute('data-value') === event.target.value;
+
+          el.style.display = isSelectedBox ? 'block' : 'none';
+        });
+      }
+
+      document.getElementById("clipboard").addEventListener("click", copySelectedToClipboard);
+
+      function copySelectedToClipboard() {
+        const tokenPre = document.querySelector('.token[data-wrt-selected="true"]');
+        const tokenContent = tokenPre.querySelector('code');
+
+        navigator.clipboard.writeText(tokenContent.textContent);
       }
     </script>
 

--- a/WcaOnRails/app/views/admin/generate_db_token.html.erb
+++ b/WcaOnRails/app/views/admin/generate_db_token.html.erb
@@ -9,19 +9,17 @@
       This token is valid for 15 minutes
     </p>
 
-    <% @db_tokens.each do |key, token| %>
-      <% pre_selected = key == @default_token %>
-
-      <pre class="token" data-value="<%= key %>" data-wrt-selected="<%= pre_selected %>" style="display: <%= pre_selected ? 'block' : 'none' %>">
-        <code><%= token %></code>
-      </pre>
-    <% end %>
+    <pre>
+      <code id="token-content"><%= @default_token %></code>
+    </pre>
 
     <label for="dbs">Choose a database:</label>
 
     <select id="dbs">
       <% @db_endpoints.each do |key, url| %>
-        <option value="<%= key %>"><%= url %></option>
+        <% db_token = @db_tokens[key] %>
+
+        <option value="<%= key %>" data-wrt-token="<%= db_token %>"><%= url %></option>
       <% end %>
     </select>
 
@@ -35,20 +33,18 @@
       document.getElementById("dbs").addEventListener("change", handleDataBaseOptions);
 
       function handleDataBaseOptions(event) {
-        document.querySelectorAll('.token').forEach((el) => {
-          const isSelectedBox = el.getAttribute('data-value') === event.target.value;
+        const selectedOption = event.target.options[event.target.selectedIndex];
+        const selectedToken = selectedOption.dataset.wrtToken;
 
-          el.style.display = isSelectedBox ? 'block' : 'none';
-        });
+        const tokenBox = document.getElementById('token-content');
+        tokenBox.innerText = selectedToken;
       }
 
       document.getElementById("clipboard").addEventListener("click", copySelectedToClipboard);
 
       function copySelectedToClipboard() {
-        const tokenPre = document.querySelector('.token[data-wrt-selected="true"]');
-        const tokenContent = tokenPre.querySelector('code');
-
-        navigator.clipboard.writeText(tokenContent.textContent);
+        const tokenBox = document.getElementById('token-content');
+        navigator.clipboard.writeText(tokenBox.textContent);
       }
     </script>
 

--- a/WcaOnRails/app/views/admin/generate_db_token.html.erb
+++ b/WcaOnRails/app/views/admin/generate_db_token.html.erb
@@ -13,15 +13,17 @@
       <code id="token-content"><%= @default_token %></code>
     </pre>
 
-    <label for="dbs">Choose a database:</label>
+    <div class="form-group">
+      <label class="control-label" for="dbs">Choose a database:</label>
 
-    <select id="dbs">
-      <% @db_endpoints.each do |key, url| %>
-        <% db_token = @db_tokens[key] %>
+      <select class="form-control" id="dbs" name="wrt-token">
+        <% @db_endpoints.each do |key, url| %>
+          <% db_token = @db_tokens[key] %>
 
-        <option value="<%= key %>" data-wrt-token="<%= db_token %>"><%= url %></option>
-      <% end %>
-    </select>
+          <option value="<%= key %>" data-wrt-token="<%= db_token %>"><%= url %></option>
+        <% end %>
+      </select>
+    </div>
 
     <br />
 

--- a/WcaOnRails/app/views/admin/generate_db_token.html.erb
+++ b/WcaOnRails/app/views/admin/generate_db_token.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <pre>
-      <code id="token-content"><%= @default_token %></code>
+      <code id="token-content"></code>
     </pre>
 
     <div class="form-group">
@@ -19,8 +19,9 @@
       <select class="form-control" id="dbs" name="wrt-token">
         <% @db_endpoints.each do |key, url| %>
           <% db_token = @db_tokens[key] %>
+          <% db_server_index = @db_server_indices[key] %>
 
-          <option value="<%= key %>" data-wrt-token="<%= db_token %>"><%= url %></option>
+          <option value="<%= key %>" data-wrt-token="<%= db_token %>" data-wrt-server-index="<%= db_server_index %>"><%= url %></option>
         <% end %>
       </select>
     </div>
@@ -31,15 +32,29 @@
       Copy to clipboard
     </label>
 
-    <script>
-      document.getElementById("dbs").addEventListener("change", handleDataBaseOptions);
+    <%= link_to t('layouts.navigation.results_database'), '/results/database/', id: 'db-link', class: 'btn btn-primary', target: '_blank' %>
 
-      function handleDataBaseOptions(event) {
-        const selectedOption = event.target.options[event.target.selectedIndex];
+    <script>
+      const databaseDropdown = document.getElementById("dbs");
+
+      databaseDropdown.addEventListener("change", function (event) {
+        updateDbTokenAndLink(event.target);
+      });
+
+      function updateDbTokenAndLink(selectEl) {
+        const selectedOption = selectEl.options[selectEl.selectedIndex];
         const selectedToken = selectedOption.dataset.wrtToken;
 
         const tokenBox = document.getElementById('token-content');
         tokenBox.innerText = selectedToken;
+
+        const dbLinkEl = document.getElementById('db-link');
+        const dbLinkUrl = new URL(dbLinkEl.href);
+
+        const uiServerIndex = selectedOption.dataset.wrtServerIndex;
+        dbLinkUrl.searchParams.set('server', uiServerIndex);
+
+        dbLinkEl.href = dbLinkUrl.toString();
       }
 
       document.getElementById("clipboard").addEventListener("click", copySelectedToClipboard);
@@ -48,8 +63,11 @@
         const tokenBox = document.getElementById('token-content');
         navigator.clipboard.writeText(tokenBox.textContent);
       }
-    </script>
 
-    <%= link_to t('layouts.navigation.results_database'), '/results/database/', class: 'btn btn-primary', target: '_blank' %>
+      document.addEventListener("DOMContentLoaded", function() {
+        // trigger refresh with default data upon page load
+        updateDbTokenAndLink(databaseDropdown);
+      });
+    </script>
   <% end %>
 </div>

--- a/WcaOnRails/app/views/admin/generate_db_token.html.erb
+++ b/WcaOnRails/app/views/admin/generate_db_token.html.erb
@@ -9,13 +9,38 @@
       This token is valid for 15 minutes
     </p>
 
-    <pre>
-      <code><%= @token %></code>
+    <pre class="token" data-value="main">
+      <code><%= @main_token %></code>
     </pre>
+    <pre class="token" data-value="replica" style="display: none">
+      <code><%= @replica_token %></code>
+    </pre>
+
+    <label for="dbs">Choose a database:</label>
+
+    <select id="dbs">
+      <option value="main"><%= EnvConfig.DATABASE_HOST %></option>
+      <option value="replica"><%= EnvConfig.READ_REPLICA_HOST %></option>
+    </select>
+    <br />
+    <br />
 
     <label class="btn btn-primary" onclick="navigator.clipboard.writeText('<%= @token %>');">
       Copy to clipboard
     </label>
+
+    <script>
+      document.getElementById("dbs").addEventListener("change", handleDataBaseOptions)
+      function handleDataBaseOptions(event){
+        document.querySelectorAll('.token').forEach((el) => {
+          if(el.getAttribute('data-value') === event.target.value){
+            el.style.display = 'block'
+          }else{
+            el.style.display = 'none'
+          }
+        })
+      }
+    </script>
 
     <%= link_to t('layouts.navigation.results_database'), '/results/database/', class: 'btn btn-primary', target: '_blank' %>
   <% end %>


### PR DESCRIPTION
I added a select to choose between the DBs and a simple vanilla JS function to update the display. 
React seemed to be a bit overkill for this, but some kind of document onready wrap for `document.getElementById("dbs").addEventListener("change", handleDataBaseOptions)` might be needed. 
I tested this locally on the browser, but it might act differently, so please test on staging first before deploying.