### PR TITLE
Make the payment intent creation endpoint backend agnostic

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,7 +3,7 @@
 require "csv"
 
 class RegistrationsController < ApplicationController
-  before_action :authenticate_user!, except: [:create, :index, :psych_sheet, :psych_sheet_event, :register, :stripe_webhook, :payment_denomination, :create_paypal_order]
+  before_action :authenticate_user!, except: [:create, :index, :psych_sheet, :psych_sheet_event, :register, :stripe_webhook, :payment_denomination]
   # Stripe has its own authenticity mechanism with Webhook Secrets.
   protect_from_forgery except: [:stripe_webhook]
 
@@ -21,7 +21,7 @@ class RegistrationsController < ApplicationController
 
   before_action -> { redirect_to_root_unless_user(:can_manage_competition?, competition_from_params) },
                 except: [:create, :index, :psych_sheet, :psych_sheet_event, :register, :payment_completion, :load_payment_intent, :stripe_webhook, :payment_denomination, :destroy,
-                         :update, :create_paypal_order, :capture_paypal_payment, :refund_paypal_payment]
+                         :update, :capture_paypal_payment, :refund_paypal_payment]
 
   before_action :competition_must_be_using_wca_registration!, except: [:import, :do_import, :add, :do_add, :index, :psych_sheet, :psych_sheet_event, :stripe_webhook, :payment_denomination]
   private def competition_must_be_using_wca_registration!
@@ -641,37 +641,30 @@ class RegistrationsController < ApplicationController
     redirect_to competition_register_path(competition_id)
   end
 
-  # This method implements the PaymentElements workflow described at:
-  # - https://stripe.com/docs/payments/quickstart
-  # - https://stripe.com/docs/payments/accept-a-payment
-  # - https://stripe.com/docs/payments/accept-a-payment?ui=elements
-  # It essentially creates a PaymentIntent for the current user-specified amount.
-  # Everything after the creation of the intent is handled by Stripe through their JS integration.
-  # At the very end, when the process is finished, it redirects the user to a return URL that we specified.
-  # This return URL handles record keeping and stuff at `payment_completion` above.
   def load_payment_intent
-    registration = Registration.includes(:user, :competition).find(params[:id])
+    registration = Registration.includes(:competition).find(params[:id])
 
     unless registration.user_id == current_user.id
-      return render status: 403, json: { error: { message: t("registrations.payment_form.errors.not_allowed") } }
+      return render status: :forbidden, json: { error: { message: t("registrations.payment_form.errors.not_allowed") } }
     end
 
     amount = params[:amount].to_i
 
     if registration.outstanding_entry_fees.cents <= 0
-      return render json: { error: { message: t("registrations.payment_form.errors.already_paid") } }
+      return render status: :bad_request, json: { error: { message: t("registrations.payment_form.errors.already_paid") } }
     end
 
     if amount < registration.outstanding_entry_fees.cents
-      return render json: { error: { message: t("registrations.payment_form.alerts.amount_too_low") } }
+      return render status: :bad_request, json: { error: { message: t("registrations.payment_form.alerts.amount_too_low") } }
     end
 
     competition = registration.competition
 
-    payment_account = competition.payment_account_for(:stripe)
-    currency_iso = registration.outstanding_entry_fees.currency.iso_code
+    payment_integration = params.require(:payment_integration).to_sym
+    return head :forbidden if payment_integration == :paypal && PaypalInterface.paypal_disabled?
 
-    intent = payment_account.prepare_intent(registration, amount, currency_iso, current_user)
+    payment_account = competition.payment_account_for(payment_integration)
+    intent = payment_account.prepare_intent(registration, amount, competition.currency_code, current_user)
 
     render json: { client_secret: intent.client_secret }
   end
@@ -795,22 +788,6 @@ class RegistrationsController < ApplicationController
   private def registration_from_params
     id = params.require(:id)
     Registration.find(id)
