### PR TITLE
Use bin/rails setup in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,11 +30,9 @@ services:
     # Next, load the database if it does not exist yet
     # Start the server and bind to 0.0.0.0 (vs 127.0.0.1) so Docker's port mappings work correctly
     command: >
-      bash -c 'bundle install && corepack install && yarn install &&
+      bash -c 'corepack install &&
       rm -f .db-inited &&
-      if ! [[ "`mysqlshow --user=root --host=wca_db wca_development`" =~ "Tables" ]] ;
-        then echo "Populating development db, this will take a while" && bin/rake db:reset ;
-      fi &&
+      bin/rails setup &&
       touch .db-inited &&
       bin/rails server -b 0.0.0.0'
     healthcheck:


### PR DESCRIPTION
This script did not exist when we originally came up with our Docker setup. Now it exists since Rails 7.0, so why not use it?