### PR TITLE
Untangle some threads (aka. clean up caching mechanisms with unnecessary thread_mattr_accessor)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -234,3 +234,12 @@ Naming/BlockForwarding:
 
 Style/ArgumentsForwarding:
   RedundantBlockArgumentNames: []
+
+# These are files where we accept in-memory caching as a trade-off
+# for thread safety. At the time of writing this comment, WST is confident that these three
+# implementations are either thread safe or don't suffer any problems from concurrent access.
+ThreadSafety/ClassAndModuleAttributes:
+  Exclude:
+    - 'app/models/concerns/cachable.rb'
+    - 'app/models/concerns/localized_sortable.rb'
+    - 'app/models/concerns/regulation.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -242,4 +242,4 @@ ThreadSafety/ClassAndModuleAttributes:
   Exclude:
     - 'app/models/concerns/cachable.rb'
     - 'app/models/concerns/localized_sortable.rb'
-    - 'app/models/concerns/regulation.rb'
+    - 'app/models/regulation.rb'

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -3,8 +3,6 @@
 class TranslationsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
-  mattr_accessor :bad_i18n_keys, instance_writer: false, default: self.compute_bad_i18n_keys
-
   def self.compute_bad_i18n_keys
     english = locale_to_translation('en')
 
@@ -18,6 +16,8 @@ class TranslationsController < ApplicationController
     filename = Rails.root.join('config', 'locales', "#{locale}.yml")
     WcaI18n::Translation.new(locale, File.read(filename))
   end
+
+  mattr_accessor :bad_i18n_keys, instance_writer: false, default: self.compute_bad_i18n_keys
 
   def index
     @bad_i18n_keys = self.bad_i18n_keys

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -3,15 +3,13 @@
 class TranslationsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
-  thread_mattr_accessor :bad_keys, instance_writer: false
+  mattr_accessor :bad_i18n_keys, instance_writer: false, default: self.compute_bad_i18n_keys
 
-  def self.bad_i18n_keys
-    self.bad_keys ||= begin
-      english = locale_to_translation('en')
+  def self.compute_bad_i18n_keys
+    english = locale_to_translation('en')
 
-      (I18n.available_locales - [:en]).index_with do |locale|
-        locale_to_translation(locale).compare_to(english)
-      end
+    (I18n.available_locales - [:en]).index_with do |locale|
+      locale_to_translation(locale).compare_to(english)
     end
   end
 
@@ -22,7 +20,7 @@ class TranslationsController < ApplicationController
   end
 
   def index
-    @bad_i18n_keys = self.class.bad_i18n_keys
+    @bad_i18n_keys = self.bad_i18n_keys
     bad_keys = @bad_i18n_keys.values.map(&:values).flatten
     @all_translations_perfect = bad_keys.empty?
   end

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -17,7 +17,7 @@ class TranslationsController < ApplicationController
     WcaI18n::Translation.new(locale, File.read(filename))
   end
 
-  mattr_accessor :bad_i18n_keys, instance_writer: false, default: self.compute_bad_i18n_keys
+  mattr_reader :bad_i18n_keys, default: self.compute_bad_i18n_keys
 
   def index
     @bad_i18n_keys = self.bad_i18n_keys

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -17,10 +17,10 @@ class TranslationsController < ApplicationController
     WcaI18n::Translation.new(locale, File.read(filename))
   end
 
-  mattr_reader :bad_i18n_keys, default: self.compute_bad_i18n_keys
+  BAD_I18N_KEYS = self.compute_bad_i18n_keys
 
   def index
-    @bad_i18n_keys = self.bad_i18n_keys
+    @bad_i18n_keys = TranslationsController::BAD_I18N_KEYS
     bad_keys = @bad_i18n_keys.values.map(&:values).flatten
     @all_translations_perfect = bad_keys.empty?
   end

--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -1,30 +1,53 @@
 # frozen_string_literal: true
 
 # For classes such as Country, Event, etc. we want to keep a local cache of the data in the db:
-#  - the data are read very often
-#  - we don't modify these tables from within the application, so cache invalidation is
-#    as simple as restarting the server, which is done whenever we deploy.
+#  - The data is being read very often
+#  - We don't modify these tables frequently, so cache invalidation is okay to control manually.
+#    Read the instructions below for details.
 #
 # /!\ READ THIS BEFORE USING THIS MODULE /!\
 #
