### PR TITLE
Changing UI layout of contact page

### DIFF
--- a/app/webpacker/components/ContactsPage/index.jsx
+++ b/app/webpacker/components/ContactsPage/index.jsx
@@ -21,7 +21,7 @@ export default function ContactsPage() {
       reducer={contactsReducer}
       initialState={getContactFormInitialState(loggedInUserData, queryParams)}
     >
-      <Container fluid>
+      <Container text>
         <Header as="h2">{I18n.t('page.contacts.title')}</Header>
         <Message visible>
           <I18nHTMLTranslate


### PR DESCRIPTION
This was a suggestion by @coder13 and I would like to get more suggestion whether this implementation is fine or whether you prefer the alternative solution (screenshot attached below)

Current
<img width="1512" alt="Screenshot 2024-06-24 at 6 38 21 AM" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/82743e7c-e0e8-4aeb-87c6-f62ab8f02aa7">

New
<img width="1509" alt="Screenshot 2024-06-24 at 6 38 49 AM" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/f23052dc-40df-415c-a5d0-4a5d59582e39">

Alternative
<img width="1512" alt="Screenshot 2024-06-24 at 6 39 43 AM" src="https://github.com/thewca/worldcubeassociation.org/assets/9512698/f81f8450-1ae2-4d2e-9b80-1596b645f66e">

To change to alternative, the 'text' flag has to be removed from Container.