### PR TITLE
Added clarification on ScheduleActivity parent object in error messages

### DIFF
--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -22,10 +22,10 @@ class ScheduleActivity < ApplicationRecord
   def included_in_parent_schedule
     return unless errors.blank?
     unless start_time >= holder.start_time
-      errors.add(:start_time, "should be after parent's start_time")
+      errors.add(:start_time, "should be after parent's start_time. Parent: #{holder.class}: #{holder&.name}")
     end
     unless end_time <= holder.end_time
-      errors.add(:end_time, "should be before parent's end_time")
+      errors.add(:end_time, "should be before parent's end_time. Parent: #{holder.class}: #{holder&.name}")
     end
     unless start_time <= end_time
       errors.add(:end_time, "should be after start_time")


### PR DESCRIPTION
Currently, the Schedule validation error is unclear because we don't know what the parent `holder` object is (it's a polymorphic association). This PR adds clarity by giving the class name of the holder object, and the name of the holder object itself if available.

![image](https://github.com/thewca/worldcubeassociation.org/assets/52967253/e2474ed7-ffec-46e1-9d78-37171e2a3bbd)
