### PR TITLE
Remove isGroupHidden parameter from post-filter

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -14,6 +14,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
   private def pre_filtered_user_roles
     active_record = UserRole
     is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
+    is_group_hidden = params.key?(:isGroupHidden) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isGroupHidden)) : nil
     group_type = params[:groupType]
     user_id = params[:userId]
 
@@ -21,6 +22,9 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     # false if foo is a boolean false but we need to actually check if the boolean is present or not.
     if !is_active.nil?
       active_record = is_active ? active_record.active : active_record.inactive
+    end
+    if !is_group_hidden.nil?
+      active_record = active_record.includes(:group).where(group: { is_hidden: is_group_hidden })
     end
     if group_type.present?
       active_record = active_record.includes(:group).where(group: { group_type: group_type })

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -153,7 +153,6 @@ class UserRole < ApplicationRecord
   def self.filter_roles_for_parameters(roles, params)
     status = params[:status]
     is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
-    is_group_hidden = params.key?(:isGroupHidden) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isGroupHidden)) : nil
     group_type = params[:groupType]
     is_lead = params.key?(:isLead) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isLead)) : nil
 
@@ -163,7 +162,6 @@ class UserRole < ApplicationRecord
       (
         (!status.nil? && status != role.metadata&.status) ||
         (!is_active.nil? && is_active != role.is_active?) ||
-        (!is_group_hidden.nil? && is_group_hidden != role.group.is_hidden) ||
         (!group_type.nil? && group_type != role.group_type) ||
         (!is_lead.nil? && is_lead != role.is_lead?)
       )

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/index.jsx
@@ -38,15 +38,15 @@ export default function Regions({ loggedInUserId }) {
   const {
     data: seniorDelegateRoles,
     loading, error,
-  } = useLoadedData(apiV0Urls.userRoles.listOfUser(
-    loggedInUserId,
-    'groupName', // Sort params
+  } = useLoadedData(apiV0Urls.userRoles.list(
     {
+      userId: loggedInUserId,
       isActive: true,
       isGroupHidden: false,
       status: delegateRegionsStatus.senior_delegate,
       groupType: groupTypes.delegate_region,
     },
+    'groupName', // Sort params
   ));
 
   if (loading) return <Loading />;

--- a/app/webpacker/components/Persons/Badges.jsx
+++ b/app/webpacker/components/Persons/Badges.jsx
@@ -52,13 +52,13 @@ function badgeParams(role) {
 }
 
 export default function Badges({ userId }) {
-  const { data } = useLoadedData(apiV0Urls.userRoles.listOfUser(
-    userId,
-    ['lead', 'eligibleVoter', 'groupTypeRank', 'status:desc', 'groupName'].join(','), // Sort params
+  const { data } = useLoadedData(apiV0Urls.userRoles.list(
     {
+      userId,
       isActive: true,
       isGroupHidden: false,
     },
+    ['lead', 'eligibleVoter', 'groupTypeRank', 'status:desc', 'groupName'].join(','), // Sort params
   ));
   const roles = data || [];
 

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -194,9 +194,9 @@ export const apiV0Urls = {
     resetClaimCount: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_wrt_person_reset_claim_count_path("${wcaId}"))%>`,
   },
   userRoles: {
-    list: ({isActive, isGroupHidden, userId} = {}, sort) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId })}`,
-    listOfUser: (userId, sort, {isActive, isGroupHidden, status, groupType} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, groupType })}`,
-    listOfGroup: (groupId, sort, {isActive, isGroupHidden, status, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, status, isLead })}`,
+    list: ({isActive, isGroupHidden, userId, status, groupType, isLead} = {}, sort) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId, status, groupType, isLead })}`,
+    listOfUser: (userId, sort, {isActive, status, groupType} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, status, groupType })}`,
+    listOfGroup: (groupId, sort, {isActive, status, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, status, isLead })}`,
     listOfGroupType: (groupType, sort, {status, isActive, extraMetadata, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive, extraMetadata, isLead })}`,
     create: () => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>`,
     update: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,


### PR DESCRIPTION
This PR aims at removing all usages of `isGroupHidden` from the role list APIs. This is achieved by replacing the API with new list API, so that the `isGroupHidden` parameter will be pre-filtered instead of post-filter.