### PR TITLE
Re-enable the "Show Registration Status" button in the new Competition List frontend

### DIFF
--- a/app/assets/stylesheets/competitions.scss
+++ b/app/assets/stylesheets/competitions.scss
@@ -258,6 +258,10 @@ $venue-map-wrapper-height: 400px;
         float: left;
         margin-right: 10px;
       }
+      div.loader {
+        float: left;
+        margin-right: 10px;
+      }
     }
 
     .location {

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -135,6 +135,16 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     render json: competition.registrations.accepted.includes(:events)
   end
 
+  def registration_data
+    competition_ids = params.require(:ids)
+
+    data = CacheAccess.hydrate_entities('comp-registration-data', competition_ids, expires_in: 5.minutes) do |uncached_ids|
+      Competition.find(uncached_ids).map { |comp| { id: comp.id, registration_status: comp.registration_status } }
+    end
+
+    render json: data
+  end
+
   def show_wcif
     competition = competition_from_params
     require_can_manage!(competition)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -933,6 +933,18 @@ class Competition < ApplicationRecord
     registration_close && registration_close < Time.now
   end
 
+  def registration_status
+    if registration_not_yet_opened?
+      :not_yet_opened
+    elsif registration_past?
+      :past
+    elsif registration_full?
+      :full
+    else
+      :open
+    end
+  end
+
   def registration_range_specified?
     registration_open.present? && registration_close.present?
   end

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -387,7 +387,6 @@ function CompDisplayCheckboxes({
               id="show_registration_status"
               checked={shouldShowRegStatus}
               onChange={() => setShouldShowRegStatus(!shouldShowRegStatus)}
-              disabled // FIXME Pending because of too expensive queries
             />
           </div>
         )

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -1,7 +1,7 @@
 import React, {
   useEffect, useMemo, useReducer, useState,
 } from 'react';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { Container } from 'semantic-ui-react';
 
 import I18n from '../../lib/i18n';
@@ -78,7 +78,7 @@ function CompetitionsView() {
 
   const {
     data: compRegistrationData,
-    isPending: regDataIsPending,
+    isFetching: regDataIsPending,
   } = useQuery({
     queryFn: () => fetchJsonOrError(apiV0Urls.competitions.registrationData, {
       headers: {
@@ -89,6 +89,10 @@ function CompetitionsView() {
     }),
     queryKey: ['registration-info', ...compIds],
     enabled: shouldShowRegStatus,
+    // This is where the magic happens: Using `keepPreviousData` makes it so that
+    //   all previously loaded indicators are held in-cache while the fetcher for the next
+    //   batch is running in the background. (Adding comment here because it's not in the docs)
+    placeholderData: keepPreviousData,
     select: (data) => data.data,
   });
 
@@ -120,6 +124,7 @@ function CompetitionsView() {
               filterState={debouncedFilterState}
               shouldShowRegStatus={shouldShowRegStatus}
               isLoading={competitionsIsFetching}
+              regStatusLoading={regDataIsPending}
               fetchMoreCompetitions={competitionsFetchNextPage}
               hasMoreCompsToLoad={hasMoreCompsToLoad}
             />

--- a/app/webpacker/components/CompetitionsOverview/ListView.js
+++ b/app/webpacker/components/CompetitionsOverview/ListView.js
@@ -13,6 +13,7 @@ function ListView({
   filterState,
   shouldShowRegStatus,
   isLoading,
+  regStatusLoading,
   fetchMoreCompetitions,
   hasMoreCompsToLoad,
 }) {
@@ -36,6 +37,7 @@ function ListView({
             title={I18n.t('competitions.index.titles.in_progress')}
             shouldShowRegStatus={shouldShowRegStatus}
             isLoading={isLoading && !upcomingComps?.length}
+            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad && !upcomingComps?.length}
           />
           {
@@ -47,6 +49,7 @@ function ListView({
             title={I18n.t('competitions.index.titles.upcoming')}
             shouldShowRegStatus={shouldShowRegStatus}
             isLoading={isLoading}
+            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
           <ListViewFooter
@@ -66,6 +69,7 @@ function ListView({
             title={I18n.t('competitions.index.titles.recent', { count: competitionConstants.competitionRecentDays })}
             shouldShowRegStatus={shouldShowRegStatus}
             isLoading={isLoading}
+            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
           <ListViewFooter
@@ -84,6 +88,7 @@ function ListView({
             title={filterState.selectedYear === 'all_years' ? I18n.t('competitions.index.titles.past_all') : I18n.t('competitions.index.titles.past', { year: filterState.selectedYear })}
             shouldShowRegStatus={shouldShowRegStatus}
             isLoading={isLoading}
+            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
           <ListViewFooter
@@ -102,6 +107,7 @@ function ListView({
             title={I18n.t('competitions.index.titles.by_announcement')}
             shouldShowRegStatus={shouldShowRegStatus}
             isLoading={isLoading}
+            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
             isSortedByAnnouncement
           />
@@ -121,6 +127,7 @@ function ListView({
             title={I18n.t('competitions.index.titles.custom')}
             shouldShowRegStatus={shouldShowRegStatus}
             isLoading={isLoading}
+            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
           <ListViewFooter

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import {
-  List, Icon, Popup,
+  List, Icon, Popup, Loader,
 } from 'semantic-ui-react';
 
 import I18n from '../../lib/i18n';
 import {
-  dayDifferenceFromToday, hasResultsPosted, isCancelled, isInProgress,
-  isProbablyOver, isRegistrationClosedAlready, isRegistrationOpenYet,
-  PseudoLinkMarkdown, startYear,
+  dayDifferenceFromToday,
+  hasResultsPosted,
+  isCancelled,
+  isInProgress,
+  isProbablyOver,
+  PseudoLinkMarkdown,
+  startYear,
 } from '../../lib/utils/competition-table';
 import { countries } from '../../lib/wca-data.js.erb';
 
@@ -16,6 +20,7 @@ function ListViewSection({
   title,
   shouldShowRegStatus,
   isLoading,
+  regStatusLoading,
   hasMoreCompsToLoad,
   isSortedByAnnouncement = false,
 }) {
@@ -39,6 +44,7 @@ function ListViewSection({
                 comp={comp}
                 shouldShowRegStatus={shouldShowRegStatus}
                 isSortedByAnnouncement={isSortedByAnnouncement}
+                regStatusLoading={regStatusLoading}
               />
               {comp.date_range}
             </span>
@@ -74,34 +80,49 @@ function ConditionalYearHeader({ competitions, index, isSortedByAnnouncement }) 
   }
 }
 
-function RegistrationStatus({ comp }) {
-  if (!isRegistrationOpenYet(comp)) {
+function RegistrationStatus({ comp, isLoading }) {
+  // It is important that we check both conditions, because the query hook
+  //   uses a `keepPreviousData` trick that holds existing data in-memory while
+  //   also executing the query for the next batch of rows in the background.
+  if (isLoading && !comp.registration_status) {
+    return (<Loader active inline size="mini" />);
+  }
+
+  if (comp.registration_status === 'not_yet_opened') {
     return (
       <Popup
-        trigger={<Icon className="clock blue" />}
+        trigger={<Icon name="clock" color="blue" />}
         content={I18n.t('competitions.index.tooltips.registration.opens_in', { duration: comp.time_until_registration })}
         position="top center"
         size="tiny"
       />
     );
   }
-  if (isRegistrationClosedAlready(comp)) {
+  if (comp.registration_status === 'past') {
     return (
       <Popup
-        trigger={<Icon className="user times red" />}
+        trigger={<Icon name="user times" color="red" />}
         content={I18n.t('competitions.index.tooltips.registration.closed', { days: I18n.t('common.days', { count: dayDifferenceFromToday(comp.start_date) }) })}
         position="top center"
         size="tiny"
       />
     );
   }
-  // TODO: This is currently not implemented because the query is *way* to expensive to execute
-  //   by default on production. We need to figure out a clever way to fetch this data on-demand.
   if (comp.registration_status === 'full') {
     return (
       <Popup
-        trigger={<Icon className="user clock orange" />}
+        trigger={<Icon name="user clock" color="orange" />}
         content={I18n.t('competitions.index.tooltips.registration.full')}
+        position="top center"
+        size="tiny"
+      />
+    );
+  }
+  if (comp.registration_status === 'open') {
+    return (
+      <Popup
+        trigger={<Icon name="user plus" color="green" />}
+        content={I18n.t('competitions.index.tooltips.registration.open')}
         position="top center"
         size="tiny"
       />
@@ -109,16 +130,16 @@ function RegistrationStatus({ comp }) {
   }
 
   return (
-    <Popup
-      trigger={<Icon className="user plus green" />}
-      content={I18n.t('competitions.index.tooltips.registration.open')}
-      position="top center"
-      size="tiny"
-    />
+    <Icon name="question circle" />
   );
 }
 
-function StatusIcon({ comp, shouldShowRegStatus, isSortedByAnnouncement }) {
+function StatusIcon({
+  comp,
+  shouldShowRegStatus,
+  isSortedByAnnouncement,
+  regStatusLoading,
+}) {
   let tooltipInfo = '';
   let iconClass = '';
 
@@ -134,7 +155,7 @@ function StatusIcon({ comp, shouldShowRegStatus, isSortedByAnnouncement }) {
     tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.in_progress');
     iconClass = 'hourglass half';
   } else if (shouldShowRegStatus) {
-    return <RegistrationStatus comp={comp} />;
+    return <RegistrationStatus comp={comp} isLoading={regStatusLoading} />;
   } else if (isSortedByAnnouncement) {
     tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.announced_on', { announcement_date: comp.announced_at });
     iconClass = 'hourglass start';

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -207,7 +207,8 @@ export const apiV0Urls = {
   },
   competitions: {
     list: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competitions_path)%>`,
-    info: (compId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_path("${compId}"))%>`
+    info: (compId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_path("${compId}"))%>`,
+    registrationData: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_registration_data_path) %>`
   },
   delegates: {
     list: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_delegates_path)%>`,

--- a/app/webpacker/lib/utils/competition-table.js
+++ b/app/webpacker/lib/utils/competition-table.js
@@ -5,10 +5,6 @@ function parseDateString(yyyymmddDateString) {
   return DateTime.fromFormat(yyyymmddDateString, 'yyyy-MM-dd');
 }
 
-function parseDateTimeString(isoDateTimeString) {
-  return DateTime.fromISO(isoDateTimeString);
-}
-
 export function dayDifferenceFromToday(yyyymmddDateString) {
   const dateLuxon = parseDateString(yyyymmddDateString);
   const exactDaysDiff = dateLuxon.diffNow('days').days;
@@ -47,20 +43,6 @@ export function isInProgress(competition) {
   const running = Interval.fromDateTimes(startDate, endDate).contains(DateTime.now());
 
   return running && !hasResultsPosted(competition);
-}
-
-export function isRegistrationOpenYet(competition) {
-  if (!competition.registration_open) return false;
-
-  const regOpen = parseDateTimeString(competition.registration_open);
-  return DateTime.now() < regOpen;
-}
-
-export function isRegistrationClosedAlready(competition) {
-  if (!competition.registration_close) return false;
-
-  const regClose = parseDateTimeString(competition.registration_close);
-  return regClose < DateTime.now();
 }
 
 // Currently, the venue attribute of a competition object can be written as markdown,

--- a/app/webpacker/packs/global_styles.js
+++ b/app/webpacker/packs/global_styles.js
@@ -19,6 +19,7 @@ import 'semantic-css/input';
 import 'semantic-css/item';
 import 'semantic-css/label';
 import 'semantic-css/list';
+import 'semantic-css/loader';
 import 'semantic-css/menu';
 import 'semantic-css/message';
 import 'semantic-css/modal';

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -383,6 +383,7 @@ Rails.application.routes.draw do
         patch '/wcif' => 'competitions#update_wcif', as: :update_wcif
       end
       get '/records' => "api#records"
+      post '/registration-data' => 'competitions#registration_data', as: :registration_data
 
       scope 'user_roles' do
         get '/user/:user_id' => 'user_roles#index_for_user', as: :index_for_user

--- a/lib/cache_access.rb
+++ b/lib/cache_access.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module CacheAccess
+  EXPIRATION_DEFAULT = 60.minutes
+
+  # The Hydration block needs to return an array of hashes that have an 'id' field
+  def self.hydrate_entities(key_prefix, ids, expires_in: EXPIRATION_DEFAULT, &hydration_block)
+    stringified_ids = ids.map(&:to_s)
+
+    keys = stringified_ids.map { |id| self.hydration_key(key_prefix, id) }
+
+    cache_hits = Rails.cache.read_multi(*keys)
+
+    cached_entities = cache_hits.values.map(&:deep_stringify_keys)
+    cached_ids = cached_entities.pluck('id').compact.uniq
+
+    uncached_ids = stringified_ids - cached_ids
+
+    if uncached_ids.empty?
+      # No need to call hydration function if we have cached all data
+      cached_entities
+    else
+      # Get Data for all uncached ids
+      uncached_entities = hydration_block.call(uncached_ids).map(&:deep_stringify_keys)
+
+      # Write all new data into the cache
+      hydrated_entries = uncached_entities.index_by do |item|
+        self.hydration_key(key_prefix, item['id'])
+      end
+
+      Rails.cache.write_multi(hydrated_entries, expires_in: expires_in)
+
+      cached_entities + uncached_entities
+    end
+  end
+
+  private_class_method def self.hydration_key(prefix, id)
+    "#{prefix}-#{id}"
+  end
+end


### PR DESCRIPTION
Suddenly had an idea to use a piece of data hydration logic from the Registrations microservice to keep registration status data in the cache. It worked for the backend, and then I found out about an awesome `keepPreviousData` placeholder function for the frontend through ChatGPT. (Scary: This isn't even in Tanstack's current documentation. You can only find it as a "sidenote" in the "Migrate to v5" guide. Really impressive that ChatGPT still knew about this!)

Basically, this batches all competition IDs into an "extra data" request that loads only the registration status in an extra request when the button is toggled. If the toggle is off, the network request is turned off with Tanstack's `enabled` option.

The code design for the backend (returning relatively arbitrary Ruby symbols as "registration status") is more of a proof-of-concept and totally up for debate.