-  end
-
-  def create_paypal_order
-    return head :forbidden if PaypalInterface.paypal_disabled?
-
-    registration = registration_from_params
-    amount = params.require(:amount)
-
-    competition = registration.competition
-    paypal_integration = competition.payment_account_for(:paypal)
-
-    render json: PaypalInterface.create_order(
-      paypal_integration.paypal_merchant_id,
-      amount,
-      competition.currency_code,
-    )
   end
 
   def capture_paypal_payment

--- a/app/models/connected_paypal_account.rb
+++ b/app/models/connected_paypal_account.rb
@@ -3,6 +3,28 @@
 class ConnectedPaypalAccount < ApplicationRecord
   has_one :competition_payment_integration, as: :connected_account
 
+  # TODO: Do we want to recycle Order items in PayPal the same way we recycle PaymentIntent items in Stripe?
+  def prepare_intent(registration, amount_iso, currency_iso, paying_user)
+    req_payload, raw_order = PaypalInterface.create_order(self.paypal_merchant_id, amount_iso, currency_iso)
+
+    paypal_record = PaypalRecord.create_from_api(
+      raw_order,
+      :paypal_order,
+      req_payload,
+      self.paypal_merchant_id,
+    )
+
+    # memoize the payment intent in our DB because payments are handled asynchronously
+    # so we need to be able to retrieve this later at any time, even when our server crashes in the meantime…
+    PaymentIntent.create!(
+      holder: registration,
+      payment_record: paypal_record,
+      client_secret: paypal_record.paypal_id,
+      initiated_by: paying_user,
+      wca_status: paypal_record.determine_wca_status,
+    )
+  end
+
   def account_details
     PaypalInterface.account_details(self.paypal_merchant_id)
                    .slice("display_name", "primary_email")

--- a/app/models/connected_stripe_account.rb
+++ b/app/models/connected_stripe_account.rb
@@ -19,6 +19,13 @@ class ConnectedStripeAccount < ApplicationRecord
     self.create_intent(registration, amount_iso, currency_iso, paying_user)
   end
 
+  # This method implements the PaymentElements workflow described at:
+  # - https://stripe.com/docs/payments/quickstart
+  # - https://stripe.com/docs/payments/accept-a-payment
+  # - https://stripe.com/docs/payments/accept-a-payment?ui=elements
+  # It essentially creates a PaymentIntent for the current user-specified amount.
+  # Everything after the creation of the intent is handled by Stripe through their JS integration.
+  # At the very end, when the process is finished, it redirects the user to a return URL that we specified.
   private def create_intent(registration, amount_iso, currency_iso, paying_user)
     stripe_amount = StripeRecord.amount_to_stripe(amount_iso, currency_iso)
 

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -105,6 +105,9 @@ class PaymentIntent < ApplicationRecord
       if payment_record_type == 'StripeRecord'
         errors.add(:wca_status, "#{wca_status} is not compatible with StripeRecord status: #{payment_record.stripe_status}") unless
           StripeRecord::WCA_TO_STRIPE_STATUS_MAP[wca_status.to_sym].include?(payment_record.stripe_status)
+      elsif payment_record_type == 'PaypalRecord'
+        errors.add(:wca_status, "#{wca_status} is not compatible with PaypalRecord status: #{payment_record.paypal_status}") unless
+          PaypalRecord::WCA_TO_PAYPAL_STATUS_MAP[wca_status.to_sym].include?(payment_record.paypal_status)
       else
         raise "No status combination validation defined for: #{payment_record_type}"
       end

--- a/app/models/paypal_record.rb
+++ b/app/models/paypal_record.rb
@@ -33,6 +33,7 @@ class PaypalRecord < ApplicationRecord
     ],
   }.freeze
 
+  # See https://developer.paypal.com/docs/api/orders/v2/#orders_get!c=200&path=status&t=response
   enum paypal_status: {
     created: "CREATED",
     payer_action_required: "PAYER_ACTION_REQUIRED",
@@ -42,15 +43,14 @@ class PaypalRecord < ApplicationRecord
     voided: "VOIDED",
   }
 
