### PR TITLE
Retry JS-based tests by default

### DIFF
--- a/spec/controllers/server_status_controller_spec.rb
+++ b/spec/controllers/server_status_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "JobsCheck" do
     expect(description).to be_nil
   end
 
-  it "finds the oldest job that has been waiting to run" do
+  it "finds the oldest job that has been waiting to run", retry: 3 do
     dummy_job, another_job = dummy_jobs
 
     dummy_job.cronjob_statistics.update!(enqueued_at: 10.minutes.ago)
@@ -62,7 +62,7 @@ RSpec.describe "JobsCheck" do
     expect(description).to match(/Job #{another_job.cronjob_statistics.id} was/)
   end
 
-  it "ignores jobs in progress" do
+  it "ignores jobs in progress", retry: 3 do
     dummy_job, another_job = dummy_jobs
 
     dummy_job.cronjob_statistics.update!(enqueued_at: 10.minutes.ago)

--- a/spec/features/competition_events_spec.rb
+++ b/spec/features/competition_events_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Competition events management" do
       let(:comp_event_333) { competition.competition_events.find_by_event_id("333") }
       let(:round_333_1) { comp_event_333.rounds.first }
 
-      scenario "close with unsaved changes prompts user before discarding changes", js: true, retry: 3 do
+      scenario "close with unsaved changes prompts user before discarding changes", js: true do
         find_round("333", 1).click_button("timeLimit")
 
         modal = find_modal
@@ -71,13 +71,13 @@ RSpec.feature "Competition events management" do
         end
       end
 
-      scenario "change scramble group count to 42", js: true, retry: 3 do
+      scenario "change scramble group count to 42", js: true do
         within_round("333", 1) { fill_in "scrambleSetCount", with: "42" }
         save_events_react
         expect(round_333_1.reload.scramble_set_count).to eq 42
       end
 
-      scenario "change time limit to 5 minutes", js: true, retry: 3 do
+      scenario "change time limit to 5 minutes", js: true do
         find_round("333", 1).click_button("timeLimit")
 
         modal = find_modal
@@ -89,7 +89,7 @@ RSpec.feature "Competition events management" do
         expect(round_333_1.reload.time_limit_to_s).to eq "5:00.00"
       end
 
-      scenario "change cutoff to best of 2 in 2 minutes", js: true, retry: 3 do
+      scenario "change cutoff to best of 2 in 2 minutes", js: true do
         find_round("333", 1).click_button("cutoff")
 
         modal = find_modal
@@ -102,7 +102,7 @@ RSpec.feature "Competition events management" do
         expect(round_333_1.reload.cutoff_to_s).to eq "2 attempts to get < 2:00.00"
       end
 
-      scenario "change advancement condition to top 12 people", js: true, retry: 3 do
+      scenario "change advancement condition to top 12 people", js: true do
         # Add a second round of 333 so we can set an advancement condition on round 1.
         event_panel = find_event_panel("333")
         select_from_ui(event_panel, "selectRoundCount", "2 rounds")
@@ -119,7 +119,7 @@ RSpec.feature "Competition events management" do
         expect(round_333_1.reload.advancement_condition_to_s).to eq "Top 12 advance to next round"
       end
 
-      scenario "change qualification time to any result", js: true, retry: 3 do
+      scenario "change qualification time to any result", js: true do
         find_event_panel("333").find("[name='qualification']").click
 
         qualification_date = 7.days.from_now.to_date
@@ -227,7 +227,7 @@ RSpec.feature "Competition events management" do
     let!(:competition) { FactoryBot.create :competition, :confirmed, :visible, :past, :results_posted, event_ids: Event.where(id: '333') }
     let(:competition_event) { competition.competition_events.find_by_event_id("333") }
 
-    scenario "delegate cannot update events", js: true, retry: 3 do
+    scenario "delegate cannot update events", js: true do
       FactoryBot.create :round, number: 2, format_id: 'a', competition_event: competition_event, total_number_of_rounds: 2
       sign_in competition.delegates.first
       visit "/competitions/#{competition.id}/events/edit"

--- a/spec/features/competition_management_spec.rb
+++ b/spec/features/competition_management_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "Competition management", js: true do
       expect(page).to have_text("You've confirmed this competition")
     end
 
-    scenario "change competition id of long name", retry: 3 do
+    scenario "change competition id of long name" do
       competition = FactoryBot.create(:competition, :with_delegate, name: "competition name id modify long 2016")
       visit edit_competition_path(competition)
 
@@ -118,7 +118,7 @@ RSpec.feature "Competition management", js: true do
       expect(Competition.find_by_id("NewId With Spaces")).to be_nil
     end
 
-    scenario "change competition id with validation error", retry: 3 do
+    scenario "change competition id with validation error" do
       competition = FactoryBot.create(:competition, :with_delegate, id: "OldId2016", name: "competition name id modify as admin 2016")
       visit edit_competition_path(competition)
       fill_in "ID", with: "NewId2016"
@@ -181,7 +181,7 @@ RSpec.feature "Competition management", js: true do
       expect(page).to have_text("Display message for free guest entry")
     end
 
-    scenario "change guest entry fee to non-zero", js: true, retry: 3 do
+    scenario "change guest entry fee to non-zero", js: true do
       competition = FactoryBot.create(:competition, :with_delegate, id: "OldId2016", guests_entry_fee_lowest_denomination: 666)
       visit edit_competition_path(competition)
 
@@ -217,7 +217,7 @@ RSpec.feature "Competition management", js: true do
       sign_in delegate
     end
 
-    scenario 'create competition', js: true, retry: 3 do
+    scenario 'create competition', js: true do
       visit new_competition_path
 
       fill_in "Name", with: "New Comp 2015"
@@ -260,7 +260,7 @@ RSpec.feature "Competition management", js: true do
       expect(comp.reload.confirmed?).to eq false
     end
 
-    scenario 'clone competition', js: true, retry: 3 do
+    scenario 'clone competition', js: true do
       visit clone_competition_path(competition_to_clone)
 
       fill_in "Name", with: "New Comp 2015"
@@ -284,7 +284,7 @@ RSpec.feature "Competition management", js: true do
     feature "edit" do
       let(:comp_with_fours) { FactoryBot.create :competition, events: [fours], delegates: [delegate] }
 
-      scenario 'can edit registration open datetime', js: true, retry: 3 do
+      scenario 'can edit registration open datetime', js: true do
         visit edit_competition_path(comp_with_fours)
 
         expect(page).to have_field("registration-openingDateTime", type: 'datetime-local', disabled: false)

--- a/spec/features/cookie_law_spec.rb
+++ b/spec/features/cookie_law_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "cookie law" do
       sign_in admin
     end
 
-    scenario "remembers acknowledgement without cookies", js: true, retry: 3 do
+    scenario "remembers acknowledgement without cookies", js: true do
       visit_homepage_and_wait_for_load
       acknowledge_cookie_banner
 

--- a/spec/features/stripe_integration_spec.rb
+++ b/spec/features/stripe_integration_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Stripe PaymentElement integration" do
       expect(page).to have_selector("#payment-element iframe")
     end
 
-    it "loads the PaymentElement", js: true, retry: 3 do
+    it "loads the PaymentElement", js: true do
       # In the beginning, the button to pay should be disabled
       expect(page).to have_button('Pay now!', disabled: true)
 
@@ -42,7 +42,7 @@ RSpec.feature "Stripe PaymentElement integration" do
       expect(page).to have_button('Pay now!', disabled: false)
     end
 
-    it "changes subtotal when using a donation", js: true, retry: 3 do
+    it "changes subtotal when using a donation", js: true do
       subtotal_label = page.find('#money-subtotal')
 
       format_money = format_money(registration.outstanding_entry_fees)
@@ -61,7 +61,7 @@ RSpec.feature "Stripe PaymentElement integration" do
       expect(subtotal_label).to have_text(format_money)
     end
 
-    it "warns when the subtotal is too high", js: true, retry: 3 do
+    it "warns when the subtotal is too high", js: true do
       # (accidentally?) donate a ridiculously high amount of money
       donation_money = competition.base_entry_fee * competition.base_entry_fee.cents
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,4 +96,14 @@ RSpec.configure do |config|
   # Rspec-retry configuration
   config.verbose_retry = true
   config.display_try_failure_messages = true
+
+  # run retry on features that have JS enabled
+  config.around :each, :js do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  # clean up the Capybara cache between reruns
+  config.retry_callback = proc do |ex|
+    Capybara.reset! if ex.metadata[:js]
+  end
 end


### PR DESCRIPTION
With more and more React code that we're patching through a third-party, horribly slow suport gem with a horribly hacky JS driver into a horribly outdated and deprecated test driver, this seems somewhat reasonable.

Code snippets taken directly from https://github.com/NoRedInk/rspec-retry README.