### PR TITLE
Venue coordinate/map fixes

### DIFF
--- a/app/webpacker/components/EditSchedule/EditVenues/VenueLocationMap.js
+++ b/app/webpacker/components/EditSchedule/EditVenues/VenueLocationMap.js
@@ -82,12 +82,12 @@ function VenueLocationMap({
     return null;
   }, [searchResultPopup]);
 
-  const mapPosition = useMemo(() => ({
+  const venuePosition = useMemo(() => ({
     lat: toDegrees(venue.latitudeMicrodegrees),
     lng: toDegrees(venue.longitudeMicrodegrees),
   }), [venue.latitudeMicrodegrees, venue.longitudeMicrodegrees]);
 
-  const setMapPosition = useCallback((evt, { lat, lng }) => {
+  const setVenuePosition = useCallback((evt, { lat, lng }) => {
     dispatch(editVenue(venue.id, 'latitudeMicrodegrees', toMicrodegrees(lat)));
     dispatch(editVenue(venue.id, 'longitudeMicrodegrees', toMicrodegrees(lng)));
   }, [dispatch, venue.id]);
@@ -95,17 +95,18 @@ function VenueLocationMap({
   const provider = userTileProvider;
 
   const onGeoSearchResult = useCallback((evt) => {
-    setMapPosition(evt, {
+    setVenuePosition(evt, {
       lat: evt.location.y,
       lng: evt.location.x,
     });
 
     setSearchResultPopup(evt.location.label);
-  }, [setMapPosition, setSearchResultPopup]);
+  }, [setVenuePosition, setSearchResultPopup]);
 
   return (
     <MapContainer
-      center={mapPosition}
+      // note: `center` only applies to initial render
+      center={venuePosition}
       zoom={16}
       scrollWheelZoom={false}
       style={{ height: '100%' }}
@@ -113,7 +114,11 @@ function VenueLocationMap({
       <ResizeMapIFrame />
       <TileLayer url={provider.url} attribution={provider.attribution} />
       <GeoSearchControl onGeoSearchResult={onGeoSearchResult} />
-      <DraggableMarker markerRef={markerRef} position={mapPosition} setPosition={setMapPosition}>
+      <DraggableMarker
+        markerRef={markerRef}
+        position={venuePosition}
+        setPosition={setVenuePosition}
+      >
         {markerPopup}
       </DraggableMarker>
     </MapContainer>

--- a/app/webpacker/components/EditSchedule/EditVenues/VenueLocationMap.js
+++ b/app/webpacker/components/EditSchedule/EditVenues/VenueLocationMap.js
@@ -44,7 +44,13 @@ export function DraggableMarker({
   markerRef = null,
   children,
 }) {
+  const map = useMap();
+
   const updatePosition = useCallback((e) => setPosition(e, e.target.getLatLng()), [setPosition]);
+
+  useEffect(() => {
+    map.panTo(position);
+  }, [map, position]);
 
   return (
     <Marker

--- a/app/webpacker/components/EditSchedule/EditVenues/VenuePanel.js
+++ b/app/webpacker/components/EditSchedule/EditVenues/VenuePanel.js
@@ -36,9 +36,7 @@ function VenuePanel({
   const confirm = useConfirm();
 
   const handleCoordinateChange = (evt, { name, value }) => {
-    dispatch(
-      editVenue(venue.id, name, Number.isNaN(toMicrodegrees(value)) ? 0 : toMicrodegrees(value)),
-    );
+    dispatch(editVenue(venue.id, name, toMicrodegrees(value)));
   };
 
   const handleVenueChange = (evt, { name, value }) => {

--- a/app/webpacker/components/EditSchedule/EditVenues/VenuePanel.js
+++ b/app/webpacker/components/EditSchedule/EditVenues/VenuePanel.js
@@ -36,7 +36,9 @@ function VenuePanel({
   const confirm = useConfirm();
 
   const handleCoordinateChange = (evt, { name, value }) => {
-    dispatch(editVenue(venue.id, name, toMicrodegrees(value)));
+    dispatch(
+      editVenue(venue.id, name, Number.isNaN(toMicrodegrees(value)) ? 0 : toMicrodegrees(value)),
+    );
   };
 
   const handleVenueChange = (evt, { name, value }) => {

--- a/app/webpacker/lib/utils/edit-schedule.js
+++ b/app/webpacker/lib/utils/edit-schedule.js
@@ -4,11 +4,19 @@ import { toLuxonDateTime } from '@fullcalendar/luxon3';
 import { parseActivityCode } from './wcif';
 
 export function toMicrodegrees(coord) {
-  return Math.trunc(parseFloat(coord) * 1e6);
+  const result = Math.trunc(parseFloat(coord) * 1e6);
+  if (Number.isNaN(result)) {
+    return 0;
+  }
+  return result;
 }
 
 export function toDegrees(coord) {
-  return coord / 1e6;
+  const result = coord / 1e6;
+  if (Number.isNaN(result)) {
+    return 0;
+  }
+  return result;
 }
 
 function withNestedActivities(activities) {


### PR DESCRIPTION
- Prevent crash when deleting all characters from a coordinate.
- Auto-center the map on the venue marker whenever it moves.
- Rename some constants which briefly slightly confused me.

For some reason, the map geo search doesn't work when I run locally, so I can't check that searching for a location and selecting it still works as expected. But dragging the marker, or directly updating the coordinates, both work as expected for me.

There's still the problem where you can't really type a coordinate from scratch because decimals and extra 0s disappear as soon as you type them. But pasting in a coordinate, or back-filling decimals, negatives, and zeros can also work. I don't have a clean solution yet so I'll save that for a later PR.