### PR TITLE
Split Payment Information from Extra Registration Requirements

### DIFF
--- a/app/views/competitions/_competition_info.html.erb
+++ b/app/views/competitions/_competition_info.html.erb
@@ -179,6 +179,12 @@
           <%= render "registration_requirements", show_links_to_register_page: true %>
         </div>
       </dd>
+      <dt><%= t 'registrations.payment_form.labels.payment_information' %></dt>
+      <dd>
+        <div class="<%= collapse ? "collapse" : "" %>" id="payment_information_text">
+          <%= render "payment_information" %>
+        </div>
+      </dd>
       <% if competition.user_can_view_results?(current_user) %>
         <% records = records(competition) %>
         <% if main_event.present? || records.present? %>

--- a/app/views/competitions/_payment_information.erb
+++ b/app/views/competitions/_payment_information.erb
@@ -1,0 +1,14 @@
+<% if @competition.using_payment_integrations? %>
+  <% if @competition.stripe_connected? %>
+    <%= t 'competitions.competition_info.payment_integration.stripe' %>
+  <% end %>
+  <% if @competition.paypal_connected? %>
+    <%= t 'competitions.competition_info.payment_integration.paypal' %>
+  <% end %>
+<% else %>
+  <% if @competition.payment_information.present? %>
+    <%=md @competition.payment_information %>
+  <% else %>
+    <%= t 'registrations.wont_pay_here' %>
+  <% end %>
+<% end %>

--- a/app/webpacker/components/CompetitionForm/FormSections/RegistrationFees.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/RegistrationFees.js
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
+import { Checkbox } from 'semantic-ui-react';
 import {
   InputBoolean,
   InputCurrencyAmount,
-  InputDate,
+  InputDate, InputMarkdown,
   InputNumber,
   InputSelect,
 } from '../../wca/FormBuilder/input/FormInputs';
@@ -13,6 +14,7 @@ import useLoadedData from '../../../lib/hooks/useLoadedData';
 import ConditionalSection from './ConditionalSection';
 import SubSection from '../../wca/FormBuilder/SubSection';
 import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider';
