### PR TITLE
Removed validation senior_delegate_must_be_senior_delegate

### DIFF
--- a/WcaOnRails/app/models/user.rb
+++ b/WcaOnRails/app/models/user.rb
@@ -408,13 +408,6 @@ class User < ApplicationRecord
     end
   end
 
-  validate :senior_delegate_must_be_senior_delegate
-  def senior_delegate_must_be_senior_delegate
-    if senior_delegate && !senior_delegate.senior_delegate?
-      errors.add(:senior_delegate, I18n.t('users.errors.must_be_senior'))
-    end
-  end
-
   validates :region_id, presence: true, if: -> { delegate_status.present? }
 
   validate :avatar_requires_wca_id

--- a/WcaOnRails/config/locales/ca.yml
+++ b/WcaOnRails/config/locales/ca.yml
@@ -2028,8 +2028,6 @@ ca:
         la persona al passat.
       #original_hash: b589014
       must_have_a_change: El nom o el país ha de ser diferent per actualitzar la persona.
-      #original_hash: 012f032
-      must_be_senior: ha de ser Delegat Sènior
       #original_hash: 2e582eb
       must_not_be_present: no pot ser present
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/cs.yml
+++ b/WcaOnRails/config/locales/cs.yml
@@ -2094,8 +2094,6 @@ cs:
         reprezentovala.
       #original_hash: b589014
       must_have_a_change: Název země musí být jiný pro aktualizaci dané osoby.
-      #original_hash: 012f032
-      must_be_senior: musí být Vyšší Delegát
       #original_hash: 2e582eb
       must_not_be_present: nesmí být přítomný
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/da.yml
+++ b/WcaOnRails/config/locales/da.yml
@@ -1932,8 +1932,6 @@ da:
       must_have_a_change: >-
         Navnet eller landet skal være anderledes end før, for at opdatere
         personen.
-      #original_hash: 012f032
-      must_be_senior: skal være en Seniordelegeret
       #original_hash: 2e582eb
       must_not_be_present: må ikke være nuværende
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/de.yml
+++ b/WcaOnRails/config/locales/de.yml
@@ -2182,8 +2182,6 @@ de:
       must_have_a_change: >-
         Der Name oder die Region müssen sich unterscheiden, um die Person
         aktualisieren zu können.
-      #original_hash: 012f032
-      must_be_senior: muss ein Senior-Delegierter sein
       #original_hash: 48653a9
       already_have_id: >-
         kann keine WCA-ID anfordern da Du bereits mit der WCA-ID %{wca_id}

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1101,7 +1101,6 @@ en:
       dob_recent: "must be at least two years old"
       already_represented_country: "Cannot change the region to a region the person has already represented in the past."
       must_have_a_change: "The name or the region must be different to update the person."
-      must_be_senior: "must be a Senior Delegate"
       already_have_id: "cannot claim a WCA ID because you already have WCA ID %{wca_id}"
       wca_id_no_birthdate_html: "We do not have a birthdate recorded for this WCA ID. Please contact the WCA Results Team using <a href=\"%{dob_form_path}\">this dedicated form</a>."
       wca_id_no_gender_html: "We do not have a gender recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."

--- a/WcaOnRails/config/locales/eo.yml
+++ b/WcaOnRails/config/locales/eo.yml
@@ -2098,8 +2098,6 @@ eo:
         pasintece.
       #original_hash: b589014
       must_have_a_change: La nomo aŭ la lando devas esti malsamaj por ĝisdatigi la personon.
-      #original_hash: 012f032
-      must_be_senior: devas esti Ĉefa Deligito
       #original_hash: 2e582eb
       must_not_be_present: ne devas ĉeesti
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/es.yml
+++ b/WcaOnRails/config/locales/es.yml
@@ -2156,8 +2156,6 @@ es:
         representado en el pasado.
       #original_hash: 5fe15d4
       must_have_a_change: El nombre de la región debe ser distinta para actualizar.
