### PR TITLE
Clearer Error text for Error Pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -662,9 +662,9 @@ en:
       error_pages:
         #context: The error pages in the case of 500s or 400s
         500_error: "We're sorry, but something went wrong."
-        500_contact: "If you report this error to the Software Team please mention the Request ID"
+        500_contact: "If you report this error to the Software Team please copy the Request ID into the email"
         400_error: "The page you were looking for doesn't exist."
-        400_contact: "If you think this is a mistake please contact the Software Team and include the Request ID"
+        400_contact: "If you think this is a mistake please contact the Software Team and copy the Request ID into the email"
     #context: Key used when an external OAuth app is willing to access a WCA user's data
     doorkeeper:
       applications:


### PR DESCRIPTION
because we've been getting to many emails where people only post a screenshot of the request id