### PR TITLE
Bug fix in Leader change form when there is no leader

### DIFF
--- a/app/webpacker/components/Panel/pages/LeadersAdminPage/LeaderChangeForm.jsx
+++ b/app/webpacker/components/Panel/pages/LeadersAdminPage/LeaderChangeForm.jsx
@@ -40,7 +40,7 @@ export default function LeaderChangeForm({
   };
 
   const addBackOldLeaderIfNeeded = () => {
-    if (formValues.oldLeaderStatus === OLD_LEADER_STATUS.RESIGN) {
+    if (formValues.oldLeaderStatus === OLD_LEADER_STATUS.RESIGN || !oldLeader) {
       endLeaderChangeAction();
     } else {
       save(


### PR DESCRIPTION
@gregorbg recently faced an issue that when a new leader was added to a new team, it caused some error and the page didn't show the updated leader list.

The error was that whenever a leader is changed, it will change the previous leader status to either resign or senior member or member. By default it will be senior member. How this happens is, this won't happen in single API call, but instead two different API call. In the first API call, the new leader gets added and whenever a position like leader or senior delegate is getting a new person, the previous person in that position's role get ended. And then in the next API, a new role will be created with status 'senior member' or 'member'. If it's 'resign', then nothing will be done.

In this case, the default status for previous leader was 'senior member' and because of that it tried to access previous leader who actually didn't exist in this case because it was a new team/committee.

In this PR, I made it 'not to take any action' if the previous leader doesn't exist.