### PR TITLE
Hotfix: Use a DST-less timezone in frontend tests

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1025,13 +1025,11 @@ class Competition < ApplicationRecord
   end
 
   def country_zones
-    ActiveSupport::TimeZone.country_zones(country.iso2).to_h { |tz| [tz.name, tz.tzinfo.name] }
+    TZInfo::Country.get(country.iso2.upcase).zone_identifiers
   rescue TZInfo::InvalidCountryCode
     # This can occur for non real country *and* XK!
     # FIXME what to provide for XA, XE, XM, XS?
-    {
-      "London" => "Europe/London",
-    }
+    ["Europe/London"]
   end
 
   private def compute_coordinates

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -8,7 +8,7 @@ class Country < ApplicationRecord
 
   has_one :wfc_dues_redirect, as: :redirect_source
 
-  SUPPORTED_TIMEZONES = ActiveSupport::TimeZone::MAPPING.values.uniq.freeze
+  SUPPORTED_TIMEZONES = TZInfo::Timezone.all_identifiers.uniq.freeze
 
   FICTIVE_COUNTRY_DATA_PATH = StaticData::DATA_FOLDER.join("#{self.data_file_handle}.fictive.json")
   MULTIPLE_COUNTRIES = self.parse_json_file(FICTIVE_COUNTRY_DATA_PATH).freeze

--- a/app/webpacker/components/EditSchedule/EditVenues/VenuePanel.js
+++ b/app/webpacker/components/EditSchedule/EditVenues/VenuePanel.js
@@ -76,7 +76,7 @@ function VenuePanel({
   //   - country_zone_a, country_zone_b, [...], other_tz_a, other_tz_b, [...]
   const timezoneOptions = useMemo(() => {
     // Stuff that is recommended based on the country list
-    const competitionZoneIds = _.uniq(Object.values(countryZones));
+    const competitionZoneIds = _.uniq(countryZones);
     const sortedCompetitionZones = sortByOffset(competitionZoneIds, referenceTime);
 
     // Stuff that is listed in our `backendTimezones` list but not in the preferred country list

--- a/spec/features/competition_manage_schedule_spec.rb
+++ b/spec/features/competition_manage_schedule_spec.rb
@@ -25,7 +25,8 @@ RSpec.feature "Competition events management" do
         click_button "Add room"
         fill_in("room-name", with: "Youpitralala")
         within(:css, "div[name='timezone'][role='listbox']>div.menu", visible: :all) do
-          find("div", class: "item", text: "America/Los_Angeles (Pacific Daylight Time, UTC-7)", visible: :all).trigger(:click)
+          # Using a timezone that does not follow Daylight Savings, so that we get consistent results all year round
+          find("div", class: "item", text: "Asia/Tokyo (Japan Standard Time, UTC+9)", visible: :all).trigger(:click)
         end
         within(:css, "div[name='countryIso2'][role='combobox']>div.menu[role='listbox']", visible: :all) do
           find("div", class: "item", text: "United States", visible: :all).trigger(:click)


### PR DESCRIPTION
California just turned their clocks due to Daylight Savings (at the time of writing this description message). This causes our test suite to fail "out of nowhere", because the string literaly "Pacific Daylight Time" cannot be found in the frontend.

Also sneaking in a tiny improvement to how available/eligible timezones are being passed from the backend to the frontend, stolen from https://github.com/thewca/worldcubeassociation.org/pull/9787