### PR TITLE
Add loading indicator for delegate selection 

### DIFF
--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -3,6 +3,7 @@ import {
   Button, Icon, Form, Dropdown, Popup, List, Input, Header,
 } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
+import PulseLoader from 'react-spinners/PulseLoader';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
@@ -161,11 +162,14 @@ function SearchBar({ dispatchFilter }) {
 }
 
 function DelegateSelector({ dispatchFilter }) {
-  const delegatesData = useDelegatesData();
+  const { delegatesLoading, delegatesData } = useDelegatesData();
 
   return (
     <>
-      <label htmlFor="delegate">{I18n.t('layouts.navigation.delegate')}</label>
+      <div style={{ display: 'inline-block' }}>
+        <label htmlFor="delegate">{I18n.t('layouts.navigation.delegate')}</label>
+        {delegatesLoading && <PulseLoader size="10" cssOverride={{ marginLeft: '5px' }} />}
+      </div>
       <Dropdown
         name="delegate"
         id="delegate"
@@ -184,6 +188,7 @@ function DelegateSelector({ dispatchFilter }) {
           }
         )) || [])]}
         onChange={(_, data) => dispatchFilter({ delegate: data.value })}
+        noResultsMessage={delegatesLoading ? I18n.t('competitions.index.delegates_loading') : I18n.t('competitions.index.no_delegates_found')}
       />
     </>
   );

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/useDelegatesData.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/useDelegatesData.js
@@ -30,7 +30,7 @@ const useDelegatesData = () => {
 
   const delegatesData = data?.pages.flatMap((page) => page.data);
 
-  return delegatesData;
+  return { delegatesLoading: hasNextPage, delegatesData };
 };
 
 export default useDelegatesData;

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1537,8 +1537,8 @@ en:
       past_from: "Past from %{year}"
       past_all: "Past from all years"
       no_delegates: "None"
-      delegates_loading: "Waiting to finish loading all delegates..."
-      no_delegates_found: "No delegate found."
+      delegates_loading: "Waiting to finish loading all Delegates..."
+      no_delegates_found: "No Delegates found."
       show_cancelled: "Show cancelled competitions"
       show_registration_status: "Show registration status icon"
       #context: titles for the competitions list

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1537,6 +1537,8 @@ en:
       past_from: "Past from %{year}"
       past_all: "Past from all years"
       no_delegates: "None"
+      delegates_loading: "Waiting to finish loading all delegates..."
+      no_delegates_found: "No delegate found."
       show_cancelled: "Show cancelled competitions"
       show_registration_status: "Show registration status icon"
       #context: titles for the competitions list


### PR DESCRIPTION
Added a loading spinner to the delegate selection box and modified the no results message for clarity

![image](https://github.com/thewca/worldcubeassociation.org/assets/58278719/86f663f7-3cda-4b7e-aab3-482ede429658)


![image](https://github.com/thewca/worldcubeassociation.org/assets/58278719/35ec6f42-ba41-4add-a7f3-6d5849145d36)

![image](https://github.com/thewca/worldcubeassociation.org/assets/58278719/3bbffcf9-d0fe-488c-8707-70d8b4f43a4a)


![image](https://github.com/thewca/worldcubeassociation.org/assets/58278719/2c60fe99-a7b5-49c9-984c-e231e5fb13b1)


