### PR TITLE
Reset AUTO INCREMENT counter upon CAD computation

### DIFF
--- a/lib/auxiliary_data_computation.rb
+++ b/lib/auxiliary_data_computation.rb
@@ -14,6 +14,7 @@ module AuxiliaryDataComputation
     ].each do |field, table_name|
       ActiveRecord::Base.transaction do
         ActiveRecord::Base.connection.execute "DELETE FROM #{table_name}"
+        ActiveRecord::Base.connection.execute "ALTER TABLE #{table_name} AUTO_INCREMENT = 1"
         ActiveRecord::Base.connection.execute <<-SQL
           INSERT INTO #{table_name} (id, #{field}, valueAndId, personId, eventId, countryId, continentId, year, month, day)
           SELECT
@@ -51,6 +52,7 @@ module AuxiliaryDataComputation
     ].each do |field, table_name, concise_table_name|
       ActiveRecord::Base.transaction do
         ActiveRecord::Base.connection.execute "DELETE FROM #{table_name}"
+        ActiveRecord::Base.connection.execute "ALTER TABLE #{table_name} AUTO_INCREMENT = 1"
         current_country_by_wca_id = Person.current.pluck(:wca_id, :countryId).to_h
         # Get all personal records (note: people that changed their country appear once for each country).
         personal_records_with_event = ActiveRecord::Base.connection.execute <<-SQL


### PR DESCRIPTION
I just noticed that the values in the dev export are getting frighteningly high, because they just kept increasing and increasing every time CAD is run.

This is more of an immediate fix to get us out of the "id column int overflow" hot waters. In the long run, I'd be interested to know why the CAD tables even have an auto increment primary key in the first place.