### PR TITLE
Cache user-groups

### DIFF
--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -35,7 +35,7 @@ module Cachable
     end
 
     def as_cached
-      self.class.try(self.cachable_id) || self.class.c_find(self.cachable_id)
+      self.class.try(self.cachable_id.to_s) || self.class.c_find(self.cachable_id)
     end
   end
 

--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -35,7 +35,7 @@ module Cachable
     end
 
     def as_cached
-      self.class.c_find(self.cachable_id)
+      self.class.try(self.cachable_id) || self.class.c_find(self.cachable_id)
     end
   end
 

--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -56,11 +56,9 @@ module Cachable
       self.c_all_by_id.values
     end
 
-    # It is vitally important that this caching declaration happens before any `enum` calls
-    # because otherwise Rails throws an error. Probably their fault, we should consider filing a bug. (GB 2024-08-07)
     def cached_entity(*ids)
       ids.each do |id|
-        self.mattr_reader(id, instance_accessor: false) { self.c_find(id) }
+        self.define_singleton_method(id) { self.c_find(id) }
       end
     end
   end

--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -41,7 +41,7 @@ module Cachable
 
   class_methods do
     def c_all_by_id
-      self.models_by_id ||= self.all.index_by(&:cachable_id)
+      self.models_by_id ||= self.all.index_by(&:cachable_id).with_indifferent_access
     end
 
     def c_find(id)
@@ -54,6 +54,14 @@ module Cachable
 
     def c_values
       self.c_all_by_id.values
+    end
+
+    # It is vitally important that this caching declaration happens before any `enum` calls
+    # because otherwise Rails throws an error. Probably their fault, we should consider filing a bug. (GB 2024-08-07)
+    def cached_entity(*ids)
+      ids.each do |id|
+        self.mattr_reader(id, instance_accessor: false) { self.c_find(id) }
+      end
     end
   end
 end

--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -26,11 +26,18 @@ module Cachable
     def clear_cache
       self.models_by_id = nil
     end
+
+    # Tells the caching mechanism what ID to cache by.
+    # For static objects like Country or Continent, this should be `id` by default.
+    # But for some other objects like T/Cs, we have a separate `friendly_id` column that we want to index by.
+    def cachable_id
+      self.id
+    end
   end
 
   class_methods do
     def c_all_by_id
-      self.models_by_id ||= self.all.index_by(&:id)
+      self.models_by_id ||= self.all.index_by(&:cachable_id)
     end
 
     def c_find(id)

--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -33,6 +33,10 @@ module Cachable
     def cachable_id
       self.id
     end
+
+    def as_cached
+      self.class.c_find(self.cachable_id)
+    end
   end
 
   class_methods do

--- a/app/models/groups_metadata_board.rb
+++ b/app/models/groups_metadata_board.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 class GroupsMetadataBoard < ApplicationRecord
+  include Cachable
+
   self.table_name = "groups_metadata_board"
 
+  has_one :user_group, as: :metadata
+
+  def self.singleton_metadata
+    self.c_values.first
+  end
+
   def self.email
-    UserGroup.board_group.metadata.email
+    self.singleton_metadata.email
   end
 end

--- a/app/models/groups_metadata_teams_committees.rb
+++ b/app/models/groups_metadata_teams_committees.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
 class GroupsMetadataTeamsCommittees < ApplicationRecord
+  include Cachable
+
   has_one :user_group, as: :metadata
+
+  # This has to happen before the `cached_reader` call below, because otherwise that call doesn't know what to index by
+  def cachable_id
+    self.friendly_id
+  end
+
+  cached_entity :wct, :wcat, :wdc, :wdpc, :wec, :weat, :wfc, :wmt, :wqac, :wrc, :wrt, :wst, :wst_admin, :wct_china, :wat, :wsot
 
   enum :preferred_contact_mode, {
     no_contact: "no_contact",

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -37,6 +37,8 @@ class UserGroup < ApplicationRecord
 
   validates :active_roles, absence: true, unless: :is_active?
 
+  mattr_accessor :board_group, instance_writer: false, instance_reader: false, default: UserGroup.board.first
+
   def all_child_groups
     [direct_child_groups, direct_child_groups.map(&:all_child_groups)].flatten
   end
@@ -78,10 +80,6 @@ class UserGroup < ApplicationRecord
       officers: "Officers",
       banned_competitors: "Banned Competitors",
     }
