### PR TITLE
Change contact API response type to formData

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -63,9 +63,11 @@ class ContactsController < ApplicationController
 
   def contact
     formValues = JSON.parse(params.require(:formValues), symbolize_names: true)
-    contact_recipient = formValues.fetch(:contactRecipient)
-    contact_params = formValues.fetch(contact_recipient.to_sym)
-    requestor_details = current_user || formValues.fetch(userData)
+    contact_recipient = formValues[:contactRecipient]
+    contact_params = formValues[contact_recipient.to_sym]
+    requestor_details = current_user || formValues[:userData]
+
+    render status: :bad_request, json: { error: "Invalid arguments" } if contact_recipient.nil? || contact_params.nil? || requestor_details.nil?
 
     case contact_recipient
     when UserGroup.teams_committees_group_wct.metadata.friendly_id

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -62,7 +62,7 @@ class ContactsController < ApplicationController
   end
 
   def contact
-    formValues = JSON.parse(params.require(:formValues)).deep_symbolize_keys
+    formValues = JSON.parse(params.require(:formValues), symbolize_names: true)
     contact_recipient = formValues.fetch(:contactRecipient)
     contact_params = formValues.fetch(contact_recipient.to_sym)
     requestor_details = current_user || formValues.fetch(userData)

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -62,9 +62,10 @@ class ContactsController < ApplicationController
   end
 
   def contact
-    contact_recipient = params.require(:contactRecipient)
-    contact_params = params.require(contact_recipient)
-    requestor_details = current_user || params.require(:userData)
+    formValues = JSON.parse(params.require(:formValues)).deep_symbolize_keys
+    contact_recipient = formValues.fetch(:contactRecipient)
+    contact_params = formValues.fetch(contact_recipient.to_sym)
+    requestor_details = current_user || formValues.fetch(userData)
 
     case contact_recipient
     when UserGroup.teams_committees_group_wct.metadata.friendly_id

--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -33,7 +33,7 @@ export default function ContactForm({ loggedInUserData }) {
   const [contactSuccess, setContactSuccess] = useState(false);
   const contactFormState = useStore();
   const dispatch = useDispatch();
-  const { contactRecipient: selectedContactRecipient, userData } = contactFormState;
+  const { formValues: { contactRecipient: selectedContactRecipient, userData } } = contactFormState;
 
   const isFormValid = (
     selectedContactRecipient && userData.name && userData.email && captchaValue
@@ -78,11 +78,13 @@ export default function ContactForm({ loggedInUserData }) {
       <Form
         onSubmit={() => {
           if (isFormValid) {
+            const formData = new FormData();
+            formData.append('formValues', JSON.stringify(contactFormState.formValues));
             save(
               contactUrl,
-              contactFormState,
+              formData,
               contactSuccessHandler,
-              { method: 'POST' },
+              { method: 'POST', headers: {}, body: formData },
             );
           }
         }}

--- a/app/webpacker/components/ContactsPage/SubForms/Competition/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Competition/index.jsx
@@ -9,7 +9,7 @@ import { updateSectionData } from '../../store/actions';
 const SECTION = 'competition';
 
 export default function Competition() {
-  const { competition } = useStore();
+  const { formValues: { competition } } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),

--- a/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wct/index.jsx
@@ -7,7 +7,7 @@ import { updateSectionData } from '../../store/actions';
 const SECTION = 'wct';
 
 export default function Wct() {
-  const { wct } = useStore();
+  const { formValues: { wct } } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),

--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/index.jsx
@@ -7,7 +7,7 @@ import { updateSectionData } from '../../store/actions';
 const SECTION = 'wrt';
 
 export default function Wrt() {
-  const { wrt } = useStore();
+  const { formValues: { wrt } } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),

--- a/app/webpacker/components/ContactsPage/SubForms/Wst/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wst/index.jsx
@@ -7,7 +7,7 @@ import { updateSectionData } from '../../store/actions';
 const SECTION = 'wst';
 
 export default function Wst() {
-  const { wst } = useStore();
+  const { formValues: { wst } } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),

--- a/app/webpacker/components/ContactsPage/UserData.jsx
+++ b/app/webpacker/components/ContactsPage/UserData.jsx
@@ -7,7 +7,7 @@ import { updateSectionData } from './store/actions';
 const SECTION = 'userData';
 
 export default function UserData({ loggedInUserData }) {
-  const { userData } = useStore();
+  const { formValues: { userData } } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),

--- a/app/webpacker/components/ContactsPage/store/reducer.js
+++ b/app/webpacker/components/ContactsPage/store/reducer.js
@@ -5,31 +5,40 @@ import {
 } from './actions';
 
 export const getContactFormInitialState = (loggedInUserData, queryParams) => ({
-  userData: {
-    name: loggedInUserData?.user?.name,
-    email: loggedInUserData?.user?.email,
+  formValues: {
+    userData: {
+      name: loggedInUserData?.user?.name,
+      email: loggedInUserData?.user?.email,
+    },
+    contactRecipient: queryParams?.contactRecipient,
+    competition: {
+      competitionId: queryParams?.competitionId,
+    },
+    wst: {
+      requestId: queryParams?.requestId,
+    },
   },
-  contactRecipient: queryParams?.contactRecipient,
-  competition: {
-    competitionId: queryParams?.competitionId,
-  },
-  wst: {
-    requestId: queryParams?.requestId,
-  },
+  attachments: [],
 });
 
 const reducers = {
   [UpdateSectionData]: (state, { payload }) => ({
     ...state,
-    [payload.section]: {
-      ...(state[payload.section] || {}),
-      [payload.name]: payload.value,
+    formValues: {
+      ...state.formValues,
+      [payload.section]: {
+        ...(state.formValues[payload.section] || {}),
+        [payload.name]: payload.value,
+      },
     },
   }),
 
   [UpdateContactRecipient]: (state, { payload }) => ({
     ...state,
-    contactRecipient: payload.contactRecipient,
+    formValues: {
+      ...state.formValues,
+      contactRecipient: payload.contactRecipient,
+    },
   }),
 
   [ClearForm]: (__, { payload }) => (


### PR DESCRIPTION
The contact form will soon have file attachment feature (one example: while contacting WRT, attach proof), so to accommodate that, converting the response type of the API body from json to formData.