### PR TITLE
Lint EditEvents React code

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -45,8 +45,6 @@ PreCommit:
     include:
       - 'WcaOnRails/app/webpacker/**/*.js'
     exclude:
-      # FIXME: we could fix it, but it's long and it's legacy code anyway...
-      - 'WcaOnRails/app/webpacker/components/EditEvents/**/*'
       # Semantic UI stuff, we need to re-exclude that here.
       - 'WcaOnRails/app/webpacker/stylesheets/semantic/**/*'
     command: ['WcaOnRails/bin/yarn', '--silent', 'run', 'eslint', '-c', '.eslintrc.json', '-f', 'compact']

--- a/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -7,6 +7,7 @@ import {
   Icon,
   Segment,
 } from 'semantic-ui-react';
+import cn from 'classnames';
 import i18n from '../../../lib/i18n';
 import { events } from '../../../lib/wca-data.js.erb';
 import { pluralize } from '../../../lib/utils/edit-events';
@@ -18,7 +19,6 @@ import {
   addEvent, addRounds, removeEvent, removeRounds,
 } from '../store/actions';
 import { EditQualificationModal } from '../Modals';
-import cn from 'classnames';
 
 export default function EventPanel({
   wcifEvent,
@@ -147,8 +147,8 @@ export default function EventPanel({
             {i18n.t('competitions.events.qualification')}
             :
             {' '}
-            {/* Qualifications cannot be edited after the competition has been announced. */}
-            {/* Qualifications cannot be added if the box from the competition form is unchecked. */}
+            {/* Qualifications cannot be edited after the competition has been announced, */}
+            {/*   or if the box from the competition form is unchecked. */}
             <EditQualificationModal
               wcifEvent={wcifEvent}
               disabled={

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/index.js
@@ -52,13 +52,15 @@ const advanceReqToExplanationText = (wcifEvent, roundNumber, { type, level }) =>
       return `The top ${level}% competitors from round ${roundNumber} will advance to round ${roundNumber + 1}.`;
     case 'attemptResult':
       return `Everyone in round ${roundNumber} with a result ${matchResult(level, wcifEvent.id)
-        } will advance to round ${roundNumber + 1}.`;
+      } will advance to round ${roundNumber + 1}.`;
     default:
       return '';
   }
 };
 
-function AdvancementInput({ eventId, type, level, onChange }) {
+function AdvancementInput({
+  eventId, type, level, onChange,
+}) {
   switch (type) {
     case 'ranking':
       return (
@@ -90,20 +92,24 @@ function AdvancementInput({ eventId, type, level, onChange }) {
     case 'attemptResult':
       return (
         eventId === '333mbf'
-            ? <MbldPointsField
-                label={<Label>Result</Label>}
-                eventId={eventId}
-                value={level}
-                onChange={onChange}
-                resultType="single"
-              />
-            : <AttemptResultField
-                label={<Label>Result</Label>}
-                eventId={eventId}
-                value={level}
-                onChange={onChange}
-                resultType="single"
-              />
+          ? (
+            <MbldPointsField
+              label={<Label>Result</Label>}
+              eventId={eventId}
+              value={level}
+              onChange={onChange}
+              resultType="single"
+            />
+          )
+          : (
+            <AttemptResultField
+              label={<Label>Result</Label>}
+              eventId={eventId}
+              value={level}
+              onChange={onChange}
+              resultType="single"
+            />
+          )
       );
     default:
       return null;

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditCutoffModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditCutoffModal/index.js
@@ -13,8 +13,8 @@ import AttemptResultField from '../../../Results/WCALive/AttemptResultField/Atte
 import MbldPointsField from '../../../Results/WCALive/AttemptResultField/MbldPointsField';
 
 /**
- * Developer notes: "cutoffFormat" and "NumberOfAttempts" is used interchangeably for written clarity
- * A cutoff is made up of a number of attempts and a format.
+ * Developer notes: "cutoffFormat" and "NumberOfAttempts" is used interchangeably
+ * for written clarity. A cutoff is made up of a number of attempts and a format.
  * This format is essentially a "number of attempts"
  * The cutoff format is stored as "cutoff.numberOfAttempts" in the round object in the wcif.
  */
@@ -82,19 +82,23 @@ export default function EditCutoffModal({ wcifEvent, wcifRound, disabled }) {
       {
         numberOfAttempts > 0 && (
           wcifEvent.id === '333mbf'
-            ? <MbldPointsField
+            ? (
+              <MbldPointsField
                 label={<Label>Cutoff Result</Label>}
                 eventId={wcifEvent.id}
                 value={attemptResult}
                 onChange={setAttemptResult}
               />
-            : <AttemptResultField
+            )
+            : (
+              <AttemptResultField
                 label={<Label>Cutoff Result</Label>}
                 eventId={wcifEvent.id}
                 value={attemptResult}
                 onChange={setAttemptResult}
                 resultType="single"
-            />
+              />
+            )
         )
       }
 

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditQualificationModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditQualificationModal/index.js
@@ -31,23 +31,24 @@ function QualificationInput({
   switch (type) {
     case 'attemptResult':
       return (
-        <>
-          {eventId === '333mbf'
-            ? <MbldPointsField
-                eventId={eventId}
-                value={level}
-                onChange={(level) => onChange(level)}
-                label={<Label>{i18n.t(`common.${resultType}`)}</Label>}
-              />
-            : <AttemptResultField
-                eventId={eventId}
-                value={level}
-                onChange={(value) => onChange(value)}
-                label={<Label>{i18n.t(`common.${resultType}`)}</Label>}
-                resultType={resultType}
-              />
-          }
-        </>
+        eventId === '333mbf'
+          ? (
+            <MbldPointsField
+              eventId={eventId}
+              value={level}
+              onChange={(newLevel) => onChange(newLevel)}
+              label={<Label>{i18n.t(`common.${resultType}`)}</Label>}
+            />
+          )
+          : (
+            <AttemptResultField
+              eventId={eventId}
+              value={level}
+              onChange={(value) => onChange(value)}
+              label={<Label>{i18n.t(`common.${resultType}`)}</Label>}
+              resultType={resultType}
+            />
+          )
       );
     case 'ranking':
       return (

--- a/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/index.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/index.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useState,
+} from 'react';
 import _ from 'lodash';
 import { Form, Label, Radio } from 'semantic-ui-react';
 import { events } from '../../../../lib/wca-data.js.erb';
@@ -49,10 +51,6 @@ export default function EditTimeLimitModal({ wcifEvent, wcifRound, disabled }) {
 
   const Title = useMemo(() => `Time limit for ${roundIdToString(wcifRound.id)}`, [wcifRound.id]);
 
-  if (!event.canChangeTimeLimit) {
-    return null;
-  }
-
   const hasUnsavedChanges = () => (
     !_.isEqual(timeLimit, { centiseconds, cumulativeRoundIds })
   );
@@ -64,6 +62,10 @@ export default function EditTimeLimitModal({ wcifEvent, wcifRound, disabled }) {
 
   // if a different event updates cumulative time limits, these inputs need resetting
   useEffect(reset, [reset]);
+
+  if (!event.canChangeTimeLimit) {
+    return null;
+  }
 
   const handleOk = () => {
     if (hasUnsavedChanges()) {

--- a/WcaOnRails/app/webpacker/components/EditEvents/utils.js
+++ b/WcaOnRails/app/webpacker/components/EditEvents/utils.js
@@ -25,6 +25,21 @@ export const generateWcifRound = (eventId, roundNumber) => {
   };
 };
 
+const removeSharedTimeLimitsFromRound = (round, roundIdsToRemove) => {
+  if (round.timeLimit) {
+    return {
+      ...round,
+      timeLimit: {
+        ...round.timeLimit,
+        cumulativeRoundIds: round.timeLimit.cumulativeRoundIds.filter((wcifRoundId) => (
+          !roundIdsToRemove.includes(wcifRoundId)
+        )),
+      },
+    };
+  }
+  return round;
+};
+
 /**
  * Removes the roundIds from the cumulativeRoundIds of the specified event.
  *
@@ -37,23 +52,8 @@ export const removeSharedTimeLimits = (event, roundIdsToRemove) => {
       ...event,
       rounds: event.rounds.map((round) => removeSharedTimeLimitsFromRound(round, roundIdsToRemove)),
     };
-  };
+  }
   return event;
-};
-
-const removeSharedTimeLimitsFromRound = (round, roundIdsToRemove) => {
-  if (round.timeLimit) {
-    return {
-      ...round,
-      timeLimit: {
-        ...round.timeLimit,
-        cumulativeRoundIds: round.timeLimit.cumulativeRoundIds.filter((wcifRoundId) => (
-          !roundIdsToRemove.includes(wcifRoundId)
-        )),
-      },
-    };
-  };
-  return round;
 };
 
 export const roundCutoffToString = (wcifRound, { short } = {}) => {


### PR DESCRIPTION
We had an exclusion rule in `.overcommit.yml` back from when it still used `react-bootstrap` and custom `rootRender` calls. Now that we use clean code, we might as well lint it.