### PR TITLE
Prevent n+1 query using delegate_role_metadata

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -16,7 +16,7 @@ class Competition < ApplicationRecord
   has_many :competitors, -> { distinct }, through: :results, source: :person
   has_many :competitor_users, -> { distinct }, through: :competitors, source: :user
   has_many :competition_delegates, dependent: :delete_all
-  has_many :delegates, through: :competition_delegates
+  has_many :delegates, -> { includes(:delegate_role_metadata) }, through: :competition_delegates
   has_many :competition_organizers, dependent: :delete_all
   has_many :organizers, through: :competition_organizers
   has_many :media, class_name: "CompetitionMedium", foreign_key: "competitionId", dependent: :delete_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -518,7 +518,15 @@ class User < ApplicationRecord
   end
 
   def trainee_delegate?
-    delegate_role_metadata.trainee_delegate.any?
+    # NOTE: `delegate_role_metadata.trainee_delegate.any?`, does fire a db query
+    # even if the `delegate_role_metadata` is eager loaded (because rails
+    # really wants to translate it to a "select 1 ..."; therefore we use a
+    # different implementation when we explicitly eager load roles.
+    if delegate_role_metadata.loaded?
+      delegate_role_metadata.any?(&:trainee_delegate?)
+    else
+      delegate_role_metadata.trainee_delegate.any?
+    end
   end
 
   private def staff_delegate?


### PR DESCRIPTION
It's slightly noticeable on prod when loading a WCIF with a large number of competitors, but in development it's obvious that GET-ing `/api/v0/competitions/CompID/wcif` is unbearably slow!

The WCIF for Euro2024 is currently taking 30s to show on my computer, and this PR put it back to the "usual" 2s (which looks good to me given the overall size of the competition).

Looking at the log without this fix it's pretty obvious what is going on: `Person`'s [to_wcif](https://github.com/thewca/worldcubeassociation.org/blob/1bf137caa153076fe4a4abf077d506b8e9d88614/app/models/user.rb#L1149) uses the competition's `trainee_delegates` which itself uses `trainee_delegate?` which uses `delegate_role_metadata`, and since it's not an eager loaded association it results in a n+1 query.
Since the `delegate_role_metadata` seems like something we pretty much always want if we want the `delegates`, I have added the `includes` directly on the association; an alternative would be to specify it explicitly at all the place we do need that information.

Interestingly, it was not enough to remove the n+1 query: rails translates `delegate_role_metadata.trainee_delegate.any?` into a `select 1 ...`, which is smart if you don't already have the association loaded or if there are a lot of associated rows, but in this case it also ignores the eager loaded data.
I saw elsewhere that `RolesMetadataDelegateRegions.statuses[:trainee_delegate]` was used to compare the status so I went for that.

I'm convinced there are other n+1 queries that were introduced with the changes to the roles structure (just look at the log when loading a competition's page), but I didn't look into them, and they must be fairly less critical than this one.

I'd definitely consider reactivating bullet or something similar; I know it has been disabled by default because it was annoying, but it's an absolutely awesome tool to prevent situation like this (maybe restricting bullet's output to the terminal log would help?).