### PR TITLE
Pull gem and Yarn installation into separate `environment` Docker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,61 @@
+x-environment: &env
+  RAILS_ENV: development
+
 x-app: &app
   build:
     dockerfile: Dockerfile.dev
     context: .
   working_dir: /app
+  entrypoint: ./entrypoint.dev.sh
+  environment:
+    <<: *env
   volumes:
     - .:/app
+    - gems_volume:/usr/local/bundle
+    - node_modules_volume:/app/node_modules
   networks:
     - wca-main
 
+x-app-environment: &appVars
+  <<: *env
+  DATABASE_HOST: wca_db
+  SIDEKIQ_REDIS_URL: redis://wca_redis:6379/1
+  MAILCATCHER_SMTP_HOST: wca_mailcatcher
+
 services:
+  wca_environment:
+    <<: *app
+    container_name: "environment"
+    command: >
+      bash -c 'corepack install &&
+      rm -f .db-inited &&
+      bin/setup &&
+      touch .db-inited'
+    healthcheck:
+      test: [ "CMD", "test", "-f", ".db-inited" ]
+      interval: 5s
+      timeout: 2s
+      retries: 20
+      # Give the container some time to populate the database
+      start_period: 15m
+
   wca_on_rails:
     <<: *app
     container_name: "rails"
     ports:
       - "3000:3000"
     environment:
-      RAILS_ENV: development
-      DATABASE_HOST: wca_db
+      <<: *appVars
       SHAKAPACKER_DEV_SERVER_HOST: wca_webpacker
       CACHE_REDIS_URL: redis://wca_redis:6379/0
-      SIDEKIQ_REDIS_URL: redis://wca_redis:6379/1
-      MAILCATCHER_SMTP_HOST: wca_mailcatcher
     tty: true
     # First, install Ruby and Node dependencies
     # Next, load the database if it does not exist yet
     # Start the server and bind to 0.0.0.0 (vs 127.0.0.1) so Docker's port mappings work correctly
-    command: >
-      bash -c 'corepack install &&
-      rm -f .db-inited &&
-      bin/setup &&
-      touch .db-inited &&
-      bin/rails server -b 0.0.0.0'
-    healthcheck:
-      test: ["CMD", "test", "-f", ".db-inited"]
-      interval: 5s
-      timeout: 2s
-      retries: 20
-      # Give the container some time to populate the database
-      start_period: 15m
+    command: bin/rails server -b 0.0.0.0
     depends_on:
+      wca_environment:
+        condition: 'service_healthy'
       wca_db:
         condition: 'service_healthy'
       wca_redis:
@@ -50,13 +67,13 @@ services:
     ports:
       - "3035:3035"
     environment:
-      DATABASE_HOST: wca_db
+      <<: *appVars
       SHAKAPACKER_DEV_SERVER_HOST: 0.0.0.0
       NODE_ENV: development
-    command: >
-      bash -c 'bundle install && yarn install &&
-      bin/shakapacker-dev-server'
+    command: bin/shakapacker-dev-server
     depends_on:
+      wca_environment:
+        condition: 'service_healthy'
       wca_db:
         condition: 'service_healthy'
       wca_on_rails:
@@ -79,17 +96,14 @@ services:
     <<: *app
     container_name: 'sidekiq'
     environment:
-      RAILS_ENV: development
-      DATABASE_HOST: wca_db
-      SIDEKIQ_REDIS_URL: redis://wca_redis:6379/1
-      MAILCATCHER_SMTP_HOST: wca_mailcatcher
+      <<: *appVars
       # Cronjobs are disabled in development by default. If you wish to run cronjobs,
       # set this env variable to any integer value greater than zero
       # CRONJOB_POLLING_MINUTES: 30
-    command: >
-      bash -c 'bundle install && yarn install &&
-      bundle exec sidekiq'
+    command: bin/bundle exec sidekiq
     depends_on:
+      wca_environment:
+        condition: 'service_healthy'
       wca_on_rails:
         condition: 'service_healthy'
       wca_redis:
@@ -131,6 +145,10 @@ services:
       - wca-main
 
 volumes:
+  gems_volume:
+    driver: local
+  node_modules_volume:
+    driver: local
   wca_db_volume:
     driver: local
   cache_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 x-environment: &env
   RAILS_ENV: development
+  DATABASE_HOST: wca_db
 
 x-app: &app
   build:
@@ -18,7 +19,6 @@ x-app: &app
 
 x-app-environment: &appVars
   <<: *env
-  DATABASE_HOST: wca_db
   SIDEKIQ_REDIS_URL: redis://wca_redis:6379/1
   MAILCATCHER_SMTP_HOST: wca_mailcatcher
 
@@ -38,6 +38,14 @@ services:
       retries: 20
       # Give the container some time to populate the database
       start_period: 15m
