### PR TITLE
Host TNoodle signing key through Vault

### DIFF
--- a/WcaOnRails/app/controllers/api/v0/api_controller.rb
+++ b/WcaOnRails/app/controllers/api/v0/api_controller.rb
@@ -13,7 +13,6 @@ class Api::V0::ApiController < ApplicationController
   end
 
   DEFAULT_API_RESULT_LIMIT = 20
-  TNOODLE_PUBLIC_KEY_PATH = "#{Rails.root}/app/views/regulations/scrambles/tnoodle/TNoodle-WCA.pem".freeze
 
   def me
     render json: { me: current_api_user }, private_attributes: doorkeeper_token.scopes
@@ -32,16 +31,15 @@ class Api::V0::ApiController < ApplicationController
 
   def scramble_program
     begin
-      raw = File.read(TNOODLE_PUBLIC_KEY_PATH)
-    rescue Errno::ENOENT
-      public_key = false
-    else
-      rsa_key = OpenSSL::PKey::RSA.new(raw)
+      rsa_key = OpenSSL::PKey::RSA.new(AppSecrets.TNOODLE_PUBLIC_KEY)
       raw_bytes = rsa_key.public_key.to_der
 
       public_key_base = Base64.encode64(raw_bytes)
+
       # DER format export from Ruby contains newlines which we don't want
       public_key = public_key_base.gsub(/\s+/, "")
+    rescue OpenSSL::PKey::PKeyError
+      public_key = false
     end
 
     render json: {

--- a/WcaOnRails/app_secrets.rb
+++ b/WcaOnRails/app_secrets.rb
@@ -70,6 +70,7 @@ AppSecrets = SuperConfig.new do
     vault :JWT_KEY
     vault :OIDC_SECRET_KEY
     vault :SLACK_WST_BOT_TOKEN
+    vault :TNOODLE_PUBLIC_KEY
   else
     mandatory :DATABASE_PASSWORD, :string
     mandatory :GOOGLE_MAPS_API_KEY, :string
@@ -98,5 +99,6 @@ AppSecrets = SuperConfig.new do
     optional :SMTP_PASSWORD, :string, ''
     optional :GOOGLE_APPLICATION_CREDENTIALS, :string, ''
     optional :SLACK_WST_BOT_TOKEN, :string, ''
+    optional :TNOODLE_PUBLIC_KEY, :string, ''
   end
 end


### PR DESCRIPTION
One of the remnants of our ECS migration. Failing to load the TNoodle key makes the API return `false` instead of an actual key, and thus lets TNoodle think it's not signed even though it clearly is.

(Yes, TNoodle should handle it better when the API returns `false`, but I cannot be bothered to create a new release just for this purpose.)