### PR TITLE
Added query-params to contact form along with few other changes

### DIFF
--- a/app/views/competitions/_competition_info.html.erb
+++ b/app/views/competitions/_competition_info.html.erb
@@ -36,7 +36,7 @@
         <% if competition.contact.present? %>
           <%=md competition.contact %>
         <% else %>
-          <%= link_to t('.organization_team'), contact_path(competitionId: competition.id) %>
+          <%= link_to t('.organization_team'), contact_path(contactRecipient: 'competition', competitionId: competition.id) %>
         <% end %>
       </dd>
 

--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Form, FormGroup, FormField, Button, Radio, Message,
 } from 'semantic-ui-react';
@@ -6,6 +6,7 @@ import ReCAPTCHA from 'react-google-recaptcha';
 import _ from 'lodash';
 import { contactUrl } from '../../lib/requests/routes.js.erb';
 import useInputState from '../../lib/hooks/useInputState';
+import useQueryParams from '../../lib/hooks/useQueryParams';
 import useSaveAction from '../../lib/hooks/useSaveAction';
 import I18n from '../../lib/i18n';
 import { RECAPTCHA_PUBLIC_KEY } from '../../lib/wca-data.js.erb';
@@ -23,25 +24,25 @@ const CONTACT_RECIPIENTS = [
 
 const CONTACT_RECIPIENTS_MAP = _.keyBy(CONTACT_RECIPIENTS);
 
-const SUBFORM_DEFAULT_VALUE = {
-  competition: null,
-  message: '',
-};
-
 export default function ContactForm({ userDetails }) {
   const [userData, setUserData] = useState({
     name: userDetails?.user?.name || '',
     email: userDetails?.user?.email || '',
   });
-  const [selectedContactRecipient, setSelectedContactRecipient] = useInputState(null);
+  const [queryParams] = useQueryParams();
+  const [selectedContactRecipient, setSelectedContactRecipient] = useInputState(
+    queryParams?.contactRecipient,
+  );
   const [subformValues, setSubformValues] = useState(SUBFORM_DEFAULT_VALUE);
+  const [subformValid, setSubformValid] = useState(false);
 
   const { save, saving } = useSaveAction();
   const [captchaValue, setCaptchaValue] = useState();
   const [captchaError, setCaptchaError] = useState(false);
 
   const isFormValid = (
-    selectedContactRecipient && userData.name && userData.email && captchaValue
+    CONTACT_RECIPIENTS_MAP[selectedContactRecipient]
+     && userData.name && userData.email && captchaValue && subformValid
   );
   const SubForm = useMemo(() => {
     if (!selectedContactRecipient) return null;
@@ -51,10 +52,6 @@ export default function ContactForm({ userDetails }) {
       default:
         return Wct;
     }
-  }, [selectedContactRecipient]);
-
-  useEffect(() => {
-    setSubformValues(SUBFORM_DEFAULT_VALUE);
   }, [selectedContactRecipient]);
 
   if (saving) return <Loading />;
@@ -99,8 +96,8 @@ export default function ContactForm({ userDetails }) {
       </FormGroup>
       {SubForm && (
         <SubForm
-          formValues={subformValues}
-          setFormValues={setSubformValues}
+          setSubformValues={setSubformValues}
+          setFormValid={setSubformValid}
         />
       )}
       <FormField>

--- a/app/webpacker/components/ContactsPage/SubForms/Competition/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Competition/index.jsx
@@ -1,23 +1,64 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormTextArea } from 'semantic-ui-react';
+import { useQuery } from '@tanstack/react-query';
 import WcaSearch from '../../../SearchWidget/WcaSearch';
 import SEARCH_MODELS from '../../../SearchWidget/SearchModel';
 import I18n from '../../../../lib/i18n';
+import useQueryParams from '../../../../lib/hooks/useQueryParams';
+import { fetchJsonOrError } from '../../../../lib/requests/fetchWithAuthenticityToken';
+import { apiV0Urls } from '../../../../lib/requests/routes.js.erb';
+import Loading from '../../../Requests/Loading';
+import { itemToOption } from '../../../SearchWidget/MultiSearchInput';
 
-export default function Competition({ formValues, setFormValues }) {
+const FORM_DEFAULT_VALUE = {
+  competition: null,
+  message: '',
+};
+
+export default function Competition({ setSubformValues, setFormValid }) {
+  const [queryParams] = useQueryParams();
+  const [formValues, setFormValues] = useState(FORM_DEFAULT_VALUE);
   const handleFormChange = (_, { name, value }) => setFormValues(
     { ...formValues, [name]: value },
   );
+  const { data: competitionData, isLoading } = useQuery({
+    queryKey: ['competition'],
+    queryFn: () => fetchJsonOrError(apiV0Urls.competitions.info(queryParams.competitionId)),
+    enabled: !!queryParams?.competitionId,
+  });
+
+  useEffect(() => {
+    setSubformValues(formValues);
+    setFormValid(formValues.competition !== null && formValues.message?.length > 0);
+  }, [formValues, setFormValid, setSubformValues]);
+
+  useEffect(() => {
+    if (competitionData && !formValues.competition) {
+      setFormValues({
+        ...formValues,
+        competition: itemToOption(competitionData.data),
+      });
+    }
+  }, [competitionData, formValues]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
   return (
     <>
-      <WcaSearch
-        label={I18n.t('page.contacts.form.competition.competition.label')}
-        name="competition"
-        value={formValues.competition}
-        onChange={handleFormChange}
-        model={SEARCH_MODELS.competition}
-        multiple={false}
-      />
+      {formValues.competition
+        ? `${I18n.t('page.contacts.form.competition.competition.label')}: ${formValues.competition.item.name}`
+        : (
+          <WcaSearch
+            label={I18n.t('page.contacts.form.competition.competition.label')}
+            name="competition"
+            value={formValues.competition}
+            onChange={handleFormChange}
+            model={SEARCH_MODELS.competition}
+            multiple={false}
+          />
+        )}
       <FormTextArea
         label={I18n.t('page.contacts.form.competition.message.label')}
         name="message"

--- a/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
@@ -1,11 +1,22 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Form } from 'semantic-ui-react';
 import I18n from '../../../../lib/i18n';
 
-export default function Wct({ formValues, setFormValues }) {
+const FORM_DEFAULT_VALUE = {
+  message: '',
+};
+
+export default function Wct({ setSubformValues, setFormValid }) {
+  const [formValues, setFormValues] = useState(FORM_DEFAULT_VALUE);
   const handleFormChange = (_, { name, value }) => setFormValues(
     { ...formValues, [name]: value },
   );
+
+  useEffect(() => {
+    setSubformValues(formValues);
+    setFormValid(formValues.message?.length > 0);
+  }, [formValues, setFormValid, setSubformValues]);
+
   return (
     <Form.TextArea
       label={I18n.t('page.contacts.form.communications_team.message.label')}

--- a/app/webpacker/components/ContactsPage/index.jsx
+++ b/app/webpacker/components/ContactsPage/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Header, Message, Container } from 'semantic-ui-react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import I18n from '../../lib/i18n';
 import I18nHTMLTranslate from '../I18nHTMLTranslate';
 import ContactForm from './ContactForm';
@@ -13,14 +14,16 @@ export default function ContactsPage() {
   if (loading) return <Loading />;
 
   return (
-    <Container fluid>
-      <Header as="h2">{I18n.t('page.contacts.title')}</Header>
-      <Message visible>
-        <I18nHTMLTranslate
-          i18nKey="page.contacts.faq_note_html"
-        />
-      </Message>
-      <ContactForm userDetails={userDetails} />
-    </Container>
+    <QueryClientProvider client={new QueryClient()}>
+      <Container fluid>
+        <Header as="h2">{I18n.t('page.contacts.title')}</Header>
+        <Message visible>
+          <I18nHTMLTranslate
+            i18nKey="page.contacts.faq_note_html"
+          />
+        </Message>
+        <ContactForm userDetails={userDetails} />
+      </Container>
+    </QueryClientProvider>
   );
 }


### PR DESCRIPTION
This PR aims at following changes related to contact form:
1. In backend, accepts `contactRecipient` instead of `contactType`.
2. In frontend, recognizes if contactRecipient is added in the queryParams. This will allow to replace WRT's contact emails with something like https://worldcubeassociation.org/contact?contactRecipient=results_team.
3. Renamed occurences of contactType with contactRecipient.
4. Moved UserData outside the SubForms folder, because UserData is not actually a subform, instead it is part of the common parent form.
5. Earlier, the subform default values were passed from the parent form. Changed it to the subform doing it's own formValues and form validation, and hence making it easier to expand more subforms in future. In other words, the work in the parent form is reduced and each subform will do some work on their own.