### PR TITLE
Renamed contact recipients to match friendly IDs of teams

### DIFF
--- a/app/models/website_contact.rb
+++ b/app/models/website_contact.rb
@@ -25,7 +25,7 @@ class WebsiteContact < ContactForm
       if competition.present?
         return ValidateEmail.valid?(competition.contact) ? competition.contact : competition.managers.map(&:email)
       end
-    elsif inquiry == "wrt"
+    elsif inquiry == UserGroup.teams_committees_group_wrt.metadata.friendly_id
       return UserGroup.teams_committees_group_wrt.metadata.email
     end
 
@@ -35,9 +35,9 @@ class WebsiteContact < ContactForm
   def subject
     topic = case inquiry
             when "competition" then "Comment for #{Competition.find_by_id(competition_id)&.name}"
-            when "wct" then "General Comment"
-            when "wrt" then "Results Team Comment"
-            when "wst" then "Software Comment"
+            when UserGroup.teams_committees_group_wct.metadata.friendly_id then "General Comment"
+            when UserGroup.teams_committees_group_wrt.metadata.friendly_id then "Results Team Comment"
+            when UserGroup.teams_committees_group_wst.metadata.friendly_id then "Software Comment"
             else
               raise "Invalid inquiry type: `#{inquiry}`" if inquiry.present?
             end

--- a/app/models/website_contact.rb
+++ b/app/models/website_contact.rb
@@ -25,7 +25,7 @@ class WebsiteContact < ContactForm
       if competition.present?
         return ValidateEmail.valid?(competition.contact) ? competition.contact : competition.managers.map(&:email)
       end
-    elsif inquiry == "results_team"
+    elsif inquiry == "wrt"
       return UserGroup.teams_committees_group_wrt.metadata.email
     end
 
@@ -35,9 +35,9 @@ class WebsiteContact < ContactForm
   def subject
     topic = case inquiry
             when "competition" then "Comment for #{Competition.find_by_id(competition_id)&.name}"
-            when "communications_team" then "General Comment"
-            when "results_team" then "Results Team Comment"
-            when "software_team" then "Software Comment"
+            when "wct" then "General Comment"
+            when "wrt" then "Results Team Comment"
+            when "wst" then "Software Comment"
             else
               raise "Invalid inquiry type: `#{inquiry}`" if inquiry.present?
             end

--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -12,16 +12,16 @@ import UserData from './UserData';
 import Loading from '../Requests/Loading';
 import { useDispatch, useStore } from '../../lib/providers/StoreProvider';
 import { updateContactRecipient } from './store/actions';
-import CommunicationsTeam from './SubForms/CommunicationsTeam';
+import Wct from './SubForms/Wct';
+import Wrt from './SubForms/Wrt';
+import Wst from './SubForms/Wst';
 import Competition from './SubForms/Competition';
-import ResultsTeam from './SubForms/ResultsTeam';
-import SoftwareTeam from './SubForms/SoftwareTeam';
 
 const CONTACT_RECIPIENTS = [
   'competition',
-  'communications_team',
-  'results_team',
-  'software_team',
+  'wct',
+  'wrt',
+  'wst',
 ];
 
 const CONTACT_RECIPIENTS_MAP = _.keyBy(CONTACT_RECIPIENTS, _.camelCase);
