### PR TITLE
Registration V2 Frontend cleanup

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -16,7 +16,6 @@ import {
   Segment,
   TextArea,
 } from 'semantic-ui-react';
-import I18n from '../../../lib/i18n';
 import updateRegistration from '../api/registration/patch/update_registration';
 import submitEventRegistration from '../api/registration/post/submit_registration';
 import { getMediumDateString, hasPassed } from '../lib/dates';
@@ -25,6 +24,7 @@ import { userPreferencesRoute } from '../../../lib/requests/routes.js.erb';
 import { EventSelector } from '../../CompetitionsOverview/CompetitionsFilters';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { setMessage } from './RegistrationMessage';
+import i18n from '../../../lib/i18n';
 
 const maxCommentLength = 240;
 
@@ -144,7 +144,7 @@ export default function CompetingStep({
   };
 
   const actionUpdateRegistration = () => {
-    dispatch(setMessage('Registration is being updated', 'basic'));
+    dispatch(setMessage('competitions.registration_v2.update.being_updated', 'basic'));
     updateRegistrationMutation({
       user_id: registration.user_id,
       competition_id: competitionInfo.id,
@@ -157,7 +157,7 @@ export default function CompetingStep({
   };
 
   const actionReRegister = () => {
-    dispatch(setMessage('Registration is being updated', 'basic'));
+    dispatch(setMessage('competitions.registration_v2.update.being_updated', 'basic'));
     updateRegistrationMutation({
       user_id: registration.user_id,
       competition_id: competitionInfo.id,
@@ -171,7 +171,7 @@ export default function CompetingStep({
   };
 
   const actionDeleteRegistration = () => {
-    dispatch(setMessage('Registration is being deleted', 'basic'));
+    dispatch(setMessage('competitions.registration_v2.update.being_deleted', 'basic'));
     updateRegistrationMutation({
       user_id: registration.user_id,
       competition_id: competitionInfo.id,
@@ -228,13 +228,12 @@ export default function CompetingStep({
       <>
         {isRegistered && (
           <Message info>
-            You have registered for
-            {competitionInfo.name}
+            {i18n.t('competitions.registration_v2.register.success', { comp_name: competitionInfo.name })}
           </Message>
         )}
         {!competitionInfo['registration_opened?'] && (
           <Message warning>
-            {I18n.t('competitions.registration_v2.register.early_registration')}
+            {i18n.t('competitions.registration_v2.register.early_registration')}
           </Message>
         )}
 
@@ -248,7 +247,7 @@ export default function CompetingStep({
             />
             <p
               dangerouslySetInnerHTML={{
-                __html: I18n.t('registrations.preferred_events_prompt_html', {
+                __html: i18n.t('registrations.preferred_events_prompt_html', {
                   link: `<a href="${userPreferencesRoute}">here</a>`,
                 }),
               }}
@@ -256,7 +255,7 @@ export default function CompetingStep({
           </Form.Field>
           <Form.Field required={competitionInfo.force_comment_in_registration}>
             <label htmlFor="comment">
-              {I18n.t('competitions.registration_v2.register.comment')}
+              {i18n.t('competitions.registration_v2.register.comment')}
             </label>
             <TextArea
               maxLength={maxCommentLength}
@@ -264,7 +263,7 @@ export default function CompetingStep({
               value={comment}
               placeholder={
                 competitionInfo.force_comment_in_registration
-                  ? I18n.t('registrations.errors.cannot_register_without_comment')
+                  ? i18n.t('registrations.errors.cannot_register_without_comment')
                   : ''
               }
               id="comment"
@@ -298,30 +297,30 @@ export default function CompetingStep({
                 position="top center"
                 content={
                   canUpdateRegistration
-                    ? I18n.t('competitions.registration_v2.register.until', {
+                    ? i18n.t('competitions.registration_v2.register.until', {
                       date: getMediumDateString(
                         competitionInfo.event_change_deadline_date
                         ?? competitionInfo.start_date,
                       ),
                     })
-                    : I18n.t('competitions.registration_v2.register.passed')
+                    : i18n.t('competitions.registration_v2.register.passed')
                 }
               />
               <Message.Content>
                 <Message.Header>
-                  {I18n.t(
+                  {i18n.t(
                     'competitions.registration_v2.register.registration_status.header',
                   )}
-                  {I18n.t(
+                  {i18n.t(
                     `simple_form.options.registration.status.${registration.competing.registration_status}`,
                   )}
                 </Message.Header>
                 {/* eslint-disable-next-line no-nested-ternary */}
                 {canUpdateRegistration
-                  ? I18n.t('registrations.update')
+                  ? i18n.t('registrations.update')
                   : hasRegistrationEditDeadlinePassed
-                    ? I18n.t('competitions.registration_v2.errors.-4001')
-                    : I18n.t(
+                    ? i18n.t('competitions.registration_v2.errors.-4001')
+                    : i18n.t(
                       'competitions.registration_v2.register.editing_disabled',
                     )}
               </Message.Content>
@@ -339,7 +338,7 @@ export default function CompetingStep({
                       checkForChanges: true,
                     })}
                   >
-                    {I18n.t('registrations.update')}
+                    {i18n.t('registrations.update')}
                   </Button>
                   <ButtonOr />
                 </>
@@ -351,7 +350,7 @@ export default function CompetingStep({
                   disabled={isUpdating}
                   onClick={() => attemptAction(actionReRegister)}
                 >
-                  Re-Register
+                  {i18n.t('competitions.registration_v2.register.re-register')}
                 </Button>
               )}
 
@@ -361,7 +360,7 @@ export default function CompetingStep({
                   negative
                   onClick={actionDeleteRegistration}
                 >
-                  {I18n.t('registrations.delete_registration')}
+                  {i18n.t('registrations.delete_registration')}
                 </Button>
               )}
             </ButtonGroup>
@@ -370,12 +369,12 @@ export default function CompetingStep({
           <>
             <Message info icon floating>
               <Popup
-                content={I18n.t('registrations.mailer.new.awaits_approval')}
+                content={i18n.t('registrations.mailer.new.awaits_approval')}
                 position="top left"
                 trigger={<Icon name="circle info" />}
               />
               <Message.Content>
-                {I18n.t('competitions.registration_v2.register.disclaimer')}
+                {i18n.t('competitions.registration_v2.register.disclaimer')}
               </Message.Content>
             </Message>
 
@@ -388,7 +387,7 @@ export default function CompetingStep({
               onClick={() => attemptAction(actionCreateRegistration)}
             >
               <Icon name="paper plane" />
-              {I18n.t('registrations.register')}
+              {i18n.t('registrations.register')}
             </Button>
           </>
         )}

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -309,10 +309,7 @@ export default function CompetingStep({
               <Message.Content>
                 <Message.Header>
                   {i18n.t(
-                    'competitions.registration_v2.register.registration_status.header',
-                  )}
-                  {i18n.t(
-                    `simple_form.options.registration.status.${registration.competing.registration_status}`,
+                    `competitions.registration_v2.register.registration_status.${registration.competing.registration_status}`,
                   )}
                 </Message.Header>
                 {/* eslint-disable-next-line no-nested-ternary */}

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -11,7 +11,7 @@ export const setMessage = (key, type, params) => ({
   },
 });
 
-export default function RegistrationMessage() {
+export default function RegistrationMessage({ ref }) {
   const { message } = useStore();
   const dispatch = useDispatch();
 
@@ -26,7 +26,7 @@ export default function RegistrationMessage() {
   if (!message?.key) return null;
 
   return (
-    <Sticky active>
+    <Sticky active context={ref}>
       <Message
         positive={message.type === 'positive'}
         negative={message.type === 'negative'}

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationRequirements.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationRequirements.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useMemo, useState,
+  useState,
 } from 'react';
 import {
   Accordion,
@@ -14,40 +14,16 @@ import useCheckboxState from '../../../lib/hooks/useCheckboxState';
 import Markdown from '../../Markdown';
 
 export default function RegistrationRequirements({ nextStep, competitionInfo }) {
-  const [generalInfoAcknowledged, setGeneralInfoAcknowledged] = useCheckboxState(false);
-  const [regRequirementsAcknowledged, setRegRequirementsAcknowledged] = useCheckboxState(false);
-
+  const [infoAcknowledged, setInfoAcknowledged] = useCheckboxState(false);
   const [showRegRequirements, setShowRegRequirements] = useState(false);
 
   const handleAccordionClick = () => {
     setShowRegRequirements((oldShowRegRequirements) => !oldShowRegRequirements);
   };
 
-  const buttonDisabled = useMemo(() => (
-    !generalInfoAcknowledged
-      || (competitionInfo.extra_registration_requirements
-        && !regRequirementsAcknowledged)
-  ), [
-    competitionInfo.extra_registration_requirements,
-    generalInfoAcknowledged,
-    regRequirementsAcknowledged,
-  ]);
-
-  useEffect(() => {
-    if (generalInfoAcknowledged) {
-      setShowRegRequirements(true);
-    }
-  }, [generalInfoAcknowledged, setShowRegRequirements]);
-
   return (
     <Segment basic>
       <Form onSubmit={nextStep}>
-        <Form.Checkbox
-          checked={generalInfoAcknowledged}
-          onClick={setGeneralInfoAcknowledged}
-          label={I18n.t('competitions.registration_v2.requirements.acknowledgement')}
-          required
-        />
         {competitionInfo.extra_registration_requirements && (
           <Accordion as={Form.Field} styled fluid>
             <Accordion.Title active index={0} onClick={handleAccordionClick}>
@@ -66,21 +42,19 @@ export default function RegistrationRequirements({ nextStep, competitionInfo }) 
                   id={`registration-requirements-${competitionInfo.id}`}
                   md={competitionInfo.extra_registration_requirements}
                 />
-                <Message positive>
-                  <Form.Checkbox
-                    checked={regRequirementsAcknowledged}
-                    onClick={setRegRequirementsAcknowledged}
-                    label={I18n.t(
-                      'competitions.registration_v2.requirements.acknowledgment_extra',
-                    )}
-                    required
-                  />
-                </Message>
               </Accordion.Content>
             </Transition>
           </Accordion>
         )}
-        <Button disabled={buttonDisabled} type="submit" positive>
+        <Message positive>
+          <Form.Checkbox
+            checked={infoAcknowledged}
+            onClick={setInfoAcknowledged}
+            label={I18n.t('competitions.registration_v2.requirements.acknowledgement')}
+            required
+          />
+        </Message>
+        <Button disabled={!infoAcknowledged} type="submit" positive>
           {I18n.t('competitions.registration_v2.requirements.next_step')}
         </Button>
       </Form>

--- a/app/webpacker/components/RegistrationsV2/Register/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import StepPanel from './StepPanel';
 import { getSingleRegistration } from '../api/registration/get/get_registrations';
@@ -25,6 +25,7 @@ export default function Index({ competitionInfo, userInfo, preferredEvents }) {
 
 function Register({ competitionInfo, userInfo, preferredEvents }) {
   const dispatch = useDispatch();
+  const ref = useRef();
   const {
     data: registration,
     isLoading,
@@ -49,7 +50,7 @@ function Register({ competitionInfo, userInfo, preferredEvents }) {
     isLoading ? <Loading />
       : (
         <>
-          <RegistrationMessage />
+          <RegistrationMessage ref={ref} />
           <StepPanel
             user={userInfo}
             preferredEvents={preferredEvents}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1738,8 +1738,7 @@ en:
         unbookmark: "You have removed your bookmark"
       requirements:
         title: "Requirements"
-        acknowledgement: "I have read and acknowledged all information under the 'Register' tab, including entry fees and refund policies"
-        acknowledgment_extra: "I have read and understood all information listed above"
+        acknowledgement: "I have read and acknowledged all information under the 'Register' tab, including entry fees, refund policies and any extra requirements listed above."
         next_step: "Continue to next Step"
       update:
         being_updated: "Registration is being updated"
@@ -1753,7 +1752,7 @@ en:
         too_many: "Accepting all these registrations would go over the competitor limit by %{count}"
       register:
         re-register: "Re-Register"
-        success: "You have registered for %{comp_name}"
+        success: "You are registered for %{comp_name}"
         error: "Registration failed with error %{error}"
         early_registration: "Registration is not open yet, but you can still register as a competition organizer or Delegate."
         comment: "Additional comments to the organizers"
@@ -1762,7 +1761,7 @@ en:
         editing_disabled: "Registration editing is disabled for this competition"
         registration_status:
           accepted: "Your registration has been accepted."
-          pending: "Your registration is pending."
+          pending: "Your registration is pending approval by the organizers."
           cancelled: "Your registration has been deleted."
           waiting_list: "You are on the Waiting List."
         disclaimer: "Submission of Registration does not mean approval to compete"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -546,8 +546,6 @@ en:
           accepted: "Accepted"
           pending: "Waiting list"
           deleted: "Deleted"
-          cancelled: "Cancelled"
-          waiting_list: "On the Waiting List"
   mail_form:
     #context: This key is used as a label for contact form attributes
     attributes:
@@ -1763,7 +1761,10 @@ en:
         passed: "You can no longer update your registration"
         editing_disabled: "Registration editing is disabled for this competition"
         registration_status:
-          header: "Your Registration Status:"
+          accepted: "Your registration has been accepted."
+          pending: "Your registration is pending."
+          cancelled: "Your registration has been deleted."
+          waiting_list: "You are on the Waiting List."
         disclaimer: "Submission of Registration does not mean approval to compete"
         processing: "Your registration is processing..."
         processing_longer: "Processing is taking longer than usual, don't go away!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1099,7 +1099,6 @@ en:
       failed: "Could not update registration"
       deleted: "Successfully deleted your registration for %{comp}"
       registered: "Registration form submitted - make sure to follow all instructions from the Registration Requirements below to ensure your registration is complete."
-
       imported: "Successfully imported registrations!"
       added: "Successfully added registration!"
     edit_registration:
@@ -1745,6 +1744,8 @@ en:
         acknowledgment_extra: "I have read and understood all information listed above"
         next_step: "Continue to next Step"
       update:
+        being_updated: "Registration is being updated"
+        being_deleted: "Registration is being deleted"
         no_changes: "There are no changes"
         email_send: "Send Email"
         email_copy: "Copy Email"
@@ -1753,6 +1754,8 @@ en:
         cancel: "Cancel Registration"
         too_many: "Accepting all these registrations would go over the competitor limit by %{count}"
       register:
+        re-register: "Re-Register"
+        success: "You have registered for %{comp_name}"
         error: "Registration failed with error %{error}"
         early_registration: "Registration is not open yet, but you can still register as a competition organizer or Delegate."
         comment: "Additional comments to the organizers"


### PR DESCRIPTION
- Added missing i18n keys
- moved registration status to its own keys to explain them more and differentiate them from v1 statuses
- combined the checkboxes for requirements into one
- added missing ref to sticky