### PR TITLE
Fixed scrambles page to show JAR name instead of GitHub link

### DIFF
--- a/WcaOnRails/app/views/regulations/scrambles.html.erb
+++ b/WcaOnRails/app/views/regulations/scrambles.html.erb
@@ -7,7 +7,7 @@
   <center>
     <span style="font-size: 200%; line-height: 150%; padding: 0.5em;">
       Download the official scramble program:<br/>
-      <strong><%= link_to latest_jarfilename, latest_jarfilename %></strong>
+      <strong><%= link_to latest_version, latest_jarfilename %></strong>
     </span>
     <br/>
     Last official change: January 22nd, 2024


### PR DESCRIPTION
The scrambles page was showing the GitHub link instead of the JAR Name:

![image](https://github.com/thewca/worldcubeassociation.org/assets/71957060/24a6c710-2d02-4f37-abf7-75b2d04d2158)

Fixed it to display only JAR name:

![Screenshot from 2024-02-11 13-40-02](https://github.com/thewca/worldcubeassociation.org/assets/71957060/59015f10-77b9-4ca8-9d0d-2b5e13b21e1e)


