### PR TITLE
Switched competition_id foreign key in microservice_registrations comp cascade

### DIFF
--- a/db/migrate/20241009111904_add_cascade_to_microservice_competition_id.rb
+++ b/db/migrate/20241009111904_add_cascade_to_microservice_competition_id.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCascadeToMicroserviceCompetitionId < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :microservice_registrations, :Competitions
+    add_foreign_key :microservice_registrations, :Competitions, on_update: :cascade
+  end
+end

--- a/db/migrate/20241009111904_add_cascade_to_microservice_competition_id.rb
+++ b/db/migrate/20241009111904_add_cascade_to_microservice_competition_id.rb
@@ -3,6 +3,6 @@
 class AddCascadeToMicroserviceCompetitionId < ActiveRecord::Migration[7.2]
   def change
     remove_foreign_key :microservice_registrations, :Competitions
-    add_foreign_key :microservice_registrations, :Competitions, on_update: :cascade
+    add_foreign_key :microservice_registrations, :Competitions, on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_30_132809) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_09_111904) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -1318,7 +1318,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_30_132809) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "microservice_registrations", "Competitions", column: "competition_id"
+  add_foreign_key "microservice_registrations", "Competitions", column: "competition_id", on_update: :cascade
   add_foreign_key "microservice_registrations", "users"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "payment_intents", "users", column: "initiated_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1318,7 +1318,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_111904) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "microservice_registrations", "Competitions", column: "competition_id", on_update: :cascade
+  add_foreign_key "microservice_registrations", "Competitions", column: "competition_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "microservice_registrations", "users"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "payment_intents", "users", column: "initiated_by_id"


### PR DESCRIPTION
As discussed in meeting, this fixes an issue where competition id's could not be updated by admins if a microservice registration existed for them.

Tested locally and works as expected.