### PR TITLE
Fix error when trying to create a Continental Championship

### DIFF
--- a/app/models/championship.rb
+++ b/app/models/championship.rb
@@ -62,7 +62,7 @@ class Championship < ApplicationRecord
   def self.grouped_championship_types
     {
       "planetary" => [CHAMPIONSHIP_TYPE_WORLD],
-      "continental" => Continent.all_sorted_by(I18n.locale, real: true).map(&:name),
+      "continental" => Continent.all_sorted_by(I18n.locale, real: true).map(&:id),
       "multi-national" => EligibleCountryIso2ForChampionship.championship_types,
       "national" => Country.all_sorted_by(I18n.locale, real: true).map(&:iso2),
     }

--- a/app/webpacker/components/CompetitionForm/Inputs/InputChampionship.js
+++ b/app/webpacker/components/CompetitionForm/Inputs/InputChampionship.js
@@ -14,7 +14,7 @@ const generateChampionshipName = (type, championship) => {
     case 'planetary':
       return I18n.t('competitions.competition_form.championship_types.world');
     case 'continental':
-      return I18n.t(`continents.${championship.replace(/_/g, "")}`);
+      return I18n.t(`continents.${championship.replace(/_/g, '')}`);
     case 'multi-national':
       return I18n.t(`competitions.competition_form.championship_types.${championship}`) || I18n.t('competitions.competition_form.championship_types.generic', { type: championship });
     case 'national':

--- a/app/webpacker/components/CompetitionForm/Inputs/InputChampionship.js
+++ b/app/webpacker/components/CompetitionForm/Inputs/InputChampionship.js
@@ -14,7 +14,7 @@ const generateChampionshipName = (type, championship) => {
     case 'planetary':
       return I18n.t('competitions.competition_form.championship_types.world');
     case 'continental':
-      return I18n.t(`continents.${championship}`);
+      return I18n.t(`continents.${championship.replace(/_/g, "")}`);
     case 'multi-national':
       return I18n.t(`competitions.competition_form.championship_types.${championship}`) || I18n.t('competitions.competition_form.championship_types.generic', { type: championship });
     case 'national':


### PR DESCRIPTION
Fixes #9097 

Validate Continental Championships on continent **name** not id (presumably we used to match on id because we were still using a Rails frontend - now it makes more sense to use name with a separate frontend/backend I think) 