-      #original_hash: 012f032
-      must_be_senior: debe ser un Delegado Senior
       #original_hash: 2e582eb
       must_not_be_present: debe no ser presente
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/fi.yml
+++ b/WcaOnRails/config/locales/fi.yml
@@ -1981,8 +1981,6 @@ fi:
       must_have_a_change: >-
         Nimen tai kansalaisuuden täytyy muuttua henkilön tietojen päivittämistä
         varten.
-      #original_hash: 012f032
-      must_be_senior: täytyy olla vastaava delegaatti
       #original_hash: 2e582eb
       must_not_be_present: ei saa olla paikalla
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/fr.yml
+++ b/WcaOnRails/config/locales/fr.yml
@@ -2186,8 +2186,6 @@ fr:
       must_have_a_change: >-
         Le nom de la région doit être différent pour mettre à jour cette
         personne.
-      #original_hash: 012f032
-      must_be_senior: doit être un·e Délégué·e Senior
       #original_hash: 5b4eac9
       senior_has_delegate: >-
         ne peut pas destituer un·e Délégué·e Senior qui supervise d'autres

--- a/WcaOnRails/config/locales/hr.yml
+++ b/WcaOnRails/config/locales/hr.yml
@@ -2127,8 +2127,6 @@ hr:
         prošlosti.
       #original_hash: 5fe15d4
       must_have_a_change: Ime ili država moraju biti različiti kako bi se moglo ažurirati osobu.
-      #original_hash: 012f032
-      must_be_senior: mora biti Senior Delegat
       #original_hash: 2e582eb
       must_not_be_present: ne smije biti trenutno
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/id.yml
+++ b/WcaOnRails/config/locales/id.yml
@@ -2082,8 +2082,6 @@ id:
         diwakili oleh orang tersebut.
       #original_hash: b589014
       must_have_a_change: Nama atau negara harus berbeda untuk memperbarui orang tersebut.
-      #original_hash: 012f032
-      must_be_senior: harus Delegate Senior yang mengubahnya
       #original_hash: 2e582eb
       must_not_be_present: tidak boleh ada
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/it.yml
+++ b/WcaOnRails/config/locales/it.yml
@@ -2165,8 +2165,6 @@ it:
         rappresentato in passato.
       #original_hash: 5fe15d4
       must_have_a_change: Il nome o il paese deve essere diverso per aggiornare la persona.
-      #original_hash: 012f032
-      must_be_senior: deve essere un Delegato Senior
       #original_hash: 2e582eb
       must_not_be_present: non deve essere presente
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/ja.yml
+++ b/WcaOnRails/config/locales/ja.yml
@@ -1632,8 +1632,6 @@ ja:
       already_represented_country: 国籍は過去に選択した国籍に変更することはできません。
       #original_hash: b589014
       must_have_a_change: 国名を変更してください。
-      #original_hash: 012f032
-      must_be_senior: 上級代理人でなくてはいけません
       #original_hash: 48653a9
       already_have_id: '既に WCA ID %{wca_id} が連携されているため、WCA ID の連携申請ができません'
       #original_hash: ec5db95

--- a/WcaOnRails/config/locales/kk.yml
+++ b/WcaOnRails/config/locales/kk.yml
@@ -1842,8 +1842,6 @@ kk:
       already_represented_country: Бұл қатысушы бұрын ұсынған елді өзгерту мүмкін емес.
       #original_hash: b589014
       must_have_a_change: Жаңарту үшін аты немесе елі әр түрлі болуы керек.
-      #original_hash: 012f032
-      must_be_senior: Үлкен Делегат болуы керек
       #original_hash: 2e582eb
       must_not_be_present: болмауы тиіс
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/ko.yml
+++ b/WcaOnRails/config/locales/ko.yml
@@ -1107,8 +1107,6 @@ ko:
       unique: '은 이미 %{used_email}에 의해 "%{used_name}"가 사용하고 있습니다.'
       #original_hash: 26f70ed
       dob_past: 과거여야 합니다
