### PR TITLE
Use wkhtmltopdf-binary gem to install wkhtmltopdf

### DIFF
--- a/WcaOnRails/Gemfile
+++ b/WcaOnRails/Gemfile
@@ -28,6 +28,7 @@ gem 'recaptcha', require: 'recaptcha/rails'
 gem 'kaminari'
 gem 'kaminari-i18n'
 gem 'devise'
+gem 'wkhtmltopdf-binary'
 # NOTE: we put devise-18n before devise-bootstrap-views intentionally.
 # See https://github.com/hisea/devise-bootstrap-views/issues/55 for more details.
 gem 'devise-i18n'

--- a/WcaOnRails/Gemfile.lock
+++ b/WcaOnRails/Gemfile.lock
@@ -797,6 +797,7 @@ GEM
     websocket-extensions (0.1.5)
     wicked_pdf (2.7.0)
       activesupport
+    wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
@@ -918,6 +919,7 @@ DEPENDENCIES
   wca_i18n
   web-console
   wicked_pdf
+  wkhtmltopdf-binary
 
 BUNDLED WITH
    2.5.4

--- a/WcaOnRails/config/initializers/wicked_pdf.rb
+++ b/WcaOnRails/config/initializers/wicked_pdf.rb
@@ -13,9 +13,8 @@
 WickedPdf.config = {
   # Path to the wkhtmltopdf executable: This usually isn't needed if using
   # one of the wkhtmltopdf-binary family of gems.
-  exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  # exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
+  exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)

--- a/WcaOnRails/config/initializers/wicked_pdf.rb
+++ b/WcaOnRails/config/initializers/wicked_pdf.rb
@@ -13,8 +13,9 @@
 WickedPdf.config = {
   # Path to the wkhtmltopdf executable: This usually isn't needed if using
   # one of the wkhtmltopdf-binary family of gems.
+  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
+  exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf'),
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)


### PR DESCRIPTION
Now that our only use for wkhtmltopdf is to generate competition pdfs, we can use this gem to install it