### PR TITLE
Consider browser timezones in addition to Ruby backend timezones

### DIFF
--- a/app/webpacker/components/Schedule/TimeZone.jsx
+++ b/app/webpacker/components/Schedule/TimeZone.jsx
@@ -6,13 +6,22 @@ import {
   Header,
   Segment,
 } from 'semantic-ui-react';
+import _ from 'lodash';
 import i18n from '../../lib/i18n';
 import { timezoneData } from '../../lib/wca-data.js.erb';
 
-const timeZoneOptions = Object.entries(timezoneData).map(([tzName, tzId]) => ({
-  key: tzId,
-  text: tzName,
-  value: tzId,
+// Timezones that our Ruby backend knows about. They represent values that might be stored
+//   in the 'competition_venues' table.
+const rubyTimeZones = Object.values(timezoneData);
+// Timezones that the user's browser knows about. The 'Set to local' button will use the
+//   browser settings, so we need to make sure all possible values are included in the list.
+const jsTimeZones = Intl.supportedValuesOf('timeZone');
+
+const uniqueTimeZones = _.uniq(rubyTimeZones.concat(jsTimeZones)).toSorted();
+const timeZoneOptions = uniqueTimeZones.map((tz) => ({
+  key: tz,
+  text: tz,
+  value: tz,
 }));
 
 const { timeZone: userTimeZone } = Intl.DateTimeFormat().resolvedOptions();


### PR DESCRIPTION
Reason for this change is explained directly in the code comments.

Note: JS does not provide "nice" human-readable names for timezones (i.e. `New York`). It can only provide the list of ISO IDs which are also somewhat human-readable (i.e. `America/New_York`) but a bit more technical than the previous implementation (which relied only on Ruby so it had nice names)