### PR TITLE
EditEvents: Rely on SemUI styles instead of custom CSS as much as possible

### DIFF
--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundCountInput.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundCountInput.js
@@ -25,6 +25,7 @@ export default function RoundCountInput({ roundCount, onChange, disabled }) {
 
   return (
     <Dropdown
+      compact
       selection
       name="selectRoundCount"
       value={roundCount}

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundCountInput.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundCountInput.js
@@ -31,9 +31,6 @@ export default function RoundCountInput({ roundCount, onChange, disabled }) {
       onChange={handleChange}
       disabled={disabled}
       options={RoundCountOptions}
-      style={{
-        fontSize: '.75em',
-      }}
     />
   );
 }

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundRow.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundRow.js
@@ -55,11 +55,10 @@ export default function RoundRow({
       verticalAlign="middle"
       name={`round-${roundNumber}`}
     >
-      <Table.Cell className="round-row__index">
+      <Table.Cell verticalAlign="middle">
         {wcifRound.id.split('-')[1].replace('r', '')}
-
       </Table.Cell>
-      <Table.Cell className="round-row__format">
+      <Table.Cell>
         <Dropdown
           selection
           name="format"
@@ -75,11 +74,15 @@ export default function RoundRow({
         />
       </Table.Cell>
 
-      <Table.Cell className="round-row__scramble-set-count">
+      <Table.Cell>
         <Input
           name="scrambleSetCount"
           type="number"
           min={1}
+          // This is arbitrary, but HTML uses this property to compute the width of the input box.
+          // No max property means HTML thinks "this number could be 13247324871321,
+          // so better make the box very very wide!"
+          max={1000}
           value={wcifRound.scrambleSetCount}
           onChange={scrambleSetCountChanged}
           disabled={disabled}
@@ -87,7 +90,7 @@ export default function RoundRow({
       </Table.Cell>
 
       {event.canChangeTimeLimit && (
-        <Table.Cell className="round-row__time-limit">
+        <Table.Cell>
           <EditTimeLimitModal
             wcifEvent={wcifEvent}
             wcifRound={wcifRound}
@@ -98,7 +101,7 @@ export default function RoundRow({
       )}
 
       {event.canHaveCutoff && (
-        <Table.Cell className="round-row__cutoff">
+        <Table.Cell>
           <EditCutoffModal
             wcifEvent={wcifEvent}
             wcifRound={wcifRound}
@@ -108,7 +111,7 @@ export default function RoundRow({
         </Table.Cell>
       )}
 
-      <Table.Cell className="round-row__advancement-condition">
+      <Table.Cell>
         {!isLastRound && (
           <EditAdvancementConditionModal
             wcifEvent={wcifEvent}

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundRow.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundRow.js
@@ -71,6 +71,7 @@ export default function RoundRow({
             text: format.shortName,
           }))}
           compact
+          className="tiny"
         />
       </Table.Cell>
 
@@ -86,6 +87,7 @@ export default function RoundRow({
           value={wcifRound.scrambleSetCount}
           onChange={scrambleSetCountChanged}
           disabled={disabled}
+          className="tiny"
         />
       </Table.Cell>
 

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
@@ -10,11 +10,11 @@ export default function RoundsTable({ wcifEvent, disabled }) {
 
   return (
     <Table
-      unstackable
+      className="tablet stackable"
       basic="very"
       textAlign="center"
       size="small"
-      compact
+      compact="very"
     >
       <Table.Header>
         <Table.Row>

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
@@ -9,21 +9,17 @@ export default function RoundsTable({ wcifEvent, disabled }) {
   const event = events.byId[wcifEvent.id];
 
   return (
-    <Segment
-      basic
-      compact
-      className="event-panel__rounds-table"
-    >
+    <Segment basic>
       <Table
-        compact
         unstackable
         basic="very"
+        textAlign="center"
       >
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>#</Table.HeaderCell>
             <Table.HeaderCell>Format</Table.HeaderCell>
-            <Table.HeaderCell style={{ width: '5em' }}>Scramble Sets</Table.HeaderCell>
+            <Table.HeaderCell>Scramble Sets</Table.HeaderCell>
             {event.canChangeTimeLimit && (
               <Table.HeaderCell>Time Limit</Table.HeaderCell>
             )}

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
@@ -14,6 +14,8 @@ export default function RoundsTable({ wcifEvent, disabled }) {
         unstackable
         basic="very"
         textAlign="center"
+        size="small"
+        compact
       >
         <Table.Header>
           <Table.Row>

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
@@ -10,7 +10,7 @@ export default function RoundsTable({ wcifEvent, disabled }) {
 
   return (
     <Table
-      className="tablet stackable"
+      unstackable
       basic="very"
       textAlign="center"
       size="small"

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/RoundsTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Segment, Table } from 'semantic-ui-react';
+import { Table } from 'semantic-ui-react';
 import { events } from '../../../lib/wca-data.js.erb';
 
 import RoundRow from './RoundRow';
@@ -9,38 +9,36 @@ export default function RoundsTable({ wcifEvent, disabled }) {
   const event = events.byId[wcifEvent.id];
 
   return (
-    <Segment basic>
-      <Table
-        unstackable
-        basic="very"
-        textAlign="center"
-        size="small"
-        compact
-      >
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell>#</Table.HeaderCell>
-            <Table.HeaderCell>Format</Table.HeaderCell>
-            <Table.HeaderCell>Scramble Sets</Table.HeaderCell>
-            {event.canChangeTimeLimit && (
-              <Table.HeaderCell>Time Limit</Table.HeaderCell>
-            )}
-            {event.canHaveCutoff && <Table.HeaderCell>Cutoff</Table.HeaderCell>}
-            <Table.HeaderCell>To Advance</Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          {wcifEvent.rounds.map((wcifRound, index) => (
-            <RoundRow
-              key={wcifRound.id}
-              index={index}
-              wcifEvent={wcifEvent}
-              wcifRound={wcifRound}
-              disabled={disabled}
-            />
-          ))}
-        </Table.Body>
-      </Table>
-    </Segment>
+    <Table
+      unstackable
+      basic="very"
+      textAlign="center"
+      size="small"
+      compact
+    >
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>#</Table.HeaderCell>
+          <Table.HeaderCell>Format</Table.HeaderCell>
+          <Table.HeaderCell>Scramble Sets</Table.HeaderCell>
+          {event.canChangeTimeLimit && (
+            <Table.HeaderCell>Time Limit</Table.HeaderCell>
+          )}
+          {event.canHaveCutoff && <Table.HeaderCell>Cutoff</Table.HeaderCell>}
+          <Table.HeaderCell>To Advance</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {wcifEvent.rounds.map((wcifRound, index) => (
+          <RoundRow
+            key={wcifRound.id}
+            index={index}
+            wcifEvent={wcifEvent}
+            wcifRound={wcifRound}
+            disabled={disabled}
+          />
+        ))}
+      </Table.Body>
+    </Table>
   );
 }

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -114,6 +114,7 @@ export default function EventPanel({
 
   return (
     <Card
+      style={{ minWidth: 'min-content' }}
       size="tiny"
       className={`event-panel event-${wcifEvent.id}`}
     >

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -5,7 +5,6 @@ import {
   Card,
   Header,
   Icon,
-  Label,
   Segment,
 } from 'semantic-ui-react';
 import i18n from '../../../lib/i18n';

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -115,11 +115,10 @@ export default function EventPanel({
   return (
     <Card
       size="tiny"
-      compact
       className={`event-panel event-${wcifEvent.id}`}
     >
       <Card.Content
-        // replicate the way SemUI Cards handle images (borderless) without an actual image
+        // replicate the way SemUI Cards handle images (borderless) without passing an actual image
         style={{ padding: 0 }}
       >
         <Segment basic tertiary>

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -5,7 +5,8 @@ import {
   Card,
   Header,
   Icon,
-  Label, Segment,
+  Label,
+  Segment,
 } from 'semantic-ui-react';
 import i18n from '../../../lib/i18n';
 import { events } from '../../../lib/wca-data.js.erb';
@@ -86,7 +87,6 @@ export default function EventPanel({
             }
             onClick={handleRemoveEvent}
             negative
-            size="small"
           >
             Remove event
           </Button>
@@ -122,13 +122,13 @@ export default function EventPanel({
         style={{ padding: 0 }}
       >
         <Segment basic tertiary>
-          <Header as="span">
+          <Header as="span" size="tiny">
             <Icon className="cubing-icon" name={`event-${event.id}`} />
             <Header.Content>
               {event.name}
             </Header.Content>
           </Header>
-          <Button.Group floated="right">
+          <Button.Group floated="right" size="tiny">
             {renderRoundCountInputs()}
           </Button.Group>
         </Segment>
@@ -143,10 +143,9 @@ export default function EventPanel({
             />
           </Card.Content>
           <Card.Content>
-            <Label basic>
-              {i18n.t('competitions.events.qualification')}
-              :
-            </Label>
+            {i18n.t('competitions.events.qualification')}
+            :
+            {' '}
             {/* Qualifications cannot be edited after the competition has been announced. */}
             {/* Qualifications cannot be added if the box from the competition form is unchecked. */}
             <EditQualificationModal

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -18,6 +18,7 @@ import {
   addEvent, addRounds, removeEvent, removeRounds,
 } from '../store/actions';
 import { EditQualificationModal } from '../Modals';
+import cn from 'classnames';
 
 export default function EventPanel({
   wcifEvent,
@@ -122,7 +123,7 @@ export default function EventPanel({
       >
         <Segment basic tertiary>
           <Header as="span" size="tiny">
-            <Icon className="cubing-icon" name={`event-${event.id}`} />
+            <Icon className={cn('cubing-icon', `event-${event.id}`)} />
             <Header.Content>
               {event.name}
             </Header.Content>

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import cn from 'classnames';
 
 import {
-  Button, Header, Segment,
+  Button,
+  Card,
+  Header,
+  Icon,
+  Label, Segment,
 } from 'semantic-ui-react';
 import i18n from '../../../lib/i18n';
 import { events } from '../../../lib/wca-data.js.erb';
@@ -82,11 +85,8 @@ export default function EventPanel({
                 : ''
             }
             onClick={handleRemoveEvent}
-            color="red"
-            size="tiny"
-            style={{
-              fontSize: '.75em',
-            }}
+            negative
+            size="small"
           >
             Remove event
           </Button>
@@ -104,11 +104,8 @@ export default function EventPanel({
             : ''
         }
         onClick={() => dispatch(addEvent(wcifEvent.id))}
-        color="green"
-        size="tiny"
-        style={{
-          fontSize: '.75em',
-        }}
+        positive
+        size="small"
       >
         Add event
       </Button>
@@ -116,74 +113,58 @@ export default function EventPanel({
   };
 
   return (
-    <Segment.Group
+    <Card
       size="tiny"
       compact
       className={`event-panel event-${wcifEvent.id}`}
     >
-
-      <Header
-        className="event-panel__heading"
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-        }}
-        attached
+      <Card.Content
+        // replicate the way SemUI Cards handle images (borderless) without an actual image
+        style={{ padding: 0 }}
       >
-        <div
-          style={{
-            margin: '-1.5em -1em',
-          }}
-        >
-          <span className={cn('img-thumbnail', 'cubing-icon', `event-${event.id}`)} />
-        </div>
-        <span
-          className="title"
-          style={{
-            flexGrow: 1,
-            marginLeft: '2em',
-          }}
-        >
-          {event.name}
-
-        </span>
-        <div>
-          {renderRoundCountInputs()}
-        </div>
-      </Header>
-
+        <Segment basic tertiary>
+          <Header as="span">
+            <Icon className="cubing-icon" name={`event-${event.id}`} />
+            <Header.Content>
+              {event.name}
+            </Header.Content>
+          </Header>
+          <Button.Group floated="right">
+            {renderRoundCountInputs()}
+          </Button.Group>
+        </Segment>
+      </Card.Content>
       {wcifEvent.rounds !== null && (
         <>
-          <RoundsTable
-            wcifEvents={wcifEvents}
-            wcifEvent={wcifEvent}
-            disabled={disabled}
-          />
-          <Segment>
-            <h5 style={{ display: 'inline' }}>
-              <span style={{ marginRight: '0.25em' }}>
-                {i18n.t('competitions.events.qualification')}
-                :
-              </span>
-              {/* Qualifications cannot be edited after the competition has been announced. */}
-              {/* Qualifications cannot be added if the box from the competition form is unchecked. */}
-              <EditQualificationModal
-                wcifEvent={wcifEvent}
-                disabled={
-                  disabled || !canAddAndRemoveEvents || !canUpdateQualifications
-                }
-                disabledReason={
-                  // todo: translations?
-                  canUpdateQualifications
-                    ? undefined
-                    : 'Turn on Qualifications under Edit > Organizer View and add a reason.'
-                }
-              />
-            </h5>
-          </Segment>
+          <Card.Content>
+            <RoundsTable
+              wcifEvents={wcifEvents}
+              wcifEvent={wcifEvent}
+              disabled={disabled}
+            />
+          </Card.Content>
+          <Card.Content>
+            <Label basic>
+              {i18n.t('competitions.events.qualification')}
+              :
+            </Label>
+            {/* Qualifications cannot be edited after the competition has been announced. */}
+            {/* Qualifications cannot be added if the box from the competition form is unchecked. */}
+            <EditQualificationModal
+              wcifEvent={wcifEvent}
+              disabled={
+                disabled || !canAddAndRemoveEvents || !canUpdateQualifications
+              }
+              disabledReason={
+                // todo: translations?
+                canUpdateQualifications
+                  ? undefined
+                  : 'Turn on Qualifications under Edit > Organizer View and add a reason.'
+              }
+            />
+          </Card.Content>
         </>
       )}
-    </Segment.Group>
+    </Card>
   );
 }

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/ButtonActivatedModal.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/ButtonActivatedModal.js
@@ -73,8 +73,7 @@ export default function ButtonActivatedModal({
         disabled={disabled}
         {...triggerButtonProps}
         size="small"
-        className="editable-text-button"
-        >
+      >
         {trigger}
       </Button>
     </span>

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/index.js
@@ -154,6 +154,7 @@ export default function EditAdvancementConditionModal({
       onOk={handleOk}
       hasUnsavedChanges={hasUnsavedChanges()}
       disabled={disabled}
+      triggerButtonProps={{ name: 'advancementCondition' }}
     >
       <AdvancementTypeField
         advancementType={type}

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditCutoffModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditCutoffModal/index.js
@@ -66,11 +66,7 @@ export default function EditCutoffModal({ wcifEvent, wcifRound, disabled }) {
   return (
     <ButtonActivatedModal
       trigger={Trigger}
-      triggerButtonProps={{
-        style: {
-          padding: '0.5em 1em',
-        },
-      }}
+      triggerButtonProps={{ name: 'cutoff' }}
       title={Title}
       reset={reset}
       onOk={handleOk}

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditQualificationModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditQualificationModal/index.js
@@ -126,7 +126,7 @@ export default function EditQualificationModal({
       hasUnsavedChanges={hasUnsavedChanges()}
       disabled={disabled}
       tooltip={disabledReason}
-      triggerButtonProps={{ name: 'qualification'}}
+      triggerButtonProps={{ name: 'qualification' }}
     >
       <QualificationResultType
         qualificationResultType={resultType}

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/index.js
@@ -87,6 +87,7 @@ export default function EditTimeLimitModal({ wcifEvent, wcifRound, disabled }) {
       disabled={disabled}
       closeOnDocumentClick={false}
       closeOnDimmerClick={false}
+      triggerButtonProps={{ name: 'timeLimit' }}
     >
       <Label>
         Time Limit

--- a/WcaOnRails/app/webpacker/components/EditEvents/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/index.js
@@ -5,7 +5,7 @@ import React, {
 } from 'react';
 import _ from 'lodash';
 
-import { Button, Message } from 'semantic-ui-react';
+import { Button, Card, Message } from 'semantic-ui-react';
 import { events } from '../../lib/wca-data.js.erb';
 
 import { useSaveWcifAction } from '../../lib/utils/wcif';
@@ -70,24 +70,19 @@ function EditEvents() {
   );
 
   return (
-    <div>
+    <>
       {unsavedChanges && renderUnsavedChangesAlert()}
-      <div
-        style={{
-          // https://css-tricks.com/an-auto-filling-css-grid-with-max-columns/
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(max(400px, calc((100% - calc(calc(3 - 1) * 1em)) / 3)), 1fr))',
-          gridGap: '1em',
-          alignItems: 'baseline',
-        }}
-        className="event-panel-container"
+      <Card.Group
+        itemsPerRow={3}
+        // this is necessary so that the cards "wrap" instead of growing to match the longest card
+        style={{ alignItems: 'baseline' }}
       >
         {wcifEvents.map((wcifEvent) => (
           <EventPanel key={wcifEvent.id} wcifEvent={wcifEvent} />
         ))}
-      </div>
+      </Card.Group>
       {unsavedChanges && renderUnsavedChangesAlert()}
-    </div>
+    </>
   );
 }
 

--- a/WcaOnRails/app/webpacker/components/EditEvents/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/index.js
@@ -74,6 +74,7 @@ function EditEvents() {
       {unsavedChanges && renderUnsavedChangesAlert()}
       <Card.Group
         itemsPerRow={3}
+        className="stackable"
         // this is necessary so that the cards "wrap" instead of growing to match the longest card
         style={{ alignItems: 'baseline' }}
       >

--- a/WcaOnRails/spec/features/competition_events_spec.rb
+++ b/WcaOnRails/spec/features/competition_events_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Competition events management" do
       let(:round_333_1) { comp_event_333.rounds.first }
 
       scenario "close with unsaved changes prompts user before discarding changes", js: true, retry: 3 do
-        find_round("333", 1).find(".round-row__time-limit").find("button").click
+        find_round("333", 1).click_button("timeLimit")
 
         modal = find_modal
         modal.find(:css, "input[type='text']").fill_in with: "4:00.00"
@@ -64,7 +64,7 @@ RSpec.feature "Competition events management" do
         end
 
         # Now that we discarded that change, try opening the modal again and check what value is shown.
-        find_round("333", 1).find(".round-row__time-limit").find("button").click
+        find_round("333", 1).click_button("timeLimit")
 
         within_modal do
           expect(page).to have_text "Competitors have 10 minutes for each of their solves."
@@ -78,7 +78,7 @@ RSpec.feature "Competition events management" do
       end
 
       scenario "change time limit to 5 minutes", js: true, retry: 3 do
-        find_round("333", 1).find(".round-row__time-limit").find("button").click
+        find_round("333", 1).click_button("timeLimit")
 
         modal = find_modal
         modal.find(:css, "input[type='text']").fill_in with: "5:00.00"
@@ -90,7 +90,7 @@ RSpec.feature "Competition events management" do
       end
 
       scenario "change cutoff to best of 2 in 2 minutes", js: true, retry: 3 do
-        find_round("333", 1).find(".round-row__cutoff").find("button").click
+        find_round("333", 1).click_button("cutoff")
 
         modal = find_modal
         select_from_ui(modal, "cutoffFormat", "Best of 2")
@@ -107,7 +107,7 @@ RSpec.feature "Competition events management" do
         event_panel = find_event_panel("333")
         select_from_ui(event_panel, "selectRoundCount", "2 rounds")
 
-        find_round("333", 1).find(".round-row__advancement-condition").find("button").click
+        find_round("333", 1).click_button('advancementCondition')
 
         modal = find_modal
         select_from_ui(modal, "advancementType", "Ranking")
@@ -236,11 +236,11 @@ RSpec.feature "Competition events management" do
 
       round = find_round("333", 1)
 
-      expect(round.find(".round-row__format").find("div[name='format'].disabled")).to be
-      expect(round.find(".round-row__scramble-set-count").find("input").disabled?).to be
-      expect(round.find(".round-row__time-limit").find("button").disabled?).to be
-      expect(round.find(".round-row__cutoff").find("button").disabled?).to be
-      expect(round.find(".round-row__advancement-condition").find("button").disabled?).to be
+      expect(round).to have_css("div[name='format'].disabled")
+      expect(round).to have_field('scrambleSetCount', disabled: true)
+      expect(round).to have_button('timeLimit', disabled: true)
+      expect(round).to have_button('cutoff', disabled: true)
+      expect(round).to have_button('advancementCondition', disabled: true)
     end
 
     scenario "board member can update events", js: true do


### PR DESCRIPTION
Before:
![image](https://github.com/thewca/worldcubeassociation.org/assets/6136469/53c38d36-bbfc-45ea-b863-a4577b4f3871)

After:
![image](https://github.com/thewca/worldcubeassociation.org/assets/6136469/ad86d440-a99f-4767-b612-b67db9cd4d50)

Context: We need a similar, shared "one box per event" panel for scrambles soon, and I don't want to rely on hard-coded `fontSize: 0.75em` and similar so much