### PR TITLE
Some cleanups related to groups

### DIFF
--- a/app/jobs/sync_mailing_lists_job.rb
+++ b/app/jobs/sync_mailing_lists_job.rb
@@ -26,7 +26,7 @@ class SyncMailingListsJob < WcaCronjob
     active_root_delegate_regions = UserGroup.delegate_regions.where(parent_group_id: nil, is_active: true)
     active_root_delegate_regions.each do |region|
       region_emails = []
-      (region.active_roles + region.active_roles_of_all_child_groups).each do |role|
+      (region.active_roles + region.active_all_child_roles).each do |role|
         role_email = role.user.email
         role_status = role.metadata.status
         region_emails << role_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1314,7 +1314,7 @@ class User < ApplicationRecord
   def subordinate_delegates
     delegate_roles
       .filter { |role| role.is_lead? }
-      .flat_map { |role| role.group.active_users + role.group.active_users_of_all_child_groups }
+      .flat_map { |role| role.group.active_users + role.group.active_all_child_users }
       .uniq
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,8 +53,6 @@ class User < ApplicationRecord
     end
   }
 
-  scope :with_delegate_data, -> { includes(:actually_delegated_competitions, :region) }
-
   def self.eligible_voters
     [
       UserGroup.delegate_regions,

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -19,8 +19,12 @@ class UserGroup < ApplicationRecord
   has_many :direct_child_groups, class_name: "UserGroup", inverse_of: :parent_group, foreign_key: "parent_group_id"
   has_many :roles, foreign_key: "group_id", class_name: "UserRole"
   has_many :active_roles, -> { active }, foreign_key: "group_id", class_name: "UserRole"
+  has_many :roles_of_direct_child_groups, through: :direct_child_groups, source: :roles
+  has_many :active_roles_of_direct_child_groups, -> { active }, through: :direct_child_groups, source: :roles
   has_many :users, through: :roles
-  has_many :active_users, through: :active_roles, source: :user, class_name: "User"
+  has_many :active_users, through: :active_roles, source: :user
+  has_many :users_of_direct_child_groups, through: :roles_of_direct_child_groups, source: :user
+  has_many :active_users_of_direct_child_groups, through: :active_roles_of_direct_child_groups, source: :user
 
   belongs_to :metadata, polymorphic: true, optional: true
   belongs_to :parent_group, class_name: "UserGroup", optional: true
@@ -32,32 +36,16 @@ class UserGroup < ApplicationRecord
     [direct_child_groups, direct_child_groups.map(&:all_child_groups)].flatten
   end
 
-  def roles_of_direct_child_groups
-    self.direct_child_groups.map(&:roles).flatten
-  end
-
   def roles_of_all_child_groups
     self.all_child_groups.map(&:roles).flatten
-  end
-
-  def active_roles_of_direct_child_groups
-    self.direct_child_groups.map(&:active_roles).flatten
   end
 
   def active_roles_of_all_child_groups
     self.all_child_groups.map(&:active_roles).flatten
   end
 
-  def users_of_direct_child_groups
-    self.roles_of_direct_child_groups.map { |role| role.user }
-  end
-
   def users_of_all_child_groups
     self.roles_of_all_child_groups.map { |role| role.user }
-  end
-
-  def active_users_of_direct_child_groups
-    self.active_roles_of_direct_child_groups.map { |role| role.user }
   end
 
   def active_users_of_all_child_groups

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Disabling Style/MixinUsage because SortHelper cannot be included inside class as static methods need to access it.
+include SortHelper # rubocop:disable Style/MixinUsage
+
 class UserRole < ApplicationRecord
   belongs_to :user
   belongs_to :group, class_name: "UserGroup"
@@ -23,9 +26,32 @@ class UserRole < ApplicationRecord
     UserGroup.group_types[:officers].to_sym => ["chair", "executive_director", "secretary", "vice_chair", "treasurer"],
   }.freeze
 
-  def self.status_rank(group_type, status)
-    STATUS_SORTING_ORDER[group_type.to_sym]&.find_index(status) || STATUS_SORTING_ORDER[group_type.to_sym]&.length || 1
-  end
+  GROUP_TYPE_RANK_ORDER = [
+    UserGroup.group_types[:board],
+    UserGroup.group_types[:officers],
+    UserGroup.group_types[:teams_committees],
+    UserGroup.group_types[:delegate_regions],
+    UserGroup.group_types[:councils],
+  ].freeze
+
+  SORT_WEIGHT_LAMBDAS = {
+    startDate:
+      lambda { |role| role.start_date.to_time.to_i },
+    lead:
+      lambda { |role| role.is_lead? ? 0 : 1 },
+    eligibleVoter:
+      lambda { |role| role.is_eligible_voter? ? 0 : 1 },
+    groupTypeRank:
+      lambda { |role| GROUP_TYPE_RANK_ORDER.find_index(role.group_type) || GROUP_TYPE_RANK_ORDER.length },
+    status:
+      lambda { |role| role.status_sort_rank },
+    name:
+      lambda { |role| role.user.name },
+    groupName:
+      lambda { |role| role.group.name },
+    location:
+      lambda { |role| role.metadata.location || '' },
+  }.freeze
 
   def status_sort_rank
     status = metadata&.status || ''
@@ -86,6 +112,48 @@ class UserRole < ApplicationRecord
     else
       nil
     end