-      #original_hash: 012f032
-      must_be_senior: 대표 파견위원이여야 합니다
       #original_hash: 2e582eb
       must_not_be_present: 현재가 아니여야 합니다
       #original_hash: 48653a9

--- a/WcaOnRails/config/locales/nl.yml
+++ b/WcaOnRails/config/locales/nl.yml
@@ -1938,8 +1938,6 @@ nl:
       must_have_a_change: >-
         De naam of het land moet verschillend zijn om de persoon te kunnen
         bijwerken.
-      #original_hash: 012f032
-      must_be_senior: moet een senior delegate zijn
       #original_hash: 2e582eb
       must_not_be_present: moet niet aanwezig zijn
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/pl.yml
+++ b/WcaOnRails/config/locales/pl.yml
@@ -1979,8 +1979,6 @@ pl:
       must_have_a_change: >-
         Imię i nazwisko lub kraj musi zostać zmienione, aby zaktualizować daną
         osobę.
-      #original_hash: 012f032
-      must_be_senior: musi być Starszym Delegatem
       #original_hash: 2e582eb
       must_not_be_present: nie może być obecne
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/pt-BR.yml
+++ b/WcaOnRails/config/locales/pt-BR.yml
@@ -2119,8 +2119,6 @@ pt-BR:
         representado no passado.
       #original_hash: 5fe15d4
       must_have_a_change: O nome ou região precisam ser diferentes para atualizar a pessoa.
-      #original_hash: 012f032
-      must_be_senior: deve ser um Delegado Senior
       #original_hash: 2e582eb
       must_not_be_present: não pode ser presente
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/pt.yml
+++ b/WcaOnRails/config/locales/pt.yml
@@ -2126,8 +2126,6 @@ pt:
         no passado.
       #original_hash: 5fe15d4
       must_have_a_change: O nome da região tem que ser diferente para atualizar o competidor.
-      #original_hash: 012f032
-      must_be_senior: deve ser um Delegado Sénior
       #original_hash: 48653a9
       already_have_id: 'não pode solicitar um ID da WCA porque já tem o ID %{wca_id}'
       #original_hash: ec5db95

--- a/WcaOnRails/config/locales/ro.yml
+++ b/WcaOnRails/config/locales/ro.yml
@@ -2145,8 +2145,6 @@ ro:
       already_represented_country: Nu se poate schimba țara într-o fostă țară a concurentului
       #original_hash: b589014
       must_have_a_change: Numele țării trebuie să fie diferit pentru actualizarea persoanei
-      #original_hash: 012f032
-      must_be_senior: trebuie să fie Delegat Senior
       #original_hash: 2e582eb
       must_not_be_present: trebuie să nu fie prezent
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/ru.yml
+++ b/WcaOnRails/config/locales/ru.yml
@@ -2116,8 +2116,6 @@ ru:
       already_represented_country: 'Невозможно поменять страну, которую этот участник уже представлял ранее.'
       #original_hash: b589014
       must_have_a_change: 'Имя или страна должны отличаться, чтобы было что обновлять.'
-      #original_hash: 012f032
-      must_be_senior: должен быть Старшим Делегатом
       #original_hash: 2e582eb
       must_not_be_present: должен отсутствовать
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/sk.yml
+++ b/WcaOnRails/config/locales/sk.yml
@@ -1115,8 +1115,6 @@ sk:
       unique: 'už je použitý použivateľom "%{used_name}" s %{used_email}'
       #original_hash: 26f70ed
       dob_past: musí byť v minulosti
-      #original_hash: f599dc5
-      must_be_senior: musí byť skúsený delegát
       #original_hash: 2e582eb
       must_not_be_present: nemôže byť terajší
       #original_hash: b2c4ecc

--- a/WcaOnRails/config/locales/sl.yml
+++ b/WcaOnRails/config/locales/sl.yml
@@ -1304,8 +1304,6 @@ sl:
       unique: 'je že v uporabi s strani "%{used_name}" z %{used_email}'
       #original_hash: 26f70ed
       dob_past: mora biti v preteklosti
