### PR TITLE
Added banned competitors group name in group_type_name

### DIFF
--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -74,6 +74,7 @@ class UserGroup < ApplicationRecord
       translators: "Translators",
       board: "Board",
       officers: "Officers",
+      banned_competitors: "Banned Competitors",
     }
   end
 


### PR DESCRIPTION
This was raised by WDC leader as the name was not shown in the role change email subject.