### PR TITLE
Added sub-queries for WRT contact form

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -41,6 +41,10 @@ class ContactsController < ApplicationController
       ContactWrt.new(
         name: requestor_details[:name],
         your_email: requestor_details[:email],
+        query_type: contact_params[:queryType],
+        profile_data_to_change: contact_params[:profileDataToChange],
+        new_profile_data: contact_params[:newProfileData],
+        edit_profile_reason: contact_params[:editProfileReason],
         message: contact_params[:message],
         request: request,
         logged_in_email: current_user&.email || 'None',

--- a/app/models/contact_wrt.rb
+++ b/app/models/contact_wrt.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class ContactWrt < ContactForm
-  attribute :message, validate: true
+  attribute :query_type
+  attribute :profile_data_to_change
+  attribute :new_profile_data
+  attribute :edit_profile_reason
+  attribute :message
 
   def to_email
     UserGroup.teams_committees_group_wrt.metadata.email

--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/EditProfileQuery.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/EditProfileQuery.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  Form, FormField, FormGroup, Radio,
+} from 'semantic-ui-react';
+import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
+import { updateSectionData } from '../../store/actions';
+import I18n from '../../../../lib/i18n';
+
+const SECTION = 'wrt';
+const PROFILE_DATA_FIELDS = ['name', 'country', 'gender', 'dob'];
+
+export default function EditProfileQuery() {
+  const {
+    formValues: {
+      wrt: { profileDataToChange, newProfileData, editProfileReason },
+    },
+  } = useStore();
+  const dispatch = useDispatch();
+  const handleFormChange = (_, { name, value }) => dispatch(
+    updateSectionData(SECTION, name, value),
+  );
+
+  return (
+    <>
+      <FormGroup grouped>
+        <div>{I18n.t('page.contacts.form.wrt.profile_data_to_change.label')}</div>
+        {PROFILE_DATA_FIELDS.map((profileDataField) => (
+          <FormField key={profileDataField}>
+            <Radio
+              label={I18n.t(`page.contacts.form.wrt.profile_data_to_change.options.${profileDataField}`)}
+              name="profileDataToChange"
+              value={profileDataField}
+              checked={profileDataToChange === profileDataField}
+              onChange={handleFormChange}
+            />
+          </FormField>
+        ))}
+      </FormGroup>
+      {profileDataToChange && (
+        <>
+          <Form.Input
+            label={I18n.t(`page.contacts.form.wrt.new_profile_data_${profileDataToChange}.label`)}
+            name="newProfileData"
+            value={newProfileData}
+            onChange={handleFormChange}
+          />
+          <Form.TextArea
+            label={I18n.t('page.contacts.form.wrt.edit_profile_reason.label')}
+            name="editProfileReason"
+            value={editProfileReason}
+            onChange={handleFormChange}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/OtherQuery.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/OtherQuery.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Form } from 'semantic-ui-react';
+import I18n from '../../../../lib/i18n';
+import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
+import { updateSectionData } from '../../store/actions';
+
+const SECTION = 'wrt';
+
+export default function OtherQuery() {
+  const { formValues: { wrt: { message } } } = useStore();
+  const dispatch = useDispatch();
+  const handleFormChange = (_, { name, value }) => dispatch(
+    updateSectionData(SECTION, name, value),
+  );
+
+  return (
+    <Form.TextArea
+      label={I18n.t('page.contacts.form.wrt.message.label')}
+      name="message"
+      value={message}
+      onChange={handleFormChange}
+    />
+  );
+}

--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/index.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/index.jsx
@@ -1,23 +1,52 @@
-import React from 'react';
-import { Form } from 'semantic-ui-react';
+import React, { useMemo } from 'react';
+import {
+  FormField, FormGroup, Radio,
+} from 'semantic-ui-react';
 import I18n from '../../../../lib/i18n';
 import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
 import { updateSectionData } from '../../store/actions';
+import EditProfileQuery from './EditProfileQuery';
+import OtherQuery from './OtherQuery';
 
 const SECTION = 'wrt';
+const QUERY_TYPES = ['edit_profile', 'report_result_issue', 'other_query'];
+const QUERY_TYPES_MAP = _.keyBy(QUERY_TYPES, _.camelCase);
 
 export default function Wrt() {
   const { formValues: { wrt } } = useStore();
+  const { queryType: selectedQueryType } = wrt || {};
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),
   );
+
+  const QueryForm = useMemo(() => {
+    if (!selectedQueryType) return null;
+    switch (selectedQueryType) {
+      case QUERY_TYPES_MAP.editProfile:
+        return EditProfileQuery;
+      default:
+        return OtherQuery;
+    }
+  }, [selectedQueryType]);
+
   return (
-    <Form.TextArea
-      label={I18n.t('page.contacts.form.wrt.message.label')}
-      name="message"
-      value={wrt?.message}
-      onChange={handleFormChange}
-    />
+    <>
+      <FormGroup grouped>
+        <div>{I18n.t('page.contacts.form.wrt.query_type.label')}</div>
+        {QUERY_TYPES.map((queryType) => (
+          <FormField key={queryType}>
+            <Radio
+              label={I18n.t(`page.contacts.form.wrt.query_type.${queryType}.label`)}
+              name="queryType"
+              value={queryType}
+              checked={selectedQueryType === queryType}
+              onChange={handleFormChange}
+            />
+          </FormField>
+        ))}
+      </FormGroup>
+      {QueryForm && <QueryForm />}
+    </>
   );
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -803,7 +803,7 @@ en:
           email:
             label: "Email"
         contact_recipient:
-          label: "Whom do you want to contact?"
+          label: "Who do you want to contact?"
           competition:
             label: "Contact organizers/delegates of a competition (to ask query regarding that particular competition)"
           wct:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -803,7 +803,7 @@ en:
           email:
             label: "Email"
         contact_recipient:
-          label: "Which of the following best describes your inquiry?"
+          label: "Whom do you want to contact?"
           competition:
             label: "Contact organizers/delegates of a competition (to ask query regarding that particular competition)"
           wct:
@@ -821,8 +821,33 @@ en:
           message:
             label: "Message"
         wrt:
+          query_type:
+            label: "Which of the following best describes your inquiry?"
+            edit_profile:
+              label: "Edit my profile data (name, country, gender or DOB)"
+            report_result_issue:
+              label: "Report an issue in a result"
+            other_query:
+              label: "Other query"
           message:
             label: "Message"
+          profile_data_to_change:
+            label: "Profile data to change"
+            options:
+              name: "Name"
+              country: "Country"
+              gender: "Gender"
+              dob: "DOB"
+          new_profile_data_name:
+            label: "New Name"
+          new_profile_data_country:
+            label: "New Country"
+          new_profile_data_gender:
+            label: "New Gender"
+          new_profile_data_dob:
+            label: "New DOB"
+          edit_profile_reason:
+            label: "Reason for the change"
         wst:
           message:
             label: "Message"


### PR DESCRIPTION
For WRT contact form, instead of just sending the message, gave options like:
- Edit profile data
- Report an issue in a result
- Other query

For 2nd and 3rd option, we are still inputing only the message, but for 'edit profile data' section, we will ask the user what to change and ask to input that data. For now it's very primitive, will be improved in future after getting more feedback.