### PR TITLE
Region page in Senior Delegate Panel

### DIFF
--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -21,6 +21,8 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
   # Filters the list of groups based on given parameters.
   private def filter_groups_for_parameters(groups: [], is_active: nil, parent_group_id: nil)
     groups.reject do |group|
+      # Here, instead of foo.present? we are using !foo.nil? because foo.present? returns false if
+      # foo is a boolean false but we need to actually check if the boolean is present or not.
       (
         (!is_active.nil? && is_active != group.is_active) ||
         (!parent_group_id.nil? && group.parent_group_id != parent_group_id)

--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -23,7 +23,7 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
     groups.reject do |group|
       (
         (!is_active.nil? && is_active != group.is_active) ||
-        (parent_group_id.present? && group.parent_group_id != parent_group_id)
+        (!parent_group_id.nil? && group.parent_group_id != parent_group_id)
       )
     end
   end

--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -19,10 +19,11 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
   end
 
   # Filters the list of groups based on given parameters.
-  private def filter_groups_for_parameters(groups: [], is_active: nil)
+  private def filter_groups_for_parameters(groups: [], is_active: nil, parent_group_id: nil)
     groups.reject do |group|
       (
-        !is_active.nil? && is_active != group.is_active
+        (!is_active.nil? && is_active != group.is_active) ||
+        (parent_group_id.present? && group.parent_group_id != parent_group_id)
       )
     end
   end
@@ -53,6 +54,7 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
     groups = filter_groups_for_parameters(
       groups: groups,
       is_active: params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil,
+      parent_group_id: params.key?(:parentGroupId) ? params.require(:parentGroupId).to_i : nil,
     )
 
     # Sorts the list of groups by name.

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -65,7 +65,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
   end
 
   # Filters the list of roles based on given parameters.
-  private def filter_roles_for_parameters(roles: [], status: nil, is_active: nil, is_group_hidden: nil)
+  private def filter_roles_for_parameters(roles: [], status: nil, is_active: nil, is_group_hidden: nil, group_type: nil, is_lead: nil)
     roles.reject do |role|
       is_actual_role = role.is_a?(UserRole) # See previous is_actual_role comment.
       # In future, the following lines will be replaced by the following:
@@ -79,7 +79,9 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       (
         (status.present? && status != (is_actual_role ? role.metadata.status : role[:metadata][:status])) ||
         (!is_active.nil? && is_active != (is_actual_role ? role.is_active? : role[:is_active])) ||
-        (!is_group_hidden.nil? && is_group_hidden != (is_actual_role ? role.group.is_hidden : role[:group][:is_hidden]))
+        (!is_group_hidden.nil? && is_group_hidden != (is_actual_role ? role.group.is_hidden : role[:group][:is_hidden])) ||
+        (group_type.present? && group_type != UserRole.group_type(role)) ||
+        (!is_lead.nil? && is_lead != UserRole.is_lead?(role))
       )
     end
   end
@@ -142,6 +144,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       is_active: params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil,
       is_group_hidden: params.key?(:isGroupHidden) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isGroupHidden)) : nil,
       status: params[:status],
+      group_type: params[:groupType],
     )
 
     # Sort the roles.
@@ -165,11 +168,13 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     status = params[:status]
     is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
     is_group_hidden = params.key?(:isGroupHidden) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isGroupHidden)) : nil
+    is_lead = params.key?(:isLead) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isLead)) : nil
     roles = filter_roles_for_parameters(
       roles: roles,
       status: status,
       is_active: is_active,
       is_group_hidden: is_group_hidden,
+      is_lead: is_lead,
     )
 
     # Sort the roles.
@@ -329,6 +334,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     if group.group_type == UserGroup.group_types[:delegate_regions] && !delegate_status_migrated?(status)
       # Creates deprecated role.
       user = User.find(user_id)
