### PR TITLE
Some cleanups related to groups

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -156,13 +156,13 @@ class Api::V0::ApiController < ApplicationController
   end
 
   def delegates
-    paginate json: UserGroup.delegate_region_groups.flat_map(&:active_users)
+    paginate json: UserGroup.delegate_regions.flat_map(&:active_users)
   end
 
   def delegates_search_index
     # TODO: There is a `uniq` call at the end which I feel shouldn't be necessary?!
     #   Postponing investigation until the Roles system migration is complete.
-    all_delegates = UserGroup.includes(roles: [:user]).delegate_region_groups.flat_map(&:active_users).uniq
+    all_delegates = UserGroup.includes(roles: [:user]).delegate_regions.flat_map(&:active_users).uniq
 
     search_index = all_delegates.map do |delegate|
       delegate.slice(:id, :name, :wca_id).merge({ thumb_url: delegate.avatar.url(:thumb) })

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -57,7 +57,7 @@ class TranslationsController < ApplicationController
     info = ["WCA Account ID: *#{user.id}*"]
     info.unshift("WCA ID: *[#{user.wca_id}](#{person_url(user.wca_id)})*") if user.wca_id
     is_verified_translator = false
-    UserGroup.translator_groups.each do |translators_group|
+    UserGroup.translators.each do |translators_group|
       if translators_group.roles.any? { |role| role.user_id == user.id && role.group.metadata.locale == locale }
         is_verified_translator = true
         break

--- a/app/jobs/sync_mailing_lists_job.rb
+++ b/app/jobs/sync_mailing_lists_job.rb
@@ -9,7 +9,7 @@ class SyncMailingListsJob < WcaCronjob
   def perform
     GsuiteMailingLists.sync_group("leaders@worldcubeassociation.org", UserGroup.teams_committees.map(&:lead_user).compact.map(&:email))
     GsuiteMailingLists.sync_group(GroupsMetadataBoard.email, UserGroup.board_group.active_users.map(&:email))
-    translator_users = UserGroup.translator_groups.flat_map(&:users)
+    translator_users = UserGroup.translators.flat_map(&:users)
     GsuiteMailingLists.sync_group("translators@worldcubeassociation.org", translator_users.map(&:email))
     User.clear_receive_delegate_reports_if_not_eligible
     GsuiteMailingLists.sync_group("reports@worldcubeassociation.org", User.delegate_reports_receivers_emails)
@@ -23,7 +23,7 @@ class SyncMailingListsJob < WcaCronjob
     delegate_emails = []
     trainee_emails = []
     senior_emails = []
-    active_root_delegate_regions = UserGroup.delegate_region_groups.where(parent_group_id: nil, is_active: true)
+    active_root_delegate_regions = UserGroup.delegate_regions.where(parent_group_id: nil, is_active: true)
     active_root_delegate_regions.each do |region|
       region_emails = []
       (region.active_roles + region.active_roles_of_all_child_groups).each do |role|

--- a/app/models/roles_metadata_delegate_regions.rb
+++ b/app/models/roles_metadata_delegate_regions.rb
@@ -11,5 +11,8 @@ class RolesMetadataDelegateRegions < ApplicationRecord
 
   has_one :user_role, as: :metadata
   has_one :group, through: :user_role
+  has_one :user, through: :user_role
   has_one :delegate_region, through: :group, source: :metadata, source_type: "GroupsMetadataDelegateRegions"
+
+  scope :senior_delegate, -> { where(status: statuses[:senior_delegate]) }
 end

--- a/app/models/roles_metadata_delegate_regions.rb
+++ b/app/models/roles_metadata_delegate_regions.rb
@@ -13,6 +13,4 @@ class RolesMetadataDelegateRegions < ApplicationRecord
   has_one :group, through: :user_role
   has_one :user, through: :user_role
   has_one :delegate_region, through: :group, source: :metadata, source_type: "GroupsMetadataDelegateRegions"
-
-  scope :senior_delegate, -> { where(status: statuses[:senior_delegate]) }
 end

--- a/app/models/roles_metadata_teams_committees.rb
+++ b/app/models/roles_metadata_teams_committees.rb
@@ -10,8 +10,6 @@ class RolesMetadataTeamsCommittees < ApplicationRecord
   has_one :user_role, as: :metadata
   has_one :user, through: :user_role
 
-  scope :leader, -> { where(status: statuses[:leader]) }
-
   def at_least_senior_member?
     [
       statuses[:senior_member],

--- a/app/models/roles_metadata_teams_committees.rb
+++ b/app/models/roles_metadata_teams_committees.rb
@@ -7,10 +7,15 @@ class RolesMetadataTeamsCommittees < ApplicationRecord
     member: "member",
   }
 
