### PR TITLE
Migrate WST to roles

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -46,10 +46,6 @@ class Team < ApplicationRecord
     Team.c_find_by_friendly_id!('wrc')
   end
 
-  def self.wst
-    Team.c_find_by_friendly_id!('wst')
-  end
-
   def self.banned
     Team.c_find_by_friendly_id!('banned')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -495,7 +495,7 @@ class User < ApplicationRecord
   end
 
   private def software_team?
-    team_member?(Team.wst)
+    group_member?(UserGroup.teams_committees_group_wst)
   end
 
   private def software_team_admin?

--- a/db/migrate/20240503154148_migrate_wst_to_roles.rb
+++ b/db/migrate/20240503154148_migrate_wst_to_roles.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MigrateWstToRoles < ActiveRecord::Migration[7.1]
+  include RoleMigrationHelper
+
+  def change
+    migrate_team_members_to_group(Team.c_find_by_friendly_id!('wst'), UserGroup.teams_committees_group_wst)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_03_144557) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_03_154148) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false

--- a/db/seeds/teams.seeds.rb
+++ b/db/seeds/teams.seeds.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 Team.create(friendly_id: 'wrc', email: "regulations@worldcubeassociation.org")
-Team.create(friendly_id: 'wst', email: "software@worldcubeassociation.org")
 Team.create(friendly_id: 'banned', email: "disciplinary@worldcubeassociation.org", hidden: true)

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -46,13 +46,6 @@ RSpec.describe TeamsController do
         expect(team.team_members.first.current_member?).to be false
       end
 
-      it 'cannot demote oneself' do
-        admin_team = admin.teams.first
-        patch :update, params: { id: admin_team.id, team: { team_members_attributes: { "0" => { user_id: admin.id, start_date: admin.team_members.first.start_date, end_date: Date.today-1 } } } }
-        admin_team.reload
-        expect(admin_team.team_members.first.end_date).to eq nil
-      end
-
       it 'cannot set start_date < end_date' do
         member = FactoryBot.create :user
         patch :update, params: { id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: Date.today, end_date: Date.today-1, team_leader: false } } } }

--- a/spec/factories/roles_metadata_teams_committees.rb
+++ b/spec/factories/roles_metadata_teams_committees.rb
@@ -28,5 +28,6 @@ FactoryBot.define do
     factory :wfc_member_metadata, traits: [:member]
     factory :wfc_leader_metadata, traits: [:leader]
     factory :wmt_member_metadata, traits: [:member]
+    factory :wst_member_metadata, traits: [:member]
   end
 end

--- a/spec/factories/user_roles.rb
+++ b/spec/factories/user_roles.rb
@@ -174,6 +174,11 @@ FactoryBot.define do
       metadata { FactoryBot.create(:wmt_member_metadata) }
     end
 
+    trait :wst_member do
+      group { UserGroup.teams_committees_group_wst }
+      metadata { FactoryBot.create(:wst_member_metadata) }
+    end
+
     trait :board do
       group_id { UserGroup.board_group.id }
     end
@@ -211,6 +216,7 @@ FactoryBot.define do
     factory :wfc_member_role, traits: [:wfc_member, :active]
     factory :wfc_leader_role, traits: [:wfc_leader, :active]
     factory :wmt_member_role, traits: [:wmt_member, :active]
+    factory :wst_member_role, traits: [:wst_member, :active]
     factory :board_role, traits: [:board, :active]
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
         if Rails.env.production?
           FactoryBot.create(:wst_admin_role, user: user)
         else
-          FactoryBot.create(:team_member, team_id: Team.wst.id, user_id: user.id, team_leader: true)
+          FactoryBot.create(:wst_member_role, user: user)
         end
       end
     end
@@ -145,8 +145,8 @@ FactoryBot.define do
     end
 
     trait :wst_member do
-      after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wst.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
+      after(:create) do |user|
+        FactoryBot.create(:wst_member_role, user: user)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -454,17 +454,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  it "#teams and #current_teams return unique team names" do
-    user = FactoryBot.create(:user)
-
-    FactoryBot.create(:team_member, team_id: Team.wst.id, user_id: user.id, start_date: Date.today - 20, end_date: Date.today - 10)
-    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today - 5, end_date: Date.today + 5)
-    FactoryBot.create(:team_member, team_id: Team.banned.id, user_id: user.id, start_date: Date.today + 6, end_date: Date.today + 10)
-
-    expect(user.teams).to match_array [Team.wst, Team.banned]
-    expect(user.current_teams).to match_array [Team.banned]
-  end
-
   it 'former banned users are not considered current members of Team.banned' do
     banned_user = FactoryBot.create :user, :banned
     banned_user.team_members.first.update!(end_date: 1.day.ago)


### PR DESCRIPTION
Migrating WST to roles is considered as tricky because an intermediate stage failed (https://github.com/thewca/worldcubeassociation.org/pull/9198). Checking if the full migration will fix this issue.