### PR TITLE
Revert "Bump sass-loader from 14.2.1 to 16.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "regenerator-runtime": "^0.14.1",
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.77.8",
-    "sass-loader": "^16.0.1",
+    "sass-loader": "^14.2.1",
     "semantic-ui-react": "^2.1.5",
     "shakapacker": "8.0.1",
     "style-loader": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10103,7 +10103,7 @@ __metadata:
     regenerator-runtime: "npm:^0.14.1"
     resolve-url-loader: "npm:^5.0.0"
     sass: "npm:^1.77.8"
-    sass-loader: "npm:^16.0.1"
+    sass-loader: "npm:^14.2.1"
     semantic-ui-react: "npm:^2.1.5"
     shakapacker: "npm:8.0.1"
     style-loader: "npm:^4.0.0"
@@ -10182,9 +10182,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-loader@npm:^16.0.1":
-  version: 16.0.1
-  resolution: "sass-loader@npm:16.0.1"
+"sass-loader@npm:^14.2.1":
+  version: 14.2.1
+  resolution: "sass-loader@npm:14.2.1"
   dependencies:
     neo-async: "npm:^2.6.2"
   peerDependencies:
@@ -10204,7 +10204,7 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 10c0/ac841ea8881354e4bf286c2c5f331b60c2edf73c6e4abbc85b954024ec16dfda01accf59ea6fcb4b29ec7dd5a81a9950fc9138dcb262b9130865367201b7699a
+  checksum: 10c0/9a48d454584d96d6c562eb323bb9e3c6808e930eeaaa916975b97d45831e0b87936a8655cdb3a4512a25abc9587dea65a9616e42396be0d7e7c507a4795a8146
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Whoops, merged the wrong one among the gazillion dependency updates