+  has_one :user_role, as: :metadata
+  has_one :user, through: :user_role
+
+  scope :leader, -> { where(status: statuses[:leader]) }
+
   def at_least_senior_member?
     [
-      RolesMetadataTeamsCommittees.statuses[:senior_member],
-      RolesMetadataTeamsCommittees.statuses[:leader],
+      statuses[:senior_member],
+      statuses[:leader],
     ].include?(status)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,8 +68,8 @@ class User < ApplicationRecord
   end
 
   def self.leader_senior_voters
-    team_leaders = UserGroup.teams_committees.map(&:lead_user)
-    senior_delegates = UserGroup.delegate_region_groups_senior_delegates
+    team_leaders = RolesMetadataTeamsCommittees.leader.includes(:user, :user_role).select { |role_metadata| role_metadata.user_role.is_active? }.map(&:user)
+    senior_delegates = RolesMetadataDelegateRegions.senior_delegate.includes(:user, :user_role).select { |role_metadata| role_metadata.user_role.is_active? }.map(&:user)
     (team_leaders + senior_delegates).uniq.compact
   end
 
@@ -1253,7 +1253,7 @@ class User < ApplicationRecord
   end
 
   def is_delegate_in_probation
-    UserGroup.delegate_probation_groups.flat_map(&:active_users).include?(self)
+    UserGroup.delegate_probation.flat_map(&:active_users).include?(self)
   end
 
   private def can_manage_delegate_probation?

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -17,26 +17,17 @@ class UserGroup < ApplicationRecord
   }
 
   has_many :direct_child_groups, class_name: "UserGroup", inverse_of: :parent_group, foreign_key: "parent_group_id"
+  has_many :roles, foreign_key: "group_id", class_name: "UserRole"
+  has_many :active_roles, -> { active }, foreign_key: "group_id", class_name: "UserRole"
+
   belongs_to :metadata, polymorphic: true, optional: true
   belongs_to :parent_group, class_name: "UserGroup", optional: true
-
-  has_many :roles, foreign_key: "group_id", class_name: "UserRole"
 
   scope :root_groups, -> { where(parent_group: nil) }
   scope :active_groups, -> { where(is_active: true) }
 
   def all_child_groups
     [direct_child_groups, direct_child_groups.map(&:all_child_groups)].flatten
-  end
-
-  # For teams which have groups migrated but not roles, this method will help to get the
-  # corresponding team to fetch the team_members.
-  def team
-    Team.find_by(friendly_id: self.metadata.friendly_id)
-  end
-
-  def active_roles
-    self.roles.select { |role| role.is_active? }
   end
 
   def roles_of_direct_child_groups
@@ -60,7 +51,7 @@ class UserGroup < ApplicationRecord
   end
 
   def active_users
-    self.active_roles.map { |role| role.user }
+    self.active_roles.includes(:user).map(&:user)
   end
 
   def users_of_direct_child_groups
@@ -99,22 +90,6 @@ class UserGroup < ApplicationRecord
       board: "Board",
       officers: "Officers",
     }
-  end
-
-  def self.delegate_region_groups
-    UserGroup.where(group_type: UserGroup.group_types[:delegate_regions])
-  end
-
-  def self.delegate_region_groups_senior_delegates
-    UserGroup.delegate_region_groups.root_groups.map(&:lead_user).compact
-  end
-
-  def self.delegate_probation_groups
-    UserGroup.where(group_type: UserGroup.group_types[:delegate_probation])
-  end
-
-  def self.translator_groups
-    UserGroup.where(group_type: UserGroup.group_types[:translators])
   end
 
   def self.board_group
@@ -198,7 +173,7 @@ class UserGroup < ApplicationRecord
   end
 
   def lead_role
-    self.active_roles.find { |role| role.is_lead? }
+    active_roles.includes(:group, metadata: [:status]).find { |role| role.is_lead? }
   end
 
   # TODO: Once the roles migration is done, add a validation to make sure there is only one lead_user per group.

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -211,7 +211,6 @@ export const apiV0Urls = {
     registrationData: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_registration_data_path) %>`
   },
   delegates: {
-    list: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_delegates_path)%>`,
     searchIndex: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_delegates_search_index_path)%>`,
   },
 }


### PR DESCRIPTION
Some of the cleanups included in this PR are:
1. Removal of some static methods like UserGroup.delegate_region_groups, in favor of rails-provided static methods like UserGroup.delegate_regions.
2. In User.leader_senior_voters, use associations to make the fetch more efficient.
3. In RolesMetadataTeamsCommittees, avoid using class name to fetch statuses.
4. Use associations for active_roles in user_group
5. Remove unused list API from routes.js.erb