-  # See https://developer.paypal.com/docs/api/orders/v2/#orders_get!c=200&path=status&t=response
   WCA_TO_PAYPAL_STATUS_MAP = {
-    created: %w[CREATED],
-    pending: %w[PAYER_ACTION_REQUIRED],
-    processing: %w[SAVED],
+    created: %w[created],
+    pending: %w[payer_action_required],
+    processing: %w[saved],
     partial: %w[],
     failed: %w[],
-    succeeded: %w[APPROVED COMPLETED], # TODO: In PayPal, WE are the ones who have to make the payment succeed, by "capturing" an already approved payment
-    canceled: %w[VOIDED],
+    succeeded: %w[approved completed], # TODO: In PayPal, WE are the ones who have to make the payment succeed, by "capturing" an already approved payment
+    canceled: %w[voided],
   }.freeze
 
   enum paypal_record_type: {

--- a/app/models/paypal_record.rb
+++ b/app/models/paypal_record.rb
@@ -33,6 +33,15 @@ class PaypalRecord < ApplicationRecord
     ],
   }.freeze
 
+  enum paypal_status: {
+    created: "CREATED",
+    payer_action_required: "PAYER_ACTION_REQUIRED",
+    saved: "SAVED",
+    approved: "APPROVED",
+    completed: "COMPLETED",
+    voided: "VOIDED",
+  }
+
   # See https://developer.paypal.com/docs/api/orders/v2/#orders_get!c=200&path=status&t=response
   WCA_TO_PAYPAL_STATUS_MAP = {
     created: %w[CREATED],

--- a/app/models/stripe_record.rb
+++ b/app/models/stripe_record.rb
@@ -49,8 +49,8 @@ class StripeRecord < ApplicationRecord
   serialize :parameters, coder: JSON
 
   def determine_wca_status
-    result = WCA_TO_STRIPE_STATUS_MAP.find { |key, values| values.include?(stripe_status) }
-    result&.first || raise("No associated wca_status for stripe_status: #{stripe_status} - our tests should prevent this from happening!")
+    result = WCA_TO_STRIPE_STATUS_MAP.find { |key, values| values.include?(self.stripe_status) }
+    result&.first || raise("No associated wca_status for stripe_status: #{self.stripe_status} - our tests should prevent this from happening!")
   end
 
   def account_id

--- a/app/views/registrations/_paypal_payment_form.html.erb
+++ b/app/views/registrations/_paypal_payment_form.html.erb
@@ -103,12 +103,12 @@
           const amount = getCurrentRubyAmount();
 
           return wrapAjaxPromise('load-payment-intent', {
-            url: '<%= registration_create_paypal_order_path(@registration) %>',
+            url: '<%= registration_payment_intent_path(@registration, :paypal) %>',
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             data: JSON.stringify({ amount: amount }),
           })
-            .then(({ id: orderId }) => orderId)
+            .then(({ client_secret: orderId }) => orderId)
             .catch(handleAjaxError);
         },
 

