### PR TITLE
Delegate Regions page actions - Promote, Demote and End Role

### DIFF
--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -3,14 +3,15 @@
 class RoleChangeMailer < ApplicationMailer
   private def role_metadata(role)
     metadata = {}
+    group = UserRole.group(role)
 
     # Populate the metadata list.
-    case UserRole.group(role).group_type
+    case group.group_type
     when UserGroup.group_types[:delegate_regions]
-      metadata[:region_name] = UserRole.group(role).name
+      metadata[:region_name] = group.name
       metadata[:status] = I18n.t("enums.user.role_status.delegate_regions.#{UserRole.status(role)}")
     when UserGroup.group_types[:translators]
-      metadata[:locale] = UserRole.group(role).metadata.locale
+      metadata[:locale] = group.metadata.locale
     end
     metadata
   end

--- a/app/views/role_change_mailer/notify_role_change.erb
+++ b/app/views/role_change_mailer/notify_role_change.erb
@@ -1,0 +1,4 @@
+<p>The role has been changed for <%= UserRole.user(@role).name %> in <%= @group_type_name %> on <%= @today_date %>.</p>
+<p>The change has been executed by <%= @user_who_made_the_change.name %>.</p>
+<p>Change made:</p>
+<p><%= @changed_parameter %>: <%= @previous_value %> -> <%= @new_value %></p>

--- a/app/views/role_change_mailer/notify_role_end.erb
+++ b/app/views/role_change_mailer/notify_role_end.erb
@@ -1,4 +1,4 @@
-<p>The role has been removed for <%= @role.user.name %> in <%= @group_type_name %> on <%= @role.end_date %>.</p>
+<p>The role has been removed for <%= UserRole.user(@role).name %> in <%= @group_type_name %> on <%= @role[:end_date] %>.</p>
 <p>The change has been executed by <%= @user_who_made_the_change.name %>.</p>
 <% if @metadata.present? %>
   <p>More details of the role were:</p>

--- a/app/webpacker/components/Panel/Leader/GroupsManager.jsx
+++ b/app/webpacker/components/Panel/Leader/GroupsManager.jsx
@@ -9,21 +9,10 @@ import Errored from '../../Requests/Errored';
 import Loading from '../../Requests/Loading';
 import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import useSaveAction from '../../../lib/hooks/useSaveAction';
-import { groupTypes, teamsCommitteesStatus, councilsStatus } from '../../../lib/wca-data.js.erb';
 import WcaSearch from '../../SearchWidget/WcaSearch';
 import useInputState from '../../../lib/hooks/useInputState';
 import SEARCH_MODELS from '../../SearchWidget/SearchModel';
-
-const statusObjectOfGroupType = (groupType) => {
-  switch (groupType) {
-    case groupTypes.teams_committees:
-      return teamsCommitteesStatus;
-    case groupTypes.councils:
-      return councilsStatus;
-    default:
-      return null;
-  }
-};
+import { statusObjectOfGroupType } from '../../../lib/helpers/status-objects';
 
 const isLead = (role) => role.metadata.status === 'leader';
 

--- a/app/webpacker/lib/helpers/status-objects.js
+++ b/app/webpacker/lib/helpers/status-objects.js
@@ -1,0 +1,46 @@
+import {
+  groupTypes, teamsCommitteesStatus, councilsStatus, delegateRegionsStatus,
+} from '../wca-data.js.erb';
+
+export function statusObjectOfGroupType(groupType) {
+  switch (groupType) {
+    case groupTypes.teams_committees:
+      return teamsCommitteesStatus;
+    case groupTypes.councils:
+      return councilsStatus;
+    case groupTypes.delegate_regions:
+      return delegateRegionsStatus;
+    default:
+      return null;
+  }
+}
+
+export function nextStatusOfGroupType(status, groupType) {
+  switch (groupType) {
+    case groupTypes.delegate_regions: {
+      switch (status) {
+        case delegateRegionsStatus.trainee_delegate:
+          return delegateRegionsStatus.junior_delegate;
+        case delegateRegionsStatus.junior_delegate:
+          return delegateRegionsStatus.delegate;
+        default: return null;
+      }
+    }
+    default: return null;
+  }
+}
+
+export function previousStatusOfGroupType(status, groupType) {
+  switch (groupType) {
+    case groupTypes.delegate_regions: {
+      switch (status) {
+        case delegateRegionsStatus.junior_delegate:
+          return delegateRegionsStatus.trainee_delegate;
+        case delegateRegionsStatus.delegate:
+          return delegateRegionsStatus.junior_delegate;
+        default: return null;
+      }
+    }
+    default: return null;
+  }
+}


### PR DESCRIPTION
The old UI still allows it, because the UI should be open till all the changes to subregion is completed.