### PR TITLE
Optionally override database cleaner suite setup for local testing

### DIFF
--- a/WcaOnRails/env_config.rb
+++ b/WcaOnRails/env_config.rb
@@ -42,6 +42,7 @@ EnvConfig = SuperConfig.new do
 
     # Local-specific stuff
     optional :ENABLE_BULLET, :bool, false
+    optional :SKIP_PRETEST_SETUP, :bool, false
     optional :MAILCATCHER_SMTP_HOST, :string, ''
   end
 

--- a/WcaOnRails/spec/support/database_cleaner.rb
+++ b/WcaOnRails/spec/support/database_cleaner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  unless ENV['SKIP_PRETEST_SETUP'] == 'true'
+  unless EnvConfig.SKIP_PRETEST_SETUP?
     config.before(:suite) do
       DatabaseCleaner.clean_with :truncation
       TestDbManager.fill_tables

--- a/WcaOnRails/spec/support/database_cleaner.rb
+++ b/WcaOnRails/spec/support/database_cleaner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  unless ENV['SKIP_PRETEST_SETUP']
+  unless ENV['SKIP_PRETEST_SETUP'] == 'true'
     config.before(:suite) do
       DatabaseCleaner.clean_with :truncation
       TestDbManager.fill_tables

--- a/WcaOnRails/spec/support/database_cleaner.rb
+++ b/WcaOnRails/spec/support/database_cleaner.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    DatabaseCleaner.clean_with :truncation
-    TestDbManager.fill_tables
+  unless ENV['SKIP_PRETEST_SETUP']
+    config.before(:suite) do
+      DatabaseCleaner.clean_with :truncation
+      TestDbManager.fill_tables
+    end
   end
 
   config.before(:each) do


### PR DESCRIPTION
If `SKIP_PRETEST_SETUP` is set to true in a `.env` file, skips DatabaseCleaner's pre-suite setup. This saves ~7s on test suite bootup. Combined with using spring in the Docker container, test setup time goes from ~14 seconds to <1s.