### PR TITLE
Sanitize input in OmniSearch bar

### DIFF
--- a/WcaOnRails/app/controllers/search_results_controller.rb
+++ b/WcaOnRails/app/controllers/search_results_controller.rb
@@ -6,6 +6,10 @@ class SearchResultsController < ApplicationController
 
   def index
     @omni_query = params[:q]&.slice(0...SEARCH_QUERY_LIMIT)
+
+    # strict sanitization to prevent injecting any HTML tags at all
+    @omni_query = sanitize(@omni_query, tags: [], attributes: [])
+
     if @omni_query.present?
       @competitions = Competition.search(@omni_query).page(params[:competitions_page]).per(SEARCH_RESULT_LIMIT)
       @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)

--- a/WcaOnRails/app/webpacker/components/SearchWidget/TextItem.js
+++ b/WcaOnRails/app/webpacker/components/SearchWidget/TextItem.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import { sanitize } from 'dompurify';
 import I18n from '../../lib/i18n';
 
 function TextItem({ item }) {
   return (
     <div
       className="multisearch-item-text"
-    /* eslint-disable-next-line react/no-danger */
+      /* eslint-disable-next-line react/no-danger */
       dangerouslySetInnerHTML={{
-        __html: I18n.t('search_results.index.search_for', { search_string: item.search }),
+        __html: I18n.t('search_results.index.search_for', { search_string: sanitize(item.search, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }) }),
       }}
     />
   );


### PR DESCRIPTION
Fixes a mild vulnerability where you can inject HTML href-tags into the search results page