### PR TITLE
Add registration V2 models back into the monolith

### DIFF
--- a/app/jobs/add_registration_v2_job.rb
+++ b/app/jobs/add_registration_v2_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddRegistrationV2Job < ApplicationJob
+  def perform(competition_id, user_id, event_ids, guests = 0, comment = '')
+    ActiveRecord::Base.transaction do
+      registration = V2Registration.create(competition_id: competition_id, user_id: user_id, guests: guests)
+      registration.add_history_entry({ event_ids: event_ids, guests: guests, comment: comment }, 'user', user_id, 'Worker processed')
+      registration.registration_lane.create(competing_lane(event_ids: event_ids, comment: comment))
+    end
+  end
+
+  def competing_lane(event_ids: [], comment: '', admin_comment: '', registration_status: 'pending', waiting_list_position: nil)
+    {
+      lane_name: 'competing',
+      completed_steps: ['Event Registration'],
+      lane_state: registration_status,
+      lane_details: {
+        'event_details' => event_ids.map { |event_id| { event_id: event_id, event_registration_state: registration_status } },
+        'comment' => comment,
+        'admin_comment' => admin_comment,
+        'waiting_list_position' => waiting_list_position.to_i,
+      }
+    }
+  end
+end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -10,6 +10,7 @@ class Competition < ApplicationRecord
   has_many :events, through: :competition_events
   has_many :rounds, through: :competition_events
   has_many :registrations, dependent: :destroy
+  has_many :v2_registrations, dependent: :destroy
   has_many :results, foreign_key: "competitionId"
   has_many :scrambles, -> { order(:groupId, :isExtra, :scrambleNum) }, foreign_key: "competitionId"
   has_many :uploaded_jsons, dependent: :destroy

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -11,6 +11,7 @@ class Competition < ApplicationRecord
   has_many :rounds, through: :competition_events
   has_many :registrations, dependent: :destroy
   has_many :v2_registrations, dependent: :destroy
+  has_one :waiting_list, dependent: :destroy
   has_many :results, foreign_key: "competitionId"
   has_many :scrambles, -> { order(:groupId, :isExtra, :scrambleNum) }, foreign_key: "competitionId"
   has_many :uploaded_jsons, dependent: :destroy

--- a/app/models/registration_history_change.rb
+++ b/app/models/registration_history_change.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class RegistrationHistoryChange < ActiveRecord::Base
+  belongs_to :registration_history_entry
+end

--- a/app/models/registration_history_entry.rb
+++ b/app/models/registration_history_entry.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'time'
+
+class RegistrationHistoryEntry < ActiveRecord::Base
+  has_many :registration_history_change, :dependent => :destroy
+end

--- a/app/models/registration_lane.rb
+++ b/app/models/registration_lane.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class RegistrationLane < ActiveRecord::Base
+  def update_events!(new_event_ids)
+    if lane_name == 'competing'
+      current_event_ids = lane_details['event_details'].pluck('event_id')
+
+      # Update events list with new events
+      new_event_ids.each do |id|
+        next if current_event_ids.include?(id)
+        new_details = {
+          'event_id' => id,
+          # NOTE: Currently event_registration_state is not used - when per-event registrations are added, we need to add validation logic to support cases like
+          # limited registrations and waiting lists for certain events
+          'event_registration_state' => lane_state,
+        }
+        lane_details['event_details'] << new_details
+      end
+
+      # Remove events not in the new events list
+      lane_details['event_details'].delete_if do |event|
+        !(new_event_ids.include?(event['event_id']))
+      end
+      save
+    end
+  end
+end

