### PR TITLE
Fixes #8487 Added logged-in email ID to request information

### DIFF
--- a/WcaOnRails/app/controllers/contacts_controller.rb
+++ b/WcaOnRails/app/controllers/contacts_controller.rb
@@ -8,7 +8,9 @@ class ContactsController < ApplicationController
   end
 
   def website_create
-    @contact = WebsiteContact.new(params[:website_contact])
+    website_contact_params = params[:website_contact]
+    website_contact_params[:logged_in_email] = current_user&.email || 'None'
+    @contact = WebsiteContact.new(website_contact_params)
     @contact.request = request
     maybe_send_email success_url: contact_website_url, fail_view: :website
   end

--- a/WcaOnRails/app/models/website_contact.rb
+++ b/WcaOnRails/app/models/website_contact.rb
@@ -8,6 +8,7 @@ class WebsiteContact < ContactForm
 
   attr_accessor :inquiry
   attr_accessor :competition_id
+  attr_accessor :logged_in_email
 
   # Override the `to_mail` validation, to show errors for `inquiry` instead.
   def validate_to_email

--- a/WcaOnRails/app/views/mail_form/contact.erb
+++ b/WcaOnRails/app/views/mail_form/contact.erb
@@ -32,5 +32,6 @@
     <p><b><%= I18n.t attribute, :scope => [ :mail_form, :request ], :default => attribute.to_s.humanize %>:</b>
     <%= value.include?("\n") ? simple_format(value) : value %></p>
   <% end %>
+  <p><b>Logged-In Email:</b> <%= @resource.logged_in_email %></p>
   <br />
 <% end %>


### PR DESCRIPTION
This is not a good/complete fix, but still works for time being.

The ideal behavior would have been to also hide the name & email ID if some validation fails (like failing of recaptcha). But that is not working. Didn't investigate deep though because this will anyway fix our problem and in future we can consider while migrating to React.

Attached the screenshot from mailcatcher.

<img width="1075" alt="Screenshot 2023-12-01 at 12 04 43" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/eddddef8-602a-43bc-8e9a-345084be3aeb">
