### PR TITLE
Enable Vault secrets for Paypal 

### DIFF
--- a/app_secrets.rb
+++ b/app_secrets.rb
@@ -49,10 +49,9 @@ AppSecrets = SuperConfig.new do
     vault :STRIPE_API_KEY
     vault :OTP_ENCRYPTION_KEY
     vault :STRIPE_CLIENT_ID
-    # TODO: Uncomment paypal items when launching in production
-    # vault :PAYPAL_CLIENT_ID, :string
-    # vault :PAYPAL_CLIENT_SECRET, :string
-    # vault :PAYPAL_ATTRIBUTION_CODE, :string
+    vault :PAYPAL_CLIENT_ID, :string
+    vault :PAYPAL_CLIENT_SECRET, :string
+    vault :PAYPAL_ATTRIBUTION_CODE, :string
     vault :DISCOURSE_SECRET
     vault :SURVEY_SECRET
     vault :ACTIVERECORD_PRIMARY_KEY
@@ -82,9 +81,6 @@ AppSecrets = SuperConfig.new do
     mandatory :STRIPE_API_KEY, :string
     mandatory :OTP_ENCRYPTION_KEY, :string
     mandatory :STRIPE_CLIENT_ID, :string
-    mandatory :PAYPAL_CLIENT_ID, :string
-    mandatory :PAYPAL_CLIENT_SECRET, :string
-    mandatory :PAYPAL_ATTRIBUTION_CODE, :string
     mandatory :DISCOURSE_SECRET, :string
     mandatory :SURVEY_SECRET, :string
     mandatory :ACTIVERECORD_PRIMARY_KEY, :string


### PR DESCRIPTION
Per discussion with Gregor, this does the following:
- Enables `vault` credentials for Paypal when `Rails.env.production?`
  - `paypal_interface:paypal_disabled?` still prevents any Paypalness appearing on the live website
- Removes the `mandatory` Paypal credentials in the `else` block of `Rails.env.production?`