### PR TITLE
Hotfix for fixing translation issue in roles tab

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/roles_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/roles_controller.rb
@@ -33,6 +33,7 @@ class Api::V0::RolesController < Api::V0::ApiController
         group: {
           id: team.id,
           name: team.name,
+          group_type: UserGroup.group_types[:teams],
           is_hidden: team.hidden,
         },
         status: status,

--- a/WcaOnRails/app/models/user_group.rb
+++ b/WcaOnRails/app/models/user_group.rb
@@ -4,6 +4,7 @@ class UserGroup < ApplicationRecord
   enum :group_type, {
     delegate_probation: "delegate_probation",
     delegate_regions: "delegate_regions",
+    teams: "teams",
   }
 
   def self.regions

--- a/WcaOnRails/app/webpacker/components/RolesTab/index.jsx
+++ b/WcaOnRails/app/webpacker/components/RolesTab/index.jsx
@@ -85,12 +85,12 @@ export default function RolesTab({ userId, loggedInUserId }) {
                   <List.Content>
                     {canEditTeamOfRole(role) && (
                       <List.Header as="a" href={`${teamUrl(role.group.id)}/edit`}>
-                        {`${I18n.t(`enums.user.role_status.teams.${role.status}`)}, ${role.group.name}`}
+                        {`${I18n.t(`enums.user.role_status.${role.group.group_type}.${role.status}`)}, ${role.group.name}`}
                       </List.Header>
                     )}
                     {!canEditTeamOfRole(role) && (
                       <List.Header>
-                        {`${I18n.t(`enums.user.role_status.delegate_regions.${role.status}`)}, ${role.group.name}`}
+                        {`${I18n.t(`enums.user.role_status.${role.group.group_type}.${role.status}`)}, ${role.group.name}`}
                       </List.Header>
                     )}
                     {!!role.start_date && (


### PR DESCRIPTION
I accidentally messed up the usage of i18n key. In a place, I assumed only delegate status will come, but other status can also come. This PR fixes it.