### PR TITLE
Give more clear error messages when DOBs cannot be parsed

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -154,6 +154,11 @@ class RegistrationsController < ApplicationController
     if wca_id_duplicates.any?
       raise I18n.t("registrations.import.errors.wca_id_duplicates", wca_ids: wca_id_duplicates.join(", "))
     end
+    raw_dobs = registration_rows.map { |registration_row| registration_row[:birth_date] }
+    wrong_format_dobs = raw_dobs.select { |raw_dob| Date.safe_parse(raw_dob)&.to_fs != raw_dob }
+    if wrong_format_dobs.any?
+      raise I18n.t("registrations.import.errors.wrong_dob_format", raw_dobs: wrong_format_dobs.join(", "))
+    end
     new_locked_users = []
     ActiveRecord::Base.transaction do
       competition.registrations.accepted.each do |registration|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1282,7 +1282,7 @@ en:
         email_user_with_different_unconfirmed_wca_id: "There is already a user with email %{email}, but it has unconfirmed WCA ID of %{unconfirmed_wca_id} instead of %{registration_wca_id}."
         email_duplicates: "Email must be unique, found the following duplicates: %{emails}."
         wca_id_duplicates: "WCA ID must be unique, found the following duplicates: %{wca_ids}."
-        wrong_dob_format: "Birthdate must follow the YYYY-mm-dd format (year-month-day, i.e. 1944-07-13 for 'July 13, 1944'), found the following dates which cannot be parsed: %{raw_dobs}."
+        wrong_dob_format: "Birthdate must follow the YYYY-mm-dd format (year-month-day, for example 1944-07-13), found the following dates which cannot be parsed: %{raw_dobs}."
     add:
       title: "Add registration for %{comp}"
       info: "This will create an approved registration. Use this form to add walk-ins during the competition."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1282,6 +1282,7 @@ en:
         email_user_with_different_unconfirmed_wca_id: "There is already a user with email %{email}, but it has unconfirmed WCA ID of %{unconfirmed_wca_id} instead of %{registration_wca_id}."
         email_duplicates: "Email must be unique, found the following duplicates: %{emails}."
         wca_id_duplicates: "WCA ID must be unique, found the following duplicates: %{wca_ids}."
+        wrong_dob_format: "Birthdate must follow the YYYY-mm-dd format (year-month-day, i.e. 1944-07-13 for 'July 13, 1944'), found the following dates which cannot be parsed: %{raw_dobs}."
     add:
       title: "Add registration for %{comp}"
       info: "This will create an approved registration. Use this form to add walk-ins during the competition."

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -98,6 +98,20 @@ RSpec.describe "registrations" do
         expect(response.body).to include "WCA ID must be unique, found the following duplicates: 2019HOLM01."
       end
 
+      it "renders an error when there are invalid DOBs" do
+        file = csv_file [
+          ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
+          ["a", "Sherlock Holmes", "United Kingdom", "2019HOLM01", "01.01.2000", "m", "sherlock@example.com", "1", "0"],
+          ["a", "John Watson", "United Kingdom", "2019WATS01", "2000-01-01", "m", "watson@example.com", "1", "1"],
+          ["a", "James Moriarty", "United Kingdom", "2019MORI01", "Jan 01 2000", "m", "moriarty@example.com", "0", "1"],
+        ]
+        expect {
+          post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
+        }.to_not change { competition.registrations.count }
+        follow_redirect!
+        expect(response.body).to include "Birthdate must follow the YYYY-mm-dd format (year-month-day, for example 1944-07-13), found the following dates which cannot be parsed: 01.01.2000, Jan 01 2000."
+      end
+
       describe "registrations import" do
         context "registrant has WCA ID" do
           it "renders an error if the WCA ID doesn't exist" do


### PR DESCRIPTION
Previously, not being able to parse a DOB would result in `nil` values being passed to the `User` constructor, which makes the validation complain with "DOB is required".

With this PR, the import endpoint gives a more informative message and shows _which_ DOBs cannot be parsed.