### PR TITLE
Fix renaming custom activities bug

### DIFF
--- a/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/EditActivityModal.js
+++ b/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/EditActivityModal.js
@@ -57,6 +57,12 @@ function EditActivityModal({
     setActivityName(activity?.name);
   }, [activity, setActivityCode, setActivityName]);
 
+  const closeModalAndCleanUp = () => {
+    onModalClose();
+    setActivityCode(undefined);
+    setActivityName(undefined);
+  };
+
   return (
     <Modal
       open={isModalOpen}
@@ -98,14 +104,14 @@ function EditActivityModal({
           positive
           onClick={() => {
             onModalSave({ activityCode, activityName });
-            onModalClose();
+            closeModalAndCleanUp();
           }}
         />
         <Button
           icon="cancel"
           content="Cancel"
           negative
-          onClick={onModalClose}
+          onClick={closeModalAndCleanUp}
         />
       </Modal.Actions>
     </Modal>

--- a/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/EditActivityModal.js
+++ b/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/EditActivityModal.js
@@ -32,8 +32,9 @@ function EditActivityModal({
   activity,
   startLuxon,
   endLuxon,
-  onModalClose,
   dateLocale,
+  onModalClose,
+  onModalSave,
 }) {
   const [activityCode, setActivityCode] = useInputState();
   const [activityName, setActivityName] = useInputState();
@@ -95,13 +96,16 @@ function EditActivityModal({
           icon="save"
           content="Save"
           positive
-          onClick={() => onModalClose(true, { activityCode, activityName })}
+          onClick={() => {
+            onModalSave({ activityCode, activityName });
+            onModalClose();
+          }}
         />
         <Button
           icon="cancel"
           content="Cancel"
           negative
-          onClick={() => onModalClose(false, { activityCode, activityName })}
+          onClick={onModalClose}
         />
       </Modal.Actions>
     </Modal>

--- a/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -277,7 +277,7 @@ function EditActivities({
 
       dispatch(addActivity(activity, wcifRoom.id));
     }
-  }
+  };
 
   return (
     <div id="schedules-edit-panel-body">

--- a/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/WcaOnRails/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -246,37 +246,38 @@ function EditActivities({
     }
   };
 
-  const onActivityModalClose = (ok, modalData) => {
+  const closeActivityModalAndCleanUp = () => {
+    // close
     setActivityModalOpen(false);
 
-    const { activityCode, activityName } = modalData;
-
-    if (ok) {
-      if (modalActivity) {
-        dispatch(editActivity(modalActivity.id, 'activityCode', activityCode, shouldUpdateMatches));
-        dispatch(editActivity(modalActivity.id, 'name', activityName, shouldUpdateMatches));
-      } else {
-        const utcStartIso = luxonToWcifIso(modalLuxonStart);
-        const utcEndIso = luxonToWcifIso(modalLuxonEnd);
-
-        const activity = {
-          name: activityName,
-          activityCode,
-          startTime: utcStartIso,
-          endTime: utcEndIso,
-          childActivities: [],
-        };
-
-        dispatch(addActivity(activity, wcifRoom.id));
-      }
-    }
-
-    // cleanup.
+    // cleanup
     setModalActivity(null);
 
     setModalLuxonStart(null);
     setModalLuxonEnd(null);
   };
+
+  const dispatchActivityModalUpdates = (modalData) => {
+    const { activityCode, activityName } = modalData;
+
+    if (modalActivity) {
+      dispatch(editActivity(modalActivity.id, 'activityCode', activityCode, shouldUpdateMatches));
+      dispatch(editActivity(modalActivity.id, 'name', activityName, shouldUpdateMatches));
+    } else {
+      const utcStartIso = luxonToWcifIso(modalLuxonStart);
+      const utcEndIso = luxonToWcifIso(modalLuxonEnd);
+
+      const activity = {
+        name: activityName,
+        activityCode,
+        startTime: utcStartIso,
+        endTime: utcEndIso,
+        childActivities: [],
+      };
+
+      dispatch(addActivity(activity, wcifRoom.id));
+    }
+  }
 
   return (
     <div id="schedules-edit-panel-body">
@@ -315,7 +316,8 @@ function EditActivities({
             startLuxon={modalLuxonStart}
             endLuxon={modalLuxonEnd}
             dateLocale={calendarLocale}
-            onModalClose={onActivityModalClose}
+            onModalClose={closeActivityModalAndCleanUp}
+            onModalSave={dispatchActivityModalUpdates}
           />
           <ActionsHeader
             selectedRoomId={selectedRoomId}

--- a/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
@@ -117,7 +117,12 @@ export function fcEventToActivityAndDates(fcEvent, calendar) {
   const utcStartIso = luxonToWcifIso(eventStartLuxon);
   const utcEndIso = luxonToWcifIso(eventEndLuxon);
 
-  const { activityId, activityCode, activityName, childActivities } = fcEvent.extendedProps;
+  const {
+    activityId,
+    activityCode,
+    activityName,
+    childActivities,
+  } = fcEvent.extendedProps;
 
   const activity = {
     id: activityId,

--- a/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
+++ b/WcaOnRails/app/webpacker/lib/utils/edit-schedule.js
@@ -117,9 +117,10 @@ export function fcEventToActivityAndDates(fcEvent, calendar) {
   const utcStartIso = luxonToWcifIso(eventStartLuxon);
   const utcEndIso = luxonToWcifIso(eventEndLuxon);
 
-  const { activityCode, activityName, childActivities } = fcEvent.extendedProps;
+  const { activityId, activityCode, activityName, childActivities } = fcEvent.extendedProps;
 
   const activity = {
+    id: activityId,
     name: activityName,
     activityCode,
     startTime: utcStartIso,


### PR DESCRIPTION
When the issue was filed, renaming did nothing. After my recent PR to copy schedules and bulk-edit activities, renaming throws an error.

This PR 1) fixes that, 2) refactors some code to make it (in my opinion) clearer, and 3) fixes some state clean-up in the activity modal (1 commit per item).