### PR TITLE
V2 Live Feedback

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
@@ -49,23 +49,25 @@ export default function TableHeader({
         >
           {i18n.t('common.user.representing')}
         </Table.HeaderCell>
-        <Table.HeaderCell
-          sorted={sortColumn === 'registered_on' ? sortDirection : undefined}
-          onClick={() => changeSortColumn('registered_on')}
-        >
-          {i18n.t('registrations.list.registered.without_stripe')}
-        </Table.HeaderCell>
-        {competitionInfo['using_payment_integrations?'] && (
-          <>
-            <Table.HeaderCell>Payment Status</Table.HeaderCell>
+        { competitionInfo['using_payment_integrations?']
+          ? (
+            <>
+              <Table.HeaderCell
+                sorted={sortColumn === 'paid_on_with_registered_on_fallback' ? sortDirection : undefined}
+                onClick={() => changeSortColumn('paid_on_with_registered_on_fallback')}
+              >
+                {i18n.t('registrations.list.registered.with_stripe')}
+              </Table.HeaderCell>
+              <Table.HeaderCell>{i18n.t('activerecord.attributes.registration.paid_entry_fees')}</Table.HeaderCell>
+            </>
+          ) : (
             <Table.HeaderCell
-              sorted={sortColumn === 'paid_on_with_registered_on_fallback' ? sortDirection : undefined}
-              onClick={() => changeSortColumn('paid_on_with_registered_on_fallback')}
+              sorted={sortColumn === 'registered_on' ? sortDirection : undefined}
+              onClick={() => changeSortColumn('registered_on')}
             >
-              {i18n.t('registrations.list.registered.with_stripe')}
+              {i18n.t('registrations.list.registered.without_stripe')}
             </Table.HeaderCell>
-          </>
-        )}
+          )}
         {events ? (
           competitionInfo.event_ids.map((eventId) => (
             <Table.HeaderCell key={`event-${eventId}`}>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -61,7 +61,8 @@ export default function TableRow({
             {...provided.dragHandleProps}
           >
             <Table.Cell>
-              {draggable ? <Icon name="bars" /> : <Checkbox onChange={onCheckboxChange} checked={isSelected} />}
+              { /* We manually set the margin to 0 here to fix the table row height */}
+              {draggable ? <Icon name="bars" /> : <Checkbox onChange={onCheckboxChange} checked={isSelected} style={{ margin: 0 }} />}
             </Table.Cell>
 
             <Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -180,7 +180,7 @@ export default function RegistrationList({ competitionInfo }) {
                     key={`registration-table-header-${id}`}
                     onClick={() => setPsychSheetEvent(id)}
                   >
-                    <EventIcon id={id} size="1em" />
+                    <EventIcon id={id} size="1em" className="selected" />
                   </Table.HeaderCell>
                 ))}
                 <Table.HeaderCell
@@ -256,7 +256,7 @@ export default function RegistrationList({ competitionInfo }) {
                         key={`registration-table-row-${registration.user.id}-${id}`}
                       >
                         {registration.competing.event_ids.includes(id) ? (
-                          <EventIcon id={id} size="1em" />
+                          <EventIcon id={id} size="1em" hoverable={false} />
                         ) : null}
                       </Table.Cell>
                     ))}

--- a/app/webpacker/components/RegistrationsV2/api/registration/get/get_registrations.js
+++ b/app/webpacker/components/RegistrationsV2/api/registration/get/get_registrations.js
@@ -10,7 +10,7 @@ const waitingCompetitorsUrl = (competitionId) => `${wcaRegistrationUrl}/api/v1/r
 export async function getConfirmedRegistrations(
   competitionID,
 ) {
-  const { data } = await fetchWithJWTToken(confirmedRegistrationsUrl(competitionID));
+  const { data } = await fetchJsonOrError(confirmedRegistrationsUrl(competitionID));
   return data;
 }
 


### PR DESCRIPTION
- Reduced Padding significantly in the Registration Administration List by setting the Margin to 0
- Replaced Payment Status by Payment Amount and combined registered_on/paid_on like we do in V1
- Used the Link color for the Psych sheet headers and made the events inside not clickable
- Fixed the competitor list not loading when not logged in by not fetching the JWT Token before sending the request