### PR TITLE
Fix error thrown when trying to pay with Stripe using ISK currency

### DIFF
--- a/app/models/stripe_transaction.rb
+++ b/app/models/stripe_transaction.rb
@@ -88,7 +88,7 @@ class StripeTransaction < ApplicationRecord
     # that need to be submitted as multiples of 100 even though they technically have subunits.
     # The details are documented at https://stripe.com/docs/currencies#special-cases
     if ZERO_DECIMAL_CURRENCIES.include?(iso_currency.upcase)
-      amount_times_hundred = amount_lowest_denomination.to_f * 100
+      amount_times_hundred = (amount_lowest_denomination.to_f * 100).to_i
 
       # Stripe API rejects payments that are below the hundreds sub-unit.
       # In practice this should never happen because the inflation on those currencies

--- a/spec/models/stripe_transaction_spec.rb
+++ b/spec/models/stripe_transaction_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe StripeTransaction do
 
     stripe_amount = StripeTransaction.amount_to_stripe(six_thousand_huf.cents, six_thousand_huf.currency.iso_code)
     expect(stripe_amount).to eq(600_000)
+    expect(stripe_amount).to be_an(Integer)
 
     ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, six_thousand_huf.currency.iso_code)
     expect(ruby_amount).to eq(six_thousand_huf.cents)
@@ -22,6 +23,7 @@ RSpec.describe StripeTransaction do
 
     stripe_amount = StripeTransaction.amount_to_stripe(sixty_thousand_ugx.cents, sixty_thousand_ugx.currency.iso_code)
     expect(stripe_amount).to eq(6_000_000)
+    expect(stripe_amount).to be_an(Integer)
 
     ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, sixty_thousand_ugx.currency.iso_code)
     expect(ruby_amount).to eq(sixty_thousand_ugx.cents)
@@ -33,6 +35,7 @@ RSpec.describe StripeTransaction do
 
     stripe_amount = StripeTransaction.amount_to_stripe(two_thousand_isk.cents, two_thousand_isk.currency.iso_code)
     expect(stripe_amount).to eq(200_000)
+    expect(stripe_amount).to be_an(Integer)
 
     ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, two_thousand_isk.currency.iso_code)
     expect(ruby_amount).to eq(two_thousand_isk.cents)
@@ -58,6 +61,7 @@ RSpec.describe StripeTransaction do
 
     stripe_amount = StripeTransaction.amount_to_stripe(fifteen_usd.cents, fifteen_usd.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
+    expect(stripe_amount).to be_an(Integer)
 
     ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, fifteen_usd.currency.iso_code)
     expect(ruby_amount).to eq(fifteen_usd.cents)
@@ -69,6 +73,7 @@ RSpec.describe StripeTransaction do
 
     stripe_amount = StripeTransaction.amount_to_stripe(fifteen_eur.cents, fifteen_eur.currency.iso_code)
     expect(stripe_amount).to eq(1_500)
+    expect(stripe_amount).to be_an(Integer)
 
     ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, fifteen_eur.currency.iso_code)
     expect(ruby_amount).to eq(fifteen_eur.cents)
@@ -80,6 +85,7 @@ RSpec.describe StripeTransaction do
 
     stripe_amount = StripeTransaction.amount_to_stripe(two_thousand_yen.cents, two_thousand_yen.currency.iso_code)
     expect(stripe_amount).to eq(2_000)
+    expect(stripe_amount).to be_an(Integer)
 
     ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, two_thousand_yen.currency.iso_code)
     expect(ruby_amount).to eq(two_thousand_yen.cents)
@@ -93,6 +99,7 @@ RSpec.describe StripeTransaction do
 
     stripe_amount = StripeTransaction.amount_to_stripe(five_hundred_twd.cents, five_hundred_twd.currency.iso_code)
     expect(stripe_amount).to eq(50_000)
+    expect(stripe_amount).to be_an(Integer)
 
     ruby_amount = StripeTransaction.amount_to_ruby(stripe_amount, five_hundred_twd.currency.iso_code)
     expect(ruby_amount).to eq(five_hundred_twd.cents)


### PR DESCRIPTION
Ran into this while testing for the StripeTransaction refactor - seems like special currency cases throw an error that wasn't caught by the tests (and I guess we haven't had a comp with a special currency using Stripe yet?), because `amount_to_stripe` returns a float which Stripe doesn't like.

You can repro the error by trying to register and pay for this competition: https://staging.worldcubeassociation.org/competitions/IcelandTestComp2024/register

The fix just ensures that the return value of stripe_amount is an integer, and the tests now explicitly check for integer as well.