### PR TITLE
Competitions overview search params in url

### DIFF
--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -117,7 +117,7 @@ function EventSelector({ selectedEvents, dispatchFilter }) {
 
 function RegionSelector({ region, dispatchFilter }) {
   const regionsOptions = [
-    { key: 'all', text: I18n.t('common.all_regions'), value: 'all_regions' },
+    { key: 'all', text: I18n.t('common.all_regions'), value: 'all' },
     {
       key: 'continents_header', value: '', disabled: true, content: <Header content={I18n.t('common.continent')} size="small" style={{ textAlign: 'center' }} />,
     },

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -49,7 +49,7 @@ function CompetitionsFilters({
 
       <Form.Group>
         <Form.Field width={8}>
-          <DelegateSelector delegate={filterState.delegate} dispatchFilter={dispatchFilter} />
+          <DelegateSelector delegateId={filterState.delegate} dispatchFilter={dispatchFilter} />
         </Form.Field>
       </Form.Group>
 
@@ -162,7 +162,7 @@ function SearchBar({ text, dispatchFilter }) {
   );
 }
 
-function DelegateSelector({ delegate, dispatchFilter }) {
+function DelegateSelector({ delegateId, dispatchFilter }) {
   const { delegatesLoading, delegatesData } = useDelegatesData();
 
   return (
@@ -187,7 +187,7 @@ function DelegateSelector({ delegate, dispatchFilter }) {
             image: { avatar: true, src: delegate.avatar?.thumb_url, style: { width: '28px', height: '28px' } },
           }
         )) || [])]}
-        value={delegate}
+        value={delegateId}
         onChange={(_, data) => dispatchFilter({ delegate: data.value })}
         noResultsMessage={delegatesLoading ? I18n.t('competitions.index.delegates_loading') : I18n.t('competitions.index.no_delegates_found')}
       />

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -168,7 +168,7 @@ function DelegateSelector({ dispatchFilter }) {
     <>
       <div style={{ display: 'inline-block' }}>
         <label htmlFor="delegate">{I18n.t('layouts.navigation.delegate')}</label>
-        {delegatesLoading && <PulseLoader size="10" cssOverride={{ marginLeft: '5px' }} />}
+        {delegatesLoading && <PulseLoader size="10px" cssOverride={{ marginLeft: '5px' }} />}
       </div>
       <Dropdown
         name="delegate"

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -40,16 +40,16 @@ function CompetitionsFilters({
 
       <Form.Group>
         <Form.Field width={6}>
-          <RegionSelector dispatchFilter={dispatchFilter} />
+          <RegionSelector region={filterState.region} dispatchFilter={dispatchFilter} />
         </Form.Field>
         <Form.Field width={6}>
-          <SearchBar dispatchFilter={dispatchFilter} />
+          <SearchBar text={filterState.search} dispatchFilter={dispatchFilter} />
         </Form.Field>
       </Form.Group>
 
       <Form.Group>
         <Form.Field width={8}>
-          <DelegateSelector dispatchFilter={dispatchFilter} />
+          <DelegateSelector delegate={filterState.delegate} dispatchFilter={dispatchFilter} />
         </Form.Field>
       </Form.Group>
 
@@ -115,7 +115,7 @@ function EventSelector({ selectedEvents, dispatchFilter }) {
   );
 }
 
-function RegionSelector({ dispatchFilter }) {
+function RegionSelector({ region, dispatchFilter }) {
   const regionsOptions = [
     { key: 'all', text: I18n.t('common.all_regions'), value: 'all_regions' },
     {
@@ -138,7 +138,7 @@ function RegionSelector({ dispatchFilter }) {
       <Dropdown
         search
         selection
-        defaultValue="all"
+        value={region}
         options={regionsOptions}
         onChange={(_, data) => dispatchFilter({ region: data.value })}
       />
@@ -146,7 +146,7 @@ function RegionSelector({ dispatchFilter }) {
   );
 }
 
-function SearchBar({ dispatchFilter }) {
+function SearchBar({ text, dispatchFilter }) {
   return (
     <>
       <label htmlFor="search">{I18n.t('competitions.index.search')}</label>
@@ -155,13 +155,14 @@ function SearchBar({ dispatchFilter }) {
         id="search"
         icon="search"
         placeholder={I18n.t('competitions.index.tooltips.search')}
+        value={text}
         onChange={(_, data) => dispatchFilter({ search: data.value })}
       />
     </>
   );
 }
 
-function DelegateSelector({ dispatchFilter }) {
+function DelegateSelector({ delegate, dispatchFilter }) {
   const { delegatesLoading, delegatesData } = useDelegatesData();
 
   return (
@@ -177,7 +178,6 @@ function DelegateSelector({ dispatchFilter }) {
         search
         deburr
         selection
-        defaultValue="None"
         style={{ textAlign: 'center' }}
         options={[{ key: 'None', text: I18n.t('competitions.index.no_delegates'), value: '' }, ...(delegatesData?.filter((item) => item.name !== 'WCA Board').map((delegate) => (
           {
@@ -187,6 +187,7 @@ function DelegateSelector({ dispatchFilter }) {
             image: { avatar: true, src: delegate.avatar?.thumb_url, style: { width: '28px', height: '28px' } },
           }
         )) || [])]}
+        value={delegate}
         onChange={(_, data) => dispatchFilter({ delegate: data.value })}
         noResultsMessage={delegatesLoading ? I18n.t('competitions.index.delegates_loading') : I18n.t('competitions.index.no_delegates_found')}
       />

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -359,6 +359,7 @@ function CompDisplayCheckboxes({
           label={I18n.t('competitions.index.show_cancelled')}
           name="show_cancelled"
           id="show_cancelled"
+          checked={shouldIncludeCancelled}
           onChange={() => dispatchFilter(
             { shouldIncludeCancelled: !shouldIncludeCancelled },
           )}

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -15,7 +15,7 @@ import {
   createFilterState,
   filterReducer,
   getDisplayMode,
-  updateSearchParams
+  updateSearchParams,
 } from './filterUtils';
 import { calculateQueryKey, createSearchParams } from './queryUtils';
 import useDebounce from '../../lib/hooks/useDebounce';
@@ -24,10 +24,16 @@ import { isCancelled, isInProgress, isProbablyOver } from '../../lib/utils/compe
 const DEBOUNCE_MS = 600;
 
 function CompetitionsView() {
-  const searchParams = new URLSearchParams(window.location.search);
+  const searchParams = useMemo(
+    () => new URLSearchParams(window.location.search),
+    [],
+  );
 
-  const [filterState, dispatchFilter] =
-    useReducer(filterReducer, searchParams, createFilterState);
+  const [filterState, dispatchFilter] = useReducer(
+    filterReducer,
+    searchParams,
+    createFilterState,
+  );
   const debouncedFilterState = useDebounce(filterState, DEBOUNCE_MS);
   const [displayMode, setDisplayMode] = useState(() => getDisplayMode(searchParams));
   const [shouldShowRegStatus, setShouldShowRegStatus] = useState(false);
@@ -49,8 +55,8 @@ function CompetitionsView() {
   } = useInfiniteQuery({
     queryKey: ['competitions', competitionQueryKey],
     queryFn: ({ pageParam = 1 }) => {
-      const searchParams = createSearchParams(debouncedFilterState, pageParam);
-      return fetchJsonOrError(`${apiV0Urls.competitions.list}?${searchParams}`);
+      const querySearchParams = createSearchParams(debouncedFilterState, pageParam);
+      return fetchJsonOrError(`${apiV0Urls.competitions.list}?${querySearchParams}`);
     },
     getNextPageParam: (previousPage, allPages) => {
       // Continue until less than a full page of data is fetched,

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -1,5 +1,5 @@
 import React, {
-  useReducer, useMemo, useState,
+  useEffect, useMemo, useReducer, useState,
 } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Container } from 'semantic-ui-react';
@@ -11,7 +11,12 @@ import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken'
 import CompetitionsFilters from './CompetitionsFilters';
 import ListView from './ListView';
 import MapView from './MapView';
-import { filterReducer, filterInitialState } from './filterUtils';
+import {
+  createFilterState,
+  filterReducer,
+  getDisplayMode,
+  updateSearchParams
+} from './filterUtils';
 import { calculateQueryKey, createSearchParams } from './queryUtils';
 import useDebounce from '../../lib/hooks/useDebounce';
 import { isCancelled, isInProgress, isProbablyOver } from '../../lib/utils/competition-table';
@@ -19,13 +24,21 @@ import { isCancelled, isInProgress, isProbablyOver } from '../../lib/utils/compe
 const DEBOUNCE_MS = 600;
 
 function CompetitionsView() {
-  const [filterState, dispatchFilter] = useReducer(filterReducer, filterInitialState);
+  const searchParams = new URLSearchParams(window.location.search);
+
+  const [filterState, dispatchFilter] =
+    useReducer(filterReducer, searchParams, createFilterState);
   const debouncedFilterState = useDebounce(filterState, DEBOUNCE_MS);
-  const [displayMode, setDisplayMode] = useState('list');
+  const [displayMode, setDisplayMode] = useState(() => getDisplayMode(searchParams));
   const [shouldShowRegStatus, setShouldShowRegStatus] = useState(false);
   const competitionQueryKey = useMemo(
     () => calculateQueryKey(debouncedFilterState),
     [debouncedFilterState],
+  );
+
+  useEffect(
+    () => updateSearchParams(searchParams, filterState, displayMode),
+    [searchParams, filterState, displayMode],
   );
 
   const {

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -4,7 +4,7 @@ import { events } from '../../lib/wca-data.js.erb';
 // note: inconsistencies with previous search params
 // - year value was 'all+years', is now 'all_years'
 // - region value was the name, is now the 2-char code (for non-continents)
-// - delegate value was user id, is now the WCA id
+// - delegate value was user id, is now the WCA ID
 // - selected events key was 'event_ids' and they were not a list
 
 const DISPLAY_MODE = 'display';
@@ -16,7 +16,7 @@ const REGION = 'region';
 const DELEGATE = 'delegate';
 const SEARCH = 'search';
 const SELECTED_EVENTS = 'events';
-const INCLUDE_CANCELLED = 'show_cancelled'
+const INCLUDE_CANCELLED = 'show_cancelled';
 
 const DEFAULT_DISPLAY_MODE = 'list';
 const DEFAULT_TIME_ORDER = 'present';
@@ -29,11 +29,12 @@ const DEFAULT_EVENTS = [];
 const INCLUDE_CANCELLED_TRUE = 'on';
 
 // without time string, date will be interpreted in user's time zone
-const parseDate = (dateString) => new Date(dateString + "T00:00:00.000");
+const parseDate = (dateString) => new Date(`${dateString}T00:00:00.000`);
 const formatDate = (date) => DateTime.fromJSDate(date).toFormat('yyyy-MM-dd');
 
-export const getDisplayMode =
-  (searchParams) => searchParams.get(DISPLAY_MODE) || DEFAULT_DISPLAY_MODE;
+export const getDisplayMode = (searchParams) => (
+  searchParams.get(DISPLAY_MODE) || DEFAULT_DISPLAY_MODE
+);
 
 export const createFilterState = (searchParams) => ({
   timeOrder: searchParams.get(TIME_ORDER) || DEFAULT_TIME_ORDER,
@@ -60,7 +61,7 @@ export const updateSearchParams = (searchParams, filterState, displayMode) => {
     delegate,
     search,
     selectedEvents,
-    shouldIncludeCancelled
+    shouldIncludeCancelled,
   } = filterState;
 
   searchParams.set(DISPLAY_MODE, displayMode);
@@ -70,23 +71,29 @@ export const updateSearchParams = (searchParams, filterState, displayMode) => {
   searchParams.delete(TIME_ORDER, DEFAULT_TIME_ORDER);
   searchParams.set(YEAR, selectedYear);
   searchParams.delete(YEAR, DEFAULT_YEAR);
-  customStartDate
-    ? searchParams.set(START_DATE, formatDate(customStartDate))
-    : searchParams.delete(START_DATE);
-  customEndDate
-    ? searchParams.set(END_DATE, formatDate(customEndDate))
-    : searchParams.delete(END_DATE);
+  if (customStartDate) {
+    searchParams.set(START_DATE, formatDate(customStartDate));
+  } else {
+    searchParams.delete(START_DATE);
+  }
+  if (customEndDate) {
+    searchParams.set(END_DATE, formatDate(customEndDate));
+  } else {
+    searchParams.delete(END_DATE);
+  }
   searchParams.set(REGION, region);
   searchParams.delete(REGION, DEFAULT_REGION);
   searchParams.set(DELEGATE, delegate);
   searchParams.delete(DELEGATE, DEFAULT_DELEGATE);
   searchParams.set(SEARCH, search);
   searchParams.delete(SEARCH, DEFAULT_SEARCH);
-  searchParams.set(SELECTED_EVENTS, selectedEvents.join(","));
-  searchParams.delete(SELECTED_EVENTS, DEFAULT_EVENTS.join(","));
-  shouldIncludeCancelled
-    ? searchParams.set(INCLUDE_CANCELLED, INCLUDE_CANCELLED_TRUE)
-    : searchParams.delete(INCLUDE_CANCELLED);
+  searchParams.set(SELECTED_EVENTS, selectedEvents.join(','));
+  searchParams.delete(SELECTED_EVENTS, DEFAULT_EVENTS.join(','));
+  if (shouldIncludeCancelled) {
+    searchParams.set(INCLUDE_CANCELLED, INCLUDE_CANCELLED_TRUE);
+  } else {
+    searchParams.delete(INCLUDE_CANCELLED);
+  }
 
   window.history.replaceState({}, '', `${window.location.pathname}?${searchParams}`);
 };

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -64,31 +64,43 @@ export const updateSearchParams = (searchParams, filterState, displayMode) => {
     shouldIncludeCancelled,
   } = filterState;
 
+  // update every string value; and then remove that value if it's redundant (ie is the default)
   searchParams.set(DISPLAY_MODE, displayMode);
   searchParams.delete(DISPLAY_MODE, DEFAULT_DISPLAY_MODE);
 
   searchParams.set(TIME_ORDER, timeOrder);
   searchParams.delete(TIME_ORDER, DEFAULT_TIME_ORDER);
+
   searchParams.set(YEAR, selectedYear);
   searchParams.delete(YEAR, DEFAULT_YEAR);
+
+  searchParams.set(REGION, region);
+  searchParams.delete(REGION, DEFAULT_REGION);
+
+  searchParams.set(DELEGATE, delegate);
+  searchParams.delete(DELEGATE, DEFAULT_DELEGATE);
+
+  searchParams.set(SEARCH, search);
+  searchParams.delete(SEARCH, DEFAULT_SEARCH);
+
+  // similarly for array-of-string values
+  searchParams.set(SELECTED_EVENTS, selectedEvents.join(','));
+  searchParams.delete(SELECTED_EVENTS, DEFAULT_EVENTS.join(','));
+
+  // for date values, format and add them if applicable, otherwise omit them
   if (customStartDate) {
     searchParams.set(START_DATE, formatDate(customStartDate));
   } else {
     searchParams.delete(START_DATE);
   }
+
   if (customEndDate) {
     searchParams.set(END_DATE, formatDate(customEndDate));
   } else {
     searchParams.delete(END_DATE);
   }
-  searchParams.set(REGION, region);
-  searchParams.delete(REGION, DEFAULT_REGION);
-  searchParams.set(DELEGATE, delegate);
-  searchParams.delete(DELEGATE, DEFAULT_DELEGATE);
-  searchParams.set(SEARCH, search);
-  searchParams.delete(SEARCH, DEFAULT_SEARCH);
-  searchParams.set(SELECTED_EVENTS, selectedEvents.join(','));
-  searchParams.delete(SELECTED_EVENTS, DEFAULT_EVENTS.join(','));
+
+  // boolean values are only present when true, otherwise omit them
   if (shouldIncludeCancelled) {
     searchParams.set(INCLUDE_CANCELLED, INCLUDE_CANCELLED_TRUE);
   } else {

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -98,7 +98,7 @@ export const updateSearchParams = (searchParams, filterState, displayMode) => {
   window.history.replaceState({}, '', `${window.location.pathname}?${searchParams}`);
 };
 
-const WCA_EVENT_IDS = Object.values(events.official).map((e) => e.id);
+const WCA_EVENT_IDS = Object.keys(events.byId);
 
 export const filterReducer = (state, action) => {
   switch (action.type) {

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -1,18 +1,91 @@
+import { DateTime } from 'luxon';
 import { events } from '../../lib/wca-data.js.erb';
 
-const WCA_EVENT_IDS = Object.values(events.official).map((e) => e.id);
+const DISPLAY_MODE = 'display';
+const TIME_ORDER = 'state';
+const YEAR = 'year';
+const START_DATE = 'from_date';
+const END_DATE = 'to_date';
+const REGION = 'region';
+const DELEGATE = 'delegate';
+const SEARCH = 'search';
+const SELECTED_EVENTS = 'events';
+const INCLUDE_CANCELLED = 'show_cancelled'
 
-export const filterInitialState = {
-  timeOrder: 'present',
-  selectedYear: 'all_years',
-  customStartDate: null,
-  customEndDate: null,
-  region: 'all_regions',
-  delegate: '',
-  search: '',
-  selectedEvents: [],
-  shouldIncludeCancelled: false,
+const DEFAULT_DISPLAY_MODE = 'list';
+const DEFAULT_TIME_ORDER = 'present';
+const DEFAULT_YEAR = 'all_years';
+const DEFAULT_DATE = null;
+const DEFAULT_REGION = 'all';
+const DEFAULT_DELEGATE = '';
+const DEFAULT_SEARCH = '';
+const DEFAULT_EVENTS = [];
+const INCLUDE_CANCELLED_TRUE = 'on';
+
+// without time string, date will be interpreted in user's time zone
+const parseDate = (dateString) => new Date(dateString + "T00:00:00.000");
+const formatDate = (date) => DateTime.fromJSDate(date).toFormat('yyyy-MM-dd');
+
+export const getDisplayMode =
+  (searchParams) => searchParams.get(DISPLAY_MODE) || DEFAULT_DISPLAY_MODE;
+
+export const createFilterState = (searchParams) => ({
+  timeOrder: searchParams.get(TIME_ORDER) || DEFAULT_TIME_ORDER,
+  selectedYear: searchParams.get(YEAR) || DEFAULT_YEAR,
+  customStartDate:
+    searchParams.get(START_DATE) ? parseDate(searchParams.get(START_DATE)) : DEFAULT_DATE,
+  customEndDate:
+    searchParams.get(END_DATE) ? parseDate(searchParams.get(END_DATE)) : DEFAULT_DATE,
+  region: searchParams.get(REGION) || DEFAULT_REGION,
+  delegate: searchParams.get(DELEGATE) || DEFAULT_DELEGATE,
+  search: searchParams.get(SEARCH) || DEFAULT_SEARCH,
+  selectedEvents:
+    searchParams.get(SELECTED_EVENTS)?.split(',')?.filter(Boolean) || DEFAULT_EVENTS,
+  shouldIncludeCancelled: searchParams.get(INCLUDE_CANCELLED) === INCLUDE_CANCELLED_TRUE,
+});
+
+export const updateSearchParams = (searchParams, filterState, displayMode) => {
+  const {
+    timeOrder,
+    selectedYear,
+    customStartDate,
+    customEndDate,
+    region,
+    delegate,
+    search,
+    selectedEvents,
+    shouldIncludeCancelled
+  } = filterState;
+
+  searchParams.set(DISPLAY_MODE, displayMode);
+  searchParams.delete(DISPLAY_MODE, DEFAULT_DISPLAY_MODE);
+
+  searchParams.set(TIME_ORDER, timeOrder);
+  searchParams.delete(TIME_ORDER, DEFAULT_TIME_ORDER);
+  searchParams.set(YEAR, selectedYear);
+  searchParams.delete(YEAR, DEFAULT_YEAR);
+  customStartDate
+    ? searchParams.set(START_DATE, formatDate(customStartDate))
+    : searchParams.delete(START_DATE);
+  customEndDate
+    ? searchParams.set(END_DATE, formatDate(customEndDate))
+    : searchParams.delete(END_DATE);
+  searchParams.set(REGION, region);
+  searchParams.delete(REGION, DEFAULT_REGION);
+  searchParams.set(DELEGATE, delegate);
+  searchParams.delete(DELEGATE, DEFAULT_DELEGATE);
+  searchParams.set(SEARCH, search);
+  searchParams.delete(SEARCH, DEFAULT_SEARCH);
+  searchParams.set(SELECTED_EVENTS, selectedEvents.join(","));
+  searchParams.delete(SELECTED_EVENTS, DEFAULT_EVENTS.join(","));
+  shouldIncludeCancelled
+    ? searchParams.set(INCLUDE_CANCELLED, INCLUDE_CANCELLED_TRUE)
+    : searchParams.delete(INCLUDE_CANCELLED);
+
+  window.history.replaceState({}, '', `${window.location.pathname}?${searchParams}`);
 };
+
+const WCA_EVENT_IDS = Object.values(events.official).map((e) => e.id);
 
 export const filterReducer = (state, action) => {
   switch (action.type) {

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -1,6 +1,12 @@
 import { DateTime } from 'luxon';
 import { events } from '../../lib/wca-data.js.erb';
 
+// note: inconsistencies with previous search params
+// - year value was 'all+years', is now 'all_years'
+// - region value was the name, is now the 2-char code (for non-continents)
+// - delegate value was user id, is now the WCA id
+// - selected events key was 'event_ids' and they were not a list
+
 const DISPLAY_MODE = 'display';
 const TIME_ORDER = 'state';
 const YEAR = 'year';

--- a/WcaOnRails/app/webpacker/components/CompetitionsOverview/queryUtils.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionsOverview/queryUtils.js
@@ -29,7 +29,7 @@ export function createSearchParams(filterState, pageParam) {
   const dateNow = DateTime.now();
   const searchParams = new URLSearchParams({});
 
-  if (region && region !== 'all_regions') {
+  if (region && region !== 'all') {
     const regionParam = isContinent(region) ? 'continent' : 'country_iso2';
     searchParams.append(regionParam, region);
   }


### PR DESCRIPTION
- Any non-default value is stored as a search param in the url. Any default value is omitted for simplicity. I mimicked the incidents log work that I did a few years ago.
- Bookmarking a url should work.
- There are some breaking changes with existing bookmarks for the old page. See the comment in `filterUtils`; most filter keys aren't affected.
- Fixed a console warning about size=10 not being valid.

There are a lot of params so there may be edge cases that I didn't think of; please play around with the page, ie change a bunch of state and then refresh the page.

Follow-up work:
- If we decide that the braking changes for existing bookmarks is a problem, then there would need to be a follow-up PR for that. The work would build on this PR, not replace anything, so I think it still makes sense to merge this regardless.
- Some kind of UI error indication (eg red border) on any input that has an invalid state (the user should only be able to get there by typing in a fake search param like `region=my_fake_region`).
- Add a button to reset filters to default values.

I'd be happy to work on the last 2 once this is merged.