### PR TITLE
Skip average computation for 333fm if needed

### DIFF
--- a/WcaOnRails/app/webpacker/lib/wca-live/attempts.js
+++ b/WcaOnRails/app/webpacker/lib/wca-live/attempts.js
@@ -77,13 +77,14 @@ export function average(attemptResults, eventId) {
   if (eventId === '333fm') {
     const scaled = attemptResults.map((attemptResult) => attemptResult * 100);
     switch (attemptResults.length) {
+      case 1:
+      case 2:
+        return SKIPPED_VALUE;
       case 3:
         return meanOf3(scaled);
-      case 5:
-        return averageOf5(scaled);
       default:
         throw new Error(
-          `Invalid number of attempt results, expected 3 or 5, given ${attemptResults.length}.`,
+          `Invalid number of attempt results, expected 1, 2, or 3, given ${attemptResults.length}.`,
         );
     }
   }


### PR DESCRIPTION
This prevents us (the WRT) from editing results for bo1/bo2 FM rounds; the code on WCA Live is still the same and I'm unsure how it even works (maybe it pads up to 3 results and therefore it's skipped?).