### PR TITLE
Mark Stripe frontend widget tests as pending

### DIFF
--- a/spec/features/stripe_integration_spec.rb
+++ b/spec/features/stripe_integration_spec.rb
@@ -25,6 +25,8 @@ RSpec.feature "Stripe PaymentElement integration" do
     end
 
     it "loads the PaymentElement", js: true do
+      pending('Stripe frontend tests intermediate failure. Signed GB 22/Jul/2024')
+
       # In the beginning, the button to pay should be disabled
       expect(page).to have_button('Pay now!', disabled: true)
 
@@ -62,6 +64,8 @@ RSpec.feature "Stripe PaymentElement integration" do
     end
 
     it "warns when the subtotal is too high", js: true do
+      pending('Stripe frontend tests intermediate failure. Signed GB 22/Jul/2024')
+
       # (accidentally?) donate a ridiculously high amount of money
       donation_money = competition.base_entry_fee * competition.base_entry_fee.cents
 


### PR DESCRIPTION
The UI tests that fill stuff within an iFrame stopped working suddenly and without any code changes on our part.

The fail first occured on the `main` branch CI check for the squashed merge commit of #9683: https://github.com/thewca/worldcubeassociation.org/commit/165df17f45d8418fe8e6c2ab509e0105ee4cac25

However, on the PR itself, the CI check for the PR worked just fine: https://github.com/thewca/worldcubeassociation.org/pull/9683/checks

So I am suspecting that Stripe's UI is at fault here, maybe the CrowdStrike outage has something to do with it. As soon as the tests begin to succeed again, the `pending` call will fail, notifying us that the tests can be enabled again.