### PR TITLE
Eager load wcif_extensions when patching WCIF

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1938,6 +1938,7 @@ class Competition < ApplicationRecord
     registration_includes = [
       { assignments: [:schedule_activity] },
       :user,
+      :wcif_extensions,
     ]
     registration_includes << :registration_competition_events unless self.uses_new_registration_service?
     registrations = registrations_relation.includes(registration_includes)


### PR DESCRIPTION
I noticed when playing around with Euro 2024's WCIF that patching would take (relatively) a lot of time locally, I narrowed it down to two main issues:
  - the request logs the parameters; it doesn't affect the response time as far as the tool's communication time is concerned, but it does clobber the shell running the website and prevent any quick interaction with it (eg: ctrl-c).
  I have not included the "fix" in that PR because I don't think it's such an issue for the website, but users trying out stuff on competitions with "big" WCIF (I'm looking at you @timreyn :)) might be interested to know that one can apply that patch to prevent the patched WCIF from showing up in the console:
```
diff --git a/config/initializers/filter_parameter_logging.rb b/config/initializers/filter_parameter_logging.rb
index 6a7232359..69cbf88fc 100644
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,5 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp_attempt, :otp, :ssn]
+# FIXME: I disabled noisy stuff during WCIF patching
+Rails.application.config.filter_parameters += [:password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp_attempt, :otp, :ssn, :schedule, :persons]
```
  - the second issue  is that there is a n+1 query in `update_persons_wcif!`, that fires one SQL request per registration. The patch is quite simple and is included in that PR :)