### PR TITLE
Fix 2FA page being served in a random language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,9 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  prepend_before_action :set_locale
   before_action :store_user_location!, if: :storable_location?
-  before_action :add_new_relic_headers, :set_locale
+  before_action :add_new_relic_headers
   protected def add_new_relic_headers
     ::NewRelic::Agent.add_custom_attributes(user_id: current_user ? current_user.id : nil)
     ::NewRelic::Agent.add_custom_attributes(HTTP_REFERER: request.headers['HTTP_REFERER'])


### PR DESCRIPTION
Fixes #7735 by changing `set_locale` to a prepend_before_action. 

Another solution is to explicitly call `set_locale` in `authenticate_with_two_factor` if there are any unintended consequences to this change - but I've tested locally and it all seems to work fine this way.