### PR TITLE
Remove custom fields from global serialization

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -14,7 +14,13 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     competitions = Competition.search(params[:q], params: params, managed_by_user: managed_by_user)
     competitions = competitions.includes(:delegates, :organizers, :events)
 
-    paginate json: competitions
+    options = {
+      only: %w[id name website start_date registration_open registration_close announced_at cancelled_at results_posted_at end_date competitor_limit venue],
+      methods: %w[url website short_name city venue_address venue_details latitude_degrees longitude_degrees country_iso2
+                  event_ids registration_status short_display_name time_until_registration date_range],
+      include: %w[delegates organizers events country],
+    }
+    paginate json: competitions.to_json(options)
   end
 
   def show

--- a/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/competitions_controller.rb
@@ -14,13 +14,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     competitions = Competition.search(params[:q], params: params, managed_by_user: managed_by_user)
     competitions = competitions.includes(:delegates, :organizers, :events)
 
-    options = {
-      only: %w[id name website start_date registration_open registration_close announced_at cancelled_at results_posted_at end_date competitor_limit venue],
-      methods: %w[url website short_name city venue_address venue_details latitude_degrees longitude_degrees country_iso2
-                  event_ids registration_status short_display_name time_until_registration date_range],
-      include: %w[delegates organizers events country],
-    }
-    paginate json: competitions.to_json(options)
+    paginate json: competitions
   end
 
   def show

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -1225,6 +1225,14 @@ class Competition < ApplicationRecord
     start_date ? ((start_date.to_time(:utc) - Time.now.utc)/(86_400)).to_i : nil
   end
 
+  def time_until_registration
+    registration_open ? ApplicationController.helpers.distance_of_time_in_words_to_now(registration_open) : nil
+  end
+
+  def date_range
+    ApplicationController.helpers.wca_date_range(self.start_date, self.end_date)
+  end
+
   def has_date_errors?
     valid?
     !errors[:start_date].empty? || !errors[:end_date].empty? || (!showAtAll && days_until && days_until < MUST_BE_ANNOUNCED_GTE_THIS_MANY_DAYS)
@@ -1319,6 +1327,10 @@ class Competition < ApplicationRecord
     else
       data
     end
+  end
+
+  def short_display_name
+    display_name(short: true)
   end
 
   def results_posted?
@@ -1999,21 +2011,6 @@ class Competition < ApplicationRecord
     # we want to change the existing behavior of our API which returns a string.
     json.merge!(
       class: self.class.to_s.downcase,
-      displayName: display_name(short: true),
-      countryName: country&.name,
-      cityName: cityName,
-      year: start_date.year,
-      isProbablyOver: is_probably_over?,
-      cancelled: cancelled?,
-      resultsPosted: results_posted?,
-      inProgress: in_progress?,
-      dateRange: ApplicationController.helpers.wca_date_range(start_date, end_date),
-      announcedDate: announced_at&.strftime(" %F %H:%M:%S"),
-      venue: venue,
-      url: url,
-      country_iso2: country_iso2,
-      timeUntilRegistration: registration_open ? ApplicationController.helpers.distance_of_time_in_words_to_now(registration_open) : nil,
-      registration_status: registration_status,
     )
   end
 

--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -910,18 +910,6 @@ class Competition < ApplicationRecord
     true
   end
 
-  def registration_status
-    if registration_not_yet_opened?
-      "not_yet_opened"
-    elsif registration_past?
-      "past"
-    elsif registration_full?
-      "full"
-    else
-      "open"
-    end
-  end
-
   def registration_opened?
     use_wca_registration? && !cancelled? && !registration_not_yet_opened? && !registration_past?
   end
