### PR TITLE
Consistently name activites in English in the EditSchedule component

### DIFF
--- a/app/webpacker/components/EditSchedule/EditActivities/ActivityPicker.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/ActivityPicker.js
@@ -8,8 +8,9 @@ import {
 import cn from 'classnames';
 import _ from 'lodash';
 import {
+  humanizeActivityCode,
   parseActivityCode,
-  roundIdToString,
+  roundIdToString, shortLabelForActivityCode,
 } from '../../../lib/utils/wcif';
 import { formats } from '../../../lib/wca-data.js.erb';
 
@@ -64,7 +65,6 @@ function PickerRow({
         key={n}
         wcifRoom={wcifRoom}
         activityCode={`${wcifRound.id}-a${n + 1}`}
-        attemptNumber={n + 1}
       />
     ));
   }
@@ -80,36 +80,24 @@ function PickerRow({
 function ActivityLabel({
   wcifRoom,
   activityCode,
-  attemptNumber,
 }) {
   const usedActivityCodes = useMemo(
     () => wcifRoom.activities.map((activity) => activity.activityCode),
     [wcifRoom.activities],
   );
 
-  const { roundNumber } = parseActivityCode(activityCode);
-
-  let tooltipText = roundIdToString(activityCode);
-  let text = `R${roundNumber}`;
-
-  if (attemptNumber) {
-    tooltipText += `, Attempt ${attemptNumber}`;
-    text += `A${attemptNumber}`;
-  }
-
   const isEnabled = !usedActivityCodes.includes(activityCode);
 
   return (
     <Popup
-      content={tooltipText}
+      content={humanizeActivityCode(activityCode)}
       trigger={(
         <Label
           className={isEnabled ? 'fc-draggable' : ''}
           color={isEnabled ? 'blue' : 'grey'}
-          wcif-title={tooltipText}
           wcif-ac={activityCode}
         >
-          {text}
+          {shortLabelForActivityCode(activityCode)}
         </Label>
       )}
     />

--- a/app/webpacker/components/EditSchedule/EditActivities/ActivityPicker.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/ActivityPicker.js
@@ -7,12 +7,9 @@ import {
 } from 'semantic-ui-react';
 import cn from 'classnames';
 import _ from 'lodash';
-import {
-  humanizeActivityCode,
-  parseActivityCode,
-  roundIdToString, shortLabelForActivityCode,
-} from '../../../lib/utils/wcif';
+import { shortLabelForActivityCode } from '../../../lib/utils/wcif';
 import { formats } from '../../../lib/wca-data.js.erb';
+import { activityToFcTitle, buildPartialActivityFromCode } from '../../../lib/utils/edit-schedule';
 
 function ActivityPicker({
   wcifEvents,
@@ -88,9 +85,11 @@ function ActivityLabel({
 
   const isEnabled = !usedActivityCodes.includes(activityCode);
 
+  const partialActivity = buildPartialActivityFromCode(activityCode);
+
   return (
     <Popup
-      content={humanizeActivityCode(activityCode)}
+      content={activityToFcTitle(partialActivity)}
       trigger={(
         <Label
           className={isEnabled ? 'fc-draggable' : ''}

--- a/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -46,7 +46,7 @@ import { friendlyTimezoneName } from '../../../lib/wca-data.js.erb';
 import {
   activityToFcTitle,
   buildPartialActivityFromCode,
-  defaultDurationFromActivityCode,
+  defaultDurationFromActivityCode, FC_ACTIVITY_ATTACHMENT,
   fcEventToActivityAndDates,
   luxonToWcifIso,
 } from '../../../lib/utils/edit-schedule';
@@ -114,7 +114,7 @@ function EditActivities({
         start: activity.startTime,
         end: activity.endTime,
         extendedProps: {
-          activity,
+          [FC_ACTIVITY_ATTACHMENT]: activity,
           matchCount,
         },
       };
@@ -139,7 +139,7 @@ function EditActivities({
           title: activityToFcTitle(partialActivity),
           duration: `00:${defaultDuration.toString().padStart(2, '0')}:00`,
           extendedProps: {
-            activity: partialActivity,
+            [FC_ACTIVITY_ATTACHMENT]: partialActivity,
           },
         };
       },
@@ -150,6 +150,9 @@ function EditActivities({
 
   const removeIfOverDropzone = ({ event: fcEvent, jsEvent }) => {
     if (!dropToDeleteRef.current) return;
+
+    // Don't bother trying to delete an activity that hasn't even been added yet
+    if (!fcEvent.extendedProps[FC_ACTIVITY_ATTACHMENT]?.id) return;
 
     const elem = dropToDeleteRef.current;
     const rect = elem.getBoundingClientRect();
@@ -166,7 +169,7 @@ function EditActivities({
         && jsEvent.pageY <= bottom
     ) {
       const {
-        activity: {
+        [FC_ACTIVITY_ATTACHMENT]: {
           id: activityId,
           name: activityName,
         },
@@ -174,6 +177,7 @@ function EditActivities({
       } = fcEvent.extendedProps;
 
       const matchText = `all ${matchCount + 1} copies of `;
+
       confirm({
         content: `Are you sure you want to delete ${shouldUpdateMatches && matchCount > 1 ? matchText : ''}the event ${activityName}? THIS ACTION CANNOT BE UNDONE!`,
       }).then(() => {
@@ -193,7 +197,7 @@ function EditActivities({
     delta,
     view: { calendar },
   }) => {
-    const { activity: { id: activityId } } = fcEvent.extendedProps;
+    const { [FC_ACTIVITY_ATTACHMENT]: { id: activityId } } = fcEvent.extendedProps;
 
     const duration = toLuxonDuration(delta, calendar);
     const deltaIso = duration.toISO();
@@ -207,7 +211,7 @@ function EditActivities({
     endDelta,
     view: { calendar },
   }) => {
-    const { activity: { id: activityId } } = fcEvent.extendedProps;
+    const { [FC_ACTIVITY_ATTACHMENT]: { id: activityId } } = fcEvent.extendedProps;
 
     const startScaleDuration = toLuxonDuration(startDelta, calendar);
     const startScaleIso = startScaleDuration.toISO();

--- a/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -44,6 +44,7 @@ import {
 
 import { friendlyTimezoneName } from '../../../lib/wca-data.js.erb';
 import {
+  activityToFcTitle,
   buildPartialActivityFromCode,
   defaultDurationFromActivityCode,
   fcEventToActivityAndDates,
@@ -106,8 +107,10 @@ function EditActivities({
       const matchCount = getMatchingActivities(wcifSchedule, activity).length - 1;
       const matchesText = ` (${matchCount} matching activit${matchCount === 1 ? 'y' : 'ies'})`;
 
+      const fcTitle = activityToFcTitle(activity) + (shouldUpdateMatches && matchCount > 0 ? matchesText : '');
+
       return {
-        title: activity.name + (shouldUpdateMatches && matchCount > 0 ? matchesText : ''),
+        title: fcTitle,
         start: activity.startTime,
         end: activity.endTime,
         extendedProps: {
@@ -133,7 +136,7 @@ function EditActivities({
         const defaultDuration = defaultDurationFromActivityCode(activityCode);
 
         return {
-          title: partialActivity.name,
+          title: activityToFcTitle(partialActivity),
           duration: `00:${defaultDuration.toString().padStart(2, '0')}:00`,
           extendedProps: {
             activity: partialActivity,

--- a/app/webpacker/lib/i18n.js
+++ b/app/webpacker/lib/i18n.js
@@ -5,7 +5,7 @@ import { registerLocale, setDefaultLocale } from 'react-datepicker';
 
 const i18nFileContext = require.context('rails_translations');
 
-const DEFAULT_LOCALE = 'en';
+export const DEFAULT_LOCALE = 'en';
 
 /**
  * Use when I18n.t should return an array.
@@ -65,6 +65,17 @@ window.I18n.tArray = tArray;
  * }}
  */
 export default window.I18n;
+
+export function withLocale(overrideLocale, fn) {
+  const actualLocale = window.I18n.locale;
+
+  try {
+    window.I18n.locale = overrideLocale;
+    return fn();
+  } finally {
+    window.I18n.locale = actualLocale;
+  }
+}
 
 function loadTranslations(i18n, locale) {
   const translations = i18nFileContext(`./${locale}.json`);

--- a/app/webpacker/lib/utils/edit-schedule.js
+++ b/app/webpacker/lib/utils/edit-schedule.js
@@ -150,6 +150,8 @@ export const buildPartialActivityFromCode = (
   };
 };
 
+export const FC_ACTIVITY_ATTACHMENT = 'activityAttachment';
+
 export function fcEventToActivityAndDates(fcEvent, calendar) {
   const eventStartLuxon = toLuxonDateTime(fcEvent.start, calendar);
   const eventEndLuxon = toLuxonDateTime(fcEvent.end, calendar);
@@ -157,7 +159,7 @@ export function fcEventToActivityAndDates(fcEvent, calendar) {
   const utcStartIso = luxonToWcifIso(eventStartLuxon);
   const utcEndIso = luxonToWcifIso(eventEndLuxon);
 
-  const { activity: attachedActivity } = fcEvent.extendedProps;
+  const { [FC_ACTIVITY_ATTACHMENT]: attachedActivity } = fcEvent.extendedProps;
   const partialActivity = buildPartialActivityFromCode(attachedActivity.activityCode);
 
   const activity = {

--- a/app/webpacker/lib/utils/edit-schedule.js
+++ b/app/webpacker/lib/utils/edit-schedule.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import { toLuxonDateTime } from '@fullcalendar/luxon3';
 import { humanizeActivityCode, parseActivityCode } from './wcif';
+import { DEFAULT_LOCALE, withLocale } from '../i18n';
 
 export function toMicrodegrees(coord) {
   const result = Math.trunc(parseFloat(coord) * 1e6);
@@ -139,7 +140,7 @@ export const buildPartialActivityFromCode = (
   childActivities = [],
   extensions = [],
 ) => {
-  const humanizedCode = humanizeActivityCode(activityCode);
+  const humanizedCode = withLocale(DEFAULT_LOCALE, () => humanizeActivityCode(activityCode));
 
   return {
     name: humanizedCode,
@@ -172,3 +173,5 @@ export function fcEventToActivityAndDates(fcEvent, calendar) {
     endLuxon: eventEndLuxon,
   };
 }
+
+export const activityToFcTitle = (activity) => activity.name;

--- a/app/webpacker/lib/utils/edit-schedule.js
+++ b/app/webpacker/lib/utils/edit-schedule.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import { toLuxonDateTime } from '@fullcalendar/luxon3';
-import { parseActivityCode } from './wcif';
+import { humanizeActivityCode, parseActivityCode } from './wcif';
 
 export function toMicrodegrees(coord) {
   const result = Math.trunc(parseFloat(coord) * 1e6);
@@ -134,6 +134,21 @@ export function changeTimezoneKeepingLocalTime(isoDateTime, oldTimezone, newTime
   return luxonToWcifIso(newZoneSameLocalTime);
 }
 
+export const buildPartialActivityFromCode = (
+  activityCode,
+  childActivities = [],
+  extensions = [],
+) => {
+  const humanizedCode = humanizeActivityCode(activityCode);
+
+  return {
+    name: humanizedCode,
+    activityCode,
+    childActivities,
+    extensions,
+  };
+};
+
 export function fcEventToActivityAndDates(fcEvent, calendar) {
   const eventStartLuxon = toLuxonDateTime(fcEvent.start, calendar);
   const eventEndLuxon = toLuxonDateTime(fcEvent.end, calendar);
@@ -141,20 +156,14 @@ export function fcEventToActivityAndDates(fcEvent, calendar) {
   const utcStartIso = luxonToWcifIso(eventStartLuxon);
   const utcEndIso = luxonToWcifIso(eventEndLuxon);
 
-  const {
-    activityId,
-    activityCode,
-    activityName,
-    childActivities,
-  } = fcEvent.extendedProps;
+  const { activity: attachedActivity } = fcEvent.extendedProps;
+  const partialActivity = buildPartialActivityFromCode(attachedActivity.activityCode);
 
   const activity = {
-    id: activityId,
-    name: activityName,
-    activityCode,
+    ...partialActivity,
+    ...attachedActivity,
     startTime: utcStartIso,
     endTime: utcEndIso,
-    childActivities: childActivities || [],
   };
 
   return {

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -103,6 +103,34 @@ export const localizeActivityCode = (activityCode, wcifRound, wcifEvent) => {
   return roundName;
 };
 
+export const humanizeActivityCode = (activityCode) => {
+  const { eventId, roundNumber, attempt } = parseActivityCode(activityCode);
+
+  const eventName = I18n.t(`events.${eventId}`);
+  const roundName = I18n.t('round.round_number', { round_number: roundNumber });
+
+  const tooltipText = `${eventName}, ${roundName}`;
+
+  if (attempt) {
+    const attemptName = I18n.t('attempts.attempt_name', { number: attempt });
+    return `${tooltipText}, ${attemptName}`;
+  }
+
+  return tooltipText;
+};
+
+export const shortLabelForActivityCode = (activityCode) => {
+  const { roundNumber, attempt } = parseActivityCode(activityCode);
+
+  const labelText = `R${roundNumber}`;
+
+  if (attempt) {
+    return `${labelText}A${attempt}`;
+  }
+
+  return labelText;
+};
+
 export function timeLimitToString(wcifRound, wcifEvents) {
   const wcifTimeLimit = wcifRound.timeLimit;
   const { eventId } = parseActivityCode(wcifRound.id);

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,8 @@ en:
   round:
     #context: e.g. event_name can be "3x3x3 Cube", and round_name can be "Cutoff First round"
     name: "%{event_name} %{round_name}"
+    #context: round_number will be a numeral like 1,2,3 and NOT a written word like "First", "Second" or "Third".
+    round_number: "Round %{round_number}"
   #context: Words used to describe the requirement to advance to the next round
   advancement_condition:
     short:


### PR DESCRIPTION
This PR splits what is stored internally as "Activity name" (see WCIF spec) and what is displayed in FullCalendar.

Previously, we immediately used the activity name (as per WCIF) as the FC display title. Now, we _compute_ an FC display title based on the activity, which may or may not have something to do with the name (and can be changed relatively easily in the future).

In doing so, I have also tried to unify and de-duplicate places in the code where we compute names.