### PR TITLE
Fix broken link to the developer dump

### DIFF
--- a/lib/db_dump_helper.rb
+++ b/lib/db_dump_helper.rb
@@ -46,7 +46,7 @@ module DbDumpHelper
   end
 
   def self.public_s3_path(file_name)
-    "http://#{BUCKET_NAME}.s3#{EnvConfig.STORAGE_AWS_REGION}.amazonaws.com/#{file_name}"
+    "https://s3.#{EnvConfig.STORAGE_AWS_REGION}.amazonaws.com/#{BUCKET_NAME}/#{file_name}"
   end
 
   def self.dump_results_db(export_timestamp = DateTime.now)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -57,7 +57,6 @@ namespace :db do
       Dir.mktmpdir do |dir|
         FileUtils.cd dir do
           dev_db_dump_url = DbDumpHelper.public_s3_path(DbDumpHelper::DEVELOPER_EXPORT_SQL_PERMALINK)
-          puts "dev dump url: #{dev_db_dump_url}"
           local_file = "./dump.zip"
           LogTask.log_task("Downloading #{dev_db_dump_url}") do
             system("curl -o #{local_file} #{dev_db_dump_url}") || raise("Error while running `curl`")


### PR DESCRIPTION
This is what I get when I try to import the developer dump:
```
root@49ecb31e682f:/app# bin/rake db:load:development
Running via Spring preloader in process 4706
dev dump url: http://assets.worldcubeassociation.org.s3us-west-2.amazonaws.com/export/developer/wca-developer-database-dump.zip
Downloading http://assets.worldcubeassociation.org.s3us-west-2.amazonaws.com/export/developer/wca-developer-database-dump.zip...  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: assets.worldcubeassociation.org.s3us-west-2.amazonaws.com
```

But the url mentioned [here](https://github.com/thewca/worldcubeassociation.org/issues/7875#issuecomment-1934027764) does work.

I think it was broken [here](https://github.com/thewca/worldcubeassociation.org/pull/9271/files#diff-1caeedb978517c51f326aebbacc03200925d5749eb5fd229249be89a0ff3af3d), along with the addition of a `puts` which is not that useful since `curl` seems to tell the user what is the downloaded url.

@dunkOnIT I can't really understand what the url change was supposed to fix so I'm not sure reverting these two lines is the best course of action; but it does look like something is broken at the moment, and this patch got the dev dump downloaded for me :)
