### PR TITLE
Don't load all docker images by default to not run out of disk space sometimes

### DIFF
--- a/.github/actions/build-environment/action.yaml
+++ b/.github/actions/build-environment/action.yaml
@@ -32,6 +32,7 @@ runs:
         tag: sidekiq-${{inputs.environment}}
         build_tag: ${{ inputs.build_tag }}
         environment: ${{ inputs.environment }}
+        load: true
     - name: Copy assets out of the container and push to S3
       shell: bash
       run: | # We do this once the first image is build so it will be definitely available

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -16,6 +16,10 @@ inputs:
   environment:
     description: 'Deployment environment (e.g., staging, production)'
     required: true
+  load:
+    description: 'If the docker image should be added to the local docker image context (default false)'
+    required: false
+    default: false
 outputs:
   imageid:
     description: 'The Docker image id build'
@@ -38,7 +42,7 @@ runs:
       id: build-image
       with:
         push: true
-        load: true
+        load: ${{ inputs.load }}
         context: .
         target: ${{ inputs.target }}
         tags: |


### PR DESCRIPTION
We only need to actually load the image into the docker context once to upload the assets. I didn't think about the disk space when I extracted the action