-# It has been designed for models that are read-only during the application's lifetime.
-# (Modifications to the data in db are typically made through migrations)
-# Please refer to the discussions in https://github.com/cubing/worldcubeassociation.org/pull/908.
-# If you plan on using it for more dynamic models you'd most likely need to add
-# a cache invalidation mechanism.
-# Keep in mind multiple instances of the application run on the server(!!!).
+# Keep in mind multiple instances of the application run on the server(!!!). The implications are explained
+#   in another comment below, especially regarding thread-safety on Puma.
+#
+# If you are using this for writing data, keep the following in mind:
+#  - The cached classes themselves will invalidate their own cache whenever an update to the DB is made
+#    (see after_commit hook below)
+#  - If you have some depending classes (that point to a cached entity) you will need them to let their cached entity
+#    "forget" about their stored relation. There are two standard ways to do that:
+#     1. Defining a `touch: true` on the belongs_to/has_one/has_many relation that points to this cached entity.
+#        Doing so will trigger the `after_commit` hook in here, reloading the data as needed.
+#     2. Defining a custom hook that uses Rails' magic `reset_{association_name}` methods to let the associated
+#        cachable entity "forget" their backlink to whatever class relies on the cachable entity.
+#     In 9/10 cases you probably want to choose option (1), just saying that a custom solution using (2) is possible.
+#
+# ***IMPORTANT*** To future WST: If we ever (for some reason) move away from the standard MRI Ruby interpreter
+#   (the one that comes bundled with modern Ruby installations and also the Docker `ruby` image)
+#   and we end up using something like JRuby -- which has _true_ multi-threading -- this class has to be redesigned!
 require 'active_support/concern'
 
 module Cachable
   extend ActiveSupport::Concern
 
   included do
-    thread_mattr_accessor :models_by_id
+    # We do NOT want to use thread_mattr_accessor here on purpose. Using the thread_* version
+    #   makes it so that each thread has its own copy of the variable, with independent values per thread
+    #   (essentially, each thread keeps its own cache). But if one user launches one request to update a team role
+    #   which is served by one single (Puma) thread, all other threads should be invalidated as well.
+    #
+    # So, we use a "thread-global" mattr_accessor on purpose, because we _want_ all threads to share the same cache.
+    #   This is not a problem because the standard Ruby interpreter has a GIL (global locking) mechanism that prevents
+    #   it from truly parallel code execution. Every thread that potentially enters the `c_all_by_id` loading mechanism
+    #   below is inherently thread-safe by virtue of the fact that the interpreter locks the code execution.
+    #
+    # (Sidenote: Our previous approach had been based on our own custom @@cache variable,
+    #   which is exactly what mattr_accessor does internally. And that one worked for literally many years.)
+    mattr_accessor :models_by_id, instance_accessor: false
 
-    after_commit :clear_cache
+    after_commit :reload_cache
 
-    def clear_cache
-      self.models_by_id = nil
+    def reload_cache
+      self.as_cached.reload
     end
 
     # Tells the caching mechanism what ID to cache by.
@@ -35,7 +58,7 @@ module Cachable
     end
 
     def as_cached
-      self.class.try(self.cachable_id.to_s) || self.class.c_find(self.cachable_id)
+      self.class.c_find(self.cachable_id)
     end
   end
 

--- a/app/models/concerns/cachable.rb
+++ b/app/models/concerns/cachable.rb
@@ -40,6 +40,8 @@ module Cachable
     #   it from truly parallel code execution. Every thread that potentially enters the `c_all_by_id` loading mechanism
     #   below is inherently thread-safe by virtue of the fact that the interpreter locks the code execution.
     #
+    # Interesting reading: https://thoughtbot.com/blog/untangling-ruby-threads
+    #
     # (Sidenote: Our previous approach had been based on our own custom @@cache variable,
     #   which is exactly what mattr_accessor does internally. And that one worked for literally many years.)
     mattr_accessor :models_by_id, instance_accessor: false

--- a/app/models/concerns/localized_sortable.rb
+++ b/app/models/concerns/localized_sortable.rb
@@ -22,9 +22,18 @@ module LocalizedSortable
   included do
     scope :uncached_real, -> { where.not(id: fictive_ids) }
 
-    # Read up on why we're NOT using thread_mattr_accessor here (despite multi-threaded Rails app servers)
-    #   in the code comments of the `cachable.rb` module.
-    mattr_accessor :real_objects, :all_sorted_by_locale, instance_accessor: false
+    # Relevant comments about `thread_mattr_accessor` vs. `mattr_accessor` and about hooks
+    #   can all be found in the code for the `cachable.rb` module.
+    mattr_accessor :real_objects, :all_sorted_by_locale
+
+    # No filter for `:create` or `:update` because we cannot access individual entities here
+    #   so we just flush the whole cache whenever any update happens
+    after_commit :clear_localized_cache
+
+    def clear_localized_cache
+      self.real_objects = nil
+      self.all_sorted_by_locale = nil
+    end
   end
 
   class_methods do
