### PR TITLE
Trainee Delegates -> Staff Avatar Guidelines

### DIFF
--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -25,7 +25,7 @@
           <div class="panel-heading">
             <h3 class="panel-title">
               <%= link_to user.name, edit_user_path(user) %>
-              <% if user.staff? || user.trainee_delegate? %>
+              <% if user.staff_or_any_delegate? %>
                 (<strong>Staff Member or Trainee Delegate</strong> - see guidelines above)
               <% end %>
             </h3>

--- a/WcaOnRails/app/views/admin/avatars/index.html.erb
+++ b/WcaOnRails/app/views/admin/avatars/index.html.erb
@@ -25,8 +25,8 @@
           <div class="panel-heading">
             <h3 class="panel-title">
               <%= link_to user.name, edit_user_path(user) %>
-              <% if user.staff? %>
-                (<strong>Staff Members</strong> - see guidelines above)
+              <% if user.staff? || user.trainee_delegate? %>
+                (<strong>Staff Member or Trainee Delegate</strong> - see guidelines above)
               <% end %>
             </h3>
           </div>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -199,7 +199,7 @@
                     <li><%= guideline %></li>
                   <% end %>
                 </ul>
-                <% if @user.staff? %>
+                <% if @user.staff? || @user.trainee_delegate? %>
                   <br /><strong><%= t('.staff_avatar_guidelines.title') %></strong>
                   <ul>
                     <% t('.staff_avatar_guidelines.paragraphs').values.each do |guideline| %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -199,7 +199,7 @@
                     <li><%= guideline %></li>
                   <% end %>
                 </ul>
-                <% if @user.staff_or_any_tdelegate? %>
+                <% if @user.staff_or_any_delegate? %>
                   <br /><strong><%= t('.staff_avatar_guidelines.title') %></strong>
                   <ul>
                     <% t('.staff_avatar_guidelines.paragraphs').values.each do |guideline| %>

--- a/WcaOnRails/app/views/users/edit.html.erb
+++ b/WcaOnRails/app/views/users/edit.html.erb
@@ -199,7 +199,7 @@
                     <li><%= guideline %></li>
                   <% end %>
                 </ul>
-                <% if @user.staff? || @user.trainee_delegate? %>
+                <% if @user.staff_or_any_tdelegate? %>
                   <br /><strong><%= t('.staff_avatar_guidelines.title') %></strong>
                   <ul>
                     <% t('.staff_avatar_guidelines.paragraphs').values.each do |guideline| %>

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1077,7 +1077,7 @@ en:
         '6': "The avatar must be submitted in correct orientation."
         '7': "The avatar must not contain offensive content (e.g. offensive gestures)."
       staff_avatar_guidelines:
-        title: "Additional guidelines for Staff Members:"
+        title: "Additional guidelines for Staff Members and Trainee Delegates:"
         paragraphs:
           '1': "The avatar must be of your current self, depicted in the same fashion as how you would appear at a competition."
           '2': "The avatar must be framed, cropped, angled, and lit, so that any competitor or spectator at a competition can use it to unambiguously identify you at a competition venue."

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -2098,7 +2098,7 @@ es:
         '7': La foto no debe contener contenido ofensivo (p.e. gestos ofensivos).
       staff_avatar_guidelines:
         #original_hash: da9e6df
-        title: 'Directrices adicionales para Personal WCA:'
+        title: 'Directrices adicionales para Personal WCA y delegados en prácticas (trainee):'
         paragraphs:
           #original_hash: ff6d2e8
           '1': >-


### PR DESCRIPTION
Closes #7819.

This allows Trainee Delegates to see the Staff avatar guidelines list and it also extends the WRT "warning" to Trainees.

I also updated the staff_avatar_guidelines.title locale to make it more precise (if you don't mind, I also updated the Spanish version, but I can revert that if you want).