### PR TITLE
Update Yarn to v4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,5 +117,5 @@
   "scripts": {
     "webpack:analyze": "mkdir -p public/packs && RACK_ENV=test NODE_ENV=production webpack --config config/webpack/webpack.config.js --profile --json > public/packs/stats.json && webpack-bundle-analyzer public/packs/stats.json"
   },
-  "packageManager": "yarn@4.2.2"
+  "packageManager": "yarn@4.4.0"
 }


### PR DESCRIPTION
Plain dependency update. See https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.4.0 for Release Notes.