### PR TITLE
Add an internal route so that v2 reg can query unannounced competitions

### DIFF
--- a/app/controllers/api/internal/v1/competitions_controller.rb
+++ b/app/controllers/api/internal/v1/competitions_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Api::Internal::V1::CompetitionsController < Api::Internal::V1::ApiController
+  # We are using our own authentication method with vault
+  protect_from_forgery except: [:show]
+
+  def show
+    competition = competition_from_params
+
+    if stale?(competition)
+      options = {
+        only: %w[id name website start_date registration_open registration_close announced_at cancelled_at end_date competitor_limit
+                 extra_registration_requirements enable_donations refund_policy_limit_date event_change_deadline_date waiting_list_deadline_date
+                 on_the_spot_registration on_the_spot_entry_fee_lowest_denomination qualification_results event_restrictions
+                 base_entry_fee_lowest_denomination currency_code allow_registration_edits allow_registration_self_delete_after_acceptance
+                 allow_registration_without_qualification refund_policy_percent use_wca_registration guests_per_registration_limit venue contact
+                 force_comment_in_registration use_wca_registration external_registration_page guests_entry_fee_lowest_denomination guest_entry_status
+                 information events_per_registration_limit],
+        methods: %w[url website short_name city venue_address venue_details latitude_degrees longitude_degrees country_iso2 event_ids registration_currently_open?
+                    main_event_id number_of_bookmarks using_payment_integrations? uses_qualification? uses_cutoff? competition_series_ids],
+        include: %w[delegates organizers tabs],
+      }
+      render json: competition.as_json(options)
+    end
+  end
+
+  private def competition_from_params
+    id = params[:competition_id]
+    competition = Competition.find_by_id(id)
+
+    raise WcaExceptions::NotFound.new("Competition with id #{id} not found") unless competition
+    competition
+  end
+end

--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -133,7 +133,7 @@
             icon: "lightbulb",
           }
         end
-        if @competition.announced? && !@competition.results_posted?
+        unless @competition.results_posted?
           if @competition.use_wca_registration?
             nav_items << {
               text: t('.menu.register'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -325,6 +325,7 @@ Rails.application.routes.draw do
       namespace :v1 do
         get '/users/:id/permissions' => 'permissions#index'
         get '/competitions/:competition_id' => 'competitions#show'
+        get '/competitions/:competition_id/qualifications' => 'competitions#qualifications'
         post '/users/competitor-info' => 'users#competitor_info'
         post '/mailers/registration' => 'mailers#registration'
         post '/payment/init_stripe' => 'payment#init_stripe'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -324,6 +324,7 @@ Rails.application.routes.draw do
     namespace :internal do
       namespace :v1 do
         get '/users/:id/permissions' => 'permissions#index'
+        get '/competitions/:competition_id' => 'competitions#show'
         post '/users/competitor-info' => 'users#competitor_info'
         post '/mailers/registration' => 'mailers#registration'
         post '/payment/init_stripe' => 'payment#init_stripe'


### PR DESCRIPTION
This will allow organizers to pre-register before competitions are announced, which is a request which has come through after we hid the Register button before announcement