### PR TITLE
Migrate banned competitors to groups

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -143,6 +143,10 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     end
   end
 
+  private def changed_value_to_human_readable(changed_value)
+    changed_value.nil? ? 'None' : changed_value
+  end
+
   # update method is written in a way that at a time, only one parameter can be changed. If multiple
   # values needs to be changed, then they need to be sent as separate APIs from the client.
   def update
@@ -264,8 +268,8 @@ class Api::V0::UserRolesController < Api::V0::ApiController
         if changed_parameter.present?
           changes << UserRole::UserRoleChange.new(
             changed_parameter: changed_parameter,
-            previous_value: values[0] || 'None',
-            new_value: values[1] || 'None',
+            previous_value: changed_value_to_human_readable(values[0]),
+            new_value: changed_value_to_human_readable(values[1]),
           )
         end
       end

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -134,6 +134,15 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     }
   end
 
+  private def changed_key_to_human_readable(changed_key)
+    case changed_key
+    when 'end_date'
+      'End Date'
+    else
+      nil
+    end
+  end
+
   # update method is written in a way that at a time, only one parameter can be changed. If multiple
   # values needs to be changed, then they need to be sent as separate APIs from the client.
   def update
@@ -251,14 +260,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
       role.save!
       role.previous_changes.each do |changed_key, values|
-        changed_parameter = (
-          case changed_key
-          when 'end_date'
-            'End Date'
-          else
-            nil
-          end
-        )
+        changed_parameter = changed_key_to_human_readable(changed_key)
         if changed_parameter.present?
           changes << UserRole::UserRoleChange.new(
             changed_parameter: changed_parameter,

--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -14,6 +14,9 @@ class PanelController < ApplicationController
   before_action -> { redirect_to_root_unless_user(:can_access_wfc_panel?) }, only: [:wfc]
   before_action -> { redirect_to_root_unless_user(:can_access_wrt_panel?) }, only: [:wrt]
   before_action -> { redirect_to_root_unless_user(:can_access_wst_panel?) }, only: [:wst]
+  before_action -> { redirect_to_root_unless_user(:can_access_wdc_panel?) }, only: [:wdc]
+  before_action -> { redirect_to_root_unless_user(:can_access_wec_panel?) }, only: [:wec]
+  before_action -> { redirect_to_root_unless_user(:can_access_weat_panel?) }, only: [:weat]
 
   def pending_claims_for_subordinate_delegates
     # Show pending claims for a given user, or the current user, if they can see them
@@ -37,6 +40,7 @@ class PanelController < ApplicationController
         "boardEditor" => "board-editor",
         "officersEditor" => "officers-editor",
         "regionsAdmin" => "regions-admin",
+        "bannedCompetitors" => "banned-competitors",
       },
       "seniorDelegate" => {
         "delegateForms" => "delegate-forms",
@@ -48,6 +52,7 @@ class PanelController < ApplicationController
       "leader" => {
         "leaderForms" => "leader-forms",
         "groupsManager" => "groups-manager",
+        "bannedCompetitors" => "banned-competitors",
       },
       "wfc" => {
         "duesExport" => "dues-export",
@@ -60,9 +65,19 @@ class PanelController < ApplicationController
         "postingDashboard" => "posting-dashboard",
         "editPerson" => "edit-person",
         "regionsManager" => "regions-manager",
+        "bannedCompetitors" => "banned-competitors",
       },
       "wst" => {
         "translators" => "translators",
+      },
+      "wdc" => {
+        "bannedCompetitors" => "banned-competitors",
+      },
+      "wec" => {
+        "bannedCompetitors" => "banned-competitors",
+      },
+      "weat" => {
+        "bannedCompetitors" => "banned-competitors",
       },
     }
   end

--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -41,6 +41,9 @@ class RoleChangeMailer < ApplicationMailer
     when UserGroup.group_types[:board], UserGroup.group_types[:officers]
       to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email]
       reply_to_list = [user_who_made_the_change.email]
+    when UserGroup.group_types[:banned_competitors]
+      to_list = [user_who_made_the_change.email, UserGroup.teams_committees_group_wdc.metadata.email]
+      reply_to_list = [user_who_made_the_change.email]
     else
       raise "Unknown/Unhandled group type: #{role.group.group_type}"
     end
