### PR TITLE
Adding message to recipients in role change emails

### DIFF
--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -27,31 +27,91 @@ class RoleChangeMailer < ApplicationMailer
     # Populate the recepient list.
     case role.group.group_type
     when UserGroup.group_types[:delegate_probation]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, role.user.senior_delegates.map(&:email)].flatten
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as a Delegate has been put in probation.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: 'Senior Delegates',
+          email: role.user.senior_delegates.map(&:email),
+          message: 'Informing as one of the Delegates under you has been put in probation.',
+        ),
+      ]
     when UserGroup.group_types[:delegate_regions]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, UserGroup.teams_committees_group_wfc.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there is a new Delegate appointment.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest and if necessary create a GSuite account.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_wfc.name,
+          email: UserGroup.teams_committees_group_wfc.metadata.email,
+          message: 'Please add the Delegate to xero contacts if necessary.',
+        ),
+      ]
     when UserGroup.group_types[:translators]
-      to_list = [user_who_made_the_change.email, UserGroup.teams_committees_group_wst.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_wst.name,
+          email: UserGroup.teams_committees_group_wst.metadata.email,
+          message: 'Informing as there is a new website translator.',
+        ),
+      ]
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, role.group.lead_user.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there is a new appointment in a Team/Committee/Council.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: 'Team/Committee/Council Leader',
+          email: role.group.lead_user.email,
+          message: 'Informing as there is a new appointment in your Team/Committee/Council.',
+        ),
+      ]
     when UserGroup.group_types[:board], UserGroup.group_types[:officers]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there is a new appointment in Board/Officers.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest.',
+        ),
+      ]
     when UserGroup.group_types[:banned_competitors]
-      to_list = [user_who_made_the_change.email, UserGroup.teams_committees_group_wdc.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: 'WDC',
+          email: UserGroup.teams_committees_group_wdc.metadata.email,
+          message: 'Informing as a competitor is newly banned.',
+        ),
+      ]
     else
       raise "Unknown/Unhandled group type: #{role.group.group_type}"
     end
 
     # Send email.
     mail(
-      to: to_list.compact.uniq,
-      reply_to: reply_to_list.compact.uniq,
+      to: [user_who_made_the_change.email, @to_list.map(&:email)].flatten.compact.uniq,
+      reply_to: [user_who_made_the_change.email],
       subject: "New role added for #{role.user.name} in #{@group_type_name}",
     )
   end
@@ -66,25 +126,70 @@ class RoleChangeMailer < ApplicationMailer
     # Populate the recepient list.
     case role.group_type
     when UserGroup.group_types[:delegate_probation]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, role.user.senior_delegates.map(&:email)].flatten
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there was a change in Delegate probations.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: 'Senior Delegates',
+          email: role.user.senior_delegates.map(&:email),
+          message: 'Informing as there was a change in the probation status for one of the Delegates under you.',
+        ),
+      ]
     when UserGroup.group_types[:delegate_regions]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, UserGroup.teams_committees_group_wfc.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there was a change in Delegates.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest and if necessary create a GSuite account.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_wfc.name,
+          email: UserGroup.teams_committees_group_wfc.metadata.email,
+          message: 'Please add the Delegate to xero contacts if necessary.',
+        ),
+      ]
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, role.group.lead_user.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there was a change in a Team/Committee/Council.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: 'Team/Committee/Council Leader',
+          email: role.group.lead_user.email,
+          message: 'Informing as there was a change in your Team/Committee/Council.',
+        ),
+      ]
     when UserGroup.group_types[:banned_competitors]
-      to_list = [user_who_made_the_change.email, UserGroup.teams_committees_group_wdc.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: 'WDC',
+          email: UserGroup.teams_committees_group_wdc.metadata.email,
+          message: 'Informing as there was a change in banned details of a competitor.',
+        ),
+      ]
     else
       raise "Unknown/Unhandled group type: #{role.group_type}"
     end
 
     # Send email.
     mail(
-      to: to_list.compact.uniq,
-      reply_to: reply_to_list.compact.uniq,
+      to: [user_who_made_the_change.email, @to_list.map(&:email)].flatten.compact.uniq,
+      reply_to: [user_who_made_the_change.email],
       subject: "Role changed for #{role.user.name} in #{@group_type_name}",
     )
   end
