### PR TITLE
Disable Moving People to the WaitingList and change default order to ascending

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -1,7 +1,5 @@
-import { useMutation } from '@tanstack/react-query';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Button, Icon } from 'semantic-ui-react';
-import { bulkUpdateRegistrations } from '../api/registration/patch/update_registration';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { setMessage } from '../Register/RegistrationMessage';
 import i18n from '../../../lib/i18n';
@@ -47,7 +45,7 @@ export default function RegistrationActions({
   const anyRejectable = pending.length < selectedCount;
   const anyApprovable = accepted.length < selectedCount;
   const anyCancellable = cancelled.length < selectedCount;
-  const anyWaitlistable = waiting.length < selectedCount;
+  // const anyWaitlistable = waiting.length < selectedCount;
 
   const selectedEmails = [...pending, ...accepted, ...cancelled, ...waiting]
     .map((userId) => userEmailMap[userId])
@@ -142,18 +140,18 @@ export default function RegistrationActions({
               </Button>
             )}
 
-            {anyWaitlistable && (
-              <Button
-                color="yellow"
-                onClick={() => changeStatus(
-                  [...pending, ...cancelled, ...accepted],
-                  'waiting_list',
-                )}
-              >
-                <Icon name="hourglass" />
-                {i18n.t('competitions.registration_v2.update.move_waiting')}
-              </Button>
-            )}
+            {/* {anyWaitlistable && ( */}
+            {/*  <Button */}
+            {/*    color="yellow" */}
+            {/*    onClick={() => changeStatus( */}
+            {/*      [...pending, ...cancelled, ...accepted], */}
+            {/*      'waiting_list', */}
+            {/*    )} */}
+            {/*  > */}
+            {/*    <Icon name="hourglass" /> */}
+            {/*    {i18n.t('competitions.registration_v2.update.move_waiting')} */}
+            {/*  </Button> */}
+            {/* )} */}
 
             {anyCancellable && (
               <Button

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -128,7 +128,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
     sortColumn: competitionInfo['using_payment_integrations?']
       ? 'paid_on_with_registered_on_fallback'
       : 'registered_on',
-    sortDirection: 'descending',
+    sortDirection: 'ascending',
   });
   const { sortColumn, sortDirection } = state;
   const changeSortColumn = (name) => dispatchSort({ type: 'CHANGE_SORT', sortColumn: name });

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -118,7 +118,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
 
   const queryClient = useQueryClient();
 
-  const [editable, setEditable] = useCheckboxState(false);
+  // const [editable, setEditable] = useCheckboxState(false);
 
   const dispatchStore = useDispatch();
 
@@ -136,7 +136,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
   const {
     isLoading: isRegistrationsLoading,
     data: registrations,
-    refetch,
   } = useQuery({
     queryKey: ['registrations-admin', competitionInfo.id],
     queryFn: () => getAllRegistrations(competitionInfo.id),
@@ -272,25 +271,25 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
     [registrationsWithUser],
   );
 
-  const handleOnDragEnd = async (result) => {
-    if (!result.destination) return;
-    if (result.destination.index === result.source.index) return;
-
-    updateRegistrationMutation({
-      competition_id: competitionInfo.id,
-      requests: [{
-        user_id: waiting[result.source.index].user_id,
-        competing: {
-          waiting_list_position: waiting[result.destination.index].competing.waiting_list_position,
-        },
-      }],
-    }, {
-      onSuccess: () => {
-        // We need to get the information for all Competitors if you change the waiting list position
-        refetch();
-      },
-    });
-  };
+  // const handleOnDragEnd = async (result) => {
+  //   if (!result.destination) return;
+  //   if (result.destination.index === result.source.index) return;
+  //
+  //   updateRegistrationMutation({
+  //     competition_id: competitionInfo.id,
+  //     requests: [{
+  //       user_id: waiting[result.source.index].user_id,
+  //       competing: {
+  //         waiting_list_position: waiting[result.destination.index].competing.waiting_list_position,
+  //       },
+  //     }],
+  //   }, {
+  //     onSuccess: () => {
+  //       // We need to get the information for all Competitors if you change the waiting list position
+  //       refetch();
+  //     },
+  //   });
+  // };
 
   return isRegistrationsLoading || infoLoading ? (
     <Loading />
@@ -370,34 +369,34 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           sortColumn={sortColumn}
           competitionInfo={competitionInfo}
         />
+        {/* Disable Waiting List Administration until we fix moving people around on the waitinglist */}
+        {/* <Header> */}
+        {/*  {i18n.t('registrations.list.waiting_list')} */}
+        {/*  {' '} */}
+        {/*  ( */}
+        {/*  {waiting.length} */}
+        {/*  ) */}
+        {/* </Header> */}
 
-        <Header>
-          {i18n.t('registrations.list.waiting_list')}
-          {' '}
-          (
-          {waiting.length}
-          )
-        </Header>
+        {/* <Checkbox toggle value={editable} onChange={setEditable} label="Enable Waiting List Edit Mode" /> */}
 
-        <Checkbox toggle value={editable} onChange={setEditable} label="Enable Waiting List Edit Mode" />
-
-        <RegistrationAdministrationTable
-          columnsExpanded={expandedColumns}
-          selected={partitionedSelected.waiting}
-          select={select}
-          unselect={unselect}
-          competition_id={competitionInfo.id}
-          changeSortColumn={changeSortColumn}
-          sortDirection={sortDirection}
-          sortColumn={sortColumn}
-          competitionInfo={competitionInfo}
-          registrations={waiting.toSorted(
-            (a, b) => a.competing.waiting_list_position - b.competing.waiting_list_position,
-          )}
-          handleOnDragEnd={handleOnDragEnd}
-          draggable={editable}
-          sortable={false}
-        />
+        {/* <RegistrationAdministrationTable */}
+        {/*  columnsExpanded={expandedColumns} */}
+        {/*  selected={partitionedSelected.waiting} */}
+        {/*  select={select} */}
+        {/*  unselect={unselect} */}
+        {/*  competition_id={competitionInfo.id} */}
+        {/*  changeSortColumn={changeSortColumn} */}
+        {/*  sortDirection={sortDirection} */}
+        {/*  sortColumn={sortColumn} */}
+        {/*  competitionInfo={competitionInfo} */}
+        {/*  registrations={waiting.toSorted( */}
+        {/*    (a, b) => a.competing.waiting_list_position - b.competing.waiting_list_position, */}
+        {/*  )} */}
+        {/*  handleOnDragEnd={handleOnDragEnd} */}
+        {/*  draggable={editable} */}
+        {/*  sortable={false} */}
+        {/* /> */}
 
         <Header>
           {i18n.t('registrations.list.deleted_registrations')}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -10,16 +10,12 @@ import {
   Form,
   Header,
   Message,
-  Popup,
   Segment,
-  Table,
 } from 'semantic-ui-react';
 import { getSingleRegistration } from '../api/registration/get/get_registrations';
 import updateRegistration from '../api/registration/patch/update_registration';
 import getUsersInfo from '../api/user/post/getUserInfo';
 import {
-  getShortDateString,
-  getShortTimeString,
   hasPassed,
 } from '../../../lib/utils/dates';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
@@ -264,15 +260,15 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
             disabled={registrationEditDeadlinePassed}
             onChange={(event, data) => setStatus(data.value)}
           />
-          <Form.Checkbox
-            radio
-            label="Waiting List"
-            name="checkboxRadioGroup"
-            value="waiting_list"
-            checked={status === 'waiting_list'}
-            disabled={registrationEditDeadlinePassed}
-            onChange={(event, data) => setStatus(data.value)}
-          />
+          {/* <Form.Checkbox */}
+          {/*  radio */}
+          {/*  label="Waiting List" */}
+          {/*  name="checkboxRadioGroup" */}
+          {/*  value="waiting_list" */}
+          {/*  checked={status === 'waiting_list'} */}
+          {/*  disabled={registrationEditDeadlinePassed} */}
+          {/*  onChange={(event, data) => setStatus(data.value)} */}
+          {/* /> */}
           <Form.Checkbox
             radio
             label="Cancelled"


### PR DESCRIPTION
Reinstates the behavior of V1 (pending being the de facto waiting list) until we properly implement moving people around the waiting list. 
Also changes the default sorting order back to ascending as it is currently