### PR TITLE
Use m6i.large as the base instance instead of m6i.2xlarge

### DIFF
--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -273,13 +273,8 @@ resource "aws_ecs_service" "this" {
   enable_execute_command = true
 
   ordered_placement_strategy {
-    type  = "spread"
-    field = "attribute:ecs.availability-zone"
-  }
-
-  ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+    type  = "binpack"
+    field = "memory"
   }
 
   load_balancer {

--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -206,14 +206,14 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn      = aws_iam_role.task_role.arn
 
   cpu = "1024"
-  memory = "3954"
+  memory = "3910"
 
   container_definitions = jsonencode([
     {
       name              = "rails-production"
       image             = "${var.shared.ecr_repository.repository_url}:latest"
       cpu    = 1024
-      memory = 3954
+      memory = 3910
       portMappings = [
         {
           # The hostPort is automatically set for awsvpc network mode,

--- a/infra/wca_on_rails/shared/ecs.tf
+++ b/infra/wca_on_rails/shared/ecs.tf
@@ -210,7 +210,7 @@ resource "aws_ecs_capacity_provider" "t3_provider" {
     managed_termination_protection = "ENABLED"
 
     managed_scaling {
-      maximum_scaling_step_size = 1
+      maximum_scaling_step_size = 4
       minimum_scaling_step_size = 1
       status                    = "ENABLED"
       target_capacity           = 100
@@ -226,7 +226,7 @@ resource "aws_ecs_capacity_provider" "m6i_provider" {
     managed_termination_protection = "ENABLED"
 
     managed_scaling {
-      maximum_scaling_step_size = 1
+      maximum_scaling_step_size = 4
       minimum_scaling_step_size = 1
       status                    = "ENABLED"
       target_capacity           = 100

--- a/infra/wca_on_rails/shared/ecs.tf
+++ b/infra/wca_on_rails/shared/ecs.tf
@@ -106,7 +106,7 @@ resource "aws_launch_configuration" "m6i_launch_config" {
   name_prefix          = "${var.name_prefix}-m6i-"
   image_id             = data.aws_ami.ecs.id
   iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
-  instance_type        = "m6i.2xlarge"
+  instance_type        = "m6i.large"
   security_groups      = [aws_security_group.cluster.id]
   user_data            = templatefile("../templates/user_data.sh.tftpl", { ecs_cluster_name = aws_ecs_cluster.this.name })
 
@@ -161,8 +161,8 @@ resource "aws_autoscaling_group" "t3_group" {
 
 resource "aws_autoscaling_group" "m6i_group" {
   name_prefix               = "${var.name_prefix}-m6i-"
-  min_size                  = 0
-  max_size                  = 2
+  min_size                  = 2
+  max_size                  = 10
   desired_capacity          = 0
   vpc_zone_identifier       = [aws_default_subnet.default_az2.id]
   launch_configuration      = aws_launch_configuration.m6i_launch_config.name

--- a/infra/wca_on_rails/staging/auxiliary_services.tf
+++ b/infra/wca_on_rails/staging/auxiliary_services.tf
@@ -104,6 +104,11 @@ resource "aws_ecs_service" "auxiliary" {
 
   enable_execute_command = true
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = false
+  }
+
   ordered_placement_strategy {
     type  = "spread"
     field = "attribute:ecs.availability-zone"


### PR DESCRIPTION
The m6i.2xlarge just has 3 network interfaces so we can't run 8 containers on it like we planned. Instead we now run the equivalent 4 m6i.large instances and run 2 containers on each. 