### PR TITLE
Bump RuboCop target version to 3.3

### DIFF
--- a/WcaOnRails/.rubocop.yml
+++ b/WcaOnRails/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3
   DisplayCopNames: true
   NewCops: enable
   Exclude:


### PR DESCRIPTION
Dependency hotfix that was overlooked during the general 3.3 upgrade