### PR TITLE
Allow change multiple parameters in single user-role update request

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -143,11 +143,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     if group_type == UserGroup.group_types[:delegate_regions]
       if params.key?(:status)
         status = params.require(:status)
-        changes << {
+        changes << UserRole::UserRoleChange.new(
           changed_parameter: 'Status',
           previous_value: I18n.t("enums.user_roles.status.delegate_regions.#{role.metadata.status}", locale: 'en'),
           new_value: I18n.t("enums.user_roles.status.delegate_regions.#{status}", locale: 'en'),
-        }
+        )
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
@@ -161,11 +161,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
         end
       elsif params.key?(:groupId)
         group_id = params.require(:groupId)
-        changes << {
+        changes << UserRole::UserRoleChange.new(
           changed_parameter: 'Delegate Region',
           previous_value: UserGroup.find(role.group.id).name,
           new_value: UserGroup.find(group_id).name,
-        }
+        )
 
         return head :unauthorized unless current_user.has_permission?(:can_edit_groups, group_id)
 
@@ -181,11 +181,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
         end
       elsif params.key?(:location)
         location = params.require(:location)
-        changes << {
+        changes << UserRole::UserRoleChange.new(
           changed_parameter: 'Location',
           previous_value: role.metadata.location,
           new_value: location,
-        }
+        )
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
@@ -203,11 +203,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     elsif group_type == UserGroup.group_types[:delegate_probation]
       if params.key?(:endDate)
         end_date = params.require(:endDate)
-        changes << {
+        changes << UserRole::UserRoleChange.new(
           changed_parameter: 'End Date',
           previous_value: role.end_date || 'Empty',
           new_value: end_date,
-        }
+        )
 
         role.update!(end_date: Date.safe_parse(end_date))
       else
@@ -216,11 +216,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     elsif [UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]].include?(group_type)
       if params.key?(:status)
         status = params.require(:status)
-        changes << {
+        changes << UserRole::UserRoleChange.new(
           changed_parameter: 'Status',
           previous_value: I18n.t("enums.user_roles.status.#{group_type}.#{role.metadata.status}", locale: 'en'),
           new_value: I18n.t("enums.user_roles.status.#{group_type}.#{status}", locale: 'en'),
-        }
+        )
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
@@ -242,7 +242,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     else
       return render status: :unprocessable_entity, json: { error: "Invalid group type" }
     end
-    RoleChangeMailer.notify_role_change(role, current_user, changes).deliver_now # Change to deliver_later
+    RoleChangeMailer.notify_role_change(role, current_user, changes).deliver_later
     render json: { success: true }
   end
 

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -136,15 +136,18 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
     role = UserRole.find(id)
     group_type = role.group.group_type
+    changes = []
 
     return head :unauthorized unless current_user.has_permission?(:can_edit_groups, role.group.id)
 
     if group_type == UserGroup.group_types[:delegate_regions]
       if params.key?(:status)
         status = params.require(:status)
-        changed_parameter = 'Status'
-        previous_value = I18n.t("enums.user_roles.status.delegate_regions.#{role.metadata.status}", locale: 'en')
-        new_value = I18n.t("enums.user_roles.status.delegate_regions.#{status}", locale: 'en')
+        changes << {
+          changed_parameter: 'Status',
+          previous_value: I18n.t("enums.user_roles.status.delegate_regions.#{role.metadata.status}", locale: 'en'),
+          new_value: I18n.t("enums.user_roles.status.delegate_regions.#{status}", locale: 'en'),
+        }
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
@@ -158,9 +161,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
         end
       elsif params.key?(:groupId)
         group_id = params.require(:groupId)
-        changed_parameter = 'Delegate Region'
-        previous_value = UserGroup.find(role.group.id).name
-        new_value = UserGroup.find(group_id).name
+        changes << {
+          changed_parameter: 'Delegate Region',
+          previous_value: UserGroup.find(role.group.id).name,
+          new_value: UserGroup.find(group_id).name,
+        }
 
         return head :unauthorized unless current_user.has_permission?(:can_edit_groups, group_id)
 
@@ -176,9 +181,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
         end
       elsif params.key?(:location)
         location = params.require(:location)
-        changed_parameter = 'Location'
-        previous_value = role.metadata.location
-        new_value = location
+        changes << {
+          changed_parameter: 'Location',
+          previous_value: role.metadata.location,
+          new_value: location,
+        }
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
@@ -196,9 +203,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     elsif group_type == UserGroup.group_types[:delegate_probation]
       if params.key?(:endDate)
         end_date = params.require(:endDate)
-        changed_parameter = 'End Date'
-        previous_value = role.end_date || 'Empty'
-        new_value = end_date
+        changes << {
+          changed_parameter: 'End Date',
+          previous_value: role.end_date || 'Empty',
+          new_value: end_date,
+        }
 
         role.update!(end_date: Date.safe_parse(end_date))
       else
