### PR TITLE
Map `rejected` competing_status to `deleted` WCIF status

### DIFF
--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -107,7 +107,7 @@ class MicroserviceRegistration < ApplicationRecord
   end
 
   def deleted?
-    self.status == "cancelled"
+    self.status == "cancelled" || self.status == "rejected"
   end
 
   def pending?


### PR DESCRIPTION
This was causing errors in production as `rejected` had no mapping. 

We'll need to think about whether and how to update the WCIF statuses to line up with the registration statuses.