@@ -38,8 +47,9 @@ module LocalizedSortable
 
     def all_sorted_by(locale, real: false)
       self.all_sorted_by_locale ||= I18n.available_locales.index_with do |available_locale|
-        I18nUtils.localized_sort_by!(available_locale, self.c_all_by_id.values) { |object| object.name_in(available_locale) }
+        I18nUtils.localized_sort_by!(available_locale, self.c_values) { |object| object.name_in(available_locale) }
       end.freeze
+
       real ? self.all_sorted_by_locale[locale].select(&:real?) : self.all_sorted_by_locale[locale]
     end
   end

--- a/app/models/concerns/localized_sortable.rb
+++ b/app/models/concerns/localized_sortable.rb
@@ -22,7 +22,9 @@ module LocalizedSortable
   included do
     scope :uncached_real, -> { where.not(id: fictive_ids) }
 
-    thread_mattr_accessor :real_objects, :all_sorted_by_locale, instance_accessor: false
+    # Read up on why we're NOT using thread_mattr_accessor here (despite multi-threaded Rails app servers)
+    #   in the code comments of the `cachable.rb` module.
+    mattr_accessor :real_objects, :all_sorted_by_locale, instance_accessor: false
   end
 
   class_methods do

--- a/app/models/regulation.rb
+++ b/app/models/regulation.rb
@@ -3,8 +3,8 @@
 class Regulation < SimpleDelegator
   REGULATIONS_JSON_PATH = "wca-regulations.json"
 
-  thread_mattr_accessor :regulations, instance_accessor: false, default: []
-  thread_mattr_accessor :regulations_load_error, instance_accessor: false
+  mattr_accessor :regulations, instance_accessor: false, default: []
+  mattr_accessor :regulations_load_error, instance_accessor: false
 
   def self.regulations_by_id
     self.regulations.index_by { |r| r["id"] }

--- a/spec/models/cachable_spec.rb
+++ b/spec/models/cachable_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cachable do
+  it "Reads only once when accessing a cached entity" do
+    # Make sure the instances are not cached in memory from previous tests
+    #   in which case there might be zero queries and the test could fail
+    Country.models_by_id = nil
+
+    assert_queries_count(1) {
+      Country.c_find('USA')
+      Country.c_find('USA')
+    }
+  end
+
+  it "Reads twice when accessing a cached entity directly" do
+    assert_queries_count(2) {
+      Country.find('USA')
+      Country.find('USA')
+    }
+  end
+
+  it "Correctly invalidates caches when an entity is updated" do
+    cached_usa = Country.c_find('USA')
+    expect(cached_usa.name).to eq('United States')
+
+    # Circumvent the cache on purpose
+    usa = Country.find(cached_usa.id)
+    usa.update!(name: "'Murica")
+
+    # The method `name` is being overwritten by `localized_sortable` (grr...)
+    #   so we need to directly read the raw underlying attribute
+    expect(cached_usa.read_attribute(:name)).to eq("'Murica")
+  end
+
+  it "Correctly invalidates caches when a linked entity is updated" do
+    cached_wst = GroupsMetadataTeamsCommittees.c_find('wst')
+
+    wst_user_group = cached_wst.user_group
+    expect(wst_user_group.name).to eq('WCA Software Team')
+
+    # Circumvent the cache on purpose
+    direct_user_group = UserGroup.find(wst_user_group.id)
+    direct_user_group.update!(name: 'The one and only WST')
+
+    # We updated an attribute through direct access, but the cache should still change
+    #   This relies on configuring the AR association correctly with a `touch: true` or similar.
+    expect(cached_wst.user_group.name).to eq('The one and only WST')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ require "capybara/rspec"
 require 'capybara-screenshot/rspec'
 require 'capybara/apparition'
 
+require 'active_record/testing/query_assertions'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -86,6 +88,7 @@ RSpec.configure do |config|
   config.include ApplicationHelper
 
   config.include ActiveJob::TestHelper
+  config.include ActiveRecord::Assertions::QueryAssertions, type: :model
 
   if EnvConfig.DISABLE_WEBMOCK?
     WebMock.disable!


### PR DESCRIPTION
Turns out we were a bit more careful than we needed to be when introducing strongly thread-safe attribute caches in #9681

The thread-safe accessors can make it so that all threads hold their own, local copies. But in most cases, we actually don't _want_ the threads to hold their own local copies. For example, we don't want the cached 3x3 event to exist N times for N threads.

Further reading on why the GIL is helpful here: https://thoughtbot.com/blog/untangling-ruby-threads