### PR TITLE
Remove JWT Token from Local Storage on Logout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,6 +78,13 @@ class ApplicationController < ActionController::Base
     super
   end
 
+  # This method is called by devise after a successful logout to know the redirect path
+  # We override it to do some action after signing in, but we want to use the original path
+  protected def after_sign_out_path_for(resource_or_scope)
+    session[:should_reset_jwt] = true
+    super
+  end
+
   # Starburst announcements, see https://github.com/starburstgem/starburst#installation
   helper Starburst::AnnouncementsHelper
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::Base
   end
 
   # This method is called by devise after a successful logout to know the redirect path
-  # We override it to do some action after signing in, but we want to use the original path
+  # We override it to do some action after signing out, but we want to use the original path
   protected def after_sign_out_path_for(resource_or_scope)
     session[:should_reset_jwt] = true
     super

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 
   <% if session.delete(:should_reset_jwt) %>
     <script>
-      localStorage.setItem("jwt", null);
+      localStorage.removeItem("jwt");
     </script>
   <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,12 @@
     };
   </script>
 
+  <% if session.delete(:should_reset_jwt) %>
+    <script>
+      localStorage.setItem("jwt", null);
+    </script>
+  <% end %>
+
   <%#
     Our sprockets assets. Loaded first, because our js packs below contains the
     css overriding stuff imported in sprockets!


### PR DESCRIPTION
You can't just set a variable because it has to be available on redirect, so I used session. We do the same for the locale on sign in. 

`session.delete(:should_reset_jwt)` is a nice little trick to check if a value is present, but also immediately delete it.