### PR TITLE
Add kill switch to allow organizers closing registration

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -841,7 +841,12 @@ class CompetitionsController < ApplicationController
     competition = competition_from_params
 
     if competition.orga_can_close_reg_full_limit?
-      competition.update!(registration_close: Time.now)
+      competition.update!(
+        # kill switch to stop a validation that disallows "now or past" closing dates
+        closing_full_registration: true,
+        registration_close: Time.now,
+      )
+
       render json: { status: "ok", message: t('competitions.messages.orga_closed_reg_success') }
     else
       render json: { error: t('competitions.messages.orga_closed_reg_failure') }, status: :bad_request

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -311,8 +311,9 @@ class Competition < ApplicationRecord
     end
   end
 
+  attr_accessor :closing_full_registration
   private def should_validate_registration_closing?
-    confirmed_or_visible? && (will_save_change_to_registration_close? || will_save_change_to_confirmed_at?)
+    confirmed_or_visible? && (will_save_change_to_registration_close? || will_save_change_to_confirmed_at?) && !closing_full_registration
   end
 
   # Same comment as for start_date_must_be_28_days_in_advance


### PR DESCRIPTION
Tehcnically it's a bugfix because they were supposed to be allowed to close registration in the first place.

But now that the new form sets `edited_by_user` correctly (which the old form was supposed to do but didn't!) a validation was triggered that would normally have caused troubles already long, long time ago.