### PR TITLE
Moved download-voters from nav dropdown to WEC panel

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -97,6 +97,7 @@ class PanelController < ApplicationController
       "boardEditor" => "board-editor",
       "officersEditor" => "officers-editor",
       "regionsAdmin" => "regions-admin",
+      "downloadVoters" => "download-voters",
     }
   end
 end

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -273,13 +273,6 @@
               <li><%= link_to t('.new_regional_organization'), new_regional_organization_path %></li>
             <% end %>
 
-            <!-- Don't show the link for admins, as they have it in the dedicated admin navigation. -->
-            <% if current_user.can_see_eligible_voters? && !current_user.can_admin_results? %>
-              <li class="divider"></li>
-              <li><%= link_to "WCA Voting Members", eligible_voters_path %></li>
-              <li><%= link_to "WCA Leaders and Seniors", leader_senior_voters_path %></li>
-            <% end %>
-
             <li class="divider"></li>
             <li><%= link_to t('.api'), api_path %></li>
             <li><%= link_to t('.manage_app'), oauth_applications_path %></li>

--- a/app/webpacker/components/Panel/PanelPages.jsx
+++ b/app/webpacker/components/Panel/PanelPages.jsx
@@ -24,6 +24,7 @@ import BoardEditorPage from './pages/BoardEditorPage';
 import OfficersEditor from './pages/OfficersEditor';
 import RegionsAdmin from './pages/RegionsAdmin';
 import RegionManager from './pages/RegionManager';
+import DownloadVoters from './pages/DownloadVoters';
 
 const DELEGATE_HANDBOOK_LINK = 'https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf';
 
@@ -123,5 +124,9 @@ export default {
   [PANEL_PAGES.regionsAdmin]: {
     name: 'Regions Admin',
     component: RegionsAdmin,
+  },
+  [PANEL_PAGES.downloadVoters]: {
+    name: 'Download Voters',
+    component: DownloadVoters,
   },
 };

--- a/app/webpacker/components/Panel/Wec.jsx
+++ b/app/webpacker/components/Panel/Wec.jsx
@@ -8,6 +8,7 @@ export default function Wec() {
       heading="WEC Panel"
       pages={[
         PANEL_PAGES.bannedCompetitors,
+        PANEL_PAGES.downloadVoters,
       ]}
     />
   );

--- a/app/webpacker/components/Panel/pages/DownloadVoters/index.jsx
+++ b/app/webpacker/components/Panel/pages/DownloadVoters/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Button } from 'semantic-ui-react';
+import { eligibleVotersUrl, leaderSeniorVotersUrl } from '../../../../lib/requests/routes.js.erb';
+
+export default function DownloadVoters() {
+  return (
+    <>
+      <Button href={eligibleVotersUrl}>WCA all voting members</Button>
+      <Button href={leaderSeniorVotersUrl}>WCA leaders and seniors</Button>
+    </>
+  );
+}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -238,3 +238,7 @@ export const wcaRegistrationUrl = `<%= CGI.unescape(EnvConfig.WCA_REGISTRATIONS_
 export const getPsychSheetForEventUrl = (competitionId, eventId, sortBy) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_event_psych_sheet_path(competition_id: '${competitionId}', event_id: '${eventId}')) %>?sort_by=${sortBy}`
 
 export const editRegistrationUrl = (userId, competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_registration_v2_path(competition_id: "${competitionId}", user_id: "${userId}"))%>`
+
+export const eligibleVotersUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.eligible_voters_path) %>`;
+
+export const leaderSeniorVotersUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.leader_senior_voters_path) %>`;


### PR DESCRIPTION
Currently this is available only to WEC leader in nav dropdown, and the downloaded file doesn't have any sensitive data. So, moved this to WEC panel so any WEC member can access it.

This has been already discussed with WEC leader over slack.

The current flow is that a WEC member will ask the leader for the list and the leader will provide it. This new flow will reduce one step for WEC.