### PR TITLE
Skip all rows for microservice_registrations in dev_dump

### DIFF
--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -587,20 +587,7 @@ module DatabaseDumper
         },
       ),
     }.freeze,
-    "microservice_registrations" => {
-      where_clause: JOIN_WHERE_VISIBLE_COMP,
-      column_sanitizers: actions_to_column_sanitizers(
-        copy: %w(
-          id
-          competition_id
-          user_id
-          roles
-          is_competing
-          created_at
-          updated_at
-        ),
-      ),
-    }.freeze,
+    "microservice_registrations" => :skip_all_rows,
     "sanity_checks" => :skip_all_rows,
     "sanity_check_categories" => :skip_all_rows,
     "sanity_check_exclusions" => :skip_all_rows,


### PR DESCRIPTION
Makes no sense to keep these anyway for the Dev Dump, as they rely on DynamoDB having the same data