### PR TITLE
Competitions Overview - Search Param Sanitization

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1669,12 +1669,12 @@ class Competition < ApplicationRecord
     end
 
     if params[:delegate].present?
-      delegate = User.find_by(wca_id: params[:delegate])
-      if !delegate
+      delegate_user = User.find_by(wca_id: params[:delegate]) || User.find(params[:delegate])
+      if !delegate_user || !delegate_user.delegate_status
         raise WcaExceptions::BadApiParameter.new("Invalid delegate: '#{params[:delegate]}'")
       end
       competitions = competitions.left_outer_joins(:delegates)
-                                 .where('competition_delegates.delegate_id = ?', delegate.id)
+                                 .where('competition_delegates.delegate_id = ?', delegate_user.id)
     end
 
     if params[:start].present?

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   Button, Icon, Form, Dropdown, Popup, List, Input, Header,
 } from 'semantic-ui-react';
-import { DateTime } from 'luxon';
 import PulseLoader from 'react-spinners/PulseLoader';
 
 import I18n from '../../lib/i18n';
@@ -12,13 +11,9 @@ import {
 
 import useDelegatesData from './useDelegatesData';
 import UtcDatePicker from '../wca/UtcDatePicker';
+import { YEARS_WITH_PAST_COMPETITIONS } from './filterUtils';
 
 const WCA_EVENT_IDS = Object.values(events.official).map((e) => e.id);
-const PAST_YEARS_WITH_COMPETITIONS = [];
-for (let { year } = DateTime.now(); year >= 2003; year -= 1) {
-  PAST_YEARS_WITH_COMPETITIONS.push(year);
-}
-PAST_YEARS_WITH_COMPETITIONS.push(1982);
 
 function CompetitionsFilters({
   filterState,
@@ -285,7 +280,7 @@ function PastCompYearSelector({ filterState, dispatchFilter }) {
           >
             {I18n.t('competitions.index.all_years')}
           </Dropdown.Item>
-          {PAST_YEARS_WITH_COMPETITIONS.map((year) => (
+          {YEARS_WITH_PAST_COMPETITIONS.map((year) => (
             <Dropdown.Item
               key={`past_select_${year}`}
               onClick={() => dispatchFilter({ timeOrder: 'past', selectedYear: year })}

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -175,7 +175,9 @@ function DelegateSelector({ delegateId, dispatchFilter }) {
         search
         deburr
         selection
-        error={!delegatesLoading && delegateId && delegatesData.every(({ id }) => id !== delegateId)}
+        error={
+          !delegatesLoading && delegateId && delegatesData.every(({ id }) => id !== delegateId)
+        }
         style={{ textAlign: 'center' }}
         options={[{ key: 'None', text: I18n.t('competitions.index.no_delegates'), value: '' }, ...(delegatesData?.filter((item) => item.name !== 'WCA Board').map((delegate) => (
           {

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -6,12 +6,11 @@ import PulseLoader from 'react-spinners/PulseLoader';
 
 import I18n from '../../lib/i18n';
 import {
-  events, continents, countries, competitionConstants,
+  events, continents, countries, competitionConstants, nonFutureCompetitionYears,
 } from '../../lib/wca-data.js.erb';
 
 import useDelegatesData from './useDelegatesData';
 import UtcDatePicker from '../wca/UtcDatePicker';
-import { YEARS_WITH_PAST_COMPETITIONS } from './filterUtils';
 
 const WCA_EVENT_IDS = Object.values(events.official).map((e) => e.id);
 
@@ -280,7 +279,7 @@ function PastCompYearSelector({ filterState, dispatchFilter }) {
           >
             {I18n.t('competitions.index.all_years')}
           </Dropdown.Item>
-          {YEARS_WITH_PAST_COMPETITIONS.map((year) => (
+          {nonFutureCompetitionYears.map((year) => (
             <Dropdown.Item
               key={`past_select_${year}`}
               onClick={() => dispatchFilter({ timeOrder: 'past', selectedYear: year })}

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -175,6 +175,7 @@ function DelegateSelector({ delegateId, dispatchFilter }) {
         search
         deburr
         selection
+        error={!delegatesLoading && delegateId && delegatesData.every(({ id }) => id !== delegateId)}
         style={{ textAlign: 'center' }}
         options={[{ key: 'None', text: I18n.t('competitions.index.no_delegates'), value: '' }, ...(delegatesData?.filter((item) => item.name !== 'WCA Board').map((delegate) => (
           {

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -181,7 +181,7 @@ function DelegateSelector({ delegateId, dispatchFilter }) {
           {
             key: delegate.id,
             text: `${delegate.name} (${delegate.wca_id})`,
-            value: delegate.wca_id,
+            value: delegate.id,
             image: { avatar: true, src: delegate.thumb_url, style: { width: '28px', height: '28px' } },
           }
         )) || [])]}

--- a/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -17,7 +17,10 @@ export { YEARS_WITH_PAST_COMPETITIONS };
 
 // note: inconsistencies with previous search params
 // - year value was 'all+years', is now 'all_years'
+// --> handled by the fact that every non-number is interpreted as "default value" all_years
+//     which means that 'all+years' lands in this "catchall" despite not being explicitly converted
 // - region value was the name, is now the 2-char code (for non-continents)
+// --> handled in sanitizer below that checks for ID or ISO or name for backwards compatibility
 
 const DISPLAY_MODE = 'display';
 const TIME_ORDER = 'state';

--- a/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -1,19 +1,11 @@
 import { DateTime } from 'luxon';
 import {
-  events, continents, countries,
+  events, continents, countries, nonFutureCompetitionYears,
 } from '../../lib/wca-data.js.erb';
 
 // constants
 
 const WCA_EVENT_IDS = Object.keys(events.byId);
-
-const YEARS_WITH_PAST_COMPETITIONS = [];
-for (let { year } = DateTime.now(); year >= 2003; year -= 1) {
-  YEARS_WITH_PAST_COMPETITIONS.push(year);
-}
-YEARS_WITH_PAST_COMPETITIONS.push(1982);
-
-export { YEARS_WITH_PAST_COMPETITIONS };
 
 // note: inconsistencies with previous search params
 // - year value was 'all+years', is now 'all_years'
@@ -61,7 +53,7 @@ const sanitizeTimeOrder = (order) => {
 };
 
 const sanitizeYear = (year) => {
-  if (YEARS_WITH_PAST_COMPETITIONS.includes(Number(year))) {
+  if (nonFutureCompetitionYears.includes(Number(year))) {
     return Number(year);
   }
   return DEFAULT_YEAR;

--- a/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -18,7 +18,6 @@ export { YEARS_WITH_PAST_COMPETITIONS };
 // note: inconsistencies with previous search params
 // - year value was 'all+years', is now 'all_years'
 // - region value was the name, is now the 2-char code (for non-continents)
-// - delegate value was user id, is now the WCA ID
 
 const DISPLAY_MODE = 'display';
 const TIME_ORDER = 'state';

--- a/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -101,7 +101,7 @@ export const createFilterState = (searchParams) => ({
   customStartDate: sanitizeDate(searchParams.get(START_DATE)),
   customEndDate: sanitizeDate(searchParams.get(END_DATE)),
   region: sanitizeRegion(searchParams.get(REGION)),
-  delegate: searchParams.get(DELEGATE) || DEFAULT_DELEGATE,
+  delegate: Number(searchParams.get(DELEGATE)) || DEFAULT_DELEGATE,
   search: searchParams.get(SEARCH) || DEFAULT_SEARCH,
   selectedEvents:
     sanitizeEvents(searchParams.getAll(SELECTED_EVENTS)),

--- a/app/webpacker/components/CompetitionsOverview/filterUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/filterUtils.js
@@ -3,6 +3,14 @@ import {
 } from '../../lib/wca-data.js.erb';
 import { DateTime } from 'luxon';
 
+const YEARS_WITH_PAST_COMPETITIONS = [];
+for (let { year } = DateTime.now(); year >= 2003; year -= 1) {
+  YEARS_WITH_PAST_COMPETITIONS.push(year);
+}
+YEARS_WITH_PAST_COMPETITIONS.push(1982);
+
+export { YEARS_WITH_PAST_COMPETITIONS };
+
 // note: inconsistencies with previous search params
 // - year value was 'all+years', is now 'all_years'
 // - region value was the name, is now the 2-char code (for non-continents)
@@ -149,10 +157,10 @@ const sanitizeTimeOrder = (order) => {
 };
 
 const  sanitizeYear = (year) => {
-  if (Number.isNaN(Number(year)) || Number(year) === 0) {
-    return DEFAULT_YEAR;
-  } else {
+  if (YEARS_WITH_PAST_COMPETITIONS.includes(Number(year))) {
     return Number(year);
+  } else {
+    return DEFAULT_YEAR;
   }
 };
 

--- a/app/webpacker/lib/wca-data.js.erb
+++ b/app/webpacker/lib/wca-data.js.erb
@@ -142,6 +142,8 @@ export const competitionConstants = {
   competitionRecentDays: <%= Competition::RECENT_DAYS %>,
 };
 
+export const nonFutureCompetitionYears = <%= Competition.non_future_years.to_json %>
+
 // ----- RAILS ENV -----
 
 export const railsEnv = '<%= Rails.env %>';


### PR DESCRIPTION
- Country/continent is now backward compatible.
- The date-picker won't crash when you manually insert an invalid date as a search param.
- Delegate param isn't touched, since it needs to be switched back to user ID (plus sanitizing it depends on first fetching the delegates data).
- Events are sanitized, but still don't have backward compatibility. @gregorbg said he could help with this (in a separate PR?).
- Search and shouldIncludeCancelled don't need sanitizing (right?).

Bonus: `PAST_YEARS_WITH_COMPETITIONS` includes the current year, so I renamed it.