### PR TITLE
Add error to contact form if submission fails

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -67,7 +67,7 @@ class ContactsController < ApplicationController
     contact_params = formValues[contact_recipient.to_sym]
     requestor_details = current_user || formValues[:userData]
 
-    render status: :bad_request, json: { error: "Invalid arguments" } if contact_recipient.nil? || contact_params.nil? || requestor_details.nil?
+    return render status: :bad_request, json: { error: "Invalid arguments" } if contact_recipient.nil? || contact_params.nil? || requestor_details.nil?
 
     case contact_recipient
     when UserGroup.teams_committees_group_wct.metadata.friendly_id

--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -16,6 +16,7 @@ import Wct from './SubForms/Wct';
 import Wrt from './SubForms/Wrt';
 import Wst from './SubForms/Wst';
 import Competition from './SubForms/Competition';
+import Errored from '../Requests/Errored';
 
 const CONTACT_RECIPIENTS = [
   'competition',
@@ -30,6 +31,7 @@ export default function ContactForm({ loggedInUserData }) {
   const { save, saving } = useSaveAction();
   const [captchaValue, setCaptchaValue] = useState();
   const [captchaError, setCaptchaError] = useState(false);
+  const [saveError, setSaveError] = useState();
   const [contactSuccess, setContactSuccess] = useState(false);
   const contactFormState = useStore();
   const dispatch = useDispatch();
@@ -66,6 +68,7 @@ export default function ContactForm({ loggedInUserData }) {
   }, [selectedContactRecipient]);
 
   if (saving) return <Loading />;
+  if (saveError) return <Errored error={saveError} />;
 
   return (
     <>
@@ -85,6 +88,7 @@ export default function ContactForm({ loggedInUserData }) {
               formData,
               contactSuccessHandler,
               { method: 'POST', headers: {}, body: formData },
+              setSaveError,
             );
           }
         }}


### PR DESCRIPTION
Currently if there is an error for the contact form submission, we are not informing the user of the same. This PR is to achieve that.