-      #original_hash: 012f032
-      must_be_senior: mora biti Senior Delegat
       #original_hash: 2e582eb
       must_not_be_present: ne sme biti sedanji
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/sv.yml
+++ b/WcaOnRails/config/locales/sv.yml
@@ -2105,8 +2105,6 @@ sv:
       must_have_a_change: >-
         Namnet eller regionen måste vara annorlunda för att personen ska kunna
         uppdateras.
-      #original_hash: 012f032
-      must_be_senior: måste vara senior-delegat
       #original_hash: 48653a9
       already_have_id: >-
         kan inte göra anspråk på ett WCA-ID eftersom du redan har WCA-ID

--- a/WcaOnRails/config/locales/th.yml
+++ b/WcaOnRails/config/locales/th.yml
@@ -2022,8 +2022,6 @@ th:
       already_represented_country: ไม่สามารถเปลี่ยนภูมิภาคเป็นภูมิภาคที่มีการใช้ในอดีตได้
       #original_hash: 5fe15d4
       must_have_a_change: ชื่อหรือภูมิภาคต้องต่างกันในการแก้ไขบุคคล
-      #original_hash: 012f032
-      must_be_senior: ต้องเป็น Senior Delegate
       #original_hash: 48653a9
       already_have_id: 'ไม่สามารถขอรับ WCA ID เพราะคุณมี WCA ID %{wca_id} แล้ว'
       #original_hash: ec5db95

--- a/WcaOnRails/config/locales/uk.yml
+++ b/WcaOnRails/config/locales/uk.yml
@@ -1749,8 +1749,6 @@ uk:
       already_represented_country: 'Не можна змінити країну на таку, яку особа вже представляла в минулому.'
       #original_hash: b589014
       must_have_a_change: 'Ім’я або країна має відрізнятись, щоб оновити інформацію про особу.'
-      #original_hash: 012f032
-      must_be_senior: має бути Провідним делегатом
       #original_hash: 2e582eb
       must_not_be_present: не має бути теперешнім
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/vi.yml
+++ b/WcaOnRails/config/locales/vi.yml
@@ -1559,8 +1559,6 @@ vi:
         diện.
       #original_hash: b589014
       must_have_a_change: Phải sử dụng tên quốc gia khác để cập nhật hồ sơ cá nhân này.
-      #original_hash: 012f032
-      must_be_senior: phải là Senior Delegate
       #original_hash: 2e582eb
       must_not_be_present: không phải hiện tại
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/zh-CN.yml
+++ b/WcaOnRails/config/locales/zh-CN.yml
@@ -1457,8 +1457,6 @@ zh-CN:
       dob_past: 必须是过去的时间
       #original_hash: b320913
       dob_recent: 必须至少满两岁
-      #original_hash: 012f032
-      must_be_senior: 必须是一个高级代表
       #original_hash: 2e582eb
       must_not_be_present: 不能是当前时间
       #original_hash: 5b4eac9

--- a/WcaOnRails/config/locales/zh-TW.yml
+++ b/WcaOnRails/config/locales/zh-TW.yml
@@ -1810,8 +1810,6 @@ zh-TW:
       already_represented_country: 不能將該人區域改為他過去所代表的區域。
       #original_hash: 5fe15d4
       must_have_a_change: 姓名或區域必須不同才能更新此人。
-      #original_hash: 012f032
-      must_be_senior: 必須為高級代表
       #original_hash: 48653a9
       already_have_id: '無法取得WCA ID，因為您已經有WCA ID %{wca_id}了'
       #original_hash: ec5db95


### PR DESCRIPTION
This validation blocks the development of senior delegates migration. Also this validation doesn't makes much sense right now. Hence, removing this and the locales connected.

This has to be merged before https://github.com/thewca/worldcubeassociation.org/pull/8868.