### PR TITLE
Optimize competition pages for competitions that use v2

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -979,7 +979,7 @@ class Competition < ApplicationRecord
 
   def any_registrations?
     if uses_new_registration_service?
-      self.microservice_registrations.any?
+      Microservices::Registrations.competitor_count_by_competition(id) > 0
     else
       self.registrations.any?
     end

--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -142,7 +142,7 @@
             }
           end
 
-          if @competition.any_registrations?
+          unless @competition.registration_not_yet_opened?
             event_icons = @competition.events.map do |event|
               { text: event.id, path: competition_psych_sheet_event_path(@competition, event.id), cubing_icon: event.id, title: event.name }
             end unless @competition.uses_new_registration_service?

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -66,8 +66,10 @@ module Microservices
     # rubocop:enable Metrics/ParameterLists
 
     def self.competitor_count_by_competition(competition_id)
-      response = self.registration_connection.get(self.get_competitor_count_path(competition_id))
-
+      # Cache for 5 seconds so we don't do multiple requests per route (we can safely be a few seconds off)
+      response = Rails.cache.fetch("#{competition_id}-microservice-competitor-count", expires_in: 5.second) do
+        self.registration_connection.get(self.get_competitor_count_path(competition_id))
+      end
       response.body["count"]
     end
 


### PR DESCRIPTION
There was a lot of unnecessary load surfaced by the load test caused by these calls

- Stopps making multiple calls to the registration service for count if used multiple times by caching for a few seconds
- Doesn't call the registration service on every page load just because it needs to know if we should show the competitors tab (I switched this to `unless @competition.registration_not_yet_opened?` and I honestly think we could even just remove this check entirely 
- Uses the much faster cached `Microservices::Registrations.competitor_count_by_competition(id)` route for `any_registrations?`, which was only called in `_nav`, so we could also remove it if we don't think it'll be useful somewhere else