### PR TITLE
Add separate endpoint for Delegates search index

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -162,7 +162,7 @@ class Api::V0::ApiController < ApplicationController
   def delegates_search_index
     # TODO: There is a `uniq` call at the end which I feel shouldn't be necessary?!
     #   Postponing investigation until the Roles system migration is complete.
-    all_delegates = UserGroup.includes(:delegate_users).delegate_region_groups.flat_map(&:active_users).uniq
+    all_delegates = UserGroup.includes(:delegate_users, user_roles: [:user]).delegate_region_groups.flat_map(&:active_users).uniq
 
     search_index = all_delegates.map do |delegate|
       delegate.slice(:id, :name, :wca_id).merge({ thumb_url: delegate.avatar.url(:thumb) })

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -159,6 +159,18 @@ class Api::V0::ApiController < ApplicationController
     paginate json: UserGroup.delegate_region_groups.flat_map(&:active_users)
   end
 
+  def delegates_search_index
+    # TODO: There is a `uniq` call at the end which I feel shouldn't be necessary?!
+    #   Postponing investigation until the Roles system migration is complete.
+    all_delegates = UserGroup.includes(:delegate_users).delegate_region_groups.flat_map(&:active_users).uniq
+
+    search_index = all_delegates.map do |delegate|
+      delegate.slice(:id, :name, :wca_id).merge({ thumb_url: delegate.avatar.url(:thumb) })
+    end
+
+    render json: search_index
+  end
+
   def records
     concise_results_date = ComputeAuxiliaryData.end_date || Date.current
     cache_key = ["records", concise_results_date.iso8601]

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -188,7 +188,7 @@ function DelegateSelector({ delegateId, dispatchFilter }) {
             key: delegate.id,
             text: `${delegate.name} (${delegate.wca_id})`,
             value: delegate.wca_id,
-            image: { avatar: true, src: delegate.avatar?.thumb_url, style: { width: '28px', height: '28px' } },
+            image: { avatar: true, src: delegate.thumb_url, style: { width: '28px', height: '28px' } },
           }
         )) || [])]}
         value={delegateId}

--- a/app/webpacker/components/CompetitionsOverview/useDelegatesData.js
+++ b/app/webpacker/components/CompetitionsOverview/useDelegatesData.js
@@ -1,36 +1,18 @@
-import { useEffect } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { apiV0Urls, WCA_API_PAGINATION } from '../../lib/requests/routes.js.erb';
+import { apiV0Urls } from '../../lib/requests/routes.js.erb';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 
 const useDelegatesData = () => {
   const {
     data,
-    fetchNextPage,
-    hasNextPage,
-  } = useInfiniteQuery({
-    queryKey: ['delegates'],
-    queryFn: ({ pageParam = 1 }) => fetchJsonOrError(`${apiV0Urls.delegates.list}?page=${pageParam}`),
-    getNextPageParam: (previousPage, allPages) => {
-      // Continue until less than a full page of data is fetched,
-      // which indicates the very last page.
-      if (previousPage.data.length < WCA_API_PAGINATION) {
-        return undefined;
-      }
-      return allPages.length + 1;
-    },
+    isPending,
+  } = useQuery({
+    queryKey: ['delegates-index'],
+    queryFn: () => fetchJsonOrError(apiV0Urls.delegates.searchIndex),
   });
 
-  useEffect(() => {
-    if (hasNextPage) {
-      fetchNextPage();
-    }
-  }, [data, hasNextPage, fetchNextPage]);
-
-  const delegatesData = data?.pages.flatMap((page) => page.data);
-
-  return { delegatesLoading: hasNextPage, delegatesData };
+  return { delegatesLoading: isPending, delegatesData: data?.data };
 };
 
 export default useDelegatesData;

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -195,6 +195,7 @@ export const apiV0Urls = {
   },
   delegates: {
     list: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_delegates_path)%>`,
+    searchIndex: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_delegates_search_index_path)%>`,
   },
 }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -359,6 +359,7 @@ Rails.application.routes.draw do
       get '/users/:id' => 'users#show_user_by_id', constraints: { id: /\d+/ }
       get '/users/:wca_id' => 'users#show_user_by_wca_id', as: :user
       get '/delegates' => 'api#delegates'
+      get '/delegates/search-index' => 'api#delegates_search_index', as: :delegates_search_index
       get '/persons' => "persons#index"
       get '/persons/:wca_id' => "persons#show", as: :person
       get '/persons/:wca_id/results' => "persons#results", as: :person_results


### PR DESCRIPTION
Contains only a boiled-down version of the necessary data for the search dropdown: ID, name, WCA ID, thumbnail URL.

Runs on four relatively cheap queries:
```
UserGroup Load (0.6ms)  SELECT `user_groups`.* FROM `user_groups` WHERE `user_groups`.`group_type` = 'delegate_regions'
rails        |   ↳ app/controllers/api/v0/api_controller.rb:165:in `flat_map'
rails        |   User Load (6.8ms)  SELECT `users`.* FROM `users` WHERE `users`.`delegate_status` IS NOT NULL AND `users`.`region_id` IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53)
rails        |   ↳ app/controllers/api/v0/api_controller.rb:165:in `flat_map'
rails        |   UserGroup Load (1.0ms)  SELECT `user_groups`.* FROM `user_groups` WHERE `user_groups`.`id` IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 14, 15, 16, 17, 18, 19, 20, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 47, 48, 49, 50, 51)
rails        |   ↳ app/controllers/api/v0/api_controller.rb:165:in `flat_map'
rails        |   UserRole Load (1.3ms)  SELECT `user_roles`.* FROM `user_roles` WHERE `user_roles`.`group_id` IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53)
rails        |   ↳ app/controllers/api/v0/api_controller.rb:165:in `flat_map'
rails        |   User Load (1.2ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (263, 259, 264, 425, 4, 15, 7184, 17812, 432, 267, 705, 8184, 1547, 108268, 6755, 136360, 5569, 5568, 255, 6115, 328, 8917, 273, 1312, 133, 79, 1558, 341, 125297, 23253, 5986, 9, 39, 61931, 50063, 1330, 128529, 16089, 118787, 6777, 2, 1686, 61698, 1197, 281, 368, 454, 1428, 232728, 388455)
rails        |   ↳ app/controllers/api/v0/api_controller.rb:165:in `flat_map'
```