### PR TITLE
Insert missing returns in v2's init_stripe error handling

### DIFF
--- a/app/controllers/api/internal/v1/payment_controller.rb
+++ b/app/controllers/api/internal/v1/payment_controller.rb
@@ -11,17 +11,17 @@ class Api::Internal::V1::PaymentController < Api::Internal::V1::ApiController
     paying_user_id = params.require(:current_user)
     paying_user = User.find(paying_user_id)
 
-    render json: { error: "Paying user not found" }, status: :not_found unless paying_user.present?
-    render json: { error: "This user can't pay for this registration" }, status: :forbidden unless paying_user_id == registering_user_id
+    return render json: { error: "Paying user not found" }, status: :not_found unless paying_user.present?
+    return render json: { error: "This user can't pay for this registration" }, status: :forbidden unless paying_user_id.to_i == registering_user_id.to_i
 
     competition = Competition.find(competition_id)
-    render json: { error: "Competition not found" }, status: :not_found unless competition.present?
+    return render json: { error: "Competition not found" }, status: :not_found unless competition.present?
 
     ms_registration = competition.microservice_registrations
                                  .includes(:competition, :user)
                                  .find_by(user_id: registering_user_id)
 
-    render json: { error: "Registration not found" }, status: :not_found unless ms_registration.present?
+    return render json: { error: "Registration not found" }, status: :not_found unless ms_registration.present?
 
     payment_account = competition.payment_account_for(:stripe)
 


### PR DESCRIPTION
Just noticed this when I sent some wrong data and got a double render error