### PR TITLE
Add request ID to WST contact form

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -13,6 +13,7 @@ class ContactsController < ApplicationController
     )
     contact_params = params.require(contact_recipient)
     website_contact.competition_id = contact_params[:competitionId] if contact_recipient == 'competition'
+    website_contact.request_id = contact_params[:requestId] if contact_recipient == 'wst'
     website_contact.message = contact_params[:message]
     website_contact.request = request
     website_contact.logged_in_email = current_user&.email || 'None'

--- a/app/models/website_contact.rb
+++ b/app/models/website_contact.rb
@@ -9,6 +9,7 @@ class WebsiteContact < ContactForm
   attr_accessor :inquiry
   attr_accessor :competition_id
   attr_accessor :logged_in_email
+  attr_accessor :request_id
 
   # Override the `to_mail` validation, to show errors for `inquiry` instead.
   def validate_to_email

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,7 +1,7 @@
 <div class="dialog" style="display: flex; height: 80vh; justify-content: center; align-items:center">
   <div>
     <h1><%= t('wca.errors.error_pages.400_error') %></h1>
-    <p><%= t('wca.errors.error_pages.400_contact') %></p>
+    <p><%= t('wca.errors.error_pages.400_contact_html', contact_url: contact_path(contactRecipient: 'wst', requestId: @request_id)) %></p>
     <p>Request ID: <%= @request_id %></p>
   </div>
 </div>

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -1,7 +1,7 @@
 <div class="dialog" style="display: flex; height: 80vh; justify-content: center; align-items:center">
   <div>
     <h1><%= t('wca.errors.error_pages.500_error') %></h1>
-    <p><%= t('wca.errors.error_pages.500_contact') %></p>
+    <p><%= t('wca.errors.error_pages.500_contact_html', contact_url: contact_path(contactRecipient: 'wst', requestId: @request_id)) %></p>
     <p>Request ID: <%= @request_id %></p>
   </div>
 </div>

--- a/app/views/mail_form/contact.erb
+++ b/app/views/mail_form/contact.erb
@@ -13,6 +13,10 @@
   %></p>
 <% end %>
 
+<% if @resource.request_id.present? %>
+  <p><b>Request ID:</b> <%= @resource.request_id %></p>
+<% end %>
+
 <% unless @resource.class.mail_appendable.blank? %>
   <br /><h4 style="text-decoration:underline"><%= I18n.t :title, :scope => [ :mail_form, :request ], :default => 'Request information' %></h4>
 

--- a/app/webpacker/components/ContactsPage/index.jsx
+++ b/app/webpacker/components/ContactsPage/index.jsx
@@ -28,6 +28,9 @@ export default function ContactsPage() {
         competition: {
           competitionId: queryParams?.competitionId,
         },
+        wst: {
+          requestId: queryParams?.requestId,
+        },
       }}
     >
       <Container fluid>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -658,9 +658,9 @@ en:
       error_pages:
         #context: The error pages in the case of 500s or 400s
         500_error: "We're sorry, but something went wrong."
-        500_contact: "If you report this error to the Software Team please copy the Request ID into the email"
+        500_contact_html: "<a href=%{contact_url}>Click here</a> to report it."
         400_error: "The page you were looking for doesn't exist."
-        400_contact: "If you think this is a mistake please contact the Software Team and copy the Request ID into the email"
+        400_contact_html: "If you think this is a mistake please <a href=%{contact_url}>click here</a> to report it to Software Team."
     #context: Key used when an external OAuth app is willing to access a WCA user's data
     doorkeeper:
       applications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -660,7 +660,7 @@ en:
         500_error: "We're sorry, but something went wrong."
         500_contact_html: "<a href=%{contact_url}>Click here</a> to report it."
         400_error: "The page you were looking for doesn't exist."
-        400_contact_html: "If you think this is a mistake please <a href=%{contact_url}>click here</a> to report it to Software Team."
+        400_contact_html: "If you think this is a mistake please <a href=%{contact_url}>click here</a> to report it."
     #context: Key used when an external OAuth app is willing to access a WCA user's data
     doorkeeper:
       applications:


### PR DESCRIPTION
For the 404 and 500 page, now users doesn't have to copy the request ID, instead just clicking the contact button will add the request ID through URL.