### PR TITLE
Fix SASS compilation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,9 @@ gem 'rails-i18n'
 gem 'i18n-js'
 gem 'activerecord-import'
 gem 'sass-rails'
-gem "sassc-embedded"
+# Some of our very old Sprockets asset code relies on gem-bundled Bootstrap 3 (grrr...)
+#   which uses SCSS features incompatible with Dart SASS 2.
+gem "sassc-embedded", '~> 1'
 gem 'terser'
 gem 'faraday'
 gem 'faraday-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -919,7 +919,7 @@ DEPENDENCIES
   rubocop
   rubocop-thread_safety
   sass-rails
-  sassc-embedded
+  sassc-embedded (~> 1)
   sdoc
   seedbank
   selectize-rails!

--- a/app/webpacker/stylesheets/user_badge.scss
+++ b/app/webpacker/stylesheets/user_badge.scss
@@ -29,12 +29,6 @@
   }
 
   .user-name {
-    .user-badge-subtext {
-      font-style: oblique;
-      margin-top: 6px;
-      font-size: 0.9em;
-    }
-
     background-color: transparent !important;
     width: 100%;
 
@@ -42,6 +36,12 @@
     align-content: center;
     justify-content: center;
     flex-direction: column;
+
+    .user-badge-subtext {
+      font-style: oblique;
+      margin-top: 6px;
+      font-size: 0.9em;
+    }
   }
 
   .show-border {


### PR DESCRIPTION
Pretty much just followed the recommendation from the deprecation messages: The bllock of rules in `user_badge.scss` has been moved from below the nested block to above the nested block.

For the Sprockets warnings, there's not much we can do because it's bundled code of a third-party gem. I've locked the Dart SASS compiler at a version that will stay compatible with our monolith for the time being.