### PR TITLE
Show local date/time in utc date picker

### DIFF
--- a/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
+++ b/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
@@ -241,11 +241,11 @@ export const InputDate = wrapInput((props) => {
           isoMaxDate={props.maxDate}
         />
       </Input>
-      {props.dateTime && (
+      {props.dateTime && props.value && (
         <p className="help-block">
           In your current time zone:
           {' '}
-          {props.value && new Date(props.value).toLocaleString(undefined, {
+          {new Date(props.value).toLocaleString(undefined, {
             dateStyle: 'full',
             timeStyle: 'short',
           })}

--- a/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
+++ b/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
@@ -221,25 +221,36 @@ export const InputDate = wrapInput((props) => {
   }, [props]);
 
   return (
-    <Input
-      id={props.htmlId}
-      name={props.htmlName}
-    >
-      <UtcDatePicker
+    <>
+      <Input
         id={props.htmlId}
-        isoDate={props.value}
-        onChange={onChangeInternal}
-        shouldCloseOnSelect={false}
-        showTimeInput={props.dateTime}
-        style={{ width: 'inherit' }}
-        selectsStart={props.selectsStart}
-        selectsEnd={props.selectsEnd}
-        isoStartDate={props.startDate}
-        isoEndDate={props.endDate}
-        isoMinDate={props.minDate}
-        isoMaxDate={props.maxDate}
-      />
-    </Input>
+        name={props.htmlName}
+      >
+        <UtcDatePicker
+          id={props.htmlId}
+          isoDate={props.value}
+          onChange={onChangeInternal}
+          shouldCloseOnSelect={false}
+          showTimeInput={props.dateTime}
+          style={{ width: 'inherit' }}
+          selectsStart={props.selectsStart}
+          selectsEnd={props.selectsEnd}
+          isoStartDate={props.startDate}
+          isoEndDate={props.endDate}
+          isoMinDate={props.minDate}
+          isoMaxDate={props.maxDate}
+        />
+      </Input>
+      {props.dateTime && (
+        <p className="help-block">
+          In your current time zone:{" "}
+          {props.value && new Date(props.value).toLocaleString(undefined, {
+            dateStyle: "full",
+            timeStyle: "short",
+          })}
+        </p>
+      )}
+    </>
   );
 }, ['dateTime', 'selectsStart', 'selectsEnd', 'startDate', 'endDate', 'minDate', 'maxDate'], '');
 

--- a/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
+++ b/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
@@ -243,10 +243,11 @@ export const InputDate = wrapInput((props) => {
       </Input>
       {props.dateTime && (
         <p className="help-block">
-          In your current time zone:{" "}
+          In your current time zone:
+          {' '}
           {props.value && new Date(props.value).toLocaleString(undefined, {
-            dateStyle: "full",
-            timeStyle: "short",
+            dateStyle: 'full',
+            timeStyle: 'short',
           })}
         </p>
       )}


### PR DESCRIPTION
When time is input is active.

Input without time (no change):
![image](https://github.com/thewca/worldcubeassociation.org/assets/49137025/7db39bce-b90d-49f8-9b6d-b29951c10951)

Input with time:
![image](https://github.com/thewca/worldcubeassociation.org/assets/49137025/d28704e9-c5d9-4cac-9607-040b700e0896)

![image](https://github.com/thewca/worldcubeassociation.org/assets/49137025/d49fd119-7fab-438c-9289-108eca3e7582)
