### PR TITLE
Updated warning when the competition name is longer than 32 characters.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1252,7 +1252,7 @@ en:
     #context: generic message
     messages:
       not_visible: "This competition is not visible to the public."
-      name_too_long: "The competition name is longer than 32 characters. We prefer shorter ones and we will be glad if you change it."
+      name_too_long: "The competition name is longer than 32 characters. Please edit the competition ID and short name appropriately."
       id_starts_with_lowercase: "The competition id starts with a lowercase letter. We prefer to have it start with an uppercase."
       must_have_events: "Please add at least one event before confirming the competition."
       schedule_must_match_rounds: "Please make sure the competition has at least one round per event and that the schedule you created includes all the rounds you declared before confirming the competition."

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Competition do
     it "warns if competition name is greater than 32 characters and it's not publicly visible" do
       competition = FactoryBot.build :competition, name: "A really long competition name 2016", showAtAll: false
       expect(competition).to be_valid
-      expect(competition.warnings_for(nil)[:name]).to eq "The competition name is longer than 32 characters. We prefer shorter ones and we will be glad if you change it."
+      expect(competition.warnings_for(nil)[:name]).to eq "The competition name is longer than 32 characters. Please edit the competition ID and short name appropriately."
     end
 
     it "does not warn about name greater than 32 when competition is publicly visible" do


### PR DESCRIPTION
WCAT would like to update the text of the warning when the competition name is longer than 32 characters. In the past the competition ID and short name fields were always open for editing. Today these fields are only editable once the name exeeds 32 characters. We would therefore like to update the warning to reminds organizers and Delegates that this is something they need to handle.