### PR TITLE
Try to fix map within markdown sections

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
   <%# NOTE: we need to create our global wca object first, because it's used in our non-webpack application.js %>
   <script>
     window.wca = {
+      env: '<%= Rails.env %>',
       currentLocale: '<%= I18n.locale %>',
     };
   </script>

--- a/app/webpacker/lib/leaflet-wca/index.js
+++ b/app/webpacker/lib/leaflet-wca/index.js
@@ -14,7 +14,6 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 import iconMarker2x from 'leaflet/dist/images/marker-icon-2x.png';
 import iconMarker from 'leaflet/dist/images/marker-icon.png';
 import iconShadow from 'leaflet/dist/images/marker-shadow.png';
-import { railsEnv } from '../wca-data.js.erb';
 import { redMarker, blueMarker } from './markers';
 import { searchProvider, userTileProvider } from './providers';
 
@@ -79,7 +78,7 @@ window.wca.createCompetitionsMapLeaflet = (elementId, center = [0, 0], iframeTri
   });
   // To avoid timeout issue on *.tile.openstreetmap.org during tests,
   // we don't add the actual tile layer in that environment.
-  if (railsEnv !== 'test') layer.addTo(map);
+  if (window.wca.env !== 'test') layer.addTo(map);
   if (iframeTrick) {
     // We create an invisible iframe that triggers an invalidate size when
     // resized (which includes bootstrap's collapse/hide/show events).


### PR DESCRIPTION
This is a small change that tries to fix an error being thrown by maps within markdown sections (such as tabs in competitions).

It looks to be some sort of race condition / similar issue caused by translations being imported as part of importing wca_data.js.erb