### PR TITLE
Removal of senior_delegate_id from users table

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/roles_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/roles_controller.rb
@@ -88,6 +88,16 @@ class Api::V0::RolesController < Api::V0::ApiController
     roles
   end
 
+  # Removes all pending WCA ID claims for the demoted Delegate and notifies the users.
+  private def remove_pending_wca_id_claims(user)
+    region_senior_delegate = user.region.senior_delegate
+    user.confirmed_users_claiming_wca_id.each do |confirmed_user|
+      WcaIdClaimMailer.notify_user_of_delegate_demotion(confirmed_user, user, region_senior_delegate).deliver_later
+    end
+    # Clear all pending WCA IDs claims for the demoted Delegate
+    User.where(delegate_to_handle_wca_id_claim: user.id).update_all(delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil)
+  end
+
   # Returns a list of roles primarily based on userId.
   def index_for_user
     user_id = params.require(:user_id)
@@ -168,13 +178,7 @@ class Api::V0::RolesController < Api::V0::ApiController
     location = params.require(:location)
 
     user = User.find(user_id)
-    if delegate_status == "senior_delegate"
-      senior_delegate_id = nil
-      User.where(region_id: region_id).where.not(id: user_id).update_all(senior_delegate_id: user_id)
-    else
-      senior_delegate_id = User.where(delegate_status: "senior_delegate", region_id: region_id).first.id
-    end
-    user.update!(delegate_status: delegate_status, senior_delegate_id: senior_delegate_id, region_id: region_id, location: location)
+    user.update!(delegate_status: delegate_status, region_id: region_id, location: location)
     send_role_change_notification(user)
 
     render json: {
@@ -186,7 +190,8 @@ class Api::V0::RolesController < Api::V0::ApiController
     user_id = params.require(:userId)
 
     user = User.find(user_id)
-    user.update!(delegate_status: '', senior_delegate_id: '', region_id: '', location: '')
+    remove_pending_wca_id_claims(user)
+    user.update!(delegate_status: '', region_id: '', location: '')
     send_role_change_notification(user)
 
     render json: {
@@ -197,14 +202,15 @@ class Api::V0::RolesController < Api::V0::ApiController
   private def send_role_change_notification(user)
     if user.saved_change_to_delegate_status
       if user.delegate_status
-        user_senior_delegate = user.senior_or_self
+        region_id = user.region_id
       else
-        user_senior_delegate = User.find(user.senior_delegate_id_before_last_save)
+        region_id = user.region_id_before_last_save
       end
+      region_senior_delegate = UserGroup.find_by(id: region_id).senior_delegate
       DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(
         user,
         current_user,
-        user_senior_delegate,
+        region_senior_delegate,
         user.delegate_status_before_last_save,
         user.delegate_status,
       ).deliver_later

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -627,7 +627,8 @@ class CompetitionsController < ApplicationController
   end
 
   def for_senior
-    @user = User.includes(subordinate_delegates: { delegated_competitions: [:delegates, :delegate_report] }).find_by_id(params[:user_id] || current_user.id)
+    user_id = params[:user_id] || current_user.id
+    @user = User.find(user_id)
     @competitions = @user.subordinate_delegates.map(&:delegated_competitions).flatten.uniq.reject(&:is_probably_over?).sort_by { |c| c.start_date || (Date.today + 20.year) }.reverse
   end
 

--- a/WcaOnRails/app/controllers/panel_controller.rb
+++ b/WcaOnRails/app/controllers/panel_controller.rb
@@ -14,7 +14,8 @@ class PanelController < ApplicationController
 
   def pending_claims_for_subordinate_delegates
     # Show pending claims for a given user, or the current user, if they can see them
-    @user = User.includes(subordinate_delegates: [:confirmed_users_claiming_wca_id]).find_by_id!(params[:user_id] || current_user.id)
+    user_id = params[:user_id] || current_user.id
+    @user = User.find(user_id)
     @subordinate_delegates = @user.subordinate_delegates.to_a.push(@user)
   end
 

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -282,7 +282,7 @@ class UsersController < ApplicationController
   private def user_params
     params.require(:user).permit(current_user.editable_fields_of_user(user_to_edit).to_a).tap do |user_params|
       if user_params.key?(:delegate_status) && !User.delegate_status_requires_senior_delegate(user_params[:delegate_status])
-        user_params["senior_delegate_id"] = nil
+        user_params["region_id"] = nil
       end
       if user_params.key?(:wca_id)
         user_params[:wca_id] = user_params[:wca_id].upcase

--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -132,8 +132,6 @@ class User < ApplicationRecord
     delegate: "delegate",
     senior_delegate: "senior_delegate",
   }
-  has_many :subordinate_delegates, class_name: "User", foreign_key: "senior_delegate_id", inverse_of: :senior_delegate
-  belongs_to :senior_delegate, -> { where(delegate_status: "senior_delegate").order(:name) }, class_name: "User", optional: true, inverse_of: :subordinate_delegates
 
   validate :wca_id_is_unique_or_for_dummy_account
   def wca_id_is_unique_or_for_dummy_account
@@ -172,13 +170,6 @@ class User < ApplicationRecord
       errors.add(:dob, I18n.t('users.errors.dob_past'))
     elsif dob && dob >= 2.years.ago
       errors.add(:dob, I18n.t('users.errors.dob_recent'))
-    end
-  end
-
-  validate :cannot_demote_senior_delegate_with_subordinate_delegates
-  def cannot_demote_senior_delegate_with_subordinate_delegates
-    if delegate_status_was == "senior_delegate" && delegate_status != "senior_delegate" && !subordinate_delegates.empty?
-      errors.add(:delegate_status, I18n.t('users.errors.senior_has_delegate'))
     end
   end
 
@@ -428,9 +419,8 @@ class User < ApplicationRecord
     end
   end
 
-  # This is a copy of def self.delegate_status_requires_senior_delegate(delegate_status) in the user model
-  # https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/app/assets/javascripts/users.js#L3-L11
-  # It is necessary to fix both files for changes to work
+  validates :region_id, presence: true, if: -> { delegate_status.present? }
+
   def self.delegate_status_requires_senior_delegate(delegate_status)
     {
       nil => false,
@@ -446,18 +436,6 @@ class User < ApplicationRecord
   def avatar_requires_wca_id
     if (!avatar.blank? || !pending_avatar.blank?) && wca_id.blank?
       errors.add(:avatar, I18n.t('users.errors.avatar_requires_wca_id'))
-    end
-  end
-
-  after_save :remove_pending_wca_id_claims
-  private def remove_pending_wca_id_claims
-    if saved_change_to_delegate_status? && !delegate_status
-      confirmed_users_claiming_wca_id.each do |user|
-        senior_delegate = User.find_by_id(senior_delegate_id_before_last_save)
-        WcaIdClaimMailer.notify_user_of_delegate_demotion(user, self, senior_delegate).deliver_later
-      end
-      # Clear all pending WCA IDs claims for the demoted Delegate
-      User.where(delegate_to_handle_wca_id_claim: self.id).update_all(delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil)
     end
   end
 
@@ -951,7 +929,7 @@ class User < ApplicationRecord
     fields += editable_avatar_fields(user)
     # Delegate Status Fields
     if admin? || board_member? || senior_delegate?
-      fields += %i(delegate_status senior_delegate_id location)
+      fields += %i(delegate_status region_id location)
     end
     fields
   end
@@ -1129,7 +1107,7 @@ class User < ApplicationRecord
     default_options = DEFAULT_SERIALIZE_OPTIONS.deep_dup
     # Delegates's emails and regions are public information.
     if any_kind_of_delegate?
-      default_options[:methods].push("email", "location", "senior_delegate_id")
+      default_options[:methods].push("email", "location", "region_id")
     end
 
     options = default_options.merge(options || {})
@@ -1277,11 +1255,6 @@ class User < ApplicationRecord
         .map(&:competition)
   end
 
-  def senior_or_self
-    return nil unless self.delegate_status.present?
-    self.delegate_status == "senior_delegate" ? self : self.senior_delegate
-  end
-
   def is_delegate_in_probation
     Role.where(user_id: self.id).where("end_date is null or end_date >= curdate()").present?
   end
@@ -1349,5 +1322,9 @@ class User < ApplicationRecord
 
   def can_access_panel?
     can_access_wfc_panel? || can_access_board_panel?
+  end
+
+  def subordinate_delegates
+    senior_delegate? ? User.where(region_id: self.region_id).where.not(id: self.id) : []
   end
 end

--- a/WcaOnRails/app/models/user_group.rb
+++ b/WcaOnRails/app/models/user_group.rb
@@ -13,6 +13,10 @@ class UserGroup < ApplicationRecord
     UserGroup.where(group_type: "delegate_regions", parent_group_id: nil)
   end
 
+  def senior_delegate
+    User.find_by(region_id: self.id, delegate_status: "senior_delegate")
+  end
+
   def roles
     if self.group_type == "delegate_regions"
       User.where(region_id: self.id).where.not(delegate_status: nil).map do |delegate_user|

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1107,7 +1107,6 @@ en:
       already_represented_country: "Cannot change the region to a region the person has already represented in the past."
       must_have_a_change: "The name or the region must be different to update the person."
       must_be_senior: "must be a Senior Delegate"
-      senior_has_delegate: "cannot demote Senior Delegate with subordinate Delegates"
       already_have_id: "cannot claim a WCA ID because you already have WCA ID %{wca_id}"
       wca_id_no_birthdate_html: "We do not have a birthdate recorded for this WCA ID. Please contact the WCA Results Team using <a href=\"%{dob_form_path}\">this dedicated form</a>."
       wca_id_no_gender_html: "We do not have a gender recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."

--- a/WcaOnRails/db/migrate/20231124161841_drop_senior_delegate_id.rb
+++ b/WcaOnRails/db/migrate/20231124161841_drop_senior_delegate_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DropSeniorDelegateId < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :senior_delegate_id
+  end
+end

--- a/WcaOnRails/db/schema.rb
+++ b/WcaOnRails/db/schema.rb
@@ -1098,7 +1098,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_02_155158) do
     t.string "name", limit: 255
     t.string "delegate_status", limit: 255
     t.bigint "region_id"
-    t.integer "senior_delegate_id"
     t.string "location", limit: 255
     t.string "wca_id"
     t.string "avatar", limit: 255
@@ -1133,7 +1132,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_02_155158) do
     t.index ["region_id", "delegate_status"], name: "index_users_on_region_id_and_delegate_status"
     t.index ["region_id"], name: "index_users_on_region_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["senior_delegate_id"], name: "index_users_on_senior_delegate_id"
     t.index ["wca_id"], name: "index_users_on_wca_id", unique: true
   end
 

