### PR TITLE
Migrate Competition model primary key to stable AUTO_INCREMENT integer

### DIFF
--- a/db/migrate/20240816041854_add_auto_increment_to_competitions.rb
+++ b/db/migrate/20240816041854_add_auto_increment_to_competitions.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddAutoIncrementToCompetitions < ActiveRecord::Migration[7.1]
+  def up
+    remove_foreign_key :microservice_registrations, :Competitions
+
+    execute "ALTER TABLE Competitions DROP PRIMARY KEY"
+
+    rename_column :Competitions, :id, :competition_id
+    add_index :Competitions, :competition_id, unique: true
+
+    add_column :Competitions, :id, :bigint, first: true
+
+    execute "UPDATE Competitions c, (SELECT competition_id, ROW_NUMBER() OVER (ORDER BY created_at, announced_at, start_date, competition_id) AS rn FROM Competitions) h SET c.id = h.rn WHERE c.competition_id = h.competition_id"
+    change_column :Competitions, :id, :primary_key, auto_increment: true
+
+    add_foreign_key :microservice_registrations, :Competitions, primary_key: :competition_id
+  end
+
+  def down
+    remove_foreign_key :microservice_registrations, :Competitions
+
+    change_column :Competitions, :id, :integer, auto_increment: false
+    execute "ALTER TABLE Competitions DROP PRIMARY KEY"
+
+    remove_column :Competitions, :id, :primary_key
+
+    remove_index :Competitions, :competition_id
+    rename_column :Competitions, :competition_id, :id
+
+    execute "ALTER TABLE Competitions ADD PRIMARY KEY(id)"
+
+    add_foreign_key :microservice_registrations, :Competitions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_09_13_052148) do
-  create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "Competitions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "competition_id", limit: 32, default: "", null: false
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
     t.string "countryId", limit: 50, default: "", null: false
@@ -83,6 +84,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_052148) do
     t.boolean "forbid_newcomers", default: false, null: false
     t.string "forbid_newcomers_reason"
     t.index ["cancelled_at"], name: "index_Competitions_on_cancelled_at"
+    t.index ["competition_id"], name: "index_Competitions_on_competition_id", unique: true
     t.index ["countryId"], name: "index_Competitions_on_countryId"
     t.index ["end_date"], name: "index_Competitions_on_end_date"
     t.index ["start_date"], name: "index_Competitions_on_start_date"
@@ -1286,7 +1288,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_052148) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "microservice_registrations", "Competitions", column: "competition_id"
+  add_foreign_key "microservice_registrations", "Competitions", column: "competition_id", primary_key: "competition_id"
   add_foreign_key "microservice_registrations", "users"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "payment_intents", "users", column: "initiated_by_id"


### PR DESCRIPTION
Should be the last of our PHP legacy problems.

This will obviously require massive code changes throughout the entire Rails app (`find` has to be replaced by `find_by`) but we can also get rid of problems like `with_old_id` and all the hacks that surround it.

WIP but it seemed appropriate for PR number 10.000 :smile: 