@@ -42,12 +42,12 @@ export default function ContactForm({ loggedInUserData }) {
     switch (selectedContactRecipient) {
       case CONTACT_RECIPIENTS_MAP.competition:
         return Competition;
-      case CONTACT_RECIPIENTS_MAP.communicationsTeam:
-        return CommunicationsTeam;
-      case CONTACT_RECIPIENTS_MAP.resultsTeam:
-        return ResultsTeam;
-      case CONTACT_RECIPIENTS_MAP.softwareTeam:
-        return SoftwareTeam;
+      case CONTACT_RECIPIENTS_MAP.wct:
+        return Wct;
+      case CONTACT_RECIPIENTS_MAP.wrt:
+        return Wrt;
+      case CONTACT_RECIPIENTS_MAP.wst:
+        return Wst;
       default:
         return null;
     }

--- a/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
@@ -4,19 +4,19 @@ import I18n from '../../../../lib/i18n';
 import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
 import { updateSectionData } from '../../store/actions';
 
-const SECTION = 'results_team';
+const SECTION = 'wct';
 
-export default function ResultsTeam() {
-  const { results_team: resultsTeam } = useStore();
+export default function Wct() {
+  const { wct } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),
   );
   return (
     <Form.TextArea
-      label={I18n.t('page.contacts.form.communications_team.message.label')}
+      label={I18n.t('page.contacts.form.wct.message.label')}
       name="message"
-      value={resultsTeam?.message}
+      value={wct?.message}
       onChange={handleFormChange}
     />
   );

--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/index.jsx
@@ -4,19 +4,19 @@ import I18n from '../../../../lib/i18n';
 import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
 import { updateSectionData } from '../../store/actions';
 
-const SECTION = 'communications_team';
+const SECTION = 'wrt';
 
-export default function CommunicationsTeam() {
-  const { communications_team: communicationsTeam } = useStore();
+export default function Wrt() {
+  const { wrt } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),
   );
   return (
     <Form.TextArea
-      label={I18n.t('page.contacts.form.communications_team.message.label')}
+      label={I18n.t('page.contacts.form.wrt.message.label')}
       name="message"
-      value={communicationsTeam?.message}
+      value={wrt?.message}
       onChange={handleFormChange}
     />
   );

--- a/app/webpacker/components/ContactsPage/SubForms/Wst/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wst/index.jsx
@@ -4,19 +4,19 @@ import I18n from '../../../../lib/i18n';
 import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
 import { updateSectionData } from '../../store/actions';
 
-const SECTION = 'software_team';
+const SECTION = 'wst';
 
-export default function SoftwareTeam() {
-  const { software_team: softwareTeam } = useStore();
+export default function Wst() {
+  const { wst } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),
   );
   return (
     <Form.TextArea
-      label={I18n.t('page.contacts.form.communications_team.message.label')}
+      label={I18n.t('page.contacts.form.wst.message.label')}
       name="message"
-      value={softwareTeam?.message}
+      value={wst?.message}
       onChange={handleFormChange}
     />
   );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -799,18 +799,24 @@ en:
           label: "Which of the following best describes your inquiry?"
           competition:
             label: "Contact organizers/delegates of a competition (to ask query regarding that particular competition)"
-          communications_team:
+          wct:
             label: "Contact WCA for general queries (this can involve anything like WCA ID/profile, organizing competitions, competition rules, competition media, etc)"
-          results_team:
+          wrt:
             label: "Contact Results Team (for anything related to the results of a competition)"
-          software_team:
+          wst:
             label: "Contact Software Team (to report some bug in website or any API related questions)"
         competition:
           competition:
             label: "Competition"
           message:
             label: "Message"
-        communications_team:
+        wct:
+          message:
+            label: "Message"
+        wrt:
+          message:
+            label: "Message"
+        wst:
           message:
             label: "Message"
         captcha:

--- a/spec/models/website_contact_spec.rb
+++ b/spec/models/website_contact_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe WebsiteContact do
     end
 
     it "builds subject line for general inquiry" do
-      form = FactoryBot.build(:website_contact, inquiry: "communications_team")
+      form = FactoryBot.build(:website_contact, inquiry: "wct")
       expect(form.subject).to start_with("[WCA Website] General Comment by #{form.name} on")
     end
 
     it "builds subject line for software inquiry" do
-      form = FactoryBot.build(:website_contact, inquiry: "software_team")
+      form = FactoryBot.build(:website_contact, inquiry: "wst")
       expect(form.subject).to start_with("[WCA Website] Software Comment by #{form.name} on")
     end
 


### PR DESCRIPTION
As discussed in another PR, we decided to rename recipients to match with friendly ID. This will help in many places probably.