### PR TITLE
Migrate WRC to roles

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -42,10 +42,6 @@ class Team < ApplicationRecord
     self.c_all_by_friendly_id[friendly_id] || raise("friendly id not found #{friendly_id}")
   end
 
-  def self.wrc
-    Team.c_find_by_friendly_id!('wrc')
-  end
-
   def self.banned
     Team.c_find_by_friendly_id!('banned')
   end

--- a/db/migrate/20240505004834_migrate_wrc_to_roles.rb
+++ b/db/migrate/20240505004834_migrate_wrc_to_roles.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MigrateWrcToRoles < ActiveRecord::Migration[7.1]
+  include RoleMigrationHelper
+
+  def change
+    migrate_team_members_to_group(Team.c_find_by_friendly_id!('wrc'), UserGroup.teams_committees_group_wrc)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_03_154148) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_05_004834) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false

--- a/db/seeds/teams.seeds.rb
+++ b/db/seeds/teams.seeds.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
-Team.create(friendly_id: 'wrc', email: "regulations@worldcubeassociation.org")
 Team.create(friendly_id: 'banned', email: "disciplinary@worldcubeassociation.org", hidden: true)

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         expect(team['leader']).to eq false
         expect(team['friendly_id']).to eq 'wrc'
         expect(team['avatar']['thumb']['url']).to be_a String
-        expect(team['id']).to be_a String
+        expect(team['id']).to be_a Numeric
         expect(team['name']).to be_a String
         expect(team['senior_member']).to be false
       end

--- a/spec/factories/roles_metadata_teams_committees.rb
+++ b/spec/factories/roles_metadata_teams_committees.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
       status { RolesMetadataTeamsCommittees.statuses[:member] }
     end
 
+    trait :senior_member do
+      status { RolesMetadataTeamsCommittees.statuses[:senior_member] }
+    end
+
     trait :leader do
       status { RolesMetadataTeamsCommittees.statuses[:leader] }
     end
@@ -29,5 +33,8 @@ FactoryBot.define do
     factory :wfc_leader_metadata, traits: [:leader]
     factory :wmt_member_metadata, traits: [:member]
     factory :wst_member_metadata, traits: [:member]
+    factory :wrc_member_metadata, traits: [:member]
+    factory :wrc_senior_member_metadata, traits: [:senior_member]
+    factory :wrc_leader_metadata, traits: [:leader]
   end
 end

--- a/spec/factories/user_roles.rb
+++ b/spec/factories/user_roles.rb
@@ -179,6 +179,21 @@ FactoryBot.define do
       metadata { FactoryBot.create(:wst_member_metadata) }
     end
 
+    trait :wrc_member do
+      group { UserGroup.teams_committees_group_wrc }
+      metadata { FactoryBot.create(:wrc_member_metadata) }
+    end
+
+    trait :wrc_senior_member do
+      group { UserGroup.teams_committees_group_wrc }
+      metadata { FactoryBot.create(:wrc_senior_member_metadata) }
+    end
+
+    trait :wrc_leader do
+      group { UserGroup.teams_committees_group_wrc }
+      metadata { FactoryBot.create(:wrc_leader_metadata) }
+    end
+
     trait :board do
       group_id { UserGroup.board_group.id }
     end
@@ -217,6 +232,9 @@ FactoryBot.define do
     factory :wfc_leader_role, traits: [:wfc_leader, :active]
     factory :wmt_member_role, traits: [:wmt_member, :active]
     factory :wst_member_role, traits: [:wst_member, :active]
+    factory :wrc_member_role, traits: [:wrc_member, :active]
+    factory :wrc_senior_member_role, traits: [:wrc_senior_member, :active]
+    factory :wrc_leader_role, traits: [:wrc_leader, :active]
     factory :board_role, traits: [:board, :active]
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
       team_senior_member { false }
     end
 
+    transient do
+      end_date { nil }
+    end
+
     trait :board_member do
       after(:create) do |user|
         FactoryBot.create(:board_role, user: user)
@@ -86,7 +90,19 @@ FactoryBot.define do
 
     trait :wrc_member do
       after(:create) do |user, options|
-        FactoryBot.create(:team_member, team_id: Team.wrc.id, user_id: user.id, team_senior_member: options.team_senior_member, team_leader: options.team_leader)
+        FactoryBot.create(:wrc_member_role, user_id: user.id)
+      end
+    end
+
+    trait :wrc_senior_member do
+      after(:create) do |user, options|
+        FactoryBot.create(:wrc_senior_member_role, user_id: user.id)
+      end
+    end
+
+    trait :wrc_leader do
+      after(:create) do |user, options|
+        FactoryBot.create(:wrc_leader_role, user_id: user.id, end_date: options.end_date)
       end
     end
 

--- a/spec/features/eligible_voters_spec.rb
+++ b/spec/features/eligible_voters_spec.rb
@@ -7,22 +7,16 @@ RSpec.feature "Eligible voters csv" do
   before { Timecop.freeze(Time.utc(2016, 5, 5, 10, 5, 3)) }
   after { Timecop.return }
 
-  let!(:wrc_team_id) { Team.find_by_friendly_id("wrc") }
-
   let!(:user) { FactoryBot.create(:user) }
-  let!(:former_team_leader) {
-    FactoryBot.create(:user, :wrc_member, team_leader: true).tap do |user|
-      user.team_members.find_by_team_id(wrc_team_id).update!(end_date: 1.day.ago)
-    end
-  }
+  let!(:former_team_leader) { FactoryBot.create(:user, :wrc_leader, end_date: 1.day.ago) }
   let!(:team_leader) { FactoryBot.create(:user, :wrt_leader) }
   let!(:wac_leader) { FactoryBot.create(:wac_role_leader) }
-  let!(:team_senior_member) { FactoryBot.create(:user, :wrc_member, team_senior_member: true) }
+  let!(:team_senior_member) { FactoryBot.create(:user, :wrc_senior_member) }
   let!(:team_member) { FactoryBot.create(:user, :wrc_member) }
   let!(:senior_delegate_role) { FactoryBot.create(:senior_delegate_role) }
   let!(:junior_delegate) { FactoryBot.create(:junior_delegate_role, group_id: senior_delegate_role.group_id) }
   let!(:delegate) { FactoryBot.create(:delegate_role, group_id: senior_delegate_role.group.id).user }
-  let!(:delegate_who_is_also_team_leader) { FactoryBot.create(:delegate, :wrc_member, team_leader: true) }
+  let!(:delegate_who_is_also_team_leader) { FactoryBot.create(:delegate, :wrc_leader) }
   let!(:board_member) { FactoryBot.create(:user, :board_member) }
   let!(:officer) { FactoryBot.create(:secretary_role) }
 


### PR DESCRIPTION
This is the last team/committee to be migrated to roles. Cleanups of helper methods will start once this PR is merged & deployed successfully.