@@ -70,6 +73,9 @@ class RoleChangeMailer < ApplicationMailer
       reply_to_list = [user_who_made_the_change.email]
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]
       to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, role.group.lead_user.email]
+      reply_to_list = [user_who_made_the_change.email]
+    when UserGroup.group_types[:banned_competitors]
+      to_list = [user_who_made_the_change.email, UserGroup.teams_committees_group_wdc.metadata.email]
       reply_to_list = [user_who_made_the_change.email]
     else
       raise "Unknown/Unhandled group type: #{role.group_type}"

--- a/app/models/roles_metadata_banned_competitors.rb
+++ b/app/models/roles_metadata_banned_competitors.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RolesMetadataBannedCompetitors < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -577,6 +577,17 @@ class User < ApplicationRecord
     delegate_roles.select { |role| role.metadata.status == RolesMetadataDelegateRegions.statuses[:senior_delegate] }
   end
 
+  private def groups_with_read_access
+    return "*" if can_edit_any_groups?
+    groups = groups_with_edit_access
+
+    if can_view_banned_competitors?
+      groups += UserGroup.banned_competitors.ids
+    end
+
+    groups
+  end
+
   private def groups_with_edit_access
     return "*" if can_edit_any_groups?
     groups = []
@@ -622,6 +633,9 @@ class User < ApplicationRecord
       },
       can_create_groups: {
         scope: groups_with_create_access,
+      },
+      can_read_groups: {
+        scope: groups_with_read_access,
       },
       can_edit_groups: {
         scope: groups_with_edit_access,
@@ -1308,6 +1322,18 @@ class User < ApplicationRecord
     admin? || staff?
   end
 
+  def can_access_wdc_panel?
+    admin? || wdc_team?
+  end
+
+  def can_access_wec_panel?
+    admin? || ethics_committee?
+  end
+
+  def can_access_weat_panel?
+    admin? || weat_team?
+  end
+
   def can_access_panel?
     (
       can_access_wfc_panel? ||
@@ -1317,7 +1343,10 @@ class User < ApplicationRecord
       can_access_leader_panel? ||
       can_access_senior_delegate_panel? ||
       can_access_delegate_panel? ||
-      can_access_staff_panel?
+      can_access_staff_panel? ||
+      can_access_wdc_panel? ||
+      can_access_wec_panel? ||
+      can_access_weat_panel?
     )
   end
 

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -14,6 +14,7 @@ class UserGroup < ApplicationRecord
     translators: "translators",
     board: "board",
     officers: "officers",
+    banned_competitors: "banned_competitors",
   }
 
   # There are few associations/methods here that are used only for testing. They are to make sure
@@ -146,6 +147,10 @@ class UserGroup < ApplicationRecord
 
   def self.teams_committees_group_wsot
     GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wsot').user_group
+  end
+
+  def self.banned_competitors_group
+    UserGroup.banned_competitors.first
   end
 
   def senior_delegate

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -141,8 +141,8 @@ class UserRole < ApplicationRecord
   def can_user_read?(user)
     # A user can view a role if:
     # 1. the role belongs to a non-hidden group, or
-    # 2. the user has edit-access to that group.
-    !group.is_hidden || user&.has_permission?(:can_edit_groups, group.id)
+    # 2. the user has read-access to that group.
+    !group.is_hidden || user&.has_permission?(:can_read_groups, group.id)
   end
 
   def self.filter_roles_for_logged_in_user(roles, current_user)

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -249,6 +249,15 @@
               <% if current_user.can_access_senior_delegate_panel? %>
                 <li><%= link_to "Senior Delegate panel", panel_senior_delegate_path %></li>
               <% end %>
+              <% if current_user.can_access_wdc_panel? %>
+                <li><%= link_to "WDC panel", panel_wdc_path %></li>
+              <% end %>
+              <% if current_user.can_access_wec_panel? %>
+                <li><%= link_to "WEC panel", panel_wec_path %></li>
+              <% end %>
+              <% if current_user.can_access_weat_panel? %>
+                <li><%= link_to "WEAT panel", panel_weat_path %></li>
+              <% end %>
             <% end %>
             <% if current_user.can_view_poll? %>
               <li class="divider"></li>

