### PR TITLE
Add competition_id index for registrations and registration_id for registration payments

### DIFF
--- a/db/migrate/20240716145605_add_more_indexes_to_registrations.rb
+++ b/db/migrate/20240716145605_add_more_indexes_to_registrations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMoreIndexesToRegistrations < ActiveRecord::Migration[7.1]
+  def change
+    add_index :registrations, :competition_id
+    add_index :registration_payments, :registration_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_05_145605) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_145605) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -977,6 +977,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_145605) do
     t.integer "user_id"
     t.index ["receipt_type", "receipt_id"], name: "index_registration_payments_on_receipt"
     t.index ["refunded_registration_payment_id"], name: "idx_reg_payments_on_refunded_registration_payment_id"
+    t.index ["registration_id"], name: "index_registration_payments_on_registration_id"
     t.index ["stripe_charge_id"], name: "index_registration_payments_on_stripe_charge_id"
   end
 
@@ -996,6 +997,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_145605) do
     t.boolean "is_competing", default: true
     t.text "administrative_notes"
     t.index ["competition_id", "user_id"], name: "index_registrations_on_competition_id_and_user_id", unique: true
+    t.index ["competition_id"], name: "index_registrations_on_competition_id"
     t.index ["user_id"], name: "index_registrations_on_user_id"
   end
 


### PR DESCRIPTION
While I was checking the performance of Puma in New Relic, I noticed that Registration.find, especially in conjunction with `RegistrationPayment` has become our slowest queries (16% of all database time). 

Every time we call `Competition.find(...).registrations` we need to scan the whole table.
Similarly with calls to  `pending.with_payments` for RegistrationPayment
Here is an example trace from new relic on a call to `registration_full?`:
```
 No index was used in this part of the query.
    This table was retrieved with a full table scan, which is often quite bad for performance, unless you only retrieve a few rows.
    You can speed up this query by querying only fields that are within the index. Or you can create an index that includes every field in your query, including the primary key.
    Approximately 427354 rows of this table were scanned.
```
Should be a quick little performance win! 