### PR TITLE
Add tentative competitor counts to report

### DIFF
--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -33,6 +33,8 @@
 
     <% if competition.results_posted? %>
       <%= competition.competitors.count %>
+    <% elseif competition.results_submitted? %>
+      <%= competition.competitors.count %> (tentative)
     <% else %>
       Unknown, results are not posted yet.
     <% end %>

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -33,7 +33,7 @@
 
     <% if competition.results_posted? %>
       <%= competition.competitors.count %>
-    <% elseif competition.results_submitted? %>
+    <% elsif competition.results_submitted? %>
       <%= competition.competitors.count %> (tentative)
     <% else %>
       Unknown, results are not posted yet.

--- a/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
+++ b/WcaOnRails/app/views/delegate_reports/_delegate_report.html.erb
@@ -34,7 +34,7 @@
     <% if competition.results_posted? %>
       <%= competition.competitors.count %>
     <% elsif competition.results_submitted? %>
-      <%= competition.competitors.count %> (tentative)
+      <%= competition.inbox_persons.count %> (tentative)
     <% else %>
       Unknown, results are not posted yet.
     <% end %>


### PR DESCRIPTION
Results must be _submitted_ before the report can be posted, but WRT may not have _posted_ the results yet, resulting in "Unknown, results are not posted yet." That text will still show up before the results/report have been submitted.

I did the first commit back in May 2022, but didn't know how to test it back then.

![image](https://github.com/thewca/worldcubeassociation.org/assets/49137025/18aa32b9-3674-4b5e-a229-043a26cc9ffa)