--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -699,7 +699,7 @@ module DatabaseDumper
           saved_pending_avatar_crop_w
           saved_pending_avatar_crop_x
           saved_pending_avatar_crop_y
-          senior_delegate_id unconfirmed_wca_id
+          unconfirmed_wca_id
           region_id
           updated_at
           wca_id

--- a/WcaOnRails/spec/controllers/api_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_controller_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
   describe 'GET #delegates' do
     it 'includes emails and regions' do
       senior_delegate = FactoryBot.create :senior_delegate
-      delegate = FactoryBot.create :delegate, location: "SF bay area, USA", senior_delegate: senior_delegate
+      delegate = FactoryBot.create :delegate, location: "SF bay area, USA", region_id: senior_delegate.region_id
 
       get :delegates
       expect(response.status).to eq 200
@@ -185,7 +185,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
       delegate_json = json.find { |user| user["id"] == delegate.id }
       expect(delegate_json["email"]).to eq delegate.email
       expect(delegate_json["location"]).to eq "SF bay area, USA"
-      expect(delegate_json["senior_delegate_id"]).to eq senior_delegate.id
+      expect(delegate_json["region_id"]).to eq senior_delegate.region_id
     end
   end
 

--- a/WcaOnRails/spec/controllers/api_users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_users_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Api::V0::UsersController do
     end
 
     it 'correctly returns delegate to be able to create competitions' do
