### PR TITLE
Remove GTID-off from mysqldump command

### DIFF
--- a/WcaOnRails/lib/database_dumper.rb
+++ b/WcaOnRails/lib/database_dumper.rb
@@ -1216,10 +1216,7 @@ module DatabaseDumper
   end
 
   def self.mysqldump(db_name, dest_filename)
-    # Use --set-gtid-purged=OFF to avoid having `SET @@GLOBAL.gtid_purged` and `SET @@SESSION.SQL_LOG_BIN`
-    # in the resulting dump file, as setting these require additional parmissions
-    # making it troublesome to import the dump into a managed databases like the staging one.
-    system_pipefail!("mysqldump #{"--set-gtid-purged=OFF " if Rails.env.production?}#{self.mysql_cli_creds} #{db_name} -r #{dest_filename} #{filter_out_mysql_warning}")
+    system_pipefail!("mysqldump #{self.mysql_cli_creds} #{db_name} -r #{dest_filename} #{filter_out_mysql_warning}")
     system_pipefail!("sed -i 's_^/\\*!50013 DEFINER.*__' #{dest_filename}")
   end
 


### PR DESCRIPTION
Our Docker setup uses `mariadb-client` (fun fact: So do modern Ubuntu distributions by default!) which does not support the `--set-gtid-purged` option anymore.

From the MariaDB documentation at https://mariadb.com/kb/en/gtid/
> GTID mode is off by default; this is needed to preserve backwards compatibility with existing replication setups (older versions of the server did not enforce any strict mode for binlog order). Global transaction ID is designed to work correctly even when strict mode is not enabled. However, with strict mode enforced, the semantics is simpler and thus easier to understand, because binlog order is always identical across servers and sequence numbers are always strictly increasing within each replication domain. This can also make automated scripting of large replication setups easier to implement correctly.