### PR TITLE
Add created_at to registration export csv

### DIFF
--- a/WcaOnRails/app/views/registrations/export.csv.erb
+++ b/WcaOnRails/app/views/registrations/export.csv.erb
@@ -1,5 +1,5 @@
 <% require 'csv' %>
-<% headers = ["Status", "Name", "Country", "WCA ID", "Birth Date", "Gender" ] + @competition.events.map(&:id) + [ "Email", "Guests", "IP" ] %>
+<% headers = ["Status", "Name", "Country", "WCA ID", "Birth Date", "Gender" ] + @competition.events.map(&:id) + [ "Email", "Guests", "IP", "Registration Date Time (UTC)" ] %>
 <%= CSV.generate_line(headers).html_safe -%>
 <% @registrations.each do |registration| %>
 <%= CSV.generate_line([
@@ -13,5 +13,6 @@
   registration.email,
   registration.guests,
   registration.ip,
+  registration.created_at,
 ]).html_safe -%>
 <% end %>

--- a/WcaOnRails/spec/factories/registrations.rb
+++ b/WcaOnRails/spec/factories/registrations.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     association :user, factory: [:user, :wca_id]
     guests { 10 }
     comments { "" }
+    created_at { Time.now }
     administrative_notes { "" }
     transient do
       events { competition.events }

--- a/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "registrations/export.csv.erb" do
         :registration,
         competition: competition,
         accepted_at: Time.now,
+        created_at: Time.utc(2014, 3, 14, 15, 16, 17)
         user: user,
         competition_events: [competition.competition_events.find_by!(event_id: "333")],
         guests: 1,
@@ -29,7 +30,7 @@ RSpec.describe "registrations/export.csv.erb" do
     assign(:registrations, competition.registrations)
     render
 
-    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\na,Bob,USA,,1990-01-01,m,1,0,bob@bob.com,1,\"\"\n"
+    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP,Registration Date Time (UTC)\na,Bob,USA,,1990-01-01,m,1,0,bob@bob.com,1,\"\",2014-03-14 15:16:17 UTC\n"
   end
 
   it "renders null (missing) gender as empty string" do
@@ -39,6 +40,6 @@ RSpec.describe "registrations/export.csv.erb" do
     assign(:registrations, competition.registrations)
     render
 
-    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP\na,Bob,USA,,1990-01-01,,1,0,bob@bob.com,1,\"\"\n"
+    expect(rendered).to eq "Status,Name,Country,WCA ID,Birth Date,Gender,333,333oh,Email,Guests,IP,Registration Date Time (UTC)\na,Bob,USA,,1990-01-01,,1,0,bob@bob.com,1,\"\",2014-03-14 15:16:17 UTC\n"
   end
 end

--- a/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
+++ b/WcaOnRails/spec/views/registrations/export.csv.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "registrations/export.csv.erb" do
         :registration,
         competition: competition,
         accepted_at: Time.now,
-        created_at: Time.utc(2014, 3, 14, 15, 16, 17)
+        created_at: Time.utc(2014, 3, 14, 15, 16, 17),
         user: user,
         competition_events: [competition.competition_events.find_by!(event_id: "333")],
         guests: 1,


### PR DESCRIPTION
See description in #8948 

This adds one column to the csv export of registrations to improve turnaround for organizers, who would otherwise refer to the tooltip.