+      return render status: :unprocessable_entity, json: { error: "Already a delegate" } if user.any_kind_of_delegate?
       user.update!(delegate_status: status, region_id: group.id, location: location)
       send_role_change_notification(user)
       return render json: {
@@ -356,24 +362,16 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
   def show
     user_id = params.require(:userId)
-    is_active_role = ActiveRecord::Type::Boolean.new.cast(params.require(:isActiveRole))
 
-    if is_active_role
-      user = User.find(user_id)
-      render json: {
-        roleData: {
-          delegateStatus: user.delegate_status,
-          regionId: user.region_id,
-          location: user.location,
-        },
-        regions: UserGroup.delegate_region_groups,
-      }
-    else
-      render json: {
-        roleData: {},
-        regions: UserGroup.delegate_region_groups,
-      }
-    end
+    user = User.find(user_id)
+    render json: {
+      roleData: {
+        delegateStatus: user.delegate_status,
+        regionId: user.region_id,
+        location: user.location,
+      },
+      regions: UserGroup.delegate_region_groups,
+    }
   end
 
   def update

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -80,7 +80,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
         (status.present? && status != (is_actual_role ? role.metadata.status : role[:metadata][:status])) ||
         (!is_active.nil? && is_active != (is_actual_role ? role.is_active? : role[:is_active])) ||
         (!is_group_hidden.nil? && is_group_hidden != (is_actual_role ? role.group.is_hidden : role[:group][:is_hidden])) ||
-        (group_type.present? && group_type != UserRole.group_type(role)) ||
+        (!group_type.nil? && group_type != UserRole.group_type(role)) ||
         (!is_lead.nil? && is_lead != UserRole.is_lead?(role))
       )
     end
@@ -334,7 +334,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     if group.group_type == UserGroup.group_types[:delegate_regions] && !delegate_status_migrated?(status)
       # Creates deprecated role.
       user = User.find(user_id)
