### PR TITLE
Lock PI row when updating charges

### DIFF
--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -40,7 +40,7 @@ class PaymentIntent < ApplicationRecord
   private
 
     def update_stripe_status_and_charges(api_intent, action_source, source_datetime)
-      ActiveRecord::Base.transaction do
+      self.with_lock do
         self.update!(error_details: api_intent.last_payment_error)
         self.payment_record.update_status(api_intent)
 


### PR DESCRIPTION
Seems like there is a weird race condition between the payment gateway return URL and the webhook implementation. This should hopefully prevent concurrent writes :upside_down_face: 