### PR TITLE
Bump Shakapacker to v8.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'i18n-country-translations', github: 'thewca/i18n-country-translations'
 gem 'http_accept_language'
 gem 'twitter_cldr'
 # version explicitly specified because Shakapacker wants to keep Gemfile and package.json in sync
-gem 'shakapacker', '7.2.3'
+gem 'shakapacker', '8.0.0'
 gem 'json-schema'
 gem 'translighterate'
 gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -690,7 +690,7 @@ GEM
     seedbank (0.5.0)
       rake (>= 10.0)
     semantic_range (3.0.0)
-    shakapacker (7.2.3)
+    shakapacker (8.0.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -906,7 +906,7 @@ DEPENDENCIES
   sdoc
   seedbank
   selectize-rails!
-  shakapacker (= 7.2.3)
+  shakapacker (= 8.0.0)
   sidekiq
   sidekiq-cron
   simple_form

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "sass": "^1.77.4",
     "sass-loader": "^14.2.1",
     "semantic-ui-react": "^2.1.5",
-    "shakapacker": "7.2.3",
+    "shakapacker": "8.0.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.91.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5806,7 +5806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.2.0":
+"glob@npm:^7.1.1, glob@npm:^7.1.3":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -9829,7 +9829,7 @@ __metadata:
     sass: "npm:^1.77.4"
     sass-loader: "npm:^14.2.1"
     semantic-ui-react: "npm:^2.1.5"
-    shakapacker: "npm:7.2.3"
+    shakapacker: "npm:8.0.0"
     style-loader: "npm:^4.0.0"
     stylelint: "npm:^16.6.1"
     stylelint-config-recommended-scss: "npm:^14.0.0"
@@ -10135,11 +10135,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shakapacker@npm:7.2.3":
-  version: 7.2.3
-  resolution: "shakapacker@npm:7.2.3"
+"shakapacker@npm:8.0.0":
+  version: 8.0.0
+  resolution: "shakapacker@npm:8.0.0"
   dependencies:
-    glob: "npm:^7.2.0"
     js-yaml: "npm:^4.1.0"
     path-complete-extname: "npm:^1.0.0"
   peerDependencies:
@@ -10162,7 +10161,7 @@ __metadata:
       optional: true
     "@types/webpack":
       optional: true
-  checksum: 10c0/77c277339e5c8acac0abea0b5161802bd8ba718d2ff0e8e12b861f2dc35b0bec6a933fd64ab4b75462a1cc672c26e5ada5c6876a53eaa5ad0cb12d739fa72a95
+  checksum: 10c0/4de846a4f2fc76eb7b39dbe9f394d301777d391b7fa12014926502021e78a51fcec93856cd0b7ec1d3b80f7eb5b4f6ea0eeee6ccfb9fd4d9d04b42ee950fb3f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because after over one year, Dependabot still has no feature to mark dependencies as "need to be updated together"...