### PR TITLE
Remove illegal cutoffs in front-end

### DIFF
--- a/app/webpacker/components/EditEvents/Modals/EditCutoffModal/index.js
+++ b/app/webpacker/components/EditEvents/Modals/EditCutoffModal/index.js
@@ -33,6 +33,11 @@ export default function EditCutoffModal({ wcifEvent, wcifRound, disabled }) {
   const [attemptResult, setAttemptResult] = useState(cutoff?.attemptResult ?? 0);
 
   const cutoffFormats = formats.byId[format].allowedFirstPhaseFormats;
+  // temporary fix until the backend properly tells us the valid formats; see issue 7555
+  const is666or777 = wcifEvent.id === "666" || wcifEvent.id === "777"
+  const sanitizedCutoffFormats = is666or777
+    ? cutoffFormats.filter((format) => format !== "2")
+    : cutoffFormats
 
   const explanationText = (
     numberOfAttempts > 0 ? roundCutoffToString({
@@ -74,7 +79,7 @@ export default function EditCutoffModal({ wcifEvent, wcifRound, disabled }) {
       disabled={disabled}
     >
       <CutoffFormatField
-        cutoffFormats={cutoffFormats}
+        cutoffFormats={sanitizedCutoffFormats}
         cutoffFormat={numberOfAttempts}
         wcifRound={wcifRound}
         onChange={setNumberOfAttempts}


### PR DESCRIPTION
As discussed in #7555, a temporary front-end fix until the back-end is fixed.

![image](https://github.com/thewca/worldcubeassociation.org/assets/49137025/538dc74f-e0e5-4c9c-85f4-b79165a72a39)
