### PR TITLE
Banned competitors migration hotfix

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -93,9 +93,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     if group.banned_competitors?
       user = User.find(user_id)
       upcoming_comps_for_user = user.competitions_registered_for.not_over.merge(Registration.not_deleted).pluck(:id)
-      return render status: :unprocessable_entity, json: {
+      unless upcoming_comps_for_user.empty?
+        return render status: :unprocessable_entity, json: {
           error: "The user has upcoming competitions: #{upcoming_comps_for_user.join(', ')}. Before banning the user, make sure their registrations are deleted.",
-        } unless upcoming_comps_for_user.empty?
+        }
+      end
     end
 
     return render status: :unprocessable_entity, json: { error: "Invalid group type" } unless create_supported_groups.include?(group.group_type)

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -90,6 +90,14 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       location = nil
     end
 
+    if group.banned_competitors?
+      user = User.find(user_id)
+      upcoming_comps_for_user = user.competitions_registered_for.not_over.merge(Registration.not_deleted).pluck(:id)
+      return render status: :unprocessable_entity, json: {
+          error: "The user has upcoming competitions: #{upcoming_comps_for_user.join(', ')}. Before banning the user, make sure their registrations are deleted.",
+        } unless upcoming_comps_for_user.empty?
+    end
+
     return render status: :unprocessable_entity, json: { error: "Invalid group type" } unless create_supported_groups.include?(group.group_type)
     return head :unauthorized unless current_user.has_permission?(:can_edit_groups, group_id)
 

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -36,16 +36,6 @@ class TeamMember < ApplicationRecord
     end
   end
 
-  validate :cannot_ban_user_with_upcoming_comps
-  def cannot_ban_user_with_upcoming_comps
-    if team == Team.banned && current_member?
-      upcoming_comps = user.competitions_registered_for.not_over.merge(Registration.not_deleted).pluck(:id)
-      unless upcoming_comps.empty?
-        errors.add(:user_id, "The user has upcoming competitions: #{upcoming_comps.join(', ')}. Before banning the user, make sure their registrations are deleted.")
-      end
-    end
-  end
-
   validates :start_date, presence: true
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -614,6 +614,10 @@ class User < ApplicationRecord
       groups << UserGroup.translators.ids
     end
 
+    if can_edit_banned_competitors?
+      groups += UserGroup.banned_competitors.ids
+    end
+
     groups
   end
 

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -53,16 +53,6 @@ RSpec.describe TeamsController do
         expect(invalid_team).to be_invalid
       end
 
-      it 'cannot ban a user with non-deleted registrations of upcoming competitions' do
-        team = Team.banned
-        member = FactoryBot.create :user
-        competition = FactoryBot.create :competition, :future
-        FactoryBot.create :registration, user_id: member.id, competition_id: competition.id
-        patch :update, params: { id: team, team: { team_members_attributes: { "0" => { user_id: member.id, start_date: Date.today, team_leader: false } } } }
-        invalid_team = assigns(:team)
-        expect(invalid_team).to be_invalid
-      end
-
       it 'can ban a user with deleted registrations of upcoming competitions' do
         team = Team.banned
         member = FactoryBot.create :user

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -207,6 +207,20 @@ FactoryBot.define do
       otp_secret { User.generate_otp_secret }
     end
 
+    trait :with_past_competitions do
+      after(:create) do |user|
+        competition = FactoryBot.create(:competition, :past)
+        FactoryBot.create(:registration, :accepted, user: user, competition: competition, events: %w(333))
+      end
+    end
+
+    trait :with_future_competitions do
+      after(:create) do |user|
+        competition = FactoryBot.create(:competition, :future)
+        FactoryBot.create(:registration, :accepted, user: user, competition: competition, events: %w(333))
+      end
+    end
+
     wca_id { person&.wca_id }
 
     after(:build) do |user|


### PR DESCRIPTION
1. Missed a validation that blocked creation of new members if the competitor has an upcoming competitors.
2. Missed to add the banned competitors group to groups_with_edit_access method.