--- a/app/views/panel/wdc.html.erb
+++ b/app/views/panel/wdc.html.erb
@@ -1,0 +1,2 @@
+<% provide(:title, 'WDC Panel') %>
+<%= react_component("Panel/Wdc") %>

--- a/app/views/panel/weat.html.erb
+++ b/app/views/panel/weat.html.erb
@@ -1,0 +1,2 @@
+<% provide(:title, 'WEAT Panel') %>
+<%= react_component("Panel/Weat") %>

--- a/app/views/panel/wec.html.erb
+++ b/app/views/panel/wec.html.erb
@@ -1,0 +1,2 @@
+<% provide(:title, 'WEC Panel') %>
+<%= react_component("Panel/Wec") %>

--- a/app/webpacker/components/Panel/Board/index.jsx
+++ b/app/webpacker/components/Panel/Board/index.jsx
@@ -9,6 +9,7 @@ import OfficersEditor from './OfficersEditor';
 import RegionsAdmin from './RegionsAdmin';
 import LeadersAdminPage from './LeadersAdminPage';
 import BoardEditorPage from './BoardEditorPage';
+import BannedCompetitorsPage from '../pages/BannedCompetitorsPage';
 
 const sections = [
   {
@@ -50,6 +51,11 @@ const sections = [
     id: PANEL_LIST.board.regionsAdmin,
     name: 'Regions Admin',
     component: RegionsAdmin,
+  },
+  {
+    id: PANEL_LIST.board.bannedCompetitors,
+    name: 'Banned Competitors',
+    component: BannedCompetitorsPage,
   },
 ];
 

--- a/app/webpacker/components/Panel/Leader/index.jsx
+++ b/app/webpacker/components/Panel/Leader/index.jsx
@@ -3,6 +3,7 @@ import PanelTemplate from '../PanelTemplate';
 import LeaderForms from './LeaderForms';
 import GroupsManager from './GroupsManager';
 import { PANEL_LIST } from '../../../lib/wca-data.js.erb';
+import BannedCompetitorsPage from '../pages/BannedCompetitorsPage';
 
 const sections = [
   {
@@ -14,6 +15,11 @@ const sections = [
     id: PANEL_LIST.leader.groupsManager,
     name: 'Groups Manager',
     component: GroupsManager,
+  },
+  {
+    id: PANEL_LIST.leader.bannedCompetitors,
+    name: 'Banned Competitors',
+    component: BannedCompetitorsPage,
   },
 ];
 

--- a/app/webpacker/components/Panel/Wdc.jsx
+++ b/app/webpacker/components/Panel/Wdc.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PanelTemplate from './PanelTemplate';
+import { PANEL_LIST } from '../../lib/wca-data.js.erb';
+import BannedCompetitorsPage from './pages/BannedCompetitorsPage';
+
+const sections = [
+  {
+    id: PANEL_LIST.wdc.bannedCompetitors,
+    name: 'Banned Competitors',
+    component: BannedCompetitorsPage,
+  },
+];
+
+export default function Wdc() {
+  return (
+    <PanelTemplate heading="WDC Panel" sections={sections} />
+  );
+}

--- a/app/webpacker/components/Panel/Weat.jsx
+++ b/app/webpacker/components/Panel/Weat.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PanelTemplate from './PanelTemplate';
+import { PANEL_LIST } from '../../lib/wca-data.js.erb';
+import BannedCompetitorsPage from './pages/BannedCompetitorsPage';
+
+const sections = [
+  {
+    id: PANEL_LIST.weat.bannedCompetitors,
+    name: 'Banned Competitors',
+    component: BannedCompetitorsPage,
+  },
+];
+
+export default function Weat() {
+  return (
+    <PanelTemplate heading="WEAT Panel" sections={sections} />
+  );
+}

--- a/app/webpacker/components/Panel/Wec.jsx
+++ b/app/webpacker/components/Panel/Wec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PanelTemplate from './PanelTemplate';
+import { PANEL_LIST } from '../../lib/wca-data.js.erb';
+import BannedCompetitorsPage from './pages/BannedCompetitorsPage';
+
+const sections = [
+  {
+    id: PANEL_LIST.wec.bannedCompetitors,
+    name: 'Banned Competitors',
+    component: BannedCompetitorsPage,
+  },
+];
+
+export default function Wec() {
+  return (
+    <PanelTemplate heading="WEC Panel" sections={sections} />
+  );
+}

--- a/app/webpacker/components/Panel/Wrt/index.jsx
+++ b/app/webpacker/components/Panel/Wrt/index.jsx
@@ -5,6 +5,7 @@ import PostingCompetitionsTable from '../../PostingCompetitions';
 import EditPerson from './EditPerson';
 import RegionManager from '../Board/RegionManager';
 import GroupsManagerAdmin from '../pages/GroupsManagerAdmin';
+import BannedCompetitorsPage from '../pages/BannedCompetitorsPage';
 
 const sections = [
   {
@@ -26,6 +27,11 @@ const sections = [
     id: PANEL_LIST.board.groupsManagerAdmin,
     name: 'Groups Manager Admin',
     component: GroupsManagerAdmin,
+  },
+  {
+    id: PANEL_LIST.wrt.bannedCompetitors,
+    name: 'Banned Competitors',
+    component: BannedCompetitorsPage,
   },
 ];
 

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitorForm.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitorForm.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Form } from 'semantic-ui-react';
+import { apiV0Urls } from '../../../../lib/requests/routes.js.erb';
+import { groupTypes } from '../../../../lib/wca-data.js.erb';
+import WcaSearch from '../../../SearchWidget/WcaSearch';
+import SEARCH_MODELS from '../../../SearchWidget/SearchModel';
+import UtcDatePicker from '../../../wca/UtcDatePicker';
+import useSaveAction from '../../../../lib/hooks/useSaveAction';
+import Loading from '../../../Requests/Loading';
+
+export default function BanendCompetitorForm({
+  sync, banAction, banActionRole, closeForm,
+}) {
+  const [formValues, setFormValues] = useState({
+    user: null,
+    endDate: banActionRole?.end_date,
+  });
+  const { save, saving } = useSaveAction();
+
+  const handleFormChange = (_, { name, value }) => setFormValues({ ...formValues, [name]: value });
+
+  const createNewBannedCompetitor = () => {
+    save(apiV0Urls.userRoles.create(), {
+      userId: formValues?.user?.id,
+      groupType: groupTypes.banned_competitors,
+      endDate: formValues?.endDate,
+    }, () => {
+      sync();
+      closeForm();
+    }, { method: 'POST' });
+  };
+
+  const editBannedCompetitor = () => {
+    save(apiV0Urls.userRoles.update(banActionRole.id), {
+      endDate: formValues?.endDate,
+    }, () => {
+      sync();
+      closeForm();
+    }, { method: 'PATCH' });
+  };
+
+  const formSubmitHandler = banAction === 'new' ? createNewBannedCompetitor : editBannedCompetitor;
+
+  if (saving) return <Loading />;
+
+  return (
+    <Form onSubmit={formSubmitHandler}>
+      {banAction === 'new' && (
+        <Form.Field
+          label="New Banned competitor"
+          control={WcaSearch}
+          name="user"
+          value={formValues?.user}
+          onChange={handleFormChange}
+          model={SEARCH_MODELS.user}
+          multiple={false}
+        />
+      )}
+      <Form.Field
+        label="End Date"
+        name="endDate"
+        control={UtcDatePicker}
+        showYearDropdown
+        dateFormatOverride="YYYY-MM-dd"
+        dropdownMode="select"
+        isoDate={formValues?.endDate}
+        onChange={(date) => handleFormChange(null, {
+          name: 'endDate',
+          value: date,
+        })}
+      />
+      <Form.Button onClick={closeForm}>Cancel</Form.Button>
+      <Form.Button type="submit">Save</Form.Button>
+    </Form>
+  );
+}

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitors.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitors.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import {
+  Button, Header, Icon, Modal, Table,
+} from 'semantic-ui-react';
+import UserBadge from '../../../UserBadge';
+import BanendCompetitorForm from './BannedCompetitorForm';
+
+export default function BannedCompetitors({ bannedCompetitorRoles, sync }) {
+  const [banModalParams, setBanModalParams] = useState(null);
+
+  return (
+    <>
+      <Header>Banned Competitors</Header>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell width={5}>User</Table.HeaderCell>
+            <Table.HeaderCell width={2}>Start date</Table.HeaderCell>
+            <Table.HeaderCell width={2}>End date</Table.HeaderCell>
+            <Table.HeaderCell width={2}>Edit</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          {bannedCompetitorRoles.map((role) => (
+            <Table.Row key={role.id}>
+              <Table.Cell>
+                <UserBadge
+                  user={role.user}
+                  hideBorder
+                  leftAlign
+                />
+              </Table.Cell>
+              <Table.Cell>{role.start_date}</Table.Cell>
+              <Table.Cell>{role.end_date}</Table.Cell>
+              <Table.Cell>
+                <Icon
+                  name="edit"
+                  link
+                  onClick={() => setBanModalParams({ action: 'edit', role })}
+                />
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      <Button onClick={() => setBanModalParams({ action: 'new' })}>Ban new competitor</Button>
+      <Modal
+        open={!!banModalParams}
+        onClose={() => setBanModalParams(null)}
+      >
+        <Modal.Header>Add/Edit Banned Competitor</Modal.Header>
+        <Modal.Content>
+          <BanendCompetitorForm
+            sync={sync}
+            banAction={banModalParams?.action}
+            banActionRole={banModalParams?.role}
+            closeForm={() => setBanModalParams(null)}
+          />
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+}

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import useLoadedData from '../../../../lib/hooks/useLoadedData';
+import { apiV0Urls } from '../../../../lib/requests/routes.js.erb';
+import { groupTypes } from '../../../../lib/wca-data.js.erb';
+import Loading from '../../../Requests/Loading';
+import Errored from '../../../Requests/Errored';
+import BannedCompetitors from './BannedCompetitors';
+
+export default function BannedCompetitorsPage() {
+  const {
+    data: bannedCompetitorRoles, loading, error, sync,
+  } = useLoadedData(apiV0Urls.userRoles.listOfGroupType(groupTypes.banned_competitors));
+
+  if (loading) return <Loading />;
+  if (error) return <Errored />;
+
+  return <BannedCompetitors bannedCompetitorRoles={bannedCompetitorRoles} sync={sync} />;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,9 @@ Rails.application.routes.draw do
     get 'board' => 'panel#board', as: :panel_board
     get 'leader' => 'panel#leader', as: :panel_leader
     get 'senior_delegate' => 'panel#senior_delegate', as: :panel_senior_delegate
+    get 'wdc' => 'panel#wdc', as: :panel_wdc
+    get 'wec' => 'panel#wec', as: :panel_wec
+    get 'weat' => 'panel#weat', as: :panel_weat
   end
   resources :notifications, only: [:index]
 

--- a/db/migrate/20240518022919_create_roles_metadata_banned_competitors.rb
+++ b/db/migrate/20240518022919_create_roles_metadata_banned_competitors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateRolesMetadataBannedCompetitors < ActiveRecord::Migration[7.1]
+  def change
+    create_table :roles_metadata_banned_competitors do |t|
+      t.string :ban_reason
+      t.string :scope
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240518023151_migrate_banned_competitors.rb
+++ b/db/migrate/20240518023151_migrate_banned_competitors.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class MigrateBannedCompetitors < ActiveRecord::Migration[7.1]
+  def change
+    banned_team = Team.banned
+    group = UserGroup.create!(
+      name: banned_team.name,
+      group_type: UserGroup.group_types[:banned_competitors],
+      is_active: true,
+      is_hidden: true,
+    )
+    banned_team.team_members.each do |team_member|
+      metadata = RolesMetadataBannedCompetitors.create!
+      UserRole.create!(
+        user_id: team_member.user_id,
+        group_id: group.id,
+        start_date: team_member.start_date,
+        end_date: team_member.end_date,
+        metadata: metadata,
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -998,6 +998,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_170239) do
     t.index ["competition_id", "user_id"], name: "index_registrations_on_competition_id_and_user_id", unique: true
   end
 
+  create_table "roles_metadata_banned_competitors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "ban_reason"
+    t.string "scope"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "roles_metadata_councils", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "status"
     t.datetime "created_at", null: false

--- a/db/seeds/user_groups.seeds.rb
+++ b/db/seeds/user_groups.seeds.rb
@@ -278,4 +278,12 @@ after :groups_metadata_board, :groups_metadata_councils, :groups_metadata_teams_
     is_active: true,
     is_hidden: true,
   )
+
+  # Banned Competitors
+  UserGroup.create!(
+    name: 'Banned Competitors',
+    group_type: :banned_competitors,
+    is_active: true,
+    is_hidden: true,
+  )
 end

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -955,6 +955,7 @@ module DatabaseDumper
         ),
       ),
     }.freeze,
+    "roles_metadata_banned_competitors" => :skip_all_rows,
     "jwt_denylist" => :skip_all_rows,
     "wfc_xero_users" => :skip_all_rows,
     "wfc_dues_redirects" => :skip_all_rows,

--- a/spec/controllers/api/v0/user_roles_controller_spec.rb
+++ b/spec/controllers/api/v0/user_roles_controller_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe Api::V0::UserRolesController do
         dob_verification: "1990-01-2",
       )
     end
+    let!(:banned_competitor) { FactoryBot.create(:banned_competitor_role) }
 
-    context 'when user is logged in and changing role data' do
+    context 'when user is logged in as senior delegate' do
       before do
         allow(controller).to receive(:current_user) { user_senior_delegate_role.user }
       end
@@ -27,6 +28,28 @@ RSpec.describe Api::V0::UserRolesController do
         get :index_for_user, params: { user_id: user_whose_delegate_status_changes.id }
 
         expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)
+      end
+
+      it 'fetches list of banned competitos' do
+        get :index_for_group_type, params: { group_type: UserGroup.group_types[:banned_competitors] }
+
+        expect(response.body).to eq([banned_competitor].to_json)
+      end
+    end
+
+    context 'when user is logged in as a normal user' do
+      sign_in { FactoryBot.create(:user) }
+
+      it 'fetches list of roles of a user' do
+        get :index_for_user, params: { user_id: user_whose_delegate_status_changes.id }
+
+        expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)
+      end
+
+      it 'fetches list of banned competitos' do
+        get :index_for_group_type, params: { group_type: UserGroup.group_types[:banned_competitors] }
+
+        expect(response.body).to eq([].to_json)
       end
     end
   end

