### PR TITLE
Enable Qualifications in the V2 Frontend

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -60,13 +60,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   def qualifications
     competition = competition_from_params(associations: [:competition_events])
 
-    qualifications = competition.competition_events
-                                .where.not(qualification: nil)
-                                .index_by(&:event_id)
-                                .transform_values(&:qualification)
-                                .transform_values(&:to_wcif)
-
-    render json: qualifications
+    render json: competition.qualification_wcif
   end
 
   def schedule

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -446,7 +446,7 @@ class RegistrationsController < ApplicationController
     @competition = competition_from_params
     @registration = nil
     @selected_events = []
-    if current_user && !@competition.uses_new_registration_service?
+    if current_user
       @registration = @competition.registrations.find_or_initialize_by(user_id: current_user.id, competition_id: @competition.id)
       @selected_events = @registration.saved_and_unsaved_events.empty? ? @registration.user.preferred_events : @registration.saved_and_unsaved_events
     end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -446,7 +446,7 @@ class RegistrationsController < ApplicationController
     @competition = competition_from_params
     @registration = nil
     @selected_events = []
-    if current_user
+    if current_user && !@competition.uses_new_registration_service?
       @registration = @competition.registrations.find_or_initialize_by(user_id: current_user.id, competition_id: @competition.id)
       @selected_events = @registration.saved_and_unsaved_events.empty? ? @registration.user.preferred_events : @registration.saved_and_unsaved_events
     end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1854,6 +1854,15 @@ class Competition < ApplicationRecord
     competition_series&.competition_ids&.split(',') || []
   end
 
+  def qualification_wcif
+    return {} unless uses_qualification?
+    competition_events
+      .where.not(qualification: nil)
+      .index_by(&:event_id)
+      .transform_values(&:qualification)
+      .transform_values(&:to_wcif)
+  end
+
   def persons_wcif(authorized: false)
     managers = self.managers
     includes_associations = [

--- a/app/views/registrations/register.html.erb
+++ b/app/views/registrations/register.html.erb
@@ -40,7 +40,7 @@
                                                         connectedAccountId: @competition.payment_account_for(:stripe)&.account_id,
                                                         qualifications: {
                                                           wcif: @competition.qualification_wcif,
-                                                          personal_records: { single: current_user.person.ranksSingle.map(&:to_wcif), average: current_user.person.ranksAverage.map(&:to_wcif) }
+                                                          personalRecords: { single: current_user.person.ranksSingle.map(&:to_wcif), average: current_user.person.ranksAverage.map(&:to_wcif) }
                                                         }
                                                         }) %>
     <% else %>

--- a/app/views/registrations/register.html.erb
+++ b/app/views/registrations/register.html.erb
@@ -38,6 +38,10 @@
                                                         preferredEvents: @current_user.preferred_events.pluck(:id),
                                                         stripePublishableKey: AppSecrets.STRIPE_PUBLISHABLE_KEY,
                                                         connectedAccountId: @competition.payment_account_for(:stripe)&.account_id,
