### PR TITLE
Add WRT to role change emails

### DIFF
--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class RoleChangeMailer < ApplicationMailer
+  private def wrt_email_recipient
+    UserRole::UserRoleEmailRecipient.new(
+      name: UserGroup.teams_committees_group_wrt.name,
+      email: UserGroup.teams_committees_group_wrt.metadata.email,
+      message: 'Please take action if this role change is inconsistent or accidental.',
+    )
+  end
+
   private def role_metadata(role)
     metadata = {}
     group = role.group
@@ -23,13 +31,7 @@ class RoleChangeMailer < ApplicationMailer
     @user_who_made_the_change = user_who_made_the_change
     @group_type_name = UserGroup.group_type_name[@role.group.group_type.to_sym]
     @metadata = role_metadata(role)
-    @to_list = [
-      UserRole::UserRoleEmailRecipient.new(
-        name: UserGroup.teams_committees_group_wrt.name,
-        email: UserGroup.teams_committees_group_wrt.metadata.email,
-        message: 'Please take action if this role change is inconsistent or accidental.',
-      ),
-    ]
+    @to_list = [wrt_email_recipient]
 
     # Populate the recepient list.
     case role.group.group_type
@@ -129,13 +131,7 @@ class RoleChangeMailer < ApplicationMailer
     @changes = JSON.parse changes
     @group_type_name = UserGroup.group_type_name[role.group_type.to_sym]
     @today_date = Date.today
-    @to_list = [
-      UserRole::UserRoleEmailRecipient.new(
-        name: UserGroup.teams_committees_group_wrt.name,
-        email: UserGroup.teams_committees_group_wrt.metadata.email,
-        message: 'Please take action if this role change is inconsistent or accidental.',
-      ),
-    ]
+    @to_list = [wrt_email_recipient]
 
     # Populate the recepient list.
     case role.group_type
@@ -213,13 +209,7 @@ class RoleChangeMailer < ApplicationMailer
     @user_who_made_the_change = user_who_made_the_change
     @group_type_name = UserGroup.group_type_name[role.group_type.to_sym]
     @metadata = role_metadata(role)
-    @to_list = [
-      UserRole::UserRoleEmailRecipient.new(
-        name: UserGroup.teams_committees_group_wrt.name,
-        email: UserGroup.teams_committees_group_wrt.metadata.email,
-        message: 'Please take action if this role change is inconsistent or accidental.',
-      ),
-    ]
+    @to_list = [wrt_email_recipient]
 
     # Populate the recepient list.
     case role.group_type

--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -23,11 +23,18 @@ class RoleChangeMailer < ApplicationMailer
     @user_who_made_the_change = user_who_made_the_change
     @group_type_name = UserGroup.group_type_name[@role.group.group_type.to_sym]
     @metadata = role_metadata(role)
+    @to_list = [
+      UserRole::UserRoleEmailRecipient.new(
+        name: UserGroup.teams_committees_group_wrt.name,
+        email: UserGroup.teams_committees_group_wrt.metadata.email,
+        message: 'Please take action if this role change is inconsistent or accidental.',
+      ),
+    ]
 
     # Populate the recepient list.
     case role.group.group_type
     when UserGroup.group_types[:delegate_probation]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -38,9 +45,9 @@ class RoleChangeMailer < ApplicationMailer
           email: role.user.senior_delegates.map(&:email),
           message: 'Informing as one of the Delegates under you has been put in probation.',
         ),
-      ]
+      )
     when UserGroup.group_types[:delegate_regions]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -56,17 +63,17 @@ class RoleChangeMailer < ApplicationMailer
           email: UserGroup.teams_committees_group_wfc.metadata.email,
           message: 'Please add the Delegate to xero contacts if necessary.',
         ),
-      ]
+      )
     when UserGroup.group_types[:translators]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.teams_committees_group_wst.name,
           email: UserGroup.teams_committees_group_wst.metadata.email,
           message: 'Informing as there is a new website translator.',
         ),
