### PR TITLE
Use UtcDatePicker throughout Rails code

### DIFF
--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -4,8 +4,6 @@ import {
 } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
 import PulseLoader from 'react-spinners/PulseLoader';
-import DatePicker from 'react-datepicker';
-import 'react-datepicker/dist/react-datepicker.css';
 
 import I18n from '../../lib/i18n';
 import {
@@ -13,6 +11,7 @@ import {
 } from '../../lib/wca-data.js.erb';
 
 import useDelegatesData from './useDelegatesData';
+import UtcDatePicker from '../wca/UtcDatePicker';
 
 const WCA_EVENT_IDS = Object.values(events.official).map((e) => e.id);
 const PAST_YEARS_WITH_COMPETITIONS = [];
@@ -325,22 +324,27 @@ function CustomDateSelector({ filterState, dispatchFilter }) {
     >
       <List>
         <List.Item>
-          <DatePicker
+          <UtcDatePicker
             name="start-date"
             showIcon
             placeholderText={I18n.t('competitions.index.from_date')}
-            selected={filterState.customStartDate}
+            isoDate={filterState.customStartDate}
             onChange={(date) => dispatchFilter({ customStartDate: date })}
-            maxDate={filterState.customEndDate}
+            selectsStart
+            isoStartDate={filterState.customStartDate}
+            isoEndDate={filterState.customEndDate}
           />
         </List.Item>
         <List.Item>
-          <DatePicker
+          <UtcDatePicker
             name="end-date"
             showIcon
             placeholderText={I18n.t('competitions.index.to_date')}
-            selected={filterState.customEndDate}
+            isoDate={filterState.customEndDate}
             onChange={(date) => dispatchFilter({ customEndDate: date })}
+            selectsEnd
+            isoStartDate={filterState.customStartDate}
+            isoEndDate={filterState.customEndDate}
             minDate={filterState.customStartDate}
           />
         </List.Item>

--- a/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import { events } from '../../lib/wca-data.js.erb';
 
 // note: inconsistencies with previous search params
@@ -28,10 +27,6 @@ const DEFAULT_SEARCH = '';
 const DEFAULT_EVENTS = [];
 const INCLUDE_CANCELLED_TRUE = 'on';
 
-// without time string, date will be interpreted in user's time zone
-const parseDate = (dateString) => new Date(`${dateString}T00:00:00.000`);
-const formatDate = (date) => DateTime.fromJSDate(date).toFormat('yyyy-MM-dd');
-
 export const getDisplayMode = (searchParams) => (
   searchParams.get(DISPLAY_MODE) || DEFAULT_DISPLAY_MODE
 );
@@ -39,10 +34,8 @@ export const getDisplayMode = (searchParams) => (
 export const createFilterState = (searchParams) => ({
   timeOrder: searchParams.get(TIME_ORDER) || DEFAULT_TIME_ORDER,
   selectedYear: searchParams.get(YEAR) || DEFAULT_YEAR,
-  customStartDate:
-    searchParams.get(START_DATE) ? parseDate(searchParams.get(START_DATE)) : DEFAULT_DATE,
-  customEndDate:
-    searchParams.get(END_DATE) ? parseDate(searchParams.get(END_DATE)) : DEFAULT_DATE,
+  customStartDate: searchParams.get(START_DATE) || DEFAULT_DATE,
+  customEndDate: searchParams.get(END_DATE) || DEFAULT_DATE,
   region: searchParams.get(REGION) || DEFAULT_REGION,
   delegate: searchParams.get(DELEGATE) || DEFAULT_DELEGATE,
   search: searchParams.get(SEARCH) || DEFAULT_SEARCH,
@@ -89,13 +82,13 @@ export const updateSearchParams = (searchParams, filterState, displayMode) => {
 
   // for date values, format and add them if applicable, otherwise omit them
   if (customStartDate) {
-    searchParams.set(START_DATE, formatDate(customStartDate));
+    searchParams.set(START_DATE, customStartDate);
   } else {
     searchParams.delete(START_DATE);
   }
 
   if (customEndDate) {
-    searchParams.set(END_DATE, formatDate(customEndDate));
+    searchParams.set(END_DATE, customEndDate);
   } else {
     searchParams.delete(END_DATE);
   }

--- a/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -80,7 +80,7 @@ export const updateSearchParams = (searchParams, filterState, displayMode) => {
   searchParams.set(SELECTED_EVENTS, selectedEvents.join(','));
   searchParams.delete(SELECTED_EVENTS, DEFAULT_EVENTS.join(','));
 
-  // for date values, format and add them if applicable, otherwise omit them
+  // for date values, add them if applicable, otherwise omit them
   if (customStartDate) {
     searchParams.set(START_DATE, customStartDate);
   } else {

--- a/app/webpacker/components/CompetitionsOverview/queryUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/queryUtils.js
@@ -42,25 +42,25 @@ export function createSearchParams(filterState, pageParam) {
 
   if (timeOrder === 'present') {
     searchParams.append('sort', 'start_date,end_date,name');
-    searchParams.append('ongoing_and_future', dateNow.toFormat('yyyy-MM-dd'));
+    searchParams.append('ongoing_and_future', dateNow.toISODate());
     searchParams.append('page', pageParam);
   } else if (timeOrder === 'recent') {
     // noinspection JSAnnotator
     const recentDaysAgo = dateNow.minus({ days: competitionConstants.competitionRecentDays });
 
     searchParams.append('sort', '-end_date,-start_date,name');
-    searchParams.append('start', recentDaysAgo.toFormat('yyyy-MM-dd'));
-    searchParams.append('end', dateNow.toFormat('yyyy-MM-dd'));
+    searchParams.append('start', recentDaysAgo.toISODate());
+    searchParams.append('end', dateNow.toISODate());
     searchParams.append('page', pageParam);
   } else if (timeOrder === 'past') {
     if (selectedYear === 'all_years') {
       searchParams.append('sort', '-end_date,-start_date,name');
-      searchParams.append('end', dateNow.toFormat('yyyy-MM-dd'));
+      searchParams.append('end', dateNow.toISODate());
       searchParams.append('page', pageParam);
     } else {
       searchParams.append('sort', '-end_date,-start_date,name');
       searchParams.append('start', `${selectedYear}-1-1`);
-      searchParams.append('end', dateNow.year === selectedYear ? dateNow.toFormat('yyyy-MM-dd') : `${selectedYear}-12-31`);
+      searchParams.append('end', dateNow.year === selectedYear ? dateNow.toISODate() : `${selectedYear}-12-31`);
       searchParams.append('page', pageParam);
     }
   } else if (timeOrder === 'by_announcement') {
@@ -71,8 +71,8 @@ export function createSearchParams(filterState, pageParam) {
     const endLuxon = DateTime.fromISO(customEndDate, { zone: 'UTC' });
 
     searchParams.append('sort', 'start_date,end_date,name');
-    searchParams.append('start', startLuxon.isValid ? startLuxon.toFormat('yyyy-MM-dd') : '');
-    searchParams.append('end', endLuxon.isValid ? endLuxon.toFormat('yyyy-MM-dd') : '');
+    searchParams.append('start', startLuxon.isValid ? startLuxon.toISODate() : '');
+    searchParams.append('end', endLuxon.isValid ? endLuxon.toISODate() : '');
     searchParams.append('page', pageParam);
   }
 

--- a/app/webpacker/components/CompetitionsOverview/queryUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/queryUtils.js
@@ -67,8 +67,8 @@ export function createSearchParams(filterState, pageParam) {
     searchParams.append('sort', '-announced_at,name');
     searchParams.append('page', pageParam);
   } else if (timeOrder === 'custom') {
-    const startLuxon = DateTime.fromJSDate(customStartDate);
-    const endLuxon = DateTime.fromJSDate(customEndDate);
+    const startLuxon = DateTime.fromISO(customStartDate, { zone: 'UTC' });
+    const endLuxon = DateTime.fromISO(customEndDate, { zone: 'UTC' });
 
     searchParams.append('sort', 'start_date,end_date,name');
     searchParams.append('start', startLuxon.isValid ? startLuxon.toFormat('yyyy-MM-dd') : '');

--- a/app/webpacker/components/DelegateProbations/index.jsx
+++ b/app/webpacker/components/DelegateProbations/index.jsx
@@ -118,7 +118,7 @@ export default function DelegateProbations() {
       <h2>Active Probations</h2>
       <ProbationListTable
         roleList={probationRoles.filter((probationRole) => probationRole.end_date === null
-           || probationRole.end_date > DateTime.now().toISODate())}
+           || DateTime.fromISO(probationRole.end_date, { zone: 'UTC' }) > DateTime.now())}
         isActive
         save={save}
         sync={sync}
@@ -126,7 +126,7 @@ export default function DelegateProbations() {
       <h2>Past Probations</h2>
       <ProbationListTable
         roleList={probationRoles.filter((probationRole) => probationRole.end_date !== null
-          && probationRole.end_date <= DateTime.now().toISODate())}
+          && DateTime.fromISO(probationRole.end_date, { zone: 'UTC' }) <= DateTime.now())}
         isActive={false}
       />
     </>

--- a/app/webpacker/components/DelegateProbations/index.jsx
+++ b/app/webpacker/components/DelegateProbations/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, Confirm, Table } from 'semantic-ui-react';
+import { DateTime } from 'luxon';
 import UserBadge from '../UserBadge';
 import useLoadedData from '../../lib/hooks/useLoadedData';
 import { apiV0Urls } from '../../lib/requests/routes.js.erb';
@@ -10,8 +11,6 @@ import SEARCH_MODELS from '../SearchWidget/SearchModel';
 import Errored from '../Requests/Errored';
 import useInputState from '../../lib/hooks/useInputState';
 import UtcDatePicker from '../wca/UtcDatePicker';
-
-const dateFormat = 'YYYY-MM-DD';
 
 function ProbationListTable({
   roleList, isActive, save, sync,
@@ -119,7 +118,7 @@ export default function DelegateProbations() {
       <h2>Active Probations</h2>
       <ProbationListTable
         roleList={probationRoles.filter((probationRole) => probationRole.end_date === null
-           || probationRole.end_date > moment().format(dateFormat))}
+           || probationRole.end_date > DateTime.now().toISODate())}
         isActive
         save={save}
         sync={sync}
@@ -127,7 +126,7 @@ export default function DelegateProbations() {
       <h2>Past Probations</h2>
       <ProbationListTable
         roleList={probationRoles.filter((probationRole) => probationRole.end_date !== null
-          && probationRole.end_date <= moment().format(dateFormat))}
+          && probationRole.end_date <= DateTime.now().toISODate())}
         isActive={false}
       />
     </>

--- a/app/webpacker/components/DelegateProbations/index.jsx
+++ b/app/webpacker/components/DelegateProbations/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Button, Confirm, Table } from 'semantic-ui-react';
-import DatePicker from 'react-datepicker';
 import UserBadge from '../UserBadge';
 import useLoadedData from '../../lib/hooks/useLoadedData';
 import { apiV0Urls } from '../../lib/requests/routes.js.erb';
@@ -10,6 +9,7 @@ import WcaSearch from '../SearchWidget/WcaSearch';
 import SEARCH_MODELS from '../SearchWidget/SearchModel';
 import Errored from '../Requests/Errored';
 import useInputState from '../../lib/hooks/useInputState';
+import UtcDatePicker from '../wca/UtcDatePicker';
 
 const dateFormat = 'YYYY-MM-DD';
 
@@ -23,6 +23,7 @@ function ProbationListTable({
     save(apiV0Urls.userRoles.update(endProbationParams.probationRoleId), {
       endDate: endProbationParams.endDate,
     }, sync, { method: 'PATCH' });
+
     setConfirmOpen(false);
     setEndProbationParams(null);
   };
@@ -54,15 +55,15 @@ function ProbationListTable({
               <Table.Cell>
                 {
                 isActive ? (
-                  <DatePicker
-                    onChange={(date) => {
+                  <UtcDatePicker
+                    isoDate={probationRole.end_date}
+                    onChange={(isoDate) => {
                       setEndProbationParams({
                         probationRoleId: probationRole.id,
-                        endDate: moment(date).format(dateFormat),
+                        endDate: isoDate,
                       });
                       setConfirmOpen(true);
                     }}
-                    selected={probationRole.end_date ? new Date(probationRole.end_date) : null}
                   />
                 ) : probationRole.end_date
               }

--- a/app/webpacker/components/EditEvents/Modals/EditQualificationModal/index.js
+++ b/app/webpacker/components/EditEvents/Modals/EditQualificationModal/index.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import _ from 'lodash';
-import DatePicker from 'react-datepicker';
 import { Form, Label } from 'semantic-ui-react';
 import i18n from '../../../../lib/i18n';
 import { events } from '../../../../lib/wca-data.js.erb';
@@ -13,8 +12,7 @@ import { updateQualification } from '../../store/actions';
 import ButtonActivatedModal from '../ButtonActivatedModal';
 import QualificationType from './QualificationTypeInput';
 import QualificationResultType from './QualificationResultTypeInput';
-
-import 'react-datepicker/dist/react-datepicker.css';
+import UtcDatePicker from '../../../wca/UtcDatePicker';
 
 /**
  *
@@ -110,11 +108,6 @@ export default function EditQualificationModal({
     }
   };
 
-  const handleDateChange = (date) => {
-    // need a default date to avoid error on empty string input
-    setWhenDate(moment(date ?? Date.now()).format('YYYY-MM-DD'));
-  };
-
   const title = i18n.t('qualification.for_event', { event: event.name });
   const trigger = eventQualificationToString(wcifEvent, qualification, { short: true });
 
@@ -151,12 +144,9 @@ export default function EditQualificationModal({
           />
           <Form.Field>
             <Label>{i18n.t('qualification.deadline.description')}</Label>
-            <DatePicker
-              onChange={handleDateChange}
-              // utc issues if not using moment, see: https://github.com/Hacker0x01/react-datepicker/issues/1018#issuecomment-461963696
-              selected={whenDate ? moment(whenDate).toDate() : null}
-              dateFormat="yyyy-MM-dd"
-              dateFormatCalendar="yyyy"
+            <UtcDatePicker
+              onChange={setWhenDate}
+              selected={whenDate}
             />
           </Form.Field>
           <br />

--- a/app/webpacker/components/Panel/Wfc/DuesExport.jsx
+++ b/app/webpacker/components/Panel/Wfc/DuesExport.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import DatePicker from 'react-datepicker';
 import {
   Button, Grid, GridColumn, GridRow,
 } from 'semantic-ui-react';
 import { wfcCompetitionsExportUrl } from '../../../lib/requests/routes.js.erb';
 
-import 'react-datepicker/dist/react-datepicker.css';
-
-const dateFormat = 'YYYY-MM-DD';
+import UtcDatePicker from '../../wca/UtcDatePicker';
 
 export default function DuesExport() {
   const [fromDate, setFromDate] = React.useState(null);
@@ -18,7 +15,7 @@ export default function DuesExport() {
       <GridRow>
         <GridColumn width={8}>Start Date</GridColumn>
         <GridColumn width={8}>
-          <DatePicker
+          <UtcDatePicker
             onChange={setFromDate}
             selected={fromDate}
           />
@@ -27,7 +24,7 @@ export default function DuesExport() {
       <GridRow>
         <GridColumn width={8}>End Date</GridColumn>
         <GridColumn width={8}>
-          <DatePicker
+          <UtcDatePicker
             onChange={setToDate}
             selected={toDate}
           />
@@ -38,8 +35,8 @@ export default function DuesExport() {
           <Button
             disabled={!fromDate || !toDate}
             href={`${wfcCompetitionsExportUrl}?${new URLSearchParams({
-              from_date: moment(fromDate).format(dateFormat),
-              to_date: moment(toDate).format(dateFormat),
+              from_date: fromDate,
+              to_date: toDate,
             }).toString()}`}
             target="_blank"
           >

--- a/app/webpacker/components/Panel/Wrt/EditPerson.jsx
+++ b/app/webpacker/components/Panel/Wrt/EditPerson.jsx
@@ -10,7 +10,6 @@ import SEARCH_MODELS from '../../SearchWidget/SearchModel';
 import Loading from '../../Requests/Loading';
 import I18n from '../../../lib/i18n';
 import { genders, countries } from '../../../lib/wca-data.js.erb';
-import 'react-datepicker/dist/react-datepicker.css';
 import useQueryParams from '../../../lib/hooks/useQueryParams';
 import useLoadedData from '../../../lib/hooks/useLoadedData';
 import Errored from '../../Requests/Errored';

--- a/app/webpacker/components/Panel/Wrt/EditPerson.jsx
+++ b/app/webpacker/components/Panel/Wrt/EditPerson.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import DatePicker from 'react-datepicker';
 import {
   Button, Form, Icon, Item, Message,
 } from 'semantic-ui-react';
@@ -15,8 +14,7 @@ import 'react-datepicker/dist/react-datepicker.css';
 import useQueryParams from '../../../lib/hooks/useQueryParams';
 import useLoadedData from '../../../lib/hooks/useLoadedData';
 import Errored from '../../Requests/Errored';
-
-const dateFormat = 'YYYY-MM-DD';
+import UtcDatePicker from '../../wca/UtcDatePicker';
 
 const genderOptions = _.map(genders.byId, (gender) => ({
   key: gender.id,
@@ -145,14 +143,14 @@ function EditPersonForm({ wcaId, clearWcaId, setResponse }) {
         <Form.Field
           label={I18n.t('activerecord.attributes.user.dob')}
           name="dob"
-          control={DatePicker}
+          control={UtcDatePicker}
           showYearDropdown
-          scrollableYearDropdown
+          dropdownMode="select"
           disabled={!editedUserDetails}
-          value={editedUserDetails?.dob || null}
+          selected={editedUserDetails?.dob}
           onChange={(date) => handleFormChange(null, {
             name: 'dob',
-            value: moment(date).format(dateFormat),
+            value: date,
           })}
         />
         <Button

--- a/app/webpacker/components/PostingCompetitions/index.js
+++ b/app/webpacker/components/PostingCompetitions/index.js
@@ -4,6 +4,7 @@ import {
   Button, Checkbox, Header, Segment, Table,
 } from 'semantic-ui-react';
 import _ from 'lodash';
+import { DateTime } from 'luxon';
 import useLoadedData from '../../lib/hooks/useLoadedData';
 import useSaveAction from '../../lib/hooks/useSaveAction';
 import Loading from '../Requests/Loading';
@@ -77,7 +78,7 @@ function PostingCompetitionsIndex({
                 <CountryFlag iso2={c.country_iso2} />
               </Header.Subheader>
               <Header.Subheader>
-                {`Submission Timestamp: ${moment(c.results_submitted_at).fromNow()}`}
+                {`Submission Timestamp: ${DateTime.fromISO(c.results_submitted_at).toRelative()}`}
               </Header.Subheader>
             </Header>
             <Button.Group floated="right">

--- a/app/webpacker/components/wca/UtcDatePicker.js
+++ b/app/webpacker/components/wca/UtcDatePicker.js
@@ -21,6 +21,7 @@ const useIsoDate = (isoString) => useMemo(() => loadAsPseudoLocal(isoString), [i
 
 function UtcDatePicker({
   id,
+  name,
   isoDate,
   onChange,
   shouldCloseOnSelect,
@@ -28,6 +29,8 @@ function UtcDatePicker({
   showYearDropdown = false,
   dropdownMode = null,
   scrollableYearDropdown = false,
+  showIcon = false,
+  placeholderText = null,
   selectsStart = false,
   selectsEnd = false,
   isoStartDate = null,
@@ -57,6 +60,7 @@ function UtcDatePicker({
   return (
     <DatePicker
       id={id}
+      name={name}
       selected={date}
       onChange={onChangeInternal}
       shouldCloseOnSelect={shouldCloseOnSelect}
@@ -67,6 +71,8 @@ function UtcDatePicker({
       timeInputLabel="UTC"
       dateFormat={showTimeInput ? 'Pp' : 'P'}
       timeFormat="p"
+      showIcon={showIcon}
+      placeholderText={placeholderText}
       selectsStart={selectsStart}
       selectsEnd={selectsEnd}
       startDate={startDate}

--- a/app/webpacker/components/wca/UtcDatePicker.js
+++ b/app/webpacker/components/wca/UtcDatePicker.js
@@ -24,13 +24,16 @@ function UtcDatePicker({
   isoDate,
   onChange,
   shouldCloseOnSelect,
-  showTimeInput,
-  selectsStart,
-  selectsEnd,
-  isoStartDate,
-  isoEndDate,
-  isoMinDate,
-  isoMaxDate,
+  showTimeInput = false,
+  showYearDropdown = false,
+  dropdownMode = null,
+  scrollableYearDropdown = false,
+  selectsStart = false,
+  selectsEnd = false,
+  isoStartDate = null,
+  isoEndDate = null,
+  isoMinDate = null,
+  isoMaxDate = null,
 }) {
   const date = useIsoDate(isoDate);
 
@@ -58,6 +61,9 @@ function UtcDatePicker({
       onChange={onChangeInternal}
       shouldCloseOnSelect={shouldCloseOnSelect}
       showTimeInput={showTimeInput}
+      showYearDropdown={showYearDropdown}
+      dropdownMode={dropdownMode}
+      scrollableYearDropdown={scrollableYearDropdown}
       timeInputLabel="UTC"
       dateFormat={showTimeInput ? 'Pp' : 'P'}
       timeFormat="p"

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -115,8 +115,11 @@ export function eventQualificationToString(wcifEvent, qualification, { short } =
   }
   let dateString = '-';
   if (qualification.whenDate) {
-    const whenDate = window.moment(qualification.whenDate).toDate();
-    dateString = whenDate.toISOString().substring(0, 10);
+    const whenDate = DateTime
+      .fromISO(qualification.whenDate, { zone: 'UTC' })
+      .setZone('local'); // We *want* to show this as a local timestamp if you're living west of Greenwich
+
+    dateString = whenDate.toString().substring(0, 10);
   }
   const deadlineString = I18n.t('qualification.deadline.by_date', { date: dateString });
   const event = events.byId[wcifEvent.id];


### PR DESCRIPTION
See title. Hopefully gets rid of timezone offset errors, because while `react-datepicker` is really nice in terms of usability, it insists on _local_ JS dates. The common component should avoid the repeating `moment` idioms.

Bonus: Removes `moment` usages throughout the rest of the code as well.