+                                                        qualifications: {
+                                                          wcif: @competition.qualification_wcif,
+                                                          personal_records: { single: current_user.person.ranksSingle.map(&:to_wcif), average: current_user.person.ranksAverage.map(&:to_wcif) }
+                                                        }
                                                         }) %>
     <% else %>
       <% if @registration.show_details?(current_user) %>

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -96,6 +96,8 @@ export function EventSelector({
   maxEvents = Infinity,
   shouldErrorOnEmpty = false,
   eventsDisabled = [],
+  // Listing event as an argument here to indicate to developers that it's needed
+  // eslint-disable-next-line no-unused-vars
   disabledText = (event) => {},
 }) {
   return (

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -122,26 +122,37 @@ export function EventSelector({
         trigger={(
           <div id="events">
             {eventList.map((eventId) => (
-              <React.Fragment key={eventId}>
-                <Button
-                  disabled={disabled
-                || (!selectedEvents.includes(eventId) && selectedEvents.length >= maxEvents) || eventsDisabled.includes(eventId)}
-                  basic
-                  icon
-                  toggle
-                  type="button"
-                  size="mini"
-                  className="event-checkbox"
-                  id={`checkbox-${eventId}`}
-                  value={eventId}
-                  data-tooltip={I18n.t(`events.${eventId}`)}
-                  data-variation="tiny"
-                  onClick={() => onEventSelection({ type: 'toggle_event', eventId })}
-                  active={selectedEvents.includes(eventId)}
-                >
-                  <Icon className={`cubing-icon event-${eventId}`} style={eventsDisabled.includes(eventId) ? { color: '#FFBBBB' } : {}} />
-                </Button>
-              </React.Fragment>
+              <Popup
+                key={eventId}
+                trigger={(
+                  <span>
+                    {/* Wrap in span so hover works on disabled buttons */}
+                    <Button
+                      key={eventId}
+                      disabled={
+                      disabled
+                        || (!selectedEvents.includes(eventId) && selectedEvents.length >= maxEvents)
+                        || eventsDisabled.includes(eventId)
+                    }
+                      basic
+                      icon
+                      toggle
+                      type="button"
+                      size="mini"
+                      className="event-checkbox"
+                      id={`checkbox-${eventId}`}
+                      value={eventId}
+                      data-variation="tiny"
+                      onClick={() => onEventSelection({ type: 'toggle_event', eventId })}
+                      active={selectedEvents.includes(eventId)}
+                    >
+                      <Icon className={`cubing-icon event-${eventId}`} style={eventsDisabled.includes(eventId) ? { color: '#FFBBBB' } : {}} />
+                    </Button>
+                  </span>
+)}
+              >
+                {I18n.t(eventsDisabled.includes(eventId) ? 'registrations.not_qualified' : `events.${eventId}`)}
+              </Popup>
             ))}
           </div>
 )}

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -124,6 +124,7 @@ export function EventSelector({
             {eventList.map((eventId) => (
               <Popup
                 key={eventId}
+                disabled={selectedEvents.length === 0}
                 trigger={(
                   <span>
                     {/* Wrap in span so hover works on disabled buttons */}

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -95,6 +95,7 @@ export function EventSelector({
   disabled = false,
   maxEvents = Infinity,
   shouldErrorOnEmpty = false,
+  eventsDisabled = [],
 }) {
   return (
     <>
@@ -124,7 +125,7 @@ export function EventSelector({
               <React.Fragment key={eventId}>
                 <Button
                   disabled={disabled
-                || (!selectedEvents.includes(eventId) && selectedEvents.length >= maxEvents)}
+                || (!selectedEvents.includes(eventId) && selectedEvents.length >= maxEvents) || eventsDisabled.includes(eventId)}
                   basic
                   icon
                   toggle
@@ -138,7 +139,7 @@ export function EventSelector({
                   onClick={() => onEventSelection({ type: 'toggle_event', eventId })}
                   active={selectedEvents.includes(eventId)}
                 >
-                  <Icon className={`cubing-icon event-${eventId}`} />
+                  <Icon className={`cubing-icon event-${eventId}`} style={eventsDisabled.includes(eventId) ? { color: '#FFBBBB' } : {}} />
                 </Button>
               </React.Fragment>
             ))}

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -96,6 +96,7 @@ export function EventSelector({
   maxEvents = Infinity,
   shouldErrorOnEmpty = false,
   eventsDisabled = [],
+  disabledText = (event) => {},
 }) {
   return (
     <>
@@ -152,7 +153,7 @@ export function EventSelector({
                   </span>
 )}
               >
-                {I18n.t(eventsDisabled.includes(eventId) ? 'registrations.not_qualified' : `events.${eventId}`)}
+                {eventsDisabled.includes(eventId) ? disabledText(eventId) : I18n.t(`events.${eventId}`)}
               </Popup>
             ))}
           </div>

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -48,6 +48,7 @@ export default function CompetingStep({
   preferredEvents,
   registration,
   refetchRegistration,
+  qualificationWCIF,
 }) {
   const maxEvents = competitionInfo.events_per_registration_limit ?? Infinity;
   const isRegistered = Boolean(registration);

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -24,6 +24,7 @@ import i18n from '../../../lib/i18n';
 import I18nHTMLTranslate from '../../I18nHTMLTranslate';
 import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import { eventsNotQualifiedFor, isQualifiedForEvent } from '../../../lib/helpers/qualifications';
+import { eventQualificationToString } from '../../../lib/utils/wcif';
 
 const maxCommentLength = 240;
 
@@ -63,7 +64,8 @@ export default function CompetingStep({
     .filter((event) => {
       const preferredEventHeld = competitionInfo.event_ids.includes(event);
       if (competitionInfo['uses_qualification?']) {
-        return preferredEventHeld && isQualifiedForEvent(event, qualifications.wcif, qualifications.personalRecords);
+        return preferredEventHeld
+          && isQualifiedForEvent(event, qualifications.wcif, qualifications.personalRecords);
       }
       return preferredEventHeld;
     });
@@ -282,7 +284,16 @@ export default function CompetingStep({
               selectedEvents={selectedEvents}
               id="event-selection"
               maxEvents={maxEvents}
-              eventsDisabled={eventsNotQualifiedFor(competitionInfo.event_ids, qualifications.wcif, qualifications.personalRecords)}
+              eventsDisabled={eventsNotQualifiedFor(
+                competitionInfo.event_ids,
+                qualifications.wcif,
+                qualifications.personalRecords,
+              )}
+              disabledText={(event) => eventQualificationToString(
+                { id: event },
+                qualifications.wcif[event],
+                { short: true },
+              )}
               // Don't error if the user hasn't interacted with the form yet
               shouldErrorOnEmpty={hasInteracted}
             />

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -213,7 +213,17 @@ export default function CompetingStep({
 
   const handleEventSelection = ({ type, eventId }) => {
     if (type === 'select_all_events') {
-      setSelectedEvents(competitionInfo.event_ids);
+      if (competitionInfo['uses_qualification?']) {
+        setSelectedEvents(
+          competitionInfo.event_ids.filter((e) => isQualifiedForEvent(
+            e,
+            qualifications.wcif,
+            qualifications.personalRecords,
+          )),
+        );
+      } else {
+        setSelectedEvents(competitionInfo.event_ids);
+      }
     } else if (type === 'clear_events') {
       setSelectedEvents([]);
     } else if (type === 'toggle_event') {

--- a/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
@@ -147,7 +147,7 @@ export default function StepPanel({
         user={user}
         stripePublishableKey={stripePublishableKey}
         connectedAccountId={connectedAccountId}
-        qualificationWCIF={qualifications}
+        qualifications={qualifications}
         nextStep={
           (overwrites = {}) => setActiveIndex((oldActiveIndex) => {
             if (overwrites?.refresh) {

--- a/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
@@ -76,6 +76,7 @@ export default function StepPanel({
   refetchRegistration,
   stripePublishableKey,
   connectedAccountId,
+  qualifications,
 }) {
   const isRegistered = Boolean(registration) && registration.competing.registration_status !== 'cancelled';
   const isAccepted = isRegistered && registration.competing.registration_status === 'accepted';
@@ -146,6 +147,7 @@ export default function StepPanel({
         user={user}
         stripePublishableKey={stripePublishableKey}
         connectedAccountId={connectedAccountId}
+        qualificationWCIF={qualifications}
         nextStep={
           (overwrites = {}) => setActiveIndex((oldActiveIndex) => {
             if (overwrites?.refresh) {

--- a/app/webpacker/components/RegistrationsV2/Register/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/index.jsx
@@ -32,7 +32,7 @@ export default function Index({
 }
 
 function Register({
-  competitionInfo, userInfo, preferredEvents, connectedAccountId, stripePublishableKey,
+  competitionInfo, qualifications, userInfo, preferredEvents, connectedAccountId, stripePublishableKey,
 }) {
   const dispatch = useDispatch();
   const ref = useRef();
@@ -69,6 +69,7 @@ function Register({
             refetchRegistration={refetch}
             connectedAccountId={connectedAccountId}
             stripePublishableKey={stripePublishableKey}
+            qualifications={qualifications}
           />
         </>
       )

--- a/app/webpacker/components/RegistrationsV2/Register/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/index.jsx
@@ -11,6 +11,7 @@ import ConfirmProvider from '../../../lib/providers/ConfirmProvider';
 
 export default function Index({
   competitionInfo, userInfo, preferredEvents,
+  qualifications,
   stripePublishableKey = '',
   connectedAccountId = '',
 }) {
@@ -24,6 +25,7 @@ export default function Index({
             preferredEvents={preferredEvents}
             stripePublishableKey={stripePublishableKey}
             connectedAccountId={connectedAccountId}
+            qualifications={qualifications}
           />
         </ConfirmProvider>
       </StoreProvider>

--- a/app/webpacker/lib/helpers/qualifications.js
+++ b/app/webpacker/lib/helpers/qualifications.js
@@ -1,6 +1,7 @@
 export function isQualifiedForEvent(event, qualificationWCIF, personalRecords) {
   const qualificationForEvent = qualificationWCIF[event];
-  const personalRecordForEvent = personalRecords[qualificationForEvent.resultType].find((r) => r.eventId === event);
+  const personalRecordForEvent = personalRecords[qualificationForEvent.resultType]
+    .find((r) => r.eventId === event);
   if (!personalRecordForEvent) {
     return false;
   }

--- a/app/webpacker/lib/helpers/qualifications.js
+++ b/app/webpacker/lib/helpers/qualifications.js
@@ -1,0 +1,28 @@
+export function isQualifiedForEvent(event, qualificationWCIF, personalRecords) {
+  const qualificationForEvent = qualificationWCIF[event];
+  const personalRecordForEvent = personalRecords[qualificationForEvent.resultType].find((r) => r.eventId === event);
+  if (!personalRecordForEvent) {
+    return false;
+  }
+  switch (qualificationForEvent.type) {
+    case 'anyResult': {
+      return true;
+    }
+    case 'ranking': {
+      return true;
+    }
+    case 'attemptResult': {
+      return personalRecordForEvent.best < qualificationForEvent.level;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+export function eventsNotQualifiedFor(events, qualificationsWCIF, personalRecords) {
+  if (_.isEmpty(qualificationsWCIF)) {
+    return [];
+  }
+  return events.filter((e) => !isQualifiedForEvent(e, qualificationsWCIF, personalRecords));
+}


### PR DESCRIPTION
Shades the non qualified events red and disables the buttons. Also removes them from the initially selected events if a user is not qualified for one of their preferred events.

I also noticed that we are currently still initializing a v1 registration object for everyone even if we are using v2 here
```
def register
    if current_user
      @registration = @competition.registrations.find_or_initialize_by(user_id: current_user.id, competition_id: @competition.id)
    end
  end
```
We sadly can't just check for `!@competition.uses_new_registration_service?` because that currently breaks v2 if people click on register for closed competitions. Something we need to look at in the future 

![image](https://github.com/user-attachments/assets/035eed17-6eaf-41ca-9fa0-753280187a83)
