### PR TITLE
Properly localize round names in frontend

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -76,15 +76,11 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
       {
         id: round&.id,
         roundTypeId: round_type.id,
-        # Also include the (localized) name here, we don't have i18n in js yet.
-        name: round&.name || "#{event.name} #{round_type.name}",
         results: results.sort_by { |r| [r.pos, r.personName] },
       }
     end
     render json: {
       id: event.id,
-      # Also include the (localized) name here, we don't have i18n in js yet.
-      name: event.name,
       rounds: rounds,
     }
   end
@@ -109,15 +105,11 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
       {
         id: round&.id,
         roundTypeId: round_type.id,
-        # Also include the (localized) name here, we don't have i18n in js yet.
-        name: round&.name || "#{event.name} #{round_type.name}",
         scrambles: scrambles,
       }
     end
     render json: {
       id: event.id,
-      # Also include the (localized) name here, we don't have i18n in js yet.
-      name: event.name,
       rounds: rounds,
     }
   end

--- a/app/webpacker/components/ResultsData/ViewData.js
+++ b/app/webpacker/components/ResultsData/ViewData.js
@@ -9,9 +9,11 @@ import '../../stylesheets/competition_results.scss';
 import EventNavigation from './EventNavigation';
 import { getUrlParams, setUrlParams } from '../../lib/utils/wca';
 import { competitionApiUrl } from '../../lib/requests/routes.js.erb';
+import { localizeRoundInformation } from '../../lib/utils/wcif';
 
 function RoundResultsTable({
   competitionId,
+  eventId,
   round,
   newEntryUrlFn,
   DataRowHeader,
@@ -20,7 +22,7 @@ function RoundResultsTable({
 }) {
   return (
     <>
-      <h2>{round.name}</h2>
+      <h2>{localizeRoundInformation(eventId, round.roundTypeId)}</h2>
       {adminMode && (
         <Button positive as="a" href={newEntryUrlFn(competitionId, round.id)} size="tiny">
           <Icon name="plus" />
@@ -61,6 +63,7 @@ function ResultsView({
         <RoundResultsTable
           key={round.id}
           competitionId={competitionId}
+          eventId={eventId}
           round={round}
           newEntryUrlFn={newEntryUrlFn}
           DataRowHeader={DataRowHeader}

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -81,15 +81,7 @@ export function getRoundTypeId(roundNumber, totalNumberOfRounds, cutoff = false)
   return cutoff ? 'g' : '3';
 }
 
-export const localizeActivityCode = (activityCode, wcifRound, wcifEvent) => {
-  const { eventId, roundNumber, attempt } = parseActivityCode(activityCode);
-
-  const roundTypeId = getRoundTypeId(
-    roundNumber,
-    wcifEvent.rounds.length,
-    Boolean(wcifRound.cutoff),
-  );
-
+export const localizeRoundInformation = (eventId, roundTypeId, attempt = null) => {
   const eventName = I18n.t(`events.${eventId}`);
   const roundTypeName = I18n.t(`rounds.${roundTypeId}.name`);
 
@@ -101,6 +93,18 @@ export const localizeActivityCode = (activityCode, wcifRound, wcifEvent) => {
   }
 
   return roundName;
+};
+
+export const localizeActivityCode = (activityCode, wcifRound, wcifEvent) => {
+  const { eventId, roundNumber, attempt } = parseActivityCode(activityCode);
+
+  const roundTypeId = getRoundTypeId(
+    roundNumber,
+    wcifEvent.rounds.length,
+    Boolean(wcifRound.cutoff),
+  );
+
+  return localizeRoundInformation(eventId, roundTypeId, attempt);
 };
 
 export const humanizeActivityCode = (activityCode) => {


### PR DESCRIPTION
With the introduction of Puma, it was possible for API requests to be served by a thread that has a different locale set than the user who is currently browsing.

We already have logic to localize round names in the frontend on-the-fly, so let's use it!