### PR TITLE
Few more panel cleanups

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -46,4 +46,12 @@ class PanelController < ApplicationController
       replica: 2,
     }
   end
+
+  def redirect
+    @panel_page = params.require(:panel_page)
+    panel_with_panel_page = current_user&.panels_with_access&.find { |panel| User.panel_list[panel][:pages].include?(@panel_page) }
+
+    return head :unauthorized if panel_with_panel_page.nil?
+    redirect_to panel_index_path(panel_id: panel_with_panel_page, anchor: @panel_page)
+  end
 end

--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -49,7 +49,7 @@ class PanelController < ApplicationController
 
   def redirect
     @panel_page = params.require(:panel_page)
-    panel_with_panel_page = current_user&.panels_with_access&.find { |panel| User.panel_list[panel][:pages].include?(@panel_page) }
+    panel_with_panel_page = current_user.panels_with_access&.find { |panel| User.panel_list[panel][:pages].include?(@panel_page) }
 
     return head :unauthorized if panel_with_panel_page.nil?
     redirect_to panel_index_path(panel_id: panel_with_panel_page, anchor: @panel_page)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1423,10 +1423,6 @@ class User < ApplicationRecord
     end
   end
 
-  def can_access_at_least_one_panel?
-    panels_with_access.any?
-  end
-
   def subordinate_delegates
     delegate_roles
       .filter { |role| role.is_lead? }

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -217,7 +217,7 @@
               <li><%= link_to t('.my_results'), person_path(current_user.wca_id) %></li>
             <% end %>
 
-            <% if current_user.can_access_at_least_one_panel? %>
+            <% if current_user.panels_with_access.any? %>
               <li class="divider"></li>
               <li role="presentation" class="dropdown-header">
                 <%= t '.panel' %>

--- a/app/webpacker/components/RolesTab/ActiveRoles.jsx
+++ b/app/webpacker/components/RolesTab/ActiveRoles.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Header, List, Icon } from 'semantic-ui-react';
-import { panelUrls } from '../../lib/requests/routes.js.erb';
+import { panelRedirectUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
 import useLoggedInUserPermissions from '../../lib/hooks/useLoggedInUserPermissions';
-import { groupTypes, delegateRegionsStatus } from '../../lib/wca-data.js.erb';
+import { groupTypes, delegateRegionsStatus, PANEL_PAGES } from '../../lib/wca-data.js.erb';
 import { getRoleDescription, getRoleSubDescription } from '../../lib/helpers/roles-tab';
 
 function hyperlink(role) {
@@ -12,17 +12,17 @@ function hyperlink(role) {
       delegateRegionsStatus.senior_delegate,
       delegateRegionsStatus.regional_delegate,
     ].includes(role.metadata.status)) {
-      return panelUrls.board.regionsManager;
+      return panelRedirectUrl(PANEL_PAGES.regionsManager);
     }
-    return panelUrls.seniorDelegate.regions;
+    return panelRedirectUrl(PANEL_PAGES.regions);
   }
   if (role.group.group_type === groupTypes.teams_committees) {
     // FIXME: Redirect to correct dropdown in groupsManager. Currently it only goes to the
     // groupsManager page without selecting the group of the user.
-    return panelUrls.leader.groupsManager;
+    return panelRedirectUrl(PANEL_PAGES.groupsManager);
   }
   if (role.group.group_type === groupTypes.translators) {
-    return panelUrls.wst.translators;
+    return panelRedirectUrl(PANEL_PAGES.translators);
   }
   return null;
 }

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -246,6 +246,8 @@ export const panelUrls = {
   },
 }
 
+export const panelRedirectUrl = (panelPage) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_redirect_path(panel_page: "${panelPage}")) %>`;
+
 export const actionUrls = {
   tickets: {
     show: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_path("${ticketId}", format: "json")) %>`,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,7 @@ Rails.application.routes.draw do
     get 'generate_db_token' => 'panel#generate_db_token', as: :panel_generate_db_token
   end
   get 'panel/:panel_id' => 'panel#index', as: :panel_index
+  get 'panel/redirect/:panel_page' => 'panel#redirect', as: :panel_redirect
   resources :tickets, only: [:show] do
     post 'update_status' => 'tickets#update_status', as: :update_status
   end


### PR DESCRIPTION
This PR aims at following cleanups for panels:
1. Removal of `can_access_at_least_one_panel?` from user.rb as it is not necessary.
2. Introduces panel redirect, which will accept a panel page with URL format "/panel/redirect/panel_page" and gets redirected to one of the panels that belong to the user. This will be helpful for adding the URL in pages like 'active roles'.