@@ -1988,12 +1976,12 @@ class Competition < ApplicationRecord
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
-    only: ["id", "name", "website", "start_date", "registration_open",
-           "registration_close", "announced_at", "cancelled_at", "end_date",
-           "competitor_limit"],
-    methods: ["url", "website", "short_name", "city", "venue_address",
-              "venue_details", "latitude_degrees", "longitude_degrees",
-              "country_iso2", "event_ids"],
+    only: ["id", "name", "website", "start_date", "end_date",
+           "registration_open", "registration_close", "announced_at",
+           "cancelled_at", "results_posted_at", "competitor_limit", "venue"],
+    methods: ["url", "website", "short_name", "short_display_name", "city",
+              "venue_address", "venue_details", "latitude_degrees", "longitude_degrees",
+              "country_iso2", "event_ids", "time_until_registration", "date_range"],
     include: ["delegates", "organizers"],
   }.freeze
 

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -369,6 +369,7 @@ function CompDisplayCheckboxes({
               id="show_registration_status"
               checked={shouldShowRegStatus}
               onChange={() => setShouldShowRegStatus(!shouldShowRegStatus)}
+              disabled // FIXME Pending because of too expensive queries
             />
           </div>
         )

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -13,6 +13,7 @@ import ListView from './ListView';
 import MapView from './MapView';
 import { filterReducer, filterInitialState } from './filterUtils';
 import { calculateQueryKey, createSearchParams } from './queryUtils';
+import { isCancelled, isInProgress, isProbablyOver } from '../../lib/utils/competition-table';
 
 function CompetitionsView() {
   const [filterState, dispatchFilter] = useReducer(filterReducer, filterInitialState);
@@ -43,7 +44,7 @@ function CompetitionsView() {
 
   const competitions = rawCompetitionData?.pages.flatMap((page) => page.data)
     .filter((comp) => (
-      (!comp.cancelled || filterState.shouldIncludeCancelled)
+      (!isCancelled(comp) || filterState.shouldIncludeCancelled)
       && (filterState.selectedEvents.every((event) => comp.event_ids.includes(event)))
     ));
 
@@ -80,7 +81,7 @@ function CompetitionsView() {
               competitions={
                 filterState.timeOrder === 'present'
                   ? competitions?.filter((comp) => (
-                    !comp.inProgress && !comp.isProbablyOver
+                    !isInProgress(comp) && !isProbablyOver(comp)
                   ))
                   : competitions
               }

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/ListView.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/ListView.js
@@ -6,6 +6,7 @@ import I18n from '../../lib/i18n';
 import { competitionConstants } from '../../lib/wca-data.js.erb';
 
 import ListViewSection from './ListViewSection';
+import { isInProgress, isProbablyOver } from '../../lib/utils/competition-table';
 
 function ListView({
   competitions,
@@ -24,9 +25,9 @@ function ListView({
 
   switch (filterState.timeOrder) {
     case 'present': {
-      const inProgressComps = competitions?.filter((comp) => comp.inProgress);
+      const inProgressComps = competitions?.filter((comp) => isInProgress(comp));
       const upcomingComps = competitions?.filter((comp) => (
-        !comp.inProgress && !comp.isProbablyOver
+        !isInProgress(comp) && !isProbablyOver(comp)
       ));
       return (
         <div id="competitions-list">

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -4,7 +4,12 @@ import {
 } from 'semantic-ui-react';
 
 import I18n from '../../lib/i18n';
-import { dayDifferenceFromToday, PseudoLinkMarkdown } from '../../lib/utils/competition-table';
+import {
+  dayDifferenceFromToday, hasResultsPosted, isCancelled, isInProgress,
+  isProbablyOver,
+  PseudoLinkMarkdown,
+  yearFromDateString,
+} from '../../lib/utils/competition-table';
 
 function ListViewSection({
   competitions,
@@ -28,24 +33,24 @@ function ListViewSection({
             index={index}
             isSortedByAnnouncement={isSortedByAnnouncement}
           />
-          <List.Item className={`${comp.isProbablyOver ? ' past' : ' not-past'}${comp.cancelled ? ' cancelled' : ''}`}>
+          <List.Item className={`${isProbablyOver(comp) ? ' past' : ' not-past'}${isCancelled(comp) ? ' cancelled' : ''}`}>
             <span className="date">
               <StatusIcon
                 comp={comp}
                 shouldShowRegStatus={shouldShowRegStatus}
                 isSortedByAnnouncement={isSortedByAnnouncement}
               />
-              {comp.dateRange}
+              {comp.date_range}
             </span>
             <span className="competition-info">
               <div className="competition-link">
-                <span className={` fi fi-${comp.country_iso2}`} />
+                <span className={` fi fi-${comp.country?.iso2?.toLowerCase()}`} />
                 &nbsp;
-                <a href={comp.url}>{comp.displayName}</a>
+                <a href={comp.url}>{comp.short_display_name}</a>
               </div>
               <div className="location">
-                <strong>{comp.countryName}</strong>
-                {`, ${comp.cityName}`}
+                <strong>{comp.country.name}</strong>
+                {`, ${comp.city}`}
               </div>
               <div className="venue-link">
                 <PseudoLinkMarkdown text={comp.venue} />
@@ -59,9 +64,13 @@ function ListViewSection({
 }
 
 function ConditionalYearHeader({ competitions, index, isSortedByAnnouncement }) {
-  if (index > 0 && competitions[index].year !== competitions[index - 1].year
-    && !isSortedByAnnouncement) {
-    return <List.Item style={{ textAlign: 'center', fontWeight: 'bold' }}>{competitions[index].year}</List.Item>;
+  if (
+    index > 0
+    && yearFromDateString(competitions[index].start_date)
+      !== yearFromDateString(competitions[index - 1].start_date)
+    && !isSortedByAnnouncement
+  ) {
+    return <List.Item style={{ textAlign: 'center', fontWeight: 'bold' }}>{yearFromDateString(competitions[index].start_date)}</List.Item>;
   }
 }
 
@@ -70,7 +79,7 @@ function RegistrationStatus({ comp }) {
     return (
       <Popup
         trigger={<Icon className="clock blue" />}
-        content={I18n.t('competitions.index.tooltips.registration.opens_in', { duration: comp.timeUntilRegistration })}
+        content={I18n.t('competitions.index.tooltips.registration.opens_in', { duration: comp.time_until_registration })}
         position="top center"
         size="tiny"
       />
@@ -111,21 +120,21 @@ function StatusIcon({ comp, shouldShowRegStatus, isSortedByAnnouncement }) {
   let tooltipInfo = '';
   let iconClass = '';
 
-  if (comp.isProbablyOver) {
-    if (comp.resultsPosted) {
+  if (isProbablyOver(comp)) {
+    if (hasResultsPosted(comp)) {
       tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.posted');
       iconClass = 'check circle result-posted-indicator';
     } else {
       tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.ended', { days: I18n.t('common.days', { count: dayDifferenceFromToday(comp.end_date) }) });
       iconClass = 'hourglass end';
     }
-  } else if (comp.inProgress) {
+  } else if (isInProgress(comp)) {
     tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.in_progress');
     iconClass = 'hourglass half';
   } else if (shouldShowRegStatus) {
     return <RegistrationStatus comp={comp} />;
   } else if (isSortedByAnnouncement) {
-    tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.announced_on', { announcement_date: comp.announcedDate });
+    tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.announced_on', { announcement_date: comp.announced_at });
     iconClass = 'hourglass start';
   } else {
     tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.starts_in', { days: I18n.t('common.days', { count: dayDifferenceFromToday(comp.start_date) }) });

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -6,10 +6,10 @@ import {
 import I18n from '../../lib/i18n';
 import {
   dayDifferenceFromToday, hasResultsPosted, isCancelled, isInProgress,
-  isProbablyOver,
-  PseudoLinkMarkdown,
-  yearFromDateString,
+  isProbablyOver, isRegistrationClosedAlready, isRegistrationOpenYet,
+  PseudoLinkMarkdown, startYear,
 } from '../../lib/utils/competition-table';
+import { countries } from '../../lib/wca-data.js.erb';
 
 function ListViewSection({
   competitions,
@@ -49,7 +49,7 @@ function ListViewSection({
                 <a href={comp.url}>{comp.short_display_name}</a>
               </div>
               <div className="location">
-                <strong>{comp.country.name}</strong>
+                <strong>{countries.byIso2[comp.country_iso2].name}</strong>
                 {`, ${comp.city}`}
               </div>
               <div className="venue-link">
@@ -66,16 +66,16 @@ function ListViewSection({
 function ConditionalYearHeader({ competitions, index, isSortedByAnnouncement }) {
   if (
     index > 0
-    && yearFromDateString(competitions[index].start_date)
-      !== yearFromDateString(competitions[index - 1].start_date)
+    && startYear(competitions[index])
+      !== startYear(competitions[index - 1])
     && !isSortedByAnnouncement
   ) {
-    return <List.Item style={{ textAlign: 'center', fontWeight: 'bold' }}>{yearFromDateString(competitions[index].start_date)}</List.Item>;
+    return <List.Item style={{ textAlign: 'center', fontWeight: 'bold' }}>{startYear(competitions[index])}</List.Item>;
   }
 }
 
 function RegistrationStatus({ comp }) {
-  if (comp.registration_status === 'not_yet_opened') {
+  if (!isRegistrationOpenYet(comp)) {
     return (
       <Popup
         trigger={<Icon className="clock blue" />}
@@ -85,7 +85,7 @@ function RegistrationStatus({ comp }) {
       />
     );
   }
-  if (comp.registration_status === 'past') {
+  if (isRegistrationClosedAlready(comp)) {
     return (
       <Popup
         trigger={<Icon className="user times red" />}
@@ -95,6 +95,8 @@ function RegistrationStatus({ comp }) {
       />
     );
   }
+  // TODO: This is currently not implemented because the query is *way* to expensive to execute
+  //   by default on production. We need to figure out a clever way to fetch this data on-demand.
   if (comp.registration_status === 'full') {
     return (
       <Popup

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/MapView.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/MapView.js
@@ -8,6 +8,7 @@ import { userTileProvider } from '../../lib/leaflet-wca/providers';
 import { redMarker, blueMarker } from '../../lib/leaflet-wca/markers';
 import ResizeMapIFrame from '../../lib/utils/leaflet-iframe';
 import 'leaflet/dist/leaflet.css';
+import { isProbablyOver } from '../../lib/utils/competition-table';
 
 // Limit number of markers on map, especially for "All Past Competitions"
 const MAP_DISPLAY_LIMIT = 500;
@@ -40,12 +41,12 @@ function MapView({
           <Marker
             key={comp.id}
             position={{ lat: comp.latitude_degrees, lng: comp.longitude_degrees }}
-            icon={comp.isProbablyOver ? blueMarker : redMarker}
+            icon={isProbablyOver(comp) ? blueMarker : redMarker}
           >
             <Popup>
               <a href={comp.url}>{comp.name}</a>
               <br />
-              {`${comp.dateRange} - ${comp.cityName}`}
+              {`${comp.date_range} - ${comp.city}`}
             </Popup>
           </Marker>
         ))}

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/queryUtils.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/queryUtils.js
@@ -45,6 +45,7 @@ export function createSearchParams(filterState, pageParam) {
     searchParams.append('ongoing_and_future', dateNow.toFormat('yyyy-MM-dd'));
     searchParams.append('page', pageParam);
   } else if (timeOrder === 'recent') {
+    // noinspection JSAnnotator
     const recentDaysAgo = dateNow.minus({ days: competitionConstants.competitionRecentDays });
 
     searchParams.append('sort', '-end_date,-start_date,name');

--- a/WcaOnRails/app/webpacker/lib/utils/competition-table.js
+++ b/WcaOnRails/app/webpacker/lib/utils/competition-table.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { DateTime } from 'luxon';
+import { DateTime, Interval } from 'luxon';
+
+function parseDateString(yyyymmddDateString) {
+  return DateTime.fromFormat(yyyymmddDateString, 'yyyy-MM-dd');
+}
 
 export function dayDifferenceFromToday(yyyymmddDateString) {
-  const dateLuxon = DateTime.fromFormat(yyyymmddDateString, 'yyyy-MM-dd');
+  const dateLuxon = parseDateString(yyyymmddDateString);
   const exactDaysDiff = dateLuxon.diffNow('days').days;
 
   if (dateLuxon > DateTime.now()) {
@@ -10,6 +14,35 @@ export function dayDifferenceFromToday(yyyymmddDateString) {
   }
 
   return Math.floor(exactDaysDiff * -1);
+}
+
+export function yearFromDateString(yyyymmddDateString) {
+  const dateLuxon = parseDateString(yyyymmddDateString);
+  return dateLuxon.year;
+}
+
+export function isProbablyOver(competition) {
+  if (!competition.end_date) return false;
+
+  const dateLuxon = parseDateString(competition.end_date);
+  return dateLuxon < DateTime.now();
+}
+
+export function isCancelled(competition) {
+  return !!competition.cancelled_at;
+}
+
+export function hasResultsPosted(competition) {
+  return !!competition.results_posted_at;
+}
+
+export function isInProgress(competition) {
+  const startDate = parseDateString(competition.start_date);
+  const endDate = parseDateString(competition.end_date);
+
+  const running = Interval.fromDateTimes(startDate, endDate).contains(DateTime.now());
+
+  return running && !hasResultsPosted(competition);
 }
 
 // Currently, the venue attribute of a competition object can be written as markdown,

--- a/WcaOnRails/app/webpacker/lib/utils/competition-table.js
+++ b/WcaOnRails/app/webpacker/lib/utils/competition-table.js
@@ -5,6 +5,10 @@ function parseDateString(yyyymmddDateString) {
   return DateTime.fromFormat(yyyymmddDateString, 'yyyy-MM-dd');
 }
 
+function parseDateTimeString(isoDateTimeString) {
+  return DateTime.fromISO(isoDateTimeString);
+}
+
 export function dayDifferenceFromToday(yyyymmddDateString) {
   const dateLuxon = parseDateString(yyyymmddDateString);
   const exactDaysDiff = dateLuxon.diffNow('days').days;
@@ -16,8 +20,8 @@ export function dayDifferenceFromToday(yyyymmddDateString) {
   return Math.floor(exactDaysDiff * -1);
 }
 
-export function yearFromDateString(yyyymmddDateString) {
-  const dateLuxon = parseDateString(yyyymmddDateString);
+export function startYear(competition) {
+  const dateLuxon = parseDateString(competition.end_date);
   return dateLuxon.year;
 }
 
@@ -43,6 +47,20 @@ export function isInProgress(competition) {
   const running = Interval.fromDateTimes(startDate, endDate).contains(DateTime.now());
 
   return running && !hasResultsPosted(competition);
+}
+
+export function isRegistrationOpenYet(competition) {
+  if (!competition.registration_open) return false;
+
+  const regOpen = parseDateTimeString(competition.registration_open);
+  return DateTime.now() < regOpen;
+}
+
+export function isRegistrationClosedAlready(competition) {
+  if (!competition.registration_close) return false;
+
+  const regClose = parseDateTimeString(competition.registration_close);
+  return regClose < DateTime.now();
 }
 
 // Currently, the venue attribute of a competition object can be written as markdown,


### PR DESCRIPTION
Adding custom fields in the `serializable_hash` had unintended side effects, which I have fixed by moving them back into separate serialization options at call-time