### PR TITLE
Removed extraMetadata and isLead from index_for_group_type APIs

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -16,6 +16,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     is_active = params.key?(:isActive) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isActive)) : nil
     is_group_hidden = params.key?(:isGroupHidden) ? ActiveRecord::Type::Boolean.new.cast(params.require(:isGroupHidden)) : nil
     group_type = params[:groupType]
+    group_id = params[:groupId]
     user_id = params[:userId]
 
     # In next few lines, instead of foo.present? we are using !foo.nil? because foo.present? returns
@@ -28,6 +29,9 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     end
     if group_type.present?
       active_record = active_record.includes(:group).where(group: { group_type: group_type })
+    end
+    if group_id.present?
+      active_record = active_record.where(group_id: group_id)
     end
     if user_id.present?
       active_record = active_record.where(user_id: user_id)

--- a/app/webpacker/components/Delegates/DelegatesOfAllRegion.jsx
+++ b/app/webpacker/components/Delegates/DelegatesOfAllRegion.jsx
@@ -26,24 +26,20 @@ export default function DelegatesOfAllRegion() {
     data: leadDelegates,
     loading: leadDelegatesLoading,
     error: leadDelegatesError,
-  } = useLoadedData(
-    apiV0Urls.userRoles.listOfGroupType(groupTypes.delegate_regions, 'name', {
-      isActive: true,
-      extraMetadata: true,
-      isLead: true,
-    }),
-  );
+  } = useLoadedData(apiV0Urls.userRoles.list({
+    groupType: groupTypes.delegate_regions,
+    isActive: true,
+    isLead: true,
+  }, 'name'));
   const {
     data: otherDelegates,
     loading: otherDelegatesLoading,
     error: otherDelegatesError,
-  } = useLoadedData(
-    apiV0Urls.userRoles.listOfGroupType(groupTypes.delegate_regions, 'name', {
-      isActive: true,
-      extraMetadata: true,
-      isLead: false,
-    }),
-  );
+  } = useLoadedData(apiV0Urls.userRoles.list({
+    groupType: groupTypes.delegate_regions,
+    isActive: true,
+    isLead: false,
+  }, 'name'));
   const otherDelegatesWithExtraData = useMemo(() => otherDelegates?.map((delegate) => ({
     ...delegate,
     status: I18n.t(`enums.user_roles.status.delegate_regions.${delegate.metadata.status}`),

--- a/app/webpacker/components/Panel/SeniorDelegate/Regions/Subregion.jsx
+++ b/app/webpacker/components/Panel/SeniorDelegate/Regions/Subregion.jsx
@@ -49,13 +49,13 @@ const canDemote = (role) => (
 export default function Subregion({ title, groupId }) {
   const {
     data: delegates, loading, error: delegatesFetchError, sync,
-  } = useLoadedData(apiV0Urls.userRoles.listOfGroup(
-    groupId,
-    'location,name',
+  } = useLoadedData(apiV0Urls.userRoles.list(
     {
+      groupId,
       isActive: true,
       isLead: false,
     },
+    'location,name',
   ));
   const [openModalType, setOpenModalType] = useState(null);
   const [delegateToChange, setDelegateToChange] = useState(null);

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -194,10 +194,10 @@ export const apiV0Urls = {
     resetClaimCount: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_wrt_person_reset_claim_count_path("${wcaId}"))%>`,
   },
   userRoles: {
-    list: ({isActive, isGroupHidden, userId, status, groupType, isLead} = {}, sort) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId, status, groupType, isLead })}`,
+    list: ({isActive, isGroupHidden, userId, groupId, status, groupType, isLead} = {}, sort) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId, groupId, status, groupType, isLead })}`,
     listOfUser: (userId, sort, {isActive, status, groupType} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, status, groupType })}`,
     listOfGroup: (groupId, sort, {isActive, status, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, status, isLead })}`,
-    listOfGroupType: (groupType, sort, {status, isActive, extraMetadata, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive, extraMetadata, isLead })}`,
+    listOfGroupType: (groupType, sort, {status, isActive} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive })}`,
     create: () => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>`,
     update: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,
     delete: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,


### PR DESCRIPTION
In this PR, extraMetadata and isLead are removed from index_for_group_type API. extraMetadata is a parameter which is no longer used. For isLead, I've replaced the usages with index API.