### PR TITLE
Show total delegated count only if it exists

### DIFF
--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -18,7 +18,9 @@ class RoleChangeMailer < ApplicationMailer
     when UserGroup.group_types[:delegate_regions]
       metadata[:region_name] = group.name
       metadata[:status] = I18n.t("enums.user_roles.status.delegate_regions.#{role.metadata.status}")
-      metadata[:delegated_competitions_count] = role.metadata.total_delegated
+      if role.metadata.total_delegated.present?
+        metadata[:delegated_competitions_count] = role.metadata.total_delegated
+      end
     when UserGroup.group_types[:translators]
       metadata[:locale] = group.metadata.locale
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils], UserGroup.group_types[:officers]

--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -18,16 +18,14 @@ class RoleChangeMailer < ApplicationMailer
     when UserGroup.group_types[:delegate_regions]
       metadata[:region_name] = group.name
       metadata[:status] = I18n.t("enums.user_roles.status.delegate_regions.#{role.metadata.status}")
-      if role.metadata.total_delegated.present?
-        metadata[:delegated_competitions_count] = role.metadata.total_delegated
-      end
+      metadata[:delegated_competitions_count] = role.metadata.total_delegated
     when UserGroup.group_types[:translators]
       metadata[:locale] = group.metadata.locale
     when UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils], UserGroup.group_types[:officers]
       metadata[:status] = I18n.t("enums.user_roles.status.#{group.group_type}.#{role.metadata.status}")
       metadata[:group_name] = group.name
     end
-    metadata
+    metadata.compact
   end
 
   def notify_role_start(role, user_who_made_the_change)


### PR DESCRIPTION
Currently if the number of delegated competitions is not available, it's showing empty in the email. This PR is to show the number of delegated competitions only if the value is actually there.