### PR TITLE
Ensure trailing slash for all /regulations pages

### DIFF
--- a/app/controllers/regulations_controller.rb
+++ b/app/controllers/regulations_controller.rb
@@ -21,7 +21,7 @@ class RegulationsController < ApplicationController
     end
   end
 
-  private def render_regulations(route, version_file = REGULATIONS_VERSION_FILE)
+  def render_regulations(route, version_file = REGULATIONS_VERSION_FILE)
     erb_file = RegulationsS3Helper.fetch_regulations_from_s3(route, version_file)
     render inline: erb_file, layout: "application"
   end

--- a/app/controllers/regulations_controller.rb
+++ b/app/controllers/regulations_controller.rb
@@ -1,10 +1,28 @@
 # frozen_string_literal: true
 
 class RegulationsController < ApplicationController
+  before_action :ensure_trailing_slash
+
   REGULATIONS_VERSION_FILE = "version"
 
-  def render_regulations(route)
-    erb_file = RegulationsS3Helper.fetch_regulations_from_s3(route, REGULATIONS_VERSION_FILE)
+  # We need this so the relative links within the regulation HTML work
+  private def trailing_slash?(url)
+    url.match(/[^?]+/).to_s.last == '/'
+  end
+
+  private def ensure_trailing_slash
+    desired_url = url_for(params.permit!.merge(trailing_slash: true))
+    # url_for doesn't always add a trailing slash (it won't add a slash to
+    # a url like example.com/index.html, for instance).
+    # Only attempt to redirect if the current url does not match the one
+    # url_for would want.
+    if trailing_slash?(request.env['REQUEST_URI']) != trailing_slash?(desired_url)
+      redirect_to desired_url, status: 301
+    end
+  end
+
+  private def render_regulations(route, version_file = REGULATIONS_VERSION_FILE)
+    erb_file = RegulationsS3Helper.fetch_regulations_from_s3(route, version_file)
     render inline: erb_file, layout: "application"
   end
 

--- a/app/controllers/regulations_translations_controller.rb
+++ b/app/controllers/regulations_translations_controller.rb
@@ -1,28 +1,10 @@
 # frozen_string_literal: true
 
-class RegulationsTranslationsController < ApplicationController
-  before_action :ensure_trailing_slash
-
+class RegulationsTranslationsController < RegulationsController
   REGULATIONS_TRANSLATIONS_VERSION_FILE = "translations/version"
 
-  # We need this so the links for the translated guidelines work
-  private def trailing_slash?(url)
-    url.match(/[^?]+/).to_s.last == '/'
-  end
-  private def ensure_trailing_slash
-    desired_url = url_for(params.permit!.merge(trailing_slash: true))
-    # url_for doesn't always add a trailing slash (it won't add a slash to
-    # a url like example.com/index.html, for instance).
-    # Only attempt to redirect if the current url does not match the one
-    # url_for would want.
-    if trailing_slash?(request.env['REQUEST_URI']) != trailing_slash?(desired_url)
-      redirect_to desired_url, status: 301
-    end
-  end
-
   def render_translated_regulations(route, language)
-    erb_file = RegulationsS3Helper.fetch_regulations_from_s3("translations/#{language}/#{route}", REGULATIONS_TRANSLATIONS_VERSION_FILE)
-    render inline: erb_file, layout: "application"
+    render_regulations("translations/#{language}/#{route}", REGULATIONS_TRANSLATIONS_VERSION_FILE)
   end
 
   def translated_regulation


### PR DESCRIPTION
This may address the issue [raised here](https://github.com/thewca/wca-regulations-compiler/pull/29), where regulation links don't generate properly