### PR TITLE
Banned competitors hotfix - edit actions & add to delegate panel

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -30,6 +30,7 @@ class PanelController < ApplicationController
       "delegate" => {
         "importantLinks" => "important-links",
         "delegateCrashCourse" => "delegate-crash-course",
+        "bannedCompetitors" => "banned-competitors",
       },
       "board" => {
         "seniorDelegatesList" => "senior-delegates-list",

--- a/app/webpacker/components/Panel/Delegate/index.jsx
+++ b/app/webpacker/components/Panel/Delegate/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PanelTemplate from '../PanelTemplate';
 import { PANEL_LIST } from '../../../lib/wca-data.js.erb';
 import ImportantLinks from './ImportantLinks';
+import BannedCompetitorsPage from '../pages/BannedCompetitorsPage';
 
 const delegateCrashCourseLink = 'https://documents.worldcubeassociation.org/edudoc/delegate-crash-course/delegate_crash_course.pdf';
 
@@ -15,6 +16,11 @@ const sections = [
     id: PANEL_LIST.delegate.delegateCrashCourse,
     name: 'Delegate Crash Course',
     link: delegateCrashCourseLink,
+  },
+  {
+    id: PANEL_LIST.delegate.bannedCompetitors,
+    name: 'Banned Competitors',
+    component: BannedCompetitorsPage,
   },
 ];
 

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
@@ -39,7 +39,7 @@ export default function BannedCompetitorsPage() {
     return <Errored />;
   }
 
-  const canEditBannedCompetitors = loggedInUserPermissions.canEditGroup(bannedGroup.id);
+  const canEditBannedCompetitors = loggedInUserPermissions.canEditGroup(bannedGroup[0].id);
 
   return (
     <>


### PR DESCRIPTION
2 hotfixes:
1. Added banned competitors to delegate panel
2. Edit actions were missing for WDC leader, I missed to take element from array.