### PR TITLE
Fix reloading / data inconsistency issue upon Stripe redirect

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -553,7 +553,14 @@ class RegistrationsController < ApplicationController
     intent_id = params[:payment_intent]
     intent_secret = params[:payment_intent_client_secret]
 
+    # We expect that the record here is a top-level PaymentIntent in Stripe's API model
     stored_record = StripeRecord.find_by(stripe_id: intent_id)
+
+    unless stored_record.payment_intent?
+      flash[:error] = t("registrations.payment_form.errors.stripe_not_an_intent")
+      return redirect_to competition_register_path(@competition)
+    end
+
     stored_intent = stored_record.payment_intent
 
     unless stored_intent.client_secret == intent_secret
@@ -585,7 +592,7 @@ class RegistrationsController < ApplicationController
     end
 
     # Payment Intent lifecycle as per https://stripe.com/docs/payments/intents#intent-statuses
-    case stored_record.stripe_status
+    case stored_intent.payment_record.stripe_status
     when 'succeeded'
       flash[:success] = t("registrations.payment_form.payment_successful")
     when 'requires_action'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1222,6 +1222,7 @@ en:
         stripe_failed: "Please check the Stripe transaction."
         stripe_not_found: "Stripe reported back a transaction ID that couldn't be found."
         stripe_secret_invalid: "Stripe reported back a transaction secret that doesn't match our records."
+        stripe_not_an_intent: "Stripe reported back a transaction ID that is not actually a payment intent."
         payment_reset: "The payment was rejected by Stripe."
         payment_pending: "The payment has not been completed yet."
     preferred_events_prompt_html: "To speed up registration in the future, you can set your preferred events %{link}."


### PR DESCRIPTION
Gist of it: Inconsistency between Rails memory and DB.

We pass the updated remote record to `payment_intent`, which internally does `self.payment_record.update(...foo...)`.
In the outer code block, we should not use `stored_record` because that reference was loaded from the DB before even loading the corresponding WCA intent. So the internal update might not hit the right reference in memory.

By accessing `payment_intent.payment_record.stripe_status` we definitely make sure that there are no weird timing issues between the code reading after lock and the DB changes being propagated in-memory.

Bonus: Little sanity check.