### PR TITLE
Create NotifyTranslatorsJob instead of checking on server boot

### DIFF
--- a/app/jobs/notify_translators._job.rb
+++ b/app/jobs/notify_translators._job.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-# We only want to attempt to send email when the server is starting up.
-# We don't want to send emails as a side effect of some rake script.
-# See https://github.com/thewca/worldcubeassociation.org/issues/2085.
-if Rails.env.production? && ENV.fetch('RAILS_RACKING', nil)
-  Rails.configuration.after_initialize do
+class NotifyTranslatorsJob < WcaCronjob
+  before_enqueue do
+    # NOTE: we want to only do this on the actual "production" server, as we need the real users' emails.
+    throw :abort unless EnvConfig.WCA_LIVE_SITE?
+  end
+
+  def perform
     modification_hash = ServerSetting.find_or_create_by!(name: ServerSetting::BASE_LOCALE_HASH)
 
     translation_base_file = "#{Rails.root}/config/locales/en.yml"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -43,6 +43,11 @@ sync_mailing_lists:
   cron: "0 * * * *"
   queue: wca_jobs
 
+notify_translators:
+  class: "NotifyTranslatorsJob"
+  cron: "0 12 * * *"
+  queue: wca_jobs
+
 wst_chores:
   class: "GenerateChore"
   cron: "0 8 23 * *"


### PR DESCRIPTION
I went through all the initializers and the application.rb/production.rb and I couldn't find anything else that we do on boot that is not config. 