### PR TITLE
Cache Microservice Registrations in a separate monolith table

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -869,7 +869,7 @@ class CompetitionsController < ApplicationController
 
   def my_competitions
     if Rails.env.production? && !EnvConfig.WCA_LIVE_SITE?
-      registrations_v2 = Microservices::Registrations.registrations_by_user(current_user.id)
+      registrations_v2 = current_user.microservice_registrations
     else
       registrations_v2 = []
     end
@@ -879,8 +879,8 @@ class CompetitionsController < ApplicationController
       competition_ids.concat(current_user.delegated_competitions.pluck(:competition_id))
       registrations = current_user.registrations.includes(:competition).accepted.reject { |r| r.competition.results_posted? }
       registrations.concat(current_user.registrations.includes(:competition).pending.select { |r| r.competition.upcoming? })
-      # Convert Registrations V2 to a format that the frontend can understand, for Competition, we only need the id.
-      registrations.concat(registrations_v2.map { |r| Microservices::Registrations.convert_registration(Struct.new(:id, keyword_init: true).new(id: r['competition_id']), current_user, r['status']) })
+      # TODO: filter like above: accepted only if results not posted, pending only if upcoming
+      registrations.concat(registrations_v2)
       @registered_for_by_competition_id = registrations.uniq.to_h do |r|
         [r.competition.id, r]
       end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Competition < ApplicationRecord
+  include MicroserviceRegistrationHolder
+
   self.table_name = "Competitions"
 
   # We need this default order, tests rely on it.
@@ -8,7 +10,6 @@ class Competition < ApplicationRecord
   has_many :events, through: :competition_events
   has_many :rounds, through: :competition_events
   has_many :registrations, dependent: :destroy
-  has_many :microservice_registrations
   has_many :results, foreign_key: "competitionId"
   has_many :scrambles, -> { order(:groupId, :isExtra, :scrambleNum) }, foreign_key: "competitionId"
   has_many :uploaded_jsons, dependent: :destroy
@@ -1510,14 +1511,6 @@ class Competition < ApplicationRecord
     :sort_by_second,
     keyword_init: true,
   )
-
-  def microservice_registrations
-    # Query most recent registrations, which triggers caching of the `microservice_registration` AR model
-    Microservices::Registrations.registrations_by_competition(self.id)
-
-    # Let Rails do its thing via the `has_many` association defined at the top of the file
-    super
-  end
 
   def psych_sheet_event(event, sort_by)
     ActiveRecord::Base.connected_to(role: :read_replica) do

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -8,6 +8,7 @@ class Competition < ApplicationRecord
   has_many :events, through: :competition_events
   has_many :rounds, through: :competition_events
   has_many :registrations, dependent: :destroy
+  has_many :microservice_registrations
   has_many :results, foreign_key: "competitionId"
   has_many :scrambles, -> { order(:groupId, :isExtra, :scrambleNum) }, foreign_key: "competitionId"
   has_many :uploaded_jsons, dependent: :destroy

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -619,7 +619,8 @@ class Competition < ApplicationRecord
              'inbox_persons',
              'announced_by_user',
              'cancelled_by_user',
-             'competition_payment_integrations'
+             'competition_payment_integrations',
+             'microservice_registrations'
           # Do nothing as they shouldn't be cloned.
         when 'organizers'
           clone.organizers = organizers

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1528,7 +1528,7 @@ class Competition < ApplicationRecord
       end
 
       if self.uses_new_registration_service?
-        accepted_registrations = Microservices::Registrations.get_registrations(self.id, 'accepted', event.id)
+        accepted_registrations = Microservices::Registrations.registrations_by_competition(self.id, 'accepted', event.id)
         registered_user_ids = accepted_registrations.map { |reg| reg['user_id'] }
       else
         registered_user_ids = self.registrations

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1533,7 +1533,7 @@ class Competition < ApplicationRecord
         # We deliberately don't go through the cached `microservice_registrations` table here, because then we
         # would need to separately check which of the cached registrations are accepted
         # and which of those are registered for the specified event. Querying the MS directly is much more efficient.
