### PR TITLE
Add ORDER BY clause to developer dump

### DIFF
--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -647,6 +647,8 @@ module DatabaseDumper
       ),
     }.freeze,
     "user_groups" => {
+      # groups have a self-referencing foreign key to their parent group, so we need to make sure that root groups are inserted first
+      order_by_clause: "ORDER BY parent_group_id ASC",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -1204,8 +1204,11 @@ module DatabaseDumper
         # Some column names like "rank" are reserved keywords starting mysql 8.0 and require quoting.
         quoted_column_list = column_sanitizers.keys.map { |column_name| ActiveRecord::Base.connection.quote_column_name column_name }.join(", ")
 
-        populate_table_sql = "INSERT INTO #{dump_db_name}.#{table_name} (#{quoted_column_list}) SELECT #{column_expressions} FROM #{source_table} #{table_sanitizer[:where_clause]}"
-        ActiveRecord::Base.connection.execute(populate_table_sql)
+        where_clause_sql = table_sanitizer.fetch(:where_clause, "")
+        order_by_clause_sql = table_sanitizer.fetch(:order_by_clause, "")
+
+        populate_table_sql = "INSERT INTO #{dump_db_name}.#{table_name} (#{quoted_column_list}) SELECT #{column_expressions} FROM #{source_table} #{where_clause_sql} #{order_by_clause_sql}"
+        ActiveRecord::Base.connection.execute(populate_table_sql.strip)
       end
 
       if dump_ts_name.present?

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -141,7 +141,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "ConciseAverageResults" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           average
@@ -158,7 +157,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "ConciseSingleResults" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           best
@@ -177,7 +175,6 @@ module DatabaseDumper
     "connected_paypal_accounts" => :skip_all_rows,
     "connected_stripe_accounts" => :skip_all_rows,
     "Continents" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -190,7 +187,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Countries" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -201,7 +197,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Events" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -213,7 +208,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Formats" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -229,7 +223,6 @@ module DatabaseDumper
     "InboxPersons" => :skip_all_rows,
     "InboxResults" => :skip_all_rows,
     "Persons" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -250,7 +243,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "RanksAverage" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -264,7 +256,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "RanksSingle" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -278,7 +269,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Results" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -324,7 +314,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "RoundTypes" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -336,7 +325,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Scrambles" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           competitionId
@@ -509,7 +497,6 @@ module DatabaseDumper
     "poll_options" => :skip_all_rows,
     "polls" => :skip_all_rows,
     "posts" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -536,7 +523,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "preferred_formats" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           event_id
@@ -546,7 +532,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "regional_organizations" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -570,7 +555,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "registration_competition_events" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -642,7 +626,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "teams" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -655,7 +638,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "user_preferred_events" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -665,7 +647,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "user_groups" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -682,7 +663,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "groups_metadata_board" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -693,7 +673,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "groups_metadata_delegate_regions" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -705,7 +684,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "groups_metadata_councils" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -717,7 +695,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "groups_metadata_teams_committees" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -730,7 +707,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "groups_metadata_translators" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -741,7 +717,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "users" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -799,21 +774,18 @@ module DatabaseDumper
     }.freeze,
     "locations" => :skip_all_rows,
     "incidents" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(id title public_summary digest_worthy resolved_at digest_sent_at created_at updated_at),
         db_default: %w(private_description private_wrc_decision),
       ),
     }.freeze,
     "incident_competitions" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(id incident_id competition_id),
         db_default: %w(comments),
       ),
     }.freeze,
     "incident_tags" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(id incident_id tag),
       ),
@@ -821,7 +793,6 @@ module DatabaseDumper
     "vote_options" => :skip_all_rows,
     "votes" => :skip_all_rows,
     "server_settings" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           name
@@ -843,7 +814,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "eligible_country_iso2s_for_championship" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -854,7 +824,6 @@ module DatabaseDumper
     }.freeze,
     "wcif_extensions" => :skip_all_rows,
     "assignments" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -882,7 +851,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "country_bands" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -908,7 +876,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "roles_metadata_delegate_regions" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -923,7 +890,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "roles_metadata_officers" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -934,7 +900,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "roles_metadata_councils" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -945,7 +910,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "roles_metadata_teams_committees" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -962,7 +926,6 @@ module DatabaseDumper
 
   RESULTS_SANITIZERS = {
     "Results" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           competitionId
@@ -988,7 +951,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "RanksSingle" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           personId
@@ -1001,7 +963,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "RanksAverage" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           personId
@@ -1014,7 +975,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "RoundTypes" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -1026,7 +986,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Events" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -1038,7 +997,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Formats" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -1052,7 +1010,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Countries" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -1063,7 +1020,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Continents" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id
@@ -1076,7 +1032,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Persons" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           subid
@@ -1125,7 +1080,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "Scrambles" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           competitionId
@@ -1155,7 +1109,6 @@ module DatabaseDumper
       ),
     }.freeze,
     "eligible_country_iso2s_for_championship" => {
-      where_clause: "",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(
           id

--- a/spec/lib/database_dumper_spec.rb
+++ b/spec/lib/database_dumper_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe "DatabaseDumper" do
     it "defines a sanitizer of table '#{table_name}'" do
       unless table_sanitizer == :skip_all_rows
         where_clause = table_sanitizer[:where_clause]
-        expect(where_clause).to_not be_nil
+        expect(where_clause).to be_nil.or(match(/WHERE/)).or(match(/JOIN/))
+        where_clause = table_sanitizer[:order_by_clause]
+        expect(where_clause).to be_nil.or(match(/ORDER BY/))
         column_sanitizers = table_sanitizer[:column_sanitizers]
         column_names = ActiveRecord::Base.connection.columns(table_name).map(&:name)
         expect(column_sanitizers.keys).to match_array(column_names)


### PR DESCRIPTION
This mitigates problems with a self-referential foreign key in `user_groups`. The error occurs mostly when existing groups are re-ordered, like recently there was a new big parent group for Asia and older groups were suddenly referencing that newer parent group.

The INSERT INTO ... SELECT ... FROM` query then tries to insert the rows in primary key order, where some earlier rows point to a primary key that is not inserted yet.

I have considered turning off foreign key checks as an alternative, but that will make debugging exponentially harder when the only error message at the very end of the whole dump is "some foreign key somewhere failed so we couldn't turn foreign key checks back on"