### PR TITLE
POC of single user_roles get API

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -11,7 +11,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     User.where(delegate_to_handle_wca_id_claim: user.id).update_all(delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil)
   end
 
-  def pre_filtered_user_roles_active_record
+  private def pre_filtered_user_roles
     active_record = UserRole
     is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
     group_type = params[:groupType]
@@ -33,7 +33,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
   # Returns a list of roles based on the parameters.
   def index
-    roles = pre_filtered_user_roles_active_record.all
+    roles = pre_filtered_user_roles
 
     # Filter & Sort roles.
     roles = UserRole.filter_roles(roles, current_user, params)

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -11,6 +11,38 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     User.where(delegate_to_handle_wca_id_claim: user.id).update_all(delegate_id_to_handle_wca_id_claim: nil, unconfirmed_wca_id: nil)
   end
 
+  def pre_filtered_user_roles_active_record
+    active_record = UserRole
+    is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
+    group_type = params[:groupType]
+    user_id = params[:userId]
+
+    # In next few lines, instead of foo.present? we are using !foo.nil? because foo.present? returns
+    # false if foo is a boolean false but we need to actually check if the boolean is present or not.
+    if !is_active.nil?
+      active_record = is_active ? active_record.active : active_record.inactive
+    end
+    if group_type.present?
+      active_record = active_record.includes(:group).where(group: { group_type: group_type })
+    end
+    if user_id.present?
+      active_record = active_record.where(user_id: user_id)
+    end
+    active_record
+  end
+
+  # Returns a list of roles based on the parameters.
+  def index
+    roles = pre_filtered_user_roles_active_record.all
+
+    # Filter & Sort roles.
+    roles = UserRole.filter_roles(roles, current_user, params)
+    roles = UserRole.sort_roles(roles, params[:sort])
+
+    # Limiting to first 100 elements of roles array to avoid serializing of large array.
+    render json: roles.first(100)
+  end
+
   # Returns a list of roles primarily based on userId.
   def index_for_user
     user_id = params.require(:user_id)

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -10,7 +10,7 @@ class UserRole < ApplicationRecord
 
   delegate :group_type, to: :group
 
-  scope :active, -> { where(end_date: nil).or(where.not(end_date: ..Date.today)) }
+  scope :active, -> { where(end_date: nil).or(inactive.invert_where) }
   scope :inactive, -> { where(end_date: ..Date.today) }
 
   UserRoleChange = Struct.new(

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -11,6 +11,7 @@ class UserRole < ApplicationRecord
   delegate :group_type, to: :group
 
   scope :active, -> { where(end_date: nil).or(where.not(end_date: ..Date.today)) }
+  scope :inactive, -> { where(end_date: ..Date.today) }
 
   UserRoleChange = Struct.new(
     :changed_parameter,

--- a/app/webpacker/components/RolesTab/index.jsx
+++ b/app/webpacker/components/RolesTab/index.jsx
@@ -13,19 +13,17 @@ export default function RolesTab({ userId }) {
     data: activeRoles,
     loading: activeRolesLoading,
     error: activeRolesError,
-  } = useLoadedData(apiV0Urls.userRoles.listOfUser(
-    userId,
+  } = useLoadedData(apiV0Urls.userRoles.list(
+    { isActive: true, isGroupHidden: false, userId },
     sortParams,
-    { isActive: true, isGroupHidden: false },
   ));
   const {
     data: pastRoles,
     loading: pastRolesLoading,
     error: pastRolesError,
-  } = useLoadedData(apiV0Urls.userRoles.listOfUser(
-    userId,
+  } = useLoadedData(apiV0Urls.userRoles.list(
+    { isActive: false, isGroupHidden: false, userId },
     sortParams,
-    { isActive: false, isGroupHidden: false },
   ));
 
   const hasNoRoles = activeRoles?.length === 0 && pastRoles?.length === 0;

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -194,6 +194,7 @@ export const apiV0Urls = {
     resetClaimCount: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_wrt_person_reset_claim_count_path("${wcaId}"))%>`,
   },
   userRoles: {
+    list: ({isActive, isGroupHidden, userId} = {}, sort) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId })}`,
     listOfUser: (userId, sort, {isActive, isGroupHidden, status, groupType} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, groupType })}`,
     listOfGroup: (groupId, sort, {isActive, isGroupHidden, status, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, isLead })}`,
     listOfGroupType: (groupType, sort, {status, isActive, extraMetadata, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive, extraMetadata, isLead })}`,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,7 +392,7 @@ Rails.application.routes.draw do
         get '/group-type/:group_type' => 'user_roles#index_for_group_type', as: :index_for_group_type
         get '/search' => 'user_roles#search', as: :user_roles_search
       end
-      resources :user_roles, only: [:show, :create, :update, :destroy]
+      resources :user_roles, only: [:index, :show, :create, :update, :destroy]
       resources :user_groups, only: [:index, :create, :update]
       namespace :wrt do
         resources :persons, only: [:update, :destroy] do

--- a/spec/controllers/api/v0/user_roles_controller_spec.rb
+++ b/spec/controllers/api/v0/user_roles_controller_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe Api::V0::UserRolesController do
       end
 
       it 'fetches list of roles of a user' do
+        get :index, params: { userId: user_whose_delegate_status_changes.id }
+
+        expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)
+      end
+
+      it 'fetches list of roles of a user using index_for_user' do
         get :index_for_user, params: { user_id: user_whose_delegate_status_changes.id }
 
         expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)


### PR DESCRIPTION
Currently there are three different roles API, and there are different filter parameters for each API. The querying in the backend is not so good. So, this API will do proper pre-filtering before fetching the actual roles, and hence making the querying more faster.

If this approach is fine, I'll deprecate the other three GET APIs and make this as the single API required for roles fetching.