### PR TITLE
Add other misc errors to frontend validation format

### DIFF
--- a/WcaOnRails/app/models/competition.rb
+++ b/WcaOnRails/app/models/competition.rb
@@ -2294,6 +2294,9 @@ class Competition < ApplicationRecord
         "fromId" => errors[:being_cloned_from_id],
         "cloneTabs" => errors[:clone_tabs],
       },
+      "other" => {
+        "competitionEvents" => errors[:competition_events],
+      },
     }
   end
 


### PR DESCRIPTION
These `:competition_events` errors just appear hard-coded throughout our validation source code.