-        accepted_registrations = Microservices::Registrations.registrations_by_competition(self.id, 'accepted', event.id)
+        accepted_registrations = Microservices::Registrations.registrations_by_competition(self.id, 'accepted', event.id, cache: false)
         registered_user_ids = accepted_registrations.map { |reg| reg['user_id'] }
       else
         registered_user_ids = self.registrations

--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -18,10 +18,13 @@ module MicroserviceRegistrationHolder
       raise "Unsupported model #{self.model_name} as MicroserviceRegistrationHolder. Currently supported are: #{Competition.model_name}, #{User.model_name}"
     end
 
-    # Let Rails do its thing via the `has_many` association defined at the top of the file
+    # Let Rails do its thing via the `has_many` association defined at the top of the file, but with a little extra
     super.all.extending do
+      # Tap into the Rails ActiveRecord engine to make sure that when records are actually loaded
+      # (i.e. after querying is completely done and the records are _just about_ to be retrieved from the DB)
       define_method :records do
         super().tap do |ar_models|
+          # we hydrate each model with the microservice information directly from above
           ar_models.each do |ar_model|
             matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
             raise "No matching Microservice registration found. This should not happen!" unless matching_ms_model.present?

--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -22,6 +22,8 @@ module MicroserviceRegistrationHolder
     super.tap do |ar_models|
       ar_models.each do |ar_model|
         matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
+        raise "No matching Microservice registration found. This should not happen!" unless matching_ms_model.present?
+
         ar_model.load_ms_model(matching_ms_model)
       end
     end

--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module MicroserviceRegistrationHolder
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :microservice_registrations
+  end
+
+  def microservice_registrations
+    # Query most recent registrations, which triggers caching of the `microservice_registration` AR model
+    case self.model_name.to_s
+    when Competition.model_name.to_s
+      ms_models = Microservices::Registrations.registrations_by_competition(self.id)
+    when User.model_name.to_s
+      ms_models = Microservices::Registrations.registrations_by_user(self.id)
+    else
+      raise "Unsupported model #{self.model_name} as MicroserviceRegistrationHolder. Currently supported are: #{Competition.model_name}, #{User.model_name}"
+    end
+
+    # Let Rails do its thing via the `has_many` association defined at the top of the file
+    super.tap do |ar_models|
+      ar_models.each do |ar_model|
+        matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
+        ar_model.load_ms_model(matching_ms_model)
+      end
+    end
+  end
+end

--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -19,12 +19,16 @@ module MicroserviceRegistrationHolder
     end
 
     # Let Rails do its thing via the `has_many` association defined at the top of the file
-    super.tap do |ar_models|
-      ar_models.each do |ar_model|
-        matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
-        raise "No matching Microservice registration found. This should not happen!" unless matching_ms_model.present?
+    super.all.extending do
+      define_method :records do
+        super().tap do |ar_models|
+          ar_models.each do |ar_model|
+            matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
+            raise "No matching Microservice registration found. This should not happen!" unless matching_ms_model.present?
 
-        ar_model.load_ms_model(matching_ms_model)
+            ar_model.load_ms_model(matching_ms_model)
+          end
+        end
       end
     end
   end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class MicroserviceRegistration < ApplicationRecord
+  belongs_to :competition
+  belongs_to :user
+end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -7,12 +7,12 @@ class MicroserviceRegistration < ApplicationRecord
   delegate :name, :email, to: :user
 
   attr_accessor :ms_registration
-  attr_writer :status, :event_ids
+  attr_writer :competing_status, :event_ids
 
   def load_ms_model(ms_model)
     self.ms_registration = ms_model
 
-    self.status = ms_model['status']
+    self.competing_status = ms_model['competing_status']
 
     self.event_ids = ms_model['lanes']&.find do |lane|
       lane['lane_name'] == 'competing'
