### PR TITLE
Debounce competition overview filter state

### DIFF
--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -13,13 +13,17 @@ import ListView from './ListView';
 import MapView from './MapView';
 import { filterReducer, filterInitialState } from './filterUtils';
 import { calculateQueryKey, createSearchParams } from './queryUtils';
+import useDebounce from '../../lib/hooks/useDebounce';
 import { isCancelled, isInProgress, isProbablyOver } from '../../lib/utils/competition-table';
+
+const DEBOUNCE_MS = 600;
 
 function CompetitionsView() {
   const [filterState, dispatchFilter] = useReducer(filterReducer, filterInitialState);
+  const debouncedFilterState = useDebounce(filterState, DEBOUNCE_MS)
   const [displayMode, setDisplayMode] = useState('list');
   const [shouldShowRegStatus, setShouldShowRegStatus] = useState(false);
-  const competitionQueryKey = useMemo(() => calculateQueryKey(filterState), [filterState]);
+  const competitionQueryKey = useMemo(() => calculateQueryKey(debouncedFilterState), [debouncedFilterState]);
 
   const {
     data: rawCompetitionData,
@@ -29,7 +33,7 @@ function CompetitionsView() {
   } = useInfiniteQuery({
     queryKey: ['competitions', competitionQueryKey],
     queryFn: ({ pageParam = 1 }) => {
-      const searchParams = createSearchParams(filterState, pageParam);
+      const searchParams = createSearchParams(debouncedFilterState, pageParam);
       return fetchJsonOrError(`${apiV0Urls.competitions.list}?${searchParams}`);
     },
     getNextPageParam: (previousPage, allPages) => {
@@ -44,8 +48,8 @@ function CompetitionsView() {
 
   const competitions = rawCompetitionData?.pages.flatMap((page) => page.data)
     .filter((comp) => (
-      (!isCancelled(comp) || filterState.shouldIncludeCancelled)
-      && (filterState.selectedEvents.every((event) => comp.event_ids.includes(event)))
+      (!isCancelled(comp) || debouncedFilterState.shouldIncludeCancelled)
+      && (debouncedFilterState.selectedEvents.every((event) => comp.event_ids.includes(event)))
     ));
 
   return (
@@ -66,7 +70,7 @@ function CompetitionsView() {
           && (
             <ListView
               competitions={competitions}
-              filterState={filterState}
+              filterState={debouncedFilterState}
               shouldShowRegStatus={shouldShowRegStatus}
               isLoading={competitionsIsFetching}
               fetchMoreCompetitions={competitionsFetchNextPage}
@@ -79,7 +83,7 @@ function CompetitionsView() {
           && (
             <MapView
               competitions={
-                filterState.timeOrder === 'present'
+                debouncedFilterState.timeOrder === 'present'
                   ? competitions?.filter((comp) => (
                     !isInProgress(comp) && !isProbablyOver(comp)
                   ))

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -20,10 +20,13 @@ const DEBOUNCE_MS = 600;
 
 function CompetitionsView() {
   const [filterState, dispatchFilter] = useReducer(filterReducer, filterInitialState);
-  const debouncedFilterState = useDebounce(filterState, DEBOUNCE_MS)
+  const debouncedFilterState = useDebounce(filterState, DEBOUNCE_MS);
   const [displayMode, setDisplayMode] = useState('list');
   const [shouldShowRegStatus, setShouldShowRegStatus] = useState(false);
-  const competitionQueryKey = useMemo(() => calculateQueryKey(debouncedFilterState), [debouncedFilterState]);
+  const competitionQueryKey = useMemo(
+    () => calculateQueryKey(debouncedFilterState),
+    [debouncedFilterState],
+  );
 
   const {
     data: rawCompetitionData,


### PR DESCRIPTION
Only the filter UI itself gets the actual current filter state, the rest of the code gets the debounced version (in particular, the query and the list/map UI). I initially intended to only put this on the search text, but it was easier to put it on the whole filter state and probably makes more sense anyway.