### PR TITLE
Fixes V2 Registration Message to move to the middle when scrolling

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -26,7 +26,7 @@ export default function RegistrationMessage() {
     if (message?.key && message.type !== 'negative') {
       setTimeout(() => {
         dispatch({ payload: { message: null } });
-      }, 40000);
+      }, 4000);
     }
   }, [dispatch, message]);
 

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -17,7 +17,7 @@ export const clearMessage = () => ({
   },
 });
 
-export default function RegistrationMessage({ parentRef }) {
+export default function RegistrationMessage() {
   const { message } = useStore();
   const dispatch = useDispatch();
 
@@ -26,22 +26,30 @@ export default function RegistrationMessage({ parentRef }) {
     if (message?.key && message.type !== 'negative') {
       setTimeout(() => {
         dispatch({ payload: { message: null } });
-      }, 4000);
+      }, 40000);
     }
   }, [dispatch, message]);
 
   if (!message?.key) return null;
 
-  return (
-    <Sticky active context={parentRef}>
+  if (Array.isArray(message.key)) {
+    return message.key.map((key) => (
       <Message
         positive={message.type === 'positive'}
         negative={message.type === 'negative'}
       >
-        {Array.isArray(message.key)
-          ? message.key.map((keys) => I18n.t(keys, message.params))
-          : I18n.t(message.key, message.params)}
+        {I18n.t(key, message.params)}
       </Message>
-    </Sticky>
+    ));
+  }
+
+  return (
+    <Message
+      style={{ margin: 0 }}
+      positive={message.type === 'positive'}
+      negative={message.type === 'negative'}
+    >
+      {I18n.t(message.key, message.params)}
+    </Message>
   );
 }

--- a/app/webpacker/components/RegistrationsV2/Register/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/index.jsx
@@ -35,7 +35,6 @@ function Register({
   competitionInfo, userInfo, preferredEvents, connectedAccountId, stripePublishableKey,
 }) {
   const dispatch = useDispatch();
-  const ref = useRef();
   const {
     data: registration,
     isFetching,
@@ -58,9 +57,7 @@ function Register({
     isFetching ? <Loading />
       : (
         <>
-          <div ref={ref}>
-            <RegistrationMessage parentRef={ref} />
-          </div>
+          <RegistrationMessage />
           <StepPanel
             user={userInfo}
             preferredEvents={preferredEvents}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { Sticky } from 'semantic-ui-react';
 import RegistrationAdministrationList from './RegistrationAdministrationList';
 import RegistrationMessage from '../Register/RegistrationMessage';
 import messageReducer from '../reducers/messageReducer';
@@ -8,13 +9,15 @@ import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvide
 export default function RegistrationEdit({ competitionInfo }) {
   const ref = useRef();
   return (
-    <WCAQueryClientProvider>
-      <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
-        <div ref={ref}>
-          <RegistrationMessage parentRef={ref} />
-        </div>
-        <RegistrationAdministrationList competitionInfo={competitionInfo} />
-      </StoreProvider>
-    </WCAQueryClientProvider>
+    <div ref={ref}>
+      <WCAQueryClientProvider>
+        <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
+          <Sticky context={ref} offset={60}>
+            <RegistrationMessage />
+          </Sticky>
+          <RegistrationAdministrationList competitionInfo={competitionInfo} />
+        </StoreProvider>
+      </WCAQueryClientProvider>
+    </div>
   );
 }

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { Sticky } from 'semantic-ui-react';
 import RegistrationEditor from './RegistrationEditor';
 import RegistrationMessage from '../Register/RegistrationMessage';
 import messageReducer from '../reducers/messageReducer';
@@ -9,15 +10,17 @@ import ConfirmProvider from '../../../lib/providers/ConfirmProvider';
 export default function RegistrationEdit({ competitionInfo, user }) {
   const ref = useRef();
   return (
-    <WCAQueryClientProvider>
-      <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
-        <ConfirmProvider>
-          <div ref={ref}>
-            <RegistrationMessage parentRef={ref} />
-          </div>
-          <RegistrationEditor competitionInfo={competitionInfo} competitor={user} />
-        </ConfirmProvider>
-      </StoreProvider>
-    </WCAQueryClientProvider>
+    <div ref={ref}>
+      <WCAQueryClientProvider>
+        <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
+          <ConfirmProvider>
+            <Sticky context={ref}>
+              <RegistrationMessage />
+            </Sticky>
+            <RegistrationEditor competitionInfo={competitionInfo} competitor={user} />
+          </ConfirmProvider>
+        </StoreProvider>
+      </WCAQueryClientProvider>
+    </div>
   );
 }


### PR DESCRIPTION
Moves the Sticky out of the RegistrationMessage (so it can be used without it like in the Register Step) and moves the ref to the top. I think the issue was that the div that contained the sticky changed size or something... 