### PR TITLE
Fix for comp page not rendering if there is no winner

### DIFF
--- a/app/helpers/competitions_helper.rb
+++ b/app/helpers/competitions_helper.rb
@@ -62,8 +62,10 @@ module CompetitionsHelper
   def winners(competition, main_event)
     top_three = competition.results.where(event: main_event).podium.order(:pos)
     results_by_place = top_three.group_by(&:pos)
-    winners = results_by_place[1]
 
+    return t('competitions.competition_info.no_winner', event_name: main_event.name) unless results_by_place.present?
+
+    winners = results_by_place[1]
     text = t('competitions.competition_info.winner', winner: people_to_sentence(winners),
                                                      result_sentence: pretty_print_result(winners.first),
                                                      event_name: main_event.name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1439,6 +1439,7 @@ en:
       average: "an average"
       mean: "a mean"
       result_sentence: "with %{a_win_by_word} of %{result}"
+      no_winner: The main event was %{event_name}. No winner was declared, as no competitors achieved successful results in the event.
       winner: "%{winner} won %{result_sentence} in the %{event_name} event."
       first_runner_up: "%{first_runner_up} finished second (%{first_runner_up_result})"
       and: "and"


### PR DESCRIPTION
Address issue raised in email: "Re: Results for Hilliard Hippocampus XV - Summer Solstice 2024"

Have tested locally and ensured that the following cases all work as expected: 
- [x] No winner (no results)
- [x] No winner (all DNF)
- [x] No winner (all DNS)
- [x] No winner (mix of DNF/DNS)
- [x] only 1st
- [x] only 1st and 2nd
- [x] full podium