### PR TITLE
Fix the test chokes with wrong number of counted rows

### DIFF
--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PaymentIntent do
   describe 'scopes' do
-    before(:all) do
+    before(:each) do
       FactoryBot.create_list(:payment_intent, 5)
       FactoryBot.create_list(:payment_intent, 2, :canceled)
       FactoryBot.create_list(:payment_intent, 3, :confirmed)


### PR DESCRIPTION
We had sporadic test chokes that caused some entities to "stick around" in the database, causing CI test failures when we did `expect(Model.count) to be 0` style assumptions. The assumptions themselves are valid, and the fact that residual data was in the test DB is clearly to blame.

Interestingly, this fail was order-dependent, which lead us to believe that one particular test is writing these persistent entities to the DB and if that test is run last (or close to the end of the suite) no problems occur.

I ran the test suite locally with `--fail-fast` to find a seed that reproduces the issue, and then used `bin/rspec --seed 20718 --bisect` to find a minimal reproduction (Note: `rspec --bisect` is an awesome feature!). This minimal reproduction came out to be `bin/rspec './spec/models/payment_intent_spec.rb[1:1:1]' './spec/requests/api_persons_spec.rb[1:1:1]' --seed 20718`, so it was the `payment_intent_spec` that caused the issue.

At that point, it was just a matter of manually investigating the file and the failure message. The top of the file conveniently creates a grand total of 10 PIs, and the `api_persons_spec` failed with a wrong count of 14 instead of the expected 4. Notice anything suspicious?

Turns out, the `user` entities that are created internally as holders of the PIs were the ones that had persisted `Persons`. Some googling led me to https://stackoverflow.com/a/37761580 and voila.