### PR TITLE
Install dartsass shims on top of deprecated sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'rails-i18n'
 gem 'i18n-js'
 gem 'activerecord-import'
 gem 'sass-rails'
+gem "sassc-embedded"
 gem 'terser'
 gem 'faraday'
 gem 'faraday-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,9 @@ GEM
       rexml
     google-cloud-env (2.1.1)
       faraday (>= 1.0, < 3.a)
+    google-protobuf (4.27.0)
+      bigdecimal
+      rake (>= 13)
     googleauth (1.11.0)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.1)
@@ -672,10 +675,15 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.0)
       ffi (~> 1.12)
+    sass-embedded (1.77.4)
+      google-protobuf (>= 3.25, < 5.0)
+      rake (>= 13)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-embedded (1.76.0)
+      sass-embedded (~> 1.76)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -903,6 +911,7 @@ DEPENDENCIES
   rspec-retry
   rubocop
   sass-rails
+  sassc-embedded
   sdoc
   seedbank
   selectize-rails!


### PR DESCRIPTION
Our SASS compiler is terribly deprecated.

This installs https://github.com/sass-contrib/sassc-embedded-shim-ruby which "overrides" the `libsass` executable provided by the deprecated `sassc` gem with a modern `dartsass` implementation.

We unfortunately cannot move away from `sassc` entirely -- there are more modern gems and approaches to solving this problem but we have legacy code which is hard-wired to `sassc` in our Sprockets pipeline. So by continuing to work towards abandoning Sprockets, we will automatically also abandon `sassc` in the medium term future.