### PR TITLE
Load MS registration data upon #find call

### DIFF
--- a/app/models/concerns/microservice_registration_holder.rb
+++ b/app/models/concerns/microservice_registration_holder.rb
@@ -34,6 +34,9 @@ module MicroserviceRegistrationHolder
             end
 
             ar_model.load_ms_model(matching_ms_model) if matching_ms_model.present?
+
+            # Give the option to fetch data later, for example when instantiation on the MS side of things is deferred.
+            ar_model.lazy_loading_enabled = !matching_ms_model.present?
           end
         end
       end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -12,13 +12,13 @@ class MicroserviceRegistration < ApplicationRecord
 
   delegate :name, :email, to: :user
 
-  attr_accessor :ms_registration
+  attr_accessor :ms_registration, :lazy_loading_enabled
   attr_writer :competing_status, :event_ids, :guests, :comments, :administrative_notes
 
-  after_find do |registration|
-    # The `unless` part is necessary because when mass-fetching from `has_many` relations,
-    #   the underlying data is loaded in bulk and we don't want to load it _again_
-    registration.load_ms_model! unless registration.ms_loaded?
+  after_initialize do |registration|
+    # Let the models load their MS data by default, unless someone from the outside world explicitly switches this off.
+    #   See also `microservice_registration_holder.rb` for reference.
+    registration.lazy_loading_enabled = true
   end
 
   def attendee_id
@@ -28,9 +28,6 @@ class MicroserviceRegistration < ApplicationRecord
   def load_ms_model!
     ms_data = Microservices::Registrations.registration_by_id(self.attendee_id)
     self.load_ms_model(ms_data)
-
-    # Return self because we're working in-place per Ruby *! conventions
-    self
   end
 
   def load_ms_model(ms_model)
@@ -50,7 +47,14 @@ class MicroserviceRegistration < ApplicationRecord
     self.ms_registration.present?
   end
 
+  private def lazy_load_ms_data?
+    # Performing a boolean comparison here to make sure nobody writes silly stuff into the variable from outside
+    self.lazy_loading_enabled == true
+  end
+
   private def read_ms_data(name_without_at)
+    self.load_ms_model! if !self.ms_loaded? && self.lazy_load_ms_data?
+
     instance_variable_get(:"@#{name_without_at}").tap do
       raise "Microservice data not loaded!" unless ms_loaded?
     end

--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -26,7 +26,7 @@ class MicroserviceRegistration < ApplicationRecord
   end
 
   def load_ms_model!
-    ms_data = Microservices::Registrations.registration_by_id(self.competition_id, self.user_id)
+    ms_data = Microservices::Registrations.registration_by_id(self.attendee_id)
     self.load_ms_model(ms_data)
 
     # Return self because we're working in-place per Ruby *! conventions

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -27,6 +27,10 @@ module Microservices
       "/api/internal/v1/#{competition_id}/registrations"
     end
 
+    def self.get_registration_path(attendee_id)
+      "/api/internal/v1/#{attendee_id}"
+    end
+
     def self.get_competitor_count_path(competition_id)
       "/api/v1/#{competition_id}/count"
     end
@@ -94,6 +98,11 @@ module Microservices
         db_registrations = registrations.map { |reg| reg.slice('competition_id', 'user_id') }
         MicroserviceRegistration.upsert_all(db_registrations)
       end
+    end
+
+    def self.registration_by_id(attendee_id)
+      response = self.registration_connection.get(self.get_registration_path(attendee_id))
+      response.body
     end
   end
 end


### PR DESCRIPTION
The mailers are serializing using Global ID mechanism, which means that `deliver_later` doesn't serialize the actual, nice, enriched MS registration. Rather, it just stores a reference to the row using the primary key, and loads it again later.

That means in order to send mails, we automatically load/enrich MS data when using `.find` directly.

NOTE: This does not affect the `has_many` bulk loading because that one doesn't go through `find` directly. And we have an `unless` guard clause for models that are already loaded :upside_down_face: 