@@ -29,9 +29,11 @@ class MicroserviceRegistration < ApplicationRecord
     end
   end
 
-  def status
-    self.read_ms_data :status
+  def competing_status
+    self.read_ms_data :competing_status
   end
+
+  alias :status :competing_status
 
   def event_ids
     self.read_ms_data :event_ids
@@ -42,6 +44,6 @@ class MicroserviceRegistration < ApplicationRecord
   end
 
   def deleted?
-    self.status == "deleted"
+    self.status == "cancelled"
   end
 end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class MicroserviceRegistration < ApplicationRecord
-  belongs_to :competition
-  belongs_to :user
+  belongs_to :competition, inverse_of: :microservice_registrations
+  belongs_to :user, inverse_of: :microservice_registrations
 
   delegate :name, :email, to: :user
 
-  attr_accessor :status
+  attr_accessor :status, :event_ids
 
   def load_ms_model(ms_model)
-    self.status = ms_model.status
+    self.status = ms_model['status']
+    self.event_ids = ms_model['event_ids']
   end
 
   def accepted?

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -3,4 +3,20 @@
 class MicroserviceRegistration < ApplicationRecord
   belongs_to :competition
   belongs_to :user
+
+  delegate :name, :email, to: :user
+
+  attr_accessor :status
+
+  def load_ms_model(ms_model)
+    self.status = ms_model.status
+  end
+
+  def accepted?
+    status == "accepted"
+  end
+
+  def deleted?
+    status == "deleted"
+  end
 end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -6,18 +6,42 @@ class MicroserviceRegistration < ApplicationRecord
 
   delegate :name, :email, to: :user
 
-  attr_accessor :status, :event_ids
+  attr_accessor :ms_registration
+  attr_writer :status, :event_ids
 
   def load_ms_model(ms_model)
+    self.ms_registration = ms_model
+
     self.status = ms_model['status']
-    self.event_ids = ms_model['event_ids']
+
+    self.event_ids = ms_model['lanes']&.find do |lane|
+      lane['lane_name'] == 'competing'
+    end&.dig('lane_details', 'event_details')&.pluck('event_id')
+  end
+
+  def ms_loaded?
+    self.ms_registration.present?
+  end
+
+  private def read_ms_data(name_without_at)
+    instance_variable_get(:"@#{name_without_at}").tap do
+      raise "Microservice data not loaded!" unless ms_loaded?
+    end
+  end
+
+  def status
+    self.read_ms_data :status
+  end
+
+  def event_ids
+    self.read_ms_data :event_ids
   end
 
   def accepted?
-    status == "accepted"
+    self.status == "accepted"
   end
 
   def deleted?
-    status == "deleted"
+    self.status == "deleted"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ require "uri"
 require "fileutils"
 
 class User < ApplicationRecord
+  include MicroserviceRegistrationHolder
+
   has_many :competition_delegates, foreign_key: "delegate_id"
   # This gives all the competitions where the user is marked as a Delegate,
   # regardless of the competition's status.
@@ -15,7 +17,6 @@ class User < ApplicationRecord
   has_many :organized_competitions, through: :competition_organizers, source: "competition"
   has_many :votes
   has_many :registrations
-  has_many :microservice_registrations
   has_many :competitions_registered_for, through: :registrations, source: "competition"
   belongs_to :person, -> { where(subId: 1) }, primary_key: "wca_id", foreign_key: "wca_id", optional: true
   belongs_to :unconfirmed_person, -> { where(subId: 1) }, primary_key: "wca_id", foreign_key: "unconfirmed_wca_id", class_name: "Person", optional: true
@@ -1108,14 +1109,6 @@ class User < ApplicationRecord
     else
       ""
     end
-  end
-
-  def microservice_registrations
-    # Query most recent registrations, which triggers caching of the `microservice_registration` AR model
-    Microservices::Registrations.registrations_by_user(self.id)
-
-    # Let Rails do its thing via the `has_many` association defined at the top of the file
-    super
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   has_many :organized_competitions, through: :competition_organizers, source: "competition"
   has_many :votes
   has_many :registrations
