### PR TITLE
add checkboxes for avatar reject reasons

### DIFF
--- a/app/controllers/admin/avatars_controller.rb
+++ b/app/controllers/admin/avatars_controller.rb
@@ -16,8 +16,11 @@ module Admin
             user.approve_pending_avatar!
           when "reject"
             user.remove_pending_avatar = true
+            rejection_guidelines = args[:rejection_guidelines] || []
+            additional_reason = args[:rejection_reason].presence
+            combined_reasons = (rejection_guidelines + [additional_reason]).compact.join(" ")
             user.save!
-            AvatarsMailer.notify_user_of_avatar_rejection(user, args[:rejection_reason]).deliver_later
+            AvatarsMailer.notify_user_of_avatar_rejection(user, args[:combined_reasons]).deliver_later
           when "defer"
             # do nothing!
           else

--- a/app/views/admin/avatars/index.html.erb
+++ b/app/views/admin/avatars/index.html.erb
@@ -96,11 +96,22 @@
                   </div>
                 <% end %>
               </div>
-              <div class="col-sm-6">
+
+              <div class="col-sm-6 rejection-reason">
+                <h4>Select the guidelines that were not followed:</h4>
+                <% avatar_guidelines = t('users.edit.avatar_guidelines').values + (user.staff_or_any_delegate? ? t('users.edit.staff_avatar_guidelines.paragraphs').values : []) %>
+                <% avatar_guidelines.each_with_index do |guideline, index| %>
+                  <div class="checkbox">
+                    <label>
+                      <%= check_box_tag "avatars[#{user.wca_id}][rejection_guidelines][]", guideline, false, id: "guideline_#{user.wca_id}_#{index}" %>
+                      <%= guideline %>
+                    </label>
+                  </div>
+                <% end %>
                 <%= text_area_tag "avatars[#{user.wca_id}][rejection_reason]", "",
-                                  class: "form-control rejection-reason",
-                                  placeholder: "Please provide the reason for rejection" %>
-              </div>
+                      class: "form-control rejection-reason",
+                      placeholder: "Provide additional reasons for rejection" %>
+                </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
When clicking reject on the admin avatar page, it displays a list of check boxes with the guidelines. These can be checked to inform the user which guideline their avatar violates. Along with a textbox for additional comments. Additional staff/delegate guidelines show up only under applicable users.

This alleviates the need to copy and pate the guidelines from the top of the page into the textbox.

Check boxes made more sense than a dropdown initially described in https://github.com/thewca/worldcubeassociation.org/issues/7994 as there are often multiple reasons given for rejection and a dropdown allowing multiple selections seemed less intuitive.
