### PR TITLE
Update WDC to WIC in visible Delegate Report contexts

### DIFF
--- a/app/mailers/competitions_mailer.rb
+++ b/app/mailers/competitions_mailer.rb
@@ -88,7 +88,7 @@ class CompetitionsMailer < ApplicationMailer
         to: "reports@worldcubeassociation.org",
         cc: competition.delegates.pluck(:email) +
           (competition.delegate_report.wrc_feedback_requested ? ["regulations@worldcubeassociation.org"] : []) +
-          (competition.delegate_report.wdc_feedback_requested ? ["disciplinary@worldcubeassociation.org"] : []),
+          (competition.delegate_report.wdc_feedback_requested ? ["integrity@worldcubeassociation.org"] : []),
         reply_to: competition.delegates.pluck(:email),
         subject: delegate_report_email_subject(competition),
       )

--- a/app/views/delegate_reports/_delegate_report.html.erb
+++ b/app/views/delegate_reports/_delegate_report.html.erb
@@ -8,7 +8,7 @@
   <% end %>
   <% if delegate_report.wdc_feedback_requested %>
     <p style="color: red; font-weight: bold">
-      @WDC: Feedback requested on incidents: <%= delegate_report.wdc_incidents %>
+      @WIC: Feedback requested on incidents: <%= delegate_report.wdc_incidents %>
     </p>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,8 +320,8 @@ en:
         incidents: "Incidents"
         wrc_feedback_requested: "I would like feedback from the WRC on some of the incidents above."
         wrc_incidents: "Incidents Needing WRC Feedback"
-        wdc_feedback_requested: "I would like feedback from the WDC on some of the incidents above."
-        wdc_incidents: "Incidents Needing WDC Feedback"
+        wdc_feedback_requested: "I would like feedback from the WIC on some of the incidents above."
+        wdc_incidents: "Incidents Needing WIC Feedback"
         remarks: "Remarks"
       #context: a person
       person:

--- a/spec/mailers/competitions_mailer_spec.rb
+++ b/spec/mailers/competitions_mailer_spec.rb
@@ -206,14 +206,14 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       it "renders the headers" do
         expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
         expect(mail.to).to eq ["reports@worldcubeassociation.org"]
-        expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["regulations@worldcubeassociation.org"] + ["disciplinary@worldcubeassociation.org"]
+        expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["regulations@worldcubeassociation.org"] + ["integrity@worldcubeassociation.org"]
         expect(mail.from).to eq ["reports@worldcubeassociation.org"]
         expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
       end
 
       it "renders the body" do
         expect(mail.body.encoded).to match(/@WRC: Feedback requested on incidents: 1, 2, 3/)
-        expect(mail.body.encoded).to match(/@WDC: Feedback requested on incidents: 4, 5, 6/)
+        expect(mail.body.encoded).to match(/@WIC: Feedback requested on incidents: 4, 5, 6/)
         expect(mail.body.encoded).to match(/This was a great competition/)
       end
     end
@@ -226,14 +226,14 @@ RSpec.describe CompetitionsMailer, type: :mailer do
       it "renders the headers" do
         expect(mail.subject).to eq "[wca-report] [Oceania] Comp of the Future 2016"
         expect(mail.to).to eq ["reports@worldcubeassociation.org"]
-        expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["disciplinary@worldcubeassociation.org"]
+        expect(mail.cc).to match_array competition.delegates.pluck(:email) + ["integrity@worldcubeassociation.org"]
         expect(mail.from).to eq ["reports@worldcubeassociation.org"]
         expect(mail.reply_to).to match_array competition.delegates.pluck(:email)
       end
 
       it "renders the body" do
         expect(mail.body.encoded).not_to match(/@WRC/)
-        expect(mail.body.encoded).to match(/@WDC: Feedback requested on incidents: 4, 5, 6/)
+        expect(mail.body.encoded).to match(/@WIC: Feedback requested on incidents: 4, 5, 6/)
         expect(mail.body.encoded).to match(/This was a great competition/)
       end
     end


### PR DESCRIPTION
This PR updates the WDC email to the WIC email when feedback is requested, and updates related strings on Delegate Reports that mention WDC. The intent of this change is to save WIC needing to be manually CC'd on all emails that request WDC feedback.

This does not try to update all instances of WDC to WIC; only the publicly visible ones. Underlying
variables referencing WDC or database migrations establishing team emails remain WDC, even in Delegate Report contexts.