### PR TITLE
Fix Link to Organizer Guidelines

### DIFF
--- a/WcaOnRails/app/views/static_pages/education.html.erb
+++ b/WcaOnRails/app/views/static_pages/education.html.erb
@@ -22,7 +22,7 @@
       <%= ui_icon("copy") %>
       <%= t('education.certificates') %>
     <% end %>
-    <%= link_to "https://documents.worldcubeassociation.org/organizer-guidelines", class: "list-group-item" do %>
+    <%= link_to "/organizer-guidelines", class: "list-group-item" do %>
       <%= ui_icon("copy") %>
       <%= t('education.orga_guidelines') %>
     <% end %>


### PR DESCRIPTION
Accidentally changed this local link to a documents link.