### PR TITLE
Remove activities from schedule when events/rounds removed

### DIFF
--- a/app/views/competitions/edit_events.html.erb
+++ b/app/views/competitions/edit_events.html.erb
@@ -11,7 +11,8 @@
     canAddAndRemoveEvents: current_user.can_add_and_remove_events?(@competition),
     canUpdateEvents: current_user.can_update_events?(@competition),
     canUpdateQualifications: current_user.can_update_qualifications?(@competition),
-    wcifEvents: @competition.events_wcif
+    wcifEvents: @competition.events_wcif,
+    wcifSchedule: @competition.schedule_wcif,
   }, {
     id: "events-edit-area",
   }) %>

--- a/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -38,7 +38,7 @@ export default function EventPanel({
         content: `Are you sure you want to remove all ${pluralize(
           wcifEvent.rounds.length,
           'round',
-        )} of ${event.name}?`,
+        )} of ${event.name}? This will also remove these rounds from the schedule.`,
       })
         .then(() => {
           dispatch(removeEvent(wcifEvent.id));
@@ -57,7 +57,7 @@ export default function EventPanel({
         content: `Are you sure you want to remove ${pluralize(
           roundsToRemoveCount,
           'round',
-        )} of ${event.name}?`,
+        )} of ${event.name}? This will also remove these rounds from the schedule.`,
       }).then(() => {
         // We have too many rounds
         dispatch(removeRounds(wcifEvent.id, roundsToRemoveCount));

--- a/app/webpacker/components/EditEvents/EventPanel/index.js
+++ b/app/webpacker/components/EditEvents/EventPanel/index.js
@@ -34,11 +34,16 @@ export default function EventPanel({
 
   const handleRemoveEvent = () => {
     if (wcifEvent.rounds && wcifEvent.rounds.length > 0) {
+      const pluralizedRound = pluralize(
+        wcifEvent.rounds.length,
+        'round',
+      );
       confirm({
-        content: `Are you sure you want to remove all ${pluralize(
-          wcifEvent.rounds.length,
-          'round',
-        )} of ${event.name}? This will also remove these rounds from the schedule.`,
+        content: `Are you sure you want to remove all ${
+          pluralizedRound
+        } of ${event.name}? This will also remove the ${
+          pluralizedRound
+        } from the schedule.`,
       })
         .then(() => {
           dispatch(removeEvent(wcifEvent.id));
@@ -53,11 +58,16 @@ export default function EventPanel({
 
     if (roundsToRemoveCount > 0) {
       // remove the rounds
+      const pluralizedRound = pluralize(
+        roundsToRemoveCount,
+        'round',
+      );
       confirm({
-        content: `Are you sure you want to remove ${pluralize(
-          roundsToRemoveCount,
-          'round',
-        )} of ${event.name}? This will also remove these rounds from the schedule.`,
+        content: `Are you sure you want to remove ${
+          pluralizedRound
+        } of ${event.name}? This will also remove the ${
+          pluralizedRound
+        } from the schedule.`,
       }).then(() => {
         // We have too many rounds
         dispatch(removeRounds(wcifEvent.id, roundsToRemoveCount));

--- a/app/webpacker/components/EditEvents/index.js
+++ b/app/webpacker/components/EditEvents/index.js
@@ -17,13 +17,13 @@ import ConfirmProvider from '../../lib/providers/ConfirmProvider';
 
 function EditEvents() {
   const {
-    competitionId, wcifEvents, initialWcifEvents,
+    competitionId, wcifEvents, initialWcifEvents, wcifSchedule, initialWcifSchedule,
   } = useStore();
   const dispatch = useDispatch();
 
   const unsavedChanges = useMemo(() => (
-    !_.isEqual(wcifEvents, initialWcifEvents)
-  ), [wcifEvents, initialWcifEvents]);
+    !_.isEqual(wcifEvents, initialWcifEvents) || !_.isEqual(wcifSchedule, initialWcifSchedule)
+  ), [wcifEvents, initialWcifEvents, wcifSchedule, initialWcifSchedule]);
 
   const onUnload = useCallback((e) => {
     // Prompt the user before letting them navigate away from this page with unsaved changes.
@@ -49,10 +49,10 @@ function EditEvents() {
   const save = useCallback(() => {
     saveWcif(
       competitionId,
-      { events: wcifEvents },
+      { events: wcifEvents, schedule: wcifSchedule },
       () => dispatch(changesSaved()),
     );
-  }, [competitionId, dispatch, saveWcif, wcifEvents]);
+  }, [competitionId, dispatch, saveWcif, wcifEvents, wcifSchedule]);
 
   const renderUnsavedChangesAlert = () => (
     <Message color="blue">
@@ -110,6 +110,7 @@ export default function Wrapper({
   canUpdateEvents,
   canUpdateQualifications,
   wcifEvents,
+  wcifSchedule,
 }) {
   const normalizedEvents = normalizeWcifEvents(wcifEvents);
 
@@ -123,6 +124,8 @@ export default function Wrapper({
         canUpdateQualifications,
         wcifEvents: normalizedEvents,
         initialWcifEvents: normalizedEvents,
+        wcifSchedule: wcifSchedule,
+        initialWcifSchedule: wcifSchedule,
         unsavedChanges: false,
       }}
     >

--- a/app/webpacker/components/EditEvents/index.js
+++ b/app/webpacker/components/EditEvents/index.js
@@ -124,7 +124,7 @@ export default function Wrapper({
         canUpdateQualifications,
         wcifEvents: normalizedEvents,
         initialWcifEvents: normalizedEvents,
-        wcifSchedule: wcifSchedule,
+        wcifSchedule,
         initialWcifSchedule: wcifSchedule,
         unsavedChanges: false,
       }}

--- a/app/webpacker/components/EditEvents/store/reducer.js
+++ b/app/webpacker/components/EditEvents/store/reducer.js
@@ -120,8 +120,8 @@ const reducers = {
           rooms: v.rooms.map((r) => ({
             ...r,
             activities: r.activities.filter(
-              (a) => getActivityEventId(a) !== eventId ||
-                !roundIdsToRemove.includes(getActivityRoundId(a)),
+              (a) => getActivityEventId(a) !== eventId
+                || !roundIdsToRemove.includes(getActivityRoundId(a)),
             ),
           })),
         })),

--- a/app/webpacker/components/EditEvents/store/reducer.js
+++ b/app/webpacker/components/EditEvents/store/reducer.js
@@ -1,3 +1,4 @@
+import { getActivityEventId, getActivityRoundId } from '../../../lib/utils/activities';
 import { generateWcifRound, removeSharedTimeLimits } from '../utils';
 import {
   AddEvent,
@@ -54,6 +55,16 @@ const reducers = {
         id: e.id,
         rounds: null,
       }) : removeSharedTimeLimits(e, roundIdsToRemove))),
+      wcifSchedule: {
+        ...state.wcifSchedule,
+        venues: state.wcifSchedule.venues.map((v) => ({
+          ...v,
+          rooms: v.rooms.map((r) => ({
+            ...r,
+            activities: r.activities.filter((a) => getActivityEventId(a) !== eventId),
+          })),
+        })),
+      },
     };
   },
 
@@ -101,6 +112,19 @@ const reducers = {
       wcifEvents: state.wcifEvents.map((e) => (
         e.id === eventId ? newEvent : removeSharedTimeLimits(e, roundIdsToRemove)
       )),
+      wcifSchedule: {
+        ...state.wcifSchedule,
+        venues: state.wcifSchedule.venues.map((v) => ({
+          ...v,
+          rooms: v.rooms.map((r) => ({
+            ...r,
+            activities: r.activities.filter(
+              (a) => getActivityEventId(a) !== eventId ||
+                !roundIdsToRemove.includes(getActivityRoundId(a)),
+            ),
+          })),
+        })),
+      },
     };
   },
 

--- a/app/webpacker/components/EditEvents/store/reducer.js
+++ b/app/webpacker/components/EditEvents/store/reducer.js
@@ -34,6 +34,7 @@ const reducers = {
   [ChangesSaved]: (state) => ({
     ...state,
     initialWcifEvents: state.wcifEvents,
+    initialWcifSchedule: state.wcifSchedule,
   }),
 
   [AddEvent]: (state, { payload }) => ({


### PR DESCRIPTION
This won't help the existing competitions which have 'invalid' activities. I looked into that a bit but I'm not sure how/if that's causing the schedule view to crash, and I won't have time to look into in the near future. And if that's indeed causing the crash then we should fix the UI because other tools might remove events without removing them from the schedule (or alternatively, add more validation to the WCIF when saving it? I don't know much about that though).