### PR TITLE
Serialize just author name in posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -52,10 +52,13 @@ class Post < ApplicationRecord
     Rails.application.routes.url_helpers.post_path(slug)
   end
 
+  def author_name
+    author&.name
+  end
+
   DEFAULT_SERIALIZE_OPTIONS = {
     only: ["id", "slug", "title", "sticky", "created_at"],
-    methods: ["url"],
-    include: ["author"],
+    methods: ["url", "author_name"],
   }.freeze
 
   def serializable_hash(options = nil)

--- a/app/webpacker/components/PostsWidget.js
+++ b/app/webpacker/components/PostsWidget.js
@@ -62,7 +62,7 @@ function PostsList({
             <Card.Meta>
               Posted by
               {' '}
-              {post.author_name ? post.author_name : 'Unknown'}
+              {post.author_name ?? 'Unknown'}
               {' '}
               on
               {' '}

--- a/app/webpacker/components/PostsWidget.js
+++ b/app/webpacker/components/PostsWidget.js
@@ -62,7 +62,7 @@ function PostsList({
             <Card.Meta>
               Posted by
               {' '}
-              {post.author ? post.author.name : 'Unknown'}
+              {post.author_name ? post.author_name : 'Unknown'}
               {' '}
               on
               {' '}


### PR DESCRIPTION
For the posts, only author name is used from the author object, hence avoiding serializing author completely.