### PR TITLE
Correctly parse override retry counts in rspec-retry

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,12 @@ RSpec.configure do |config|
 
   # run retry on features that have JS enabled
   config.around :each, :js do |ex|
-    ex.run_with_retry retry: 3
+    # hard-coding the number 3 directly unfortunately overrides any individual retry count
+    # on single/grouped specs because the library authors used `merge` instead of `reverse_merge`.
+    # So we hack around this limitation by reading any potential custom retry count ourselves!
+    retry_count = ex.metadata[:retry] || 3
+
+    ex.run_with_retry retry: retry_count
   end
 
   # clean up the Capybara cache between reruns


### PR DESCRIPTION
Working around a shortcoming of the `rspec-retry` library. See the code comment for details.