### PR TITLE
Optimize queries for new competitions list page

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -162,7 +162,7 @@ class Api::V0::ApiController < ApplicationController
   def delegates_search_index
     # TODO: There is a `uniq` call at the end which I feel shouldn't be necessary?!
     #   Postponing investigation until the Roles system migration is complete.
-    all_delegates = UserGroup.includes(roles: [:user]).delegate_regions.flat_map(&:active_users).uniq
+    all_delegates = UserGroup.includes(:active_users).delegate_regions.flat_map(&:active_users).uniq
 
     search_index = all_delegates.map do |delegate|
       delegate.slice(:id, :name, :wca_id).merge({ thumb_url: delegate.avatar.url(:thumb) })

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -17,6 +17,24 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     paginate json: competitions
   end
 
+  def competition_index
+    competitions = Competition.includes(:events)
+                              .search(params[:q], params: params)
+
+    serial_methods = ["url", "short_name", "short_display_name", "city", "venue_address", "venue_details", "country_iso2", "event_ids", "date_range", "latitude_degrees", "longitude_degrees"]
+    serial_includes = {}
+
+    admin_mode = current_user.can_see_admin_competitions?
+
+    serial_includes["delegates"] = { only: ["id", "name"], include: ["avatar"] } if admin_mode
+    serial_methods |= ["announced_at", "results_submitted_at"] if admin_mode
+
+    paginate json: competitions,
+             only: ["id", "name", "start_date", "end_date", "registration_open", "registration_close", "venue"],
+             methods: serial_methods,
+             include: serial_includes
+  end
+
   def show
     competition = competition_from_params
 

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -26,8 +26,10 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
     admin_mode = current_user.can_see_admin_competitions?
 
+    competitions = competitions.includes(:delegate_report) if admin_mode
+
     serial_includes["delegates"] = { only: ["id", "name"], include: ["avatar"] } if admin_mode
-    serial_methods |= ["announced_at", "results_submitted_at"] if admin_mode
+    serial_methods |= ["announced_at", "results_submitted_at", "report_posted_at"] if admin_mode
 
     paginate json: competitions,
              only: ["id", "name", "start_date", "end_date", "registration_open", "registration_close", "venue"],

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -21,7 +21,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     competitions = Competition.includes(:events)
                               .search(params[:q], params: params)
 
-    serial_methods = ["url", "short_name", "short_display_name", "city", "venue_address", "venue_details", "country_iso2", "event_ids", "date_range", "latitude_degrees", "longitude_degrees"]
+    serial_methods = ["short_display_name", "city", "country_iso2", "event_ids", "date_range", "latitude_degrees", "longitude_degrees"]
     serial_includes = {}
 
     admin_mode = current_user.can_see_admin_competitions?

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -24,7 +24,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     serial_methods = ["short_display_name", "city", "country_iso2", "event_ids", "date_range", "latitude_degrees", "longitude_degrees"]
     serial_includes = {}
 
-    admin_mode = current_user.can_see_admin_competitions?
+    admin_mode = current_user&.can_see_admin_competitions?
 
     competitions = competitions.includes(:delegate_report) if admin_mode
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -16,7 +16,7 @@ class Competition < ApplicationRecord
   has_many :competitors, -> { distinct }, through: :results, source: :person
   has_many :competitor_users, -> { distinct }, through: :competitors, source: :user
   has_many :competition_delegates, dependent: :delete_all
-  has_many :delegates, -> { includes(:delegate_role_metadata) }, through: :competition_delegates
+  has_many :delegates, -> { includes(:delegate_roles, :delegate_role_metadata) }, through: :competition_delegates
   has_many :competition_organizers, dependent: :delete_all
   has_many :organizers, through: :competition_organizers
   has_many :media, class_name: "CompetitionMedium", foreign_key: "competitionId", dependent: :delete_all
@@ -2163,9 +2163,12 @@ class Competition < ApplicationRecord
     # in the json (eg: specify an empty 'methods' to remove these attributes,
     # or set a custom array in 'only' without getting the default ones), therefore
     # we only use 'merge' here, which doesn't "deeply" merge into the default options.
-    json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
-    # Fallback to the default 'serializable_hash' method, but always include our
-    # custom 'class' attribute.
+    options = DEFAULT_SERIALIZE_OPTIONS.merge(options || {}).deep_dup
+
+    # Fallback to the default 'serializable_hash' method BUT...
+    json = super
+
+    # ...always include our custom 'class' attribute.
     # We can't put that in our DEFAULT_SERIALIZE_OPTIONS because the 'class'
     # method already exists, and we definitely don't want to override it, nor do
     # we want to change the existing behavior of our API which returns a string.

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -802,6 +802,10 @@ class Competition < ApplicationRecord
     end
   end
 
+  def report_posted_at
+    delegate_report&.posted_at
+  end
+
   # This callback updates all tables having the competition id, when the id changes.
   # This should be deleted after competition id is made immutable: https://github.com/thewca/worldcubeassociation.org/pull/381
   after_save :update_foreign_keys, if: :saved_change_to_id?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1148,7 +1148,7 @@ class User < ApplicationRecord
       default_options[:methods].push("email", "location", "region_id")
     end
 
