### PR TITLE
Add proof attachment field for contact form

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -44,7 +44,7 @@ class ContactsController < ApplicationController
     end
   end
 
-  private def contact_wrt(requestor_details, contact_params)
+  private def contact_wrt(requestor_details, contact_params, attachments)
     profile_data_to_change = contact_params[:profileDataToChange]
     maybe_send_contact_email(
       ContactWrt.new(
@@ -55,6 +55,7 @@ class ContactsController < ApplicationController
         new_profile_data: new_profile_data_key_to_value(contact_params[:newProfileData], profile_data_to_change),
         edit_profile_reason: contact_params[:editProfileReason],
         message: contact_params[:message],
+        document: attachments,
         request: request,
         logged_in_email: current_user&.email || 'None',
       ),
@@ -77,6 +78,7 @@ class ContactsController < ApplicationController
   def contact
     formValues = JSON.parse(params.require(:formValues), symbolize_names: true)
     contact_recipient = formValues[:contactRecipient]
+    attachments = params[:attachment]
     contact_params = formValues[contact_recipient.to_sym]
     requestor_details = current_user || formValues[:userData]
 
@@ -86,7 +88,7 @@ class ContactsController < ApplicationController
     when UserGroup.teams_committees_group_wct.metadata.friendly_id
       contact_wct(requestor_details, contact_params)
     when UserGroup.teams_committees_group_wrt.metadata.friendly_id
-      contact_wrt(requestor_details, contact_params)
+      contact_wrt(requestor_details, contact_params, attachments)
     when UserGroup.teams_committees_group_wst.metadata.friendly_id
       contact_wst(requestor_details, contact_params)
     when "competition"

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -44,7 +44,7 @@ class ContactsController < ApplicationController
     end
   end
 
-  private def contact_wrt(requestor_details, contact_params, attachments)
+  private def contact_wrt(requestor_details, contact_params, attachment)
     profile_data_to_change = contact_params[:profileDataToChange]
     maybe_send_contact_email(
       ContactWrt.new(
@@ -55,7 +55,7 @@ class ContactsController < ApplicationController
         new_profile_data: new_profile_data_key_to_value(contact_params[:newProfileData], profile_data_to_change),
         edit_profile_reason: contact_params[:editProfileReason],
         message: contact_params[:message],
-        document: attachments,
+        document: attachment,
         request: request,
         logged_in_email: current_user&.email || 'None',
       ),
@@ -78,7 +78,7 @@ class ContactsController < ApplicationController
   def contact
     formValues = JSON.parse(params.require(:formValues), symbolize_names: true)
     contact_recipient = formValues[:contactRecipient]
-    attachments = params[:attachment]
+    attachment = params[:attachment]
     contact_params = formValues[contact_recipient.to_sym]
     requestor_details = current_user || formValues[:userData]
 
@@ -88,7 +88,7 @@ class ContactsController < ApplicationController
     when UserGroup.teams_committees_group_wct.metadata.friendly_id
       contact_wct(requestor_details, contact_params)
     when UserGroup.teams_committees_group_wrt.metadata.friendly_id
-      contact_wrt(requestor_details, contact_params, attachments)
+      contact_wrt(requestor_details, contact_params, attachment)
     when UserGroup.teams_committees_group_wst.metadata.friendly_id
       contact_wst(requestor_details, contact_params)
     when "competition"

--- a/app/models/contact_wrt.rb
+++ b/app/models/contact_wrt.rb
@@ -6,6 +6,7 @@ class ContactWrt < ContactForm
   attribute :new_profile_data
   attribute :edit_profile_reason
   attribute :message
+  attribute :document, attachment: true
 
   def to_email
     UserGroup.teams_committees_group_wrt.metadata.email

--- a/app/webpacker/components/ContactsPage/ContactForm.jsx
+++ b/app/webpacker/components/ContactsPage/ContactForm.jsx
@@ -88,6 +88,7 @@ export default function ContactForm({
           if (isFormValid) {
             const formData = new FormData();
             formData.append('formValues', JSON.stringify(contactFormState.formValues));
+            formData.append('attachment', contactFormState.attachments[0]);
             save(
               contactUrl,
               formData,

--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/EditProfileQuery.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/EditProfileQuery.jsx
@@ -3,7 +3,7 @@ import {
   Form, FormField, FormGroup, Radio,
 } from 'semantic-ui-react';
 import { useDispatch, useStore } from '../../../../lib/providers/StoreProvider';
-import { updateSectionData, clearForm } from '../../store/actions';
+import { updateSectionData, clearForm, uploadProfileChangeProof } from '../../store/actions';
 import I18n from '../../../../lib/i18n';
 import UtcDatePicker from '../../../wca/UtcDatePicker';
 import { genders, countries } from '../../../../lib/wca-data.js.erb';
@@ -44,6 +44,10 @@ export default function EditProfileQuery() {
       queryType: 'edit_profile',
       profileDataToChange: value,
     }),
+  );
+
+  const handleFileUpload = (event) => dispatch(
+    uploadProfileChangeProof(event.target.files[0]),
   );
 
   return (
@@ -111,6 +115,11 @@ export default function EditProfileQuery() {
             name="editProfileReason"
             value={editProfileReason}
             onChange={handleFormChange}
+          />
+          <Form.Input
+            label={I18n.t('page.contacts.form.wrt.edit_profile_proof_attach.label')}
+            type="file"
+            onChange={handleFileUpload}
           />
         </>
       )}

--- a/app/webpacker/components/ContactsPage/store/actions.js
+++ b/app/webpacker/components/ContactsPage/store/actions.js
@@ -1,6 +1,7 @@
 export const UpdateSectionData = 'UPDATE_SECTION_DATA';
 export const UpdateContactRecipient = 'UPDATE_CONTACT_RECIPIENT';
 export const ClearForm = 'CLEAR_FORM';
+export const UploadProfileChangeProof = 'UPLOAD_PROFILE_CHANGE_PROOF';
 
 export const updateSectionData = (section, name, value) => ({
   type: UpdateSectionData,
@@ -15,4 +16,9 @@ export const updateContactRecipient = (contactRecipient) => ({
 export const clearForm = (params) => ({
   type: ClearForm,
   payload: { params },
+});
+
+export const uploadProfileChangeProof = (file) => ({
+  type: UploadProfileChangeProof,
+  payload: { file },
 });

--- a/app/webpacker/components/ContactsPage/store/reducer.js
+++ b/app/webpacker/components/ContactsPage/store/reducer.js
@@ -2,6 +2,7 @@ import {
   ClearForm,
   UpdateContactRecipient,
   UpdateSectionData,
+  UploadProfileChangeProof,
 } from './actions';
 
 export const getContactFormInitialState = (params) => ({
@@ -48,6 +49,11 @@ const reducers = {
   [ClearForm]: (__, { payload }) => (
     getContactFormInitialState(payload.params)
   ),
+
+  [UploadProfileChangeProof]: (state, { payload }) => ({
+    ...state,
+    attachments: [payload.file],
+  }),
 };
 
 export default function rootReducer(state, action) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -848,6 +848,8 @@ en:
             label: "New DOB"
           edit_profile_reason:
             label: "Reason for the change"
+          edit_profile_proof_attach:
+            label: "Attach proof"
         wst:
           message:
             label: "Message"


### PR DESCRIPTION
In this PR, allowed the user to attach proof for changing profile data. But I couldn't test if the attachment is coming in email as the MailCatcher is not working. This can probably tested only in production. I can see the email in logs, so pretty sure this will not break anything, the worst case will be that the mail will come but without any attachment.