### PR TITLE
Switch out Root CA for RDS in PMA and add PMA deploy action

### DIFF
--- a/.github/workflows/deploy-pma.yml
+++ b/.github/workflows/deploy-pma.yml
@@ -27,3 +27,6 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:pma
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Deploy new PMA Image
+        run: |
+          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-prod-auxiliary-services --force-new-deployment

--- a/.github/workflows/deploy-pma.yml
+++ b/.github/workflows/deploy-pma.yml
@@ -1,0 +1,29 @@
+name: Deploy PMA
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.CI_CD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_CD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and Push PMA image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: ./docker
+          file: ./docker/Dockerfile.pma
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:pma
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/load-ca-and-start.sh
+++ b/docker/load-ca-and-start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Download the RDS ca
-curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /etc/phpmyadmin/rds_ca.pem
+curl https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /etc/phpmyadmin/rds_ca.pem
 
 # Execute the original entrypoint script with its CMD
 exec /docker-entrypoint.sh "$@"


### PR DESCRIPTION
Enables us to update the root CA for RDS. Also added an action so we don't have to manually deploy PMA from the terminal