### PR TITLE
Panel paths to a global variable for easy pathing

### DIFF
--- a/WcaOnRails/app/webpacker/components/Panel/Board/index.jsx
+++ b/WcaOnRails/app/webpacker/components/Panel/Board/index.jsx
@@ -4,25 +4,26 @@ import PanelTemplate from '../PanelTemplate';
 import SeniorDelegatesList from './SeniorDelegatesList';
 import RegionManager from './RegionManager';
 import CouncilLeaders from './CouncilLeaders';
+import PANEL_LIST from '../PanelList';
 
 const sections = [
   {
-    id: 'senior-delegates-list',
+    id: PANEL_LIST.board.seniorDelegatesList,
     name: 'Senior Delegates List',
     component: SeniorDelegatesList,
   },
   {
-    id: 'council-leaders',
+    id: PANEL_LIST.board.councilLeaders,
     name: 'Council Leaders',
     component: CouncilLeaders,
   },
   {
-    id: 'regions-manager',
+    id: PANEL_LIST.board.regionsManager,
     name: 'Regions Manager',
     component: RegionManager,
   },
   {
-    id: 'delegate-probations',
+    id: PANEL_LIST.board.delegateProbations,
     name: 'Delegate Probations',
     component: DelegateProbations,
   },

--- a/WcaOnRails/app/webpacker/components/Panel/PanelList.js
+++ b/WcaOnRails/app/webpacker/components/Panel/PanelList.js
@@ -1,0 +1,23 @@
+const PANEL_LIST = {
+  board: {
+    seniorDelegatesList: 'senior-delegates-list',
+    councilLeaders: 'council-leaders',
+    regionsManager: 'regions-manager',
+    delegateProbations: 'delegate-probations',
+  },
+  seniorDelegate: {
+    delegateForms: 'delegate-forms',
+    delegateProbations: 'delegate-probations',
+    subordinateDelegateClaims: 'subordinate-delegate-claims',
+    subordinateUpcomingCompetitions: 'subordinate-upcoming-competitions',
+  },
+  wfc: {
+    duesExport: 'dues-export',
+    countryBands: 'country-bands',
+    delegateProbations: 'delegate-probations',
+    xeroUsers: 'xero-users',
+    duesRedirect: 'dues-redirect',
+  },
+};
+
+export default PANEL_LIST;

--- a/WcaOnRails/app/webpacker/components/Panel/SeniorDelegate/index.jsx
+++ b/WcaOnRails/app/webpacker/components/Panel/SeniorDelegate/index.jsx
@@ -6,25 +6,26 @@ import {
 import DelegateProbations from '../../DelegateProbations';
 import PanelTemplate from '../PanelTemplate';
 import DelegateForms from './DelegateForms';
+import PANEL_LIST from '../PanelList';
 
 const sections = [
   {
-    id: 'delegate-forms',
+    id: PANEL_LIST.seniorDelegate.delegateForms,
     name: 'Delegate Forms',
     component: DelegateForms,
   },
   {
-    id: 'delegate-probations',
+    id: PANEL_LIST.seniorDelegate.delegateProbations,
     name: 'Delegate Probations',
     component: DelegateProbations,
   },
   {
-    id: 'subordinate-delegate-claims',
+    id: PANEL_LIST.seniorDelegate.subordinateDelegateClaims,
     name: 'Subordinate Delegate Claims',
     link: subordinateDelegateClaimsUrl,
   },
   {
-    id: 'subordinate-upcoming-competitions',
+    id: PANEL_LIST.seniorDelegate.subordinateUpcomingCompetitions,
     name: 'Subordinate Upcoming Competitions',
     link: subordinateUpcomingCompetitionsUrl,
   },

--- a/WcaOnRails/app/webpacker/components/Panel/Wfc/index.jsx
+++ b/WcaOnRails/app/webpacker/components/Panel/Wfc/index.jsx
@@ -11,31 +11,32 @@ import DuesExport from './DuesExport';
 import PanelTemplate from '../PanelTemplate';
 import XeroUsers from './XeroUsers';
 import DuesRedirect from './DuesRedirect';
+import PANEL_LIST from '../PanelList';
 
 const sections = [
   {
-    id: 'dues-export',
+    id: PANEL_LIST.wfc.duesExport,
     name: 'Dues Export',
     component: DuesExport,
   },
   {
-    id: 'country-bands',
+    id: PANEL_LIST.wfc.countryBands,
     name: 'Country Bands',
     link: countryBandsUrl,
   },
   {
-    id: 'delegate-probations',
+    id: PANEL_LIST.wfc.delegateProbations,
     name: 'Delegate Probations',
     component: DelegateProbations,
     forAtleastSeniorMember: true,
   },
   {
-    id: 'xero-users',
+    id: PANEL_LIST.wfc.xeroUsers,
     name: 'Xero Users',
     component: XeroUsers,
   },
   {
-    id: 'dues-redirect',
+    id: PANEL_LIST.wfc.duesRedirect,
     name: 'Dues Redirect',
     component: DuesRedirect,
   },


### PR DESCRIPTION
If we want to route to the panel from any other part of the website, it's difficult currently. Example, if we want to link the edit icon of senior delegate in roles page to board panel's 'regions-manager' tab, only way is hardcoding but that doesn't look good. So instead, we can do something like `${panelRoute.board}/${PANEL_LIST.board.regionsManager}`.

There might be better way to handle this, if anybody get any idea, please pitch in.