### PR TITLE
Make contact form clear form action a bit easier to call

### DIFF
--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -44,7 +44,10 @@ export default function ContactForm({
   );
 
   const contactSuccessHandler = () => {
-    dispatch(clearForm(loggedInUserData));
+    dispatch(clearForm({
+      userName: loggedInUserData?.user?.name,
+      userEmail: loggedInUserData?.user?.email,
+    }));
     setContactSuccess(true);
   };
 

--- a/app/webpacker/components/ContactsPage/index.jsx
+++ b/app/webpacker/components/ContactsPage/index.jsx
@@ -19,7 +19,11 @@ export default function ContactsPage({ recaptchaPublicKey }) {
   return (
     <StoreProvider
       reducer={contactsReducer}
-      initialState={getContactFormInitialState(loggedInUserData, queryParams)}
+      initialState={getContactFormInitialState({
+        ...queryParams,
+        userName: loggedInUserData?.user?.name,
+        userEmail: loggedInUserData?.user?.email,
+      })}
     >
       <Container text>
         <Header as="h2">{I18n.t('page.contacts.title')}</Header>

--- a/app/webpacker/components/ContactsPage/store/actions.js
+++ b/app/webpacker/components/ContactsPage/store/actions.js
@@ -12,7 +12,7 @@ export const updateContactRecipient = (contactRecipient) => ({
   payload: { contactRecipient },
 });
 
-export const clearForm = (loggedInUserData, queryParams) => ({
+export const clearForm = (params) => ({
   type: ClearForm,
-  payload: { loggedInUserData, queryParams },
+  payload: { params },
 });

--- a/app/webpacker/components/ContactsPage/store/reducer.js
+++ b/app/webpacker/components/ContactsPage/store/reducer.js
@@ -4,18 +4,18 @@ import {
   UpdateSectionData,
 } from './actions';
 
-export const getContactFormInitialState = (loggedInUserData, queryParams) => ({
+export const getContactFormInitialState = (params) => ({
   formValues: {
     userData: {
-      name: loggedInUserData?.user?.name,
-      email: loggedInUserData?.user?.email,
+      name: params?.userName,
+      email: params?.userEmail,
     },
-    contactRecipient: queryParams?.contactRecipient,
+    contactRecipient: params?.contactRecipient,
     competition: {
-      competitionId: queryParams?.competitionId,
+      competitionId: params?.competitionId,
     },
     wst: {
-      requestId: queryParams?.requestId,
+      requestId: params?.requestId,
     },
   },
   attachments: [],
@@ -42,7 +42,7 @@ const reducers = {
   }),
 
   [ClearForm]: (__, { payload }) => (
-    getContactFormInitialState(payload.loggedInUserData, payload.queryParams)
+    getContactFormInitialState(payload.params)
   ),
 };
 


### PR DESCRIPTION
Currently to dispatch clearForm action, we need to pass two arguments: loggedInUserData and queryParams. In this PR, these two arguments are combined into single argument named 'params', so that it will be easy to do clearForm.

There are some cases where clearForm needs to be dispatched, but loggedInUserData may not be available at that file. So, if this PR is merged, the loggedInUserData can be taken from the state itself when needed.