### PR TITLE
Add registrations from the new Registration Service to the my competitions page

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -870,13 +870,12 @@ class CompetitionsController < ApplicationController
       competition_ids.concat(current_user.delegated_competitions.pluck(:competition_id))
       registrations = current_user.registrations.includes(:competition).accepted.reject { |r| r.competition.results_posted? }
       registrations.concat(current_user.registrations.includes(:competition).pending.select { |r| r.competition.upcoming? })
-      # Convert Registrations V2 to a format that the frontend can understand
-      registrations.concat(registrations_v2.map { |r| Microservices::Registrations.convert_registration(r['competition_id'], current_user.id, r['status']) })
+      # Convert Registrations V2 to a format that the frontend can understand, for Competition, we only need the id.
+      registrations.concat(registrations_v2.map { |r| Microservices::Registrations.convert_registration(Struct.new(:id, keyword_init: true).new(id: r['competition_id']), current_user, r['status']) })
       @registered_for_by_competition_id = registrations.uniq.to_h do |r|
         [r.competition.id, r]
       end
       competition_ids.concat(@registered_for_by_competition_id.keys)
-      competition_ids.concat(registrations_v2.pluck("competition_id"))
       if current_user.person
         competition_ids.concat(current_user.person.competitions.pluck(:competitionId))
       end

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -859,15 +859,24 @@ class CompetitionsController < ApplicationController
   end
 
   def my_competitions
+    if Rails.env.production? && !EnvConfig.WCA_LIVE_SITE?
+      registrations_v2 = Microservices::Registrations.registrations_by_user(current_user.id)
+    else
+      registrations_v2 = []
+    end
+
     ActiveRecord::Base.connected_to(role: :read_replica) do
       competition_ids = current_user.organized_competitions.pluck(:competition_id)
       competition_ids.concat(current_user.delegated_competitions.pluck(:competition_id))
       registrations = current_user.registrations.includes(:competition).accepted.reject { |r| r.competition.results_posted? }
       registrations.concat(current_user.registrations.includes(:competition).pending.select { |r| r.competition.upcoming? })
+      # Convert Registrations V2 to a format that the frontend can understand
+      registrations.concat(registrations_v2.map { |r| Microservices::Registrations.convert_registration(r) })
       @registered_for_by_competition_id = registrations.uniq.to_h do |r|
         [r.competition.id, r]
       end
       competition_ids.concat(@registered_for_by_competition_id.keys)
+      competition_ids.concat(registrations_v2.pluck("competition_id"))
       if current_user.person
         competition_ids.concat(current_user.person.competitions.pluck(:competitionId))
       end

--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -871,7 +871,7 @@ class CompetitionsController < ApplicationController
       registrations = current_user.registrations.includes(:competition).accepted.reject { |r| r.competition.results_posted? }
       registrations.concat(current_user.registrations.includes(:competition).pending.select { |r| r.competition.upcoming? })
       # Convert Registrations V2 to a format that the frontend can understand
-      registrations.concat(registrations_v2.map { |r| Microservices::Registrations.convert_registration(r) })
+      registrations.concat(registrations_v2.map { |r| Microservices::Registrations.convert_registration(r['competition_id'], current_user.id, r['status']) })
       @registered_for_by_competition_id = registrations.uniq.to_h do |r|
         [r.competition.id, r]
       end

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -12,7 +12,7 @@ module CompetitionsHelper
       return t('competitions.messages.cancelled')
     end
 
-    messages_to_join << get_registration_status_message_if_registered(competition, user)
+    messages_to_join << get_registration_status_message_if_registered(competition, user, registration)
     messages_to_join << get_competition_status_message(competition)
 
     messages_to_join.join(' ')

--- a/WcaOnRails/app/helpers/competitions_helper.rb
+++ b/WcaOnRails/app/helpers/competitions_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CompetitionsHelper
-  def competition_message_for_user(competition, user)
+  def competition_message_for_user(competition, user, registration = nil)
     # Generates a list of messages, which will be combined and displayed in a tooltip to the user in their bookmarked
     # competitions list when they hover over a competition.
     # Message indicates the state of the competition, and the state of the user's registration.
@@ -316,18 +316,18 @@ module CompetitionsHelper
 
   private
 
-    def get_registration_status_message_if_registered(competition, user)
+    def get_registration_status_message_if_registered(competition, user, registration = nil)
       # Helper function for `competition_message_for_user`
       # Determines what message to display to the user based on the state of their registration.
 
-      registration_status = competition.registrations.find_by_user_id(user.id)
+      registration_status = registration || competition.registrations.find_by_user_id(user.id)
       return unless registration_status.present?
 
       if registration_status.accepted?
         t('competitions.messages.tooltip_registered')
       elsif registration_status.deleted?
         t('competitions.messages.tooltip_deleted')
