### PR TITLE
Enforce strict competition ID changes when pre-registering

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -612,7 +612,7 @@ class Competition < ApplicationRecord
   end
 
   def user_can_pre_register?(user)
-    delegates.include?(user) || trainee_delegates.include?(user) || organizers.include?(user)
+    (delegates.include?(user) || trainee_delegates.include?(user) || organizers.include?(user)) && self.announced?
   end
 
   attr_accessor :being_cloned_from_id

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -612,7 +612,7 @@ class Competition < ApplicationRecord
   end
 
   def user_can_pre_register?(user)
-    (delegates.include?(user) || trainee_delegates.include?(user) || organizers.include?(user)) && self.announced?
+    (delegates.include?(user) || trainee_delegates.include?(user) || organizers.include?(user)) && self.confirmed_or_visible?
   end
 
   attr_accessor :being_cloned_from_id

--- a/app/views/competitions/_competition_form.html.erb
+++ b/app/views/competitions/_competition_form.html.erb
@@ -4,6 +4,7 @@
   competition: @competition.to_form_data,
   usesV2Registrations: @competition.uses_v2_registrations,
   canChangeRegistrationSystem: @competition.can_change_registration_system?,
+  hasAnyRegistrations: @competition.any_registrations?,
   storedEvents: @competition.events,
   isAdminView: @competition_admin_view,
   isPersisted: @competition.persisted?,

--- a/app/webpacker/components/CompetitionForm/FormSections/NameDetails.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/NameDetails.js
@@ -6,7 +6,7 @@ import { competitionMaxShortNameLength } from '../../../lib/wca-data.js.erb';
 import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider';
 
 export default function NameDetails() {
-  const { isPersisted, isAdminView } = useStore();
+  const { hasAnyRegistrations, isPersisted, isAdminView } = useStore();
 
   const { name } = useFormObject();
 
@@ -15,7 +15,7 @@ export default function NameDetails() {
 
   return (
     <>
-      {isPersisted && <InputString id="competitionId" disabled={disableIdAndShortName} />}
+      {isPersisted && <InputString id="competitionId" disabled={disableIdAndShortName || hasAnyRegistrations} />}
       <InputString id="name" required />
       {isPersisted && (
         <InputString

--- a/app/webpacker/components/CompetitionForm/index.js
+++ b/app/webpacker/components/CompetitionForm/index.js
@@ -77,6 +77,7 @@ export default function Wrapper({
   competition = null,
   usesV2Registrations = false,
   canChangeRegistrationSystem = false,
+  hasAnyRegistrations = false,
   storedEvents = [],
   isAdminView = false,
   isPersisted = false,
@@ -105,6 +106,7 @@ export default function Wrapper({
       initialState={{
         usesV2Registrations,
         canChangeRegistrationSystem,
+        hasAnyRegistrations,
         storedEvents,
         isAdminView,
         isPersisted,

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe RegistrationsController, clean_db_with_truncation: true do
   context "signed in as organizer" do
     let!(:organizer) { FactoryBot.create(:user) }
-    let(:competition) { FactoryBot.create(:competition, :registration_open, organizers: [organizer], events: Event.where(id: %w(222 333))) }
+    let(:competition) { FactoryBot.create(:competition, :registration_open, :visible, organizers: [organizer], events: Event.where(id: %w(222 333))) }
     let(:zzyzx_user) { FactoryBot.create :user, name: "Zzyzx" }
     let(:registration) { FactoryBot.create(:registration, competition: competition, user: zzyzx_user) }
 

--- a/spec/features/competition_management_spec.rb
+++ b/spec/features/competition_management_spec.rb
@@ -40,6 +40,12 @@ end
 # Apparition browser engine does not render React state changes properly.
 # We can remove this `retry` count when we migrated to a "proper" browser engine in tests.
 RSpec.feature "Competition management", js: true, retry: 10 do
+  before(:each) do
+    # Stub microservice as an interim solution during our Microservice->Monolith V2 migration
+    #   Can safely be removed once the wca-registrations microservice is gone. (GB 2024-10-15)
+    allow(Microservices::Registrations).to receive(:competitor_count_by_competition).and_return(0)
+  end
+
   context "when signed in as admin" do
     let!(:admin) { FactoryBot.create :admin }
     before :each do


### PR DESCRIPTION
Competition ID changes cannot be propagated to our independent microservice DynamoDB. As a short-term fix (i.e. before the full V2 migration is complete) we enforce two interim rules:

1. Organizers/Delegates can only pre-register once the competition has been announced publicly. (The risk of changing a competition ID after announcement is significantly lower than during WCAT submission process)
2. Once there are any registrations, you cannot change the competition ID anymore. If that should indeed become necessary, WCAT has to loop in WST and we can make the changes manually instead of waiting for people to complain about errors