### PR TITLE
Fix Server Status page

### DIFF
--- a/WcaOnRails/app/controllers/server_status_controller.rb
+++ b/WcaOnRails/app/controllers/server_status_controller.rb
@@ -15,7 +15,6 @@ class ServerStatusController < ApplicationController
     [
       JobsCheck.new,
       RegulationsCheck.new,
-      StripeChargesCheck.new,
       MysqlSettingsCheck.new,
     ]
   end
@@ -85,22 +84,6 @@ class RegulationsCheck < StatusCheck
       [:success, nil]
     else
       [:danger, "Error while loading regulations: #{Regulation.regulations_load_error} from #{Regulation.regulations_load_error.class}"]
-    end
-  end
-end
-
-class StripeChargesCheck < StatusCheck
-  def label
-    "Stripe Charges"
-  end
-
-  protected def _status_description
-    unknown_stripe_charges_count = StripeTransaction.where(status: "unknown").count
-
-    if unknown_stripe_charges_count == 0
-      [:success, nil]
-    else
-      [:danger, "#{pluralize(unknown_stripe_charges_count, "Stripe charge")} with status 'unknown'."]
     end
   end
 end

--- a/WcaOnRails/app/models/regulation.rb
+++ b/WcaOnRails/app/models/regulation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Regulation < SimpleDelegator
-  REGULATIONS_JSON_PATH = "regulations/wca-regulations.json"
+  REGULATIONS_JSON_PATH = "wca-regulations.json"
 
   def self.reload_regulations(s3)
     @regulations = JSON.parse(s3.bucket(RegulationTranslationsHelper::BUCKET_NAME).object(REGULATIONS_JSON_PATH).get.body.read).freeze

--- a/WcaOnRails/spec/controllers/server_status_controller_spec.rb
+++ b/WcaOnRails/spec/controllers/server_status_controller_spec.rb
@@ -75,28 +75,6 @@ RSpec.describe "JobsCheck" do
   end
 end
 
-RSpec.describe "StripeChargesCheck" do
-  let(:check) { StripeChargesCheck.new }
-
-  it "passes" do
-    status, description = check.status_description
-    expect(status).to eq :success
-    expect(description).to be_nil
-  end
-
-  it "warns about stripe charges with status unknown" do
-    StripeTransaction.create!(
-      parameters: {},
-      status: "unknown",
-    )
-
-    status, description = check.status_description
-
-    expect(status).to eq :danger
-    expect(description).to match("1 Stripe charge with status 'unknown'")
-  end
-end
-
 RSpec.describe "RegulationsCheck" do
   let(:check) { RegulationsCheck.new }
   let(:s3) { Aws::S3::Client.new(stub_responses: true) }


### PR DESCRIPTION
Actually fixes the JSON Path this time (I tested with one bucket for documents/regulations which is why this happened).

For stripe: I perused the StripeTransaction Table and the Webhook table but I couldn't really find anything which we could use. Any idea?