### PR TITLE
Remove container css from delegates page and panel

### DIFF
--- a/WcaOnRails/app/webpacker/components/Delegates/index.jsx
+++ b/WcaOnRails/app/webpacker/components/Delegates/index.jsx
@@ -82,7 +82,7 @@ export default function Delegates() {
   }
 
   return (
-    <div className="container">
+    <div style={{ margin: '16px' }}>
       <Header as="h1">{I18n.t('delegates_page.title')}</Header>
       <p>
         <I18nHTMLTranslate
@@ -101,10 +101,10 @@ export default function Delegates() {
           onChange={(__, { checked }) => setToggleAdmin(checked)}
         />
       )}
-      <Grid container>
+      <Grid>
         <Grid.Column only="computer" computer={4}>
           <Header>{I18n.t('delegates_page.regions')}</Header>
-          <Menu vertical>
+          <Menu vertical fluid>
             {delegateRegions.map((region) => (
               <Menu.Item
                 key={region.id}

--- a/WcaOnRails/app/webpacker/components/Delegates/index.jsx
+++ b/WcaOnRails/app/webpacker/components/Delegates/index.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import {
   Checkbox,
+  Container,
   Dropdown,
   Grid,
   Header,
@@ -82,7 +83,7 @@ export default function Delegates() {
   }
 
   return (
-    <div style={{ margin: '16px' }}>
+    <Container fluid>
       <Header as="h1">{I18n.t('delegates_page.title')}</Header>
       <p>
         <I18nHTMLTranslate
@@ -151,6 +152,6 @@ export default function Delegates() {
           </Segment>
         </Grid.Column>
       </Grid>
-    </div>
+    </Container>
   );
 }

--- a/WcaOnRails/app/webpacker/components/Panel/PanelTemplate.jsx
+++ b/WcaOnRails/app/webpacker/components/Panel/PanelTemplate.jsx
@@ -23,11 +23,11 @@ export default function PanelTemplate({ heading, sections, loggedInUserId }) {
   }, [sections, hash, setHash]);
 
   return (
-    <div className="container">
+    <div style={{ margin: '16px' }}>
       <Header as="h1">{heading}</Header>
-      <Grid container>
+      <Grid>
         <Grid.Column only="computer" computer={4}>
-          <Menu vertical>
+          <Menu vertical fluid>
             {sections.map((section) => (
               <Menu.Item
                 key={section.id}

--- a/WcaOnRails/app/webpacker/components/Panel/PanelTemplate.jsx
+++ b/WcaOnRails/app/webpacker/components/Panel/PanelTemplate.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Container,
   Dropdown,
   Grid, Header, Icon, Menu, Segment,
 } from 'semantic-ui-react';
@@ -23,7 +24,7 @@ export default function PanelTemplate({ heading, sections, loggedInUserId }) {
   }, [sections, hash, setHash]);
 
   return (
-    <div style={{ margin: '16px' }}>
+    <Container fluid>
       <Header as="h1">{heading}</Header>
       <Grid>
         <Grid.Column only="computer" computer={4}>
@@ -67,6 +68,6 @@ export default function PanelTemplate({ heading, sections, loggedInUserId }) {
           </Segment>
         </Grid.Column>
       </Grid>
-    </div>
+    </Container>
   );
 }


### PR DESCRIPTION
I don't know the use of `container` CSS class, but removing it is making the UI slightly better. Maybe I was wrongly using the `container` class? No idea, looking forward for suggestions from CSS experts out there.

Posting the before and after screenshots of Delegates page and Panel page in Mac 14 inch Chrome browser:

Before
<img width="1512" alt="Screenshot 2024-02-03 at 21 01 13" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/3d9db3f8-6f6a-4628-b3ef-2d27e1f7675e">
<img width="1512" alt="Screenshot 2024-02-03 at 21 01 57" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/29956797-86b7-4095-aa35-cfb914768582">

After
<img width="1512" alt="Screenshot 2024-02-03 at 21 02 18" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/bc3c3199-d708-4944-b3fd-b8c31aad097d">
<img width="1509" alt="Screenshot 2024-02-03 at 21 02 34" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/4953b31d-d05c-44ed-a5ae-59cb89b808d0">