### PR TITLE
Changes in banned competitors page UI

### DIFF
--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitors.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitors.jsx
@@ -1,23 +1,26 @@
 import React, { useState } from 'react';
 import {
-  Button, Header, Icon, Modal, Table,
+  Button, Icon, Modal, Table,
 } from 'semantic-ui-react';
 import UserBadge from '../../../UserBadge';
 import BanendCompetitorForm from './BannedCompetitorForm';
 
-export default function BannedCompetitors({ bannedCompetitorRoles, sync }) {
+export default function BannedCompetitors({
+  bannedCompetitorRoles,
+  sync,
+  canEditBannedCompetitors,
+}) {
   const [banModalParams, setBanModalParams] = useState(null);
 
   return (
     <>
-      <Header>Banned Competitors</Header>
       <Table>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell width={5}>User</Table.HeaderCell>
             <Table.HeaderCell width={2}>Start date</Table.HeaderCell>
             <Table.HeaderCell width={2}>End date</Table.HeaderCell>
-            <Table.HeaderCell width={2}>Edit</Table.HeaderCell>
+            {canEditBannedCompetitors && <Table.HeaderCell width={2}>Edit</Table.HeaderCell>}
           </Table.Row>
         </Table.Header>
 
@@ -29,22 +32,25 @@ export default function BannedCompetitors({ bannedCompetitorRoles, sync }) {
                   user={role.user}
                   hideBorder
                   leftAlign
+                  subtexts={role.user.wca_id ? [role.user.wca_id] : []}
                 />
               </Table.Cell>
               <Table.Cell>{role.start_date}</Table.Cell>
               <Table.Cell>{role.end_date}</Table.Cell>
-              <Table.Cell>
-                <Icon
-                  name="edit"
-                  link
-                  onClick={() => setBanModalParams({ action: 'edit', role })}
-                />
-              </Table.Cell>
+              {canEditBannedCompetitors && (
+                <Table.Cell>
+                  <Icon
+                    name="edit"
+                    link
+                    onClick={() => setBanModalParams({ action: 'edit', role })}
+                  />
+                </Table.Cell>
+              )}
             </Table.Row>
           ))}
         </Table.Body>
       </Table>
-      <Button onClick={() => setBanModalParams({ action: 'new' })}>Ban new competitor</Button>
+      {canEditBannedCompetitors && <Button onClick={() => setBanModalParams({ action: 'new' })}>Ban new competitor</Button>}
       <Modal
         open={!!banModalParams}
         onClose={() => setBanModalParams(null)}

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
@@ -1,18 +1,56 @@
 import React from 'react';
+import { Header } from 'semantic-ui-react';
 import useLoadedData from '../../../../lib/hooks/useLoadedData';
 import { apiV0Urls } from '../../../../lib/requests/routes.js.erb';
 import { groupTypes } from '../../../../lib/wca-data.js.erb';
 import Loading from '../../../Requests/Loading';
 import Errored from '../../../Requests/Errored';
 import BannedCompetitors from './BannedCompetitors';
+import useLoggedInUserPermissions from '../../../../lib/hooks/useLoggedInUserPermissions';
 
 export default function BannedCompetitorsPage() {
   const {
-    data: bannedCompetitorRoles, loading, error, sync,
-  } = useLoadedData(apiV0Urls.userRoles.listOfGroupType(groupTypes.banned_competitors));
+    data: bannedCompetitorRoles,
+    loading: bannedCompetitorRolesLoading,
+    error: bannedCompetitorRolesError,
+    sync,
+  } = useLoadedData(apiV0Urls.userRoles.listOfGroupType(groupTypes.banned_competitors, 'startDate', {
+    isActive: true,
+  }));
+  const {
+    data: pastBannedCompetitorRoles,
+    loading: pastBannedCompetitorRolesLoading,
+    error: pastBannedCompetitorRolesError,
+  } = useLoadedData(apiV0Urls.userRoles.listOfGroupType(groupTypes.banned_competitors, 'startDate', {
+    isActive: false,
+  }));
+  const {
+    data: bannedGroup,
+    loading: bannedGroupLoading,
+    error: bannedGroupError,
+  } = useLoadedData(apiV0Urls.userGroups.list(groupTypes.banned_competitors));
+  const { loggedInUserPermissions, permissionsLoading } = useLoggedInUserPermissions();
 
-  if (loading) return <Loading />;
-  if (error) return <Errored />;
+  if (bannedCompetitorRolesLoading || pastBannedCompetitorRolesLoading
+    || bannedGroupLoading || permissionsLoading) {
+    return <Loading />;
+  }
+  if (bannedCompetitorRolesError || pastBannedCompetitorRolesError || bannedGroupError) {
+    return <Errored />;
+  }
 
-  return <BannedCompetitors bannedCompetitorRoles={bannedCompetitorRoles} sync={sync} />;
+  const canEditBannedCompetitors = loggedInUserPermissions.canEditGroup(bannedGroup.id);
+
+  return (
+    <>
+      <Header>Banned Competitors</Header>
+      <BannedCompetitors
+        bannedCompetitorRoles={bannedCompetitorRoles}
+        sync={sync}
+        canEditBannedCompetitors={canEditBannedCompetitors}
+      />
+      <Header>Past Banned Competitors</Header>
+      <BannedCompetitors bannedCompetitorRoles={pastBannedCompetitorRoles} />
+    </>
+  );
 }


### PR DESCRIPTION
1. As per the suggestion by WDC Leader, I've splitted the list into two separate views: Banned competitors & Past Banned competitors.
2. Now showing edit actions only if the user has permission to modify banned competitors (it was having a backend validation, so currently this is not an issue).