### PR TITLE
Bug fix: added ban reason and scope while creating new ban

### DIFF
--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -89,6 +89,8 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
     if group.banned_competitors?
       user = User.find(user_id)
+      ban_reason = params[:banReason]
+      scope = params[:scope]
       upcoming_comps_for_user = user.competitions_registered_for.not_over.merge(Registration.not_deleted).pluck(:id)
       unless upcoming_comps_for_user.empty?
         return render status: :unprocessable_entity, json: {
@@ -120,7 +122,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       elsif group.group_type == UserGroup.group_types[:councils]
         metadata = RolesMetadataCouncils.create!(status: status)
       elsif group.group_type == UserGroup.group_types[:banned_competitors]
-        metadata = RolesMetadataBannedCompetitors.create!
+        metadata = RolesMetadataBannedCompetitors.create!(ban_reason: ban_reason, scope: scope)
       else
         metadata = nil
       end

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitorForm.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitorForm.jsx
@@ -37,6 +37,8 @@ export default function BanendCompetitorForm({
       userId: formValues?.user?.id,
       groupType: groupTypes.banned_competitors,
       endDate: formValues?.endDate,
+      banReason: formValues?.banReason,
+      scope: formValues?.scope,
     }, () => {
       sync();
       closeForm();


### PR DESCRIPTION
Earlier when creating a new ban, the reason and scope was not working - they needed to be manually added later. This PR allows to add them during initial creation itself. (The form already had those fields, but the code was just not reading them during creation, instead it was used only during updation)