### PR TITLE
Update wca-states.json

### DIFF
--- a/WcaOnRails/config/wca-states.json
+++ b/WcaOnRails/config/wca-states.json
@@ -295,6 +295,14 @@
         },
         {
           "info": "",
+          "name": "Chinese Taipei",
+          "continent_id": "_Asia",
+          "class": "state",
+          "iso2": "TW",
+          "id": "Taiwan"
+        },
+        {
+          "info": "",
           "name": "Colombia",
           "continent_id": "_South America",
           "class": "state",
@@ -1391,14 +1399,6 @@
         },
         {
           "info": "",
-          "name": "Chinese Taipei",
-          "continent_id": "_Asia",
-          "class": "state",
-          "iso2": "TW",
-          "id": "Taiwan"
-        },
-        {
-          "info": "",
           "name": "Tajikistan",
           "continent_id": "_Asia",
           "class": "state",
@@ -1601,6 +1601,6 @@
       "title": ""
     }
   ],
-  "version": "Version: March 06, 2020",
+  "version": "Version: January 1, 2024",
   "version_hash": "cd0e6f0"
 }


### PR DESCRIPTION
Bump version and move Chinese Taipei up in order to preserve the alphabetical order [here](https://www.worldcubeassociation.org/regulations/countries/) (as reported by Felipe Rojas). I am assuming that the file does not need to be ordered by ID, which may be incorrect.

The version_hash field must be changed before merging, but I guess we need to merge the relevant PR in the wca-regulations repository first.