### PR TITLE
Include V2 registrations in WCIF output

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Assignment < ApplicationRecord
-  belongs_to :registration
+  belongs_to :registration, polymorphic: true
   belongs_to :schedule_activity
 
   validates :station_number, numericality: { only_integer: true }, allow_nil: true

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1950,7 +1950,11 @@ class Competition < ApplicationRecord
       # If no registration is found, and the Registration is marked as non-competing, add this person as a non-competing staff member.
       adding_non_competing = wcif_person["registration"].present? && wcif_person["registration"]["isCompeting"] == false
       if adding_non_competing
-        registration ||= registrations.create_non_competing(self, wcif_person["wcaUserId"])
+        registration ||= registrations.create(
+          competition: self,
+          user_id: wcif_person["wcaUserId"],
+          is_competing: false,
+        )
       end
       next unless registration.present?
       WcifExtension.update_wcif_extensions!(registration, wcif_person["extensions"]) if wcif_person["extensions"]
@@ -1959,7 +1963,7 @@ class Competition < ApplicationRecord
         roles = wcif_person["roles"] - ["delegate", "trainee-delegate", "organizer"] # These three are added on the fly.
         # The additional roles are only for WCIF purposes and we don't validate them,
         # so we can safely skip validations by using update_attribute
-        registration.update_roles(roles)
+        registration.update_attribute(:roles, roles)
       end
       if wcif_person["assignments"]
         wcif_person["assignments"].each do |assignment_wcif|

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1773,13 +1773,15 @@ class Competition < ApplicationRecord
   def persons_wcif(authorized: false)
     managers = self.managers
     includes_associations = [
-      :events,
       { assignments: [:schedule_activity] },
       { user: {
         person: [:ranksSingle, :ranksAverage],
       } },
       :wcif_extensions,
     ]
+    # V2 registrations store the event IDs in the microservice data, not in the monolith
+    includes_associations << :events unless self.uses_new_registration_service?
+
     # NOTE: we're including non-competing registrations so that they can have job
     # assignments as well. These registrations don't have accepted?, but they
     # should appear in the WCIF.

--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -27,7 +27,7 @@ module MicroserviceRegistrationHolder
           # we hydrate each model with the microservice information directly from above
           ar_models.each do |ar_model|
             matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
-            raise "No matching Microservice registration found. This should not happen!" unless matching_ms_model.present? || ar_model.non_competing_dummy?
+            raise "No matching Microservice registration found. This should not happen!" if !matching_ms_model.present? && ar_model.is_competing?
 
             ar_model.load_ms_model(matching_ms_model) if matching_ms_model.present?
           end

--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -27,9 +27,9 @@ module MicroserviceRegistrationHolder
           # we hydrate each model with the microservice information directly from above
           ar_models.each do |ar_model|
             matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
-            raise "No matching Microservice registration found. This should not happen!" unless matching_ms_model.present?
+            raise "No matching Microservice registration found. This should not happen!" unless matching_ms_model.present? || ar_model.non_competing_dummy?
 
-            ar_model.load_ms_model(matching_ms_model)
+            ar_model.load_ms_model(matching_ms_model) if matching_ms_model.present?
           end
         end
       end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -59,12 +59,6 @@ class MicroserviceRegistration < ApplicationRecord
     self.read_ms_data :event_ids
   end
 
-  def roles
-    return [] unless self.is_competing?
-
-    self.read_ms_data :roles
-  end
-
   def guests
     return 0 unless self.is_competing?
 

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -45,7 +45,13 @@ class MicroserviceRegistration < ApplicationRecord
   end
 
   alias :status :competing_status
-  alias :wcif_status :competing_status
+
+  def wcif_status
+    return "deleted" if self.deleted?
+    return "pending" if self.pending?
+
+    self.competing_status
+  end
 
   def event_ids
     return [] unless self.is_competing?
@@ -85,6 +91,12 @@ class MicroserviceRegistration < ApplicationRecord
 
   def deleted?
     self.status == "cancelled"
+  end
+
+  def pending?
+    # WCIF interprets "pending" as "not approved to compete yet"
+    #   which is why these two statuses collapse into one.
+    self.status == "pending" || self.status == "waiting_list"
   end
 
   def to_wcif(authorized: false)

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -88,4 +88,12 @@ class MicroserviceRegistration < ApplicationRecord
       "isCompeting" => is_competing?,
     }.merge(authorized ? authorized_fields : {})
   end
+
+  def self.create_non_competing(competition, user_id)
+    nil # TODO: stub
+  end
+
+  def update_roles(new_roles)
+    nil # TODO: stub
+  end
 end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -66,14 +66,14 @@ class MicroserviceRegistration < ApplicationRecord
   end
 
   def comments
-    # TODO: Better return nil here? -> Check WCIF spec!
+    # nil is not allowed here, see WCIF spec!
     return '' unless self.is_competing?
 
     self.read_ms_data :comments
   end
 
   def administrative_notes
-    # TODO: Better return nil here? -> Check WCIF spec!
+    # nil is not allowed here, see WCIF spec!
     return '' unless self.is_competing?
 
     self.read_ms_data :administrative_notes

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -4,6 +4,9 @@ class MicroserviceRegistration < ApplicationRecord
   belongs_to :competition, inverse_of: :microservice_registrations
   belongs_to :user, inverse_of: :microservice_registrations
 
+  has_many :assignments, as: :registration
+  has_many :wcif_extensions, as: :extendable, dependent: :delete_all
+
   delegate :name, :email, to: :user
 
   attr_accessor :ms_registration

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -16,7 +16,7 @@ class Registration < ApplicationRecord
   has_many :registration_payments
   has_many :competition_events, through: :registration_competition_events
   has_many :events, through: :competition_events
