### PR TITLE
Added more metadata to role change emails

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -193,8 +193,14 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
-          metadata = RolesMetadataDelegateRegions.create!(status: status, location: role.metadata.location)
-          UserRole.create!(
+          metadata = RolesMetadataDelegateRegions.create!(
+            status: status,
+            location: role.metadata.location,
+            first_delegated: role.metadata.first_delegated,
+            last_delegated: role.metadata.last_delegated,
+            total_delegated: role.metadata.total_delegated,
+          )
+          role = UserRole.create!(
             user_id: role.user.id,
             group_id: role.group.id,
             start_date: Date.today,
@@ -213,8 +219,14 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
-          metadata = RolesMetadataDelegateRegions.create!(status: role.metadata.status, location: role.metadata.location)
-          UserRole.create!(
+          metadata = RolesMetadataDelegateRegions.create!(
+            status: role.metadata.status,
+            location: role.metadata.location,
+            first_delegated: role.metadata.first_delegated,
+            last_delegated: role.metadata.last_delegated,
+            total_delegated: role.metadata.total_delegated,
+          )
+          role = UserRole.create!(
             user_id: role.user.id,
             group_id: group_id,
             start_date: Date.today,
@@ -231,8 +243,14 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
         ActiveRecord::Base.transaction do
           role.update!(end_date: Date.today)
-          metadata = RolesMetadataDelegateRegions.create!(status: role.metadata.status, location: location)
-          UserRole.create!(
+          metadata = RolesMetadataDelegateRegions.create!(
+            status: role.metadata.status,
+            location: location,
+            first_delegated: role.metadata.first_delegated,
+            last_delegated: role.metadata.last_delegated,
+            total_delegated: role.metadata.total_delegated,
+          )
+          role = UserRole.create!(
             user_id: role.user.id,
             group_id: role.group.id,
             start_date: Date.today,
@@ -271,7 +289,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
           elsif group_type == UserGroup.group_types[:councils]
             metadata = RolesMetadataCouncils.create!(status: status)
           end
-          UserRole.create!(
+          role = UserRole.create!(
             user_id: role.user.id,
             group_id: role.group.id,
             start_date: Date.today,

--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -18,10 +18,12 @@ class RoleChangeMailer < ApplicationMailer
     when UserGroup.group_types[:delegate_regions]
       metadata[:region_name] = group.name
       metadata[:status] = I18n.t("enums.user_roles.status.delegate_regions.#{role.metadata.status}")
+      metadata[:delegated_competitions_count] = role.metadata.total_delegated
     when UserGroup.group_types[:translators]
       metadata[:locale] = group.metadata.locale
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils], UserGroup.group_types[:officers]
       metadata[:status] = I18n.t("enums.user_roles.status.#{group.group_type}.#{role.metadata.status}")
+      metadata[:group_name] = group.name
     end
     metadata
   end
@@ -125,6 +127,7 @@ class RoleChangeMailer < ApplicationMailer
     @user_who_made_the_change = user_who_made_the_change
     @changes = JSON.parse changes
     @group_type_name = UserGroup.group_type_name[role.group_type.to_sym]
+    @metadata = role_metadata(role)
     @today_date = Date.today
     @to_list = [wrt_email_recipient]
 

--- a/app/views/role_change_mailer/notify_role_change.erb
+++ b/app/views/role_change_mailer/notify_role_change.erb
@@ -4,6 +4,14 @@
 <% @changes.each do |change| %>
   <p><%= change['changed_parameter'] %>: <%= change['previous_value'] %> -> <%= change['new_value'] %></p>
 <% end %>
+<% if @metadata.present? %>
+  <p>More details of the role are:</p>
+  <ul>
+    <% @metadata.each do |key, value| %>
+      <li><%= I18n.t("user_roles.email.role_metadata.#{key}" , locale: 'en') %>: <%= value %></li>
+    <% end %>
+  </ul>
+<% end %>
 <p>Messages to recipients:</p>
 <% @to_list.each do |recipient| %>
   <li><%= recipient.name %>: <%= recipient.message %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1077,6 +1077,8 @@ en:
         region_name: "Region Name"
         status: "Status"
         locale: "Locale"
+        group_name: "Team/Committee Name"
+        delegated_competitions_count: "Number of Delegated Competitions"
   user_groups:
     group_types:
       board: "WCA Board of Directors"


### PR DESCRIPTION
(FYI: The metadata in description means the extra data shown in the email and is not related to the metadata in roles table)

This PR mainly aims in adding two new details (aka metadata) to role change emails:
1. Total number of delegated competitions (for delegates)
2. Team/Committee name (for teams/committees roles)

It was also found that the `metadata` was shown only in role create and role end emails, but not in role change emails. In this PR, I've added it to role change emails as well.

While doing this, another challenge that came in. Whenever some data like location or status is changed, it will create a new role. But the role change method was still pointing to old role instead of the new role. I've fixed that as well.

Another thing noted was while creating new roles in role updates for delegates, while creating RolesMetadataDelegateRegions, it was not taking all values from previous role's metadata. I've fixed that as well, now it will copy all data from previous role's metadata.