### PR TITLE
Added email to api/v0/users/me API

### DIFF
--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -5,7 +5,7 @@ class Api::V0::UsersController < Api::V0::ApiController
     require_user!
     if stale?(current_user)
       # Also include the users current prs so we can handle qualifications on the Frontend
-      show_user(current_user, show_rankings: true, current_user: true)
+      show_user(current_user, show_rankings: true, private_attributes: ['email'])
     end
   end
 
@@ -62,13 +62,9 @@ class Api::V0::UsersController < Api::V0::ApiController
 
   private
 
-    def show_user(user, show_rankings: false, current_user: false)
+    def show_user(user, show_rankings: false, private_attributes: [])
       if user
-        if current_user
-          json = { user: user.serializable_hash(private_attributes: ['email']) }
-        else
-          json = { user: user }
-        end
+        json = { user: user.serializable_hash(private_attributes: private_attributes) }
         if params[:upcoming_competitions]
           json[:upcoming_competitions] = user.accepted_competitions.select(&:upcoming?)
         end

--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -5,7 +5,7 @@ class Api::V0::UsersController < Api::V0::ApiController
     require_user!
     if stale?(current_user)
       # Also include the users current prs so we can handle qualifications on the Frontend
-      show_user(current_user, show_rankings: true)
+      show_user(current_user, show_rankings: true, current_user: true)
     end
   end
 
@@ -62,9 +62,13 @@ class Api::V0::UsersController < Api::V0::ApiController
 
   private
 
-    def show_user(user, show_rankings: false)
+    def show_user(user, show_rankings: false, current_user: false)
       if user
-        json = { user: user }
+        if current_user
+          json = { user: user.serializable_hash(private_attributes: ['email']) }
+        else
+          json = { user: user }
+        end
         if params[:upcoming_competitions]
           json[:upcoming_competitions] = user.accepted_competitions.select(&:upcoming?)
         end

--- a/spec/controllers/api_users_controller_spec.rb
+++ b/spec/controllers/api_users_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Api::V0::UsersController do
       get :show_me
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["user"]).to eq normal_user.as_json
+      expect(json["user"]).to eq normal_user.serializable_hash(private_attributes: ['email']).as_json
     end
     let!(:id_less_user) { FactoryBot.create(:user, email: "example@email.com") }
 
@@ -66,7 +66,7 @@ RSpec.describe Api::V0::UsersController do
       get :show_me
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["user"]).to eq id_less_user.as_json
+      expect(json["user"]).to eq id_less_user.serializable_hash(private_attributes: ['email']).as_json
     end
 
     let(:competed_person) { FactoryBot.create(:person_who_has_competed_once, name: "Jeremy", wca_id: "2005FLEI01") }
@@ -77,7 +77,7 @@ RSpec.describe Api::V0::UsersController do
       get :show_me
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
-      expect(json["user"]).to eq competed_user.as_json
+      expect(json["user"]).to eq competed_user.serializable_hash(private_attributes: ['email']).as_json
       expect(json.key?("rankings")).to eq true
     end
   end


### PR DESCRIPTION
In contacts form, the name and email is prefilled. But I just realized that the email is not getting prefilled. This is because the user serialization is not including email. This PR is adding email to the user serialization if the requested user is `current_user`.