### PR TITLE
added event reg limit and comeptition series ids to competition api

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -22,14 +22,15 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
     if stale?(competition)
       options = {
-        only: %w[id name website start_date registration_open registration_close
-                 announced_at cancelled_at end_date competitor_limit
-                 extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results
-                 event_restrictions base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance allow_registration_without_qualification refund_policy_percent
-                 use_wca_registration guests_per_registration_limit venue contact force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status information],
-        methods: %w[url website short_name city venue_address venue_details latitude_degrees
-                    longitude_degrees country_iso2 event_ids
-                    registration_opened? main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff?],
+        only: %w[id name website start_date registration_open registration_close announced_at cancelled_at end_date competitor_limit
+                 extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date
+                 on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results event_restrictions
+                 base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance
+                 allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact
+                 force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status
+                 information events_per_registration_limit],
+        methods: %w[url website short_name city venue_address venue_details latitude_degrees longitude_degrees country_iso2 event_ids registration_opened?
+                    main_event_id number_of_bookmarks using_stripe_payments? uses_qualification? uses_cutoff? competition_series_ids],
         include: %w[delegates organizers tabs],
       }
       render json: competition.as_json(options)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1643,7 +1643,7 @@ class Competition < ApplicationRecord
   end
 
   def competition_series_ids
-    competition_series&.competition_ids
+    competition_series&.competition_ids || []
   end
 
   def persons_wcif(authorized: false)

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1642,6 +1642,10 @@ class Competition < ApplicationRecord
     competition_series&.to_wcif(authorized: authorized)
   end
 
+  def competition_series_ids
+    competition_series&.competition_ids
+  end
+
   def persons_wcif(authorized: false)
     managers = self.managers
     includes_associations = [


### PR DESCRIPTION
This adds two fields from the Competition model needed for registration validation to `/api/v0/comeptitions/{comp-id}`

Also reordered the fields in `api/competitions_controller#show` to take up more of the line before going to the next line