### PR TITLE
Add user_id index to registrations (speeds up my competitions by 2-3x)

### DIFF
--- a/db/migrate/20240605145605_add_indexes_to_registrations.rb
+++ b/db/migrate/20240605145605_add_indexes_to_registrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexesToRegistrations < ActiveRecord::Migration[7.1]
+  def change
+    add_index :registrations, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_04_023859) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_145605) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -996,6 +996,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_023859) do
     t.boolean "is_competing", default: true
     t.text "administrative_notes"
     t.index ["competition_id", "user_id"], name: "index_registrations_on_competition_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_registrations_on_user_id"
   end
 
   create_table "roles_metadata_banned_competitors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
I've been noticing that my_competitions was our slowest page to load for a while and it's getting unbearably slow on staging and on local (and is pretty slow on prod as well). 

I did some digging and found out that these two queries take about a second to load on local: 

```
SELECT `registrations`.* FROM `registrations` WHERE `registrations`.`user_id` = 15073 AND `registrations`.`accepted_at` IS NOT NULL AND `registrations`.`deleted_at` IS NULL; 
```
and
```
SELECT `registrations`.* FROM `registrations` WHERE `registrations`.`user_id` = 15073 AND `registrations`.`accepted_at` IS NULL AND `registrations`.`deleted_at` IS NULL AND `registrations`.`is_competing` = TRUE; 
```
You can see in Rails here:
```
puts Registration.where(user_id: 15073).where.not(accepted_at: nil).where(deleted_at: nil).explain
-> Registration Load (757.7ms) 
puts Registration.where(user_id: 15073).where(accepted_at: nil).where(deleted_at: nil).where(is_competing: true).explain
-> Registration Load (875.4ms)
```
After adding the index this now is down to 2ms
```
puts Registration.where(user_id: 15073).where.not(accepted_at: nil).where(deleted_at: nil).explain
-> Registration Load (2.2ms)
puts Registration.where(user_id: 15073).where(accepted_at: nil).where(deleted_at: nil).where(is_competing: true).explain
-> Registration Load (2.0ms) 
```

This lowers the page load time by a factor of 2+ on dev.
The page is still not the fastest for people with a lot of competitions, but that's just because we are rendering a lot of HTML and a React Rewrite would fix this (by for example only loading the past competitions when a user clicks on the accordion).
 