### PR TITLE
Added location to roles tab

### DIFF
--- a/app/webpacker/lib/helpers/roles-tab.js
+++ b/app/webpacker/lib/helpers/roles-tab.js
@@ -9,6 +9,9 @@ export function getRoleDescription(role) {
     roleDescription += 'Translator, ';
   }
   roleDescription += role.group.name;
+  if (role.metadata?.location) {
+    roleDescription += ` (${role.metadata.location})`;
+  }
   return roleDescription;
 }
 


### PR DESCRIPTION
Recently while debugging an incident, found that roles tab doesn't have location. It will be good if we have location in the roles tab.