### PR TITLE
Display validation errors when trying to confirm a competition

### DIFF
--- a/WcaOnRails/app/webpacker/components/CompetitionForm/ConfirmationActions.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionForm/ConfirmationActions.js
@@ -38,6 +38,7 @@ function ConfirmButton({
   competitionId,
   data,
   sync,
+  onError,
 }) {
   const { canConfirm } = data;
 
@@ -60,7 +61,7 @@ function ConfirmButton({
       }, {
         body: null,
         method: 'PUT',
-      });
+      }, onError);
     });
   };
 
@@ -113,6 +114,7 @@ function DeleteButton({
 export default function ConfirmationActions({
   createComp,
   updateComp,
+  onError,
 }) {
   const {
     isAdminView,
@@ -138,7 +140,7 @@ export default function ConfirmationActions({
       <Button.Group>
         <CreateOrUpdateButton createComp={createComp} updateComp={updateComp} />
         {isPersisted && !isAdminView && !isConfirmed && (
-          <ConfirmButton competitionId={competitionId} data={data} sync={sync} />
+          <ConfirmButton competitionId={competitionId} data={data} sync={sync} onError={onError} />
         )}
         {isPersisted && !isConfirmed && (
           <DeleteButton competitionId={competitionId} data={data} />

--- a/WcaOnRails/app/webpacker/components/CompetitionForm/index.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionForm/index.js
@@ -97,6 +97,7 @@ function AnnouncementMessage() {
 function BottomConfirmationPanel({
   createComp,
   updateComp,
+  onError,
   unsavedChanges,
 }) {
   const { isPersisted } = useStore();
@@ -106,6 +107,7 @@ function BottomConfirmationPanel({
       <ConfirmationActions
         createComp={createComp}
         updateComp={updateComp}
+        onError={onError}
       />
     );
   }
@@ -286,6 +288,7 @@ function CompetitionForm() {
       <BottomConfirmationPanel
         createComp={createComp}
         updateComp={updateComp}
+        onError={onError}
         unsavedChanges={unsavedChanges}
       />
     </div>


### PR DESCRIPTION
Some validations are configured to only run for _confirmed_ competitions (god knows why...).

In other words, certain validation errors can only be displayed _upon confirming_ and we need to propagate them to the global model state in order to display them neatly to the user.