### PR TITLE
Removed update_delegate_crash_course_route as it is no longer used

### DIFF
--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -159,7 +159,6 @@ Rails.application.routes.draw do
 
   get 'panel' => 'panel#index'
   get 'panel/delegate-crash-course', to: redirect('/edudoc/delegate-crash-course/delegate_crash_course.pdf', status: 302)
-  patch 'panel/delegate-crash-course' => 'panel#update_delegate_crash_course'
   get 'panel/pending-claims(/:user_id)' => 'panel#pending_claims_for_subordinate_delegates', as: 'pending_claims'
   scope 'panel' do
     get 'wfc' => 'panel#wfc', as: :panel_wfc


### PR DESCRIPTION
Links to some related commits:

- https://github.com/thewca/worldcubeassociation.org/commit/619f8a3ed8578a3fa9ec750c4755aba03349069b
- https://github.com/thewca/worldcubeassociation.org/commit/e46d7d4d7c247bbb0ba3665ae3d1001c32074f7f