### PR TITLE
Remove occurrences of WRT email

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -106,11 +106,12 @@ class Person < ApplicationRecord
   # Note this is very similar to the cannot_register_for_competition_reasons method in user.rb.
   def cannot_be_assigned_to_user_reasons
     dob_form_path = Rails.application.routes.url_helpers.contact_dob_path
+    wrt_contact_path = Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt')
     [].tap do |reasons|
-      reasons << I18n.t('users.errors.wca_id_no_name_html').html_safe if name.blank?
-      reasons << I18n.t('users.errors.wca_id_no_gender_html').html_safe if gender.blank?
+      reasons << I18n.t('users.errors.wca_id_no_name_html', wrt_contact_path: wrt_contact_path).html_safe if name.blank?
+      reasons << I18n.t('users.errors.wca_id_no_gender_html', wrt_contact_path: wrt_contact_path).html_safe if gender.blank?
       reasons << I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path).html_safe if dob.blank?
-      reasons << I18n.t('users.errors.wca_id_no_citizenship_html').html_safe if country_iso2.blank?
+      reasons << I18n.t('users.errors.wca_id_no_citizenship_html', wrt_contact_path: wrt_contact_path).html_safe if country_iso2.blank?
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,11 +221,12 @@ class User < ApplicationRecord
       dob_verification_date = Date.safe_parse(dob_verification, nil)
       if unconfirmed_person && (!current_user || !current_user.can_view_all_users?)
         dob_form_path = Rails.application.routes.url_helpers.contact_dob_path
+        wrt_contact_path = Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt')
         remaining_wca_id_claims = [0, MAX_INCORRECT_WCA_ID_CLAIM_COUNT - unconfirmed_person.incorrect_wca_id_claim_count].max
         if remaining_wca_id_claims == 0 || !unconfirmed_person.dob
           errors.add(:dob_verification, I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path).html_safe)
         elsif unconfirmed_person.gender.blank?
-          errors.add(:gender, I18n.t('users.errors.wca_id_no_gender_html').html_safe)
+          errors.add(:gender, I18n.t('users.errors.wca_id_no_gender_html', wrt_contact_path: wrt_contact_path).html_safe)
         elsif !already_assigned_to_user && unconfirmed_person.dob != dob_verification_date
           # Note that we don't verify DOB for WCA IDs that have already been
           # claimed. This protects people from DOB guessing attacks.
@@ -876,6 +877,7 @@ class User < ApplicationRecord
     if cannot_edit_reason
       I18n.t('users.edit.cannot_edit.msg',
              reason: cannot_edit_reason,
+             wrt_contact_path: Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt'),
              delegate_url: Rails.application.routes.url_helpers.delegates_path).html_safe
     end
   end

--- a/app/views/database/_public_results_readme.md.erb
+++ b/app/views/database/_public_results_readme.md.erb
@@ -4,8 +4,8 @@
 
 - Date: <%= long_date.strftime('%B %e, %Y') %>
 - Export Format Version: <%= export_version %>
-- Contact: WCA Results Team (results@worldcubeassociation.org)
-- Website: https://www.worldcubeassociation.org/results
+- Contact: WCA Results Team (https://www.worldcubeassociation.org/contact?contactRecipient=wrt)
+- Website: https://www.worldcubeassociation.org/export/results
 
 ## Description
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -976,7 +976,7 @@ en:
       account_is_special: "The WCA ID and account are connected to special roles in the WCA (e.g. delegates, organizers, team members) and cannot be removed. Please email the WCA Results Team to help change the WCA ID to a different account."
       #context: used in the error message when a user can't edit some part of their profile
       cannot_edit:
-        msg: "You cannot change your name, birthdate, gender, or region. Reason: %{reason}. Contact the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> or your <a href='%{delegate_url}'>Delegate</a> if you need to change any of these."
+        msg: "You cannot change your name, birthdate, gender, or region. Reason: %{reason}. Contact the <a href='%{wrt_contact_path}' target='_blank'>WCA Results Team</a> or your <a href='%{delegate_url}'>Delegate</a> if you need to change any of these."
         reason:
           assigned: "you have a WCA ID assigned"
           registered: "you have registered for a competition"
@@ -1023,9 +1023,9 @@ en:
       must_have_a_change: "The name or the region must be different to update the person."
       already_have_id: "cannot claim a WCA ID because you already have WCA ID %{wca_id}"
       wca_id_no_birthdate_html: "We do not have a birthdate recorded for this WCA ID. Please contact the WCA Results Team using <a href=\"%{dob_form_path}\">this dedicated form</a>."
-      wca_id_no_gender_html: "We do not have a gender recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
-      wca_id_no_citizenship_html: "We do not have a citizenship recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
-      wca_id_no_name_html: "We do not have a name recorded for this WCA ID. Please email the <a href='mailto:results@worldcubeassociation.org' target='_blank'>WCA Results Team</a> to resolve this."
+      wca_id_no_gender_html: "We do not have a gender recorded for this WCA ID. Please contact the <a href='%{wrt_contact_path}' target='_blank'>WCA Results Team</a> to resolve this."
+      wca_id_no_citizenship_html: "We do not have a citizenship recorded for this WCA ID. Please contact the <a href='%{wrt_contact_path}' target='_blank'>WCA Results Team</a> to resolve this."
+      wca_id_no_name_html: "We do not have a name recorded for this WCA ID. Please contact the <a href='%{wrt_contact_path}' target='_blank'>WCA Results Team</a> to resolve this."
       avatar_requires_wca_id: "requires a WCA ID to be assigned"
       email_used_by_locked_account_html: "is already used by another account. It's been created automatically as a result of you registering for a competition via an external service. If you are the owner of this email, you can use the account after resetting your password <a href='/users/password/new'>here</a>."
       must_match_person: "must match person details corresponding to the WCA ID"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   let(:dob_form_path) { Rails.application.routes.url_helpers.contact_dob_path }
+  let(:wrt_contact_path) { Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt') }
 
   it "defines a valid user" do
     user = FactoryBot.create :user
@@ -120,7 +121,7 @@ RSpec.describe User, type: :model do
 
     it "does not allow assigning a genderless WCA ID to a user" do
       user.wca_id = genderless_person.wca_id
-      expect(user).to be_invalid_with_errors(wca_id: [I18n.t('users.errors.wca_id_no_gender_html')])
+      expect(user).to be_invalid_with_errors(wca_id: [I18n.t('users.errors.wca_id_no_gender_html', wrt_contact_path: wrt_contact_path)])
     end
 
     it "nullifies empty WCA IDs" do
@@ -380,7 +381,7 @@ RSpec.describe User, type: :model do
     it "does not allow claiming wca id Person without gender" do
       user.unconfirmed_wca_id = person_without_gender.wca_id
       user.dob_verification = "1234-04-03"
-      expect(user).to be_invalid_with_errors(gender: [I18n.t('users.errors.wca_id_no_gender_html')])
+      expect(user).to be_invalid_with_errors(gender: [I18n.t('users.errors.wca_id_no_gender_html', wrt_contact_path: wrt_contact_path)])
     end
 
     it "does not show a message about incorrect dob for people who have already claimed their wca id" do


### PR DESCRIPTION
There are some more occurrences where WRT's email is publicly given. These has been now replaced with WRT contact URL.