+  has_many :microservice_registrations
   has_many :competitions_registered_for, through: :registrations, source: "competition"
   belongs_to :person, -> { where(subId: 1) }, primary_key: "wca_id", foreign_key: "wca_id", optional: true
   belongs_to :unconfirmed_person, -> { where(subId: 1) }, primary_key: "wca_id", foreign_key: "unconfirmed_wca_id", class_name: "Person", optional: true
@@ -1107,6 +1108,14 @@ class User < ApplicationRecord
     else
       ""
     end
+  end
+
+  def microservice_registrations
+    # Query most recent registrations, which triggers caching of the `microservice_registration` AR model
+    Microservices::Registrations.registrations_by_user(self.id)
+
+    # Let Rails do its thing via the `has_many` association defined at the top of the file
+    super
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/db/migrate/20240306133747_add_registration_microservice_shadow_table.rb
+++ b/db/migrate/20240306133747_add_registration_microservice_shadow_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddRegistrationMicroserviceShadowTable < ActiveRecord::Migration[7.1]
+  def change
+    create_table :microservice_registrations do |t|
+      t.string :competition_id
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240306133747_add_registration_microservice_shadow_table.rb
+++ b/db/migrate/20240306133747_add_registration_microservice_shadow_table.rb
@@ -7,6 +7,8 @@ class AddRegistrationMicroserviceShadowTable < ActiveRecord::Migration[7.1]
       t.integer :user_id
 
       t.timestamps
+
+      t.index [:competition_id, :user_id], unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -778,6 +778,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_053739) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["competition_id", "user_id"], name: "index_microservice_registrations_on_competition_id_and_user_id", unique: true
   end
 
   create_table "oauth_access_grants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -773,6 +773,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_053739) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "microservice_registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "competition_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "oauth_access_grants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -642,6 +642,7 @@ module DatabaseDumper
         },
       ),
     }.freeze,
+    "microservice_registrations" => :skip_all_rows,
     "sanity_checks" => :skip_all_rows,
     "sanity_check_categories" => :skip_all_rows,
     "sanity_check_exclusions" => :skip_all_rows,

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -43,10 +43,10 @@ module Microservices
       end
     end
 
-    def self.registrations_by_user(user_id)
+    def self.registrations_by_user(user_id, cache: true)
       response = self.registration_connection.get(self.registrations_by_user_path(user_id))
 
-      self.cache_and_return response.body
+      cache ? self.cache_and_return(response.body) : response.body
     end
 
     def self.update_registration_payment(attendee_id, payment_id, iso_amount, currency_iso, status)
@@ -58,7 +58,7 @@ module Microservices
       response.body
     end
 
-    def self.registrations_by_competition(competition_id, status = nil, event_id = nil)
+    def self.registrations_by_competition(competition_id, status = nil, event_id = nil, cache: true)
       response = self.registration_connection.get(self.get_registrations_path(competition_id)) do |req|
         if status.present?
           req.params[:status] = status
@@ -69,7 +69,7 @@ module Microservices
         end
       end
 
-      self.cache_and_return response.body
+      cache ? self.cache_and_return(response.body) : response.body
     end
 
     def self.cache_and_return(ms_registrations)

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -78,7 +78,7 @@ module Microservices
       response.body
     end
 
-    def self.get_registrations(competition_id, status = nil, event_id = nil)
+    def self.registrations_by_competition(competition_id, status = nil, event_id = nil)
       response = self.registration_connection.get(self.get_registrations_path(competition_id)) do |req|
         if status.present?
           req.params[:status] = status

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -67,7 +67,10 @@ module Microservices
 
     def self.registrations_by_user(user_id)
       response = self.registration_connection.get(self.registrations_by_user_path(user_id))
-      response.body
+
+      response.body.tap do |registrations_v2|
+        MicroserviceRegistration.upsert_all(registrations_v2, unique_by: [:competition_id, :user_id])
+      end
     end
 
     def self.update_registration_payment(attendee_id, payment_id, iso_amount, currency_iso, status)
