### PR TITLE
Prevent user being redirected to an API endpoint after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,7 +94,11 @@ class ApplicationController < ActionController::Base
 
     # For redirecting user to source after login - https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update
     def storable_location?
-      request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+      request.get? && is_navigational_format? && !devise_controller? && !request.xhr? && !is_api_request?
+    end
+
+    def is_api_request?
+      request.fullpath.include?('/api/')
     end
 
     def store_user_location!


### PR DESCRIPTION
We could also add a check for the content type not being JSON, but the URL _seems_ like the most reliable method of determining whether a request is going to the API? 