### PR TITLE
Add Rejected Status to V2

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
@@ -32,6 +32,9 @@ export default function RegistrationOverview({
   const hasRegistrationEditDeadlinePassed = hasPassed(
     competitionInfo.event_change_deadline_date ?? competitionInfo.start_date,
   );
+
+  const isRejected = registration.competing.registration_status === 'rejected';
+
   const editsAllowed = competitionInfo.allow_registration_edits
     && !hasRegistrationEditDeadlinePassed;
 
@@ -74,6 +77,10 @@ export default function RegistrationOverview({
     event.preventDefault();
     confirm({ content: i18n.t('registrations.delete_confirm') }).then(() => deleteRegistrationMutation()).catch(() => nextStep({ refresh: true }));
   };
+
+  if (isRejected) {
+    return <RegistrationStatus registration={registration} competitionInfo={competitionInfo} />;
+  }
 
   return (
     <>

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationStatus.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationStatus.jsx
@@ -31,7 +31,9 @@ function canIBookPlaneTickets(registrationStatus, paymentStatus, competitionInfo
     case 'accepted':
       return 'Book your flights and pack your bags - you have a spot at the competition!';
     case 'cancelled':
-      return 'Your registration has been deleted and you will not be competing.';
+      return 'Your registration has been deleted and you will not be competing, but you can sign up again';
+    case 'rejected':
+      return "Your registration has been rejected by the organizers, you can't sign up again";
     case 'waiting_list':
       return "Don't book a flight, but don't give up hope either. The competition is full, but you have been placed on a waiting list, and you will receive an email if enough spots open up for you to be able to attend.";
     default:
@@ -44,7 +46,8 @@ function RegistrationStatusMessage({ registration, competitionInfo }) {
     <Message
       info={registration.competing.registration_status === 'pending'}
       success={registration.competing.registration_status === 'accepted'}
-      negative={registration.competing.registration_status === 'cancelled'}
+      negative={registration.competing.registration_status === 'cancelled'
+        || registration.competing.registration_status === 'rejected'}
       warning={registration.competing.registration_status === 'waiting_list'}
       icon
     >

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationStatus.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationStatus.jsx
@@ -33,7 +33,7 @@ function canIBookPlaneTickets(registrationStatus, paymentStatus, competitionInfo
     case 'cancelled':
       return 'Your registration has been deleted and you will not be competing, but you can sign up again';
     case 'rejected':
-      return "Your registration has been rejected by the organizers, you can't sign up again";
+      return 'Your registration has been rejected by the organizers. Please contact the organizing team if you believe this was a mistake.';
     case 'waiting_list':
       return "Don't book a flight, but don't give up hope either. The competition is full, but you have been placed on a waiting list, and you will receive an email if enough spots open up for you to be able to attend.";
     default:

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationStatus.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationStatus.jsx
@@ -31,7 +31,7 @@ function canIBookPlaneTickets(registrationStatus, paymentStatus, competitionInfo
     case 'accepted':
       return 'Book your flights and pack your bags - you have a spot at the competition!';
     case 'cancelled':
-      return 'Your registration has been deleted and you will not be competing, but you can sign up again';
+      return 'Your registration has been cancelled and you will not be competing, but you can sign up again';
     case 'rejected':
       return 'Your registration has been rejected by the organizers. Please contact the organizing team if you believe this was a mistake.';
     case 'waiting_list':

--- a/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
@@ -50,12 +50,16 @@ const shouldShowCompleted = (isRegistered, hasPaid, isAccepted, key, index) => {
   }
 };
 
-const shouldBeDisabled = (hasPaid, key, activeIndex, index, competitionInfo) => {
+const shouldBeDisabled = (hasPaid, key, activeIndex, index, competitionInfo, isRejected) => {
   const hasRegistrationEditDeadlinePassed = hasPassed(
     competitionInfo.event_change_deadline_date ?? competitionInfo.start_date,
   );
   const editsAllowed = competitionInfo.allow_registration_edits
     && !hasRegistrationEditDeadlinePassed;
+
+  if (isRejected) {
+    return true;
+  }
 
   if (key === paymentStepConfig.key) {
     return !hasPaid && index > activeIndex;
@@ -79,6 +83,7 @@ export default function StepPanel({
 }) {
   const isRegistered = Boolean(registration) && registration.competing.registration_status !== 'cancelled';
   const isAccepted = isRegistered && registration.competing.registration_status === 'accepted';
+  const isRejected = isRegistered && registration.competing.registration_status === 'rejected';
   const hasPaid = registration?.payment.payment_status === 'succeeded';
   const registrationFinished = hasPaid || (isRegistered && !competitionInfo['using_payment_integrations?']);
 
@@ -96,7 +101,7 @@ export default function StepPanel({
 
   const [activeIndex, setActiveIndex] = useState(() => {
     // Don't show payment panel if a user was accepted (for people with waived payment)
-    if (registrationFinished || isAccepted) {
+    if (registrationFinished || isAccepted || isRejected) {
       return steps.findIndex(
         (step) => step === (registrationOverviewConfig),
       );
@@ -128,6 +133,7 @@ export default function StepPanel({
               activeIndex,
               index,
               competitionInfo,
+              isRejected,
             )}
             onClick={() => setActiveIndex(index)}
           >

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -40,12 +40,13 @@ export default function RegistrationActions({
   const anySelected = selectedCount > 0;
 
   const {
-    pending, accepted, cancelled, waiting,
+    pending, accepted, cancelled, waiting, rejected,
   } = partitionedSelected;
-  const anyRejectable = pending.length < selectedCount;
+  const anyPending = pending.length < selectedCount;
   const anyApprovable = accepted.length < selectedCount;
   const anyCancellable = cancelled.length < selectedCount;
   const anyWaitlistable = waiting.length < selectedCount;
+  const anyRejectable = rejected.length < selectedCount;
 
   const selectedEmails = [...pending, ...accepted, ...cancelled, ...waiting]
     .map((userId) => userEmailMap[userId])
@@ -67,7 +68,7 @@ export default function RegistrationActions({
   };
 
   const attemptToApprove = () => {
-    const idsToAccept = [...pending, ...cancelled, ...waiting];
+    const idsToAccept = [...pending, ...cancelled, ...waiting, ...rejected];
     if (idsToAccept.length > spotsRemaining) {
       dispatch(setMessage(
         'competitions.registration_v2.update.too_many',
@@ -91,7 +92,7 @@ export default function RegistrationActions({
       <Button
         onClick={() => {
           csvExport(
-            [...pending, ...accepted, ...cancelled, ...waiting],
+            [...pending, ...accepted, ...cancelled, ...waiting, ...rejected],
             registrations,
           );
         }}
@@ -127,10 +128,10 @@ export default function RegistrationActions({
               </Button>
             )}
 
-            {anyRejectable && (
+            {anyPending && (
               <Button
                 onClick={() => changeStatus(
-                  [...accepted, ...cancelled, ...waiting],
+                  [...accepted, ...cancelled, ...waiting, ...rejected],
                   'pending',
                 )}
               >
@@ -143,7 +144,7 @@ export default function RegistrationActions({
             <Button
               color="yellow"
               onClick={() => changeStatus(
-                [...pending, ...cancelled, ...accepted],
+                [...pending, ...cancelled, ...accepted, ...rejected],
                 'waiting_list',
               )}
             >
@@ -156,12 +157,25 @@ export default function RegistrationActions({
               <Button
                 negative
                 onClick={() => changeStatus(
-                  [...pending, ...accepted, ...waiting],
+                  [...pending, ...accepted, ...waiting, ...rejected],
                   'cancelled',
                 )}
               >
                 <Icon name="trash" />
                 {i18n.t('competitions.registration_v2.update.cancel')}
+              </Button>
+            )}
+
+            {anyRejectable && (
+              <Button
+                color="orange"
+                onClick={() => changeStatus(
+                  [...pending, ...accepted, ...waiting, ...cancelled],
+                  'rejected',
+                )}
+              >
+                <Icon name="delete" />
+                {i18n.t('competitions.registration_v2.update.reject')}
               </Button>
             )}
           </>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -155,7 +155,7 @@ export default function RegistrationActions({
 
             {anyCancellable && (
               <Button
-                negative
+                color="orange"
                 onClick={() => changeStatus(
                   [...pending, ...accepted, ...waiting, ...rejected],
                   'cancelled',
@@ -168,7 +168,7 @@ export default function RegistrationActions({
 
             {anyRejectable && (
               <Button
-                color="orange"
+                negative
                 onClick={() => changeStatus(
                   [...pending, ...accepted, ...waiting, ...cancelled],
                   'rejected',

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -74,13 +74,16 @@ const partitionRegistrations = (registrations) => registrations.reduce(
       case 'cancelled':
         result.cancelled.push(registration);
         break;
+      case 'rejected':
+        result.rejected.push(registration);
+        break;
       default:
         break;
     }
     return result;
   },
   {
-    pending: [], waiting: [], accepted: [], cancelled: [],
+    pending: [], waiting: [], accepted: [], cancelled: [], rejected: [],
   },
 );
 
@@ -238,7 +241,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
   }, [registrationsWithUser, sortColumn, sortDirection]);
 
   const {
-    waiting, accepted, cancelled, pending,
+    waiting, accepted, cancelled, pending, rejected,
   } = useMemo(
     () => partitionRegistrations(sortedRegistrationsWithUser ?? []),
     [sortedRegistrationsWithUser],
@@ -251,8 +254,9 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
       waiting: selected.filter((id) => waiting.some((reg) => id === reg.user.id)),
       accepted: selected.filter((id) => accepted.some((reg) => id === reg.user.id)),
       cancelled: selected.filter((id) => cancelled.some((reg) => id === reg.user.id)),
+      rejected: selected.filter((id) => rejected.some((reg) => id === reg.user.id)),
     }),
-    [selected, pending, waiting, accepted, cancelled],
+    [selected, pending, waiting, accepted, cancelled, rejected],
   );
 
   const select = (attendees) => dispatch({ type: 'add', attendees });
@@ -402,16 +406,42 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
         />
 
         <Header>
-          {i18n.t('registrations.list.deleted_registrations')}
+          {i18n.t('competitions.registration_v2.list.cancelled.title')}
           {' '}
           (
           {cancelled.length}
           )
         </Header>
+        <Header.Subheader>
+          {i18n.t('competitions.registration_v2.list.cancelled.information')}
+        </Header.Subheader>
         <RegistrationAdministrationTable
           columnsExpanded={expandedColumns}
           registrations={cancelled}
           selected={partitionedSelected.cancelled}
+          select={select}
+          unselect={unselect}
+          competition_id={competitionInfo.id}
+          changeSortColumn={changeSortColumn}
+          sortDirection={sortDirection}
+          sortColumn={sortColumn}
+          competitionInfo={competitionInfo}
+        />
+
+        <Header>
+          {i18n.t('competitions.registration_v2.list.rejected.title')}
+          {' '}
+          (
+          {rejected.length}
+          )
+        </Header>
+        <Header.Subheader>
+          {i18n.t('competitions.registration_v2.list.rejected.information')}
+        </Header.Subheader>
+        <RegistrationAdministrationTable
+          columnsExpanded={expandedColumns}
+          registrations={rejected}
+          selected={partitionedSelected.rejected}
           select={select}
           unselect={unselect}
           competition_id={competitionInfo.id}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -278,6 +278,15 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
             checked={status === 'cancelled'}
             onChange={(event, data) => setStatus(data.value)}
           />
+          <Form.Checkbox
+            radio
+            label="Rejected"
+            name="checkboxRadioGroup"
+            value="cancelled"
+            disabled={registrationEditDeadlinePassed}
+            checked={status === 'rejected'}
+            onChange={(event, data) => setStatus(data.value)}
+          />
         </Form.Group>
         <label>Guests</label>
         <Form.Input

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1802,6 +1802,12 @@ en:
           zero: "no spots remaining"
           one: "%{count} spot remaining"
           other: "%{count} spots remaining"
+        cancelled:
+          title: "Cancelled registrations"
+          information: "Cancelled competitors are allowed to register again."
+        rejected:
+          title: "Rejected registrations"
+          information: "Rejected competitors cannot re-register."
         payment:
          refunded_status: "Refunded"
          initialized: "Payment process was started on %{date}, but not finished."
@@ -1823,6 +1829,7 @@ en:
         move_pending: "Move to Pending"
         move_waiting: "Move to Waiting List"
         cancel: "Cancel Registration"
+        reject: "Reject Registration"
         amount: "Amount"
         too_many: "Accepting all these registrations would go over the competitor limit by %{count}"
         no_self_update: "Contact the Organization Team to update your registration."
@@ -1840,6 +1847,7 @@ en:
           accepted: "Your registration has been accepted."
           pending: "Your registration is pending approval by the organizers."
           cancelled: "Your registration has been deleted."
+          rejected: "Your registration has been rejected."
           waiting_list: "You are on the Waiting List at position %{waiting_list_position}."
         disclaimer: "Submission of Registration does not mean approval to compete"
         processing: "Your registration is processing..."


### PR DESCRIPTION
Adds the option to reject a competitor from the frontend and explains the difference between cancelled and rejected registrations. 

Do we want to do a separate email for rejected? Or do we depend on organizers to notify them with the reason.