### PR TITLE
Added /competitions/:comp_id/qualifications route

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -38,11 +38,14 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def qualifications
-    competition = competition_from_params
-    qualifications = competition.competition_events.each_with_object({}) do |event, hash|
-      next if event.qualification.nil?
-      hash[event.event_id] = event.qualification.to_wcif
-    end
+    competition = competition_from_params(associations: [:competition_events])
+
+    qualifications = competition.competition_events
+                                .where.not(qualification: nil)
+                                .index_by(&:event_id)
+                                .transform_values(&:qualification)
+                                .transform_values(&:to_wcif)
+
     render json: qualifications
   end
 

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -37,6 +37,15 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     end
   end
 
+  def qualifications
+    competition = competition_from_params
+    qualifications = competition.competition_events.each_with_object({}) do |event, hash|
+      next if event.qualification.nil?
+      hash[event.event_id] = event.qualification.to_wcif
+    end
+    render json: qualifications
+  end
+
   def schedule
     competition = competition_from_params
     render json: competition.schedule_wcif

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -375,6 +375,7 @@ Rails.application.routes.draw do
         get '/results' => 'competitions#results', as: :results
         get '/results/:event_id' => 'competitions#event_results', as: :event_results
         get '/competitors' => 'competitions#competitors'
+        get '/qualifications' => 'competitions#qualifications'
         get '/registrations' => 'competitions#registrations'
         get '/schedule' => 'competitions#schedule'
         get '/scrambles' => 'competitions#scrambles', as: :scrambles


### PR DESCRIPTION
Adds a route where competition qualification restrictions can be accessed directly, instead of needing to get them off the WCIF, for the Registration Service Backend to enforce qualification limits