### PR TITLE
WRT contact form: reset values if another option is selected

### DIFF
--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/EditProfileQuery.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/EditProfileQuery.jsx
@@ -3,7 +3,7 @@ import {
   Form, FormField, FormGroup, Radio,
 } from 'semantic-ui-react';
 import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
-import { updateSectionData } from '../../store/actions';
+import { updateSectionData, clearForm } from '../../store/actions';
 import I18n from '../../../../lib/i18n';
 import UtcDatePicker from '../../../wca/UtcDatePicker';
 import { genders, countries } from '../../../../lib/wca-data.js.erb';
@@ -26,12 +26,24 @@ const countryOptions = _.map(countries.byIso2, (country) => ({
 export default function EditProfileQuery() {
   const {
     formValues: {
+      userData: { name: userName, email: userEmail },
+      contactRecipient,
       wrt: { profileDataToChange, newProfileData, editProfileReason },
     },
   } = useStore();
   const dispatch = useDispatch();
   const handleFormChange = (_, { name, value }) => dispatch(
     updateSectionData(SECTION, name, value),
+  );
+
+  const handleProfileDataFieldChange = (_, { value }) => dispatch(
+    clearForm({
+      userName,
+      userEmail,
+      contactRecipient,
+      queryType: 'edit_profile',
+      profileDataToChange: value,
+    }),
   );
 
   return (
@@ -45,7 +57,7 @@ export default function EditProfileQuery() {
               name="profileDataToChange"
               value={profileDataField}
               checked={profileDataToChange === profileDataField}
-              onChange={handleFormChange}
+              onChange={handleProfileDataFieldChange}
             />
           </FormField>
         ))}

--- a/app/webpacker/components/ContactsPage/store/reducer.js
+++ b/app/webpacker/components/ContactsPage/store/reducer.js
@@ -17,6 +17,10 @@ export const getContactFormInitialState = (params) => ({
     wst: {
       requestId: params?.requestId,
     },
+    wrt: {
+      queryType: params?.queryType,
+      profileDataToChange: params?.profileDataToChange,
+    },
   },
   attachments: [],
 });


### PR DESCRIPTION
Currently if 'edit name' is selected and then if it's changed to 'country', the value still remains. With this PR, when user clicks another option under edit profile, it resets the form till that point.