### PR TITLE
Skip 'orphaned' activities in the Schedule View component

### DIFF
--- a/app/webpacker/components/Schedule/CalendarView.jsx
+++ b/app/webpacker/components/Schedule/CalendarView.jsx
@@ -31,14 +31,14 @@ export default function CalendarView({
   timeZone,
   activeVenues,
   activeRooms,
-  activeEvents,
+  activeEventIds,
   calendarLocale,
+  wcifEvents,
 }) {
-  const activeEventIds = activeEvents.map(({ id }) => id);
   const fcActivities = activeRooms.flatMap((room) => room.activities
     .filter((activity) => ['other', ...activeEventIds].includes(getActivityEventId(activity)))
     .map((activity) => {
-      const eventName = activity.activityCode.startsWith('other') ? activity.name : localizeActivityName(activity, activeEvents);
+      const eventName = activity.activityCode.startsWith('other') ? activity.name : localizeActivityName(activity, wcifEvents);
       const eventColor = activity.activityCode.startsWith('other') ? ACTIVITY_OTHER_GREY : room.color;
 
       return ({

--- a/app/webpacker/components/Schedule/CalendarView.jsx
+++ b/app/webpacker/components/Schedule/CalendarView.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {
   earliestTimeOfDayWithBuffer,
   getActivityEventId,
+  isOrphanedActivity,
   latestTimeOfDayWithBuffer,
   localizeActivityName,
 } from '../../lib/utils/activities';
@@ -37,6 +38,7 @@ export default function CalendarView({
 }) {
   const fcActivities = activeRooms.flatMap((room) => room.activities
     .filter((activity) => ['other', ...activeEventIds].includes(getActivityEventId(activity)))
+    .filter((activity) => !isOrphanedActivity(activity, wcifEvents))
     .map((activity) => {
       const eventName = activity.activityCode.startsWith('other') ? activity.name : localizeActivityName(activity, wcifEvents);
       const eventColor = activity.activityCode.startsWith('other') ? ACTIVITY_OTHER_GREY : room.color;

--- a/app/webpacker/components/Schedule/TableView.jsx
+++ b/app/webpacker/components/Schedule/TableView.jsx
@@ -9,7 +9,9 @@ import {
   earliestWithLongestTieBreaker,
   getActivityEventId,
   getActivityRoundId,
-  groupActivities, localizeActivityName,
+  groupActivities,
+  isOrphanedActivity,
+  localizeActivityName,
 } from '../../lib/utils/activities';
 import { getSimpleTimeString } from '../../lib/utils/dates';
 import { toDegrees } from '../../lib/utils/edit-schedule';
@@ -42,8 +44,10 @@ export default function TableView({
     .flatMap((room) => room.activities)
     .toSorted(earliestWithLongestTieBreaker);
 
-  const eventIds = activeEvents.map(({ id }) => id);
-  const visibleActivities = sortedActivities.filter((activity) => ['other', ...eventIds].includes(getActivityEventId(activity)));
+  const activeEventIds = activeEvents.map(({ id }) => id);
+  const visibleActivities = sortedActivities
+    .filter((activity) => ['other', ...activeEventIds].includes(getActivityEventId(activity)))
+    .filter((activity) => !isOrphanedActivity(activity, wcifEvents));
 
   return (
     <>

--- a/app/webpacker/components/Schedule/TableView.jsx
+++ b/app/webpacker/components/Schedule/TableView.jsx
@@ -69,7 +69,6 @@ export default function TableView({
             date={date}
             timeZone={timeZone}
             groupedActivities={groupedActivitiesForDay}
-            events={activeEvents}
             rounds={activeRounds}
             rooms={activeRooms}
             isExpanded={isExpanded}
@@ -87,7 +86,6 @@ function SingleDayTable({
   date,
   timeZone,
   groupedActivities,
-  events,
   rounds,
   rooms,
   isExpanded,
@@ -137,7 +135,6 @@ function SingleDayTable({
                 key={representativeActivity.id}
                 isExpanded={isExpanded}
                 activityGroup={activityGroup}
-                events={events}
                 round={activityRound}
                 rooms={rooms}
                 timeZone={timeZone}
@@ -179,7 +176,6 @@ function HeaderRow({ isExpanded }) {
 function ActivityRow({
   isExpanded,
   activityGroup,
-  events,
   round,
   rooms,
   timeZone,
@@ -188,7 +184,7 @@ function ActivityRow({
   const representativeActivity = activityGroup[0];
   const { startTime, endTime } = representativeActivity;
 
-  const name = representativeActivity.activityCode.startsWith('other') ? representativeActivity.name : localizeActivityName(representativeActivity, events);
+  const name = representativeActivity.activityCode.startsWith('other') ? representativeActivity.name : localizeActivityName(representativeActivity, wcifEvents);
   const eventId = representativeActivity.activityCode.startsWith('other') ? 'other' : parseActivityCode(representativeActivity.activityCode).eventId;
 
   const activityIds = activityGroup.map((activity) => activity.id);

--- a/app/webpacker/components/Schedule/index.jsx
+++ b/app/webpacker/components/Schedule/index.jsx
@@ -167,8 +167,9 @@ export default function Schedule({
           timeZone={activeTimeZone}
           activeVenues={activeVenues}
           activeRooms={activeRooms}
-          activeEvents={activeEvents}
+          activeEventIds={activeEventIds}
           calendarLocale={calendarLocale}
+          wcifEvents={wcifEvents}
         />
       ) : (
         <TableView

--- a/app/webpacker/lib/utils/activities.js
+++ b/app/webpacker/lib/utils/activities.js
@@ -124,4 +124,16 @@ export const localizeActivityName = (activity, wcifEvents) => {
   return localizeActivityCode(activity.activityCode, activityRound, activityEvent);
 };
 
-export const isOrphanedActivity = (activity, wcifEvents) => getActivityEventId(activity) !== 'other' && findActivityEvent(activity, wcifEvents) === undefined;
+export const isOrphanedActivity = (activity, wcifEvents) => {
+  if (getActivityEventId(activity) === 'other') {
+    // 'other' activities are never matched to an event because by definition,
+    //   they are not a standard WCA event.
+    return false;
+  }
+
+  const activityEvent = findActivityEvent(activity, wcifEvents);
+
+  return (
+    activityEvent === undefined || findActivityRound(activity, activityEvent.rounds) === undefined
+  );
+};

--- a/app/webpacker/lib/utils/activities.js
+++ b/app/webpacker/lib/utils/activities.js
@@ -123,3 +123,5 @@ export const localizeActivityName = (activity, wcifEvents) => {
 
   return localizeActivityCode(activity.activityCode, activityRound, activityEvent);
 };
+
+export const isOrphanedActivity = (activity, wcifEvents) => getActivityEventId(activity) !== 'other' && findActivityEvent(activity, wcifEvents) === undefined;


### PR DESCRIPTION
We need the list of WCA events (from WCIF `events`) to be able to compute humainzed strings for the round name, time limits, etc. This causes problems when there are activities for events which are not listed in the WCIF (Yes, unfortunately this can occur.)