### PR TITLE
Hide trainee delegate's information as they are not public

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -542,6 +542,10 @@ class User < ApplicationRecord
     delegate_roles.any? { |role| role.metadata.status == RolesMetadataDelegateRegions.statuses[:trainee_delegate] }
   end
 
+  private def staff_delegate?
+    any_kind_of_delegate? && !trainee_delegate?
+  end
+
   def senior_delegate?
     senior_delegate_roles.any?
   end
@@ -1126,7 +1130,7 @@ class User < ApplicationRecord
     # of the freezed variables (which would leak PII)!
     default_options = DEFAULT_SERIALIZE_OPTIONS.deep_dup
     # Delegates's emails and regions are public information.
-    if any_kind_of_delegate?
+    if staff_delegate?
       default_options[:methods].push("email", "location", "region_id")
     end
 


### PR DESCRIPTION
This was a request from trainee delegate that their email shouldn't be public and the request makes sense, so raising PR to hide trainee's data from public API