### PR TITLE
Allow to enter DOB in Finish unfinished persons

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -489,7 +489,9 @@ class AdminController < ApplicationController
             old_country = inbox_person.countryId
           end
 
-          FinishUnfinishedPersons.insert_person(inbox_person, new_name, new_country, new_id)
+          new_dob = inbox_person&.dob || procedure[:new_dob]
+
+          FinishUnfinishedPersons.insert_person(inbox_person, new_name, new_country, new_id, new_dob)
           FinishUnfinishedPersons.adapt_results(pending_person_id.presence, old_name, old_country, new_id, new_name, new_country, pending_competition_id)
         else
           action, merge_id = procedure[:action].split '-'

--- a/app/views/admin/complete_persons.html.erb
+++ b/app/views/admin/complete_persons.html.erb
@@ -59,7 +59,11 @@
           <td><%= display_string p[:person_name] %></td>
           <td><%= country.name %></td>
           <td><%= link_to "(results)", admin_peek_unfinished_results_path(**p.slice(:person_name, :country_id, :person_id)), target: '_blank' %></td>
-          <td><%= p[:person_dob] %></td>
+          <% if p[:person_dob].present? %>
+            <td><%= p[:person_dob] %></td>
+          <% else %>
+            <td><%= f.input "#{case_id}][new_dob", input_html: { value: p[:person_dob] }, label: false, hint: false %></td>
+          <% end %>
           <td><%= f.input "#{case_id}][new_name", input_html: { value: p[:person_name] }, label: false, hint: false %></td>
           <td><%= f.input "#{case_id}][new_country", collection: Country.all_sorted_by(I18n.locale, real: true), value_method: :id, label_method: :name, selected: p[:country_id], label: false, hint: false %></td>
           <td><%= f.input "#{case_id}][new_semi_id", input_html: { value: p[:computed_semi_id] }, maxlength: 8, label: false, hint: false %></td>

--- a/lib/finish_unfinished_persons.rb
+++ b/lib/finish_unfinished_persons.rb
@@ -177,14 +177,14 @@ module FinishUnfinishedPersons
     raise "Could not compute a WCA ID suffix for #{semi_id}"
   end
 
-  def self.insert_person(inbox_person, new_name, new_country, new_wca_id)
+  def self.insert_person(inbox_person, new_name, new_country, new_wca_id, new_dob)
     Person.create!(
       wca_id: new_wca_id,
       subId: 1,
       name: new_name,
       countryId: new_country,
       gender: inbox_person&.gender || :o,
-      dob: inbox_person&.dob,
+      dob: new_dob,
       comments: '',
     )
   end


### PR DESCRIPTION
Currently, if we create a newcomer using "Finish unfinished persons" script, and if there is no DOB (for example, if the person is created from the existing results instead of InboxPersons), creation of person fails due to empty DOB.

This change will allow to enter DOB manually, so that we can manually enter DOB in case DOB is not available.