### PR TITLE
Remove obsolete ClearTmpCache cronjob

### DIFF
--- a/app/jobs/clear_tmp_cache.rb
+++ b/app/jobs/clear_tmp_cache.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class ClearTmpCache < ApplicationJob
-  def perform(args)
-    # stolen from `railties` gem lib/rails/tasks/tmp.rake
-    rm_rf Dir["tmp/cache/[^.]*"], verbose: false
-  end
-end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -57,9 +57,3 @@ delegates_metadata_sync:
   class: "DelegatesMetadataSyncJob"
   cron: "0 * * * *"
   queue: wca_jobs
-
-clear_tmp_cache:
-  class: "ClearTmpCache"
-  cron: "0 5 1,3,6 * *"
-  # Queueing on default because this is only a temporary task that we don't need statistics for
-  queue: default


### PR DESCRIPTION
The purpose of this job was to clear cache entries that were (previously) written to the disk of the Ubuntu EC2 machine we were running on.

This job was already obsolete way back when we started using Redis as a cache layer. Now it's even more obsolete because we moved to ECS container builds which are re-built and freshly spun up during each deploy.