### PR TITLE
Enable V2 Registrations for my competitions in prod

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -848,7 +848,7 @@ class CompetitionsController < ApplicationController
   end
 
   def my_competitions
-    if Rails.env.production? && !EnvConfig.WCA_LIVE_SITE?
+    if Rails.env.production?
       registrations_v2 = current_user.microservice_registrations
     else
       registrations_v2 = []


### PR DESCRIPTION
We still need to figure out what to do in development because we don't persist v2 registrations locally right now which causes errors. 