### PR TITLE
serialization: restore initial behavior

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -102,7 +102,6 @@ gem 'sprockets-rails'
 gem 'fuzzy-string-match'
 gem 'sidekiq'
 gem 'sidekiq-cron'
-gem 'deep_merge', require: 'deep_merge/rails_compat'
 
 group :development, :test do
   gem 'spring'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -238,7 +238,6 @@ GEM
     date (3.3.3)
     debug_inspector (1.0.0)
     declarative (0.0.20)
-    deep_merge (1.2.2)
     devise (4.9.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -776,7 +775,6 @@ DEPENDENCIES
   daemons
   database_cleaner
   datetimepicker-rails!
-  deep_merge
   devise
   devise-bootstrap-views
   devise-i18n

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -17,19 +17,22 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     paginate json: competitions
   end
 
-  COMPETITION_INFO_SERIALIZE_OPTIONS = {
-    only: %w[extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results
-             event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent
-             use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
-    methods: %w[registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff?],
-    include: %w[tabs],
-  }.freeze
-
   def show
     competition = competition_from_params
 
     if stale?(competition)
-      render json: competition.as_json(COMPETITION_INFO_SERIALIZE_OPTIONS)
+      options = {
+        only: %w[id name website start_date registration_open registration_close
+                 announced_at cancelled_at end_date competitor_limit
+                 extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results
+                 event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent
+                 use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
+        methods: %w[url website short_name city venue_address venue_details latitude_degrees
+                    longitude_degrees country_iso2 event_ids
+                    registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff?],
+        include: %w[delegates organizers tabs],
+      }
+      render json: competition.as_json(options)
     end
   end
 

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1915,10 +1915,12 @@ class Competition < ApplicationRecord
   }.freeze
 
   def serializable_hash(options = nil)
-    # This looks weird, but we need the 'deeper_merge' method to handle arrays inside hashes.
-    #   In turn, the 'deeper_merge' library has a quirk that even though it doesn't use the ! naming convention,
-    #   it tries to modify the source array in-place. This is not cool so we need to circumvent by duplicating.
-    json = super(DEFAULT_SERIALIZE_OPTIONS.deep_dup.deeper_merge(options || {}))
+    # The intent behind this is to have a "good" default setup for serialization.
+    # We also want the caller to be able to be picky about the attributes included
+    # in the json (eg: specify an empty 'methods' to remove these attributes,
+    # or set a custom array in 'only' without getting the default ones), therefore
+    # we only use 'merge' here, which doesn't "deeply" merge into the default options.
+    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
     # Fallback to the default 'serializable_hash' method, but always include our
     # custom 'class' attribute.
     # We can't put that in our DEFAULT_SERIALIZE_OPTIONS because the 'class'

--- a/WcaOnRails/spec/requests/admin_results_spec.rb
+++ b/WcaOnRails/spec/requests/admin_results_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin Results" do
+  describe "Posting Check In" do
+    let!(:competition) { FactoryBot.create :competition, :with_valid_submitted_results }
+    let!(:wrt_member) { FactoryBot.create :user, :wrt_member }
+
+    it "locks a competition and returns the correct attributes" do
+      sign_in wrt_member
+      post start_posting_path, params: {
+        'competition_ids' => [competition.id],
+      }
+      expect(response).to be_successful
+      response_json = JSON.parse(response.body)
+      expect(response_json["message"]).to eq "Competitions successfully locked, go on posting!"
+      get results_posting_dashboard_path(format: :json)
+      expect(response).to be_successful
+      competitions = JSON.parse(response.body)["competitions"]
+      expect(competitions.size).to eq 1
+      expect(competitions[0]["id"]).to eq competition.id
+      expect(competitions[0]["posting_user"]["id"]).to eq wrt_member.id
+    end
+  end
+end


### PR DESCRIPTION
This attempts to fix serialization for the results posting check-in, which was broken in #8409.

Gregor saw it coming:
> deep_merge(a, b) tries to recursively merge, but crucially only works for hashes. Merging arrays inside hashes upon colliding keys is not supported by default :(
>    Providing a block works because it "teaches" Rails how to merge arrays. But it may break when we ever pass nested hashes in the include part.
    The library dynamically determines what to do. Yay!

We do pass a hash in the include part [here](https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/app/controllers/admin/results_controller.rb#L24) ^^
It means that the `include` part is not merged at all and it broke the results check in (my bad for not testing the endpoint I think).

I read a bit through #8409 and the initial implementation of `serializable_hash` was correct: the behavior I intended in #7199, is *not* to do a deep merge, but to be able to simply override `only`, `methods`, and `include` to be *more selective* when creating hashes, and to be able to *not* include all the default options if you don't need them, which I believe is the purpose of `serializable_hash` options.

Some example of what I think the options should be used for:
  - be able to keep the default `only` field while passing an empty `methods` because we don't need them
  - be able to override the `only` field by letting the caller pick exactly the field they want

I think this behavior is necessary when it comes to generate smaller json-s for objects than the default one (for instance now the json for the result "check in" is relatively big compared to the data we actually need).

I think an appropriate fix is to make the api competition controller explicit about the field it expects, rather than implementing a deep merge which prevent being selective about attributes we want to include in the serialization.
Here I explicitly set the attributes so that it's clear from just reading the endpoint what attributes end up in the json, but it would also be possible to use `Competitions::DEFAULT_SERIALIZABLE_OPTIONS[:...]` if you feel it's more appropriate.
