### PR TITLE
Use ruby instead of sed in mysqldump

### DIFF
--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -1205,7 +1205,7 @@ module DatabaseDumper
 
   def self.mysqldump(db_name, dest_filename)
     system_pipefail!("mysqldump #{self.mysql_cli_creds} #{db_name} -r #{dest_filename} #{filter_out_mysql_warning}")
-    system_pipefail!("sed -i 's_^/\\*!50013 DEFINER.*__' #{dest_filename}")
+    system_pipefail!("ruby -i -pe '$_.gsub!(%r{^/\\*!50013 DEFINER.*\\n}, \"\")' #{dest_filename}")
   end
 
   def self.filter_out_mysql_warning(dest_filename = nil)


### PR DESCRIPTION
Hi all. I'm new to the project and encountered an error running the specs for the first time. It seemed straight-forward to fix so thought I'd cut a PR. Let me know if there's anything I'm missing as a first-time contributor.

Here's the error I got running on OSX:

```
Failures:

  1) DatabaseDumper dumps the database according to sanitizers
     Failure/Error: system("bash -c #{cmd.shellescape}", exception: true)

     RuntimeError:
       Command failed with exit 1: bash -c set\ -o\ pipefail\ \&\&\ sed\ -i\ \'s_\^/\\\*\!50013\ DEFINER.\*__\'\ /var/folders/3_/vs8c57m53xd1ltmvsxb6gt640000gn/T/20240707-61926-iaxuhx
     # ./lib/database_dumper.rb:1219:in `system'
     # ./lib/database_dumper.rb:1219:in `system_pipefail!'
     # ./lib/database_dumper.rb:1208:in `mysqldump'
     # ./lib/database_dumper.rb:1158:in `block (2 levels) in development_dump'
     # ./lib/log_task.rb:6:in `log_task'
     # ./lib/database_dumper.rb:1157:in `block in development_dump'
     # ./lib/database_dumper.rb:1147:in `with_dumped_db'
     # ./lib/database_dumper.rb:1156:in `development_dump'
     # ./spec/lib/database_dumper_spec.rb:54:in `block (2 levels) in <top (required)>'
```

The issue is sed's -i option isn't a part of POSIX and gets implemented differently on GNU and BSD. As a result the way it's used in `DatabaseDumper::mysqldump` isn't cross-platform.

There are a few ways to fix this, such as platform detection, or even just using a file extension and rming the backup file. However since we can reasonably expect ruby to be installed on the target platforms for this app, and it offers similar functionality to sed, it seems simplest to just replace sed with it.

See this discussion for further info:

https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux