### PR TITLE
Show button to switch to new competition page overview

### DIFF
--- a/app/assets/javascripts/competitions.js
+++ b/app/assets/javascripts/competitions.js
@@ -11,6 +11,9 @@ function resizeMapContainer() {
 }
 
 onPage('competitions#index', function() {
+  const queryParams = new URLSearchParams(window.location.search);
+  if (queryParams.get('legacy') === 'off') return;
+
   resizeMapContainer();
   $(window).on('resize', resizeMapContainer);
 

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -195,7 +195,7 @@ class CompetitionsController < ApplicationController
       @competitions = @competitions.select { |competition| competition.pending_results_or_report(days) }
     end
 
-    @enable_react = params[:beta]&.to_s == '0xDbOverload'
+    @enable_react = params[:legacy]&.to_s == 'off'
 
     respond_to do |format|
       format.html {}

--- a/app/views/competitions/index.html.erb
+++ b/app/views/competitions/index.html.erb
@@ -2,7 +2,13 @@
 
 <% if !@enable_react %>
   <div class="container">
-    <h2><%= yield(:title) %></h2>
+    <h2>
+      <%= yield(:title) %>
+
+      <%= link_to competitions_path(**request.query_parameters.merge(legacy: 'off')), class: "btn btn-success" do %>
+        <%= ui_icon("magic") %> Go to new UI
+      <% end %>
+    </h2>
 
     <%= form_tag competitions_path, method: :get, remote: true, class: "competition-select form-inline #{@display}", id: "competition-query-form" do %>
       <%= render 'index_form' %>

--- a/app/views/competitions/index.html.erb
+++ b/app/views/competitions/index.html.erb
@@ -2,13 +2,16 @@
 
 <% if !@enable_react %>
   <div class="container">
-    <h2>
-      <%= yield(:title) %>
 
-      <%= link_to competitions_path(**request.query_parameters.merge(legacy: 'off')), class: "btn btn-success" do %>
-        <%= ui_icon("magic") %> Go to new UI
-      <% end %>
-    </h2>
+      <h2>
+        <%= yield(:title) %>
+
+        <% unless EnvConfig.WCA_LIVE_SITE? %>
+          <%= link_to competitions_path(**request.query_parameters.merge(legacy: 'off')), class: "btn btn-success" do %>
+            <%= ui_icon("magic") %> Go to new UI
+          <% end %>
+        <% end %>
+      </h2>
 
     <%= form_tag competitions_path, method: :get, remote: true, class: "competition-select form-inline #{@display}", id: "competition-query-form" do %>
       <%= render 'index_form' %>

--- a/spec/features/competitions_list_spec.rb
+++ b/spec/features/competitions_list_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Competitions list" do
       let(:delegate) { competition.delegates.first }
 
       before do
-        visit "/competitions?beta=0xDbOverload"
+        visit "/competitions?legacy=off"
         within(:css, "#delegate") do
           find(".search").set(delegate.name)
           find(".search").send_keys(:enter)


### PR DESCRIPTION
Title says it all.

Query params are ported from the old to the new UI, so when you start setting up some search filters in the old UI and then switch to the new UI, the search state should persist.