### PR TITLE
Ignore CAD data during dev dump

### DIFF
--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -150,40 +150,8 @@ module DatabaseDumper
         },
       ),
     }.freeze,
-    "ConciseAverageResults" => {
-      where_clause: "",
-      column_sanitizers: actions_to_column_sanitizers(
-        copy: %w(
-          average
-          continentId
-          countryId
-          day
-          eventId
-          id
-          month
-          personId
-          valueAndId
-          year
-        ),
-      ),
-    }.freeze,
-    "ConciseSingleResults" => {
-      where_clause: "",
-      column_sanitizers: actions_to_column_sanitizers(
-        copy: %w(
-          best
-          continentId
-          countryId
-          day
-          eventId
-          id
-          month
-          personId
-          valueAndId
-          year
-        ),
-      ),
-    }.freeze,
+    "ConciseAverageResults" => :skip_all_rows,
+    "ConciseSingleResults" => :skip_all_rows,
     "connected_paypal_accounts" => {
       where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
@@ -287,34 +255,8 @@ module DatabaseDumper
         },
       ),
     }.freeze,
-    "RanksAverage" => {
-      where_clause: "",
-      column_sanitizers: actions_to_column_sanitizers(
-        copy: %w(
-          id
-          best
-          continentRank
-          countryRank
-          eventId
-          personId
-          worldRank
-        ),
-      ),
-    }.freeze,
-    "RanksSingle" => {
-      where_clause: "",
-      column_sanitizers: actions_to_column_sanitizers(
-        copy: %w(
-          id
-          best
-          continentRank
-          countryRank
-          eventId
-          personId
-          worldRank
-        ),
-      ),
-    }.freeze,
+    "RanksAverage" => :skip_all_rows,
+    "RanksSingle" => :skip_all_rows,
     "Results" => {
       where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(


### PR DESCRIPTION
See title.

The database sanitizer rules for the CAD tables were dated February 2017, at which time we were still running lots of PHP. Now we even have a very simple (in terms of running/starting the thing) Ruby script which didn't exist back then, so I feel like we can remove these auxiliary tables and save filesize and import time.

**IMPLICATION**: Developers who are working on Ranking Tables or the Persons page will need to run CAD on their machines individually. Where should we document this?

Sindenote: This does **not** impact the "Results Dump". That one uses separate sanitizers where the table data is maintained.