### PR TITLE
Changes related to Delegate page

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -245,10 +245,12 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     # Filter the list based on the other parameters.
     status = params[:status]
     is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
+    is_lead = params.key?(:isLead) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isLead)) : nil
     roles = filter_roles_for_parameters(
       roles: roles,
       status: status,
       is_active: is_active,
+      is_lead: is_lead,
     )
 
     # Sort the roles.

--- a/app/webpacker/components/Delegates/DelegatesOfAllRegion.jsx
+++ b/app/webpacker/components/Delegates/DelegatesOfAllRegion.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Header } from 'semantic-ui-react';
+import DelegatesTable from './DelegatesTable';
+import useLoadedData from '../../lib/hooks/useLoadedData';
+import { apiV0Urls } from '../../lib/requests/routes.js.erb';
+import { groupTypes } from '../../lib/wca-data.js.erb';
+import Loading from '../Requests/Loading';
+import Errored from '../Requests/Errored';
+
+export default function DelegatesOfAllRegion() {
+  const {
+    data: leadDelegates,
+    loading: leadDelegatesLoading,
+    error: leadDelegatesError,
+  } = useLoadedData(
+    apiV0Urls.userRoles.listOfGroupType(groupTypes.delegate_regions, 'name', {
+      isActive: true,
+      extraMetadata: true,
+      isLead: true,
+    }),
+  );
+  const {
+    data: otherDelegates,
+    loading: otherDelegatesLoading,
+    error: otherDelegatesError,
+  } = useLoadedData(
+    apiV0Urls.userRoles.listOfGroupType(groupTypes.delegate_regions, 'name', {
+      isActive: true,
+      extraMetadata: true,
+      isLead: false,
+    }),
+  );
+
+  if (leadDelegatesLoading || otherDelegatesLoading) return <Loading />;
+  if (leadDelegatesError || otherDelegatesError) return <Errored />;
+
+  return (
+    <>
+      <Header as="h3">Lead Delegates</Header>
+      <DelegatesTable
+        delegates={leadDelegates}
+        isAdminMode
+        isAllLeadDelegates
+      />
+      <Header as="h3">Other Delegates</Header>
+      <DelegatesTable
+        delegates={otherDelegates}
+        isAdminMode
+        isAllNonLeadDelegates
+      />
+    </>
+  );
+}

--- a/app/webpacker/components/Delegates/DelegatesOfRegion.jsx
+++ b/app/webpacker/components/Delegates/DelegatesOfRegion.jsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from 'react';
 import { Grid, Label, Segment } from 'semantic-ui-react';
 import I18n from '../../lib/i18n';
 import { apiV0Urls } from '../../lib/requests/routes.js.erb';
-import { groupTypes } from '../../lib/wca-data.js.erb';
 import Errored from '../Requests/Errored';
 import Loading from '../Requests/Loading';
 import useLoadedData from '../../lib/hooks/useLoadedData';
