### PR TITLE
Add Preferred Events and seperate Personal Recods Route

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -196,6 +196,11 @@ class Api::V0::ApiController < ApplicationController
     @current_api_user = User.find_by_id(doorkeeper_token&.resource_owner_id)
   end
 
+  private def require_user!
+    raise WcaExceptions::MustLogIn.new if current_api_user.nil? && current_user.nil?
+    current_api_user || current_user
+  end
+
   def countries
     render json: Country.all
   end

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -171,11 +171,6 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     api_user_can_manage || current_user&.can_manage_competition?(competition)
   end
 
-  private def require_user!
-    raise WcaExceptions::MustLogIn.new if current_api_user.nil? && current_user.nil?
-    current_api_user || current_user
-  end
-
   private def require_scope!(scope)
     require_user!
     if current_api_user # If we deal with an OAuth user then check the scopes.

--- a/WcaOnRails/app/controllers/api/v0/users_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/users_controller.rb
@@ -3,7 +3,10 @@
 class Api::V0::UsersController < Api::V0::ApiController
   def show_me
     require_user!
-    show_user(current_user)
+    if stale?(current_user)
+      # Also include the users current prs so we can handle qualifications on the Frontend
+      show_user(current_user, show_rankings: true)
+    end
   end
 
   def show_user_by_id
@@ -32,13 +35,13 @@ class Api::V0::UsersController < Api::V0::ApiController
   def personal_records
     require_user!
     return render json: { single: [], average: [] } unless current_user.wca_id.present?
-    person = Person.includes(:user, :ranksSingle, :ranksAverage).find_by_wca_id!(current_user.wca_id)
+    person = Person.includes(:ranksSingle, :ranksAverage).find_by_wca_id!(current_user.wca_id)
     render json: { single: person.ranksSingle, average: person.ranksAverage }
   end
 
   def preferred_events
     require_user!
-    preferred_events = Rails.cache.fetch("#{current_user.id}-preferred", expires_in: 24.hours) do
+    preferred_events = Rails.cache.fetch("#{current_user.id}-preferred-events", expires_in: 24.hours) do
       current_user.preferred_events.pluck(:id)
     end
     render json: preferred_events
@@ -46,7 +49,7 @@ class Api::V0::UsersController < Api::V0::ApiController
 
   def bookmarked_competitions
     require_user!
-    bookmarked_competitions = Rails.cache.fetch("#{current_user.id}-bookmarked", expires_in: 60.minutes) do
+    bookmarked_competitions = Rails.cache.fetch("#{current_user.id}-competitions-bookmarked", expires_in: 60.minutes) do
       current_user.competitions_bookmarked.pluck(:competition_id)
     end
     render json: bookmarked_competitions
@@ -59,7 +62,7 @@ class Api::V0::UsersController < Api::V0::ApiController
 
   private
 
-    def show_user(user)
+    def show_user(user, show_rankings: false)
       if user
         json = { user: user }
         if params[:upcoming_competitions]
@@ -67,6 +70,10 @@ class Api::V0::UsersController < Api::V0::ApiController
         end
         if params[:ongoing_competitions]
           json[:ongoing_competitions] = user.accepted_competitions.select(&:in_progress?)
+        end
+        if show_rankings && user.wca_id.present?
+          person = Person.includes(:ranksSingle, :ranksAverage).find_by_wca_id!(user.wca_id)
+          json[:rankings] = { single: person.ranksSingle, average: person.ranksAverage }
         end
         render status: :ok, json: json
       else

--- a/WcaOnRails/app/controllers/api/v0/users_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/users_controller.rb
@@ -53,11 +53,8 @@ class Api::V0::UsersController < Api::V0::ApiController
   end
 
   def token
-    if current_user
-      render json: { status: "ok" }
-    else
-      render status: :unauthorized, json: { error: I18n.t('api.login_message') }
-    end
+    require_user!
+    render json: { status: "ok" }
   end
 
   private

--- a/WcaOnRails/app/controllers/api/v0/users_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/users_controller.rb
@@ -38,7 +38,7 @@ class Api::V0::UsersController < Api::V0::ApiController
 
   def preferred_events
     require_user!
-    preferred_events = Rails.cache.fetch("#{current_user.id}-preferred", expires_in: 60.minutes) do
+    preferred_events = Rails.cache.fetch("#{current_user.id}-preferred", expires_in: 24.hours) do
       current_user.preferred_events.pluck(:id)
     end
     render json: preferred_events

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -503,14 +503,14 @@ class CompetitionsController < ApplicationController
   def bookmark
     @competition = competition_from_params
     BookmarkedCompetition.find_or_create_by(competition: @competition, user: current_user)
