### PR TITLE
Fix in badges not showing in couple of cases

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/user_roles_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/user_roles_controller.rb
@@ -70,9 +70,9 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       if is_group_hidden
         case group_type
         when UserGroup.group_types[:delegate_probation]
-          current_user.can_manage_delegate_probation?
+          current_user&.can_manage_delegate_probation?
         when UserGroup.group_types[:translators]
-          current_user.software_team?
+          current_user&.software_team?
         else
           false # Don't accept any other hidden groups.
         end

--- a/WcaOnRails/app/webpacker/components/Persons/Badges.jsx
+++ b/WcaOnRails/app/webpacker/components/Persons/Badges.jsx
@@ -51,6 +51,7 @@ export default function Badges({ userId }) {
     ['lead', 'eligibleVoter', 'groupTypeRank', 'status', 'groupName'].join(','), // Sort params
     {
       isActive: true,
+      isGroupHidden: false,
     },
   ));
   const roles = data || [];


### PR DESCRIPTION
The badge was not working in two cases when the user is also a translator:
1. If user signed in: This time, only the non-hidden groups should have been considered for badges. But since I missed to give parameter to not take hidden groups, and if the user has permission to view hidden groups, they will get selected, but will fail while sorting because translators doesn't have 'status'.
2. If user is not signed in: This time, hidden groups will get removed much before sorting as they are not visible to public. But this time, `current_user` is nil, and while filtering, I didn't consider that it can be nil as well.
Both are fixed in this PR.