### PR TITLE
Hotfix: Fix teams-committees page issue

### DIFF
--- a/app/models/roles_metadata_teams_committees.rb
+++ b/app/models/roles_metadata_teams_committees.rb
@@ -11,9 +11,6 @@ class RolesMetadataTeamsCommittees < ApplicationRecord
   has_one :user, through: :user_role
 
   def at_least_senior_member?
-    [
-      statuses[:senior_member],
-      statuses[:leader],
-    ].include?(status)
+    user_role.status_sort_rank <= UserRole.status_rank(UserGroup.group_types[:teams_committees], RolesMetadataTeamsCommittees.statuses[:senior_member])
   end
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -23,9 +23,13 @@ class UserRole < ApplicationRecord
     UserGroup.group_types[:officers].to_sym => ["chair", "executive_director", "secretary", "vice_chair", "treasurer"],
   }.freeze
 
+  def self.status_rank(group_type, status)
+    STATUS_SORTING_ORDER[group_type.to_sym]&.find_index(status) || STATUS_SORTING_ORDER[group_type.to_sym]&.length || 1
+  end
+
   def status_sort_rank
     status = metadata&.status || ''
-    STATUS_SORTING_ORDER[group_type.to_sym]&.find_index(status) || STATUS_SORTING_ORDER[group_type.to_sym]&.length || 1
+    UserRole.status_rank(group_type, status)
   end
 
   def is_active?


### PR DESCRIPTION
Teams-Committees page is not working because of a recent change in roles_metadata_teams_committees.rb, where I removed the reference of class while calling the enum. But this was applicable only for static methods, I realized lately.

Instead of fixing by adding back the class, I've changed it to a bit more meaningful method in user_role.