### PR TITLE
Fixed logic of at_least_senior_member?

### DIFF
--- a/app/models/roles_metadata_teams_committees.rb
+++ b/app/models/roles_metadata_teams_committees.rb
@@ -11,6 +11,6 @@ class RolesMetadataTeamsCommittees < ApplicationRecord
   has_one :user, through: :user_role
 
   def at_least_senior_member?
-    user_role.status_rank <= UserRole.status_rank(UserGroup.group_types[:teams_committees], RolesMetadataTeamsCommittees.statuses[:senior_member])
+    user_role.status_rank >= UserRole.status_rank(UserGroup.group_types[:teams_committees], RolesMetadataTeamsCommittees.statuses[:senior_member])
   end
 end

--- a/spec/models/roles_metadata_teams_committees_spec.rb
+++ b/spec/models/roles_metadata_teams_committees_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RolesMetadataTeamsCommittees, type: :model do
+  describe 'at_least_senior_member?' do
+    it 'returns false when the role is a WRC member' do
+      role = FactoryBot.create(:user_role, :active, :wrc_member)
+      expect(role.metadata.at_least_senior_member?).to be false
+    end
+
+    it 'returns true when the role is a WRC senior member' do
+      role = FactoryBot.create(:user_role, :active, :wrc_senior_member)
+      expect(role.metadata.at_least_senior_member?).to be true
+    end
+
+    it 'returns true when the role is a WRC leader' do
+      role = FactoryBot.create(:user_role, :active, :wrc_leader)
+      expect(role.metadata.at_least_senior_member?).to be true
+    end
+  end
+end


### PR DESCRIPTION
The logic of status rank was changed few days ago and this was a section which was missed.