--- a/app/models/v2_registration.rb
+++ b/app/models/v2_registration.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'time'
+
+class V2Registration < ActiveRecord::Base
+
+  has_many :registration_history_entry, foreign_key: :registration_id
+  has_many :registration_lane, foreign_key: :registration_id
+  belongs_to :competition
+  belongs_to :user
+
+  def competing_lane
+    registration_lane.select { |l| l.lane_name == 'competing' }.first
+  end
+
+  def payment_lane
+    registration_lane.select { |l| l.lane_name ==  'payment' }.first
+  end
+
+  # Returns all event ids irrespective of registration status
+  def event_ids
+    competing_lane.lane_details&.[]('event_details')&.pluck('event_id')
+  end
+
+  def registered_event_ids
+    event_ids = []
+
+    competing_lane.lane_details['event_details'].each do |event|
+      if event['event_registration_state'] != 'cancelled'
+        event_ids << event['event_id']
+      end
+    end
+    event_ids
+  end
+
+  def event_details
+    competing_lane&.lane_details&.[]('event_details')
+  end
+
+  def comment
+    competing_lane&.lane_details&.[]('comment')
+  end
+
+  def admin_comment
+    competing_lane&.lane_details&.[]('admin_comment')
+  end
+
+  def payment_ticket
+    payment_lane&.lane_details&.[]('payment_id')
+  end
+
+  def payment_status
+    payment_lane&.lane_state
+  end
+
+  def payment_amount
+    payment_lane&.lane_details&.[]('amount_lowest_denominator')
+  end
+
+  def waiting_list_position(waiting_list)
+    return nil if competing_status != 'waiting_list'
+    waiting_list.entries.find_index(user_id) + 1
+  end
+
+  def payment_amount_human_readable
+    payment_details = payment_lane&.lane_details
+    unless payment_details.nil?
+      MoneyFormat.format_human_readable(payment_details['amount_lowest_denominator'], payment_details['currency_code'])
+    end
+  end
+
+  def payment_date
+    payment_lane&.lane_details&.[]('last_updated')
+  end
+
+  def payment_history
+    payment_lane&.lane_details&.[]('payment_history')
+  end
+
+  def registration_history
+    registration_history_entry.map do |r|
+      changed_attributes = r.registration_history_change.each_with_object({}) do |change, attrs|
+        attrs[change.key] = change.value
+      end
+
+      {
+        changed_attributes: changed_attributes,
+        actor_type: r.actor_type,
+        actor_id: r.actor_id,
+        timestamp: r.timestamp,
+        action: r.action
+      }
+    end
+  end
+
+  def update_competing_lane!(update_params, waiting_list)
+    ActiveRecord::Base.transaction do
+      if update_params[:status].present?
+        competing_lane.lane_state = update_params[:status]
+
+        competing_lane.lane_details['event_details'].each do |event|
+          # NOTE: Currently event_registration_state is not used - when per-event registrations are added, we need to add validation logic to support cases like
+          # limited registrations and waiting lists for certain events
+          event['event_registration_state'] = update_params[:status]
+        end
+      end
+
+      competing_lane.lane_details['comment'] = update_params[:comment] if update_params[:comment].present?
+      competing_lane.lane_details['admin_comment'] = update_params[:admin_comment] if update_params[:admin_comment].present?
+
+      competing_lane.save!
+
+      if update_params[:event_ids].present? && update_params[:status] != 'cancelled'
+        competing_lane.update_events!(update_params[:event_ids])
+      end
+
+      update_column(:guests, update_params[:guests]) if update_params[:guests].present?
+    end
+  end
+
+  def add_history_entry(changes, actor_type, actor_id, action, timestamp = Time.now.utc)
+    new_entry = registration_history_entry.create(actor_type: actor_type, actor_id: actor_id, action: action, timestamp: timestamp)
+    changes.keys.each do |key|
+      new_entry.registration_history_change.create(from: changes[key][:from] || '', to: changes[key][:to], key: key.to_s)
+    end
+  end
+
+  def init_payment_lane(amount, currency_code, id, donation)
+    registration_lane.create(LaneFactory.payment_lane(amount, currency_code, id, donation))
+  end
+
+  def update_payment_lane(id, iso_amount, currency_iso, status)
+    payment_lane.update_columns(lane_state: status, lane_details: {
+      payment_id: id,
+      amount_lowest_denominator: iso_amount,
+      currency_code: currency_iso,
+    })
+  end
+
+  def competing_status
+    competing_lane&.lane_state
+  end
+
+  def might_attend?
+    MIGHT_ATTEND_STATES.include?(competing_status)
+  end
+end