@@ -207,9 +216,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     elsif [UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]].include?(group_type)
       if params.key?(:status)
         status = params.require(:status)
-        changed_parameter = 'Status'
-        previous_value = I18n.t("enums.user_roles.status.#{group_type}.#{role.metadata.status}", locale: 'en')
-        new_value = I18n.t("enums.user_roles.status.#{group_type}.#{status}", locale: 'en')
+        changes << {
+          changed_parameter: 'Status',
+          previous_value: I18n.t("enums.user_roles.status.#{group_type}.#{role.metadata.status}", locale: 'en'),
+          new_value: I18n.t("enums.user_roles.status.#{group_type}.#{status}", locale: 'en'),
+        }
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
@@ -231,7 +242,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     else
       return render status: :unprocessable_entity, json: { error: "Invalid group type" }
     end
-    RoleChangeMailer.notify_role_change(role, current_user, changed_parameter, previous_value, new_value).deliver_later
+    RoleChangeMailer.notify_role_change(role, current_user, changes).deliver_now # Change to deliver_later
     render json: { success: true }
   end
 

--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -53,12 +53,10 @@ class RoleChangeMailer < ApplicationMailer
     )
   end
 
-  def notify_role_change(role, user_who_made_the_change, changed_parameter, previous_value, new_value)
+  def notify_role_change(role, user_who_made_the_change, changes)
     @role = role
     @user_who_made_the_change = user_who_made_the_change
-    @changed_parameter = changed_parameter
-    @previous_value = previous_value
-    @new_value = new_value
+    @changes = changes
     @group_type_name = UserGroup.group_type_name[role.group_type.to_sym]
     @today_date = Date.today
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -12,6 +12,13 @@ class UserRole < ApplicationRecord
 
   scope :active, -> { where(end_date: nil).or(where.not(end_date: ..Date.today)) }
 
+  UserRoleChange = Struct.new(
+    :changed_parameter,
+    :previous_value,
+    :new_value,
+    keyword_init: true,
+  )
+
   STATUS_RANK = {
     UserGroup.group_types[:delegate_regions].to_sym => [
       RolesMetadataDelegateRegions.statuses[:trainee_delegate],

--- a/app/views/role_change_mailer/notify_role_change.erb
+++ b/app/views/role_change_mailer/notify_role_change.erb
@@ -1,4 +1,6 @@
 <p>The role has been changed for <%= @role.user.name %> in <%= @group_type_name %> on <%= @today_date %>.</p>
 <p>The change has been executed by <%= @user_who_made_the_change.name %>.</p>
 <p>Change made:</p>
-<p><%= @changed_parameter %>: <%= @previous_value %> -> <%= @new_value %></p>
+<% @changes.each do |change| %>
+  <p><%= change[:changed_parameter] %>: <%= change[:previous_value] %> -> <%= change[:new_value] %></p>
+<% end %>

--- a/spec/mailers/role_change_mailer_spec.rb
+++ b/spec/mailers/role_change_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RoleChangeMailer, type: :mailer do
     let(:senior_delegate) { FactoryBot.create(:senior_delegate_role) }
     let(:delegate) { FactoryBot.create(:delegate_role, group: senior_delegate.group) }
     let(:role) { FactoryBot.create(:probation_role, user: delegate.user) }
-    let(:mail) { described_class.notify_role_change(role, user_who_made_the_change, 'End Date', 'Empty', '01-01-2024') }
+    let(:mail) { described_class.notify_role_change(role, user_who_made_the_change, [{ changed_parameter: 'End Date', previous_value: 'Empty', new_value: '01-01-2024' }]) }
 
     it 'renders the headers' do
       expect(mail.to).to match_array [user_who_made_the_change.email, GroupsMetadataBoard.email, senior_delegate.user.email].flatten

--- a/spec/mailers/role_change_mailer_spec.rb
+++ b/spec/mailers/role_change_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RoleChangeMailer, type: :mailer do
     let(:senior_delegate) { FactoryBot.create(:senior_delegate_role) }
     let(:delegate) { FactoryBot.create(:delegate_role, group: senior_delegate.group) }
     let(:role) { FactoryBot.create(:probation_role, user: delegate.user) }
-    let(:mail) { described_class.notify_role_change(role, user_who_made_the_change, [{ changed_parameter: 'End Date', previous_value: 'Empty', new_value: '01-01-2024' }]) }
+    let(:mail) { described_class.notify_role_change(role, user_who_made_the_change, [UserRole::UserRoleChange.new(changed_parameter: 'End Date', previous_value: 'Empty', new_value: '01-01-2024')]) }
 
     it 'renders the headers' do
       expect(mail.to).to match_array [user_who_made_the_change.email, GroupsMetadataBoard.email, senior_delegate.user.email].flatten


### PR DESCRIPTION
Currently using user_roles_controller#update, we can update only one parameter. This PR is to allow editing more than one parameters. This will be helpful in banned competitors because more parameters will be updated there.