@@ -89,7 +92,9 @@ module Microservices
         end
       end
 
-      response.body
+      response.body.tap do |registrations_v2|
+        MicroserviceRegistration.upsert_all(registrations_v2, unique_by: [:competition_id, :user_id])
+      end
     end
   end
 end

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -46,15 +46,14 @@ module Microservices
     def self.registrations_by_user(user_id)
       response = self.registration_connection.get(self.registrations_by_user_path(user_id))
 
-      response.body.tap do |registrations_v2|
-        MicroserviceRegistration.upsert_all(registrations_v2, unique_by: [:competition_id, :user_id])
-      end
+      self.cache_and_return response.body
     end
 
     def self.update_registration_payment(attendee_id, payment_id, iso_amount, currency_iso, status)
       response = self.registration_connection.post(self.update_payment_status_path) do |req|
         req.body = { attendee_id: attendee_id, payment_id: payment_id, iso_amount: iso_amount, currency_iso: currency_iso, payment_status: status }.to_json
       end
+
       # If we ever need the response body
       response.body
     end
@@ -70,8 +69,12 @@ module Microservices
         end
       end
 
-      response.body.tap do |registrations_v2|
-        MicroserviceRegistration.upsert_all(registrations_v2, unique_by: [:competition_id, :user_id])
+      self.cache_and_return response.body
+    end
+
+    def self.cache_and_return(ms_registrations)
+      ms_registrations.tap do |registrations|
+        MicroserviceRegistration.upsert_all(registrations, unique_by: [:competition_id, :user_id])
       end
     end
   end

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -74,7 +74,8 @@ module Microservices
 
     def self.cache_and_return(ms_registrations)
       ms_registrations.tap do |registrations|
-        MicroserviceRegistration.upsert_all(registrations)
+        db_registrations = registrations.map { |reg| reg.slice('competition_id', 'user_id') }
+        MicroserviceRegistration.upsert_all(db_registrations)
       end
     end
   end

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -74,7 +74,7 @@ module Microservices
 
     def self.cache_and_return(ms_registrations)
       ms_registrations.tap do |registrations|
-        MicroserviceRegistration.upsert_all(registrations, unique_by: [:competition_id, :user_id])
+        MicroserviceRegistration.upsert_all(registrations)
       end
     end
   end

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -43,28 +43,6 @@ module Microservices
       end
     end
 
-    RegistrationConverter = Struct.new(:competition, :user, :status) do
-      def accepted?
-        status == "accepted"
-      end
-
-      def deleted?
-        status == "deleted"
-      end
-
-      def name
-        user.name
-      end
-
-      def email
-        user.email
-      end
-    end
-
-    def self.convert_registration(competition, user, registration_status)
-      RegistrationConverter.new(competition: competition, user: user, status: registration_status)
-    end
-
     def self.registrations_by_user(user_id)
       response = self.registration_connection.get(self.registrations_by_user_path(user_id))
 


### PR DESCRIPTION
Preparation for showing them in the WCIF. Decided to split it up because there's some Rails black magic happening under the hood which would have been too complex to review in one big PR.

We are essentially storing a copy of "which registrations exist" in a shadow table. The table does *not* contain any other details like status, event IDs, etc. because that would lead to data duplication across (micro)services and synchronization hell. It only contains foreign keys to competition and user. That's it.

Instead, we are reading the "relevant" bits of data directly from the microservice. To that effect, there are two caching hooks in place:
1. Every time a registration is read from the Microservice, it is also "upserted" (inserted or updated) in the database.
2. Every time a MicroserviceRegistration is read from the database, the models are "enriched" with microservice information

For realizing point (2) above, I had to tap into Rails' ActiveRecord query interface. There is a method called `def records` in the Rails interface which collects the records just before returning them to the user. I hook into this method with some Ruby reflection magic to be able to link the entities up with the pre-loaded data.