### PR TITLE
Removed WRC competitio permissions, added view users permissions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -707,7 +707,7 @@ class User < ApplicationRecord
   end
 
   def can_view_all_users?
-    admin? || board_member? || results_team? || communication_team? || wdc_team? || any_kind_of_delegate? || weat_team?
+    admin? || board_member? || results_team? || communication_team? || wdc_team? || any_kind_of_delegate? || weat_team? || wrc_team?
   end
 
   def can_edit_user?(user)
@@ -766,7 +766,6 @@ class User < ApplicationRecord
       can_admin_competitions? ||
       competition.organizers.include?(self) ||
       competition.delegates.include?(self) ||
-      wrc_team? ||
       competition.delegates.flat_map(&:senior_delegates).compact.include?(self) ||
       ethics_committee?
     )


### PR DESCRIPTION
Finn noticed an inconsistency that WRC members are allowed to view competition registrations. 

In the email thread "[QUERY] Does WRC need to view a competition's "Registrations" tab?", I asked WRC if they need this permission. They clarified that they don't, but they do need to be able to view users to get email addresses where needed. 

The scope of access still seems larger than needed, but the PR was trivial enough to raise quickly and if we're going to give broad access it makes sense to at least give broad access to the right thing. 