### PR TITLE
Add seperate Deploy Main to Staging workflow

### DIFF
--- a/.github/workflows/deploy-main-to-staging.yml
+++ b/.github/workflows/deploy-main-to-staging.yml
@@ -1,7 +1,5 @@
-name: Deploy Image on GitHub Release
+name: Deploy Main to Staging Manually
 on:
-  release:
-    types: [created]
   workflow_dispatch:
 jobs:
   build:
@@ -25,27 +23,25 @@ jobs:
           push: true
           target: sidekiq
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:sidekiq-production
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:sidekiq-staging
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_TAG=${{ github.sha }}
-            WCA_LIVE_SITE=true
-        # this will trigger the deployment pipeline for prod
-      - name: Build and push Prod Image
+            WCA_LIVE_SITE=false
+      - name: Build and push Staging Image
         uses: docker/build-push-action@v6
         with:
           push: true
           target: monolith
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:latest
+            ${{ steps.login-ecr.outputs.registry }}/wca-on-rails:staging
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_TAG=${{ github.sha }}
-            WCA_LIVE_SITE=true
-        # Replace the old sidekiq image with the new one
-      - name: Deploy Sidekiq
-        run: |
-          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-prod-auxiliary-services --force-new-deployment
+            WCA_LIVE_SITE=false
         # There is no pipeline for staging so we manually force to update the image
+      - name: Deploy staging
+        run: |
+          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-staging --force-new-deployment

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -48,4 +48,3 @@ jobs:
       - name: Deploy Sidekiq
         run: |
           aws ecs update-service --cluster wca-on-rails --service wca-on-rails-prod-auxiliary-services --force-new-deployment
-        # There is no pipeline for staging so we manually force to update the image


### PR DESCRIPTION
Introducing the asset precompilation PR, I accidentally made it so prod assets where compiled when using the deploy-on-release github action (Because WCA_LIVE_SITE was set to true when pushing to both staging and prod ECR). Luckily this only affected a couple of links for the registration service which failed when the jwt token didn't matched. 
I split up the deploy to staging and prod workflows which we wanted to do anyway.