### PR TITLE
Switch Dependabot updates to weekly cycle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,15 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: monthly
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: monthly
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: monthly
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
The amount of monthly updates is costing me several hours every month, which is mostly due to the fact that merging one dependency causes all others to be rebased (to avoid Lockfile conflicts) and then our tests need to run again for ~20 minutes...