### PR TITLE
Remove leader panel access to senior delegates

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1324,7 +1324,7 @@ class User < ApplicationRecord
   end
 
   def can_access_leader_panel?
-    admin? || active_roles.any? { |role| UserRole.is_lead?(role) }
+    admin? || active_roles.any? { |role| UserRole.is_lead?(role) && (UserRole.group(role).teams_committees? || UserRole.group(role).councils?) }
   end
 
   def can_access_senior_delegate_panel?


### PR DESCRIPTION
Got to know from a senior delegate that they are getting access to leader panel, and I realized the mistake in code. Fixing this.