### PR TITLE
Add V2 Registration Administration Frontend

### DIFF
--- a/app/assets/javascripts/registrations.js
+++ b/app/assets/javascripts/registrations.js
@@ -1,78 +1,80 @@
-onPage('registrations#edit_registrations', function() {
-  var $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
+onPage('registrations#edit_registrations', () => {
+  const $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
+  if (!$registrationsTable) {
+    return null;
+  }
 
-  var showHideActions = function(e) {
-    var $selectedRows = $registrationsTable.find("tr.selected");
+  const showHideActions = function (e) {
+    const $selectedRows = $registrationsTable.find('tr.selected');
     $('.selected-registrations-actions').toggle($selectedRows.length > 0);
 
-    var $selectedPendingDeletedRows = $selectedRows.filter(".registration-pending, .registration-deleted");
+    const $selectedPendingDeletedRows = $selectedRows.filter('.registration-pending, .registration-deleted');
     $('.selected-pending-deleted-registrations-actions').toggle($selectedPendingDeletedRows.length > 0);
 
-    var $selectedApprovedDeletedRows = $selectedRows.filter(".registration-accepted, .registration-deleted");
+    const $selectedApprovedDeletedRows = $selectedRows.filter('.registration-accepted, .registration-deleted');
     $('.selected-approved-deleted-registrations-actions').toggle($selectedApprovedDeletedRows.length > 0);
 
-    var $selectedPendingApprovedRows = $selectedRows.filter(".registration-pending, .registration-accepted");
+    const $selectedPendingApprovedRows = $selectedRows.filter('.registration-pending, .registration-accepted');
     $('.selected-pending-approved-registrations-actions').toggle($selectedPendingApprovedRows.length > 0);
 
-    var emails = $selectedRows.find("a[href^=mailto]").map(function() { return this.href.match(/^mailto:(.*)/)[1]; }).toArray();
-    document.getElementById("email-selected").href = "mailto:?bcc=" + emails.join(",");
+    const emails = $selectedRows.find('a[href^=mailto]').map(function () { return this.href.match(/^mailto:(.*)/)[1]; }).toArray();
+    document.getElementById('email-selected').href = `mailto:?bcc=${emails.join(',')}`;
   };
-  $registrationsTable.on('check.bs.table uncheck.bs.table check-all.bs.table uncheck-all.bs.table', function() {
+  $registrationsTable.on('check.bs.table uncheck.bs.table check-all.bs.table uncheck-all.bs.table', () => {
     // Wait in order to let bootstrap-table script add a 'selected' class to the appropriate rows
     setTimeout(showHideActions, 0);
   });
   showHideActions();
 
-  $('button[value=delete-selected]').on("click", function(e) {
-    var $selectedRows = $registrationsTable.find("tr.selected");
-    if(!confirm("Delete the " + $selectedRows.length + " selected registrations?")) {
+  $('button[value=delete-selected]').on('click', (e) => {
+    const $selectedRows = $registrationsTable.find('tr.selected');
+    if (!confirm(`Delete the ${$selectedRows.length} selected registrations?`)) {
       e.preventDefault();
     }
   });
 });
 
-onPage('registrations#index', function() {
+onPage('registrations#index', () => {
   // To improve performance we do the first sorting by name server-side.
   // This makes the interface resemble the order.
   $('.name .sortable').addClass('asc');
 });
 
 function comparePaymentDate(a, b) {
-  var elemA = $(a);
-  var elemB = $(b);
-  var paidA = elemA.data("paidDate");
-  var paidB = elemB.data("paidDate");
-  if (paidA !== "" && paidB !== "") {
+  const elemA = $(a);
+  const elemB = $(b);
+  const paidA = elemA.data('paidDate');
+  const paidB = elemB.data('paidDate');
+  if (paidA !== '' && paidB !== '') {
     // Both have paid, compare their last payment dates
     return paidA.localeCompare(paidB);
-  } else if (paidA === "" && paidB === "") {
+  } if (paidA === '' && paidB === '') {
     // None have paid, compare their registration dates
-    return elemA.data("registeredAt").localeCompare(elemB.data("registeredAt"));
-  } else {
-    return paidA === "" ? 1 : -1;
+    return elemA.data('registeredAt').localeCompare(elemB.data('registeredAt'));
   }
+  return paidA === '' ? 1 : -1;
 }
 
 function compareHtmlContent(a, b) {
-  var first = $('<p>' + a + '</p>').text().trim();
-  var second = $('<p>' + b + '</p>').text().trim();
+  const first = $(`<p>${a}</p>`).text().trim();
+  const second = $(`<p>${b}</p>`).text().trim();
   return first.localeCompare(second);
 }
 
-onPage('registrations#add, registrations#do_add', function() {
+onPage('registrations#add, registrations#do_add', () => {
   // Bind all/clear cubing event buttons
-  $('#clear-all-events').on('click', function() {
+  $('#clear-all-events').on('click', () => {
     $('#events input[type="checkbox"]').prop('checked', false);
   });
-  $('#select-all-events').on('click', function() {
+  $('#select-all-events').on('click', () => {
     $('#events input[type="checkbox"]').prop('checked', true);
   });
 });
 
-onPage('registrations#create, registrations#register', function() {
+onPage('registrations#create, registrations#register', () => {
   // Hide the hint when the user selects an event
   // or selects all events
-  $('.associated-events input[type="checkbox"], .select-all-events').click(function() {
+  $('.associated-events input[type="checkbox"], .select-all-events').click(() => {
     // opacity:0 rather than display:none to avoid DOM shifting
     $('.associated-events .select-hint').css('visibility', 'hidden');
   });

--- a/app/assets/javascripts/registrations.js
+++ b/app/assets/javascripts/registrations.js
@@ -1,80 +1,82 @@
-onPage('registrations#edit_registrations', () => {
-  const $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
+onPage('registrations#edit_registrations', function() {
+  var $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
+
   if ($registrationsTable.empty()) {
-    return null;
+    return;
   }
 
-  const showHideActions = function (e) {
-    const $selectedRows = $registrationsTable.find('tr.selected');
+  var showHideActions = function(e) {
+    var $selectedRows = $registrationsTable.find("tr.selected");
     $('.selected-registrations-actions').toggle($selectedRows.length > 0);
 
-    const $selectedPendingDeletedRows = $selectedRows.filter('.registration-pending, .registration-deleted');
+    var $selectedPendingDeletedRows = $selectedRows.filter(".registration-pending, .registration-deleted");
     $('.selected-pending-deleted-registrations-actions').toggle($selectedPendingDeletedRows.length > 0);
 
-    const $selectedApprovedDeletedRows = $selectedRows.filter('.registration-accepted, .registration-deleted');
+    var $selectedApprovedDeletedRows = $selectedRows.filter(".registration-accepted, .registration-deleted");
     $('.selected-approved-deleted-registrations-actions').toggle($selectedApprovedDeletedRows.length > 0);
 
-    const $selectedPendingApprovedRows = $selectedRows.filter('.registration-pending, .registration-accepted');
+    var $selectedPendingApprovedRows = $selectedRows.filter(".registration-pending, .registration-accepted");
     $('.selected-pending-approved-registrations-actions').toggle($selectedPendingApprovedRows.length > 0);
 
-    const emails = $selectedRows.find('a[href^=mailto]').map(function () { return this.href.match(/^mailto:(.*)/)[1]; }).toArray();
-    document.getElementById('email-selected').href = `mailto:?bcc=${emails.join(',')}`;
+    var emails = $selectedRows.find("a[href^=mailto]").map(function() { return this.href.match(/^mailto:(.*)/)[1]; }).toArray();
+    document.getElementById("email-selected").href = "mailto:?bcc=" + emails.join(",");
   };
-  $registrationsTable.on('check.bs.table uncheck.bs.table check-all.bs.table uncheck-all.bs.table', () => {
+  $registrationsTable.on('check.bs.table uncheck.bs.table check-all.bs.table uncheck-all.bs.table', function() {
     // Wait in order to let bootstrap-table script add a 'selected' class to the appropriate rows
     setTimeout(showHideActions, 0);
   });
   showHideActions();
 
-  $('button[value=delete-selected]').on('click', (e) => {
-    const $selectedRows = $registrationsTable.find('tr.selected');
-    if (!confirm(`Delete the ${$selectedRows.length} selected registrations?`)) {
+  $('button[value=delete-selected]').on("click", function(e) {
+    var $selectedRows = $registrationsTable.find("tr.selected");
+    if(!confirm("Delete the " + $selectedRows.length + " selected registrations?")) {
       e.preventDefault();
     }
   });
 });
 
-onPage('registrations#index', () => {
+onPage('registrations#index', function() {
   // To improve performance we do the first sorting by name server-side.
   // This makes the interface resemble the order.
   $('.name .sortable').addClass('asc');
 });
 
 function comparePaymentDate(a, b) {
-  const elemA = $(a);
-  const elemB = $(b);
-  const paidA = elemA.data('paidDate');
-  const paidB = elemB.data('paidDate');
-  if (paidA !== '' && paidB !== '') {
+  var elemA = $(a);
+  var elemB = $(b);
+  var paidA = elemA.data("paidDate");
+  var paidB = elemB.data("paidDate");
+  if (paidA !== "" && paidB !== "") {
     // Both have paid, compare their last payment dates
     return paidA.localeCompare(paidB);
-  } if (paidA === '' && paidB === '') {
+  } else if (paidA === "" && paidB === "") {
     // None have paid, compare their registration dates
-    return elemA.data('registeredAt').localeCompare(elemB.data('registeredAt'));
+    return elemA.data("registeredAt").localeCompare(elemB.data("registeredAt"));
+  } else {
+    return paidA === "" ? 1 : -1;
   }
-  return paidA === '' ? 1 : -1;
 }
 
 function compareHtmlContent(a, b) {
-  const first = $(`<p>${a}</p>`).text().trim();
-  const second = $(`<p>${b}</p>`).text().trim();
+  var first = $('<p>' + a + '</p>').text().trim();
+  var second = $('<p>' + b + '</p>').text().trim();
   return first.localeCompare(second);
 }
 
-onPage('registrations#add, registrations#do_add', () => {
+onPage('registrations#add, registrations#do_add', function() {
   // Bind all/clear cubing event buttons
-  $('#clear-all-events').on('click', () => {
+  $('#clear-all-events').on('click', function() {
     $('#events input[type="checkbox"]').prop('checked', false);
   });
-  $('#select-all-events').on('click', () => {
+  $('#select-all-events').on('click', function() {
     $('#events input[type="checkbox"]').prop('checked', true);
   });
 });
 
-onPage('registrations#create, registrations#register', () => {
+onPage('registrations#create, registrations#register', function() {
   // Hide the hint when the user selects an event
   // or selects all events
-  $('.associated-events input[type="checkbox"], .select-all-events').click(() => {
+  $('.associated-events input[type="checkbox"], .select-all-events').click(function() {
     // opacity:0 rather than display:none to avoid DOM shifting
     $('.associated-events .select-hint').css('visibility', 'hidden');
   });

--- a/app/assets/javascripts/registrations.js
+++ b/app/assets/javascripts/registrations.js
@@ -1,6 +1,6 @@
 onPage('registrations#edit_registrations', () => {
   const $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
-  if (!$registrationsTable) {
+  if ($registrationsTable.empty()) {
     return null;
   }
 

--- a/app/assets/javascripts/registrations.js
+++ b/app/assets/javascripts/registrations.js
@@ -1,7 +1,8 @@
 onPage('registrations#edit_registrations', function() {
   var $registrationsTable = $('table.registrations-table:not(.floatThead-table)');
 
-  if ($registrationsTable.empty()) {
+  // return early if the new registration V2 React frontend is used
+  if ($registrationsTable.length === 0) {
     return;
   }
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -77,6 +77,11 @@ class RegistrationsController < ApplicationController
     @competition = @registration.competition
   end
 
+  def edit_v2
+    @competition = Competition.find(params[:comp_id])
+    @user = User.find(params[:user_id])
+  end
+
   def destroy
     @competition = competition_from_params
     @registration = Registration.find(params[:id])

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -78,7 +78,7 @@ class RegistrationsController < ApplicationController
   end
 
   def edit_v2
-    @competition = Competition.find(params[:comp_id])
+    @competition = Competition.find(params[:competition_id])
     @user = User.find(params[:user_id])
   end
 

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -2,104 +2,98 @@
 <% add_to_packs("auto_numeric") %>
 
 <%= render layout: 'nav' do %>
-  <% if @competition.uses_new_registration_service? %>
-    <%= react_component('RegistrationsV2/RegistrationEdit', { competitionInfo: @competition.to_competition_info ,
-                                                                  userId: @registration.id,
-    }) %>
-  <% else %>
-    <%= horizontal_simple_form_for @registration, html: { class: 'are-you-sure' } do |f| %>
-      <%= hidden_field_tag :from_admin_view, "1" %>
-      <%= f.hidden_field :updated_at %>
+  <%= horizontal_simple_form_for @registration, html: { class: 'are-you-sure' } do |f| %>
+    <%= hidden_field_tag :from_admin_view, "1" %>
+    <%= f.hidden_field :updated_at %>
 
-      <% if current_user&.can_edit_user?(@registration.user) %>
-        <%= alert :info do %>
-          <%= t('registrations.registered_with_account_html', here: link_to(t('common.here'), edit_user_path(@registration.user))) %>
-        <% end %>
+    <% if current_user&.can_edit_user?(@registration.user) %>
+      <%= alert :info do %>
+        <%= t('registrations.registered_with_account_html', here: link_to(t('common.here'), edit_user_path(@registration.user))) %>
       <% end %>
-      <h4><%= @registration.name %></h4>
-
-      <%= render "shared/associated_events_picker",
-                 form_builder: f,
-                 events_association_name: :registration_competition_events,
-                 allowed_events: @competition.events,
-                 disabled_events: @competition.ineligible_events(@registration.user),
-                 disabled_tooltip: t('registrations.not_qualified'),
-                 selected_events: @registration.saved_and_unsaved_events
-      %>
-
-      <% if @competition.guests_enabled? %>
-        <%= f.input :guests %>
-      <% end %>
-
-      <%= f.input :comments %>
-
-      <%= f.input :administrative_notes %>
-
-      <%= f.input :status, as: :radio_buttons, collection: [:accepted, :pending, :deleted], checked: @registration.checked_status, include_blank: false %>
-
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <%= f.submit t('registrations.update'), class: "btn btn-primary" %>
-        </div>
-      </div>
     <% end %>
-    <% if @registration.registration_payments.count > 0 %>
-      <hr/>
-      <div>
-        <h4>Payment History</h4>
-        <% @registration.registration_payments.each do |payment| %>
-          <p>
-            <b><%= wca_local_time(payment.created_at) %></b>
-            <br />
-            Amount: <%= format_money payment.amount %>
-            <br />
-            Made by: <%= name_for_payment(payment) %>
-            <%#
+    <h4><%= @registration.name %></h4>
+
+    <%= render "shared/associated_events_picker",
+               form_builder: f,
+               events_association_name: :registration_competition_events,
+               allowed_events: @competition.events,
+               disabled_events: @competition.ineligible_events(@registration.user),
+               disabled_tooltip: t('registrations.not_qualified'),
+               selected_events: @registration.saved_and_unsaved_events
+    %>
+
+    <% if @competition.guests_enabled? %>
+      <%= f.input :guests %>
+    <% end %>
+
+    <%= f.input :comments %>
+
+    <%= f.input :administrative_notes %>
+
+    <%= f.input :status, as: :radio_buttons, collection: [:accepted, :pending, :deleted], checked: @registration.checked_status, include_blank: false %>
+
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10">
+        <%= f.submit t('registrations.update'), class: "btn btn-primary" %>
+      </div>
+    </div>
+  <% end %>
+  <% if @registration.registration_payments.count > 0 %>
+    <hr/>
+    <div>
+      <h4>Payment History</h4>
+      <% @registration.registration_payments.each do |payment| %>
+        <p>
+          <b><%= wca_local_time(payment.created_at) %></b>
+          <br />
+          Amount: <%= format_money payment.amount %>
+          <br />
+          Made by: <%= name_for_payment(payment) %>
+          <%#
           NOTE: the connected Stripe account id is cleared roughly 3 weeks
           after the competition, therefore we need to check for that before
           offering the refund payment button.
           %>
-            <% if @competition.using_payment_integrations? && payment.amount_available_for_refund > 0 %>
-              <% if @competition.stripe_connected? %>
-                <% refund_url = registration_payment_refund_path(@registration, payment) %>
-              <% else %>
-                <% refund_url = paypal_payment_refund_path(@registration, payment) %>
-              <% end %>
-              <%= horizontal_simple_form_for :payment, url: refund_url, html: { id: :form_refund } do |f| %>
-                <%= f.input :refund_amount, as: :money_amount, currency: payment.amount.currency.iso_code, value: payment.amount_available_for_refund, label: t('registrations.refund_form.labels.refund_amount'), hint: t('registrations.refund_form.hints.refund_amount') %>
-                <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>
-              <% end %>
+          <% if @competition.using_payment_integrations? && payment.amount_available_for_refund > 0 %>
+            <% if @competition.stripe_connected? %>
+              <% refund_url = registration_payment_refund_path(@registration, payment) %>
+            <% else %>
+              <% refund_url = paypal_payment_refund_path(@registration, payment) %>
             <% end %>
-          </p>
-        <% end %>
-      </div>
-    <% end %>
-    <% unless @registration.series_sibling_registrations.empty? %>
-      <hr/>
-      <div>
-        <h4>Series Registrations</h4>
-        <ul>
-          <% @registration.series_sibling_registrations.each do |reg| %>
-            <% registration_i18n_status = t("simple_form.options.registration.status.#{reg.checked_status}") %>
-            <li><%= link_to reg.competition.name, edit_registration_path(reg) %> (<%= registration_i18n_status %>)</li>
+            <%= horizontal_simple_form_for :payment, url: refund_url, html: { id: :form_refund } do |f| %>
+              <%= f.input :refund_amount, as: :money_amount, currency: payment.amount.currency.iso_code, value: payment.amount_available_for_refund, label: t('registrations.refund_form.labels.refund_amount'), hint: t('registrations.refund_form.hints.refund_amount') %>
+              <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>
+            <% end %>
           <% end %>
-        </ul>
-      </div>
-    <% end %>
-    <hr />
-    <div>
-      <h4>Registration History</h4>
-      Created on <%= wca_local_time(@registration.created_at) %> by <%= @registration.user.name %>
+        </p>
+      <% end %>
     </div>
-    <% if @registration.accepted_at %>
-      <div>
-        Accepted on <%= wca_local_time(@registration.accepted_at) %> by <%= @registration.accepted_user.name unless @registration.accepted_user.nil? %>
-      </div>
-    <% end %>
-    <% if @registration.deleted_at %>
-      <div>
-        Deleted on <%= wca_local_time(@registration.deleted_at) %> by <%= @registration.deleted_user.name %>
-      </div>
-    <% end %>
+  <% end %>
+  <% unless @registration.series_sibling_registrations.empty? %>
+    <hr/>
+    <div>
+      <h4>Series Registrations</h4>
+      <ul>
+        <% @registration.series_sibling_registrations.each do |reg| %>
+          <% registration_i18n_status = t("simple_form.options.registration.status.#{reg.checked_status}") %>
+          <li><%= link_to reg.competition.name, edit_registration_path(reg) %> (<%= registration_i18n_status %>)</li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <hr />
+  <div>
+    <h4>Registration History</h4>
+    Created on <%= wca_local_time(@registration.created_at) %> by <%= @registration.user.name %>
+  </div>
+  <% if @registration.accepted_at %>
+    <div>
+      Accepted on <%= wca_local_time(@registration.accepted_at) %> by <%= @registration.accepted_user.name unless @registration.accepted_user.nil? %>
+    </div>
+  <% end %>
+  <% if @registration.deleted_at %>
+    <div>
+      Deleted on <%= wca_local_time(@registration.deleted_at) %> by <%= @registration.deleted_user.name %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -2,98 +2,104 @@
 <% add_to_packs("auto_numeric") %>
 
 <%= render layout: 'nav' do %>
-  <%= horizontal_simple_form_for @registration, html: { class: 'are-you-sure' } do |f| %>
-    <%= hidden_field_tag :from_admin_view, "1" %>
-    <%= f.hidden_field :updated_at %>
+  <% if @competition.uses_new_registration_service? %>
+    <%= react_component('RegistrationsV2/RegistrationEdit', { competitionInfo: @competition.to_competition_info ,
+                                                                  userId: @registration.id,
+    }) %>
+  <% else %>
+    <%= horizontal_simple_form_for @registration, html: { class: 'are-you-sure' } do |f| %>
+      <%= hidden_field_tag :from_admin_view, "1" %>
+      <%= f.hidden_field :updated_at %>
 
-    <% if current_user&.can_edit_user?(@registration.user) %>
-      <%= alert :info do %>
-        <%= t('registrations.registered_with_account_html', here: link_to(t('common.here'), edit_user_path(@registration.user))) %>
+      <% if current_user&.can_edit_user?(@registration.user) %>
+        <%= alert :info do %>
+          <%= t('registrations.registered_with_account_html', here: link_to(t('common.here'), edit_user_path(@registration.user))) %>
+        <% end %>
       <% end %>
-    <% end %>
-    <h4><%= @registration.name %></h4>
+      <h4><%= @registration.name %></h4>
 
-    <%= render "shared/associated_events_picker",
-               form_builder: f,
-               events_association_name: :registration_competition_events,
-               allowed_events: @competition.events,
-               disabled_events: @competition.ineligible_events(@registration.user),
-               disabled_tooltip: t('registrations.not_qualified'),
-               selected_events: @registration.saved_and_unsaved_events
-    %>
+      <%= render "shared/associated_events_picker",
+                 form_builder: f,
+                 events_association_name: :registration_competition_events,
+                 allowed_events: @competition.events,
+                 disabled_events: @competition.ineligible_events(@registration.user),
+                 disabled_tooltip: t('registrations.not_qualified'),
+                 selected_events: @registration.saved_and_unsaved_events
+      %>
 
-    <% if @competition.guests_enabled? %>
-      <%= f.input :guests %>
-    <% end %>
+      <% if @competition.guests_enabled? %>
+        <%= f.input :guests %>
+      <% end %>
 
-    <%= f.input :comments %>
+      <%= f.input :comments %>
 
-    <%= f.input :administrative_notes %>
+      <%= f.input :administrative_notes %>
 
-    <%= f.input :status, as: :radio_buttons, collection: [:accepted, :pending, :deleted], checked: @registration.checked_status, include_blank: false %>
+      <%= f.input :status, as: :radio_buttons, collection: [:accepted, :pending, :deleted], checked: @registration.checked_status, include_blank: false %>
 
-    <div class="form-group">
-      <div class="col-sm-offset-2 col-sm-10">
-        <%= f.submit t('registrations.update'), class: "btn btn-primary" %>
+      <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+          <%= f.submit t('registrations.update'), class: "btn btn-primary" %>
+        </div>
       </div>
-    </div>
-  <% end %>
-  <% if @registration.registration_payments.count > 0 %>
-    <hr/>
-    <div>
-      <h4>Payment History</h4>
-      <% @registration.registration_payments.each do |payment| %>
-        <p>
-          <b><%= wca_local_time(payment.created_at) %></b>
-          <br />
-          Amount: <%= format_money payment.amount %>
-          <br />
-          Made by: <%= name_for_payment(payment) %>
-          <%#
+    <% end %>
+    <% if @registration.registration_payments.count > 0 %>
+      <hr/>
+      <div>
+        <h4>Payment History</h4>
+        <% @registration.registration_payments.each do |payment| %>
+          <p>
+            <b><%= wca_local_time(payment.created_at) %></b>
+            <br />
+            Amount: <%= format_money payment.amount %>
+            <br />
+            Made by: <%= name_for_payment(payment) %>
+            <%#
           NOTE: the connected Stripe account id is cleared roughly 3 weeks
           after the competition, therefore we need to check for that before
           offering the refund payment button.
           %>
-          <% if @competition.using_payment_integrations? && payment.amount_available_for_refund > 0 %>
-            <% if @competition.stripe_connected? %>
-              <% refund_url = registration_payment_refund_path(@registration, payment) %>
-            <% else %>
-              <% refund_url = paypal_payment_refund_path(@registration, payment) %>
+            <% if @competition.using_payment_integrations? && payment.amount_available_for_refund > 0 %>
+              <% if @competition.stripe_connected? %>
+                <% refund_url = registration_payment_refund_path(@registration, payment) %>
+              <% else %>
+                <% refund_url = paypal_payment_refund_path(@registration, payment) %>
+              <% end %>
+              <%= horizontal_simple_form_for :payment, url: refund_url, html: { id: :form_refund } do |f| %>
+                <%= f.input :refund_amount, as: :money_amount, currency: payment.amount.currency.iso_code, value: payment.amount_available_for_refund, label: t('registrations.refund_form.labels.refund_amount'), hint: t('registrations.refund_form.hints.refund_amount') %>
+                <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>
+              <% end %>
             <% end %>
-            <%= horizontal_simple_form_for :payment, url: refund_url, html: { id: :form_refund } do |f| %>
-              <%= f.input :refund_amount, as: :money_amount, currency: payment.amount.currency.iso_code, value: payment.amount_available_for_refund, label: t('registrations.refund_form.labels.refund_amount'), hint: t('registrations.refund_form.hints.refund_amount') %>
-              <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>
-            <% end %>
-          <% end %>
-        </p>
-      <% end %>
-    </div>
-  <% end %>
-  <% unless @registration.series_sibling_registrations.empty? %>
-    <hr/>
-    <div>
-      <h4>Series Registrations</h4>
-      <ul>
-        <% @registration.series_sibling_registrations.each do |reg| %>
-          <% registration_i18n_status = t("simple_form.options.registration.status.#{reg.checked_status}") %>
-          <li><%= link_to reg.competition.name, edit_registration_path(reg) %> (<%= registration_i18n_status %>)</li>
+          </p>
         <% end %>
-      </ul>
-    </div>
-  <% end %>
-  <hr />
-  <div>
-    <h4>Registration History</h4>
-    Created on <%= wca_local_time(@registration.created_at) %> by <%= @registration.user.name %>
-  </div>
-  <% if @registration.accepted_at %>
+      </div>
+    <% end %>
+    <% unless @registration.series_sibling_registrations.empty? %>
+      <hr/>
+      <div>
+        <h4>Series Registrations</h4>
+        <ul>
+          <% @registration.series_sibling_registrations.each do |reg| %>
+            <% registration_i18n_status = t("simple_form.options.registration.status.#{reg.checked_status}") %>
+            <li><%= link_to reg.competition.name, edit_registration_path(reg) %> (<%= registration_i18n_status %>)</li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <hr />
     <div>
-      Accepted on <%= wca_local_time(@registration.accepted_at) %> by <%= @registration.accepted_user.name unless @registration.accepted_user.nil? %>
+      <h4>Registration History</h4>
+      Created on <%= wca_local_time(@registration.created_at) %> by <%= @registration.user.name %>
     </div>
-  <% end %>
-  <% if @registration.deleted_at %>
-    <div>
-      Deleted on <%= wca_local_time(@registration.deleted_at) %> by <%= @registration.deleted_user.name %>
-    </div>
+    <% if @registration.accepted_at %>
+      <div>
+        Accepted on <%= wca_local_time(@registration.accepted_at) %> by <%= @registration.accepted_user.name unless @registration.accepted_user.nil? %>
+      </div>
+    <% end %>
+    <% if @registration.deleted_at %>
+      <div>
+        Deleted on <%= wca_local_time(@registration.deleted_at) %> by <%= @registration.deleted_user.name %>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/registrations/edit_registrations.html.erb
+++ b/app/views/registrations/edit_registrations.html.erb
@@ -1,64 +1,67 @@
 <% provide(:title, I18n.t('registrations.list.title', comp: @competition.name)) %>
 
 <%= render layout: 'nav' do %>
-  <p>
-    <% if @show_events %>
-      <%= link_to competition_edit_registrations_path(@competition, show_events: "false", show_full_emails: @show_full_emails.to_s, show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
-        <%= ui_icon("minus") %> Hide Events
+  <% if @competition.uses_new_registration_service? %>
+    <%= react_component('RegistrationsV2/RegistrationAdministration', { competitionInfo: @competition.to_competition_info }) %>
+  <% else %>
+    <p>
+      <% if @show_events %>
+        <%= link_to competition_edit_registrations_path(@competition, show_events: "false", show_full_emails: @show_full_emails.to_s, show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
+          <%= ui_icon("minus") %> Hide Events
+        <% end %>
+      <% else %>
+        <%= link_to competition_edit_registrations_path(@competition, show_events: "true", show_full_emails: @show_full_emails.to_s, show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
+          <%= ui_icon("plus") %> Show Events
+        <% end %>
       <% end %>
-    <% else %>
-      <%= link_to competition_edit_registrations_path(@competition, show_events: "true", show_full_emails: @show_full_emails.to_s, show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
-        <%= ui_icon("plus") %> Show Events
-      <% end %>
-    <% end %>
 
-    <% if @show_full_emails %>
-      <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: "false", show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
-        <%= ui_icon("minus") %> Hide Emails
+      <% if @show_full_emails %>
+        <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: "false", show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
+          <%= ui_icon("minus") %> Hide Emails
+        <% end %>
+      <% else %>
+        <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: "true", show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
+          <%= ui_icon("plus") %> Show Emails
+        <% end %>
       <% end %>
-    <% else %>
-      <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: "true", show_birthdays: @show_birthdays.to_s), class: "btn btn-primary" do %>
-        <%= ui_icon("plus") %> Show Emails
-      <% end %>
-    <% end %>
 
-    <% if @show_birthdays %>
-      <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: @show_full_emails.to_s, show_birthdays: "false"), class: "btn btn-primary" do %>
-        <%= ui_icon("minus") %> Hide Birthdays
+      <% if @show_birthdays %>
+        <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: @show_full_emails.to_s, show_birthdays: "false"), class: "btn btn-primary" do %>
+          <%= ui_icon("minus") %> Hide Birthdays
+        <% end %>
+      <% else %>
+        <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: @show_full_emails.to_s, show_birthdays: "true"), class: "btn btn-primary" do %>
+          <%= ui_icon("plus") %> Show Birthdays
+        <% end %>
       <% end %>
-    <% else %>
-      <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: @show_full_emails.to_s, show_birthdays: "true"), class: "btn btn-primary" do %>
-        <%= ui_icon("plus") %> Show Birthdays
+
+      <% if @competition.part_of_competition_series? %>
+        <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: @show_full_emails.to_s, show_birthdays: @show_birthdays.to_s, run_validations: "true"), class: "btn btn-success" do %>
+          <%= ui_icon("refresh") %> Run validations
+        <% end %>
       <% end %>
-    <% end %>
+    </p>
 
     <% if @competition.part_of_competition_series? %>
-      <%= link_to competition_edit_registrations_path(@competition, show_events: @show_events.to_s, show_full_emails: @show_full_emails.to_s, show_birthdays: @show_birthdays.to_s, run_validations: "true"), class: "btn btn-success" do %>
-        <%= ui_icon("refresh") %> Run validations
-      <% end %>
+      <% format_description = Registration::SERIES_SIBLING_DISPLAY_STATUSES.map { |st| t("simple_form.options.registration.status.#{st}") }.join(" + ") %>
+      <p class="text-right"><%= t 'registrations.list.series_registrations_hint_html', description: format_description %></p>
     <% end %>
-  </p>
 
-  <% if @competition.part_of_competition_series? %>
-    <% format_description = Registration::SERIES_SIBLING_DISPLAY_STATUSES.map { |st| t("simple_form.options.registration.status.#{st}") }.join(" + ") %>
-    <p class="text-right"><%= t 'registrations.list.series_registrations_hint_html', description: format_description %></p>
-  <% end %>
-
-  <%= form_for @competition, url: competition_registrations_do_actions_for_selected_path(@competition), remote: true do |f| %>
-    <% [:pending, :accepted, :deleted, :non_competing].each do |status| %>
-      <% if :pending == status %>
-        <h2><%= t 'registrations.list.waiting_list' %></h2>
-      <% elsif :accepted == status %>
-        <h2><%= t 'registrations.list.approved_registrations' %></h2>
-      <% elsif :deleted == status %>
-        <h2><%= t 'registrations.list.deleted_registrations' %></h2>
-      <% else %>
-        <h2><%= t 'registrations.list.non_competing' %></h2>
-      <% end %>
-      <% registrations = @registrations.public_send(status) %>
-      <%= wca_table table_class: "registrations-table #{status}",
-                    data: { toggle: "table", sort_name: "registration-date", select_item_name: "selected_registrations[]", click_to_select: "true" } do %>
-        <thead>
+    <%= form_for @competition, url: competition_registrations_do_actions_for_selected_path(@competition), remote: true do |f| %>
+      <% [:pending, :accepted, :deleted, :non_competing].each do |status| %>
+        <% if :pending == status %>
+          <h2><%= t 'registrations.list.waiting_list' %></h2>
+        <% elsif :accepted == status %>
+          <h2><%= t 'registrations.list.approved_registrations' %></h2>
+        <% elsif :deleted == status %>
+          <h2><%= t 'registrations.list.deleted_registrations' %></h2>
+        <% else %>
+          <h2><%= t 'registrations.list.non_competing' %></h2>
+        <% end %>
+        <% registrations = @registrations.public_send(status) %>
+        <%= wca_table table_class: "registrations-table #{status}",
+                      data: { toggle: "table", sort_name: "registration-date", select_item_name: "selected_registrations[]", click_to_select: "true" } do %>
+          <thead>
           <tr>
             <th data-checkbox="true"></th>
             <th></th>
@@ -95,9 +98,9 @@
             <!-- Extra column for .table-greedy-last-column -->
             <th></th>
           </tr>
-        </thead>
+          </thead>
 
-        <tbody>
+          <tbody>
           <% registrations.each do |registration| %>
             <tr id="registration-<%= registration.id %>" class="registration-<%= registration.checked_status %>">
               <td></td>
@@ -110,13 +113,13 @@
                 <%= wca_id_link registration.wca_id %>
               </td>
 
-            <td class="name">
-              <%= registration.name %>
+              <td class="name">
+                <%= registration.name %>
 
-              <% if @run_validations && !registration.valid? %>
-                <%= ui_icon('exclamation triangle', data: { toggle: "tooltip", placement: "top" }, title: registration.errors.full_messages.join(" // ")) %>
-              <% end %>
-            </td>
+                <% if @run_validations && !registration.valid? %>
+                  <%= ui_icon('exclamation triangle', data: { toggle: "tooltip", placement: "top" }, title: registration.errors.full_messages.join(" // ")) %>
+                <% end %>
+              </td>
               <td class="countryId"><%= registration.country.name %></td>
               <% if @show_birthdays %>
                 <td class="birthday"><%= registration.birthday %></td>
@@ -163,44 +166,44 @@
                 </td>
               <% end %>
               <td>
-              <% if @show_full_emails %>
-                <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
-                  <%= registration.email %>
+                <% if @show_full_emails %>
+                  <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
+                    <%= registration.email %>
+                  <% end %>
+                <% else %>
+                  <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
+                    <%= ui_icon("envelope") %>
+                  <% end %>
                 <% end %>
-              <% else %>
-                <%= mail_to registration.email, target: "_blank", class: "hide-new-window-icon" do %>
-                  <%= ui_icon("envelope") %>
-                <% end %>
-              <% end %>
               </td>
 
               <!-- Extra column for .table-greedy-last-column -->
               <td></td>
             </tr>
           <% end %>
-        </tbody>
+          </tbody>
 
-        <%= render "edit_registrations_table_footer", registrations: registrations %>
+          <%= render "edit_registrations_table_footer", registrations: registrations %>
+        <% end %>
       <% end %>
+
+      <div id="registrations-actions" class="btn-group" role="group">
+        <button type="submit" class="btn btn-info selected-registrations-actions" name="registrations_action" value="export-selected">
+          <%= ui_icon 'download' %> <%= t('registrations.list.export_csv') %>
+        </button>
+        <a href="#" id="email-selected" target="_blank" class="btn btn-info selected-registrations-actions">
+          <%= ui_icon 'envelope' %> <%= t('registrations.list.email') %>
+        </a>
+        <button type="submit" class="btn btn-success selected-pending-deleted-registrations-actions" name="registrations_action" value="accept-selected">
+          <%= ui_icon 'check' %> <%= t('registrations.list.approve') %>
+        </button>
+        <button type="submit" class="btn btn-warning selected-approved-deleted-registrations-actions" name="registrations_action" value="reject-selected">
+          <%= ui_icon 'times' %> <%= t('registrations.list.reject') %>
+        </button>
+        <button type="submit" class="btn btn-danger selected-pending-approved-registrations-actions" name="registrations_action" value="delete-selected">
+          <%= ui_icon 'trash' %> <%= t('registrations.list.delete') %>
+        </button>
+      </div>
     <% end %>
-
-    <div id="registrations-actions" class="btn-group" role="group">
-      <button type="submit" class="btn btn-info selected-registrations-actions" name="registrations_action" value="export-selected">
-        <%= ui_icon 'download' %> <%= t('registrations.list.export_csv') %>
-      </button>
-      <a href="#" id="email-selected" target="_blank" class="btn btn-info selected-registrations-actions">
-        <%= ui_icon 'envelope' %> <%= t('registrations.list.email') %>
-      </a>
-      <button type="submit" class="btn btn-success selected-pending-deleted-registrations-actions" name="registrations_action" value="accept-selected">
-        <%= ui_icon 'check' %> <%= t('registrations.list.approve') %>
-      </button>
-      <button type="submit" class="btn btn-warning selected-approved-deleted-registrations-actions" name="registrations_action" value="reject-selected">
-        <%= ui_icon 'times' %> <%= t('registrations.list.reject') %>
-      </button>
-      <button type="submit" class="btn btn-danger selected-pending-approved-registrations-actions" name="registrations_action" value="delete-selected">
-        <%= ui_icon 'trash' %> <%= t('registrations.list.delete') %>
-      </button>
-    </div>
   <% end %>
-
 <% end %>

--- a/app/views/registrations/edit_v2.html.erb
+++ b/app/views/registrations/edit_v2.html.erb
@@ -1,6 +1,4 @@
 <% provide(:title, t('registrations.edit_registration.title', person: @user.person.name, comp: @competition.name)) %>
-<% add_to_packs("auto_numeric") %>
-
 <%= render layout: 'nav' do %>
   <%= react_component('RegistrationsV2/RegistrationEdit', { competitionInfo: @competition.to_competition_info ,
                                                             user: @user }) %>

--- a/app/views/registrations/edit_v2.html.erb
+++ b/app/views/registrations/edit_v2.html.erb
@@ -1,0 +1,7 @@
+<% provide(:title, t('registrations.edit_registration.title', person: @user.person.name, comp: @competition.name)) %>
+<% add_to_packs("auto_numeric") %>
+
+<%= render layout: 'nav' do %>
+  <%= react_component('RegistrationsV2/RegistrationEdit', { competitionInfo: @competition.to_competition_info ,
+                                                            user: @user }) %>
+<% end %>

--- a/app/views/registrations/register.html.erb
+++ b/app/views/registrations/register.html.erb
@@ -36,7 +36,7 @@
                                                         userInfo: @current_user,
                                                         preferredEvents: @current_user.preferred_events.pluck(:id),
                                                         }) %>
-    <%else %>
+    <% else %>
       <% user_may_register = current_user.cannot_register_for_competition_reasons(@competition).length == 0 %>
       <% if @registration.show_details?(current_user) %>
         <p><%= t 'registrations.greeting', name: current_user.name %></p>

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -78,7 +78,8 @@ function CompetitionsFilters({
 
 export function EventSelector({
   selectedEvents,
-  onEventSelection, eventList = WCA_EVENT_IDS,
+  onEventSelection,
+  eventList = WCA_EVENT_IDS,
   disabled = false,
 }) {
   return (

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -76,7 +76,11 @@ function CompetitionsFilters({
   );
 }
 
-export function EventSelector({ selectedEvents, onEventSelection, eventList = WCA_EVENT_IDS }) {
+export function EventSelector({
+  selectedEvents,
+  onEventSelection, eventList = WCA_EVENT_IDS,
+  disabled = false,
+}) {
   return (
     <>
       <label htmlFor="events">
@@ -90,6 +94,7 @@ export function EventSelector({ selectedEvents, onEventSelection, eventList = WC
         {eventList.map((eventId) => (
           <React.Fragment key={eventId}>
             <Button
+              disabled={disabled}
               basic
               icon
               toggle

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -1,7 +1,7 @@
 import { PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
 import React, { useState } from 'react';
 import I18n from '../../../lib/i18n';
-import { paymentFinishRoute } from '../../../lib/requests/routes.js.erb';
+import { paymentFinishUrl } from '../../../lib/requests/routes.js.erb';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { setMessage } from './RegistrationMessage';
 
@@ -27,7 +27,7 @@ export default function PaymentStep({
     const { error } = await stripe.confirmPayment({
       elements,
       confirmParams: {
-        return_url: paymentFinishRoute(competitionInfo.id, user.id),
+        return_url: paymentFinishUrl(competitionInfo.id, user.id),
       },
     });
 

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -3,10 +3,11 @@ import React, { useEffect } from 'react';
 import { useDispatch, useStore } from '../../../lib/providers/StoreProvider';
 import I18n from '../../../lib/i18n';
 
-export const setMessage = (key, type) => ({
+export const setMessage = (key, type, params) => ({
   payload: {
     key,
     type,
+    params,
   },
 });
 
@@ -30,7 +31,7 @@ export default function RegistrationMessage() {
         positive={message.type === 'positive'}
         negative={message.type === 'negative'}
       >
-        {I18n.t(message.key)}
+        {I18n.t(message.key, message.params)}
       </Message>
     </Sticky>
   );

--- a/app/webpacker/components/RegistrationsV2/Register/StripeWrapper.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StripeWrapper.jsx
@@ -4,7 +4,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { useQuery } from '@tanstack/react-query';
 import React, { useEffect, useState } from 'react';
 import I18n from '../../../lib/i18n';
-import getStripeConfig from '../api/payment/get/get_stripe_config';
+import getStripeConfig from '../api/payment/get/getStripeConfig';
 import getPaymentId from '../api/registration/get/get_payment_intent';
 import PaymentStep from './PaymentStep';
 import { useDispatch } from '../../../lib/providers/StoreProvider';

--- a/app/webpacker/components/RegistrationsV2/Register/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/index.jsx
@@ -5,13 +5,9 @@ import { getSingleRegistration } from '../api/registration/get/get_registrations
 import Loading from '../../Requests/Loading';
 import RegistrationMessage, { setMessage } from './RegistrationMessage';
 import StoreProvider, { useDispatch } from '../../../lib/providers/StoreProvider';
+import messageReducer from '../reducers/messageReducer';
 
 const queryClient = new QueryClient();
-
-const messageReducer = (state, { payload }) => ({
-  ...state,
-  message: { key: payload.key, type: payload.type },
-});
 
 export default function Index({ competitionInfo, userInfo, preferredEvents }) {
   return (

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -2,7 +2,6 @@ import { useMutation } from '@tanstack/react-query';
 import React from 'react';
 import { Button, Icon } from 'semantic-ui-react';
 import updateRegistration from '../api/registration/patch/update_registration';
-import './actions.css';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { setMessage } from '../Register/RegistrationMessage';
 import i18n from '../../../lib/i18n';
@@ -108,7 +107,7 @@ export default function RegistrationActions({
 
   return (
     anySelected && (
-      <Button.Group className="actions">
+      <Button.Group>
         <Button
           onClick={() => {
             csvExport(

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -1,0 +1,192 @@
+import { useMutation } from '@tanstack/react-query';
+import React from 'react';
+import { Button, Icon } from 'semantic-ui-react';
+import updateRegistration from '../api/registration/patch/update_registration';
+import './actions.css';
+import { useDispatch } from '../../../lib/providers/StoreProvider';
+import { setMessage } from '../Register/RegistrationMessage';
+import i18n from '../../../lib/i18n';
+
+function csvExport(selected, registrations) {
+  let csvContent = 'data:text/csv;charset=utf-8,';
+  csvContent
+    += 'user_id,guests,competing.event_ids,competing.registration_status,competing.registered_on,competing.comment,competing.admin_comment\n';
+  registrations
+    .filter((r) => selected.includes(r.user.id))
+    .forEach((registration) => {
+      csvContent += `${registration.user_id},${
+        registration.guests
+      },${registration.competing.event_ids.join(';')},${
+        registration.competing.registration_status
+      },${registration.competing.registered_on},${
+        registration.competing.comment
+      },${registration.competing.admin_comment}\n`;
+    });
+  const encodedUri = encodeURI(csvContent);
+  window.open(encodedUri);
+}
+
+export default function RegistrationActions({
+  partitionedSelected,
+  userEmailMap,
+  refresh,
+  registrations,
+  spotsRemaining,
+  competitionInfo,
+}) {
+  const dispatch = useDispatch();
+  const selectedCount = Object.values(partitionedSelected).reduce(
+    (sum, part) => sum + part.length,
+    0,
+  );
+  const anySelected = selectedCount > 0;
+
+  const {
+    pending, accepted, cancelled, waiting,
+  } = partitionedSelected;
+  const anyRejectable = pending.length < selectedCount;
+  const anyApprovable = accepted.length < selectedCount;
+  const anyCancellable = cancelled.length < selectedCount;
+  const anyWaitlistable = waiting.length < selectedCount;
+
+  const selectedEmails = [...pending, ...accepted, ...cancelled, ...waiting]
+    .map((userId) => userEmailMap[userId])
+    .join(',');
+
+  const { mutate: updateRegistrationMutation } = useMutation({
+    mutationFn: updateRegistration,
+    onError: (data) => {
+      const { error } = data.json;
+      dispatch(setMessage(
+        error
+          ? `competitions.registration_v2.errors.${error}`
+          : 'registrations.flash.failed',
+        'negative',
+      ));
+    },
+  });
+
+  const changeStatus = (attendees, status) => {
+    attendees.forEach(async (attendee) => {
+      await updateRegistrationMutation(
+        {
+          user_id: attendee,
+          competing: {
+            status,
+          },
+          competition_id: competitionInfo.id,
+        },
+        {
+          onSuccess: () => {
+            dispatch(setMessage('registrations.flash.updated', 'positive'));
+            refresh();
+          },
+        },
+      );
+    });
+  };
+
+  const attemptToApprove = () => {
+    const idsToAccept = [...pending, ...cancelled, ...waiting];
+    if (idsToAccept.length > spotsRemaining) {
+      dispatch(setMessage(
+        'competitions.registration_v2.update.tooMany',
+        'negative',
+        {
+          count: idsToAccept.length - spotsRemaining,
+        },
+      ));
+    } else {
+      changeStatus(idsToAccept, 'accepted');
+    }
+  };
+
+  const copyEmails = (emails) => {
+    navigator.clipboard.writeText(emails);
+    dispatch(setMessage('Copied to clipboard. Remember to use bcc!', 'positive'));
+  };
+
+  return (
+    anySelected && (
+      <Button.Group className="actions">
+        <Button
+          onClick={() => {
+            csvExport(
+              [...pending, ...accepted, ...cancelled, ...waiting],
+              registrations,
+            );
+          }}
+        >
+          <Icon name="download" />
+          {' '}
+          {i18n.t('registrations.list.export_csv')}
+        </Button>
+
+        <Button>
+          <a
+            href={`mailto:?bcc=${selectedEmails}`}
+            id="email-selected"
+            target="_blank"
+            className="btn btn-info selected-registrations-actions"
+            rel="noreferrer"
+          >
+            <Icon name="envelope" />
+            {i18n.t('competitions.registration_v2.update.email_send')}
+          </a>
+        </Button>
+
+        <Button onClick={() => copyEmails(selectedEmails)}>
+          <Icon name="copy" />
+          {i18n.t('competitions.registration_v2.update.email_copy')}
+        </Button>
+        <>
+          {anyApprovable && (
+          <Button positive onClick={attemptToApprove}>
+            <Icon name="check" />
+            {i18n.t('registrations.list.approve')}
+          </Button>
+          )}
+
+          {anyRejectable && (
+          <Button
+            onClick={() => changeStatus(
+              [...accepted, ...cancelled, ...waiting],
+              'pending',
+            )}
+          >
+            <Icon name="times" />
+            {i18n.t('competitions.registration_v2.update.move_pending')}
+          </Button>
+          )}
+
+          {anyWaitlistable && (
+          <Button
+            color="yellow"
+            onClick={() => changeStatus(
+              [...pending, ...cancelled, ...accepted],
+              'waiting_list',
+            )}
+          >
+            <Icon name="hourglass" />
+            {i18n.t('competitions.registration_v2.update.move_waiting')}
+          </Button>
+          )}
+
+          {anyCancellable && (
+          <Button
+            negative
+            onClick={() => changeStatus(
+              [...pending, ...accepted, ...waiting],
+              'cancelled',
+            )}
+          >
+            <Icon name="trash" />
+            {i18n.t('competitions.registration_v2.update.cancel')}
+          </Button>
+          )}
+        </>
+        )
+      </Button.Group>
+    )
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -11,7 +11,7 @@ function csvExport(selected, registrations) {
   csvContent
     += 'user_id,guests,competing.event_ids,competing.registration_status,competing.registered_on,competing.comment,competing.admin_comment\n';
   registrations
-    .filter((r) => selected.includes(r.user.id))
+    .filter((r) => selected.length === 0 || selected.includes(r.user.id))
     .forEach((registration) => {
       csvContent += `${registration.user_id},${
         registration.guests
@@ -106,86 +106,88 @@ export default function RegistrationActions({
   };
 
   return (
-    anySelected && (
-      <Button.Group>
-        <Button
-          onClick={() => {
-            csvExport(
-              [...pending, ...accepted, ...cancelled, ...waiting],
-              registrations,
-            );
-          }}
-        >
-          <Icon name="download" />
-          {' '}
-          {i18n.t('registrations.list.export_csv')}
-        </Button>
+    <Button.Group>
+      <Button
+        onClick={() => {
+          csvExport(
+            [...pending, ...accepted, ...cancelled, ...waiting],
+            registrations,
+          );
+        }}
+      >
+        <Icon name="download" />
+        {' '}
+        {i18n.t('registrations.list.export_csv')}
+      </Button>
 
-        <Button>
-          <a
-            href={`mailto:?bcc=${selectedEmails}`}
-            id="email-selected"
-            target="_blank"
-            className="btn btn-info selected-registrations-actions"
-            rel="noreferrer"
-          >
-            <Icon name="envelope" />
-            {i18n.t('competitions.registration_v2.update.email_send')}
-          </a>
-        </Button>
-
-        <Button onClick={() => copyEmails(selectedEmails)}>
-          <Icon name="copy" />
-          {i18n.t('competitions.registration_v2.update.email_copy')}
-        </Button>
+      {anySelected && (
         <>
-          {anyApprovable && (
-          <Button positive onClick={attemptToApprove}>
-            <Icon name="check" />
-            {i18n.t('registrations.list.approve')}
+          <Button>
+            <a
+              href={`mailto:?bcc=${selectedEmails}`}
+              id="email-selected"
+              target="_blank"
+              className="btn btn-info selected-registrations-actions"
+              rel="noreferrer"
+            >
+              <Icon name="envelope" />
+              {i18n.t('competitions.registration_v2.update.email_send')}
+            </a>
           </Button>
-          )}
 
-          {anyRejectable && (
-          <Button
-            onClick={() => changeStatus(
-              [...accepted, ...cancelled, ...waiting],
-              'pending',
-            )}
-          >
-            <Icon name="times" />
-            {i18n.t('competitions.registration_v2.update.move_pending')}
+          <Button onClick={() => copyEmails(selectedEmails)}>
+            <Icon name="copy" />
+            {i18n.t('competitions.registration_v2.update.email_copy')}
           </Button>
-          )}
+          <>
+            {anyApprovable && (
+              <Button positive onClick={attemptToApprove}>
+                <Icon name="check" />
+                {i18n.t('registrations.list.approve')}
+              </Button>
+            )}
 
-          {anyWaitlistable && (
-          <Button
-            color="yellow"
-            onClick={() => changeStatus(
-              [...pending, ...cancelled, ...accepted],
-              'waiting_list',
+            {anyRejectable && (
+              <Button
+                onClick={() => changeStatus(
+                  [...accepted, ...cancelled, ...waiting],
+                  'pending',
+                )}
+              >
+                <Icon name="times" />
+                {i18n.t('competitions.registration_v2.update.move_pending')}
+              </Button>
             )}
-          >
-            <Icon name="hourglass" />
-            {i18n.t('competitions.registration_v2.update.move_waiting')}
-          </Button>
-          )}
 
-          {anyCancellable && (
-          <Button
-            negative
-            onClick={() => changeStatus(
-              [...pending, ...accepted, ...waiting],
-              'cancelled',
+            {anyWaitlistable && (
+              <Button
+                color="yellow"
+                onClick={() => changeStatus(
+                  [...pending, ...cancelled, ...accepted],
+                  'waiting_list',
+                )}
+              >
+                <Icon name="hourglass" />
+                {i18n.t('competitions.registration_v2.update.move_waiting')}
+              </Button>
             )}
-          >
-            <Icon name="trash" />
-            {i18n.t('competitions.registration_v2.update.cancel')}
-          </Button>
-          )}
+
+            {anyCancellable && (
+              <Button
+                negative
+                onClick={() => changeStatus(
+                  [...pending, ...accepted, ...waiting],
+                  'cancelled',
+                )}
+              >
+                <Icon name="trash" />
+                {i18n.t('competitions.registration_v2.update.cancel')}
+              </Button>
+            )}
+          </>
+          )
         </>
-        )
-      </Button.Group>
-    )
+      )}
+    </Button.Group>
   );
 }

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -268,6 +268,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           changeSortColumn={changeSortColumn}
           sortDirection={sortDirection}
           sortColumn={sortColumn}
+          competitionInfo={competitionInfo}
         />
 
         <Header>
@@ -293,6 +294,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           changeSortColumn={changeSortColumn}
           sortDirection={sortDirection}
           sortColumn={sortColumn}
+          competitionInfo={competitionInfo}
         />
 
         <Header>
@@ -313,6 +315,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           changeSortColumn={changeSortColumn}
           sortDirection={sortDirection}
           sortColumn={sortColumn}
+          competitionInfo={competitionInfo}
         />
 
         <Header>
@@ -332,6 +335,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           changeSortColumn={changeSortColumn}
           sortDirection={sortDirection}
           sortColumn={sortColumn}
+          competitionInfo={competitionInfo}
         />
       </div>
 
@@ -358,6 +362,7 @@ function RegistrationAdministrationTable({
   sortDirection,
   sortColumn,
   changeSortColumn,
+  competitionInfo,
 }) {
   const handleHeaderCheck = (_, data) => {
     if (data.checked) {
@@ -378,6 +383,7 @@ function RegistrationAdministrationTable({
           sortDirection={sortDirection}
           sortColumn={sortColumn}
           changeSortColumn={changeSortColumn}
+          competitionInfo={competitionInfo}
         />
 
         <Table.Body>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -1,0 +1,671 @@
+import { useQuery } from '@tanstack/react-query';
+import React, { useMemo, useReducer } from 'react';
+import {
+  Checkbox, Flag, Form, Header, Icon, Popup, Table,
+} from 'semantic-ui-react';
+import { getAllRegistrations } from '../api/registration/get/get_registrations';
+import { getShortDateString, getShortTimeString } from '../lib/dates';
+import createSortReducer from '../reducers/sortReducer';
+import RegistrationActions from './RegistrationActions';
+import { setMessage } from '../Register/RegistrationMessage';
+import { useDispatch } from '../../../lib/providers/StoreProvider';
+import i18n from '../../../lib/i18n';
+import Loading from '../../Requests/Loading';
+import EventIcon from '../../wca/EventIcon';
+import useWithUserData from '../hooks/useWithUserData';
+import { editRegistrationUrl, editResultUrl, personUrl } from '../../../lib/requests/routes.js.erb';
+
+const selectedReducer = (state, action) => {
+  let newState = [...state];
+
+  const { type, attendee, attendees } = action;
+  const idList = attendees || [attendee];
+
+  switch (type) {
+    case 'add':
+      idList.forEach((id) => {
+        // Make sure no one adds an attendee twice
+        if (!newState.includes(id)) newState.push(id);
+      });
+      break;
+
+    case 'remove':
+      newState = newState.filter((id) => !idList.includes(id));
+      break;
+
+    case 'clear-selected':
+      return [];
+
+    default:
+      throw new Error('Unknown action.');
+  }
+
+  return newState;
+};
+
+const sortReducer = createSortReducer([
+  'name',
+  'wca_id',
+  'country',
+  'registered_on',
+  'events',
+  'guests',
+  'paid_on',
+  'comment',
+  'dob',
+]);
+
+const partitionRegistrations = (registrations) => registrations.reduce(
+  (result, registration) => {
+    switch (registration.competing.registration_status) {
+      case 'pending':
+        result.pending.push(registration);
+        break;
+      case 'waiting_list':
+        result.waiting.push(registration);
+        break;
+      case 'accepted':
+        result.accepted.push(registration);
+        break;
+      case 'cancelled':
+        result.cancelled.push(registration);
+        break;
+      default:
+        break;
+    }
+    return result;
+  },
+  {
+    pending: [], waiting: [], accepted: [], cancelled: [],
+  },
+);
+
+const expandableColumns = {
+  dob: 'Date of Birth',
+  region: 'Region',
+  events: 'Events',
+  comments: 'Comment & Note',
+  email: 'Email',
+};
+const initialExpandedColumns = {
+  dob: false,
+  region: false,
+  events: false,
+  comments: true,
+  email: false,
+};
+
+const columnReducer = (state, action) => {
+  if (action.type === 'reset') {
+    return initialExpandedColumns;
+  }
+  if (Object.keys(expandableColumns).includes(action.column)) {
+    return { ...state, [action.column]: !state[action.column] };
+  }
+  return state;
+};
+
+// Semantic Table only allows truncating _all_ columns in a table in
+// single line fixed mode. As we only want to truncate the comment/admin notes
+// this function is used to manually truncate the columns.
+// TODO: We could fix this by building our own table component here
+const truncateComment = (comment) => (comment?.length > 12 ? `${comment.slice(0, 12)}...` : comment);
+
+export default function RegistrationAdministrationList({ competitionInfo }) {
+  const [expandedColumns, dispatchColumns] = useReducer(
+    columnReducer,
+    initialExpandedColumns,
+  );
+
+  const dispatchStore = useDispatch();
+
+  const [state, dispatchSort] = useReducer(sortReducer, {
+    sortColumn: competitionInfo['using_stripe_payments?']
+      ? 'paid_on'
+      : 'registered_on',
+    sortDirection: undefined,
+  });
+  const { sortColumn, sortDirection } = state;
+  const changeSortColumn = (name) => dispatchSort({ type: 'CHANGE_SORT', sortColumn: name });
+
+  const {
+    isLoading: isRegistrationsLoading,
+    data: registrations,
+    refetch,
+  } = useQuery({
+    queryKey: ['registrations-admin', competitionInfo.id],
+    queryFn: () => getAllRegistrations(competitionInfo.id),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+    refetchOnMount: 'always',
+    retry: false,
+    onError: (err) => {
+      const { errorCode } = err;
+      dispatchStore(setMessage(
+        errorCode
+          ? `competitions.registration_v2.errors.${errorCode}`
+          : 'registrations.flash.failed',
+        'negative',
+      ));
+    },
+  });
+
+  const {
+    isLoading: infoLoading,
+    data: registrationsWithUser,
+  } = useWithUserData(registrations ?? []);
+
+  const sortedRegistrationsWithUser = useMemo(() => {
+    if (registrationsWithUser) {
+      const sorted = registrationsWithUser.toSorted((a, b) => {
+        switch (sortColumn) {
+          case 'name':
+            return a.user.name.localeCompare(b.user.name);
+          case 'wca_id':
+            return a.user.wca_id.localeCompare(b.user.wca_id);
+          case 'country':
+            return a.user.country.name.localeCompare(b.user.country.name);
+          case 'events':
+            return a.competing.event_ids.length - b.competing.event_ids.length;
+          case 'guests':
+            return a.guests - b.guests;
+          case 'dob':
+            return a.user.dob - b.user.dob;
+          case 'comment':
+            return a.competing.comment.localeCompare(b.competing.comment);
+          case 'registered_on':
+            return a.competing.registered_on.localeCompare(
+              b.competing.registered_on,
+            );
+          case 'paid_on':
+            return a.payment.updated_at.localeCompare(b.payment.updated_at);
+          default:
+            return 0;
+        }
+      });
+      if (sortDirection === 'descending') {
+        return sorted.toReversed();
+      }
+      return sorted;
+    }
+    return [];
+  }, [registrationsWithUser, sortColumn, sortDirection]);
+
+  const {
+    waiting, accepted, cancelled, pending,
+  } = useMemo(
+    () => partitionRegistrations(sortedRegistrationsWithUser ?? []),
+    [sortedRegistrationsWithUser],
+  );
+
+  const [selected, dispatch] = useReducer(selectedReducer, []);
+  const partitionedSelected = useMemo(
+    () => ({
+      pending: selected.filter((id) => pending.some((reg) => id === reg.user.id)),
+      waiting: selected.filter((id) => waiting.some((reg) => id === reg.user.id)),
+      accepted: selected.filter((id) => accepted.some((reg) => id === reg.user.id)),
+      cancelled: selected.filter((id) => cancelled.some((reg) => id === reg.user.id)),
+    }),
+    [selected, pending, waiting, accepted, cancelled],
+  );
+
+  const select = (attendees) => dispatch({ type: 'add', attendees });
+  const unselect = (attendees) => dispatch({ type: 'remove', attendees });
+
+  // some sticky/floating bar somewhere with totals/info would be better
+  // than putting this in the table headers which scroll out of sight
+  const spotsRemaining = (competitionInfo.competitor_limit ?? Infinity) - accepted.length;
+  const spotsRemainingText = i18n.t(
+    'competitions.registration_v2.list.spots_remaining',
+    'competitions.registration_v2.list.spots_remaining',
+    { spots: spotsRemaining },
+  );
+
+  const userEmailMap = useMemo(
+    () => Object.fromEntries(
+      (registrationsWithUser ?? []).map((registration) => [
+        registration.user.id,
+        registration.email,
+      ]),
+    ),
+    [registrationsWithUser],
+  );
+
+  return isRegistrationsLoading || infoLoading ? (
+    <Loading />
+  ) : (
+    <>
+      <Form>
+        <Form.Group widths="equal">
+          {Object.entries(expandableColumns).map(([id, name]) => (
+            <Form.Field key={id}>
+              <Checkbox
+                name={id}
+                label={name}
+                toggle
+                checked={expandedColumns[id]}
+                onChange={() => dispatchColumns({ column: id })}
+              />
+            </Form.Field>
+          ))}
+        </Form.Group>
+      </Form>
+
+      <div>
+        <Header>
+          Pending registrations (
+          {pending.length}
+          )
+        </Header>
+        <RegistrationAdministrationTable
+          columnsExpanded={expandedColumns}
+          registrations={pending}
+          selected={partitionedSelected.pending}
+          select={select}
+          unselect={unselect}
+          competition_id={competitionInfo.id}
+          changeSortColumn={changeSortColumn}
+          sortDirection={sortDirection}
+          sortColumn={sortColumn}
+        />
+
+        <Header>
+          {i18n.t('registrations.list.approved_registrations')}
+          {' '}
+          (
+          {accepted.length}
+          {competitionInfo.competitor_limit && (
+            <>
+              {`/${competitionInfo.competitor_limit}; `}
+              {spotsRemainingText}
+            </>
+          )}
+          )
+        </Header>
+        <RegistrationAdministrationTable
+          columnsExpanded={expandedColumns}
+          registrations={accepted}
+          selected={partitionedSelected.accepted}
+          select={select}
+          unselect={unselect}
+          competition_id={competitionInfo.id}
+          changeSortColumn={changeSortColumn}
+          sortDirection={sortDirection}
+          sortColumn={sortColumn}
+        />
+
+        <Header>
+          {i18n.t('simple_form.options.registration.status.waiting_list')}
+          {' '}
+          (
+          {waiting.length}
+          {competitionInfo.competitor_limit && `; ${spotsRemainingText}`}
+          )
+        </Header>
+        <RegistrationAdministrationTable
+          columnsExpanded={expandedColumns}
+          registrations={waiting}
+          selected={partitionedSelected.waiting}
+          select={select}
+          unselect={unselect}
+          competition_id={competitionInfo.id}
+          changeSortColumn={changeSortColumn}
+          sortDirection={sortDirection}
+          sortColumn={sortColumn}
+        />
+
+        <Header>
+          {i18n.t('simple_form.options.registration.status.cancelled')}
+          {' '}
+          (
+          {cancelled.length}
+          )
+        </Header>
+        <RegistrationAdministrationTable
+          columnsExpanded={expandedColumns}
+          registrations={cancelled}
+          selected={partitionedSelected.cancelled}
+          select={select}
+          unselect={unselect}
+          competition_id={competitionInfo.id}
+          changeSortColumn={changeSortColumn}
+          sortDirection={sortDirection}
+          sortColumn={sortColumn}
+        />
+      </div>
+
+      <RegistrationActions
+        partitionedSelected={partitionedSelected}
+        refresh={async () => {
+          await refetch();
+          dispatch({ type: 'clear-selected' });
+        }}
+        registrations={registrations}
+        spotsRemaining={spotsRemaining}
+        userEmailMap={userEmailMap}
+      />
+    </>
+  );
+}
+
+function RegistrationAdministrationTable({
+  columnsExpanded,
+  registrations,
+  selected,
+  select,
+  unselect,
+  sortDirection,
+  sortColumn,
+  changeSortColumn,
+}) {
+  const handleHeaderCheck = (_, data) => {
+    if (data.checked) {
+      select(registrations.map(({ user }) => user.id));
+    } else {
+      unselect(registrations.map(({ user }) => user.id));
+    }
+  };
+
+  return (
+    <div>
+      <Table sortable striped textAlign="left">
+        <TableHeader
+          columnsExpanded={columnsExpanded}
+          showCheckbox={registrations.length > 0}
+          isChecked={registrations.length === selected.length}
+          onCheckboxChanged={handleHeaderCheck}
+          sortDirection={sortDirection}
+          sortColumn={sortColumn}
+          changeSortColumn={changeSortColumn}
+        />
+
+        <Table.Body>
+          {registrations.length > 0 ? (
+            registrations.map((registration) => {
+              const { id } = registration.user;
+              return (
+                <TableRow
+                  key={id}
+                  columnsExpanded={columnsExpanded}
+                  registration={registration}
+                  isSelected={selected.includes(id)}
+                  onCheckboxChange={(_, data) => {
+                    if (data.checked) {
+                      select([id]);
+                    } else {
+                      unselect([id]);
+                    }
+                  }}
+                />
+              );
+            })
+          ) : (
+            <Table.Row>
+              <Table.Cell colSpan={6}>
+                {i18n.t('competitions.registration_v2.list.empty')}
+              </Table.Cell>
+            </Table.Row>
+          )}
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}
+
+function TableHeader({
+  columnsExpanded,
+  showCheckbox,
+  isChecked,
+  onCheckboxChanged,
+  sortDirection,
+  sortColumn,
+  changeSortColumn,
+  competitionInfo,
+}) {
+  const { dob, events, comments } = columnsExpanded;
+
+  return (
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>
+          {showCheckbox && (
+            <Checkbox checked={isChecked} onChange={onCheckboxChanged} />
+          )}
+        </Table.HeaderCell>
+        <Table.HeaderCell />
+        <Table.HeaderCell
+          sorted={sortColumn === 'wca_id' ? sortDirection : undefined}
+          onClick={() => changeSortColumn('wca_id')}
+        >
+          {i18n.t('common.user.wca_id')}
+        </Table.HeaderCell>
+        <Table.HeaderCell
+          sorted={sortColumn === 'name' ? sortDirection : undefined}
+          onClick={() => changeSortColumn('name')}
+        >
+          {i18n.t('delegates_page.table.name')}
+        </Table.HeaderCell>
+        {dob && (
+          <Table.HeaderCell
+            sorted={sortColumn === 'dob' ? sortDirection : undefined}
+            onClick={() => changeSortColumn('dob')}
+          >
+            {i18n.t('activerecord.attributes.user.dob')}
+          </Table.HeaderCell>
+        )}
+        <Table.HeaderCell
+          sorted={sortColumn === 'country' ? sortDirection : undefined}
+          onClick={() => changeSortColumn('country')}
+        >
+          {i18n.t('common.user.representing')}
+        </Table.HeaderCell>
+        <Table.HeaderCell
+          sorted={sortColumn === 'registered_on' ? sortDirection : undefined}
+          onClick={() => changeSortColumn('registered_on')}
+        >
+          {i18n.t('registrations.list.registered.without_stripe')}
+        </Table.HeaderCell>
+        {competitionInfo['using_stripe_payments?'] && (
+          <>
+            <Table.HeaderCell>Payment Status</Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={sortColumn === 'paid_on' ? sortDirection : undefined}
+              onClick={() => changeSortColumn('paid_on')}
+            >
+              {i18n.t('registrations.list.registered.with_stripe')}
+            </Table.HeaderCell>
+          </>
+        )}
+        {events ? (
+          competitionInfo.event_ids.map((eventId) => (
+            <Table.HeaderCell key={`event-${eventId}`}>
+              <EventIcon event={eventId} className="selected" />
+            </Table.HeaderCell>
+          ))
+        ) : (
+          <Table.HeaderCell
+            sorted={sortColumn === 'events' ? sortDirection : undefined}
+            onClick={() => changeSortColumn('events')}
+          >
+            {i18n.t('competitions.competition_info.events')}
+          </Table.HeaderCell>
+        )}
+        <Table.HeaderCell
+          sorted={sortColumn === 'guests' ? sortDirection : undefined}
+          onClick={() => changeSortColumn('guests')}
+        >
+          {i18n.t(
+            'competitions.competition_form.labels.registration.guests_enabled',
+          )}
+        </Table.HeaderCell>
+        {comments && (
+          <>
+            <Table.HeaderCell
+              sorted={sortColumn === 'comment' ? sortDirection : undefined}
+              onClick={() => changeSortColumn('comment')}
+            >
+              {i18n.t('activerecord.attributes.registration.comments')}
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              {i18n.t('activerecord.attributes.registration.administrative_notes')}
+            </Table.HeaderCell>
+          </>
+        )}
+        <Table.HeaderCell>{i18n.t('registrations.list.email')}</Table.HeaderCell>
+      </Table.Row>
+    </Table.Header>
+  );
+}
+
+function TableRow({
+  columnsExpanded,
+  registration,
+  isSelected,
+  onCheckboxChange,
+  competitionInfo,
+}) {
+  const {
+    dob, region, events, comments, email,
+  } = columnsExpanded;
+  const {
+    id, wca_id: wcaId, name, country,
+  } = registration.user;
+  const {
+    registered_on: registeredOn, event_ids: eventIds, comment, admin_comment: adminComment,
+  } = registration.competing;
+  const { dob: dateOfBirth, email: emailAddress } = registration;
+  const { payment_status: paymentStatus, updated_at: updatedAt } = registration.payment;
+
+  const copyEmail = () => {
+    navigator.clipboard.writeText(emailAddress);
+    setMessage('Copied email address to clipboard.', 'positive');
+  };
+
+  return (
+    <Table.Row key={id} active={isSelected}>
+      <Table.Cell>
+        <Checkbox onChange={onCheckboxChange} checked={isSelected} />
+      </Table.Cell>
+
+      <Table.Cell>
+        <a href={editRegistrationUrl(`${competitionInfo.id}-${id}`)}>
+          Edit
+        </a>
+      </Table.Cell>
+      )
+
+      <Table.Cell>
+        {wcaId ? (
+          <a href={personUrl(wcaId)}>{wcaId}</a>
+        ) : (
+          <a href={editResultUrl(id)}>
+            <Icon name="edit" />
+            Profile
+          </a>
+        )}
+      </Table.Cell>
+
+      <Table.Cell>{name}</Table.Cell>
+
+      {dob && <Table.Cell>{dateOfBirth}</Table.Cell>}
+
+      <Table.Cell>
+        {region ? (
+          <>
+            <Flag name={country.iso2.toLowerCase()} />
+            {region && country.name}
+          </>
+        ) : (
+          <Popup
+            content={country.name}
+            trigger={(
+              <span>
+                <Flag name={country.iso2.toLowerCase()} />
+              </span>
+            )}
+          />
+        )}
+      </Table.Cell>
+
+      <Table.Cell>
+        <Popup
+          content={getShortTimeString(registeredOn)}
+          trigger={<span>{getShortDateString(registeredOn)}</span>}
+        />
+      </Table.Cell>
+
+      {competitionInfo['using_stripe_payments?'] && (
+        <>
+          <Table.Cell>{paymentStatus ?? 'not paid'}</Table.Cell>
+          <Table.Cell>
+            {updatedAt && (
+              <Popup
+                content={getShortTimeString(updatedAt)}
+                trigger={<span>{getShortDateString(updatedAt)}</span>}
+              />
+            )}
+          </Table.Cell>
+        </>
+      )}
+
+      {events ? (
+        competitionInfo.event_ids.map((eventId) => (
+          <Table.Cell key={`event-${eventId}`}>
+            {eventIds.includes(eventId) && (
+              <EventIcon event={eventId} size="1x" selected />
+            )}
+          </Table.Cell>
+        ))
+      ) : (
+        <Table.Cell>
+          <Popup
+            content={eventIds.map((eventId) => (
+              <EventIcon key={eventId} event={eventId} className="selected" />
+            ))}
+            trigger={<span>{eventIds.length}</span>}
+          />
+        </Table.Cell>
+      )}
+
+      <Table.Cell>{registration.guests}</Table.Cell>
+
+      {comments && (
+        <>
+          <Table.Cell>
+            <Popup
+              content={comment}
+              trigger={<span>{truncateComment(comment)}</span>}
+            />
+          </Table.Cell>
+
+          <Table.Cell>
+            <Popup
+              content={adminComment}
+              trigger={<span>{truncateComment(adminComment)}</span>}
+            />
+          </Table.Cell>
+        </>
+      )}
+
+      <Table.Cell>
+        <a href={`mailto:${emailAddress}`}>
+          {email ? (
+            emailAddress
+          ) : (
+            <Popup
+              content={emailAddress}
+              trigger={(
+                <span>
+                  <Icon name="mail" />
+                </span>
+              )}
+            />
+          )}
+        </a>
+        {' '}
+        <Icon link onClick={copyEmail} name="copy" title="Copy Email Address" />
+      </Table.Cell>
+    </Table.Row>
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -393,6 +393,7 @@ function RegistrationAdministrationTable({
               return (
                 <TableRow
                   key={id}
+                  competitionInfo={competitionInfo}
                   columnsExpanded={columnsExpanded}
                   registration={registration}
                   isSelected={selected.includes(id)}
@@ -486,7 +487,7 @@ function TableHeader({
         {events ? (
           competitionInfo.event_ids.map((eventId) => (
             <Table.HeaderCell key={`event-${eventId}`}>
-              <EventIcon event={eventId} className="selected" />
+              <EventIcon id={eventId} className="selected" />
             </Table.HeaderCell>
           ))
         ) : (
@@ -559,7 +560,6 @@ function TableRow({
           Edit
         </a>
       </Table.Cell>
-      )
 
       <Table.Cell>
         {wcaId ? (
@@ -619,7 +619,7 @@ function TableRow({
         competitionInfo.event_ids.map((eventId) => (
           <Table.Cell key={`event-${eventId}`}>
             {eventIds.includes(eventId) && (
-              <EventIcon event={eventId} size="1x" selected />
+              <EventIcon id={eventId} size="1x" selected />
             )}
           </Table.Cell>
         ))
@@ -627,7 +627,7 @@ function TableRow({
         <Table.Cell>
           <Popup
             content={eventIds.map((eventId) => (
-              <EventIcon key={eventId} event={eventId} className="selected" />
+              <EventIcon key={eventId} id={eventId} className="selected" />
             ))}
             trigger={<span>{eventIds.length}</span>}
           />

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import React, { useMemo, useReducer } from 'react';
+import React, { useMemo, useReducer, useRef } from 'react';
 import {
-  Checkbox, Flag, Form, Header, Icon, Popup, Table,
+  Checkbox, Flag, Form, Header, Icon, Popup, Sticky, Table,
 } from 'semantic-ui-react';
 import { getAllRegistrations } from '../api/registration/get/get_registrations';
 import { getShortDateString, getShortTimeString } from '../lib/dates';
@@ -118,6 +118,8 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
   );
 
   const dispatchStore = useDispatch();
+
+  const actionsRef = useRef();
 
   const [state, dispatchSort] = useReducer(sortReducer, {
     sortColumn: competitionInfo['using_stripe_payments?']
@@ -252,7 +254,20 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
         </Form.Group>
       </Form>
 
-      <div>
+      <div ref={actionsRef}>
+        <Sticky context={actionsRef} offset={20}>
+          <RegistrationActions
+            partitionedSelected={partitionedSelected}
+            refresh={async () => {
+              await refetch();
+              dispatch({ type: 'clear-selected' });
+            }}
+            registrations={registrations}
+            spotsRemaining={spotsRemaining}
+            userEmailMap={userEmailMap}
+          />
+        </Sticky>
+
         <Header>
           Pending registrations (
           {pending.length}
@@ -338,17 +353,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           competitionInfo={competitionInfo}
         />
       </div>
-
-      <RegistrationActions
-        partitionedSelected={partitionedSelected}
-        refresh={async () => {
-          await refetch();
-          dispatch({ type: 'clear-selected' });
-        }}
-        registrations={registrations}
-        spotsRemaining={spotsRemaining}
-        userEmailMap={userEmailMap}
-      />
     </>
   );
 }

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/actions.css
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/actions.css
@@ -1,8 +1,0 @@
-.actions {
-  position: fixed;
-  z-index: 1000;
-  bottom: 5vh;
-  left: 20px;
-  right: 20px;
-  flex-wrap: wrap;
-}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/actions.css
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/actions.css
@@ -1,0 +1,8 @@
+.actions {
+  position: fixed;
+  z-index: 1000;
+  bottom: 5vh;
+  left: 20px;
+  right: 20px;
+  flex-wrap: wrap;
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import RegistrationAdministrationList from './RegistrationAdministrationList';
+import RegistrationMessage from '../Register/RegistrationMessage';
+import messageReducer from '../reducers/messageReducer';
+import StoreProvider from '../../../lib/providers/StoreProvider';
+
+export default function RegistrationEdit({ competitionInfo }) {
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
+        <RegistrationMessage />
+        <RegistrationAdministrationList competitionInfo={competitionInfo} />
+      </StoreProvider>
+    </QueryClientProvider>
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
@@ -1,0 +1,97 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import {
+  Button, Input, Label, Modal, Table,
+} from 'semantic-ui-react';
+import getAvailableRefunds from '../api/payment/get/getAvailableRefunds';
+import refundPayment from '../api/payment/get/refundPayment';
+import { useDispatch } from '../../../lib/providers/StoreProvider';
+import { setMessage } from '../Register/RegistrationMessage';
+import Loading from '../../Requests/Loading';
+
+export default function Refunds({
+  open, onExit, userId, competitionId,
+}) {
+  const [refundAmount, setRefundAmount] = useState(0);
+  const dispatch = useDispatch();
+
+  const {
+    data: refunds,
+    isLoading: refundsLoading,
+    isError: refundError,
+  } = useQuery({
+    queryKey: ['refunds', competitionId, userId],
+    queryFn: () => getAvailableRefunds(competitionId, userId),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+    refetchOnMount: 'always',
+  });
+  const { mutate: refundMutation, isLoading: isMutating } = useMutation({
+    mutationFn: refundPayment,
+    onError: (data) => {
+      dispatch(setMessage(
+        `Refund payment failed with error: ${data.errorCode}`,
+        'negative',
+      ));
+    },
+    onSuccess: () => {
+      dispatch(setMessage('Refund succeeded', 'positive'));
+      onExit();
+    },
+  });
+  return refundsLoading ? (
+    <Loading />
+  ) : (
+    !refundError && (
+      <Modal open={open} dimmer="blurring">
+        <Modal.Header>Available Refunds:</Modal.Header>
+        <Modal.Content>
+          <Table>
+            <Table.Header>
+              <Table.Header>Amount</Table.Header>
+              <Table.Header> </Table.Header>
+            </Table.Header>
+            <Table.Body>
+              {refunds.charges.map((refund) => (
+                <Table.Row key={refund.payment_id}>
+                  <Table.Cell>
+                    <Input
+                      labelPosition="right"
+                      type="text"
+                      placeholder={refund.amount}
+                    >
+                      <Label basic>$</Label>
+                      <input
+                        value={refundAmount}
+                        max={refund.amount}
+                        onChange={(event) => setRefundAmount(event.target.value)}
+                      />
+                    </Input>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Button
+                      onClick={() => refundMutation({
+                        competitionId,
+                        userId,
+                        paymentId: refund.payment_id,
+                        amount: refundAmount,
+                      })}
+                    >
+                      Refund Amount
+                    </Button>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button disabled={isMutating} onClick={onExit}>
+            Go Back
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    )
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -1,0 +1,361 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import _ from 'lodash';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  Accordion,
+  Button,
+  Checkbox,
+  Header,
+  Input,
+  Message,
+  Popup,
+  Segment,
+  Table,
+  TextArea,
+} from 'semantic-ui-react';
+import { getSingleRegistration } from '../api/registration/get/get_registrations';
+import updateRegistration from '../api/registration/patch/update_registration';
+import getUsersInfo from '../api/user/post/getUserInfo';
+import {
+  getShortDateString,
+  getShortTimeString,
+  hasPassed,
+} from '../lib/dates';
+import { useDispatch } from '../../../lib/providers/StoreProvider';
+import { setMessage } from '../Register/RegistrationMessage';
+import Loading from '../../Requests/Loading';
+import { EventSelector } from '../../CompetitionsOverview/CompetitionsFilters';
+
+export default function RegistrationEditor({ userId, competitionInfo }) {
+  const dispatch = useDispatch();
+  const [comment, setComment] = useState('');
+  const [adminComment, setAdminComment] = useState('');
+  const [status, setStatus] = useState('');
+  const [waitingListPosition, setWaitingListPosition] = useState(0);
+  const [guests, setGuests] = useState(0);
+  const [selectedEvents, setSelectedEvents] = useState([]);
+  const [registration, setRegistration] = useState({});
+  const [isCheckingRefunds, setIsCheckingRefunds] = useState(false);
+  const [isHistoryCollapsed, setIsHistoryCollapsed] = useState(true);
+
+  const queryClient = useQueryClient();
+
+  const { data: serverRegistration } = useQuery({
+    queryKey: ['registration-admin', competitionInfo.id, userId],
+    queryFn: () => getSingleRegistration(userId, competitionInfo.id),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+    refetchOnMount: 'always',
+  });
+
+  const { isLoading, data: competitorsInfo } = useQuery({
+    queryKey: ['info', userId],
+    queryFn: () => getUsersInfo([
+      ...new Set([
+        userId,
+        ...serverRegistration.history.map((e) => e.actor_user_id),
+      ]),
+    ]),
+    enabled: Boolean(serverRegistration),
+  });
+
+  const { mutate: updateRegistrationMutation, isLoading: isUpdating } = useMutation({
+    mutationFn: updateRegistration,
+    onError: (data) => {
+      const { errorCode } = data;
+      dispatch(setMessage(
+        errorCode
+          ? `competitions.registration_v2.errors.${errorCode}`
+          : 'registrations.flash.failed',
+        'negative',
+      ));
+    },
+    onSuccess: (data) => {
+      setMessage(setMessage('Registration update succeeded', 'positive'));
+      queryClient.setQueryData(
+        ['registration', competitionInfo.id, userId],
+        data,
+      );
+    },
+  });
+
+  useEffect(() => {
+    if (serverRegistration) {
+      setRegistration(serverRegistration);
+      setComment(serverRegistration.competing.comment ?? '');
+      setStatus(serverRegistration.competing.registration_status);
+      setSelectedEvents(serverRegistration.competing.event_ids);
+      setAdminComment(serverRegistration.competing.admin_comment ?? '');
+      setWaitingListPosition(
+        serverRegistration.competing.waiting_list_position ?? 0,
+      );
+      setGuests(serverRegistration.guests ?? 0);
+    }
+  }, [serverRegistration]);
+
+  const hasEventsChanged = serverRegistration
+    && _.xor(serverRegistration.competing.event_ids, selectedEvents).length > 0;
+  const hasCommentChanged = serverRegistration
+    && comment !== (serverRegistration.competing.comment ?? '');
+  const hasAdminCommentChanged = serverRegistration
+    && adminComment !== (serverRegistration.competing.admin_comment ?? '');
+  const hasStatusChanged = serverRegistration
+    && status !== serverRegistration.competing.registration_status;
+  const hasGuestsChanged = false;
+
+  const hasChanges = hasEventsChanged
+    || hasCommentChanged
+    || hasAdminCommentChanged
+    || hasStatusChanged
+    || hasGuestsChanged;
+
+  const commentIsValid = comment || !competitionInfo.force_comment_in_registration;
+  const maxEvents = competitionInfo.events_per_registration_limit ?? Infinity;
+  const eventsAreValid = selectedEvents.length > 0 && selectedEvents.length <= maxEvents;
+
+  const handleRegisterClick = useCallback(() => {
+    if (!hasChanges) {
+      dispatch(setMessage('There are no changes', 'basic'));
+    } else if (!commentIsValid) {
+      dispatch(setMessage('You must include a comment', 'negative'));
+    } else if (!eventsAreValid) {
+      dispatch(setMessage(
+        maxEvents === Infinity
+          ? 'You must select at least 1 event'
+          : `You must select between 1 and ${maxEvents} events`,
+        'negative',
+      ));
+    } else {
+      dispatch(setMessage('Updating Registration', 'basic'));
+      updateRegistrationMutation({
+        user_id: userId,
+        competing: {
+          status,
+          event_ids: selectedEvents,
+          comment,
+          admin_comment: adminComment,
+          waiting_list_position: waitingListPosition,
+        },
+        competition_id: competitionInfo.id,
+      });
+    }
+  }, [hasChanges,
+    commentIsValid,
+    eventsAreValid, dispatch, maxEvents,
+    updateRegistrationMutation, userId,
+    status, selectedEvents, comment,
+    adminComment, waitingListPosition, competitionInfo.id]);
+
+  const registrationEditDeadlinePassed = Boolean(competitionInfo.event_change_deadline_date)
+    && hasPassed(competitionInfo.event_change_deadline_date);
+
+  const competitorInfo = useMemo(() => {
+    if (competitorsInfo) {
+      return competitorsInfo.find((c) => c.id === userId);
+    }
+    return null;
+  }, [competitorsInfo, userId]);
+
+  return (
+    <Segment padded attached>
+      {!registration?.competing?.registration_status || isLoading ? (
+        <Loading />
+      ) : (
+        <div>
+          {competitorInfo.wca_id && (
+            <Message>
+              This person registered with an account. You can edit their
+              personal information
+              {' '}
+              <a href={`${process.env.WCA_URL}/users/${userId}/edit`}>here.</a>
+            </Message>
+          )}
+          <Header>{competitorInfo.name}</Header>
+          <EventSelector
+            handleEventSelection={setSelectedEvents}
+            selected={selectedEvents}
+            disabled={registrationEditDeadlinePassed}
+            eventList={competitionInfo.event_ids}
+          />
+
+          <Header>Comment</Header>
+          <TextArea
+            id="competitor-comment"
+            maxLength={240}
+            value={comment}
+            disabled={registrationEditDeadlinePassed}
+            onChange={(_, data) => {
+              setComment(data.value);
+            }}
+          />
+
+          <Header>Administrative Notes</Header>
+          <TextArea
+            id="admin-comment"
+            maxLength={240}
+            value={adminComment}
+            disabled={registrationEditDeadlinePassed}
+            onChange={(_, data) => {
+              setAdminComment(data.value);
+            }}
+          />
+
+          <Header>Status</Header>
+          <div>
+            <Checkbox
+              radio
+              label="Pending"
+              name="checkboxRadioGroup"
+              value="pending"
+              checked={status === 'pending'}
+              disabled={registrationEditDeadlinePassed}
+              onChange={(_, data) => setStatus(data.value)}
+            />
+            <br />
+            <Checkbox
+              radio
+              label="Accepted"
+              name="checkboxRadioGroup"
+              value="accepted"
+              checked={status === 'accepted'}
+              disabled={registrationEditDeadlinePassed}
+              onChange={(_, data) => setStatus(data.value)}
+            />
+            <br />
+            <Checkbox
+              radio
+              label="Waiting List"
+              name="checkboxRadioGroup"
+              value="waiting_list"
+              checked={status === 'waiting_list'}
+              disabled={registrationEditDeadlinePassed}
+              onChange={(_, data) => setStatus(data.value)}
+            />
+            <br />
+            <Checkbox
+              radio
+              label="Cancelled"
+              name="checkboxRadioGroup"
+              value="cancelled"
+              disabled={registrationEditDeadlinePassed}
+              checked={status === 'cancelled'}
+              onChange={(_, data) => setStatus(data.value)}
+            />
+            <br />
+            <Header>Guests</Header>
+            <Input
+              disabled={registrationEditDeadlinePassed}
+              type="number"
+              min={0}
+              max={99}
+              value={guests}
+              onChange={(_, data) => setGuests(data.value)}
+            />
+          </div>
+
+          {registrationEditDeadlinePassed ? (
+            <Message negative>Registration edit deadline has passed.</Message>
+          ) : (
+            <Button
+              color="blue"
+              onClick={handleRegisterClick}
+              disabled={isUpdating}
+            >
+              Update Registration
+            </Button>
+          )}
+
+          {competitionInfo['using_stripe_payments?'] && (
+            <>
+              <Header>
+                Payment status:
+                {' '}
+                {registration.payment.payment_status}
+              </Header>
+              {registration.payment.payment_status === 'succeeded' && (
+                <Button onClick={() => setIsCheckingRefunds(true)}>
+                  Show Available Refunds
+                </Button>
+              )}
+              <Refunds
+                competitionId={competitionInfo.id}
+                userId={userId}
+                open={isCheckingRefunds}
+                onExit={() => setIsCheckingRefunds(false)}
+              />
+            </>
+          )}
+          <Accordion>
+            <Accordion.Title
+              active={isHistoryCollapsed}
+              onClick={() => setIsHistoryCollapsed(!isHistoryCollapsed)}
+            >
+              Registration History
+            </Accordion.Title>
+            <Accordion.Content active={isHistoryCollapsed}>
+              <Table>
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell>Timestamp</Table.HeaderCell>
+                    <Table.HeaderCell>Changes</Table.HeaderCell>
+                    <Table.HeaderCell>Acting User</Table.HeaderCell>
+                    <Table.HeaderCell>Action</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {registration.history.map((entry) => (
+                    <Table.Row key={entry.timestamp}>
+                      <Table.Cell>
+                        <Popup
+                          content={getShortTimeString(entry.timestamp)}
+                          trigger={
+                            <span>{getShortDateString(entry.timestamp)}</span>
+                          }
+                        />
+                      </Table.Cell>
+                      <Table.Cell>
+                        {!_.isEmpty(entry.changed_attributes) ? (
+                          Object.entries(entry.changed_attributes).map(
+                            ([k, v]) => (
+                              <span key={k}>
+                                Changed
+                                {' '}
+                                {k}
+                                {' '}
+                                to
+                                {' '}
+                                {JSON.stringify(v)}
+                                {' '}
+                                <br />
+                              </span>
+                            ),
+                          )
+                        ) : (
+                          <span>Registration Created</span>
+                        )}
+                      </Table.Cell>
+                      <Table.Cell>
+                        {
+                          competitorsInfo.find(
+                            (c) => c.id === entry.actor_user_id,
+                          ).name
+                        }
+                      </Table.Cell>
+                      <Table.Cell>{entry.action}</Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table>
+            </Accordion.Content>
+          </Accordion>
+        </div>
+      )}
+    </Segment>
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import RegistrationEditor from './RegistrationEditor';
+import RegistrationMessage from '../Register/RegistrationMessage';
+import messageReducer from '../reducers/messageReducer';
+import StoreProvider from '../../../lib/providers/StoreProvider';
+
+export default function RegistrationEdit({ competitionInfo, userId }) {
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
+        <RegistrationMessage />
+        <RegistrationEditor competitionInfo={competitionInfo} userId={userId} />
+      </StoreProvider>
+    </QueryClientProvider>
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
@@ -5,12 +5,12 @@ import RegistrationMessage from '../Register/RegistrationMessage';
 import messageReducer from '../reducers/messageReducer';
 import StoreProvider from '../../../lib/providers/StoreProvider';
 
-export default function RegistrationEdit({ competitionInfo, userId }) {
+export default function RegistrationEdit({ competitionInfo, user }) {
   return (
     <QueryClientProvider client={new QueryClient()}>
       <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
         <RegistrationMessage />
-        <RegistrationEditor competitionInfo={competitionInfo} userId={userId} />
+        <RegistrationEditor competitionInfo={competitionInfo} competitor={user} />
       </StoreProvider>
     </QueryClientProvider>
   );

--- a/app/webpacker/components/RegistrationsV2/api/payment/get/getAvailableRefunds.js
+++ b/app/webpacker/components/RegistrationsV2/api/payment/get/getAvailableRefunds.js
@@ -1,0 +1,9 @@
+import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
+import { paymentRefundsUrl } from '../../../../../lib/requests/routes.js.erb';
+
+export default async function getAvailableRefunds(
+  competitionId,
+  userId,
+) {
+  return fetchJsonOrError(paymentRefundsUrl(competitionId, userId));
+}

--- a/app/webpacker/components/RegistrationsV2/api/payment/get/getStripeConfig.js
+++ b/app/webpacker/components/RegistrationsV2/api/payment/get/getStripeConfig.js
@@ -1,9 +1,9 @@
-import { paymentConfigRoute } from '../../../../../lib/requests/routes.js.erb';
+import { paymentConfigUrl } from '../../../../../lib/requests/routes.js.erb';
 import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
 
 export default async function getStripeConfig(
   competitionId,
   paymentId,
 ) {
-  return fetchJsonOrError(paymentConfigRoute(competitionId, paymentId));
+  return fetchJsonOrError(paymentConfigUrl(competitionId, paymentId));
 }

--- a/app/webpacker/components/RegistrationsV2/api/payment/get/refundPayment.js
+++ b/app/webpacker/components/RegistrationsV2/api/payment/get/refundPayment.js
@@ -1,0 +1,13 @@
+import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
+import { paymentRefundsUrl } from '../../../../../lib/requests/routes.js.erb';
+
+export default async function refundPayment({
+  competitionId,
+  userId,
+  paymentId,
+  amount,
+}) {
+  return fetchJsonOrError(
+    paymentRefundsUrl(competitionId, userId, paymentId, amount),
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/api/user/post/getUserInfo.js
+++ b/app/webpacker/components/RegistrationsV2/api/user/post/getUserInfo.js
@@ -11,5 +11,5 @@ export default async function getUsersInfo(
   }
 
   const { data } = await fetchJsonOrError(apiV0Urls.users.show(userIds));
-  return data;
+  return data.users;
 }

--- a/app/webpacker/components/RegistrationsV2/api/user/post/getUserInfo.js
+++ b/app/webpacker/components/RegistrationsV2/api/user/post/getUserInfo.js
@@ -1,4 +1,5 @@
-import fetchWithJWTToken from '../../../../../lib/requests/fetchWithJWTToken';
+import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
+import { apiV0Urls } from '../../../../../lib/requests/routes.js.erb';
 
 export default async function getUsersInfo(
   userIds,
@@ -9,12 +10,6 @@ export default async function getUsersInfo(
     return [];
   }
 
-  const { data } = await fetchWithJWTToken('/api/v1/users', {
-    body: JSON.stringify({ ids: userIds }),
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+  const { data } = await fetchJsonOrError(apiV0Urls.users.show(userIds));
   return data;
 }

--- a/app/webpacker/components/RegistrationsV2/api/user/post/getUserInfo.js
+++ b/app/webpacker/components/RegistrationsV2/api/user/post/getUserInfo.js
@@ -1,0 +1,20 @@
+import fetchWithJWTToken from '../../../../../lib/requests/fetchWithJWTToken';
+
+export default async function getUsersInfo(
+  userIds,
+) {
+  // safeguard for when there is nothing to query.
+  // Rails blows up with an empty param array so we cannot do this check in the backend.
+  if (userIds.length === 0) {
+    return [];
+  }
+
+  const { data } = await fetchWithJWTToken('/api/v1/users', {
+    body: JSON.stringify({ ids: userIds }),
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  return data;
+}

--- a/app/webpacker/components/RegistrationsV2/hooks/useWithUserData.js
+++ b/app/webpacker/components/RegistrationsV2/hooks/useWithUserData.js
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import getUsersInfo from '../api/user/post/getUserInfo';
+import { addUserData } from '../lib/users';
+
+export default function useWithUserData(
+  registrations,
+) {
+  // requires a custom comparator because standard JS interprets everything as strings when sorting:
+  // https://typescript-eslint.io/rules/require-array-sort-compare/
+  const sortedIds = registrations
+    .map((reg) => reg.user_id)
+    .toSorted((a, b) => a - b);
+
+  return useQuery({
+    queryFn: () => getUsersInfo(sortedIds),
+    queryKey: ['user-info', ...sortedIds],
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+    refetchOnMount: 'always',
+    retry: false,
+    select: (data) => addUserData(registrations, data),
+  });
+}

--- a/app/webpacker/components/RegistrationsV2/lib/users.js
+++ b/app/webpacker/components/RegistrationsV2/lib/users.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line import/prefer-default-export
+export function addUserData(
+  registrations,
+  userInfo,
+) {
+  return registrations.map((r) => {
+    const user = userInfo.find((u) => u.id === r.user_id);
+    return user ? { ...r, user } : r;
+  });
+}

--- a/app/webpacker/components/RegistrationsV2/reducers/messageReducer.jsx
+++ b/app/webpacker/components/RegistrationsV2/reducers/messageReducer.jsx
@@ -1,0 +1,6 @@
+const messageReducer = (state, { payload }) => ({
+  ...state,
+  message: { key: payload.key, type: payload.type, params: payload.params },
+});
+
+export default messageReducer;

--- a/app/webpacker/components/RegistrationsV2/reducers/sortReducer.jsx
+++ b/app/webpacker/components/RegistrationsV2/reducers/sortReducer.jsx
@@ -1,0 +1,21 @@
+export default function createSortReducer(columns) {
+  return (state, action) => {
+    if (action.type === 'CHANGE_SORT') {
+      if (state.sortColumn === action.sortColumn) {
+        return {
+          ...state,
+          sortDirection:
+            state.sortDirection === 'ascending' ? 'descending' : 'ascending',
+        };
+      }
+      if (!columns.includes(action.sortColumn)) {
+        throw new Error('Unknown Column');
+      }
+      return {
+        sortColumn: action.sortColumn,
+        sortDirection: 'ascending',
+      };
+    }
+    throw new Error('Unknown Action');
+  };
+}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -176,6 +176,7 @@ export const apiV0Urls = {
       permissions: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_users_me_permissions_path) %>`,
       token: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_token_path) %>`,
     },
+    show: (ids) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_users_path) %>?${ids.map(id => "ids[]=" + id).join('&')}`
   },
   persons: {
     show: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_persons_path) %>/${wcaId}`,

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -5,6 +5,8 @@ function jsonToQueryString(json) {
   return (new URLSearchParams(jsonAfterRemovingUndefinedAndNull)).toString();
 }
 
+export const editPersonUrl = (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_user_path("${userId}"))%>`;
+
 export const personUrl = (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.person_path("${wcaId}"))%>`;
 
 export const personsUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.persons_path) %>`;
@@ -80,9 +82,13 @@ export const adminFixResultsUrl = (personId, competition_id = undefined, event_i
   return `<%= CGI.unescape(Rails.application.routes.url_helpers.admin_fix_results_path) %>?${searchParams.toString()}`
 };
 
-export const paymentFinishRoute = "<%= CGI.unescape(Rails.application.routes.url_helpers.finish_path) %>"
+export const paymentFinishUrl = "<%= CGI.unescape(Rails.application.routes.url_helpers.finish_path) %>"
 
-export const paymentConfigRoute = "<%= CGI.unescape(Rails.application.routes.url_helpers.config_path) %>"
+export const paymentRefundsUrl = (competitionId, userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refunds_path) %>?attendee_id=${competitionId}-${userId}`
+
+export const refundPaymentUrl = (competitionId, userId, paymentId, amount) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refund_path) %>?attendee_id=${competitionId}-${userId}&payment_id=${paymentId}&refund_amount=${amount}`
+
+export const paymentConfigUrl = "<%= CGI.unescape(Rails.application.routes.url_helpers.config_path) %>"
 
 export const adminGenerateIds = `<%= CGI.unescape(Rails.application.routes.url_helpers.persons_new_id_path) %>`;
 
@@ -224,3 +230,5 @@ export const userPreferencesRoute = `<%= CGI.unescape(Rails.application.routes.u
 export const pollingRoute = (userId, competitionId) => `<%= CGI.unescape(EnvConfig.WCA_REGISTRATIONS_POLL_URL)%>?attendee_id=${competitionId}-${userId}`;
 
 export const wcaRegistrationUrl = `<%= CGI.unescape(EnvConfig.WCA_REGISTRATIONS_URL)%>`;
+
+export const editRegistrationUrl = (attendeeId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_registration_path("${attendeeId}"))%>`

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -232,4 +232,4 @@ export const pollingRoute = (userId, competitionId) => `<%= CGI.unescape(EnvConf
 
 export const wcaRegistrationUrl = `<%= CGI.unescape(EnvConfig.WCA_REGISTRATIONS_URL)%>`;
 
-export const editRegistrationUrl = (userId, competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_registration_v2_path("${competitionId}","${userId}"))%>`
+export const editRegistrationUrl = (userId, competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_edit_registration_v2_path(competition_id: "${competitionId}", user_id: "${userId}"))%>`

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -82,13 +82,13 @@ export const adminFixResultsUrl = (personId, competition_id = undefined, event_i
   return `<%= CGI.unescape(Rails.application.routes.url_helpers.admin_fix_results_path) %>?${searchParams.toString()}`
 };
 
-export const paymentFinishUrl = "<%= CGI.unescape(Rails.application.routes.url_helpers.finish_path) %>"
+export const paymentFinishUrl = "TODO"; //"<%= CGI.unescape(Rails.application.routes.url_helpers.finish_path) %>"
 
-export const paymentRefundsUrl = (competitionId, userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refunds_path) %>?attendee_id=${competitionId}-${userId}`
+export const paymentRefundsUrl = "TODO"; //(competitionId, userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refunds_path) %>?attendee_id=${competitionId}-${userId}`
 
-export const refundPaymentUrl = (competitionId, userId, paymentId, amount) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refund_path) %>?attendee_id=${competitionId}-${userId}&payment_id=${paymentId}&refund_amount=${amount}`
+export const refundPaymentUrl = "TODO"; // (competitionId, userId, paymentId, amount) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refund_path) %>?attendee_id=${competitionId}-${userId}&payment_id=${paymentId}&refund_amount=${amount}`
 
-export const paymentConfigUrl = "<%= CGI.unescape(Rails.application.routes.url_helpers.config_path) %>"
+export const paymentConfigUrl = "TODO"; // <%= CGI.unescape(Rails.application.routes.url_helpers.config_path) %>"
 
 export const adminGenerateIds = `<%= CGI.unescape(Rails.application.routes.url_helpers.persons_new_id_path) %>`;
 

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -232,4 +232,4 @@ export const pollingRoute = (userId, competitionId) => `<%= CGI.unescape(EnvConf
 
 export const wcaRegistrationUrl = `<%= CGI.unescape(EnvConfig.WCA_REGISTRATIONS_URL)%>`;
 
-export const editRegistrationUrl = (attendeeId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_registration_path("${attendeeId}"))%>`
+export const editRegistrationUrl = (userId, competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_registration_v2_path("${competitionId}","${userId}"))%>`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
     post 'registrations/export' => 'registrations#export', as: :registrations_export
     get 'registrations/import' => 'registrations#import', as: :registrations_import
     post 'registrations/import' => 'registrations#do_import', as: :registrations_do_import
+    get 'registrations_v2/:competition_id/:user_id/edit' => 'registrations#edit_v2', as: :edit_registration_v2
     get 'registrations/add' => 'registrations#add', as: :registrations_add
     post 'registrations/add' => 'registrations#do_add', as: :registrations_do_add
     get 'registrations/psych-sheet' => 'registrations#psych_sheet', as: :psych_sheet


### PR DESCRIPTION
This adds Registration Administration for all and one registration. I have a couple issues currently though which I would like some input on:

- Currently the registration edit page is routed to by using a unique registration id from the DB. The new registration service uses attendee ids instead. This will need changes in the controller to not load @registration when v2 is used, is that fine or do we want to redirect?
- There is some jQuery that is loaded on the onPage 'hook' like `onPage('registrations#edit_registrations', function() {` which currently breaks my rendering, is there a way to load this conditionally?