-      return render status: :unprocessable_entity, json: { error: "Already a delegate" } if user.any_kind_of_delegate?
+      return render status: :unprocessable_entity, json: { error: "Already a Delegate" } if user.any_kind_of_delegate?
       user.update!(delegate_status: status, region_id: group.id, location: location)
       send_role_change_notification(user)
       return render json: {

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -76,8 +76,10 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       # )
       # Till then, we need to support both the old and new systems. So, we will be using ternary
       # operator to access the parameters.
+      # Here, instead of foo.present? we are using !foo.nil? because foo.present? returns false if
+      # foo is a boolean false but we need to actually check if the boolean is present or not.
       (
-        (status.present? && status != (is_actual_role ? role.metadata.status : role[:metadata][:status])) ||
+        (!status.nil? && status != (is_actual_role ? role.metadata.status : role[:metadata][:status])) ||
         (!is_active.nil? && is_active != (is_actual_role ? role.is_active? : role[:is_active])) ||
         (!is_group_hidden.nil? && is_group_hidden != (is_actual_role ? role.group.is_hidden : role[:group][:is_hidden])) ||
         (!group_type.nil? && group_type != UserRole.group_type(role)) ||

--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -38,6 +38,7 @@ class PanelController < ApplicationController
       },
       "seniorDelegate" => {
         "delegateForms" => "delegate-forms",
+        "regions" => "regions",
         "delegateProbations" => "delegate-probations",
         "subordinateDelegateClaims" => "subordinate-delegate-claims",
         "subordinateUpcomingCompetitions" => "subordinate-upcoming-competitions",

--- a/app/views/panel/senior_delegate.html.erb
+++ b/app/views/panel/senior_delegate.html.erb
@@ -1,2 +1,4 @@
 <% provide(:title, 'Senior Delegate Panel') %>
-<%= react_component("Panel/SeniorDelegate") %>
+<%= react_component("Panel/SeniorDelegate", {
+  loggedInUserId: current_user.id,
+}) %>

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/Region.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/Region.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import useLoadedData from '../../../../lib/hooks/useLoadedData';
+import { apiV0Urls } from '../../../../lib/requests/routes.js.erb';
+import { groupTypes } from '../../../../lib/wca-data.js.erb';
+import Loading from '../../../Requests/Loading';
+import Errored from '../../../Requests/Errored';
+import Subregion from './Subregion';
+
+export default function Region({ group }) {
+  const { data: subregions, loading, error } = useLoadedData(
+    apiV0Urls.userGroups.list(groupTypes.delegate_regions, 'name', {
+      isActive: true,
+      parentGroupId: group.id,
+    }),
+  );
+
+  if (loading) return <Loading />;
+  if (error) return <Errored />;
+
+  return (
+    <>
+      {subregions.map((subregion) => (
+        <Subregion
+          key={subregion.id}
+          title={subregion.name}
+          groupId={subregion.id}
+        />
+      ))}
+      <Subregion
+        key="no-subregion"
+        title="No subregion"
+        groupId={group.id}
+      />
+    </>
+  );
+}

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/Subregion.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/Subregion.jsx
@@ -11,6 +11,10 @@ import I18n from '../../../../lib/i18n';
 import useSaveAction from '../../../../lib/hooks/useSaveAction';
 
 const delegateStatusOptions = ['trainee_delegate', 'candidate_delegate', 'delegate'];
+const delegateStatusOptionsList = delegateStatusOptions.map((option) => ({
+  text: I18n.t(`enums.user.role_status.delegate_regions.${option}`),
+  value: option,
+}));
 const initialValue = {
   newDelegate: null,
   status: delegateStatusOptions[0],
@@ -111,10 +115,7 @@ export default function Subregion({ title, groupId }) {
               selection
               name="status"
               value={formValues.status}
-              options={delegateStatusOptions.map((option) => ({
-                text: I18n.t(`enums.user.role_status.delegate_regions.${option}`),
-                value: option,
-              }))}
+              options={delegateStatusOptionsList}
               onChange={handleFormChange}
             />
             <Form.Input

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/Subregion.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/Subregion.jsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import {
+  Header, Table, Button, Modal, Form, Message,
+} from 'semantic-ui-react';
+import { apiV0Urls, editUserAvatarUrl } from '../../../../lib/requests/routes.js.erb';
+import useLoadedData from '../../../../lib/hooks/useLoadedData';
+import Loading from '../../../Requests/Loading';
+import Errored from '../../../Requests/Errored';
+import WcaSearch from '../../../SearchWidget/WcaSearch';
+import I18n from '../../../../lib/i18n';
+import useSaveAction from '../../../../lib/hooks/useSaveAction';
+
+const delegateStatusOptions = ['trainee_delegate', 'candidate_delegate', 'delegate'];
+const initialValue = {
+  newDelegate: null,
+  status: delegateStatusOptions[0],
+};
+
+export default function Subregion({ title, groupId }) {
+  const {
+    data: delegates, loading, error: delegatesFetchError, sync,
+  } = useLoadedData(apiV0Urls.userRoles.listOfGroup(
+    groupId,
+    'location,name',
+    {
+      isActive: true,
+      isLead: false,
+    },
+  ));
+  const [openModalType, setOpenModalType] = useState(null);
+  const [formValues, setFormValues] = useState(initialValue);
+  const [newDelegateUser, setNewDelegateUser] = useState(null);
+  const [formError, setFormError] = useState(null);
+  const { save, saving } = useSaveAction();
+  const error = delegatesFetchError || formError;
+
+  const handleFormChange = (_, { name, value }) => setFormValues({ ...formValues, [name]: value });
+
+  const addNewDelegateAction = () => {
+    save(
+      apiV0Urls.userRoles.create(),
+      {
+        userId: formValues.newDelegate.id,
+        groupId,
+        status: formValues.status,
+        location: formValues.location || '',
+      },
+      () => {
+        sync();
+        setNewDelegateUser(formValues.newDelegate);
+        setFormValues(initialValue);
+        setOpenModalType(null);
+      },
+      { method: 'POST' },
+      (err) => setFormError(err),
+    );
+  };
+
+  if (loading || saving) return <Loading />;
+  if (error) return <Errored />;
+
+  return (
+    <>
+      {newDelegateUser && (
+        <Message content={(
+          <>
+            {'New Delegate has been created. Please adjust the thumbnail of the new Delegate '}
+            <a href={editUserAvatarUrl(newDelegateUser.id)}>here</a>
+          </>
+        )}
+        />
+      )}
+      <Header as="h4">{title}</Header>
+      <Button onClick={() => setOpenModalType('newDelegate')}>New Delegate</Button>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Name</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {delegates.map((delegate) => (
+            <Table.Row key={delegate.id}>
+              <Table.Cell>{delegate.user.name}</Table.Cell>
+              <Table.Cell>{I18n.t(`enums.user.role_status.delegate_regions.${delegate.metadata.status}`)}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      <Modal
+        size="fullscreen"
+        onClose={() => setOpenModalType(null)}
+        open={openModalType === 'newDelegate'}
+      >
+        <Modal.Content>
+          <Header>New Delegate</Header>
+          <Form onSubmit={addNewDelegateAction}>
+            <Form.Field
+              label="New Delegate"
+              control={WcaSearch}
+              name="newDelegate"
+              value={formValues?.newDelegate}
+              onChange={handleFormChange}
+              model="user"
+              multiple={false}
+            />
+            <Form.Dropdown
+              label="Delegate Status"
+              fluid
+              selection
+              name="status"
+              value={formValues.status}
+              options={delegateStatusOptions.map((option) => ({
+                text: I18n.t(`enums.user.role_status.delegate_regions.${option}`),
+                value: option,
+              }))}
+              onChange={handleFormChange}
+            />
+            <Form.Input
+              label="Location"
+              name="location"
+              value={formValues.location || ''}
+              onChange={handleFormChange}
+            />
+            <Form.Button onClick={() => setOpenModalType(null)}>Cancel</Form.Button>
+            <Form.Button type="submit">Save</Form.Button>
+          </Form>
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+}

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { Dropdown, Header } from 'semantic-ui-react';
 
@@ -24,20 +24,16 @@ export default function Regions({ loggedInUserId }) {
       groupType: groupTypes.delegate_region,
     },
   ));
-  const [selectedGroupIndex, setSelectedGroupIndex] = useInputState();
+  const [selectedGroupIndex, setSelectedGroupIndex] = useInputState(0);
 
-  useEffect(() => {
-    if (seniorDelegateRoles?.length > 0) setSelectedGroupIndex(0);
-  }, [seniorDelegateRoles, setSelectedGroupIndex]);
-
-  const groupOptions = useMemo(() => seniorDelegateRoles.map((role, index) => ({
+  const groupOptions = useMemo(() => seniorDelegateRoles?.map((role, index) => ({
     key: role.id,
     text: role.group.name,
     value: index,
   })), [seniorDelegateRoles]);
 
-  if (!loading && seniorDelegateRoles.length === 0) return <p>You cannot manage any regions..</p>;
-  if (loading || selectedGroupIndex === undefined) return <Loading />;
+  if (!loading && seniorDelegateRoles.length === 0) return <p>You cannot manage any regions.</p>;
+  if (loading) return <Loading />;
   if (error) return <Errored />;
 
   return (

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+
+import { Dropdown, Header } from 'semantic-ui-react';
+
+import useInputState from '../../../../lib/hooks/useInputState';
+import useLoadedData from '../../../../lib/hooks/useLoadedData';
+import { apiV0Urls } from '../../../../lib/requests/routes.js.erb';
+import { delegateRegionsStatus, groupTypes } from '../../../../lib/wca-data.js.erb';
+import Errored from '../../../Requests/Errored';
+import Loading from '../../../Requests/Loading';
+import Region from './Region';
+
+export default function Regions({ loggedInUserId }) {
+  const {
+    data: seniorDelegateRoles,
+    loading, error,
+  } = useLoadedData(apiV0Urls.userRoles.listOfUser(
+    loggedInUserId,
+    'groupName', // Sort params
+    {
+      isActive: true,
+      isGroupHidden: false,
+      status: delegateRegionsStatus.senior_delegate,
+      groupType: groupTypes.delegate_region,
+    },
+  ));
+  const [selectedGroupIndex, setSelectedGroupIndex] = useInputState();
+
+  useEffect(() => {
+    if (seniorDelegateRoles?.length > 0) setSelectedGroupIndex(0);
+  }, [seniorDelegateRoles, setSelectedGroupIndex]);
+
+  if (!loading && seniorDelegateRoles.length === 0) return <p>You cannot manage any regions..</p>;
+  if (loading || selectedGroupIndex === undefined) return <Loading />;
+  if (error) return <Errored />;
+
+  return (
+    <>
+      <Header>Regions</Header>
+      <div>
+        <Dropdown
+          options={seniorDelegateRoles.map((role, index) => ({
+            key: role.id,
+            text: role.group.name,
+            value: index,
+          }))}
+          value={selectedGroupIndex}
+          onChange={setSelectedGroupIndex}
+        />
+      </div>
+      <Region group={seniorDelegateRoles[selectedGroupIndex].group} />
+    </>
+  );
+}

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { Dropdown, Header } from 'semantic-ui-react';
 
@@ -30,6 +30,12 @@ export default function Regions({ loggedInUserId }) {
     if (seniorDelegateRoles?.length > 0) setSelectedGroupIndex(0);
   }, [seniorDelegateRoles, setSelectedGroupIndex]);
 
+  const groupOptions = useMemo(() => seniorDelegateRoles.map((role, index) => ({
+    key: role.id,
+    text: role.group.name,
+    value: index,
+  })), [seniorDelegateRoles]);
+
   if (!loading && seniorDelegateRoles.length === 0) return <p>You cannot manage any regions..</p>;
   if (loading || selectedGroupIndex === undefined) return <Loading />;
   if (error) return <Errored />;
@@ -39,11 +45,7 @@ export default function Regions({ loggedInUserId }) {
       <Header>Regions</Header>
       <div>
         <Dropdown
-          options={seniorDelegateRoles.map((role, index) => ({
-            key: role.id,
-            text: role.group.name,
-            value: index,
-          }))}
+          options={groupOptions}
           value={selectedGroupIndex}
           onChange={setSelectedGroupIndex}
         />

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
@@ -32,9 +32,9 @@ export default function Regions({ loggedInUserId }) {
     value: index,
   })), [seniorDelegateRoles]);
 
-  if (!loading && seniorDelegateRoles.length === 0) return <p>You cannot manage any regions.</p>;
   if (loading) return <Loading />;
   if (error) return <Errored />;
+  if (seniorDelegateRoles.length === 0) return <p>You cannot manage any regions.</p>;
 
   return (
     <>

--- a/app/webpacker/components/Panel/SeniorDelegate/index.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/index.jsx
@@ -7,12 +7,18 @@ import DelegateProbations from '../../DelegateProbations';
 import PanelTemplate from '../PanelTemplate';
 import DelegateForms from './DelegateForms';
 import { PANEL_LIST } from '../../../lib/wca-data.js.erb';
+import Regions from './Regions';
 
 const sections = [
   {
     id: PANEL_LIST.seniorDelegate.delegateForms,
     name: 'Delegate Forms',
     component: DelegateForms,
+  },
+  {
+    id: PANEL_LIST.seniorDelegate.regions,
+    name: 'Regions',
+    component: Regions,
   },
   {
     id: PANEL_LIST.seniorDelegate.delegateProbations,
@@ -31,8 +37,12 @@ const sections = [
   },
 ];
 
-export default function SeniorDelegate() {
+export default function SeniorDelegate({ loggedInUserId }) {
   return (
-    <PanelTemplate heading="Senior Delegate Panel" sections={sections} />
+    <PanelTemplate
+      heading="Senior Delegate Panel"
+      sections={sections}
+      loggedInUserId={loggedInUserId}
+    />
   );
 }

--- a/app/webpacker/components/RolesTab/RoleForm.jsx
+++ b/app/webpacker/components/RolesTab/RoleForm.jsx
@@ -23,8 +23,8 @@ const groups = [{
 
 const delegateStatusOptions = ['trainee_delegate', 'candidate_delegate', 'delegate'];
 
-export default function RoleForm({ userId, isActiveRole }) {
-  const { data, loading, error } = useLoadedData(roleDataUrl(userId, isActiveRole));
+export default function RoleForm({ userId }) {
+  const { data, loading, error } = useLoadedData(roleDataUrl(userId));
   const { data: delegateRegions, loading: regionsLoading, error: regionsError } = useLoadedData(
     apiV0Urls.userGroups.list(groupTypes.delegate_regions),
   );
@@ -103,13 +103,12 @@ export default function RoleForm({ userId, isActiveRole }) {
           type="submit"
           disabled={(_.isEqual(formValues, data?.roleData))}
         >
-          {isActiveRole ? 'Update Role' : 'Create Role'}
+          Update Role
         </Form.Button>
         <Form.Button
           secondary
           type="button"
           onClick={endRole}
-          disabled={!isActiveRole}
         >
           End Role
         </Form.Button>

--- a/app/webpacker/components/RolesTab/index.jsx
+++ b/app/webpacker/components/RolesTab/index.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { Modal, Button } from 'semantic-ui-react';
+import { Modal } from 'semantic-ui-react';
 import useLoadedData from '../../lib/hooks/useLoadedData';
 import { apiV0Urls } from '../../lib/requests/routes.js.erb';
 import Errored from '../Requests/Errored';
 import Loading from '../Requests/Loading';
 import RoleForm from './RoleForm';
-import { groupTypes } from '../../lib/wca-data.js.erb';
 import ActiveRoles from './ActiveRoles';
 import PastRoles from './PastRoles';
 
@@ -48,10 +47,6 @@ export default function RolesTab({ userId }) {
 
   const [open, setOpen] = React.useState(false);
 
-  const isDelegate = activeRoles?.some(
-    (role) => role.group.group_type === groupTypes.delegate_regions,
-  );
-
   const hasNoRoles = activeRoles?.length === 0 && pastRoles?.length === 0;
 
   if (activeRolesLoading || pastRolesLoading) return <Loading />;
@@ -62,7 +57,6 @@ export default function RolesTab({ userId }) {
       {activeRoles?.length > 0 && (<ActiveRoles activeRoles={activeRoles} setOpen={setOpen} />)}
       {pastRoles?.length > 0 && (<PastRoles pastRoles={pastRoles} />)}
       {hasNoRoles && <p>No Roles...</p>}
-      <Button onClick={() => setOpen(true)} disabled={isDelegate}>New Role</Button>
 
       <Modal
         size="fullscreen"
@@ -79,7 +73,7 @@ export default function RolesTab({ userId }) {
         open={open}
       >
         <Modal.Content>
-          <RoleForm userId={userId} isActiveRole={isDelegate} />
+          <RoleForm userId={userId} />
         </Modal.Content>
       </Modal>
     </>

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -131,7 +131,7 @@ export const addUserGroupsUrl = `<%= Rails.application.routes.url_helpers.api_v0
 export const userGroupsUpdateUrl = (userGroupId) => `<%= Rails.application.routes.url_helpers.api_v0_user_groups_path %>/${userGroupId}`;
 
 // dummyRoleId is used temporarily because delegates is yet to get a role id
-export const roleDataUrl = (userId, isActiveRole) => `<%= Rails.application.routes.url_helpers.api_v0_user_role_path('dummyRoleId') %>?userId=${userId}&isActiveRole=${isActiveRole}`;
+export const roleDataUrl = (userId, isActiveRole) => `<%= Rails.application.routes.url_helpers.api_v0_user_role_path('dummyRoleId') %>?userId=${userId}`;
 export const roleUpdateUrl = `<%= Rails.application.routes.url_helpers.api_v0_user_role_path('dummyRoleId') %>`;
 
 export const countryBandsUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.country_bands_path) %>`;
@@ -162,6 +162,8 @@ export const teamsCommitteesPageUrl = `<%= CGI.unescape(Rails.application.routes
 
 export const translatorsPageUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.translators_path)%>`;
 
+export const editUserAvatarUrl = (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.users_avatar_thumbnail_edit_path("${userId}"))%>`;
+
 export const apiV0Urls = {
   users: {
     me: {
@@ -177,15 +179,15 @@ export const apiV0Urls = {
     resetClaimCount: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_wrt_person_reset_claim_count_path("${wcaId}"))%>`,
   },
   userRoles: {
-    listOfUser: (userId, sort, {isActive, isGroupHidden, status} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status })}`,
-    listOfGroup: (groupId, sort, {isActive, isGroupHidden, status} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status })}`,
+    listOfUser: (userId, sort, {isActive, isGroupHidden, status, groupType} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, groupType })}`,
+    listOfGroup: (groupId, sort, {isActive, isGroupHidden, status, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, isLead })}`,
     listOfGroupType: (groupType, sort, {status, isActive} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive })}`,
     create: () => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>`,
     update: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,
     delete: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,
   },
   userGroups: {
-    list: (groupType, sort, {isActive} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_groups_path) %>?${jsonToQueryString({ groupType, sort, isActive })}`,
+    list: (groupType, sort, {isActive, parentGroupId} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_groups_path) %>?${jsonToQueryString({ groupType, sort, isActive, parentGroupId })}`,
   },
   competitions: {
     list: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competitions_path)%>`,


### PR DESCRIPTION
Currently, one user can hold only one Delegate role. But once the role migration is completed, one user can be a Delegate of more than one subregion.

But the current way of 'creating new delegate' through the 'role form' won't allow multiple Delegate role. To achieve it in the same UI will make it more complicated.

To solve this, we now have a new page in Senior Delegate Panel named as 'Regions' which will list all the Delegates of their regions and subregions. From this UI, the Senior Delegate can create a new Delegate under respective subregion.

Attaching the screenshot:
<img width="1512" alt="Screenshot 2024-03-05 at 22 00 30" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/50ba86ff-26ec-461c-9f49-5b90a0b5a78b">
