### PR TITLE
Don't skip database clean when skipping pretest db setup

### DIFF
--- a/WcaOnRails/spec/support/database_cleaner.rb
+++ b/WcaOnRails/spec/support/database_cleaner.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  unless EnvConfig.SKIP_PRETEST_SETUP?
-    config.before(:suite) do
-      DatabaseCleaner.clean_with :truncation
-      TestDbManager.fill_tables
-    end
+  config.before(:suite) do
+    DatabaseCleaner.clean_with :truncation
+    TestDbManager.fill_tables unless EnvConfig.SKIP_PRETEST_SETUP?
   end
 
   config.before(:each) do


### PR DESCRIPTION
SKIP_PRETEST_SETUP currently skips _all_ before(:suite) hooks, when in fact we just want to not pre-populate the db - we definitely still want to clean the db.