+import useCheckboxState from '../../../lib/hooks/useCheckboxState';
 
 const currenciesOptions = Object.keys(currenciesData.byIso).map((iso) => ({
   key: iso,
@@ -28,7 +30,10 @@ export default function RegistrationFees() {
     entryFees,
     competitorLimit,
     registration,
+    paymentInformation,
   } = useFormObject();
+
+  const [useWCAPayment, setUseWCAPayment] = useCheckboxState(Boolean(paymentInformation));
 
   const currency = entryFees.currencyCode;
 
@@ -75,6 +80,10 @@ export default function RegistrationFees() {
 
   return (
     <SubSection section="entryFees">
+      <Checkbox id="useWCAPayment" checked={useWCAPayment} onChange={setUseWCAPayment} label={I18n.t('competitions.competition_form.labels.entry_fees.use_wca_payment')} />
+      <ConditionalSection showIf={!useWCAPayment}>
+        <InputMarkdown id="paymentInformation" required={!useWCAPayment} />
+      </ConditionalSection>
       <InputSelect id="currencyCode" options={currenciesOptions} required />
       <InputCurrencyAmount id="baseEntryFee" currency={currency} required />
       <p className="help-block">

--- a/app/webpacker/components/RegistrationsV2/Register/ExternalPaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/ExternalPaymentStep.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {
+  Form,
+  Segment,
+} from 'semantic-ui-react';
+import Markdown from '../../Markdown';
+import i18n from '../../../lib/i18n';
+
+export default function ExternalPaymentStep({
+  competitionInfo,
+  nextStep,
+}) {
+  return (
+    <Segment>
+      <Form onSubmit={nextStep}>
+        {competitionInfo.payment_information ? <Markdown md={competitionInfo.payment_information} /> : i18n.t('registrations.wont_pay_here') }
+        <br />
+        <Form.Button type="submit">I have paid</Form.Button>
+      </Form>
+    </Segment>
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -18,7 +18,6 @@ import Loading from '../../Requests/Loading';
 import i18n from '../../../lib/i18n';
 import useCheckboxState from '../../../lib/hooks/useCheckboxState';
 import AutonumericField from '../../wca/FormBuilder/input/AutonumericField';
-import RegistrationOverview from './RegistrationOverview';
 
 export default function PaymentStep({
   competitionInfo,

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
@@ -83,11 +83,6 @@ export default function RegistrationOverview({
         {i18n.t(updateRegistrationKey(editsAllowed, hasRegistrationEditDeadlinePassed))}
       </Message>
       )}
-      { !competitionInfo['using_payment_integrations?'] && registration.competing.registration_status === 'pending' && competitionInfo.base_entry_fee_lowest_denomination && (
-        <Message info>
-          {i18n.t('registrations.wont_pay_here')}
-        </Message>
-      )}
       <Segment loading={isDeleting}>
         <Header>{i18n.t('competitions.nav.menu.registration')}</Header>
         <Form onSubmit={nextStep} size="large">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1444,6 +1444,9 @@ en:
       guests_free:
         free: "Any spectator can attend for free."
         restricted: "Spectators are only permitted as companions of competitors."
+      payment_integration:
+        stripe: "You will pay via Stripe as part of the Registration Process"
+        paypal: "You will pay via PayPal as part of the Registration Process"
       guest_limit:
         one: "Competitors may bring at most 1 guest."
         other: "Competitors may bring at most %{count} guests."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1636,6 +1636,8 @@ en:
           uses_wca_registration: "I would like to use the WCA website for registration"
           uses_wca_live: "I will be using WCA Live for scoretaking"
         entry_fees:
+          use_wca_payment: "Use WCA Payment?"
+          payment_information: "Payment information text"
           currency_code: "Currency code"
           base_entry_fee: "Base registration fee"
           on_the_spot_entry_fee: "On the spot base registration fee"
@@ -1720,6 +1722,8 @@ en:
         user_settings:
           receive_registration_emails: ""
         entry_fees:
+          use_wca_payment: "If you want to use the WCA Website to collect payments (You will still need to connect your stripe account separately)"
+          payment_information: "Explanation on how users will pay for the competition.  <br/>Please fill this out <b>in English</b> and whatever other languages your competitors speak; this will be displayed on the competition's information page, as well on the registration page if you are using the WCA website registrations."
           currency_code: "The currency code for fees."
           base_entry_fee: 'The base registration fee for the competition. It will be displayed on the competition information page and the registration page if used. If this is set to 0, a sentence will be displayed saying that registrations will be accepted for free. <br><br><b>DISCLAIMER: The following WCA Dues estimate is solely an approximation based on current exchange rates and is in no way legally binding for the Dues payment.</b>'
           on_the_spot_entry_fee: "If this is set to 0, a sentence will be displayed saying that on the spot registrations will be accepted for free."
@@ -1738,7 +1742,7 @@ en:
           guests_enabled: ""
           guest_entry_status: ""
           guests_per_registration: "The number of guests per registration allowed at this competition. Registration with too many guests will be blocked. Leave blank if there is no limit."
-          extra_requirements: "Please indicate here any extra registration requirements not covered above, like for example directions on how to pay. <br/>Please fill this out <b>in English</b> and whatever other languages your competitors speak; this will be displayed on the competition's information page, as well on the registration page if you are using the WCA website registrations."
+          extra_requirements: "Please indicate here any extra registration requirements not covered above. <br/>Please fill this out <b>in English</b> and whatever other languages your competitors speak; this will be displayed on the competition's information page, as well on the registration page if you are using the WCA website registrations."
           force_comment: ""
         event_restrictions:
           forbid_newcomers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1245,7 +1245,7 @@ en:
     accepted: "Your registration has been accepted!"
     entry_fees_fully_paid: "You have paid %{paid}, which fully covers the registration fees."
     will_pay_here: "You will pay them here after submitting your registration"
-    wont_pay_here: "Please check competition's information for instruction about how to pay"
+    wont_pay_here: "This competition uses external payments. Please check competition's information for instruction about how to pay"
     not_qualified: "Not qualified"
     refund_form:
       hints:

--- a/db/migrate/20240802134540_add_payment_information.rb
+++ b/db/migrate/20240802134540_add_payment_information.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPaymentInformation < ActiveRecord::Migration[7.1]
+  def change
+    add_column :Competitions, :payment_information, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_142240) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_02_134540) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_142240) do
     t.boolean "uses_v2_registrations", default: false, null: false
     t.boolean "forbid_newcomers", default: false, null: false
     t.string "forbid_newcomers_reason"
+    t.text "payment_information"
     t.index ["cancelled_at"], name: "index_Competitions_on_cancelled_at"
     t.index ["countryId"], name: "index_Competitions_on_countryId"
     t.index ["end_date"], name: "index_Competitions_on_end_date"


### PR DESCRIPTION
This allows for showing the user how to pay externally as part of the Registration Step Panel. Setting to draft because I am still waiting on WCAT on some implementation Details

TODO:
- Make sure the Registration Create Form works as expected 
- Finalize Design of External Payment Step
- Save the external payment 'approval' step in Localstorage or maybe even in the registration service?