### PR TITLE
Fix role tab issues

### DIFF
--- a/WcaOnRails/app/webpacker/components/RolesTab/ActiveRoles.jsx
+++ b/WcaOnRails/app/webpacker/components/RolesTab/ActiveRoles.jsx
@@ -45,7 +45,10 @@ export default function ActiveRoles({ activeRoles, setOpen }) {
       <Header>Active Roles</Header>
       <List divided relaxed>
         {activeRoles?.map((role) => (
-          <List.Item key={role.id}>
+          <List.Item
+            key={role.id}
+            disabled={!loggedInUserPermissions.canEditRole(role)}
+          >
             <List.Content
               floated="left"
               href={hyperlink(role)}
@@ -54,8 +57,8 @@ export default function ActiveRoles({ activeRoles, setOpen }) {
                 name="edit"
                 size="large"
                 link
-                disabled={!loggedInUserPermissions.canEditRole(role)}
                 onClick={isHyperlinkableRole(role) ? null : () => setOpen(true)}
+                disabled={!loggedInUserPermissions.canEditRole(role)}
               />
             </List.Content>
             <List.Content>

--- a/WcaOnRails/app/webpacker/lib/helpers/roles-tab.js
+++ b/WcaOnRails/app/webpacker/lib/helpers/roles-tab.js
@@ -2,7 +2,7 @@ import I18n from '../i18n';
 
 export function getRoleDescription(role) {
   let roleDescription = '';
-  if (role.metadata.status) {
+  if (role.metadata?.status) {
     roleDescription += `${I18n.t(`enums.user.role_status.${role.group.group_type}.${role.metadata.status}`)}, `;
   }
   roleDescription += role.group.name;


### PR DESCRIPTION
Fixed couple of role tab issues:
1. Disable the row if edit is not supported
2. Doesn't throw error if the role doesn't have status (eg: translator)