### PR TITLE
Translators metadata fix

### DIFF
--- a/WcaOnRails/app/webpacker/components/Panel/Wst/Translators.jsx
+++ b/WcaOnRails/app/webpacker/components/Panel/Wst/Translators.jsx
@@ -36,7 +36,7 @@ export default function Translators() {
         <Table.Body>
           {data.map((translator) => (
             <Table.Row>
-              <Table.Cell>{translator.metadata.locale}</Table.Cell>
+              <Table.Cell>{translator.group.metadata.locale}</Table.Cell>
               <Table.Cell>{translator.user.name}</Table.Cell>
               <Table.Cell>
                 <Button onClick={() => handleEndRole(translator)}>End Role</Button>

--- a/WcaOnRails/db/migrate/20240203180115_fix_translators_groups.rb
+++ b/WcaOnRails/db/migrate/20240203180115_fix_translators_groups.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class FixTranslatorsGroups < ActiveRecord::Migration[7.1]
+  def change
+    existing_translators_group = UserGroup.find_by(group_type: UserGroup.group_types[:translators])
+    translators = UserRole.where(group_id: existing_translators_group.id)
+    group_name_suffix = " Translators"
+    translators.each do |translator|
+      locale = translator.metadata[:locale]
+      if UserGroup.find_by(name: locale + group_name_suffix).nil?
+        group = UserGroup.create!(name: locale + group_name_suffix, group_type: UserGroup.group_types[:translators], is_active: true, is_hidden: true)
+        group.metadata = GroupsMetadataTranslators.create!(locale: locale)
+        group.save!
+      else
+        group = UserGroup.find_by(name: locale + group_name_suffix)
+      end
+      translator.metadata.delete
+      translator.update!(group_id: group.id, metadata: nil)
+    end
+    existing_translators_group.delete
+  end
+end

--- a/WcaOnRails/db/schema.rb
+++ b/WcaOnRails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_27_053701) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_03_180115) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false


### PR DESCRIPTION
Initially, we planned to keep all translators under single group, but that had a problem like we won't get the list of locales available. So, we are now having one group for one locale.

Also, in the initial implementation, I accidentally named RolesMetadataTranslators as GroupsMetadataTranslators. Now we anyway need GroupsMetadataTranslators, so using that.