-  end
-
-  def self.board_group
-    UserGroup.board.first
   end
 
   def self.teams_committees_group_wct

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -37,7 +37,11 @@ class UserGroup < ApplicationRecord
 
   validates :active_roles, absence: true, unless: :is_active?
 
+  # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+  #
+  # This is for caching Board group to avoid DB querying everytime it's referenced.
   mattr_accessor :board_group, instance_writer: false, instance_reader: false, default: UserGroup.board.first
+  # rubocop:enable ThreadSafety/ClassAndModuleAttributes
 
   # This is important because we generally access "semantic" UserGroups
   # (ie T/Cs, DelegateRegions, Translators) etc. by metadata. This metadata usually has an `user_group`

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -102,47 +102,47 @@ class UserGroup < ApplicationRecord
   end
 
   def self.teams_committees_group_wct
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wct').user_group
+    GroupsMetadataTeamsCommittees.wct.user_group
   end
 
   def self.teams_committees_group_wcat
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wcat').user_group
+    GroupsMetadataTeamsCommittees.wcat.user_group
   end
 
   def self.teams_committees_group_wdc
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wdc').user_group
+    GroupsMetadataTeamsCommittees.wdc.user_group
   end
 
   def self.teams_committees_group_wdpc
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wdpc').user_group
+    GroupsMetadataTeamsCommittees.wdpc.user_group
   end
 
   def self.teams_committees_group_wec
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wec').user_group
+    GroupsMetadataTeamsCommittees.wec.user_group
   end
 
   def self.teams_committees_group_weat
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'weat').user_group
+    GroupsMetadataTeamsCommittees.weat.user_group
   end
 
   def self.teams_committees_group_wfc
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wfc').user_group
+    GroupsMetadataTeamsCommittees.wfc.user_group
   end
 
   def self.teams_committees_group_wmt
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wmt').user_group
+    GroupsMetadataTeamsCommittees.wmt.user_group
   end
 
   def self.teams_committees_group_wqac
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wqac').user_group
+    GroupsMetadataTeamsCommittees.wqac.user_group
   end
 
   def self.teams_committees_group_wrc
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wrc').user_group
+    GroupsMetadataTeamsCommittees.wrc.user_group
   end
 
   def self.teams_committees_group_wrt
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wrt').user_group
+    GroupsMetadataTeamsCommittees.wrt.user_group
   end
 
   def self.council_group_wac
@@ -150,23 +150,23 @@ class UserGroup < ApplicationRecord
   end
 
   def self.teams_committees_group_wst
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wst').user_group
+    GroupsMetadataTeamsCommittees.wst.user_group
   end
 
   def self.teams_committees_group_wst_admin
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wst_admin').user_group
+    GroupsMetadataTeamsCommittees.wst_admin.user_group
   end
 
   def self.teams_committees_group_wct_china
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wct_china').user_group
+    GroupsMetadataTeamsCommittees.wct_china.user_group
   end
 
   def self.teams_committees_group_wat
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wat').user_group
+    GroupsMetadataTeamsCommittees.wat.user_group
   end
 
   def self.teams_committees_group_wsot
-    GroupsMetadataTeamsCommittees.find_by(friendly_id: 'wsot').user_group
+    GroupsMetadataTeamsCommittees.wsot.user_group
   end
 
   def self.banned_competitors_group

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -37,12 +37,6 @@ class UserGroup < ApplicationRecord
 
   validates :active_roles, absence: true, unless: :is_active?
 
