### PR TITLE
Correct nearby competitions display

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -259,7 +259,7 @@ class CompetitionsController < ApplicationController
   end
 
   def get_nearby_competitions(competition)
-    nearby_competitions = competition.nearby_competitions_warning.to_a[0, 10]
+    nearby_competitions = competition.nearby_competitions_danger.to_a[0, 10]
     nearby_competitions.select!(&:confirmed?) unless current_user.can_view_hidden_competitions?
     nearby_competitions
   end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1182,6 +1182,10 @@ class Competition < ApplicationRecord
     adjacent_competitions(NEARBY_DAYS_WARNING, NEARBY_DISTANCE_KM_WARNING)
   end
 
+  def nearby_competitions_danger
+    adjacent_competitions(NEARBY_DAYS_DANGER, NEARBY_DISTANCE_KM_DANGER)
+  end
+
   def series_eligible_competitions
     adjacent_competitions(CompetitionSeries::MAX_SERIES_DISTANCE_DAYS, CompetitionSeries::MAX_SERIES_DISTANCE_KM)
   end

--- a/spec/controllers/competitions_controller_spec.rb
+++ b/spec/controllers/competitions_controller_spec.rb
@@ -204,7 +204,11 @@ RSpec.describe CompetitionsController do
     let(:organizer) { FactoryBot.create(:user) }
     let(:admin) { FactoryBot.create :admin }
     let!(:my_competition) { FactoryBot.create(:competition, :confirmed, latitude: 10.0, longitude: 10.0, organizers: [organizer], starts: 1.week.ago) }
-    let!(:other_competition) { FactoryBot.create(:competition, :with_delegate, :with_valid_schedule, latitude: 11.0, longitude: 11.0, starts: 5.weeks.from_now) }
+    let!(:other_competition) {
+      FactoryBot.create(
+        :competition, :with_delegate, :with_valid_schedule, latitude: 10.005, longitude: 10.005, starts: 4.days.ago, registration_close: 5.days.ago
+      )
+    }
 
     context 'when signed in as an organizer' do
       before :each do


### PR DESCRIPTION
Should close #9062 - it looks like we were using the `WARNING` constants, when we should have been using the `DANGER` values.

There's also a case to be made for changing the "Nearby competitions" strings to something more descriptive - such as:
- "Conflicting competitions (within 5 days and 10km)"
- "Nearby competitions (within 33 days and 200km)" (ie, keep it the same)
  - We could also say "possible series competitions" or something, but I think the more general description is more helpful/less confusing