+  end
+
+  def can_user_read?(user)
+    # A user can view a role if:
+    # 1. the role belongs to a non-hidden group, or
+    # 2. the user has edit-access to that group.
+    !group.is_hidden || user&.has_permission?(:can_edit_groups, group.id)
+  end
+
+  def self.filter_roles_for_logged_in_user(roles, current_user)
+    roles.select { |role| role.can_user_read?(current_user) }
+  end
+
+  def self.filter_roles_for_parameters(roles, params)
+    status = params[:status]
+    is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
+    is_group_hidden = params.key?(:isGroupHidden) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isGroupHidden)) : nil
+    group_type = params[:groupType]
+    is_lead = params.key?(:isLead) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isLead)) : nil
+
+    roles.reject do |role|
+      # Here, instead of foo.present? we are using !foo.nil? because foo.present? returns false if
+      # foo is a boolean false but we need to actually check if the boolean is present or not.
+      (
+        (!status.nil? && status != role.metadata&.status) ||
+        (!is_active.nil? && is_active != role.is_active?) ||
+        (!is_group_hidden.nil? && is_group_hidden != role.group.is_hidden) ||
+        (!group_type.nil? && group_type != role.group_type) ||
+        (!is_lead.nil? && is_lead != role.is_lead?)
+      )
+    end
+  end
+
+  def self.filter_roles(roles, current_user, params)
+    roles = UserRole.filter_roles_for_logged_in_user(roles, current_user)
+    UserRole.filter_roles_for_parameters(roles, params)
+  end
+
+  # Sorts the list of roles based on the given list of sort keys and directions.
+  def self.sort_roles(roles, sort_param)
+    sort_param ||= ''
+    sort(roles, sort_param, SORT_WEIGHT_LAMBDAS)
   end
 
   def deprecated_team_role

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -53,6 +53,10 @@ class UserRole < ApplicationRecord
       lambda { |role| role.metadata.location || '' },
   }.freeze
 
+  def self.status_rank(group_type, status)
+    STATUS_SORTING_ORDER[group_type.to_sym]&.find_index(status) || STATUS_SORTING_ORDER[group_type.to_sym]&.length || 1
+  end
+
   def status_sort_rank
     status = metadata&.status || ''
     UserRole.status_rank(group_type, status)

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -95,20 +95,20 @@ RSpec.describe UserGroup, type: :model do
     expect(asia_region.active_roles).to eq(delegate_roles[5..7])
   end
 
-  it "roles_of_direct_child_groups has the roles of the direct child groups of the user group" do
-    expect(asia_region.roles_of_direct_child_groups).to eq(delegate_roles[25..34])
+  it "direct_child_roles has the roles of the direct child groups of the user group" do
+    expect(asia_region.direct_child_roles).to eq(delegate_roles[25..34])
   end
 
-  it "roles_of_all_child_groups has the roles of the child groups of the user group" do
-    expect(asia_region.roles_of_all_child_groups).to eq(delegate_roles[25..38])
+  it "all_child_roles has the roles of the child groups of the user group" do
+    expect(asia_region.all_child_roles).to eq(delegate_roles[25..38])
   end
 
-  it "active_roles_of_direct_child_groups has the active roles of the direct child groups of the user group" do
-    expect(asia_region.active_roles_of_direct_child_groups).to eq(delegate_roles[25..27] + delegate_roles[30..32])
+  it "active_direct_child_roles has the active roles of the direct child groups of the user group" do
+    expect(asia_region.active_direct_child_roles).to eq(delegate_roles[25..27] + delegate_roles[30..32])
   end
 
-  it "active_roles_of_all_child_groups has the active roles of the child groups of the user group" do
-    expect(asia_region.active_roles_of_all_child_groups).to eq([
+  it "active_all_child_roles has the active roles of the child groups of the user group" do
+    expect(asia_region.active_all_child_roles).to eq([
       delegate_roles[25..27],
       delegate_roles[30..32],
       delegate_roles[35..36],
@@ -123,20 +123,20 @@ RSpec.describe UserGroup, type: :model do
     expect(asia_region.active_users).to eq(delegate_users[5..7])
   end
 
-  it "users_of_direct_child_groups has the users of the direct child groups of the user group" do
-    expect(asia_region.users_of_direct_child_groups).to eq(delegate_users[25..34])
+  it "direct_child_users has the users of the direct child groups of the user group" do
+    expect(asia_region.direct_child_users).to eq(delegate_users[25..34])
   end
 
-  it "users_of_all_child_groups has the users of the child groups of the user group" do
-    expect(asia_region.users_of_all_child_groups).to eq(delegate_users[25..38])
+  it "all_child_users has the users of the child groups of the user group" do
+    expect(asia_region.all_child_users).to eq(delegate_users[25..38])
   end
 
-  it "active_users_of_direct_child_groups has the active users of the direct child groups of the user group" do
-    expect(asia_region.active_users_of_direct_child_groups).to eq(delegate_users[25..27] + delegate_users[30..32])
+  it "active_direct_child_users has the active users of the direct child groups of the user group" do
+    expect(asia_region.active_direct_child_users).to eq(delegate_users[25..27] + delegate_users[30..32])
   end
 
-  it "active_users_of_all_child_groups has the active users of the child groups of the user group" do
-    expect(asia_region.active_users_of_all_child_groups).to eq([
+  it "active_all_child_users has the active users of the child groups of the user group" do
+    expect(asia_region.active_all_child_users).to eq([
       delegate_users[25..27],
       delegate_users[30..32],
       delegate_users[35..36],


### PR DESCRIPTION
The cleanups done in this PR are:
- Move filter & sort of roles to UserRole, because `roles_of_group_type` will be moved to a static method in user_group, and that method can be used from different controllers.
- Created few more associations.
- Removed an unused scope in user.rb.