### PR TITLE
Fix RegistrationOverview crashing when a user cancels their registration

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
@@ -59,6 +59,7 @@ export default function RegistrationOverview({
       ));
     },
     onSuccess: (data) => {
+      nextStep({ toStart: true });
       queryClient.setQueryData(
         ['registration', competitionInfo.id, registration.user_id],
         {
@@ -67,7 +68,6 @@ export default function RegistrationOverview({
         },
       );
       dispatch(setMessage('competitions.registration_v2.register.registration_status.cancelled', 'positive'));
-      nextStep({ toStart: true });
     },
   });
 


### PR DESCRIPTION
Not sure when this became an issue, but we just have to set the active index to 0 before setting the new query data, otherwise it'll try to load the registration overview again, but can't find it because the registration has been deleted.