### PR TITLE
Run 8 small containers instead of 1 big one

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,22 +35,6 @@ port ENV.fetch("PORT", 3000)
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-if ENV["RAILS_ENV"] == "production"
-  require "concurrent-ruby"
-  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.available_processor_count })
-  workers worker_count if worker_count > 1
-
-  # Use the `preload_app!` method when specifying a `workers` number.
-  # This directive tells Puma to first boot the application and load code
-  # before forking the application. This takes advantage of Copy On Write
-  # process behavior so workers use less memory.
-  preload_app!
-
-  # reconnecting active Record on fork is no longer needed https://github.com/rails/rails/pull/31241
-
-  # queue_requests false # I'm not sure if our AWS Loadbalancer would handle that, I think so?
-end
-
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]

--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -205,15 +205,15 @@ resource "aws_ecs_task_definition" "this" {
   execution_role_arn = aws_iam_role.task_execution_role.arn
   task_role_arn      = aws_iam_role.task_role.arn
 
-  cpu = "8192"
-  memory = "31634"
+  cpu = "1024"
+  memory = "3954"
 
   container_definitions = jsonencode([
     {
       name              = "rails-production"
       image             = "${var.shared.ecr_repository.repository_url}:latest"
-      cpu    = 8192
-      memory = 31634
+      cpu    = 1024
+      memory = 3954
       portMappings = [
         {
           # The hostPort is automatically set for awsvpc network mode,
@@ -259,7 +259,7 @@ resource "aws_ecs_service" "this" {
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
   task_definition                    = data.aws_ecs_task_definition.this.arn
-  desired_count                      = 1
+  desired_count                      = 8
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50

--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -303,8 +303,6 @@ resource "aws_ecs_service" "this" {
 
   lifecycle {
     ignore_changes = [
-      # The desired count is modified by Application Auto Scaling
-      desired_count,
       # The target group changes during Blue/Green deployment
       load_balancer,
       # The Task definition will be set by Code Deploy


### PR DESCRIPTION
Same specs, I removed the block that sets the web concurrency because we are running a single worker everywhere now, which is the default when you don't set `WEB_CONCURRENCY` as per rails default puma.rb
```
# You can control the number of workers using ENV["WEB_CONCURRENCY"]. You
# should only set this value when you want to run 2 or more workers. The
# default is already 1.
```
Next step could be to move the prod containers to the t3 medium capacity provider, which would allow us to scale prod (wow). But let's monitor this for a while.  