### PR TITLE
Manually sync WIC to former Ethics Google Group

### DIFF
--- a/app/jobs/sync_mailing_lists_job.rb
+++ b/app/jobs/sync_mailing_lists_job.rb
@@ -15,6 +15,10 @@ class SyncMailingListsJob < WcaCronjob
     GsuiteMailingLists.sync_group("reports@worldcubeassociation.org", User.delegate_reports_receivers_emails)
 
     UserGroup.teams_committees.active_groups.each { |team_committee| GsuiteMailingLists.sync_group(team_committee.metadata.email, team_committee.active_users.map(&:email)) }
+    # Special case: WIC is the first committee in our (recent) history that "absorbed" another team's duties:
+    #   They are now a "mix" of WDC and WEC. The structures have been mapped so that WIC reuses WDC's groups,
+    #   so they get WDC access "for free". But they _also_ need to be synced to ethics@ to view old conversations from there.
+    GsuiteMailingLists.sync_group("ethics@worldcubeassociation.org", GroupsMetadataTeamsCommittees.wic.user_group.active_users.map(&:email))
 
     treasurers = UserGroup.officers.flat_map(&:active_roles).filter { |role| role.metadata.status == RolesMetadataOfficers.statuses[:treasurer] }
     GsuiteMailingLists.sync_group("treasurer@worldcubeassociation.org", treasurers.map(&:user).map(&:email))

--- a/spec/jobs/sync_mailing_lists_job_spec.rb
+++ b/spec/jobs/sync_mailing_lists_job_spec.rb
@@ -202,6 +202,12 @@ RSpec.describe SyncMailingListsJob, type: :job do
       a_collection_containing_exactly(wapc_member.email),
     )
 
+    # ethics@ mailing list
+    expect(GsuiteMailingLists).to receive(:sync_group).with(
+      "ethics@worldcubeassociation.org",
+      a_collection_containing_exactly(wic_leader.email, wic_member.email),
+    )
+
     # treasurer@ mailing list
     expect(GsuiteMailingLists).to receive(:sync_group).with(
       "treasurer@worldcubeassociation.org",


### PR DESCRIPTION
Edge case that never happened before because we never (since becoming a nonprofit) experienced the case of one team absorbing another's duties.

I don't think this needs a custom implementation / generic support from the Groups/Roles models. This way of hard-coded semi-manual sync is fine for the forseeable future.