-      ]
+      )
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -82,9 +89,9 @@ class RoleChangeMailer < ApplicationMailer
           email: role.group.lead_user.email,
           message: 'Informing as there is a new appointment in your Team/Committee/Council.',
         ),
-      ]
+      )
     when UserGroup.group_types[:board], UserGroup.group_types[:officers]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -95,15 +102,15 @@ class RoleChangeMailer < ApplicationMailer
           email: UserGroup.teams_committees_group_weat.metadata.email,
           message: 'Please add this to monthly digest.',
         ),
-      ]
+      )
     when UserGroup.group_types[:banned_competitors]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: 'WDC',
           email: UserGroup.teams_committees_group_wdc.metadata.email,
           message: 'Informing as a competitor is newly banned.',
         ),
-      ]
+      )
     else
       raise "Unknown/Unhandled group type: #{role.group.group_type}"
     end
@@ -122,11 +129,18 @@ class RoleChangeMailer < ApplicationMailer
     @changes = JSON.parse changes
     @group_type_name = UserGroup.group_type_name[role.group_type.to_sym]
     @today_date = Date.today
+    @to_list = [
+      UserRole::UserRoleEmailRecipient.new(
+        name: UserGroup.teams_committees_group_wrt.name,
+        email: UserGroup.teams_committees_group_wrt.metadata.email,
+        message: 'Please take action if this role change is inconsistent or accidental.',
+      ),
+    ]
 
     # Populate the recepient list.
     case role.group_type
     when UserGroup.group_types[:delegate_probation]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -137,9 +151,9 @@ class RoleChangeMailer < ApplicationMailer
           email: role.user.senior_delegates.map(&:email),
           message: 'Informing as there was a change in the probation status for one of the Delegates under you.',
         ),
-      ]
+      )
     when UserGroup.group_types[:delegate_regions]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -155,9 +169,9 @@ class RoleChangeMailer < ApplicationMailer
           email: UserGroup.teams_committees_group_wfc.metadata.email,
           message: 'Please add the Delegate to xero contacts if necessary.',
         ),
-      ]
+      )
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -173,15 +187,15 @@ class RoleChangeMailer < ApplicationMailer
           email: role.group.lead_user.email,
           message: 'Informing as there was a change in your Team/Committee/Council.',
         ),
-      ]
+      )
     when UserGroup.group_types[:banned_competitors]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: 'WDC',
           email: UserGroup.teams_committees_group_wdc.metadata.email,
           message: 'Informing as there was a change in banned details of a competitor.',
         ),
-      ]
+      )
     else
       raise "Unknown/Unhandled group type: #{role.group_type}"
     end
@@ -199,11 +213,18 @@ class RoleChangeMailer < ApplicationMailer
     @user_who_made_the_change = user_who_made_the_change
     @group_type_name = UserGroup.group_type_name[role.group_type.to_sym]
     @metadata = role_metadata(role)
+    @to_list = [
+      UserRole::UserRoleEmailRecipient.new(
+        name: UserGroup.teams_committees_group_wrt.name,
+        email: UserGroup.teams_committees_group_wrt.metadata.email,
+        message: 'Please take action if this role change is inconsistent or accidental.',
+      ),
+    ]
 
     # Populate the recepient list.
     case role.group_type
     when UserGroup.group_types[:delegate_regions]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -219,17 +240,17 @@ class RoleChangeMailer < ApplicationMailer
           email: UserGroup.teams_committees_group_wfc.metadata.email,
           message: 'Please take necessary action if there is a pending dues for the Delegate whose role is ended.',
         ),
-      ]
+      )
     when UserGroup.group_types[:translators]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.teams_committees_group_wst.name,
           email: UserGroup.teams_committees_group_wst.metadata.email,
           message: 'Informing as the role ended for a website translator.',
         ),
-      ]
+      )
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -245,9 +266,9 @@ class RoleChangeMailer < ApplicationMailer
           email: role.group.lead_user.email,
           message: 'Informing as there is a role end in your Team/Committee/Council.',
         ),
-      ]
+      )
     when UserGroup.group_types[:board], UserGroup.group_types[:officers]
