### PR TITLE
Form bug fix and adding WCA ID

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -50,8 +50,9 @@ class ContactsController < ApplicationController
       ContactWrt.new(
         name: requestor_details[:name],
         your_email: requestor_details[:email],
+        wca_id: User.find_by(email: requestor_details[:email])&.wca_id || 'None',
         query_type: contact_params[:queryType].titleize,
-        profile_data_to_change: profile_data_to_change.titleize,
+        profile_data_to_change: profile_data_to_change&.titleize,
         new_profile_data: new_profile_data_key_to_value(contact_params[:newProfileData], profile_data_to_change),
         edit_profile_reason: contact_params[:editProfileReason],
         message: contact_params[:message],

--- a/app/models/contact_wrt.rb
+++ b/app/models/contact_wrt.rb
@@ -2,6 +2,7 @@
 
 class ContactWrt < ContactForm
   attribute :query_type
+  attribute :wca_id
   attribute :profile_data_to_change
   attribute :new_profile_data
   attribute :edit_profile_reason


### PR DESCRIPTION
This PR does two things:
1. Fixes a bug: Changed `profile_data_to_change.titleize` to `profile_data_to_change&.titleize`. This is because if any query type other than profile_data_change is selected, it will crash. This is now fixed.
2. Added WCA ID to contact form email for WRT. (This has small style issue - in the email it shows 'Wca' instead of 'WCA ID', I didn't work to fix that, instead will fix it later, because having WCA ID in contact form email will be really helpful for WRT.