-  # rubocop:disable ThreadSafety/ClassAndModuleAttributes
-  #
-  # This is for caching Board group to avoid DB querying everytime it's referenced.
-  mattr_accessor :board_group, instance_writer: false, instance_reader: false, default: UserGroup.board.first
-  # rubocop:enable ThreadSafety/ClassAndModuleAttributes
-
   # This is important because we generally access "semantic" UserGroups
   # (ie T/Cs, DelegateRegions, Translators) etc. by metadata. This metadata usually has an `user_group`
   # association defined, and Rails uses caching on that. So if the server after booting loads all T/Cs once,
@@ -175,6 +169,10 @@ class UserGroup < ApplicationRecord
 
   def self.banned_competitors_group
     UserGroup.banned_competitors.first
+  end
+
+  def self.board_group
+    GroupsMetadataBoard.singleton_metadata.user_group
   end
 
   def senior_delegate

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -45,14 +45,13 @@ class UserGroup < ApplicationRecord
   #
   # This commit hook makes it so that whenever a change happens, we reset the metadata
   # so that it finds the newest changes even in cache mode (reset_* methods are provided by Rails magically.)
-  after_commit :reset_metadata
+  after_commit :reset_metadata, on: [:update, :destroy]
 
   private def reset_metadata
-    metadata_persisted = self.metadata.persisted?
     metadata_cachable = self.metadata.class < Cachable
     metadata_has_assoc = self.metadata.class.reflect_on_association(:user_group).present?
 
-    if metadata_persisted && metadata_cachable && metadata_has_assoc
+    if metadata_cachable && metadata_has_assoc
       self.metadata&.as_cached&.reset_user_group
     end
   end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -48,10 +48,11 @@ class UserGroup < ApplicationRecord
   after_commit :reset_metadata
 
   private def reset_metadata
+    metadata_persisted = self.metadata.persisted?
     metadata_cachable = self.metadata.class < Cachable
     metadata_has_assoc = self.metadata.class.reflect_on_association(:user_group).present?
 
-    if metadata_cachable && metadata_has_assoc
+    if metadata_persisted && metadata_cachable && metadata_has_assoc
       self.metadata&.as_cached&.reset_user_group
     end
   end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -48,11 +48,13 @@ class UserGroup < ApplicationRecord
   after_commit :reset_metadata, on: [:update, :destroy]
 
   private def reset_metadata
+    return unless self.metadata.present?
+
     metadata_cachable = self.metadata.class < Cachable
     metadata_has_assoc = self.metadata.class.reflect_on_association(:user_group).present?
 
     if metadata_cachable && metadata_has_assoc
-      self.metadata&.as_cached&.reset_user_group
+      self.metadata.as_cached.reset_user_group
     end
   end
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -18,6 +18,9 @@ class UserRole < ApplicationRecord
   scope :active, -> { where(end_date: nil).or(inactive.invert_where) }
   scope :inactive, -> { where(end_date: ..Date.today) }
 
+  # We need this for creating new roles that would otherwise be instantiated with an out-of-date group reference
+  after_commit :reset_group, on: :create
+
   UserRoleChange = Struct.new(
     :changed_parameter,
     :previous_value,

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -5,7 +5,12 @@ include SortHelper # rubocop:disable Style/MixinUsage
 
 class UserRole < ApplicationRecord
   belongs_to :user
-  belongs_to :group, class_name: "UserGroup"
+  # The `touch` flag is necessary so that whenever a role is updated,
+  #   the associated UserGroup is notified and a small hook is triggered which makes sure
+  #   that the cached parts of our code get a hold of the most recent changes
+  #
+  # (briefly put: Propagate all changes made to this role to the after_commit hook in user_group.rb)
+  belongs_to :group, class_name: "UserGroup", touch: true
   belongs_to :metadata, polymorphic: true, optional: true
 
   delegate :group_type, to: :group


### PR DESCRIPTION
Currently whenever a user-group is loaded from the class methods in user_group.rb, a database read happens. This PR aims to avoid that.