--- a/spec/controllers/api/v0/user_roles_controller_spec.rb
+++ b/spec/controllers/api/v0/user_roles_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::V0::UserRolesController do
         expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)
       end
 
-      it 'fetches list of banned competitos' do
+      it 'does not fetches list of banned competitos' do
         get :index_for_group_type, params: { group_type: UserGroup.group_types[:banned_competitors] }
 
         expect(response.body).to eq([banned_competitor].to_json)

--- a/spec/factories/user_roles.rb
+++ b/spec/factories/user_roles.rb
@@ -198,6 +198,10 @@ FactoryBot.define do
       group_id { UserGroup.board_group.id }
     end
 
+    trait :banned_competitor do
+      group_id { UserGroup.banned_competitors.first.id }
+    end
+
     factory :probation_role, traits: [:delegate_probation, :active]
     factory :translator_role, traits: [:translators, :active]
     factory :trainee_delegate_role, traits: [:delegate_regions, :delegate_regions_trainee_delegate, :active]
@@ -236,5 +240,6 @@ FactoryBot.define do
     factory :wrc_senior_member_role, traits: [:wrc_senior_member, :active]
     factory :wrc_leader_role, traits: [:wrc_leader, :active]
     factory :board_role, traits: [:board, :active]
+    factory :banned_competitor_role, traits: [:banned_competitor, :active]
   end
 end


### PR DESCRIPTION
This PR is migration of banned competitors to groups.

This PR is ready for review for existing changes, but there are couple of more changes which might depend on other upcoming PRs:
- Update banned competitors is not working now
- Currently banned competitors list is shown only in leader panel, it has to be shown in some other relevant panels as well
I'm working on the above couple of issues and will submit them soon.
- Add to role change mailers