### PR TITLE
Install Rails 7.1 configuration defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module WcaOnRails
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     config.active_job.queue_adapter = :sidekiq
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module WcaOnRails
     config.load_defaults 7.1
 
     # Force belongs_to validations even on empty/unset keys.
-    #   This is potentially a Rails bug (?!?) and will be reported to their upstream repository
+    #   This is potentially a Rails bug (?!?) and has been reported at https://github.com/rails/rails/issues/52614
     config.active_record.belongs_to_required_validates_foreign_key = true
 
     config.active_job.queue_adapter = :sidekiq

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,10 @@ module WcaOnRails
 
     config.load_defaults 7.1
 
+    # Force belongs_to validations even on empty/unset keys.
+    #   This is potentially a Rails bug (?!?) and will be reported to their upstream repository
+    config.active_record.belongs_to_required_validates_foreign_key = true
+
     config.active_job.queue_adapter = :sidekiq
 
     config.generators do |g|


### PR DESCRIPTION
Preparation for Rails 7.2

According to the release notes at https://guides.rubyonrails.org/7_1_release_notes.html, there's nothing breaking. Let's see whether our tests agree.