### PR TITLE
Remove usages of Team.wrc

### DIFF
--- a/app/controllers/delegate_reports_controller.rb
+++ b/app/controllers/delegate_reports_controller.rb
@@ -82,12 +82,8 @@ class DelegateReportsController < ApplicationController
   end
 
   private def assign_wrc_users(delegate_report)
-    # TODO(https://github.com/thewca/worldcubeassociation.org/issues/4535):
-    # We're reloading here as a workaround. This should be handled in a more
-    # general way.
-    Team.wrc.reload
-    wrc_primary_team_member, wrc_secondary_team_member = Team.wrc.current_members.sample 2
-    delegate_report.wrc_primary_user = wrc_primary_team_member.user
-    delegate_report.wrc_secondary_user = wrc_secondary_team_member.user
+    wrc_primary_user, wrc_secondary_user = UserGroup.teams_committees_group_wrc.active_users.sample 2
+    delegate_report.wrc_primary_user = wrc_primary_user
+    delegate_report.wrc_secondary_user = wrc_secondary_user
   end
 end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -6,31 +6,6 @@ RSpec.describe TeamsController do
   let(:team) { FactoryBot.create :team }
 
   describe 'GET #edit' do
-    context 'when signed in as a team leader without rights to manage all teams' do
-      let(:team_where_is_leader) { Team.wrc }
-      let(:team_where_is_not_leader) { Team.wst }
-      let!(:leader) do
-        user = FactoryBot.create(:user)
-        FactoryBot.create(:team_member, team_id: team_where_is_leader.id, user_id: user.id, team_leader: true)
-        user
-      end
-
-      before :each do
-        sign_in leader
-      end
-
-      it 'can edit his team' do
-        get :edit, params: { id: team_where_is_leader.id }
-        expect(response).to render_template :edit
-      end
-
-      it 'cannot edit other teams' do
-        get :edit, params: { id: team_where_is_not_leader.id }
-        expect(response).to redirect_to root_url
-        expect(flash[:danger]).to_not be_nil
-      end
-    end
-
     it "leader of WDC can manage the banned team, despite not being a member of the banned team" do
       sign_in FactoryBot.create :user, :wdc_leader
 

--- a/spec/mailers/previews/competitions_mailer_preview.rb
+++ b/spec/mailers/previews/competitions_mailer_preview.rb
@@ -61,10 +61,9 @@ class CompetitionsMailerPreview < ActionMailer::Preview
     report = DelegateReport.where.not(posted_at: nil).first
 
     # Copied from `app/controllers/delegate_reports_controller.rb`
-    Team.wrc.reload
-    wrc_primary_team_member, wrc_secondary_team_member = Team.wrc.current_members.sample 2
-    report.wrc_primary_user = wrc_primary_team_member.user
-    report.wrc_secondary_user = wrc_secondary_team_member.user
+    wrc_primary_user, wrc_secondary_user = UserGroup.teams_committees_group_wrc.active_users.sample 2
+    delegate_report.wrc_primary_user = wrc_primary_user
+    delegate_report.wrc_secondary_user = wrc_secondary_user
 
     if !report
       report = Competition.first.delegate_report


### PR DESCRIPTION
Team.wrc was used in few places, and not sure if changing them will cause any issues. So thought of making those changes before migrating WRC to roles.