### PR TITLE
Install packages from dependency list as part of dev environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,14 +19,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash && \
 # Enable 'corepack' feature that lets NPM download the package manager on-the-fly as required.
 RUN corepack enable
 
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y \
-      git \
-      build-essential \
-      mariadb-client \
-      libssl-dev \
-      libyaml-dev \
-      tzdata
+# Copy a file of our development runtime dependencies into the image for initial install
+COPY packages.dev.txt /tmp/packages.txt
+COPY package-install.dev.sh /tmp/package-install.sh
+
+RUN /tmp/package-install.sh /tmp/packages.txt
 
 RUN gem update --system && gem install bundler
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       <<: *env
       DISABLE_SPRING: 1
     command: >
-      bash -c 'corepack install &&
+      bash -c './package-install.dev.sh packages.dev.txt &&
       rm -f .db-inited &&
       bin/setup &&
       touch .db-inited'

--- a/package-install.dev.sh
+++ b/package-install.dev.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Make sure we have the required version of Yarn running
+#  (because for some reason, this isn't done automatically even when corepack is explicitly enabled)
+corepack install
+
+# Make sure all sources are up-to-date
+apt-get update -qq
+
+# Install the packages from a line-separated package list,
+#   making sure that one failure doesn't affect the other packages.
+for pkg in $(cat "$@"); do
+  apt-get install --no-install-recommends -y "$pkg";
+done

--- a/packages.dev.txt
+++ b/packages.dev.txt
@@ -1,0 +1,6 @@
+git
+build-essential
+mariadb-client
+libssl-dev
+libyaml-dev
+tzdata


### PR DESCRIPTION
The problem I'm trying to solve is related to #9787: We need a new native dependency `clang` in the development Docker container, to be able to build native Ruby bindings to Rust code (because one new library relies on native Rust, and in the future there will be at least one more such library).

This means that in its current state, we'd have to tell everyone on the whole team as well as external contributors to rebuild their Docker containers. This can take time and be costly for such a "simple" thing as adding one Debian dependency.

So my idea is to run the install step as part of the new `environment` base container. If there is a more elegant way to achieve the same goal, please feel free to suggest that instead.