-      sign_in FactoryBot.create :user, :delegate, senior_delegate: senior_delegate
+      sign_in FactoryBot.create :user, :delegate, region_id: senior_delegate.region_id
       get :permissions
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
@@ -168,7 +168,7 @@ RSpec.describe Api::V0::UsersController do
       expect(json["can_administer_competitions"]["scope"]).to eq "*"
     end
 
-    let!(:delegate_user) { FactoryBot.create :delegate, senior_delegate: senior_delegate }
+    let!(:delegate_user) { FactoryBot.create :delegate, region_id: senior_delegate.region_id }
     let!(:organizer_user) { FactoryBot.create :user }
     let!(:competition) {
       FactoryBot.create(:competition, :confirmed, delegates: [delegate_user], organizers: [organizer_user])

--- a/WcaOnRails/spec/features/eligible_voters_spec.rb
+++ b/WcaOnRails/spec/features/eligible_voters_spec.rb
@@ -20,9 +20,9 @@ RSpec.feature "Eligible voters csv" do
   let!(:team_senior_member) { FactoryBot.create(:user, :wrc_member, team_senior_member: true) }
   let!(:team_member) { FactoryBot.create(:user, :wrc_member) }
   let!(:senior_delegate) { FactoryBot.create(:senior_delegate) }
-  let!(:candidate_delegate) { FactoryBot.create(:candidate_delegate, senior_delegate: senior_delegate) }
-  let!(:delegate) { FactoryBot.create(:delegate, senior_delegate: senior_delegate) }
-  let!(:delegate_who_is_also_team_leader) { FactoryBot.create(:delegate, :wrc_member, team_leader: true, senior_delegate: senior_delegate) }
+  let!(:candidate_delegate) { FactoryBot.create(:candidate_delegate, region_id: senior_delegate.region_id) }
+  let!(:delegate) { FactoryBot.create(:delegate, region_id: senior_delegate.region_id) }
+  let!(:delegate_who_is_also_team_leader) { FactoryBot.create(:delegate, :wrc_member, team_leader: true, region_id: senior_delegate.region_id) }
   let!(:board_member) { FactoryBot.create(:user, :board_member) }
   let!(:officer) { FactoryBot.create(:user, :secretary) }
 

--- a/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/competitions_mailer_spec.rb
@@ -193,8 +193,8 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
   describe "notify_of_delegate_report_submission" do
     let(:senior) { FactoryBot.create(:senior_delegate) }
-    let(:delegate) { FactoryBot.create(:delegate, senior_delegate_id: senior.id) }
-    let(:trainee_delegate) { FactoryBot.create(:trainee_delegate, senior_delegate_id: senior.id) }
+    let(:delegate) { FactoryBot.create(:delegate, region_id: senior.region_id) }
+    let(:trainee_delegate) { FactoryBot.create(:trainee_delegate, region_id: senior.region_id) }
     let(:competition) do
       competition = FactoryBot.create(:competition, :with_delegate_report,
                                       countryId: "Australia",

--- a/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
+++ b/WcaOnRails/spec/mailers/delegate_status_change_mailer_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
   describe "notify_board_and_assistants_of_delegate_status_change" do
     let(:senior_delegate1) { FactoryBot.create :senior_delegate, name: "Eddard Stark" }
     let(:senior_delegate2) { FactoryBot.create :senior_delegate, name: "Catelyn Stark" }
-    let(:delegate) { FactoryBot.create :delegate, name: "Daenerys Targaryen", delegate_status: "candidate_delegate", senior_delegate: senior_delegate1 }
+    let(:delegate) { FactoryBot.create :delegate, name: "Daenerys Targaryen", delegate_status: "candidate_delegate", region_id: senior_delegate1.region_id }
     let(:user) { FactoryBot.create :user, name: "Jon Snow" }
 
     it "email headers are correct" do
-      user.update!(delegate_status: "candidate_delegate", senior_delegate: senior_delegate1)
+      user.update!(delegate_status: "candidate_delegate", region_id: senior_delegate1.region_id)
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(user, senior_delegate1, senior_delegate1, nil, "candidate_delegate")
 
       expect(mail.subject).to eq("Eddard Stark just changed the Delegate status of Jon Snow")
@@ -21,7 +21,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
     end
 
     it "promoting a registered speedcuber to a delegate" do
-      user.update!(delegate_status: "candidate_delegate", senior_delegate: senior_delegate1)
+      user.update!(delegate_status: "candidate_delegate", region_id: senior_delegate1.region_id)
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(user, senior_delegate1, senior_delegate1, nil, "candidate_delegate")
 
       expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Jon Snow from Registered Speedcuber to Junior Delegate.")
@@ -39,7 +39,7 @@ RSpec.describe DelegateStatusChangeMailer, type: :mailer do
     end
 
     it "demoting a Junior delegate to a registered speedcuber" do
-      delegate.update!(delegate_status: nil, senior_delegate: nil)
+      delegate.update!(delegate_status: nil, region_id: nil)
       mail = DelegateStatusChangeMailer.notify_board_and_assistants_of_delegate_status_change(delegate, senior_delegate1, senior_delegate1, "candidate_delegate", nil)
 
       expect(mail.body.encoded).to match("Eddard Stark has changed the Delegate status of Daenerys Targaryen from Junior Delegate to Registered Speedcuber.")

--- a/WcaOnRails/spec/models/competition_spec.rb
+++ b/WcaOnRails/spec/models/competition_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Competition do
 
     it "delegates for past comps no longer need to be delegates" do
       competition = FactoryBot.build :competition, :with_delegate, :past
-      competition.delegates.first.update_columns(delegate_status: nil, senior_delegate_id: nil)
+      competition.delegates.first.update_columns(delegate_status: nil, region_id: nil)
 
       expect(competition).to be_valid
     end

--- a/WcaOnRails/spec/models/reassign_wca_id_spec.rb
+++ b/WcaOnRails/spec/models/reassign_wca_id_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ReassignWcaId do
-  let(:account1) { FactoryBot.create(:user_with_wca_id, :senior_delegate, country_iso2: "US") }
+  let(:region) { FactoryBot.create(:africa_region) }
+  let(:account1) { FactoryBot.create(:user_with_wca_id, :senior_delegate, region_id: region.id, country_iso2: "US") }
   let(:shared_attributes) { account1.attributes.symbolize_keys.slice(:name, :country_iso2, :gender, :dob) }
   let(:account2) { FactoryBot.create(:user, shared_attributes) }
   let(:reassign_wca_id) { ReassignWcaId.new(account1: account1, account2: account2) }
@@ -51,8 +52,10 @@ RSpec.describe ReassignWcaId do
 
   it "can actually reassign wca id" do
     team_member = FactoryBot.create(:team_member, user_id: account1.id)
-    organized_competition = FactoryBot.create(:competition, organizers: [account1])
-    delegated_competition = FactoryBot.create(:competition, delegates: [account1])
+    delegated_competition = FactoryBot.create(:competition)
+    delegated_competition.delegates << account1
+    organized_competition = FactoryBot.create(:competition)
+    organized_competition.organizers << account1
     posted_competition = FactoryBot.create(:competition, :past, announced_by: account1.id, results_posted_by: account1.id)
 
     wca_id = account1.wca_id

--- a/WcaOnRails/spec/models/user_spec.rb
+++ b/WcaOnRails/spec/models/user_spec.rb
@@ -65,24 +65,31 @@ RSpec.describe User, type: :model do
     user.confirm
   end
 
-  it "doesn't allow demotion of a senior delegate with subordinate delegates" do
-    delegate = FactoryBot.create :delegate
-    senior_delegate = FactoryBot.create :senior_delegate
-
-    delegate.senior_delegate = senior_delegate
-    delegate.save!
-
-    senior_delegate.delegate_status = ""
-    expect(senior_delegate.save).to eq false
-    expect(senior_delegate.errors.messages[:delegate_status]).to eq ["cannot demote Senior Delegate with subordinate Delegates"]
-  end
-
   it "allows demotion of a senior delegate with no subordinate delegates" do
     senior_delegate = FactoryBot.create :senior_delegate
 
     senior_delegate.delegate_status = ""
+    senior_delegate.region_id = nil
     expect(senior_delegate.save).to eq true
     expect(senior_delegate.reload.delegate_status).to eq nil
+  end
+
+  it "requires senior delegate be a senior delegate" do
+    delegate = FactoryBot.create :delegate
+    region_id = delegate.region_id
+    user = FactoryBot.create :user
+
+    delegate.region_id = user.region_id
+    expect(delegate).to be_invalid_with_errors(region_id: ["can't be blank"])
+
+    delegate.region_id = region_id
+    user.update(delegate_status: "delegate", region_id: region_id)
+    expect(delegate).to be_valid
+  end
+
+  it "requires senior delegate if delegate status allows it" do
+    delegate = FactoryBot.build :delegate, region_id: nil
+    expect(delegate).to be_invalid_with_errors(region_id: ["can't be blank"])
   end
 
   it "doesn't delete a real account when a dummy account's WCA ID is cleared" do
@@ -104,11 +111,10 @@ RSpec.describe User, type: :model do
   it "allows senior delegate if board member" do
     board_member = FactoryBot.create :delegate, :board_member
 
-    senior_delegate = FactoryBot.create :user
-    senior_delegate.senior_delegate!
+    senior_delegate = FactoryBot.create :senior_delegate
 
     expect(board_member).to be_valid
-    board_member.senior_delegate = senior_delegate
+    board_member.region_id = senior_delegate.region_id
     expect(board_member).to be_valid
   end
 
@@ -355,7 +361,7 @@ RSpec.describe User, type: :model do
   describe "unconfirmed_wca_id" do
     let!(:person) { FactoryBot.create :person, dob: '1990-01-02' }
     let!(:senior_delegate) { FactoryBot.create :senior_delegate }
-    let!(:delegate) { FactoryBot.create :delegate, senior_delegate: senior_delegate }
+    let!(:delegate) { FactoryBot.create :delegate, region_id: senior_delegate.region_id }
     let!(:user) do
       FactoryBot.create(:user, unconfirmed_wca_id: person.wca_id,
                                delegate_id_to_handle_wca_id_claim: delegate.id,
@@ -477,27 +483,6 @@ RSpec.describe User, type: :model do
       user_with_wca_id.unconfirmed_wca_id = person.wca_id
       user_with_wca_id.delegate_id_to_handle_wca_id_claim = delegate.id
       expect(user_with_wca_id).to be_invalid_with_errors(unconfirmed_wca_id: ["cannot claim a WCA ID because you already have WCA ID #{user_with_wca_id.wca_id}"])
-    end
-
-    context "when the delegate to handle WCA ID claim is demoted" do
-      it "sets delegate_id_to_handle_wca_id_claim and unconfirmed_wca_id to nil" do
-        delegate.update!(delegate_status: nil, senior_delegate_id: nil)
-        user.reload
-        expect(user.delegate_id_to_handle_wca_id_claim).to eq nil
-        expect(user.unconfirmed_wca_id).to eq nil
-      end
-
-      it "notifies the user via email" do
-        unconfirmed_user = FactoryBot.create(:user,
-                                             confirmed: false,
-                                             unconfirmed_wca_id: person.wca_id,
-                                             delegate_id_to_handle_wca_id_claim: delegate.id,
-                                             claiming_wca_id: true,
-                                             dob_verification: "1990-01-2")
-        expect(WcaIdClaimMailer).to receive(:notify_user_of_delegate_demotion).with(user, delegate, senior_delegate).and_call_original
-        expect(WcaIdClaimMailer).not_to receive(:notify_user_of_delegate_demotion).with(unconfirmed_user, delegate, senior_delegate).and_call_original
-        delegate.update!(delegate_status: nil, senior_delegate_id: nil)
-      end
     end
 
     it "when empty, is set to nil" do
@@ -635,7 +620,7 @@ RSpec.describe User, type: :model do
       user = FactoryBot.create :user
       senior_delegate = FactoryBot.create :senior_delegate
       expect(senior_delegate.can_edit_user?(user)).to eq true
-      expect(senior_delegate.editable_fields_of_user(user).to_a).to include(:delegate_status, :senior_delegate_id, :location)
+      expect(senior_delegate.editable_fields_of_user(user).to_a).to include(:delegate_status, :region_id, :location)
     end
 
     it "disallows delegates to edit WCA IDs of special accounts" do
@@ -660,7 +645,7 @@ RSpec.describe User, type: :model do
     end
 
     it "returns true for users that are delegates" do
-      senior_delegate = FactoryBot.create :user, :senior_delegate
+      senior_delegate = FactoryBot.create :senior_delegate
       expect(senior_delegate.is_special_account?).to eq true
     end
 


### PR DESCRIPTION
I've removed many cases because that won't be needed once we migrate to roles completely.