### PR TITLE
Allow POST request for show_users_by_id

### DIFF
--- a/WcaOnRails/config/routes.rb
+++ b/WcaOnRails/config/routes.rb
@@ -319,6 +319,7 @@ Rails.application.routes.draw do
       get '/search/regulations' => 'api#regulations_search'
       get '/search/incidents' => 'api#incidents_search'
       get '/users' => 'users#show_users_by_id'
+      post '/users' => 'users#show_users_by_id'
       get '/users/me' => 'users#show_me'
       get '/users/me/personal_records' => 'users#personal_records'
       get '/users/me/preferred_events' => 'users#preferred_events'


### PR DESCRIPTION
This allows to query more than 500 users at once without going over the GET request size limit. This is an issue currently with competitions that have more than 500 registrations in the new registration service. Another solution would be to start batching the requests if that would be better?