### PR TITLE
Set unique IDs for hidden AutoNumeric fields in Refunds view

### DIFF
--- a/app/inputs/money_amount_input.rb
+++ b/app/inputs/money_amount_input.rb
@@ -18,8 +18,13 @@ class MoneyAmountInput < SimpleForm::Inputs::Base
     # Get the id of the currency selector's selector
     currency_selector = options.delete(:currency_selector)
 
+    # The hidden inputs are targeted via jQuery using their ID as CSS selector.
+    # This means that the ID for the hidden field must be as unique as possible, to avoid
+    # structurally similar, repeated forms firing their AutoNumeric update to the wrong input
+    hidden_id = "#{@builder.id}_#{object_name}_#{attribute_name}"
+
     # This will create the hidden input tag, using SimpleForm's predefined helper
-    actual_field = @builder.hidden_field(attribute_name, value: value)
+    actual_field = @builder.hidden_field(attribute_name, value: value, id: hidden_id)
     input_id = attribute_name.to_s + "_input_field"
 
     # On page load, inputs with this class get their mask setup
@@ -31,7 +36,7 @@ class MoneyAmountInput < SimpleForm::Inputs::Base
                                         id: input_id,
                                         type: "text",
                                         data: {
-                                          target: "##{@builder.object_name}_#{attribute_name}",
+                                          target: "##{hidden_id}",
                                           currency: currency,
                                           'currency-selector': currency_selector,
                                         },

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -56,7 +56,7 @@
           %>
           <% if @competition.using_payment_integrations? && payment.amount_available_for_refund > 0 %>
             <% refund_provider = CompetitionPaymentIntegration::INTEGRATION_RECORD_TYPES.invert[payment.receipt_type] %>
-            <%= horizontal_simple_form_for :payment, url: registration_payment_refund_path(@competition, refund_provider, payment.receipt_id), html: { id: :form_refund } do |f| %>
+            <%= horizontal_simple_form_for :payment, url: registration_payment_refund_path(@competition, refund_provider, payment.receipt_id), html: { id: "form_refund_#{payment.id}" } do |f| %>
               <%= f.input :refund_amount, as: :money_amount, currency: payment.amount.currency.iso_code, value: payment.amount_available_for_refund, label: t('registrations.refund_form.labels.refund_amount'), hint: t('registrations.refund_form.hints.refund_amount') %>
               <%= submit_tag t('registrations.refund'), class: "btn btn-warning", data: { confirm: t('registrations.refund_confirmation') } %>
             <% end %>


### PR DESCRIPTION
This is actually a bug that exists in Prod, so it's rather urgent.

The hidden fields backing the "old-style" (non-React) AutoNumeric inputs get assigned repetitive IDs. In the old (i.e. current registration system) "Refunds" panel, we render one form per payment, and each payment is structurally identical so the ID `payment_refund_amount` gets assigned to **every** hidden field.

We did not encounter this issue yet because (a) it's very rare that someone has two payments in the first place and (b) that the _second_ (or third or fourth) payment should only be _partially_ refunded.
But if any organizer would have tried that, the second AutoNumeric field's jQuery would have fired on the _first_ hidden field of the page because that's what it finds by ID