--- a/app/models/v2_registration.rb
+++ b/app/models/v2_registration.rb
@@ -93,7 +93,7 @@ class V2Registration < ActiveRecord::Base
     end
   end
 
-  def update_competing_lane!(update_params, waiting_list)
+  def update_competing_lane!(update_params)
     ActiveRecord::Base.transaction do
       if update_params[:status].present?
         competing_lane.lane_state = update_params[:status]
@@ -118,8 +118,8 @@ class V2Registration < ActiveRecord::Base
     end
   end
 
-  def add_history_entry(changes, actor_type, actor_id, action, timestamp = Time.now.utc)
-    new_entry = registration_history_entry.create(actor_type: actor_type, actor_id: actor_id, action: action, timestamp: timestamp)
+  def add_history_entry(changes, actor_type, actor_id, action)
+    new_entry = registration_history_entry.create(actor_type: actor_type, actor_id: actor_id, action: action)
     changes.keys.each do |key|
       new_entry.registration_history_change.create(from: changes[key][:from] || '', to: changes[key][:to], key: key.to_s)
     end

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class WaitingList < ActiveRecord::Base
+  belongs_to :holder, polymorphic: true
+
+  def remove(user_id)
+    update_column :entries, entries - [user_id]
+  end
+
+  def add(user_id)
+    if entries.nil?
+      update_column :entries, [user_id]
+    else
+      update_column :entries, entries + [user_id]
+    end
+  end
+
+  def move_to_position(user_id, new_position)
+    raise ArgumentError.new('Target position out of waiting list range') if new_position > entries.length || new_position < 1
+
+    old_index = entries.find_index(user_id)
+    return if old_index == new_position-1
+
+    update_column :entries, entries.insert(new_position-1, entries.delete_at(old_index))
+  end
+end

--- a/db/migrate/20240924131739_create_registration_v2.rb
+++ b/db/migrate/20240924131739_create_registration_v2.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateRegistrationV2 < ActiveRecord::Migration[7.2]
+  def change
+    create_table :v2_registrations do |t|
+      t.references :user, null: false, index: true, foreign_key: true
+      t.integer :guests
+      t.references :competition, null: false, type: :string, index: true, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :v2_registrations, [:user_id, :competition_id], unique: true
+  end
+end

--- a/db/migrate/20240924132217_create_waiting_list.rb
+++ b/db/migrate/20240924132217_create_waiting_list.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateWaitingList < ActiveRecord::Migration[7.2]
+  def change
+    create_table :waiting_lists do |t|
+      t.references :holder, polymorphic: true
+      t.json :entries
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240924132323_create_lane.rb
+++ b/db/migrate/20240924132323_create_lane.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateLane < ActiveRecord::Migration[7.2]
+  def change
+    create_table :registration_lanes do |t|
+      t.references :v2_registrations, null: false, index: true, foreign_key: true
+      t.string :lane_name
+      t.string :lane_state
+      t.json :completed_steps
+      t.json :lane_details
+
+      t.timestamps
+    end
+    add_index :registration_lanes, [:v2_registration_id, :lane_name], unique: true
+  end
+end

--- a/db/migrate/20240924132724_create_registration_history_entry.rb
+++ b/db/migrate/20240924132724_create_registration_history_entry.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateRegistrationHistoryEntry < ActiveRecord::Migration[7.2]
+  def change
+    create_table :registration_history_entries do |t|
+      t.references :v2_registrations, index: true
+      t.string :actor_type
+      t.string :actor_id
+      t.string :action
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240924132809_create_registration_history_changes.rb
+++ b/db/migrate/20240924132809_create_registration_history_changes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateRegistrationHistoryChanges < ActiveRecord::Migration[7.2]
+  def change
+    create_table :registration_history_changes do |t|
+      t.references :registration_history_entries, foreign_key: true, index: true
+      t.string :key
+      t.string :value
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
Work in Progress, but I wanted to already create it so @gregorbg can implement his ideas about a better relational model for lanes. 
I added a Job to create a v2 registration as well, which is about what it will look like later for event registration