### PR TITLE
Allow editing room with id 0

### DIFF
--- a/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -290,10 +290,10 @@ function EditActivities({
         </List>
       </Container>
       <Divider />
-      {!selectedRoomId && (
+      {selectedRoomId === undefined && (
         <Message info>Please select a room by clicking one of the labels above</Message>
       )}
-      {selectedRoomId && (
+      {selectedRoomId !== undefined && (
         <Container fluid>
           <EditActivityModal
             isModalOpen={isActivityModalOpen}


### PR DESCRIPTION
I'm having trouble running locally again, so I haven't test this change.

I'm surprised this hasn't effected other people/resulted in complaints. I've got 2 competitions right now where I can't edit the schedule.