--- a/app/views/registrations/_stripe_payment_form.html.erb
+++ b/app/views/registrations/_stripe_payment_form.html.erb
@@ -157,7 +157,7 @@
           if (confirmedAmount) {
             // Fetches a payment intent and captures the client secret
             window.wca.cancelPendingAjaxAndAjax('load-payment-intent', {
-              url: '<%= registration_payment_intent_path(@registration) %>',
+              url: '<%= registration_payment_intent_path(@registration, :stripe) %>',
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               data: JSON.stringify({ amount: amount }),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,6 @@ Rails.application.routes.draw do
 
   # Don't expose Paypal routes in production until we're reading to launch
   unless PaypalInterface.paypal_disabled?
-    post 'registration/:id/create-paypal-order' => 'registrations#create_paypal_order', as: :registration_create_paypal_order
     post 'registration/:id/capture-paypal-payment' => 'registrations#capture_paypal_payment', as: :registration_capture_paypal_payment
     post 'registration/:id/paypal_refund/:payment_id' => 'registrations#refund_paypal_payment', as: :paypal_payment_refund
   end
@@ -46,7 +45,7 @@ Rails.application.routes.draw do
   post 'registration/:id/refund/:payment_id' => 'registrations#payment_refund_legacy', as: :registration_payment_refund_legacy
   get 'registration/:id/payment-completion' => 'registrations#payment_completion_legacy', as: :registration_payment_completion_legacy
 
-  post 'registration/:id/load-payment-intent' => 'registrations#load_payment_intent', as: :registration_payment_intent
+  post 'registration/:id/load-payment-intent/:payment_integration' => 'registrations#load_payment_intent', as: :registration_payment_intent
   post 'competitions/:competition_id/refund/:payment_id' => 'registrations#refund_payment', as: :registration_payment_refund
   get 'competitions/:competition_id/payment-completion' => 'registrations#payment_completion', as: :registration_payment_completion
   post 'registration/stripe-webhook' => 'registrations#stripe_webhook', as: :registration_stripe_webhook

--- a/lib/paypal_interface.rb
+++ b/lib/paypal_interface.rb
@@ -84,16 +84,7 @@ module PaypalInterface
       req.body = payload
     end
 
-    body = response.body
-
-    PaypalRecord.create_from_api(
-      body,
-      :paypal_order,
-      payload,
-      merchant_id,
-    )
-
-    body
+    [payload, response.body]
   end
 
   # TODO: Update the status of the PaypalRecord object?

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -849,6 +849,7 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
           sign_in organizer
           post :load_payment_intent, params: {
             id: registration.id,
+            payment_integration: :stripe,
             amount: registration.outstanding_entry_fees.cents,
           }
           payment_intent = registration.reload.payment_intents.first

--- a/spec/models/paypal_record_spec.rb
+++ b/spec/models/paypal_record_spec.rb
@@ -3,6 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe PaypalRecord do
+  describe 'status mappings' do
+    it 'contains all wca_statuses' do
+      expect(PaypalRecord::WCA_TO_PAYPAL_STATUS_MAP.keys.sort.map(&:to_s)).to eq(PaymentIntent.wca_statuses.values.sort)
+    end
+
+    it 'contains all paypal_statuses' do
+      mapped_statuses = PaypalRecord::WCA_TO_PAYPAL_STATUS_MAP.values.flatten
+      expect(PaypalRecord.paypal_statuses.values.sort).to eq(mapped_statuses.sort)
+    end
+  end
+
+  describe 'validates stripe_status' do
+    it 'allows a valid status' do
+      record = PaypalRecord.new(paypal_status: 'SAVED')
+      expect(record).to be_valid
+    end
+
+    it 'does not allow an invalid status' do
+      expect {
+        PaypalRecord.new(paypal_status: 'random_invalid_status')
+      }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#amount_to_paypal" do
     it 'returns USD as a decimal string' do
       ruby_amount = "1000"

--- a/spec/models/paypal_record_spec.rb
+++ b/spec/models/paypal_record_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PaypalRecord do
     end
   end
 
-  describe 'validates stripe_status' do
+  describe 'validates paypal_status' do
     it 'allows a valid status' do
       record = PaypalRecord.new(paypal_status: 'SAVED')
       expect(record).to be_valid

--- a/spec/models/paypal_record_spec.rb
+++ b/spec/models/paypal_record_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe PaypalRecord do
     end
 
     it 'contains all paypal_statuses' do
-      mapped_statuses = PaypalRecord::WCA_TO_PAYPAL_STATUS_MAP.values.flatten
-      expect(PaypalRecord.paypal_statuses.values.sort).to eq(mapped_statuses.sort)
+      expect(PaypalRecord.paypal_statuses.keys.sort).to eq(PaypalRecord::WCA_TO_PAYPAL_STATUS_MAP.values.flatten.sort)
     end
   end
 

--- a/spec/models/stripe_record_spec.rb
+++ b/spec/models/stripe_record_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe StripeRecord do
     end
 
     it 'contains all stripe_statuses' do
-      mapped_statuses = StripeRecord::WCA_TO_STRIPE_STATUS_MAP.values.flatten
-      expect(StripeRecord.stripe_statuses.values.sort).to eq(mapped_statuses.sort)
+      expect(StripeRecord.stripe_statuses.keys.sort).to eq(StripeRecord::WCA_TO_STRIPE_STATUS_MAP.values.flatten.sort)
     end
   end
 

--- a/spec/models/stripe_record_spec.rb
+++ b/spec/models/stripe_record_spec.rb
@@ -7,18 +7,12 @@ require 'rails_helper'
 RSpec.describe StripeRecord do
   describe 'status mappings' do
     it 'contains all wca_statuses' do
-      expect(StripeRecord::WCA_TO_STRIPE_STATUS_MAP.keys.sort.map { |x| x.to_s }).to eq(PaymentIntent.wca_statuses.values.sort)
+      expect(StripeRecord::WCA_TO_STRIPE_STATUS_MAP.keys.sort.map(&:to_s)).to eq(PaymentIntent.wca_statuses.values.sort)
     end
 
     it 'contains all stripe_statuses' do
-      mapped_statuses = []
-      StripeRecord::WCA_TO_STRIPE_STATUS_MAP.each_value do |values_list|
-        values_list.each do |value|
-          mapped_statuses << value
-        end
-      end
-
-      expect(StripeRecord.stripe_statuses.keys.sort).to eq(mapped_statuses.sort)
+      mapped_statuses = StripeRecord::WCA_TO_STRIPE_STATUS_MAP.values.flatten
+      expect(StripeRecord.stripe_statuses.values.sort).to eq(mapped_statuses.sort)
     end
   end
 

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -520,7 +520,7 @@ RSpec.describe "registrations" do
       sign_out
 
       it "redirects to the sign in page" do
-        post registration_payment_intent_path(registration)
+        post registration_payment_intent_path(registration, :stripe)
         expect(response).to redirect_to new_user_session_path
       end
     end
@@ -537,17 +537,20 @@ RSpec.describe "registrations" do
       it "restricts access to the registration's owner" do
         user2 = FactoryBot.create(:user, :wca_id)
         registration2 = FactoryBot.create(:registration, competition: competition, user: user2)
-        post registration_payment_intent_path(registration2.id)
+        post registration_payment_intent_path(registration2.id, :stripe)
         expect(response.status).to eq 403
       end
 
       context "with a valid credit card without SCA" do
         it "rejects insufficient payment" do
           outstanding_fees_money = registration.outstanding_entry_fees
-          post registration_payment_intent_path(registration.id), params: {
+
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: outstanding_fees_money / 2,
           }
+
           expect_error_to_be(response, I18n.t("registrations.payment_form.alerts.amount_too_low"))
+
           # Should not have created a payment intent in the first place, so assume `payment_intent` to be nil.
           payment_intent = registration.reload.payment_intents.first
           expect(payment_intent).to be_nil
@@ -557,9 +560,10 @@ RSpec.describe "registrations" do
         it "processes sufficient payment when confirmed by redirect" do
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
 
           # mimic the user clicking through the interface
@@ -589,7 +593,7 @@ RSpec.describe "registrations" do
         it "processes sufficient payment when confirmed by webhook" do
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
 
@@ -625,7 +629,7 @@ RSpec.describe "registrations" do
           donation_lowest_denomination = 100
           payment_amount = registration.outstanding_entry_fees.cents + donation_lowest_denomination
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: payment_amount,
           }
           payment_intent = registration.reload.payment_intents.first
@@ -652,11 +656,13 @@ RSpec.describe "registrations" do
           expect(StripeRecord.count).to eq 0
           expect(PaymentIntent.count).to eq 0
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
           expect(payment_intent).to_not be_nil
+
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
           expect(payment_intent.wca_status).not_to eq('succeeded')
@@ -687,9 +693,10 @@ RSpec.describe "registrations" do
         it "asks for further action before recording payment" do
           # The #process_payment_intent endpoint doesn't redirect, it's
           # the 'register' page which does.
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
 
           # NOTE: The PI confirmation sends a redirect code where the user would _normally_ proceed with authentication,
@@ -717,11 +724,14 @@ RSpec.describe "registrations" do
         it "inserts a 'confirmation pending' event in the stripe journal" do
           expect(StripeRecord.count).to eq 0
           expect(PaymentIntent.count).to eq 0
-          post registration_payment_intent_path(registration.id), params: {
+
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
           expect(payment_intent).to_not be_nil
+
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
 
@@ -731,6 +741,7 @@ RSpec.describe "registrations" do
             { payment_method: 'pm_card_authenticationRequired' },
             stripe_account: competition.payment_account_for(:stripe).account_id,
           )
+
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
           get registration_payment_completion_path(competition.id), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
@@ -738,6 +749,7 @@ RSpec.describe "registrations" do
           }
 
           stripe_record = payment_intent.reload.payment_record
+
           # Now we should still wait for the confirmation because SCA hasn't been completed yet
           expect(payment_intent.confirmed_at).to be_nil
           expect(stripe_record).to_not be_nil
@@ -751,9 +763,10 @@ RSpec.describe "registrations" do
       # not to actually test Stripe's correctness...
       context "rejected credit cards" do
         it "rejects payment with declined credit card" do
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
 
           expect {
@@ -780,9 +793,10 @@ RSpec.describe "registrations" do
         end
 
         it "rejects payment with expired credit card" do
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
 
           expect {
@@ -809,9 +823,10 @@ RSpec.describe "registrations" do
         end
 
         it "rejects payment with incorrect cvc" do
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
 
           expect {
@@ -838,9 +853,10 @@ RSpec.describe "registrations" do
         end
 
         it "rejects payment due to fraud protection" do
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
 
           expect {
@@ -867,9 +883,10 @@ RSpec.describe "registrations" do
         end
 
         it "rejects payment despite successful 3DSecure" do
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
 
           expect {
@@ -896,11 +913,13 @@ RSpec.describe "registrations" do
           expect(StripeRecord.count).to eq 0
           expect(PaymentIntent.count).to eq 0
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
           expect(payment_intent).to_not be_nil
+
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
 
@@ -933,11 +952,13 @@ RSpec.describe "registrations" do
           expect(StripeRecord.count).to eq 0
           expect(PaymentIntent.count).to eq 0
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
           expect(payment_intent).to_not be_nil
+
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
 
@@ -960,9 +981,10 @@ RSpec.describe "registrations" do
           }
 
           # Try to pay again. The old PI should be fetched as "not pending", so we expect that no new PI is being created
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           new_payment_intents = registration.reload.payment_intents
           expect(new_payment_intents.size).to eq(1)
 
@@ -977,9 +999,10 @@ RSpec.describe "registrations" do
           expect(StripeRecord.count).to eq 0
           expect(PaymentIntent.count).to eq 0
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
           expect(payment_intent).to_not be_nil
 
@@ -1005,10 +1028,11 @@ RSpec.describe "registrations" do
           }
 
           # Try to pay again. The old PI should be fetched as "not pending", so we expect that no new PI is being created
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             # Pay some non-zero additional amount / donations.
             amount: registration.outstanding_entry_fees.cents * 2,
           }
+
           new_payment_intents = registration.reload.payment_intents
           expect(new_payment_intents.size).to eq(1)
 
@@ -1024,9 +1048,10 @@ RSpec.describe "registrations" do
           expect(StripeRecord.count).to eq 0
           expect(PaymentIntent.count).to eq 0
 
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
           expect(payment_intent).to_not be_nil
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
@@ -1054,9 +1079,10 @@ RSpec.describe "registrations" do
           competition.update!(base_entry_fee_lowest_denomination: 2000)
 
           # Try to pay again. The old PI should be fetched as "completed", so we expect that a new PI is being created
-          post registration_payment_intent_path(registration.id), params: {
+          post registration_payment_intent_path(registration.id, :stripe), params: {
             amount: registration.outstanding_entry_fees.cents,
           }
+
           new_payment_intents = registration.reload.payment_intents
           expect(new_payment_intents.size).to eq(2)
 
@@ -1090,8 +1116,8 @@ RSpec.describe "registrations" do
       stub_request(:post, order_url)
         .to_return(status: 200, body: stubbed_order, headers: { 'Content-Type' => 'application/json' })
 
-      payload = { amount: competition.base_entry_fee_lowest_denomination, currency_code: competition.currency_code }
-      post registration_create_paypal_order_path(registration.id), params: payload
+      payload = { amount: competition.base_entry_fee_lowest_denomination }
+      post registration_payment_intent_path(registration, :paypal), params: payload
     end
 
     it 'creates a PaypalRecord' do
@@ -1109,20 +1135,20 @@ RSpec.describe "registrations" do
     let!(:registration) { FactoryBot.create(:registration, competition: competition, user: user) }
 
     before :each do
-      sign_in user # TODO: Why do we need to sign in here?
+      sign_in user
 
       stubbed_order = create_order_payload(
         PaypalRecord.amount_to_paypal(competition.base_entry_fee_lowest_denomination, competition.currency_code),
         competition.currency_code,
       )
 
-      order_url = "#{EnvConfig.PAYPAL_BASE_URL}/v2/checkout/orders"
-      stub_request(:post, order_url)
+      create_order_url = "#{EnvConfig.PAYPAL_BASE_URL}/v2/checkout/orders"
+      stub_request(:post, create_order_url)
         .to_return(status: 200, body: stubbed_order, headers: { 'Content-Type' => 'application/json' })
 
-      # Create a PaypalOrder - TODO: maybe we only need to create a PaypalRecord object?
-      payload = { amount: competition.base_entry_fee_lowest_denomination, currency_code: competition.currency_code }
-      post registration_create_paypal_order_path(registration.id), params: payload
+      # Create a PaypalOrder
+      payload = { amount: competition.base_entry_fee_lowest_denomination }
+      post registration_payment_intent_path(registration, :paypal), params: payload
 
       # Stub the create order response
       @record_id = JSON.parse(stubbed_order)['id']
@@ -1167,20 +1193,20 @@ RSpec.describe "registrations" do
     let!(:registration) { FactoryBot.create(:registration, competition: competition, user: user) }
 
     before :each do
-      sign_in user # TODO: Why do we need to sign in here?
+      sign_in user
 
       stubbed_order = create_order_payload(
         PaypalRecord.amount_to_paypal(competition.base_entry_fee_lowest_denomination, competition.currency_code),
         competition.currency_code,
       )
 
-      order_url = "#{EnvConfig.PAYPAL_BASE_URL}/v2/checkout/orders"
-      stub_request(:post, order_url)
+      create_order_url = "#{EnvConfig.PAYPAL_BASE_URL}/v2/checkout/orders"
+      stub_request(:post, create_order_url)
         .to_return(status: 200, body: stubbed_order, headers: { 'Content-Type' => 'application/json' })
 
-      # Create a PaypalOrder - TODO: maybe we only need to create a PaypalRecord object?
-      payload = { amount: competition.base_entry_fee_lowest_denomination, currency_code: competition.currency_code }
-      post registration_create_paypal_order_path(registration.id), params: payload
+      # Create a PaypalOrder
+      payload = { amount: competition.base_entry_fee_lowest_denomination }
+      post registration_payment_intent_path(registration, :paypal), params: payload
 
       # Stub the create order response
       @record_id = JSON.parse(stubbed_order)['id']


### PR DESCRIPTION
Same idea as #9539 

Partial implementation of #9208 