### PR TITLE
Use Tanstack-Query instead of useManyLoadedData custom hook

### DIFF
--- a/WcaOnRails/app/webpacker/components/CompetitionForm/index.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionForm/index.js
@@ -11,6 +11,7 @@ import {
   Message, Sticky,
 } from 'semantic-ui-react';
 import _ from 'lodash';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import VenueInfo from './FormSections/VenueInfo';
 import {
   InputBoolean,
@@ -318,7 +319,9 @@ export default function Wrapper({
       }}
     >
       <SectionProvider>
-        <CompetitionForm />
+        <QueryClientProvider client={new QueryClient()}>
+          <CompetitionForm />
+        </QueryClientProvider>
       </SectionProvider>
     </StoreProvider>
   );

--- a/WcaOnRails/app/webpacker/lib/hooks/useLoadedData.js
+++ b/WcaOnRails/app/webpacker/lib/hooks/useLoadedData.js
@@ -2,7 +2,6 @@ import {
   useState,
   useEffect,
   useCallback,
-  useMemo,
 } from 'react';
 
 import { fetchJsonOrError } from '../requests/fetchWithAuthenticityToken';
@@ -40,60 +39,6 @@ const useLoadedData = (url) => {
     loading,
     error,
     sync,
-  };
-};
-
-export const useManyLoadedData = (ids, urlFn) => {
-  const defaultData = useCallback(
-    (defaultValue) => Object.fromEntries(ids.map((id) => [id, defaultValue])),
-    [ids],
-  );
-
-  const [data, setData] = useState(defaultData(null));
-  const [headers, setHeaders] = useState(defaultData(new Headers()));
-  const [error, setError] = useState(defaultData(null));
-
-  const [anyLoading, setAnyLoading] = useState(true);
-
-  const promises = useMemo(() => ids.map(async (id) => {
-    const url = urlFn(id);
-
-    return fetchJsonOrError(url)
-      .then((response) => {
-        setData((prevData) => ({
-          ...prevData,
-          [id]: response.data,
-        }));
-        setHeaders((prevHeaders) => ({
-          ...prevHeaders,
-          [id]: response.headers,
-        }));
-      })
-      .catch((err) => {
-        setError((prevError) => ({
-          ...prevError,
-          [id]: err.message,
-        }));
-      });
-  }), [ids, urlFn, setData, setHeaders, setError]);
-
-  const syncAll = useCallback(() => {
-    setAnyLoading(true);
-
-    setHeaders(defaultData(new Headers()));
-    setError(defaultData(null));
-
-    Promise.all(promises).finally(() => setAnyLoading(false));
-  }, [promises, defaultData, setAnyLoading]);
-
-  useEffect(syncAll, [syncAll]);
-
-  return {
-    data,
-    headers,
-    anyLoading,
-    error,
-    syncAll,
   };
 };
 


### PR DESCRIPTION
Gets entirely rid of the `useManyLoadedData` hook. Might (potentially?) fix https://github.com/thewca/worldcubeassociation.org/issues/8880, not sure though.

In the long run, we should have the `WcaSearch` component be responsible for fetching its own internal data, and only pass the ID to the outside world. I might give this a shot as a follow-up PR if it's straight-forward to implement.