### PR TITLE
More small Registration V2 Fixes

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -341,7 +341,7 @@ export default function CompetingStep({
 
               {shouldShowReRegisterButton && (
               <Button
-                secondary
+                primary
                 disabled={isUpdating}
                 type="submit"
               >

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -186,7 +186,6 @@ export default function CompetingStep({
   };
 
   const actionReRegister = () => {
-    dispatch(setMessage('competitions.registration_v2.update.being_updated', 'basic'));
     updateRegistrationMutation({
       user_id: registration.user_id,
       competition_id: competitionInfo.id,
@@ -200,7 +199,6 @@ export default function CompetingStep({
   };
 
   const actionDeleteRegistration = () => {
-    dispatch(setMessage('competitions.registration_v2.update.being_deleted', 'basic'));
     updateRegistrationMutation({
       user_id: registration.user_id,
       competition_id: competitionInfo.id,
@@ -239,13 +237,13 @@ export default function CompetingStep({
 
   const handleSubmit = useCallback((event) => {
     event.preventDefault();
-    if (shouldShowUpdateButton) {
-      attemptAction(actionUpdateRegistration, { checkForChanges: true });
-    } else if (shouldShowReRegisterButton) {
-      attemptAction(actionReRegister);
-    } else {
-      attemptAction(actionCreateRegistration);
+    if (shouldShowReRegisterButton) {
+      return attemptAction(actionReRegister);
     }
+    if (shouldShowUpdateButton) {
+      return attemptAction(actionUpdateRegistration, { checkForChanges: true });
+    }
+    attemptAction(actionCreateRegistration);
   }, [
     actionCreateRegistration,
     actionReRegister,

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -319,7 +319,7 @@ export default function CompetingStep({
               }}
               min="0"
               max={competitionInfo.guests_per_registration_limit}
-              error={guests > competitionInfo.guests_per_registration_limit && i18n.t('competitions.competition_info.guest_limit', { count: competitionInfo.guests_per_registration_limit })}
+              error={competitionInfo.guests_per_registration_limit && guests > competitionInfo.guests_per_registration_limit && i18n.t('competitions.competition_info.guest_limit', { count: competitionInfo.guests_per_registration_limit })}
             />
           </Form.Field>
           {isRegistered ? (

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -262,7 +262,7 @@ export default function CompetingStep({
       <>
         {hasPaid && (
           <Message success>
-            {i18n.t('competitions.registration_v2.register.already_paid', { comp_name: competitionInfo.name })}
+            {i18n.t('registrations.entry_fees_fully_paid', { paid: registration?.payment.payment_amount_human_readable })}
           </Message>
         )}
 
@@ -319,7 +319,7 @@ export default function CompetingStep({
               }}
               min="0"
               max={competitionInfo.guests_per_registration_limit}
-              error={competitionInfo.guests_per_registration_limit && guests > competitionInfo.guests_per_registration_limit && i18n.t('competitions.competition_info.guest_limit', { count: competitionInfo.guests_per_registration_limit })}
+              error={Number.isInteger(competitionInfo.guests_per_registration_limit) && guests > competitionInfo.guests_per_registration_limit && i18n.t('competitions.competition_info.guest_limit', { count: competitionInfo.guests_per_registration_limit })}
             />
           </Form.Field>
           {isRegistered ? (

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -96,17 +96,16 @@ export default function CompetingStep({
       // Going from pending -> Cancelled
       if (data.registration.competing.registration_status === 'cancelled') {
         dispatch(setMessage('competitions.registration_v2.register.registration_status.cancelled', 'positive'));
-        nextStep({ toStart: true });
-      } else {
-        // Going from cancelled -> pending
-        if (registration.competing.registration_status === 'cancelled') {
-          dispatch(setMessage('registrations.flash.registered', 'positive'));
-          // Not changing status
-        } else {
-          dispatch(setMessage('registrations.flash.updated', 'positive'));
-        }
-        nextStep();
+        return nextStep({ toStart: true });
       }
+      // Going from cancelled -> pending
+      if (registration.competing.registration_status === 'cancelled') {
+        dispatch(setMessage('registrations.flash.registered', 'positive'));
+        // Not changing status
+      } else {
+        dispatch(setMessage('registrations.flash.updated', 'positive'));
+      }
+      nextStep();
     },
   });
 

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Button, Form, FormField, Header, Message, Segment, TransitionGroup,
+  Button, Form, FormField, Header, Message, Segment,
 } from 'semantic-ui-react';
 import i18n from '../../../lib/i18n';
 import EventIcon from '../../wca/EventIcon';
@@ -31,6 +31,11 @@ export default function RegistrationOverview({
       <Message info>
         {i18n.t(updateRegistrationKey(editsAllowed, hasRegistrationEditDeadlinePassed))}
       </Message>
+      )}
+      { !competitionInfo['using_payment_integrations?'] && registration.competing.registration_status === 'pending' && competitionInfo.base_entry_fee_lowest_denomination && (
+        <Message info>
+          {i18n.t('registrations.wont_pay_here')}
+        </Message>
       )}
       <Segment>
         <Header>{i18n.t('competitions.nav.menu.registration')}</Header>

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
@@ -32,23 +32,33 @@ export default function RegistrationOverview({
         {i18n.t(updateRegistrationKey(editsAllowed, hasRegistrationEditDeadlinePassed))}
       </Message>
       )}
-      <TransitionGroup animation="slide down">
-        <Segment>
-          <Header>{i18n.t('competitions.nav.menu.registration')}</Header>
-          <Form onSubmit={nextStep} size="large">
-            <FormField>
-              <label>{i18n.t('activerecord.attributes.registration.registration_competition_events')}</label>
-              {registration.competing.event_ids.map((id) => (<EventIcon key={id} id={id} style={{ cursor: 'unset' }} />))}
-            </FormField>
-            <FormField>
-              <label>{i18n.t('competitions.registration_v2.register.comment')}</label>
-              {registration.competing.comment.length > 0 ? registration.competing.comment : i18n.t('competitions.schedule.rooms_panel.none')}
-            </FormField>
-            <FormField>
-              <label>{i18n.t('activerecord.attributes.registration.guests')}</label>
-              {registration.guests}
-            </FormField>
-            { editsAllowed && (
+      <Segment>
+        <Header>{i18n.t('competitions.nav.menu.registration')}</Header>
+        <Form onSubmit={nextStep} size="large">
+          <FormField>
+            <label>
+              {i18n.t('activerecord.attributes.registration.registration_competition_events')}
+              :
+            </label>
+            {registration.competing.event_ids.map((id) => (<EventIcon key={id} id={id} style={{ cursor: 'unset' }} />))}
+          </FormField>
+          <FormField />
+          <FormField>
+            <label>
+              {i18n.t('activerecord.attributes.registration.comments')}
+              :
+            </label>
+            {registration.competing.comment.length > 0 ? registration.competing.comment : i18n.t('competitions.schedule.rooms_panel.none')}
+          </FormField>
+          <FormField />
+          <FormField>
+            <label>
+              {i18n.t('activerecord.attributes.registration.guests')}
+              :
+            </label>
+            {registration.guests}
+          </FormField>
+          { editsAllowed && (
             <Button
               primary
               fluid
@@ -56,10 +66,9 @@ export default function RegistrationOverview({
             >
               {i18n.t('registrations.update')}
             </Button>
-            )}
-          </Form>
-        </Segment>
-      </TransitionGroup>
+          )}
+        </Form>
+      </Segment>
     </>
   );
 }

--- a/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
@@ -48,7 +48,7 @@ export default function StepPanel({
   stripePublishableKey,
   connectedAccountId,
 }) {
-  const isRegistered = Boolean(registration);
+  const isRegistered = Boolean(registration) && registration.competing.registration_status !== 'cancelled';
   const hasPaid = registration?.payment.payment_status === 'succeeded';
   const registrationFinished = hasPaid || (isRegistered && !competitionInfo['using_payment_integrations?']);
 

--- a/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
@@ -113,7 +113,13 @@ export default function StepPanel({
         stripePublishableKey={stripePublishableKey}
         connectedAccountId={connectedAccountId}
         nextStep={
-          () => setActiveIndex((oldActiveIndex) => {
+          (overwrites = {}) => setActiveIndex((oldActiveIndex) => {
+            if (overwrites?.refresh) {
+              return oldActiveIndex;
+            }
+            if (overwrites?.toStart) {
+              return 0;
+            }
             if (oldActiveIndex === steps.length - 1) {
               return registrationOverviewConfig.index;
             }

--- a/app/webpacker/components/RegistrationsV2/Waiting/WaitingList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Waiting/WaitingList.jsx
@@ -25,11 +25,11 @@ export default function WaitingList({ competitionInfo }) {
     <Loading />
   )
     : (
-      <Table>
+      <Table collapsing>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell>Name</Table.HeaderCell>
             <Table.HeaderCell>Position</Table.HeaderCell>
+            <Table.HeaderCell>Name</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -40,10 +40,10 @@ export default function WaitingList({ competitionInfo }) {
               ) // We just care about the order of the waitlisted competitors
               .map((w, i) => (
                 <Table.Row key={w.user_id}>
-                  <Table.Cell>{w.user.name}</Table.Cell>
                   <Table.Cell>
                     {w.waiting_list_position === 0 ? 'Not yet assigned' : i + 1}
                   </Table.Cell>
+                  <Table.Cell>{w.user.name}</Table.Cell>
                 </Table.Row>
               ))
           ) : (

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1789,7 +1789,6 @@ en:
         comment: "Additional comments to the organizers"
         until: "You can update your registration until %{date}"
         passed: "You can no longer update your registration"
-        already_paid: "You have already paid for %{comp_name}"
         editing_disabled: "Registration editing is disabled for this competition"
         registration_status:
           accepted: "Your registration has been accepted."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1772,8 +1772,8 @@ en:
         acknowledgement: "I have read and acknowledged all information under the 'Register' tab, including entry fees, refund policies and any extra requirements listed above."
         next_step: "Continue to next Step"
       update:
-        being_updated: "Registration is being updated"
-        being_deleted: "Registration is being deleted"
+        being_updated: "Registration is being updated..."
+        being_deleted: "Registration is being deleted..."
         no_changes: "There are no changes"
         email_send: "Send Email"
         email_copy: "Copy Email"
@@ -2458,7 +2458,7 @@ en:
             paragraph: "Only use the mono variant when the primary variant is not suitable."
         logo_only:
           title: "Logo Only"
-          paragraph: The WCA logo may be used without the logotype, following the same color guidelines above. 
+          paragraph: The WCA logo may be used without the logotype, following the same color guidelines above.
       download_logo_assets:
         title: "Download Logo Assets"
         paragraph: "High resolution PNGs and vector versions of the WCA logo are available for download."


### PR DESCRIPTION
- Fixes Guests being errored incorrectly
- Fixed Event Selector showing error before being interacted with if no preferred event is set or a favourite competition is used
- Fixed a bunch of strings
- deleted some unused imports
- flipped the columns of the waiting list table

Needs a small PR on wca-registration to add `registration?.payment.payment_amount_human_readable`([already done, just need to open it](https://github.com/thewca/wca-registration/pull/605))