### PR TITLE
Explicitly require CSV gem to avoid deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'eu_central_bank'
 gem 'devise-jwt'
 gem 'jwt'
 gem 'iso', github: 'thewca/ruby-iso'
+gem 'csv'
 
 # Pointing to jfly/selectize-rails which has a workaround for
 #  https://github.com/selectize/selectize.js/issues/953

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,7 @@ GEM
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
+    csv (3.2.8)
     daemons (1.4.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
@@ -853,6 +854,7 @@ DEPENDENCIES
   carrierwave-crop!
   cocoon
   cookies_eu
+  csv
   daemons
   database_cleaner
   datetimepicker-rails!


### PR DESCRIPTION
(see title)

copy of the relevant snippet: `warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of zeitwerk-2.6.17 to add csv into its gemspec.`

Since `zeitwerk` is our classloader, they definitely shouldn't include it in their gemspec. But we can!