### PR TITLE
Allow waiting list deadline during the competition

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1102,8 +1102,8 @@ class Competition < ApplicationRecord
       if refund_policy_limit_date? && waiting_list_deadline_date < refund_policy_limit_date
         errors.add(:waiting_list_deadline_date, I18n.t('competitions.errors.waiting_list_deadline_before_refund_date'))
       end
-      if waiting_list_deadline_date >= start_date
-        errors.add(:waiting_list_deadline_date, I18n.t('competitions.errors.waiting_list_deadline_after_start'))
+      if waiting_list_deadline_date > end_date
+        errors.add(:waiting_list_deadline_date, I18n.t('competitions.errors.waiting_list_deadline_after_end'))
       end
     end
   end

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1631,7 +1631,7 @@ en:
       registration_period_after_start: "Registration period cannot be after start date."
       waiting_list_deadline_before_registration_close: "Wailting list deadline cannot be before registration close date."
       waiting_list_deadline_before_refund_date: "Waiting list deadline cannot be before limit date for refunds."
-      waiting_list_deadline_after_start: "Waiting list deadline must be before start date."
+      waiting_list_deadline_after_end: "Waiting list deadline must be before the competition ends."
       event_change_deadline_before_registration_close: "Deadline for updating events cannot be before registration close date."
       event_change_deadline_after_end_date: "Deadline for updating events cannot be after the competition."
       event_change_deadline_with_ots: "Deadline for updating events must be during the competition if on the spot registrations are accepted."

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -333,7 +333,19 @@ RSpec.describe Competition do
     )
   end
 
-  it "requires the waiting list deadline to be before the competition start" do
+  it "allows the waiting list deadline to be during the competition" do
+    competition = FactoryBot.build :competition,
+                                   name: "Foo Test 2015",
+                                   starts: 1.month.from_now,
+                                   ends: 1.month.from_now + 1.day,
+                                   registration_open: 1.month.ago,
+                                   registration_close: 1.week.from_now,
+                                   use_wca_registration: true,
+                                   waiting_list_deadline_date: 1.months.from_now
+    expect(competition).to be_valid
+  end
+
+  it "requires the waiting list deadline to be before the competition ends" do
     competition = FactoryBot.build :competition,
                                    name: "Foo Test 2015",
                                    starts: 1.month.from_now,
@@ -343,7 +355,7 @@ RSpec.describe Competition do
                                    use_wca_registration: true,
                                    waiting_list_deadline_date: 2.months.from_now
     expect(competition).to be_invalid_with_errors(
-      waiting_list_deadline_date: [I18n.t('competitions.errors.waiting_list_deadline_after_start')],
+      waiting_list_deadline_date: [I18n.t('competitions.errors.waiting_list_deadline_after_end')],
     )
   end
 


### PR DESCRIPTION
Based on previous WCAT decisions to allow this, and based on Wilson's input on Sorg'Open 2023 report, it's pretty clear that being unable to set the WL deadline during the competition is a software restriction, and not something forbidden by the WCRP.

This PR:
  - fixes the competition's validation to enable setting the deadline during the competition
  - fixes the test to check it cannot be set *after* the competition
  - fixes the test to check it *can* be set during the competition

Of course someone from WCAT should come here/contact WST to confirm I'm not making things up and that they are fine with these changes :)