-  has_many :assignments, dependent: :delete_all
+  has_many :assignments, as: :registration, dependent: :delete_all
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
   has_many :stripe_payment_intents, as: :holder, dependent: :delete_all
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -239,8 +239,6 @@ class Registration < ApplicationRecord
     self.create(
       competition: competition,
       user_id: user_id,
-      created_at: DateTime.now,
-      updated_at: DateTime.now,
       is_competing: false,
     )
   end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -235,20 +235,6 @@ class Registration < ApplicationRecord
     }
   end
 
-  def self.create_non_competing(competition, user_id)
-    self.create(
-      competition: competition,
-      user_id: user_id,
-      is_competing: false,
-    )
-  end
-
-  def update_roles(new_roles)
-    # The additional roles are only for WCIF purposes and we don't validate them,
-    # so we can safely skip validations by using update_attribute
-    self.update_attribute(:roles, new_roles)
-  end
-
   def self.accepted_and_paid_pending_count
     accepted.count + pending.with_payments.count
   end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -235,6 +235,22 @@ class Registration < ApplicationRecord
     }
   end
 
+  def self.create_non_competing(competition, user_id)
+    self.create(
+      competition: competition,
+      user_id: user_id,
+      created_at: DateTime.now,
+      updated_at: DateTime.now,
+      is_competing: false,
+    )
+  end
+
+  def update_roles(new_roles)
+    # The additional roles are only for WCIF purposes and we don't validate them,
+    # so we can safely skip validations by using update_attribute
+    self.update_attribute(:roles, new_roles)
+  end
+
   def self.accepted_and_paid_pending_count
     accepted.count + pending.with_payments.count
   end

--- a/db/migrate/20240306134217_make_assignments_table_registration_polymorphic.rb
+++ b/db/migrate/20240306134217_make_assignments_table_registration_polymorphic.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class MakeAssignmentsTableRegistrationPolymorphic < ActiveRecord::Migration[7.1]
+  def change
+    add_column :assignments, :registration_type, :string, after: :registration_id
+
+    remove_index :assignments, column: :registration_id
+    add_index :assignments, [:registration_id, :registration_type]
+
+    Assignment.update_all(registration_type: 'Registration')
+  end
+end

--- a/db/migrate/20240307181801_add_non_competing_dummy_to_microservice_registrations.rb
+++ b/db/migrate/20240307181801_add_non_competing_dummy_to_microservice_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNonCompetingDummyToMicroserviceRegistrations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :microservice_registrations, :non_competing_dummy, :boolean, after: :user_id, default: false
+  end
+end

--- a/db/migrate/20240307181801_add_non_competing_dummy_to_microservice_registrations.rb
+++ b/db/migrate/20240307181801_add_non_competing_dummy_to_microservice_registrations.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddNonCompetingDummyToMicroserviceRegistrations < ActiveRecord::Migration[7.1]
-  def change
-    add_column :microservice_registrations, :non_competing_dummy, :boolean, after: :user_id, default: false
-  end
-end

--- a/db/migrate/20240307181801_add_staff_dummy_fields_to_microservice_registrations.rb
+++ b/db/migrate/20240307181801_add_staff_dummy_fields_to_microservice_registrations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddStaffDummyFieldsToMicroserviceRegistrations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :microservice_registrations, :roles, :text, after: :user_id, null: true
+    add_column :microservice_registrations, :is_competing, :boolean, after: :roles, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -777,7 +777,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_053739) do
   create_table "microservice_registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "competition_id"
     t.integer "user_id"
-    t.boolean "non_competing_dummy", default: false
+    t.text "roles"
+    t.boolean "is_competing", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["competition_id", "user_id"], name: "index_microservice_registrations_on_competition_id_and_user_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -549,10 +549,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_053739) do
 
   create_table "assignments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "registration_id"
+    t.string "registration_type"
     t.bigint "schedule_activity_id"
     t.integer "station_number"
     t.string "assignment_code", null: false
-    t.index ["registration_id"], name: "index_assignments_on_registration_id"
+    t.index ["registration_id", "registration_type"], name: "index_assignments_on_registration_id_and_registration_type"
     t.index ["schedule_activity_id"], name: "index_assignments_on_schedule_activity_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -777,6 +777,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_11_053739) do
   create_table "microservice_registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "competition_id"
     t.integer "user_id"
+    t.boolean "non_competing_dummy", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["competition_id", "user_id"], name: "index_microservice_registrations_on_competition_id_and_user_id", unique: true

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -642,7 +642,20 @@ module DatabaseDumper
         },
       ),
     }.freeze,
-    "microservice_registrations" => :skip_all_rows,
+    "microservice_registrations" => {
+      where_clause: JOIN_WHERE_VISIBLE_COMP,
+      column_sanitizers: actions_to_column_sanitizers(
+        copy: %w(
+          id
+          competition_id
+          user_id
+          roles
+          is_competing
+          created_at
+          updated_at
+        ),
+      ),
+    }.freeze,
     "sanity_checks" => :skip_all_rows,
     "sanity_check_categories" => :skip_all_rows,
     "sanity_check_exclusions" => :skip_all_rows,
@@ -851,6 +864,7 @@ module DatabaseDumper
         copy: %w(
           id
           registration_id
+          registration_type
           schedule_activity_id
           station_number
           assignment_code


### PR DESCRIPTION
This adds both reading and writing support for microservice registrations.

Note that writing support does not actually relay information to the microservice. It only stores information like the role strings in a temporary table, which is then also used to mock non-competing registrations.

Doing so is an intermediate solution until we have staff lanes in the microservice.