### PR TITLE
Add board roles to db/seeds

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -108,6 +108,9 @@ class UserRole < ApplicationRecord
   }.freeze
 
   def serializable_hash(options = nil)
+    puts("User ID: #{self.user_id}")
+    puts("User Object: #{User.find_by(id: self.user_id)}")
+    puts("User ID from user object#{user&.id}")
     json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
     json[:class] = self.class.to_s.downcase
     json

--- a/db/seeds/user_roles.seeds.rb
+++ b/db/seeds/user_roles.seeds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+after :user_groups do
+  UserRole.create!(
+    user: FactoryBot.create(:user_with_wca_id),
+    group: UserGroup.find_by!(group_type: :board),
+    start_date: Faker::Date.between(from: 10.years.ago, to: 5.years.ago),
+  )
+end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -215,7 +215,12 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
 
     context 'signed in as board member' do
       before :each do
-        api_sign_in_as(FactoryBot.create(:user, :board_member))
+        board_user = UserGroup.board_group.active_roles.sample.user
+        puts("Some debug logs are below:")
+        puts("Role json: #{UserGroup.board_group.active_roles[0].to_json}")
+        puts("Board user ID: #{board_user&.id}")
+        puts("Board user name: #{board_user&.name}")
+        api_sign_in_as(board_user)
       end
 
       it 'has correct team membership' do

--- a/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe SyncMailingListsJob, type: :job do
     translator_3 = FactoryBot.create :translator_role, group_id: translators_group.id
 
     # leaders@ mailing list
-    board_member = FactoryBot.create :user, :board_member
     wct_member = FactoryBot.create :user, :wct_member
     wct_china_member = FactoryBot.create :user, :wct_china_member
     wcat_member = FactoryBot.create :user, :wcat_member
@@ -93,7 +92,7 @@ RSpec.describe SyncMailingListsJob, type: :job do
     # board@ mailing list
     expect(GsuiteMailingLists).to receive(:sync_group).with(
       "board@worldcubeassociation.org",
-      a_collection_containing_exactly(board_member.email),
+      a_collection_containing_exactly(*UserGroup.board_group.active_users.map(&:email)),
     )
 
     # communication-china@ mailing list

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+DEFAULT_PASSWORD = 'wca'
+
 module SessionHelper
   def sign_in(user)
     visit "/users/sign_in"
     fill_in "Email or WCA ID", with: user.email
-    fill_in "Password", with: user.password
+    fill_in "Password", with: DEFAULT_PASSWORD # Maybe later change to user.password || DEFAULT_PASSWORD.
     click_button "Sign in"
   end
 end

--- a/spec/support/test_db_manager.rb
+++ b/spec/support/test_db_manager.rb
@@ -12,6 +12,7 @@ class TestDbManager
     RoundTypes
     teams
     user_groups
+    user_roles
     groups_metadata_delegate_regions
     groups_metadata_board
     groups_metadata_councils


### PR DESCRIPTION
This PR is kind of like subset of https://github.com/thewca/worldcubeassociation.org/pull/9187. This PR aims in debugging the issue of sign_in during unit tests with roles from db/seeds. One example is `bin/rspec spec/features/eligible_voters_spec.rb`.