@@ -40,17 +39,11 @@ function SeniorDelegate({ seniorDelegate }) {
 }
 
 export default function DelegatesOfRegion({ activeRegion, delegateSubregions, isAdminMode }) {
-  const isAllRegions = activeRegion.id === ALL_REGIONS.id;
-  const { data: delegates, loading, error } = useLoadedData(
-    isAllRegions
-      ? apiV0Urls.userRoles.listOfGroupType(groupTypes.delegate_regions, 'name', {
-        isActive: true,
-        extraMetadata: true,
-      })
-      : apiV0Urls.userRoles.listOfGroup(activeRegion.id, 'location,name', {
-        isActive: true,
-      }),
-  );
+  const { data: delegates, loading, error } = useLoadedData(apiV0Urls.userRoles.listOfGroup(
+    activeRegion.id,
+    'location,name',
+    { isActive: true },
+  ));
 
   const getSeniorDelegate = useCallback(
     () => delegates?.find((delegate) => delegate.metadata.status === 'senior_delegate'),
@@ -67,12 +60,13 @@ export default function DelegatesOfRegion({ activeRegion, delegateSubregions, is
 
   return (
     <>
-      {!isAllRegions && <SeniorDelegate seniorDelegate={getSeniorDelegate()} />}
-      <DelegatesTable
-        delegates={nonSeniorDelegates}
-        isAdminMode={isAdminMode}
-        isAllRegions={isAllRegions}
-      />
+      <SeniorDelegate seniorDelegate={getSeniorDelegate()} />
+      {nonSeniorDelegates.length > 0 && (
+        <DelegatesTable
+          delegates={nonSeniorDelegates}
+          isAdminMode={isAdminMode}
+        />
+      )}
       {delegateSubregions.map((subregion) => (
         <DelegatesOfSubregion subregion={subregion} isAdminMode={isAdminMode} />
       ))}

--- a/app/webpacker/components/Delegates/DelegatesTable.jsx
+++ b/app/webpacker/components/Delegates/DelegatesTable.jsx
@@ -19,7 +19,9 @@ const dateSince = (date) => {
   return Math.floor(diff.as('days'));
 };
 
-export default function DelegatesTable({ delegates, isAdminMode, isAllRegions }) {
+export default function DelegatesTable({
+  delegates, isAdminMode, isAllLeadDelegates, isAllNonLeadDelegates,
+}) {
   const tableData = useMemo(() => delegates.filter(
     (delegate) => delegate.metadata.status !== 'trainee_delegate' || isAdminMode,
   ), [delegates, isAdminMode]);
@@ -36,10 +38,12 @@ export default function DelegatesTable({ delegates, isAdminMode, isAllRegions })
             <Table.HeaderCell>
               {I18n.t('delegates_page.table.role')}
             </Table.HeaderCell>
-            <Table.HeaderCell>
-              {I18n.t('delegates_page.table.region')}
-            </Table.HeaderCell>
-            {isAllRegions && (
+            {!isAllLeadDelegates && (
+              <Table.HeaderCell>
+                {I18n.t('delegates_page.table.region')}
+              </Table.HeaderCell>
+            )}
+            {isAllNonLeadDelegates && (
               <>
                 <Table.HeaderCell>
                   {I18n.t('delegates_page.table.first_delegated')}
@@ -85,8 +89,8 @@ export default function DelegatesTable({ delegates, isAdminMode, isAllRegions })
               <Table.Cell>
                 {I18n.t(`enums.user.role_status.delegate_regions.${delegate.metadata.status}`)}
               </Table.Cell>
-              <Table.Cell>{delegate.metadata.location}</Table.Cell>
-              {isAllRegions && (
+              {!isAllLeadDelegates && (<Table.Cell>{delegate.metadata.location}</Table.Cell>)}
+              {isAllNonLeadDelegates && (
                 <>
                   <Table.Cell>{delegate.metadata.first_delegated}</Table.Cell>
                   <Table.Cell>{delegate.metadata.last_delegated}</Table.Cell>

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -181,7 +181,7 @@ export const apiV0Urls = {
   userRoles: {
     listOfUser: (userId, sort, {isActive, isGroupHidden, status, groupType} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, groupType })}`,
     listOfGroup: (groupId, sort, {isActive, isGroupHidden, status, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, isLead })}`,
-    listOfGroupType: (groupType, sort, {status, isActive, extraMetadata} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive, extraMetadata })}`,
+    listOfGroupType: (groupType, sort, {status, isActive, extraMetadata, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive, extraMetadata, isLead })}`,
     create: () => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>`,
     update: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,
     delete: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,


### PR DESCRIPTION
There are multiple small things included in this PR, they are as follows:

- All Delegates page was not listing senior delegates, this is fixed now.
- All Delegates page is now split into two sections - lead delegates & other delegates. This is because some columns (like first delegated, last delegated, delegate location, etc) are not applicable for lead delegates and hence it was not looking good UI wise.
- Since All Delegates page is getting more complicated, it's now split into it's own class.
- Menu options was not displaying special characters. Example, 'Asia West & South' was displayed as 'Asia West South'. This is now fixed.