-      @to_list = [
+      @to_list.push(
         UserRole::UserRoleEmailRecipient.new(
           name: UserGroup.board_group.name,
           email: GroupsMetadataBoard.email,
@@ -258,7 +279,7 @@ class RoleChangeMailer < ApplicationMailer
           email: UserGroup.teams_committees_group_weat.metadata.email,
           message: 'Please add this to monthly digest.',
         ),
-      ]
+      )
     else
       raise "Unknown/Unhandled group type: #{role.group.group_type}"
     end

--- a/spec/mailers/role_change_mailer_spec.rb
+++ b/spec/mailers/role_change_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RoleChangeMailer, type: :mailer do
     let(:mail) { described_class.notify_role_start(role, user_who_made_the_change) }
 
     it 'renders the headers' do
-      expect(mail.to).to match_array [user_who_made_the_change.email, GroupsMetadataBoard.email, senior_delegate.user.email].flatten
+      expect(mail.to).to match_array [user_who_made_the_change.email, GroupsMetadataBoard.email, senior_delegate.user.email, UserGroup.teams_committees_group_wrt.metadata.email].flatten
       expect(mail.reply_to).to match_array [user_who_made_the_change.email]
       expect(mail.subject).to eq "New role added for #{role.user.name} in Delegate Probation"
     end
@@ -29,7 +29,7 @@ RSpec.describe RoleChangeMailer, type: :mailer do
     let(:mail) { described_class.notify_role_start(role, senior_delegate.user) }
 
     it 'renders the headers' do
-      expect(mail.to).to match_array [GroupsMetadataBoard.email, senior_delegate.user.email]
+      expect(mail.to).to match_array [GroupsMetadataBoard.email, senior_delegate.user.email, UserGroup.teams_committees_group_wrt.metadata.email]
       expect(mail.reply_to).to match_array [senior_delegate.user.email]
       expect(mail.subject).to eq "New role added for #{role.user.name} in Delegate Probation"
     end
@@ -48,7 +48,7 @@ RSpec.describe RoleChangeMailer, type: :mailer do
     let(:mail) { described_class.notify_role_change(role, user_who_made_the_change, [UserRole::UserRoleChange.new(changed_parameter: 'End Date', previous_value: 'Empty', new_value: '01-01-2024')].to_json) }
 
     it 'renders the headers' do
-      expect(mail.to).to match_array [user_who_made_the_change.email, GroupsMetadataBoard.email, senior_delegate.user.email].flatten
+      expect(mail.to).to match_array [user_who_made_the_change.email, GroupsMetadataBoard.email, senior_delegate.user.email, UserGroup.teams_committees_group_wrt.metadata.email].flatten
       expect(mail.reply_to).to match_array [user_who_made_the_change.email]
       expect(mail.subject).to eq "Role changed for #{role.user.name} in Delegate Probation"
     end
@@ -65,7 +65,13 @@ RSpec.describe RoleChangeMailer, type: :mailer do
     let(:mail) { described_class.notify_role_end(translator, user_who_made_the_change) }
 
     it 'renders the headers' do
-      expect(mail.to).to match_array [user_who_made_the_change.email, GroupsMetadataBoard.email, UserGroup.teams_committees_group_weat.metadata.email, UserGroup.teams_committees_group_wfc.metadata.email]
+      expect(mail.to).to match_array [
+        user_who_made_the_change.email,
+        GroupsMetadataBoard.email,
+        UserGroup.teams_committees_group_weat.metadata.email,
+        UserGroup.teams_committees_group_wfc.metadata.email,
+        UserGroup.teams_committees_group_wrt.metadata.email,
+      ]
       expect(mail.reply_to).to match_array [user_who_made_the_change.email]
       expect(mail.subject).to eq "Role removed for #{translator.user.name} in Delegate Regions"
     end


### PR DESCRIPTION
Add WRT to the role change emails. This is to handle mistaken role changes. For example, sometimes leaders will accidentally promote wrong person and then undo it and do the correct action. In these cases, the role table gets manipulated with wrong value, which needs to be fixed by WRT.