### PR TITLE
Update to Bundler 2.5 for Ruby Gems

### DIFF
--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -907,4 +907,4 @@ DEPENDENCIES
   wicked_pdf
 
 BUNDLED WITH
-   2.4.15
+   2.5.4


### PR DESCRIPTION
This caught my attention while rolling out the Ruby 3.3.0 update.
Quite frankly, I'm surprised that Dpeendabot doesn't handle this.