### PR TITLE
Add note about Band 1 and 2 Dues estimate being incorrect to disclaimer

### DIFF
--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -545,7 +545,7 @@ en:
         end_date: ""
         generate_website: ""
         external_registration_page: "The page where the competitors have to register for the competition. Must be a valid http(s) url."
-        base_entry_fee_lowest_denomination: 'The base registration fee for the competition. It will be displayed on the competition information page and the registration page if used. If this is set to 0, a sentence will be displayed saying that registrations will be accepted for free. <br><br><b>DISCLAIMER: The following WCA Dues estimate is solely an approximation based on current exchange rates and is in no way legally binding for the Dues payment.</b>'
+        base_entry_fee_lowest_denomination: 'The base registration fee for the competition. It will be displayed on the competition information page and the registration page if used. If this is set to 0, a sentence will be displayed saying that registrations will be accepted for free. <br><br><b>DISCLAIMER: The following WCA Dues estimate is solely an approximation based on current exchange rates and is in no way legally binding for the Dues payment. There is a known bug that may result in the Dues estimate for Band 1 and 2 countries being significantly overstated.</b>'
         currency_code: "The currency code for fees."
         guests_enabled: ""
         enable_donations: ""


### PR DESCRIPTION
Adds a note to the Dues Estimate calculation that it may be significantly overstated (up to 3x the amount) for Band 1 and 2 countries. 

Notes on a permanent fix related to #8159 

Please let me know if I've done this incorrectly - I'm not that familiar with how the website handles translations etc - if there's a better way to do this I'm happy for someone else to edit the disclaimer that way. 