### PR TITLE
Create db/seeds for board & officers

### DIFF
--- a/db/seeds/development/user_roles.seeds.rb
+++ b/db/seeds/development/user_roles.seeds.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+after :user_groups do
+  # Board Roles
+  past_board_roles = 9.times.collect { |index| FactoryBot.create!(:board_role, :inactive) }
+  current_board_roles = 4.times.collect { |index| FactoryBot.create!(:board_role, :active) }
+
+  # Officer Roles
+  # Giving officer roles to all board users except a few
+  FactoryBot.create!(:executive_director_role, :inactive, user: past_board_roles[1].user)
+  FactoryBot.create!(:executive_director_role, :inactive, user: past_board_roles[2].user)
+  FactoryBot.create!(:executive_director_role, user: current_board_roles[1].user)
+  FactoryBot.create!(:chair_role, :inactive, user: past_board_roles[2].user)
+  FactoryBot.create!(:chair_role, :inactive, user: past_board_roles[3].user)
+  FactoryBot.create!(:chair_role, user: current_board_roles[1].user)
+  FactoryBot.create!(:vice_chair_role, :inactive, user: past_board_roles[4].user)
+  FactoryBot.create!(:vice_chair_role, :inactive, user: past_board_roles[5].user)
+  FactoryBot.create!(:vice_chair_role, user: current_board_roles[2].user)
+  FactoryBot.create!(:secretary_role, :inactive, user: past_board_roles[6].user)
+  FactoryBot.create!(:secretary_role, :inactive, user: past_board_roles[7].user)
+  FactoryBot.create!(:secretary_role, user: current_board_roles[3].user)
+  FactoryBot.create!(:secretary_role)
+  FactoryBot.create!(:treasurer_role, :inactive, user: past_board_roles[8].user)
+  FactoryBot.create!(:treasurer_role, :inactive)
+  FactoryBot.create!(:treasurer_role)
+end

--- a/db/seeds/development/user_roles.seeds.rb
+++ b/db/seeds/development/user_roles.seeds.rb
@@ -6,7 +6,7 @@ after :user_groups do
   current_board_roles = 4.times.collect { |index| FactoryBot.create!(:board_role, :active) }
 
   # Officer Roles
-  # Giving officer roles to all board users except a few
+  # Giving officer roles to all board users except past_board_roles[0] and current_board_roles[0]
   FactoryBot.create!(:executive_director_role, :inactive, user: past_board_roles[1].user)
   FactoryBot.create!(:executive_director_role, :inactive, user: past_board_roles[2].user)
   FactoryBot.create!(:executive_director_role, user: current_board_roles[1].user)

--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -13,11 +13,6 @@ after :teams do
     }
   end
 
-  # Create board members
-  8.times do
-    FactoryBot.create(:user, :board_member)
-  end
-
   # Create senior delegates and their subordinate delegates
   5.times do
     senior_delegate = FactoryBot.create(:senior_delegate_role)

--- a/spec/factories/user_roles.rb
+++ b/spec/factories/user_roles.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :user_role do
-    user { rand(2) == 0 ? FactoryBot.create(:user_with_wca_id) : FactoryBot.create(:user) }
+    user { FactoryBot.create(:user) }
 
     trait :active do
       start_date { Date.today }

--- a/spec/factories/user_roles.rb
+++ b/spec/factories/user_roles.rb
@@ -2,15 +2,15 @@
 
 FactoryBot.define do
   factory :user_role do
-    user { FactoryBot.create(:user) }
+    user { rand(2) == 0 ? FactoryBot.create(:user_with_wca_id) : FactoryBot.create(:user) }
 
     trait :active do
       start_date { Date.today }
     end
 
     trait :inactive do
-      start_date { Date.today - 1.year }
-      end_date { Date.today - 1.day }
+      start_date { Faker::Date.between(from: 10.years.ago, to: 5.years.ago) }
+      end_date { Faker::Date.between(from: 5.years.ago, to: Date.today) }
     end
 
     trait :delegate_probation do


### PR DESCRIPTION
For now, creating just board & officers in db/seeds. If this way of creating user_roles is fine, I'll do the same for other group types as well in upcoming PRs.