-    options = default_options.merge(options || {})
+    options = default_options.merge(options || {}).deep_dup
     # Preempt the values for avatar and teams, they have a special treatment.
     include_avatar = options[:include]&.delete("avatar")
     include_teams = options[:include]&.delete("teams")

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -64,7 +64,7 @@ function CompetitionsView({ canViewAdminDetails = false }) {
         canViewAdminDetails,
       );
 
-      return fetchJsonOrError(`${apiV0Urls.competitions.list}?${querySearchParams}`);
+      return fetchJsonOrError(`${apiV0Urls.competitions.listIndex}?${querySearchParams}`);
     },
     getNextPageParam: (previousPage, allPages) => {
       // Continue until less than a full page of data is fetched,

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -152,6 +152,7 @@ function CompetitionsView({ canViewAdminDetails = false }) {
                   ))
                   : competitions
               }
+              isLoading={competitionsIsFetching}
               fetchMoreCompetitions={competitionsFetchNextPage}
               hasMoreCompsToLoad={hasMoreCompsToLoad}
             />

--- a/app/webpacker/components/CompetitionsOverview/ListView.js
+++ b/app/webpacker/components/CompetitionsOverview/ListView.js
@@ -21,12 +21,13 @@ function ListView({
   const { ref: bottomRef, inView: bottomInView } = useInView();
 
   useEffect(() => {
-    if (hasMoreCompsToLoad && bottomInView) {
+    if (hasMoreCompsToLoad && bottomInView && !isLoading) {
       fetchMoreCompetitions();
     }
   }, [
-    bottomInView,
     hasMoreCompsToLoad,
+    bottomInView,
+    isLoading,
     fetchMoreCompetitions,
     // The bottom ref can still _stay_ in view even after loading new comps.
     //   In that case, the useEffect will not be triggered, so we introduce this extra dependency.

--- a/app/webpacker/components/CompetitionsOverview/ListView.js
+++ b/app/webpacker/components/CompetitionsOverview/ListView.js
@@ -29,9 +29,6 @@ function ListView({
     bottomInView,
     isLoading,
     fetchMoreCompetitions,
-    // The bottom ref can still _stay_ in view even after loading new comps.
-    //   In that case, the useEffect will not be triggered, so we introduce this extra dependency.
-    competitions,
   ]);
 
   switch (filterState.timeOrder) {

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -64,7 +64,7 @@ function ListViewSection({
           isSortedByAnnouncement={isSortedByAnnouncement}
         />
       )}
-      {isLoading && <BarLoader cssOverride={{ width: '100%' }} />}
+      <BarLoader loading={isLoading} cssOverride={{ width: '100%' }} />
     </>
   );
 }

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -20,7 +20,7 @@ import {
   timeDifferenceBefore,
 } from '../../lib/utils/competition-table';
 import { countries } from '../../lib/wca-data.js.erb';
-import { adminCompetitionUrl } from '../../lib/requests/routes.js.erb';
+import { adminCompetitionUrl, competitionUrl } from '../../lib/requests/routes.js.erb';
 
 function ListViewSection({
   competitions,
@@ -158,7 +158,7 @@ export function CompetitionsTable({
               </Table.Cell>
               <Table.Cell width={6}>
                 <Flag name={comp.country_iso2?.toLowerCase()} />
-                <a href={comp.url}>{comp.short_display_name}</a>
+                <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
               <Table.Cell width={4}>
                 <strong>{countries.byIso2[comp.country_iso2].name}</strong>
@@ -214,7 +214,7 @@ export function CompetitionsTabletTable({
               </Table.Cell>
               <Table.Cell width={6}>
                 <Flag name={comp.country_iso2?.toLowerCase()} />
-                <a href={comp.url}>{comp.short_display_name}</a>
+                <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
               <Table.Cell width={7}>
                 <strong>{countries.byIso2[comp.country_iso2].name}</strong>
@@ -259,7 +259,7 @@ export function CompetitionsMobileTable({
               </Table.Cell>
               <Table.Cell>
                 <Flag name={comp.country_iso2?.toLowerCase()} />
-                <a href={comp.url}>{comp.short_display_name}</a>
+                <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
               <Table.Cell>
                 <strong>{countries.byIso2[comp.country_iso2].name}</strong>
@@ -330,7 +330,7 @@ function AdminCompetitionsTable({
                 </Table.Cell>
                 <Table.Cell width={4}>
                   <Flag name={comp.country_iso2?.toLowerCase()} />
-                  <a href={comp.url}>{comp.short_display_name}</a>
+                  <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
                   <br />
                   <strong>{countries.byIso2[comp.country_iso2].name}</strong>
                   {`, ${comp.city}`}

--- a/app/webpacker/components/CompetitionsOverview/MapView.js
+++ b/app/webpacker/components/CompetitionsOverview/MapView.js
@@ -9,6 +9,7 @@ import { redMarker, blueMarker } from '../../lib/leaflet-wca/markers';
 import ResizeMapIFrame from '../../lib/utils/leaflet-iframe';
 import 'leaflet/dist/leaflet.css';
 import { isProbablyOver } from '../../lib/utils/competition-table';
+import { competitionUrl } from '../../lib/requests/routes.js.erb';
 
 // Limit number of markers on map, especially for "All Past Competitions"
 const MAP_DISPLAY_LIMIT = 500;
@@ -44,7 +45,7 @@ function MapView({
             icon={isProbablyOver(comp) ? blueMarker : redMarker}
           >
             <Popup>
-              <a href={comp.url}>{comp.name}</a>
+              <a href={competitionUrl(comp.id)}>{comp.name}</a>
               <br />
               {`${comp.date_range} - ${comp.city}`}
             </Popup>

--- a/app/webpacker/components/CompetitionsOverview/MapView.js
+++ b/app/webpacker/components/CompetitionsOverview/MapView.js
@@ -4,14 +4,13 @@ import {
   MapContainer, TileLayer, Marker, Popup,
 } from 'react-leaflet';
 
+import { BarLoader } from 'react-spinners';
 import { userTileProvider } from '../../lib/leaflet-wca/providers';
 import { redMarker, blueMarker } from '../../lib/leaflet-wca/markers';
 import ResizeMapIFrame from '../../lib/utils/leaflet-iframe';
 import 'leaflet/dist/leaflet.css';
 import { isProbablyOver } from '../../lib/utils/competition-table';
 import { competitionUrl } from '../../lib/requests/routes.js.erb';
-import { Loader } from 'semantic-ui-react';
-import { BarLoader } from 'react-spinners';
 
 // Limit number of markers on map, especially for "All Past Competitions"
 const MAP_DISPLAY_LIMIT = 500;

--- a/app/webpacker/components/CompetitionsOverview/MapView.js
+++ b/app/webpacker/components/CompetitionsOverview/MapView.js
@@ -16,15 +16,20 @@ const MAP_DISPLAY_LIMIT = 500;
 
 function MapView({
   competitions,
+  isLoading,
   fetchMoreCompetitions,
   hasMoreCompsToLoad,
 }) {
   useEffect(() => {
-    if (hasMoreCompsToLoad && competitions?.length < MAP_DISPLAY_LIMIT) {
+    if (hasMoreCompsToLoad && competitions?.length < MAP_DISPLAY_LIMIT && !isLoading) {
       fetchMoreCompetitions();
     }
-  }, [hasMoreCompsToLoad, competitions,
-    fetchMoreCompetitions]);
+  }, [
+    hasMoreCompsToLoad,
+    competitions,
+    isLoading,
+    fetchMoreCompetitions,
+  ]);
 
   const provider = userTileProvider;
 

--- a/app/webpacker/components/CompetitionsOverview/MapView.js
+++ b/app/webpacker/components/CompetitionsOverview/MapView.js
@@ -10,6 +10,8 @@ import ResizeMapIFrame from '../../lib/utils/leaflet-iframe';
 import 'leaflet/dist/leaflet.css';
 import { isProbablyOver } from '../../lib/utils/competition-table';
 import { competitionUrl } from '../../lib/requests/routes.js.erb';
+import { Loader } from 'semantic-ui-react';
+import { BarLoader } from 'react-spinners';
 
 // Limit number of markers on map, especially for "All Past Competitions"
 const MAP_DISPLAY_LIMIT = 500;
@@ -57,6 +59,7 @@ function MapView({
           </Marker>
         ))}
       </MapContainer>
+      <BarLoader loading={isLoading} cssOverride={{ width: '100%' }} />
     </div>
   );
 }

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -208,6 +208,7 @@ export const apiV0Urls = {
   },
   competitions: {
     list: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competitions_path)%>`,
+    listIndex: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_index_path)%>`,
     info: (compId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_path("${compId}"))%>`,
     registrationData: `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_registration_data_path) %>`
   },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -371,6 +371,7 @@ Rails.application.routes.draw do
       get '/geocoding/search' => 'geocoding#get_location_from_query', as: :geocoding_search
       get '/countries' => 'api#countries'
       get '/competition_series/:id' => 'api#competition_series'
+      get '/competition_index' => 'competitions#competition_index', as: :competition_index
       resources :competitions, only: [:index, :show] do
         get '/wcif' => 'competitions#show_wcif'
         get '/wcif/public' => 'competitions#show_wcif_public'


### PR DESCRIPTION
The generic API endpoint was returning way too much data.

This PR introduces a separate `competitions_index` API endpoint which only returns as much data as we need. It also computes admin data only if the current user has the corresponding privileges.

Lastly, this contains a few frontend fixes to only fire loading requests to the new API when no other page request is currently loading. Before, you could trigger simultaneous duplicated requests by scrolling.