### PR TITLE
Competition Form fixes

### DIFF
--- a/WcaOnRails/app/controllers/competitions_controller.rb
+++ b/WcaOnRails/app/controllers/competitions_controller.rb
@@ -279,6 +279,8 @@ class CompetitionsController < ApplicationController
   def new
     @competition = Competition.new(
       competitor_limit_enabled: true,
+      base_entry_fee_lowest_denomination: 0,
+      guests_entry_fee_lowest_denomination: 0,
     )
 
     assign_editing_user(@competition)

--- a/WcaOnRails/app/models/competition_series.rb
+++ b/WcaOnRails/app/models/competition_series.rb
@@ -14,17 +14,18 @@ class CompetitionSeries < ApplicationRecord
   VALID_NAME_RE = Competition::VALID_NAME_RE
   VALID_ID_RE = Competition::VALID_ID_RE
 
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: MAX_NAME_LENGTH },
+                   format: { with: VALID_NAME_RE, message: proc { I18n.t('competitions.errors.invalid_name_message') } }
+
   validates :wcif_id, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: MAX_ID_LENGTH },
                       format: { with: VALID_ID_RE }, if: :name_valid_or_updating?
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: MAX_NAME_LENGTH },
-                   format: { with: VALID_NAME_RE, message: proc { I18n.t('competitions.errors.invalid_name_message') } }
   validates :short_name, length: { maximum: MAX_SHORT_NAME_LENGTH },
                          format: { with: VALID_NAME_RE, message: proc { I18n.t('competitions.errors.invalid_name_message') } },
                          if: :name_valid_or_updating?
 
   private def name_valid_or_updating?
-    self.persisted? || (name.length <= MAX_NAME_LENGTH && name =~ VALID_NAME_RE)
+    self.persisted? || (name.present? && name.length <= MAX_NAME_LENGTH && name =~ VALID_NAME_RE)
   end
 
   before_validation :create_id_and_cell_name

--- a/WcaOnRails/app/webpacker/components/CompetitionForm/FormSections/EventRestrictions.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionForm/FormSections/EventRestrictions.js
@@ -21,6 +21,7 @@ export default function EventRestrictions() {
       },
     },
     isCloning,
+    isPersisted,
     storedEvents,
   } = useStore();
 
@@ -65,7 +66,7 @@ export default function EventRestrictions() {
         </ConditionalSection>
       </SubSection>
 
-      {!isCloning && (
+      {!isCloning && isPersisted && (
         <>
           <Divider />
           <InputSelect id="mainEventId" options={mainEventOptions} />

--- a/WcaOnRails/app/webpacker/components/CompetitionForm/FormSections/RegistrationDetails.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionForm/FormSections/RegistrationDetails.js
@@ -23,10 +23,10 @@ const guestMessageOptions = ['unclear', 'free', 'restricted'].map((status) => ({
 }));
 
 export default function RegistrationDetails() {
-  const { competition: { entryFees } } = useStore();
+  const { competition: { entryFees, registration } } = useStore();
 
-  const guestsGoFree = entryFees && entryFees.guestEntryFee === 0;
-  const guestsRestricted = entryFees && guestsGoFree && entryFees.guestEntryStatus === 'restricted';
+  const guestsGoFree = entryFees?.guestEntryFee === 0;
+  const guestsRestricted = guestsGoFree && registration?.guestEntryStatus === 'restricted';
 
   return (
     <SubSection section="registration">

--- a/WcaOnRails/app/webpacker/components/CompetitionForm/Tables/SeriesComps.js
+++ b/WcaOnRails/app/webpacker/components/CompetitionForm/Tables/SeriesComps.js
@@ -31,6 +31,7 @@ export default function SeriesComps() {
       endDate,
       series,
     },
+    isPersisted,
   } = useStore();
 
   const dispatch = useDispatch();
@@ -103,6 +104,16 @@ export default function SeriesComps() {
     return (
       <TableWrapper label={label}>
         <MissingInfo missingDate={missingDate} missingLocation={missingLocation} />
+      </TableWrapper>
+    );
+  }
+
+  if (!isPersisted) {
+    return (
+      <TableWrapper label={label}>
+        <Message info visible>
+          <p>{I18n.t('competitions.adjacent_competitions.save_first')}</p>
+        </Message>
       </TableWrapper>
     );
   }

--- a/WcaOnRails/config/locales/en.yml
+++ b/WcaOnRails/config/locales/en.yml
@@ -1690,6 +1690,7 @@ en:
       no_comp_nearby: "No nearby competitions!"
       no_date_yet: "You have not assigned a date for this competition yet."
       no_location_yet: "You have not assigned a location for this competition yet."
+      save_first: "Please save this competition before adding it to a Series."
       name: "Name"
       delegates: "Delegate(s)"
       date: "Date"


### PR DESCRIPTION
Some quickfixes for reports that came in via email. Specifically:

- Fix error where the number of guests per competitor restriction was not shown
- Don't allow adding a competition to a Series upon creation. This causes trouble when trying to load the items in the SearchBar, because it looks up values based on ID but the competition being created does not have an ID yet.
- Correctly report the error about the missing name field when adding to a Series