### PR TITLE
Replace some usages of teams with Team.banned

### DIFF
--- a/app/models/groups_metadata_teams_committees.rb
+++ b/app/models/groups_metadata_teams_committees.rb
@@ -2,4 +2,11 @@
 
 class GroupsMetadataTeamsCommittees < ApplicationRecord
   has_one :user_group, as: :metadata
+
+  def self.at_least_senior_member?(role)
+    [
+      RolesMetadataTeamsCommittees.statuses[:senior_member],
+      RolesMetadataTeamsCommittees.statuses[:leader],
+    ].include?(UserRole.status(role))
+  end
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -26,10 +26,6 @@ class TeamMember < ApplicationRecord
     end_date.nil? || end_date > Date.today
   end
 
-  def at_least_senior_member?
-    current_member? && (senior_member? || leader?)
-  end
-
   validate :start_date_must_be_earlier_than_or_same_as_end_date
   def start_date_must_be_earlier_than_or_same_as_end_date
     if start_date && end_date && start_date > end_date

--- a/spec/features/manage_team_spec.rb
+++ b/spec/features/manage_team_spec.rb
@@ -3,19 +3,19 @@
 require "rails_helper"
 
 RSpec.feature "Manage team" do
-  let!(:results_team) { Team.find_by_friendly_id("wrt") }
-  let!(:results_team_member) { FactoryBot.create(:user, :wrt_member) }
+  let!(:banned_team) { Team.banned }
+  let!(:banned_user) { FactoryBot.create(:user, :banned) }
 
   before(:each) do
     sign_in FactoryBot.create(:admin)
   end
 
   it 'remove member from team' do
-    visit "/teams/#{results_team.id}/edit"
+    visit "/teams/#{banned_team.id}/edit"
     fill_in "team_team_members_attributes_0_end_date", with: Date.today.to_s
 
-    expect(results_team_member.current_teams).to eq [results_team]
+    expect(banned_user.current_teams).to eq [banned_team]
     click_button "Update Team"
-    expect(results_team_member.reload.current_teams).to eq []
+    expect(banned_user.reload.current_teams).to eq []
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -457,10 +457,11 @@ RSpec.describe User, type: :model do
   it "#teams and #current_teams return unique team names" do
     user = FactoryBot.create(:user)
 
-    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 20)
-    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 10)
+    FactoryBot.create(:team_member, team_id: Team.wst.id, user_id: user.id, start_date: Date.today - 20, end_date: Date.today - 10)
+    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 5, end_date: Date.today + 5)
+    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today + 6, end_date: Date.today + 10)
 
-    expect(user.teams).to match_array [Team.banned]
+    expect(user.teams).to match_array [Team.wst, Team.banned]
     expect(user.current_teams).to match_array [Team.banned]
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -457,15 +457,11 @@ RSpec.describe User, type: :model do
   it "#teams and #current_teams return unique team names" do
     user = FactoryBot.create(:user)
 
-    team_member = FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 20)
+    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 20)
+    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 10)
 
     expect(user.teams).to match_array [Team.banned]
     expect(user.current_teams).to match_array [Team.banned]
-
-    team_member.update(end_date: Date.today - 10)
-
-    expect(user.teams).to match_array [Team.banned]
-    expect(user.current_teams.reload).to match_array []
   end
 
   it 'former banned users are not considered current members of Team.banned' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -457,29 +457,22 @@ RSpec.describe User, type: :model do
   it "#teams and #current_teams return unique team names" do
     user = FactoryBot.create(:user)
 
-    FactoryBot.create(:team_member, team_id: Team.wrc.id, user_id: user.id, start_date: Date.today - 20, end_date: Date.today - 10)
-    FactoryBot.create(:team_member, team_id: Team.wrt.id, user_id: user.id, start_date: Date.today - 5, end_date: Date.today + 5)
-    FactoryBot.create(:team_member, team_id: Team.wrt.id, user_id: user.id, start_date: Date.today + 6, end_date: Date.today + 10)
+    team_member = FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 20)
 
-    expect(user.teams).to match_array [Team.wrc, Team.wrt]
-    expect(user.current_teams).to match_array [Team.wrt]
+    expect(user.teams).to match_array [Team.banned]
+    expect(user.current_teams).to match_array [Team.banned]
+
+    team_member.update(end_date: Date.today - 10)
+
+    expect(user.teams).to match_array [Team.banned]
+    expect(user.current_teams.reload).to match_array []
   end
 
-  it 'former members of the results team are not considered current members' do
-    wrt_member = FactoryBot.create :user, :wrt_member
-    team_member = wrt_member.team_members.first
-    team_member.update!(end_date: 1.day.ago)
+  it 'former banned users are not considered current members of Team.banned' do
+    banned_user = FactoryBot.create :user, :banned
+    banned_user.team_members.first.update!(end_date: 1.day.ago)
 
-    expect(wrt_member.reload.team_member?(Team.wrt)).to eq false
-  end
-
-  it 'former leaders of the results team are not considered current leaders' do
-    wrt_leader = FactoryBot.create :user, :wrt_member
-    team_member = wrt_leader.team_members.first
-    team_member.update!(team_leader: true)
-    team_member.update!(end_date: 1.day.ago)
-
-    expect(wrt_leader.reload.team_leader?(Team.wrt)).to eq false
+    expect(banned_user.reload.team_member?(Team.banned)).to eq false
   end
 
   it "removes whitespace around names" do


### PR DESCRIPTION
current_teams, teams, current_team_members, etc of user model is not used for official teams now (there might be some, but no longer relevant once migration is finished). They are still used for Team.banned though. Hence, changed the unit tests to check from Team.banned.

Also cleaned up some usages with roles methods.

The purpose of this PR to cleanup little more before the final migration.