### PR TITLE
Add regional delegates to notication emails sent to WCAT

### DIFF
--- a/app/mailers/competitions_mailer.rb
+++ b/app/mailers/competitions_mailer.rb
@@ -13,7 +13,7 @@ class CompetitionsMailer < ApplicationMailer
       mail(
         from: Team.wcat.email,
         to: Team.wcat.email,
-        cc: (competition.delegates.map(&:email) + delegates_to_senior_delegates_email(competition.delegates)).compact.uniq,
+        cc: (competition.delegates.map(&:email) + delegates_to_senior_delegates_email(competition.delegates) + delegates_to_regional_delegates_email(competition.delegates)).compact.uniq,
         reply_to: confirmer.email,
         subject: "#{competition.name} is confirmed",
       )
@@ -173,6 +173,10 @@ class CompetitionsMailer < ApplicationMailer
 
   private def delegates_to_senior_delegates_email(delegates)
     delegates.flat_map { |delegate| delegate.senior_delegates.map(&:email) }.uniq.compact
+  end
+
+  private def delegates_to_regional_delegates_email(delegates)
+    delegates.flat_map { |delegate| delegate.region&.lead_user.email }.uniq.compact
   end
 
   private def delegate_report_email_subject(competition)

--- a/app/mailers/competitions_mailer.rb
+++ b/app/mailers/competitions_mailer.rb
@@ -176,7 +176,7 @@ class CompetitionsMailer < ApplicationMailer
   end
 
   private def delegates_to_regional_delegates_email(delegates)
-    delegates.flat_map { |delegate| delegate.region&.lead_user.email }.uniq.compact
+    delegates.flat_map { |delegate| delegate.regional_delegates.map(&:email) }.uniq.compact
   end
 
   private def delegate_report_email_subject(competition)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1324,6 +1324,12 @@ class User < ApplicationRecord
       .map { |role| UserRole.group(role).senior_delegate }
   end
 
+  def regional_delegates
+    active_roles
+      .select { |role| UserRole.is_group_type?(role, UserGroup.group_types[:delegate_regions]) }
+      .map { |role| UserRole.group(role).lead_user }
+  end
+
   def active_roles
     roles.select { |role| UserRole.is_active?(role) }
   end


### PR DESCRIPTION
WCAT is currently adding the regional delegates manually for each submission. This is a lot of work, so here is the code to do it automatically.

The current repo mixed with the docker file works quite poorly. But from the test I were able to do, this works.