### PR TITLE
Hotfix for newcomers not being able to view v2 registration page

### DIFF
--- a/app/views/registrations/register.html.erb
+++ b/app/views/registrations/register.html.erb
@@ -40,7 +40,10 @@
                                                         connectedAccountId: @competition.payment_account_for(:stripe)&.account_id,
                                                         qualifications: {
                                                           wcif: @competition.qualification_wcif,
-                                                          personalRecords: { single: current_user.person.ranksSingle.map(&:to_wcif), average: current_user.person.ranksAverage.map(&:to_wcif) }
+                                                          personalRecords: {
+                                                            single: current_user.person&.ranksSingle&.map(&:to_wcif) || [],
+                                                            average: current_user.person&.ranksAverage&.map(&:to_wcif) || [],
+                                                          }
                                                         }
                                                         }) %>
     <% else %>


### PR DESCRIPTION
Currently newcomers can't view the v2 register page because they don't have a related person yet. This solves that issue.