### PR TITLE
Fix file URLs for the CDN and move TW Flag Overwrite to webpacker

### DIFF
--- a/app/assets/stylesheets/wca.scss
+++ b/app/assets/stylesheets/wca.scss
@@ -374,17 +374,6 @@ table.wca-results {
     border: 1px solid;
     border-image: linear-gradient(to right, red, blue) 1;
   }
-  &.fi-tw {
-    background-color: white;
-    background-image: asset_url("ChineseTaipei.svg");
-  }
-
-  &.fis {
-    &.fi-tw {
-      background-color: white;
-      background-image: asset_url("ChineseTaipeiSquared.svg");
-    }
-  }
 }
 
 // Textarea resizes dynamically, so changing its size manually is no longer necessary.

--- a/app/views/static_pages/documents.html.erb
+++ b/app/views/static_pages/documents.html.erb
@@ -34,7 +34,7 @@
     <div class="panel panel-default">
       <div class="panel-heading heading-as-link">
         <h4 class="panel-title">
-          <%= link_to "/files/WCA_IRS_Determination_Letter.pdf", class: "full-space" do %>
+          <%= link_to asset_url("/files/WCA_IRS_Determination_Letter.pdf"), class: "full-space" do %>
             <%= ui_icon("file alt") %> <%= t('documents.determination_letter') %>
           <% end %>
         </h4>

--- a/app/views/static_pages/score_tools.html.erb
+++ b/app/views/static_pages/score_tools.html.erb
@@ -53,7 +53,7 @@
       wst: false,
     }.merge(t("score_tools.tools.scorecards")),
     nightmare: {
-      download_url: "https://www.worldcubeassociation.org/files/results.xls",
+      download_url: asset_url("/files/results.xls"),
       wst: true,
     }.merge(t("score_tools.tools.nightmare")),
   },

--- a/app/webpacker/stylesheets/override.scss
+++ b/app/webpacker/stylesheets/override.scss
@@ -65,6 +65,20 @@ body, html {
     }
   }
 
+  .fi {
+    &.fi-tw {
+      background-color: white;
+      background-image: url("../images/ChineseTaipei.svg");
+    }
+
+    &.fis {
+      &.fi-tw {
+        background-color: white;
+        background-image: url("../images/ChineseTaipeiSquared.svg");
+      }
+    }
+  }
+
   i.flag {
     &.tw::before {
       background-size: contain;


### PR DESCRIPTION
Another two file urls that weren't prefixed with `asset_url`. I also moved the TW Flag overwrite from Sprockets to webpacker because I couldn't figure out why the `ASSET_HOST` was being ignored. Hoping we can move all the CSS to webpacker soon anyway!