### PR TITLE
Execute check records script from Read Replica

### DIFF
--- a/app/models/check_regional_records_form.rb
+++ b/app/models/check_regional_records_form.rb
@@ -10,6 +10,8 @@ class CheckRegionalRecordsForm
   end
 
   def run_check
-    CheckRegionalRecords.check_records(self.check_event_id, self.competition_id)
+    ActiveRecord::Base.connected_to(role: :read_replica) do
+      CheckRegionalRecords.check_records(self.check_event_id, self.competition_id)
+    end
   end
 end


### PR DESCRIPTION
Attempt to accelerate Check Records by running the expensive read operation off the Read Replica.

Does not work (quite as easily) for Create Newcomers, because that requires immediate write operations in batches which are reflected in subsequent read operations. (In other words, the data written immediately needs to be read).

Check Records however reads all the data in one batch, lets WRT assign overrides, and "just" stores them. No pagination or anything.