### PR TITLE
Replace staff? with a method in roles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -455,11 +455,6 @@ class User < ApplicationRecord
     team_member?(Team.board)
   end
 
-  # Officers are defined in our Bylaws. Every Officer has a team on the website except for the WCA Treasurer, as it is the WFC Leader.
-  def officer?
-    team_member?(Team.chair) || team_member?(Team.executive_director) || team_member?(Team.secretary) || team_member?(Team.vice_chair) || team_leader?(Team.wfc)
-  end
-
   def communication_team?
     team_member?(Team.wct)
   end
@@ -517,7 +512,7 @@ class User < ApplicationRecord
   end
 
   def staff?
-    staff_delegate? || member_of_any_official_team? || board_member? || officer?
+    active_roles.any? { |role| UserRole.is_staff?(role) }
   end
 
   def team_member?(team)

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -84,6 +84,23 @@ class UserRole < ApplicationRecord
     end
   end
 
+  def self.is_staff?(role)
+    group_type = UserRole.group_type(role)
+    case group_type
+    when UserGroup.group_types[:delegate_regions]
+      [
+        RolesMetadataDelegateRegions.statuses[:senior_delegate],
+        RolesMetadataDelegateRegions.statuses[:regional_delegate],
+        RolesMetadataDelegateRegions.statuses[:delegate],
+        RolesMetadataDelegateRegions.statuses[:junior_delegate],
+      ].include?(UserRole.status(role))
+    when UserGroup.group_types[:board], UserGroup.group_types[:officers], UserGroup.group_types[:teams_committees]
+      true
+    else
+      false
+    end
+  end
+
   # In future, we will remove the 'self.' and make this a class method.
   def self.group_type(role)
     is_actual_role = role.is_a?(UserRole) # Eventually, all roles will be migrated to the new system, till then some roles will actually be hashes.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -741,6 +741,52 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "staff? method" do
+    it "returns false for non-staff user" do
+      user = FactoryBot.create(:user)
+      expect(user.staff?).to be false
+    end
+
+    it "returns false for trainee delegate" do
+      user = FactoryBot.create(:trainee_delegate)
+      expect(user.staff?).to be false
+    end
+
+    it "returns true for non-trainee Delegate roles" do
+      junior_delegate_user = FactoryBot.create(:candidate_delegate)
+      full_delegate_user = FactoryBot.create(:delegate)
+      regional_delegate = FactoryBot.create(:regional_delegate_role)
+      senior_delegate = FactoryBot.create(:senior_delegate_role)
+
+      expect(junior_delegate_user.staff?).to be true
+      expect(full_delegate_user.staff?).to be true
+      expect(regional_delegate.user.staff?).to be true
+      expect(senior_delegate.user.staff?).to be true
+    end
+
+    it "returns true for WST member" do
+      user = FactoryBot.create(:user, :wst_member)
+      expect(user.staff?).to be true
+    end
+
+    it "returns true for Board roles" do
+      user = FactoryBot.create(:user, :board_member)
+      expect(user.staff?).to be true
+    end
+
+    it "returns true for Officer roles" do
+      executive_director = FactoryBot.create(:user, :executive_director)
+      chair = FactoryBot.create(:user, :chair)
+      vice_chair = FactoryBot.create(:user, :vice_chair)
+      secretary = FactoryBot.create(:user, :secretary)
+
+      expect(executive_director.staff?).to be true
+      expect(chair.staff?).to be true
+      expect(vice_chair.staff?).to be true
+      expect(secretary.staff?).to be true
+    end
+  end
+
   describe "has_permission? method" do
     it "returns false for any permissions that are not defined" do
       user = FactoryBot.create(:user)


### PR DESCRIPTION
Since the check whether a person is staff is based on the roles, the core logic of checking whether a role is staff role has been moved to user roles model