### PR TITLE
Update links from Delegate Crash Course to Delegate Handbook

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -30,7 +30,7 @@ class PanelController < ApplicationController
     {
       "delegate" => {
         "importantLinks" => "important-links",
-        "delegateCrashCourse" => "delegate-crash-course",
+        "delegateHandbook" => "delegate-handbook",
         "bannedCompetitors" => "banned-competitors",
       },
       "board" => {

--- a/app/views/results_submission/_results_submission_panel.html.erb
+++ b/app/views/results_submission/_results_submission_panel.html.erb
@@ -21,8 +21,8 @@
       <p>Make sure the schedule on the WCA website actually reflects what happened during the competition.</p>
       <p>
         Please also make sure to include any other additional details required by the
-        <%= link_to "'Submitting competition results' section of the delegate crash course",
-          panel_delegate_crash_course_path %>.
+        <%= link_to "'Competition Results' section of the Delegate Handbook",
+          "https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf#competition-results" %>.
       </p>
 
       <%= simple_form_for results_submission, url: competition_submit_results_path do |f| %>

--- a/app/webpacker/components/Panel/Delegate/index.jsx
+++ b/app/webpacker/components/Panel/Delegate/index.jsx
@@ -4,7 +4,7 @@ import { PANEL_LIST } from '../../../lib/wca-data.js.erb';
 import ImportantLinks from './ImportantLinks';
 import BannedCompetitorsPage from '../pages/BannedCompetitorsPage';
 
-const delegateCrashCourseLink = 'https://documents.worldcubeassociation.org/edudoc/delegate-crash-course/delegate_crash_course.pdf';
+const delegateHandbookLink = 'https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf';
 
 const sections = [
   {
@@ -13,9 +13,9 @@ const sections = [
     component: ImportantLinks,
   },
   {
-    id: PANEL_LIST.delegate.delegateCrashCourse,
-    name: 'Delegate Crash Course',
-    link: delegateCrashCourseLink,
+    id: PANEL_LIST.delegate.delegateHandbook,
+    name: 'Delegate Handbook',
+    link: delegateHandbookLink,
   },
   {
     id: PANEL_LIST.delegate.bannedCompetitors,

--- a/app/webpacker/components/Panel/pages/EditPerson/index.jsx
+++ b/app/webpacker/components/Panel/pages/EditPerson/index.jsx
@@ -193,8 +193,8 @@ function EditPerson() {
   return (
     <>
       <div>
-        To know the difference between fix and update, refer delegate crash course&apos;s
-        &#34;Requesting changes to person data&#34; section.
+        To know the difference between fix and update, refer to the Delegate Handbook&apos;s
+        &#34;Requesting Changes to Personal Data&#34; section.
       </div>
       {response != null && (
         <Message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -407,6 +407,6 @@ Rails.application.routes.draw do
 
   # Deprecated Links
   get 'teams-committees' => redirect('teams-committees-councils')
-  get 'panel/delegate-crash-course' => redirect('panel/delegate#delegate-crash-course')
+  get 'panel/delegate-handbook' => redirect('panel/delegate#delegate-handbook')
   get 'panel' => redirect('panel/staff')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -407,6 +407,6 @@ Rails.application.routes.draw do
 
   # Deprecated Links
   get 'teams-committees' => redirect('teams-committees-councils')
-  get 'panel/delegate-handbook' => redirect('panel/delegate#delegate-handbook')
+  get 'panel/delegate-crash-course' => redirect('panel/delegate#delegate-handbook')
   get 'panel' => redirect('panel/staff')
 end


### PR DESCRIPTION
The Delegate Crash Course has been deprecated in favor of the Delegate Handbook. This PR updates existing references to the DCC to the Handbook where it is still relevant, or removes references to the DCC entirely where they are no longer needed.