-    Rails.cache.delete("#{current_user.id}-bookmarked")
+    Rails.cache.delete("#{current_user.id}-competitions-bookmarked")
     head :ok
   end
 
   def unbookmark
     @competition = competition_from_params
     BookmarkedCompetition.where(competition: @competition, user: current_user).each(&:destroy!)
-    Rails.cache.delete("#{current_user.id}-bookmarked")
+    Rails.cache.delete("#{current_user.id}-competitions-bookmarked")
     head :ok
   end
 

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -197,6 +197,8 @@ class UsersController < ApplicationController
       if ActiveRecord::Type::Boolean.new.cast(user_params['remove_avatar'])
         AvatarsMailer.notify_user_of_avatar_removal(@user.current_user, @user, params[:user][:removal_reason]).deliver_later
       end
+      # Clear preferred Events cache
+      Rails.cache.delete("#{current_user.id}-preferred") if user_params.key? "user_preferred_events_attributes"
     elsif @user.claiming_wca_id
       render :claim_wca_id
     else

--- a/WcaOnRails/app/controllers/users_controller.rb
+++ b/WcaOnRails/app/controllers/users_controller.rb
@@ -198,7 +198,7 @@ class UsersController < ApplicationController
         AvatarsMailer.notify_user_of_avatar_removal(@user.current_user, @user, params[:user][:removal_reason]).deliver_later
       end
       # Clear preferred Events cache
-      Rails.cache.delete("#{current_user.id}-preferred") if user_params.key? "user_preferred_events_attributes"
+      Rails.cache.delete("#{current_user.id}-preferred-events") if user_params.key? "user_preferred_events_attributes"
     elsif @user.claiming_wca_id
       render :claim_wca_id
     else

--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -312,6 +312,8 @@ Rails.application.routes.draw do
       get '/search/incidents' => 'api#incidents_search'
       get '/users' => 'users#show_users_by_id'
       get '/users/me' => 'users#show_me'
+      get '/users/me/personal_records' => 'users#personal_records'
+      get '/users/me/preferred_events' => 'users#preferred_events'
       get '/users/me/permissions' => 'users#permissions'
       get '/users/me/bookmarks' => 'users#bookmarked_competitions'
       get '/users/me/token' => 'users#token'

--- a/WcaOnRails/lib/wca_exceptions.rb
+++ b/WcaOnRails/lib/wca_exceptions.rb
@@ -23,7 +23,7 @@ module WcaExceptions
 
   class MustLogIn < ApiException
     def initialize
-      super(:unauthorized, "Not logged in")
+      super(:unauthorized, I18n.t('api.login_message'))
     end
   end
 

--- a/WcaOnRails/spec/controllers/api_users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_users_controller_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Api::V0::UsersController do
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
       expect(json["user"]).to eq competed_user.as_json
+      expect(json.key?("rankings")).to eq true
     end
   end
 

--- a/WcaOnRails/spec/controllers/api_users_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/api_users_controller_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe Api::V0::UsersController do
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
       expect(json["user"]).to eq competed_user.as_json
-      expect(json.key?("rankings")).to eq true
     end
   end
 

--- a/WcaOnRails/spec/requests/api_competitions_spec.rb
+++ b/WcaOnRails/spec/requests/api_competitions_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "API Competitions" do
         patch api_v0_competition_wcif_path(competition)
         expect(response).to have_http_status(401)
         response_json = JSON.parse(response.body)
-        expect(response_json["error"]).to eq "Not logged in"
+        expect(response_json["error"]).to eq "Please log in"
       end
     end
 
@@ -167,7 +167,7 @@ RSpec.describe "API Competitions" do
         patch api_v0_competition_update_wcif_path(competition)
         expect(response).to have_http_status(401)
         response_json = JSON.parse(response.body)
-        expect(response_json["error"]).to eq "Not logged in"
+        expect(response_json["error"]).to eq "Please log in"
       end
     end
 


### PR DESCRIPTION
This is needed for the Registration Frontend.

I moved the personal records back out of the `me` route because I started putting preferred events into it, but then I felt like it's getting bloated. I also moved the require_user! method out of the `competition_controller` into the `api_controller` because we now need it everywhere. 
Technically you can always get personal records using the `persons/:wca_id/` route, but I feel like we should keep that separate. Thoughts?