### PR TITLE
Fixed WcaSearch issue in DuesRedirect

### DIFF
--- a/WcaOnRails/app/webpacker/components/CountrySelector/CountrySelector.js
+++ b/WcaOnRails/app/webpacker/components/CountrySelector/CountrySelector.js
@@ -12,11 +12,14 @@ const countryOptions = countries.real.map((country) => ({
   image: <CountryFlag iso2={country.iso2} />,
 }));
 
-function CountrySelector({ countryIso2, onChange, error }) {
+function CountrySelector({
+  name, countryIso2, onChange, error,
+}) {
   return (
     <Form.Select
       className="country-selector"
       search
+      name={name}
       label="Country"
       value={countryIso2}
       error={error}

--- a/WcaOnRails/app/webpacker/components/DelegateProbations/index.jsx
+++ b/WcaOnRails/app/webpacker/components/DelegateProbations/index.jsx
@@ -94,8 +94,9 @@ export default function DelegateProbations() {
     <>
       <h1>Delegate Probations</h1>
       <WcaSearch
-        selectedValue={user}
-        setSelectedValue={setUser}
+        name="user"
+        value={user}
+        onChange={(_, { value }) => setUser(value)}
         multiple={false}
         model="user"
         params={{ only_staff_delegates: true }}

--- a/WcaOnRails/app/webpacker/components/Panel/Wfc/DuesRedirect.jsx
+++ b/WcaOnRails/app/webpacker/components/Panel/Wfc/DuesRedirect.jsx
@@ -19,6 +19,8 @@ export default function DuesRedirect() {
   const [open, setOpen] = React.useState(false);
   const [formData, setFormData] = React.useState({ redirectType: 'Country' });
 
+  const handleFormChange = (_, { name, value }) => setFormData({ ...formData, [name]: value });
+
   if (loading || saving || xeroUsersFetch.loading) return <Loading />;
   if (error || xeroUsersFetch.err) return <Errored />;
   return (
@@ -63,30 +65,27 @@ export default function DuesRedirect() {
             <Form.Select
               label="Type"
               placeholder="Type"
-              name="redirect_type"
+              name="redirectType"
               options={[
                 { key: 'country', text: 'Country', value: 'Country' },
                 { key: 'organizer', text: 'Organizer', value: 'User' },
               ]}
               value={formData.redirectType}
-              onChange={(e, { value }) => setFormData({ ...formData, redirectType: value })}
+              onChange={handleFormChange}
             />
             {formData.redirectType === 'Country' && (
               <CountrySelector
                 label="From"
-                name="redirect_from_country_id"
+                name="redirectFromCountryIso2"
                 value={formData.redirectFromCountryIso2}
-                onChange={
-                  (e, { value }) => setFormData({ ...formData, redirectFromCountryIso2: value })
-                }
+                onChange={handleFormChange}
               />
             )}
             {formData.redirectType === 'User' && (
               <WcaSearch
-                selectedValue={formData.redirectFromOrganizer}
-                setSelectedValue={
-                  (value) => setFormData({ ...formData, redirectFromOrganizer: value })
-                }
+                name="redirectFromOrganizer"
+                value={formData.redirectFromOrganizer}
+                onChange={handleFormChange}
                 multiple={false}
                 model="user"
               />
@@ -94,14 +93,14 @@ export default function DuesRedirect() {
             <Form.Select
               label="To"
               placeholder="To"
-              name="redirect_to"
+              name="redirectToId"
               options={xeroUsersFetch.data.map((xeroUser) => ({
                 key: xeroUser.id,
                 text: xeroUser.name,
                 value: xeroUser.id,
               }))}
               value={formData.redirectTo}
-              onChange={(e, { value }) => setFormData({ ...formData, redirectToId: value })}
+              onChange={handleFormChange}
             />
             <Form.Button
               type="submit"

--- a/WcaOnRails/app/webpacker/components/SearchWidget/WcaSearch.jsx
+++ b/WcaOnRails/app/webpacker/components/SearchWidget/WcaSearch.jsx
@@ -6,8 +6,9 @@ import { userSearchApiUrl, personSearchApiUrl } from '../../lib/requests/routes.
 import MultiSearchInput from './MultiSearchInput';
 
 export default function WcaSearch({
-  selectedValue,
-  setSelectedValue,
+  name,
+  value,
+  onChange,
   multiple = true,
   model,
   params,
@@ -21,11 +22,16 @@ export default function WcaSearch({
     return '';
   }, [params, model]);
 
+  const setValue = (setValueFn) => {
+    const newValue = setValueFn();
+    onChange(null, { name, value: newValue });
+  };
+
   return (
     <MultiSearchInput
       url={urlFn}
-      selectedValue={multiple ? selectedValue || [] : selectedValue}
-      setSelectedValue={setSelectedValue}
+      selectedValue={multiple ? value || [] : value}
+      setSelectedValue={setValue}
       multiple={multiple}
     />
   );


### PR DESCRIPTION
After the merging of [this PR](https://github.com/thewca/worldcubeassociation.org/pull/8527), the WcaSearch of DuesRedirect broke because `WcaSearch` was expecting `setSelectedValue` to be a hook's 'set' part. But in `DuesRedirect`, it was a normal function.

To avoid confusion, I've changed the name to `onChange`. This also allows to use in Form.Field more easily. I've also done some cleanup associated with this.