@@ -98,25 +203,70 @@ class RoleChangeMailer < ApplicationMailer
     # Populate the recepient list.
     case role.group_type
     when UserGroup.group_types[:delegate_regions]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, UserGroup.teams_committees_group_wfc.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there is a role end action for a Delegate.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest and if necessary suspend the GSuite & Slack account.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_wfc.name,
+          email: UserGroup.teams_committees_group_wfc.metadata.email,
+          message: 'Please take necessary action if there is a pending dues for the Delegate whose role is ended.',
+        ),
+      ]
     when UserGroup.group_types[:translators]
-      to_list = [user_who_made_the_change.email, UserGroup.teams_committees_group_wst.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_wst.name,
+          email: UserGroup.teams_committees_group_wst.metadata.email,
+          message: 'Informing as the role ended for a website translator.',
+        ),
+      ]
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, role.group.lead_user.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there was a role end in a Team/Committee/Council.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest and if necessary suspend the GSuite & Slack account.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: 'Team/Committee/Council Leader',
+          email: role.group.lead_user.email,
+          message: 'Informing as there is a role end in your Team/Committee/Council.',
+        ),
+      ]
     when UserGroup.group_types[:board], UserGroup.group_types[:officers]
-      to_list = [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email]
-      reply_to_list = [user_who_made_the_change.email]
+      @to_list = [
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.board_group.name,
+          email: GroupsMetadataBoard.email,
+          message: 'Informing as there is a role end in Board/Officers.',
+        ),
+        UserRole::UserRoleEmailRecipient.new(
+          name: UserGroup.teams_committees_group_weat.name,
+          email: UserGroup.teams_committees_group_weat.metadata.email,
+          message: 'Please add this to monthly digest.',
+        ),
+      ]
     else
       raise "Unknown/Unhandled group type: #{role.group.group_type}"
     end
 
     # Send email.
     mail(
-      to: to_list.compact.uniq,
-      reply_to: reply_to_list.compact.uniq,
+      to: [user_who_made_the_change.email, @to_list.map(&:email)].flatten.compact.uniq,
+      reply_to: [user_who_made_the_change.email],
       subject: "Role removed for #{role.user.name} in #{@group_type_name}",
     )
   end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -20,6 +20,12 @@ class UserRole < ApplicationRecord
     keyword_init: true,
   )
 
+  UserRoleEmailRecipient = Struct.new(
+    :name,
+    :email,
+    :message,
+  )
+
   STATUS_RANK = {
     UserGroup.group_types[:delegate_regions].to_sym => [
       RolesMetadataDelegateRegions.statuses[:trainee_delegate],

--- a/app/views/role_change_mailer/notify_role_change.erb
+++ b/app/views/role_change_mailer/notify_role_change.erb
@@ -4,3 +4,7 @@
 <% @changes.each do |change| %>
   <p><%= change['changed_parameter'] %>: <%= change['previous_value'] %> -> <%= change['new_value'] %></p>
 <% end %>
+<p>Messages to recipients:</p>
+<% @to_list.each do |recipient| %>
+  <li><%= recipient.name %>: <%= recipient.message %></li>
+<% end %>

--- a/app/views/role_change_mailer/notify_role_end.erb
+++ b/app/views/role_change_mailer/notify_role_end.erb
@@ -8,3 +8,7 @@
     <% end %>
   </ul>
 <% end %>
+<p>Messages to recipients:</p>
+<% @to_list.each do |recipient| %>
+  <li><%= recipient.name %>: <%= recipient.message %></li>
+<% end %>

--- a/app/views/role_change_mailer/notify_role_start.erb
+++ b/app/views/role_change_mailer/notify_role_start.erb
@@ -8,3 +8,7 @@
     <% end %>
   </ul>
 <% end %>
+<p>Messages to recipients:</p>
+<% @to_list.each do |recipient| %>
+  <li><%= recipient.name %>: <%= recipient.message %></li>
+<% end %>


### PR DESCRIPTION
This is to inform in the role change emails on why the email is sent to different groups. The message will be improved further in future. This message will help them to know whether any action is required from them.