### PR TITLE
Clean up staging deployment workflow

### DIFF
--- a/.github/workflows/staging-deployment-from-prs.yml
+++ b/.github/workflows/staging-deployment-from-prs.yml
@@ -40,6 +40,10 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
         if: steps.trigger-deployment.outputs.triggered == 'true'
+      - name: Get the SHA of the current branch/fork
+        shell: bash
+        run: |
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
       - name: Build Sidekiq if triggered
         if: steps.trigger-deployment.outputs.triggered == 'true'
         uses: docker/build-push-action@v5
@@ -60,7 +64,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            BUILD_TAG=${{ github.sha }}
+            BUILD_TAG=${{ env.SHORT_SHA }}
       - name: Deploy staging if triggered
         if: steps.trigger-deployment.outputs.triggered == 'true'
         run: |

--- a/.github/workflows/staging-deployment-from-prs.yml
+++ b/.github/workflows/staging-deployment-from-prs.yml
@@ -48,6 +48,7 @@ jobs:
         if: steps.trigger-deployment.outputs.triggered == 'true'
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           file: ./Dockerfile.sidekiq
           tags: |
@@ -58,6 +59,7 @@ jobs:
         if: steps.trigger-deployment.outputs.triggered == 'true'
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:staging

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN fc-cache -f -v
 # because the Ruby base image runs on Debian 12, which provides an older MariaDB version that suffers from a
 # mysqldump bug in conjunction with MySQL 8.0 servers: https://jira.mariadb.org/browse/MDEV-31836
 # (the issue was fixed in 10.11.5 but Debian only provides 10.11.4 so we need to override)
-RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-10.11" && \
+RUN curl -fsSL https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-10.11" && \
     apt-get install -y mariadb-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 

--- a/Dockerfile.sidekiq
+++ b/Dockerfile.sidekiq
@@ -39,7 +39,7 @@ RUN apt-get update -qq && \
       libssl-dev
 
 # See the comment in Prod Dockerfile for an explanation why the separate MariaDB source is necessary.
-RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-10.11" && \
+RUN curl -fsSL https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version="mariadb-10.11" && \
     apt-get install -y mariadb-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 


### PR DESCRIPTION
- Add `--fail` flag to MariaDB script curl to make sure we're not piping bogus into `bash`