+    # Tell Docker that it's okay and expected that this container terminates (with exit code 0)
+    #   after completing the script listed under `command` above
+    restart: no
+    depends_on:
+      wca_db:
+        condition: 'service_healthy'
+      wca_redis:
+        condition: 'service_started'
 
   wca_on_rails:
     <<: *app
@@ -49,17 +57,11 @@ services:
       SHAKAPACKER_DEV_SERVER_HOST: wca_webpacker
       CACHE_REDIS_URL: redis://wca_redis:6379/0
     tty: true
-    # First, install Ruby and Node dependencies
-    # Next, load the database if it does not exist yet
     # Start the server and bind to 0.0.0.0 (vs 127.0.0.1) so Docker's port mappings work correctly
     command: bin/rails server -b 0.0.0.0
     depends_on:
       wca_environment:
-        condition: 'service_healthy'
-      wca_db:
-        condition: 'service_healthy'
-      wca_redis:
-        condition: 'service_started'
+        condition: service_completed_successfully
 
   wca_webpacker:
     <<: *app
@@ -73,13 +75,9 @@ services:
     command: bin/shakapacker-dev-server
     depends_on:
       wca_environment:
-        condition: 'service_healthy'
-      wca_db:
-        condition: 'service_healthy'
-      wca_on_rails:
         # We need to make sure that the database is populated because our frontend code
         # pulls stuff like WCA Events and Round formats from the DB when compiling assets
-        condition: 'service_healthy'
+        condition: service_completed_successfully
 
   wca_mailcatcher:
     <<: *app
@@ -103,13 +101,7 @@ services:
     command: bin/bundle exec sidekiq
     depends_on:
       wca_environment:
-        condition: 'service_healthy'
-      wca_on_rails:
-        condition: 'service_healthy'
-      wca_redis:
-        condition: 'service_started'
-      wca_db:
-        condition: 'service_healthy'
+        condition: service_completed_successfully
 
   wca_db:
     image: mysql:8.0

--- a/entrypoint.dev.sh
+++ b/entrypoint.dev.sh
@@ -9,9 +9,23 @@ BUNDLE_PATH="/usr/local/bundle/${RUBY_VERSION}"
 # Create the versioned directory if it doesn't exist
 mkdir -p "$BUNDLE_PATH"
 
+CURRENT_SYMLINK="/usr/local/bundle/current"
+
+# Check if the 'current' symlink exists
+if [ -L "$CURRENT_SYMLINK" ]; then
+  # Read the target of the 'current' symlink
+  CURRENT_TARGET=$(readlink "$CURRENT_SYMLINK")
+
+  # If the target doesn't match the current Ruby version, remove the old target
+  if [[ "$CURRENT_TARGET" != "$BUNDLE_PATH" ]]; then
+    echo "Removing gems for old Ruby version: $CURRENT_TARGET"
+    rm -rf "$CURRENT_TARGET"
+  fi
+fi
+
 # Symlink the versioned directory to a common 'current' path
-ln -sfn "$BUNDLE_PATH" /usr/local/bundle/current
-BUNDLE_PATH=/usr/local/bundle/current
+ln -sfn "$BUNDLE_PATH" "$CURRENT_SYMLINK"
+BUNDLE_PATH="$CURRENT_SYMLINK"
 
 # Set the BUNDLE_PATH to the symlink for all processes
 export BUNDLE_PATH

--- a/entrypoint.dev.sh
+++ b/entrypoint.dev.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Get the installed Ruby version from the runtime
+RUBY_VERSION=$(ruby -e 'puts RUBY_VERSION')
+
+# Set the versioned bundle path based on the Ruby version
+BUNDLE_PATH="/usr/local/bundle/${RUBY_VERSION}"
+
+# Create the versioned directory if it doesn't exist
+mkdir -p "$BUNDLE_PATH"
+
+# Symlink the versioned directory to a common 'current' path
+ln -sfn "$BUNDLE_PATH" /usr/local/bundle/current
+BUNDLE_PATH=/usr/local/bundle/current
+
+# Set the BUNDLE_PATH to the symlink for all processes
+export BUNDLE_PATH
+
+# Run the main command (e.g., rails server or sidekiq)
+exec "$@"


### PR DESCRIPTION
Problem: Rails, Webpacker and Sidekiq all need our Ruby runtime. Currently, all three download the same gems independently, and without caching them into a volume.

Solution: Let one central `environment` service download everything (and also configure it, courtesy of the new `bin/setup` script in Rails 7) and also cache it via mounted volumes.

Note: Previously, we had problems with native bindings in a shared volume. Whenever Ruby was updated, the native gems that were built for the previous version caused errors/crashes. This is now fixed through a (somewhat complex) `entrypoint` script, that loads the gems into per-version directories.