### PR TITLE
Speed up senior_delegate computation during transition to user_groups

### DIFF
--- a/WcaOnRails/db/migrate/20231202155158_add_senior_delegate_region_index.rb
+++ b/WcaOnRails/db/migrate/20231202155158_add_senior_delegate_region_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSeniorDelegateRegionIndex < ActiveRecord::Migration[7.1]
   def change
     add_index :users, [:region_id, :delegate_status]

--- a/WcaOnRails/db/migrate/20231202155158_add_senior_delegate_region_index.rb
+++ b/WcaOnRails/db/migrate/20231202155158_add_senior_delegate_region_index.rb
@@ -1,0 +1,5 @@
+class AddSeniorDelegateRegionIndex < ActiveRecord::Migration[7.1]
+  def change
+    add_index :users, [:region_id, :delegate_status]
+  end
+end

--- a/WcaOnRails/db/schema.rb
+++ b/WcaOnRails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_25_061943) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_02_155158) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -1124,6 +1124,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_25_061943) do
     t.string "otp_secret"
     t.index ["delegate_id_to_handle_wca_id_claim"], name: "index_users_on_delegate_id_to_handle_wca_id_claim"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["region_id", "delegate_status"], name: "index_users_on_region_id_and_delegate_status"
     t.index ["region_id"], name: "index_users_on_region_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["senior_delegate_id"], name: "index_users_on_senior_delegate_id"


### PR DESCRIPTION
This does not change the underlying query, but
1. It now has an index for lightning-fast `SELECT`. Previously, when `senior_delegate` was computed via `senior_delegate_id`, it was able to use the primary key of `users` table, but with the new method it had no index anymore. So I added one.
2. ~It can cache the result. Rails associations like `belongs_to` or `has_many` can do caching under the hood, while a method like `def senior_delegate` is "just a method" that has a return value which is being re-computed every time it is called.~