### PR TITLE
Serve React ReCaptcha secret through backend

### DIFF
--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,2 +1,2 @@
 <% provide(:title, t('page.contacts.title')) %>
-<%= react_component("ContactsPage") %>
+<%= react_component("ContactsPage", { recaptchaPublicKey: AppSecrets.RECAPTCHA_PUBLIC_KEY }) %>

--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -7,7 +7,6 @@ import _ from 'lodash';
 import { contactUrl } from '../../lib/requests/routes.js.erb';
 import useSaveAction from '../../lib/hooks/useSaveAction';
 import I18n from '../../lib/i18n';
-import { RECAPTCHA_PUBLIC_KEY } from '../../lib/wca-data.js.erb';
 import UserData from './UserData';
 import Loading from '../Requests/Loading';
 import { useDispatch, useStore } from '../../lib/providers/StoreProvider';
@@ -27,7 +26,10 @@ const CONTACT_RECIPIENTS = [
 
 const CONTACT_RECIPIENTS_MAP = _.keyBy(CONTACT_RECIPIENTS, _.camelCase);
 
-export default function ContactForm({ loggedInUserData }) {
+export default function ContactForm({
+  loggedInUserData,
+  recaptchaPublicKey,
+}) {
   const { save, saving } = useSaveAction();
   const [captchaValue, setCaptchaValue] = useState();
   const [captchaError, setCaptchaError] = useState(false);
@@ -112,7 +114,7 @@ export default function ContactForm({ loggedInUserData }) {
         {SubForm && <SubForm />}
         <FormField>
           <ReCAPTCHA
-            sitekey={RECAPTCHA_PUBLIC_KEY}
+            sitekey={recaptchaPublicKey}
           // onChange is a mandatory parameter for ReCAPTCHA. According to the documentation, this
           // is called when user successfully completes the captcha, hence we are assuming that any
           // existing errors will be cleared when onChange is called.

--- a/app/webpacker/components/ContactsPage/index.jsx
+++ b/app/webpacker/components/ContactsPage/index.jsx
@@ -10,7 +10,7 @@ import StoreProvider from '../../lib/providers/StoreProvider';
 import contactsReducer, { getContactFormInitialState } from './store/reducer';
 import useQueryParams from '../../lib/hooks/useQueryParams';
 
-export default function ContactsPage() {
+export default function ContactsPage({ recaptchaPublicKey }) {
   const { data: loggedInUserData, loading } = useLoadedData(apiV0Urls.users.me.userDetails);
   const [queryParams] = useQueryParams();
 
@@ -28,7 +28,7 @@ export default function ContactsPage() {
             i18nKey="page.contacts.faq_note_html"
           />
         </Message>
-        <ContactForm loggedInUserData={loggedInUserData} />
+        <ContactForm loggedInUserData={loggedInUserData} recaptchaPublicKey={recaptchaPublicKey} />
       </Container>
     </StoreProvider>
   );

--- a/app/webpacker/lib/wca-data.js.erb
+++ b/app/webpacker/lib/wca-data.js.erb
@@ -148,8 +148,6 @@ export const nonFutureCompetitionYears = <%= Competition.non_future_years.to_jso
 
 export const railsEnv = '<%= Rails.env %>';
 
-export const RECAPTCHA_PUBLIC_KEY = '<%= AppSecrets.RECAPTCHA_PUBLIC_KEY %>';
-
 // ----- COMP RULES -----
 
 export const nearbyCompetitionDistanceWarning = <%= Competition::NEARBY_DISTANCE_KM_WARNING.to_json.html_safe %>


### PR DESCRIPTION
The goal here is to be able to compile frontend assets in our CI, which doesn't have access to our Vault credentials storage.
No change in functionality.