### PR TITLE
Correct the tsv_permalink.

### DIFF
--- a/WcaOnRails/app/controllers/database_controller.rb
+++ b/WcaOnRails/app/controllers/database_controller.rb
@@ -16,7 +16,7 @@ class DatabaseController < ApplicationController
   end
 
   def tsv_permalink
-    url, = current_results_export("sql")
+    url, = current_results_export("tsv")
     redirect_to url, status: 301, allow_other_host: true
   end
 


### PR DESCRIPTION
After #8795, it is pointed to the latest sql export.

```
$ curl -v https://www.worldcubeassociation.org/export/results/WCA_export.tsv
...
< HTTP/2 301 
< date: Sat, 03 Feb 2024 13:59:41 GMT
< content-type: text/html; charset=utf-8
< location: https://s3.us-west-2.amazonaws.com/assets.worldcubeassociation.org/export/results/WCA_export033_20240202T164043Z.sql.zip
```