### PR TITLE
Fix Webpack DevServer https option deprecation

### DIFF
--- a/WcaOnRails/config/shakapacker.yml
+++ b/WcaOnRails/config/shakapacker.yml
@@ -30,7 +30,7 @@ development:
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
-    https: false
+    server: http
     host: localhost
     port: 3035
     # Hot Module Replacement updates modules while the application is running without a full reload


### PR DESCRIPTION
See https://webpack.js.org/configuration/dev-server/#devserverserver