### PR TITLE
Expand eligible voters permission to WEC instead of WEC Leader

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -864,7 +864,7 @@ class User < ApplicationRecord
   end
 
   def can_see_eligible_voters?
-    can_admin_results? || group_leader?(UserGroup.teams_committees_group_wec)
+    can_admin_results? || ethics_committee?
   end
 
   def get_cannot_delete_competition_reason(competition)


### PR DESCRIPTION
Eligible voters list is something that was accessible only by WEC Leader (and the admins). Recently this was moved to WEC Panel in https://github.com/thewca/worldcubeassociation.org/pull/9592, but not leaders can't still access it as there was a permission connected with it. Fixing the permission issue in this PR.