### PR TITLE
Remove user-roles fetch from user API

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -51,19 +51,6 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     render json: roles.first(100)
   end
 
-  # Returns a list of roles primarily based on userId.
-  def index_for_user
-    user_id = params.require(:user_id)
-    user = User.find(user_id)
-    roles = user.roles
-
-    # Filter & Sort roles
-    roles = UserRole.filter_roles(roles, current_user, params)
-    roles = UserRole.sort_roles(roles, params[:sort])
-
-    render json: roles
-  end
-
   # Returns a list of roles primarily based on groupId.
   def index_for_group
     group_id = params.require(:group_id)

--- a/app/webpacker/components/Panel/Leader/GroupsManager.jsx
+++ b/app/webpacker/components/Panel/Leader/GroupsManager.jsx
@@ -155,10 +155,9 @@ export function GroupsManagerForGroups({ groups }) {
 }
 
 export default function GroupsManager({ loggedInUserId }) {
-  const { data: roles, loading, error } = useLoadedData(apiV0Urls.userRoles.listOfUser(
-    loggedInUserId,
+  const { data: roles, loading, error } = useLoadedData(apiV0Urls.userRoles.list(
+    { isActive: true, status: 'leader', userId: loggedInUserId },
     'groupName', // Sort params
-    { isActive: true, status: 'leader' },
   ));
 
   if (loading) return <Loading />;

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -196,7 +196,6 @@ export const apiV0Urls = {
   },
   userRoles: {
     list: ({isActive, isGroupHidden, userId, groupId, status, groupType, isLead} = {}, sort) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId, groupId, status, groupType, isLead })}`,
-    listOfUser: (userId, sort, {isActive, status, groupType} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_user_path('${userId}')) %>?${jsonToQueryString({ sort, isActive, status, groupType })}`,
     listOfGroup: (groupId, sort, {isActive, status, isLead} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_path('${groupId}')) %>?${jsonToQueryString({ sort, isActive, status, isLead })}`,
     listOfGroupType: (groupType, sort, {status, isActive} = {}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_index_for_group_type_path('${groupType}')) %>?${jsonToQueryString({ sort, status, isActive })}`,
     create: () => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>`,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -388,7 +388,6 @@ Rails.application.routes.draw do
       post '/registration-data' => 'competitions#registration_data', as: :registration_data
 
       scope 'user_roles' do
-        get '/user/:user_id' => 'user_roles#index_for_user', as: :index_for_user
         get '/group/:group_id' => 'user_roles#index_for_group', as: :index_for_group
         get '/group-type/:group_type' => 'user_roles#index_for_group_type', as: :index_for_group_type
         get '/search' => 'user_roles#search', as: :user_roles_search

--- a/spec/controllers/api/v0/user_roles_controller_spec.rb
+++ b/spec/controllers/api/v0/user_roles_controller_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe Api::V0::UserRolesController do
         expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)
       end
 
-      it 'fetches list of roles of a user using index_for_user' do
-        get :index_for_user, params: { user_id: user_whose_delegate_status_changes.id }
-
-        expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)
-      end
-
       it 'does not fetches list of banned competitos' do
         get :index_for_group_type, params: { group_type: UserGroup.group_types[:banned_competitors] }
 
@@ -47,7 +41,7 @@ RSpec.describe Api::V0::UserRolesController do
       sign_in { FactoryBot.create(:user) }
 
       it 'fetches list of roles of a user' do
-        get :index_for_user, params: { user_id: user_whose_delegate_status_changes.id }
+        get :index, params: { userId: user_whose_delegate_status_changes.id }
 
         expect(response.body).to eq(user_whose_delegate_status_changes.active_roles.to_json)
       end


### PR DESCRIPTION
In favor of the new user-roles API, replacing the usages of index_for_user with index