### PR TITLE
Fix banned competitor form issues

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -283,11 +283,11 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       end
     elsif group_type == UserGroup.group_types[:banned_competitors]
       if params.key?(:endDate)
-        role.end_date = params.require(:endDate)
+        role.end_date = params[:endDate]
       end
 
       if params.key?(:banReason)
-        role.metadata.ban_reason = params.require(:banReason)
+        role.metadata.ban_reason = params[:banReason]
       end
 
       if params.key?(:scope)

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
@@ -13,7 +13,7 @@ export default function BannedCompetitorsPage() {
     data: bannedCompetitorRoles,
     loading: bannedCompetitorRolesLoading,
     error: bannedCompetitorRolesError,
-    sync,
+    sync: syncBannedCompetitorRoles,
   } = useLoadedData(apiV0Urls.userRoles.list({
     isActive: true,
     groupType: groupTypes.banned_competitors,
@@ -22,6 +22,7 @@ export default function BannedCompetitorsPage() {
     data: pastBannedCompetitorRoles,
     loading: pastBannedCompetitorRolesLoading,
     error: pastBannedCompetitorRolesError,
+    sync: syncPastBannedCompetitorRoles,
   } = useLoadedData(apiV0Urls.userRoles.list({
     isActive: false,
     groupType: groupTypes.banned_competitors,
@@ -56,7 +57,7 @@ export default function BannedCompetitorsPage() {
           <Header>Banned Competitors</Header>
           <BannedCompetitors
             bannedCompetitorRoles={bannedCompetitorRoles}
-            sync={sync}
+            sync={syncBannedCompetitorRoles}
             canEditBannedCompetitors={canEditBannedCompetitors}
           />
         </>
@@ -66,6 +67,7 @@ export default function BannedCompetitorsPage() {
           <Header>Past Banned Competitors</Header>
           <BannedCompetitors
             bannedCompetitorRoles={pastBannedCompetitorRoles}
+            sync={syncPastBannedCompetitorRoles}
             canEditBannedCompetitors={canEditBannedCompetitors}
           />
         </>


### PR DESCRIPTION
WDC was facing issue when some change was made in banned competitors page. This PR is to fix them.

1. End date and ban reason can be null as well, but if either of them is null in the request, it's failing.
2. I missed to add sync for past banned competitors earlier, because there was no edit-feature in past list earlier.