### PR TITLE
Make contact form more cleaner for user

### DIFF
--- a/app/models/website_contact.rb
+++ b/app/models/website_contact.rb
@@ -35,12 +35,9 @@ class WebsiteContact < ContactForm
   def subject
     topic = case inquiry
             when "competition" then "Comment for #{Competition.find_by_id(competition_id)&.name}"
-            when "competitions_in_general" then "General Competition Comment"
+            when "communications_team" then "General Comment"
             when "results_team" then "Results Team Comment"
-            when "wca_id_or_profile" then "WCA ID or WCA Profile Comment"
-            when "media" then "Media Comment"
             when "software" then "Software Comment"
-            when "different" then "Other Comment"
             else
               raise "Invalid inquiry type: `#{inquiry}`" if inquiry.present?
             end

--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -14,17 +14,14 @@ import Loading from '../Requests/Loading';
 import Wct from './SubForms/Wct';
 import Competition from './SubForms/Competition';
 
-const CONTACT_TYPES = [
+const CONTACT_RECIPIENTS = [
   'competition',
-  'competitions_in_general',
+  'communications_team',
   'results_team',
-  'wca_id_or_profile',
-  'media',
   'software',
-  'different',
 ];
 
-const CONTACT_TYPES_MAP = _.keyBy(CONTACT_TYPES);
+const CONTACT_RECIPIENTS_MAP = _.keyBy(CONTACT_RECIPIENTS);
 
 const SUBFORM_DEFAULT_VALUE = {
   competition: null,
@@ -49,7 +46,7 @@ export default function ContactForm({ userDetails }) {
   const SubForm = useMemo(() => {
     if (!selectedContactType) return null;
     switch (selectedContactType) {
-      case CONTACT_TYPES_MAP.competition:
+      case CONTACT_RECIPIENTS_MAP.competition:
         return Competition;
       default:
         return Wct;
@@ -80,17 +77,18 @@ export default function ContactForm({ userDetails }) {
       }}
       error={!!captchaError}
     >
-      <UserData
-        formValues={userData}
-        setFormValues={setUserData}
-        isInputDisabled={!!userDetails}
-      />
+      {!userDetails && (
+        <UserData
+          formValues={userData}
+          setFormValues={setUserData}
+        />
+      )}
       <FormGroup grouped>
-        <div>{I18n.t('page.contacts.form.contact_type.label')}</div>
-        {CONTACT_TYPES.map((contactType) => (
+        <div>{I18n.t('page.contacts.form.contact_recipient.label')}</div>
+        {CONTACT_RECIPIENTS.map((contactType) => (
           <FormField key={contactType}>
             <Radio
-              label={I18n.t(`page.contacts.form.contact_type.${contactType}.label`)}
+              label={I18n.t(`page.contacts.form.contact_recipient.${contactType}.label`)}
               name="contactType"
               value={contactType}
               checked={selectedContactType === contactType}

--- a/app/webpacker/components/ContactsPage/SubForms/UserData/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/UserData/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Form } from 'semantic-ui-react';
 import I18n from '../../../../lib/i18n';
 
-export default function UserData({ formValues, setFormValues, isInputDisabled }) {
+export default function UserData({ formValues, setFormValues }) {
   const handleFormChange = (_, { name, value }) => setFormValues(
     { ...formValues, [name]: value },
   );
@@ -12,14 +12,12 @@ export default function UserData({ formValues, setFormValues, isInputDisabled })
       <Form.Input
         label={I18n.t('page.contacts.form.user_data.name.label')}
         name="name"
-        disabled={isInputDisabled}
         value={formValues.name}
         onChange={handleFormChange}
       />
       <Form.Input
         label={I18n.t('page.contacts.form.user_data.email.label')}
         name="email"
-        disabled={isInputDisabled}
         value={formValues.email}
         onChange={handleFormChange}
       />

--- a/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
@@ -8,7 +8,7 @@ export default function Wct({ formValues, setFormValues }) {
   );
   return (
     <Form.TextArea
-      label={I18n.t('page.contacts.form.wct.message.label')}
+      label={I18n.t('page.contacts.form.communications_team.message.label')}
       name="message"
       value={formValues.message}
       onChange={handleFormChange}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,28 +796,22 @@ en:
             label: "Name"
           email:
             label: "Email"
-        contact_type:
+        contact_recipient:
           label: "Which of the following best describes your inquiry?"
           competition:
-            label: "Contact the Organizers of a Specific Competition (please select below)"
-          competitions_in_general:
-            label: "Competitions in General (organizing, competition rules, etc.)"
+            label: "Contact organizers/delegates of a competition (to ask query regarding that particular competition)"
+          communications_team:
+            label: "Contact WCA for general queries (this can involve anything like WCA ID/profile, organizing competitions, competition rules, competition media, etc)"
           results_team:
-            label: "Contact the Results Team"
-          wca_id_or_profile:
-            label: "WCA ID or WCA Profile"
-          media:
-            label: "Media"
+            label: "Contact Results Team (for anything related to the results of a competition)"
           software:
-            label: "Software"
-          different:
-            label: "Other"
+            label: "Contact Software Team (to report some bug in website or any API related questions)"
         competition:
           competition:
             label: "Competition"
           message:
             label: "Message"
-        wct:
+        communications_team:
           message:
             label: "Message"
         captcha:

--- a/spec/models/website_contact_spec.rb
+++ b/spec/models/website_contact_spec.rb
@@ -62,29 +62,14 @@ RSpec.describe WebsiteContact do
       expect(form.subject).to start_with("[WCA Website] Comment for #{competition_name} by #{form.name} on")
     end
 
-    it "builds subject line for general competition inquiry" do
-      form = FactoryBot.build(:website_contact, inquiry: "competitions_in_general")
-      expect(form.subject).to start_with("[WCA Website] General Competition Comment by #{form.name} on")
-    end
-
-    it "builds subject line for wca id or profile inquiry" do
-      form = FactoryBot.build(:website_contact, inquiry: "wca_id_or_profile")
-      expect(form.subject).to start_with("[WCA Website] WCA ID or WCA Profile Comment by #{form.name} on")
-    end
-
-    it "builds subject line for media inquiry" do
-      form = FactoryBot.build(:website_contact, inquiry: "media")
-      expect(form.subject).to start_with("[WCA Website] Media Comment by #{form.name} on")
+    it "builds subject line for general inquiry" do
+      form = FactoryBot.build(:website_contact, inquiry: "communications_team")
+      expect(form.subject).to start_with("[WCA Website] General Comment by #{form.name} on")
     end
 
     it "builds subject line for software inquiry" do
       form = FactoryBot.build(:website_contact, inquiry: "software")
       expect(form.subject).to start_with("[WCA Website] Software Comment by #{form.name} on")
-    end
-
-    it "builds subject line for other inquiry" do
-      form = FactoryBot.build(:website_contact, inquiry: "different")
-      expect(form.subject).to start_with("[WCA Website] Other Comment by #{form.name} on")
     end
 
     it "raises error for invalid inquiry type" do


### PR DESCRIPTION
This does two things:
1. Changes the inquiry types to contact recipient, making the form more easier for users, and hence change the options to more easier ones.
2. Won't show user name & email if user is logged in.


<img width="1086" alt="Screenshot 2024-04-24 at 8 31 10 AM" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/420d882f-c67a-445b-92d9-cc2bb2c0a55c">