-      else # If not delted or accepted, assume user is on the waiting list
+      else # If not deleted or accepted, assume user is on the waiting list
         t('competitions.messages.tooltip_waiting_list')
       end
     end

--- a/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
+++ b/WcaOnRails/app/views/competitions/_my_competitions_table.html.erb
@@ -38,7 +38,7 @@
                           past ? "past" : "not-past" ].join(' ') %>
           <tr class="<%= tr_classes %>"
               data-toggle="tooltip" data-placement="bottom" data-container="body"
-              title="<%= competition_message_for_user(competition, current_user) unless past %>">
+              title="<%= competition_message_for_user(competition, current_user, registration) unless past %>">
             <% if @show_registration_status && bookmarked %>
               <td><%= registration_status_icon(competition) %></td>
             <% end %>

--- a/WcaOnRails/lib/microservices/registrations.rb
+++ b/WcaOnRails/lib/microservices/registrations.rb
@@ -15,6 +15,10 @@ module Microservices
       "/api/internal/v1/update_payment"
     end
 
+    def self.registrations_by_user_path(id)
+      "/api/internal/v1/users/#{id}/registrations"
+    end
+
     def self.registration_connection
       Faraday.new(
         url: EnvConfig.WCA_REGISTRATIONS_URL,
@@ -29,6 +33,15 @@ module Microservices
         # By default, it only logs the request method and URL, and the request/response headers.
         builder.response :logger
       end
+    end
+
+    def self.convert_registration(r)
+      OpenStruct.new(accepted?: r["status"] == "accepted", competition: OpenStruct.new(id: r["competition_id"]))
+    end
+
+    def self.registrations_by_user(user_id)
+      response = self.registration_connection.get(self.registrations_by_user_path(user_id))
+      response.body
     end
 
     def self.update_registration_payment(attendee_id, payment_id, iso_amount, currency_iso, status)

--- a/WcaOnRails/lib/microservices/registrations.rb
+++ b/WcaOnRails/lib/microservices/registrations.rb
@@ -36,7 +36,7 @@ module Microservices
     end
 
     def self.convert_registration(r)
-      OpenStruct.new(accepted?: r["status"] == "accepted", competition: OpenStruct.new(id: r["competition_id"]))
+      OpenStruct.new(accepted?: r["status"] == "accepted", deleted?: r["status"] == "cancelled", competition: OpenStruct.new(id: r["competition_id"]))
     end
 
     def self.registrations_by_user(user_id)

--- a/WcaOnRails/lib/microservices/registrations.rb
+++ b/WcaOnRails/lib/microservices/registrations.rb
@@ -39,8 +39,26 @@ module Microservices
       end
     end
 
-    def self.convert_registration(r)
-      OpenStruct.new(accepted?: r["status"] == "accepted", deleted?: r["status"] == "cancelled", competition: OpenStruct.new(id: r["competition_id"]))
+    RegistrationConverter = Struct.new(:competition, :user, :status) do
+      def accepted?
+        status == "accepted"
+      end
+
+      def deleted?
+        status == "deleted"
+      end
+
+      def name
+        user.person.name
+      end
+
+      def email
+        user.email
+      end
+    end
+
+    def self.convert_registration(competition_id, user_id, registration_status)
+      RegistrationConverter.new(competition: Competition.find(competition_id), user: User.find(user_id), status: registration_status)
     end
 
     def self.registrations_by_user(user_id)

--- a/WcaOnRails/lib/microservices/registrations.rb
+++ b/WcaOnRails/lib/microservices/registrations.rb
@@ -17,7 +17,8 @@ module Microservices
 
     def self.registrations_by_user_path(id)
       "/api/internal/v1/users/#{id}/registrations"
-      
+    end
+
     def self.get_registrations_path(competition_id)
       "/api/internal/v1/#{competition_id}/registrations"
     end

--- a/WcaOnRails/lib/microservices/registrations.rb
+++ b/WcaOnRails/lib/microservices/registrations.rb
@@ -49,7 +49,7 @@ module Microservices
       end
 
       def name
-        user.person.name
+        user.name
       end
 
       def email

--- a/WcaOnRails/lib/microservices/registrations.rb
+++ b/WcaOnRails/lib/microservices/registrations.rb
@@ -57,8 +57,8 @@ module Microservices
       end
     end
 
-    def self.convert_registration(competition_id, user_id, registration_status)
-      RegistrationConverter.new(competition: Competition.find(competition_id), user: User.find(user_id), status: registration_status)
+    def self.convert_registration(competition, user, registration_status)
+      RegistrationConverter.new(competition: competition, user: user, status: registration_status)
     end
 
     def self.registrations_by_user(user_id)


### PR DESCRIPTION
This works. The only issue is the tooltip. Which is using `get_registration_status_message_if_registered`. Which for some reason is fetching the registration_status again, even though we already have it here. 

I can rewrite the `competition_message_for_user` to also take the registration to fix this. Thoughts?