### PR TITLE
Use Unicode pluralizers in JS frontend i18n

### DIFF
--- a/app/webpacker/lib/i18n.js
+++ b/app/webpacker/lib/i18n.js
@@ -85,9 +85,9 @@ function loadTranslations(i18n, locale) {
   const dateFnsLocale = Locales[locale];
 
   registerLocale(locale, dateFnsLocale);
-  setDefaultLocale(window.wca.currentLocale);
+  setDefaultLocale(locale);
 
-  const baseLocale = window.wca.currentLocale.split('-')[0];
+  const baseLocale = locale.split('-')[0];
   const pluralizer = Pluralizers[baseLocale];
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/app/webpacker/lib/i18n.js
+++ b/app/webpacker/lib/i18n.js
@@ -1,7 +1,8 @@
-import { I18n } from 'i18n-js';
+import { I18n, useMakePlural } from 'i18n-js';
 
 import * as Locales from 'date-fns/locale';
 import { registerLocale, setDefaultLocale } from 'react-datepicker';
+import * as Pluralizers from 'make-plural';
 
 const i18nFileContext = require.context('rails_translations');
 
@@ -80,6 +81,12 @@ export function withLocale(overrideLocale, fn) {
 function loadTranslations(i18n, locale) {
   const translations = i18nFileContext(`./${locale}.json`);
   i18n.store(translations);
+
+  const baseLocale = window.wca.currentLocale.split('-')[0];
+  const pluralizer = Pluralizers[baseLocale];
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  i18n.pluralization.register(locale, useMakePlural({ pluralizer }));
 }
 
 // store the actual translations.

--- a/app/webpacker/lib/i18n.js
+++ b/app/webpacker/lib/i18n.js
@@ -82,6 +82,11 @@ function loadTranslations(i18n, locale) {
   const translations = i18nFileContext(`./${locale}.json`);
   i18n.store(translations);
 
+  const dateFnsLocale = Locales[locale];
+
+  registerLocale(locale, dateFnsLocale);
+  setDefaultLocale(window.wca.currentLocale);
+
   const baseLocale = window.wca.currentLocale.split('-')[0];
   const pluralizer = Pluralizers[baseLocale];
 
@@ -92,8 +97,3 @@ function loadTranslations(i18n, locale) {
 // store the actual translations.
 loadTranslations(window.I18n, DEFAULT_LOCALE);
 loadTranslations(window.I18n, window.wca.currentLocale);
-
-const dateFnsLocale = Locales[window.wca.currentLocale];
-
-registerLocale(window.wca.currentLocale, dateFnsLocale);
-setDefaultLocale(window.wca.currentLocale);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "leaflet-geosearch": "^4.0.0",
     "lodash": "^4.17.21",
     "luxon": "^3.5.0",
+    "make-plural": "^7.4.0",
     "mini-css-extract-plugin": "^2.9.1",
     "path-complete-extname": "^1.0.0",
     "pnp-webpack-plugin": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7419,6 +7419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-plural@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "make-plural@npm:7.4.0"
+  checksum: 10c0/10f24e932865c88d4cdb14d4bb809ce8e615cae7d083c63ad008b3bcaf0d22941ca0bd76acd9cdd7ae4047563501104fff3c37ce8ad2bc5671facde1818fa57f
+  languageName: node
+  linkType: hard
+
 "marked@npm:^4.1.0":
   version: 4.1.1
   resolution: "marked@npm:4.1.1"
@@ -10167,6 +10174,7 @@ __metadata:
     leaflet-geosearch: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.5.0"
+    make-plural: "npm:^7.4.0"
     mini-css-extract-plugin: "npm:^2.9.1"
     path-complete-extname: "npm:^1.0.0"
     pnp-webpack-plugin: "npm:^1.7.0"


### PR DESCRIPTION
Courtesy of https://github.com/eemeli/make-plural/tree/main/packages/plurals, which is not the exact same implementation as our backend project but at least relies on the same Unicode standard.

Also cleaning up the date-fns locale code a tiny bit while we're at it (essentially just moved the function calls to another block without modifying the calls themselves)

Should solve the problem(s) described in https://github.com/thewca/worldcubeassociation.org/pull/9942