### PR TITLE
Clarify nullability in MicroserviceRegistrations shadow table

### DIFF
--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -27,7 +27,11 @@ module MicroserviceRegistrationHolder
           # we hydrate each model with the microservice information directly from above
           ar_models.each do |ar_model|
             matching_ms_model = ms_models.find { |ms_model| ms_model['competition_id'] == ar_model.competition_id && ms_model['user_id'] == ar_model.user_id }
-            raise "No matching Microservice registration found. This should not happen!" if !matching_ms_model.present? && ar_model.is_competing?
+
+            if !matching_ms_model.present? && ar_model.is_competing?
+              raise "No matching Microservice registration found: Row ID #{ar_model.id}, competition '#{ar_model.competition_id}', user '#{ar_model.user_id}'. " \
+                    "This means the microservice suddenly 'forgot' about an entry that it told us about before, and it should not happen!"
+            end
 
             ar_model.load_ms_model(matching_ms_model) if matching_ms_model.present?
           end

--- a/db/migrate/20240520170239_set_microservice_reg_table_not_null.rb
+++ b/db/migrate/20240520170239_set_microservice_reg_table_not_null.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SetMicroserviceRegTableNotNull < ActiveRecord::Migration[7.1]
+  def change
+    # First make sure we don't have any erroneous data temporarily present
+    MicroserviceRegistration.where(competition_id: nil).delete_all
+    MicroserviceRegistration.where(user_id: nil).delete_all
+
+    # The 'limit' option on the competition_id column is implied by the primary key in 'Competitions' table
+    #   (which is historically set at VARCHAR(32))
+    change_column :microservice_registrations, :competition_id, :string, limit: 32, null: false
+    change_column :microservice_registrations, :user_id, :integer, null: false
+
+    add_foreign_key :microservice_registrations, :Competitions, column: :competition_id, index: true
+    add_foreign_key :microservice_registrations, :users, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_05_004834) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_20_170239) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -792,13 +792,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_05_004834) do
   end
 
   create_table "microservice_registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "competition_id"
-    t.integer "user_id"
+    t.string "competition_id", limit: 32, null: false
+    t.integer "user_id", null: false
     t.text "roles"
     t.boolean "is_competing", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["competition_id", "user_id"], name: "index_microservice_registrations_on_competition_id_and_user_id", unique: true
+    t.index ["user_id"], name: "fk_rails_dc6d05bc5e"
   end
 
   create_table "oauth_access_grants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1293,6 +1294,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_05_004834) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "microservice_registrations", "Competitions", column: "competition_id"
+  add_foreign_key "microservice_registrations", "users"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "payment_intents", "users", column: "initiated_by_id"
   add_foreign_key "paypal_records", "paypal_records", column: "parent_record_id"


### PR DESCRIPTION
(I don't have the slightest clue why Rails refuses to generate an index for `competition_id` even though `index: true` is set. I guess it has something to do with `VARCHAR(32)` vs `INT`, because for the latter's `user_id` it does create the index hassle-free. Just let it be and don't worry about it too much)