### PR TITLE
Changed regional organization path for patching changes

### DIFF
--- a/WcaOnRails/app/views/regional_organizations/_regional_organization_form.html.erb
+++ b/WcaOnRails/app/views/regional_organizations/_regional_organization_form.html.erb
@@ -1,4 +1,4 @@
-<% url = @regional_organization.new_record? ? new_regional_organization_path : edit_regional_organization_path(@regional_organization) %>
+<% url = @regional_organization.new_record? ? new_regional_organization_path : regional_organization_path(@regional_organization) %>
 <%= simple_form_for @regional_organization, url: url, html: { class: 'form-horizontal' } do |f| %>
   <p><%= t('.filling_instructions_html') %></p>
 

--- a/WcaOnRails/app/views/regional_organizations/_regional_organization_form.html.erb
+++ b/WcaOnRails/app/views/regional_organizations/_regional_organization_form.html.erb
@@ -1,4 +1,4 @@
-<% url = @regional_organization.new_record? ? new_regional_organization_path : regional_organization_path(@regional_organization) %>
+<% url = @regional_organization.new_record? ? regional_organizations_path : regional_organization_path(@regional_organization) %>
 <%= simple_form_for @regional_organization, url: url, html: { class: 'form-horizontal' } do |f| %>
   <p><%= t('.filling_instructions_html') %></p>
 


### PR DESCRIPTION
This allows the submission of the edit regional organization form - the previous path generated an error. Tested locally and it no longer generates the error.

Thanks @danieljames-dj for spotting the 1-word fix when I was massively overcomplicating things :P 