### PR TITLE
Sunset old Universal Analytics property in favor of new GA4 Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,6 +78,8 @@
       window.wca.gtag = gtag;
       gtag('js', new Date());
       gtag('config', 'G-QB1H9R123K', { 'anonymize_ip': true });
+      // as per https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced
+      //   this is being overridden by the `cookies-eu-acknowledged` event listener of our cookie banner
       const consentValue = '<%= current_user&.cookies_acknowledged? ? 'granted' : 'denied' %>';
       gtag('consent', 'default', {
         'ad_storage': consentValue,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,17 +70,6 @@
   <%= auto_discovery_link_tag(:rss, rss_url(format: :xml)) %>
   <% if EnvConfig.WCA_LIVE_SITE? %>
     <script data-ad-client="ca-pub-8682718775826560" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-    <!-- Legacy GA property still active for transitioning numbers -->
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-41256017-1', 'auto');
-      ga("set", "anonymizeIp", true);
-      ga('send', 'pageview');
-    </script>
     <!-- New Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-QB1H9R123K"></script>
     <script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,8 +75,16 @@
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
+      window.wca.gtag = gtag;
       gtag('js', new Date());
       gtag('config', 'G-QB1H9R123K', { 'anonymize_ip': true });
+      const consentValue = '<%= current_user&.cookies_acknowledged? ? 'granted' : 'denied' %>';
+      gtag('consent', 'default', {
+        'ad_storage': consentValue,
+        'ad_user_data': consentValue,
+        'ad_personalization': consentValue,
+        'analytics_storage': consentValue,
+      });
     </script>
   <% end %>
 </head>

--- a/app/webpacker/lib/acknowledge-cookies.js
+++ b/app/webpacker/lib/acknowledge-cookies.js
@@ -12,4 +12,13 @@ document.addEventListener('cookies-eu-acknowledged', async () => {
   if (!response.ok) {
     throw new Error(`${response.status}: ${response.statusText}\n${json.error}`);
   }
+
+  if (window.wca.gtag) {
+    window.wca.gtag('consent', 'update', {
+      ad_user_data: 'granted',
+      ad_personalization: 'granted',
+      ad_storage: 'granted',
+      analytics_storage: 'granted',
+    });
+  }
 });


### PR DESCRIPTION
We've had the new property run and record data for a long time now.
Also, the new GA4 allows for more fine-grained access models, which is great for GDPR.