### PR TITLE
New comp overview: Filter for events and cancelled status in the backend

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1724,6 +1724,11 @@ class Competition < ApplicationRecord
       competitions = Competition.visible
     end
 
+    if params[:include_cancelled].present?
+      include_cancelled = ActiveRecord::Type::Boolean.new.cast(params[:include_cancelled])
+      competitions = competitions.not_cancelled unless include_cancelled
+    end
+
     if params[:continent].present?
       continent = Continent.find(params[:continent])
       if !continent

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1755,6 +1755,19 @@ class Competition < ApplicationRecord
                                  .where('competition_delegates.delegate_id = ?', delegate_user.id)
     end
 
+    if params[:event_ids].present?
+      event_ids = params[:event_ids].presence
+      unless event_ids.is_a?(Array)
+        raise WcaExceptions::BadApiParameter.new("Invalid event IDs: '#{params[:event_ids]}'")
+      end
+      event_ids.each do |event_id|
+        # This looks completely crazy (why not just pass the array as a whole, to build a `WHERE event_id IN (...)`??)
+        #   but is actually necessary to make sure that the competition holds ALL of the required events
+        #   and not just one or more (ie any) of the requested events.
+        competitions = competitions.has_event(event_id)
+      end
+    end
+
     if params[:start].present?
       start_date = Date.safe_parse(params[:start])
       if !start_date

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -78,8 +78,7 @@ function CompetitionsView({ canViewAdminDetails = false }) {
 
   const baseCompetitions = rawCompetitionData?.pages.flatMap((page) => page.data)
     .filter((comp) => (
-      (!isCancelled(comp) || debouncedFilterState.shouldIncludeCancelled)
-      && (debouncedFilterState.selectedEvents.every((event) => comp.event_ids.includes(event)))
+      (debouncedFilterState.selectedEvents.every((event) => comp.event_ids.includes(event)))
     ));
 
   const compIds = baseCompetitions?.map((comp) => comp.id) || [];

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -19,7 +19,7 @@ import {
 } from './filterUtils';
 import { calculateQueryKey, createSearchParams } from './queryUtils';
 import useDebounce from '../../lib/hooks/useDebounce';
-import { isCancelled, isInProgress, isProbablyOver } from '../../lib/utils/competition-table';
+import { isInProgress, isProbablyOver } from '../../lib/utils/competition-table';
 
 const DEBOUNCE_MS = 600;
 
@@ -76,11 +76,7 @@ function CompetitionsView({ canViewAdminDetails = false }) {
     },
   });
 
-  const baseCompetitions = rawCompetitionData?.pages.flatMap((page) => page.data)
-    .filter((comp) => (
-      (debouncedFilterState.selectedEvents.every((event) => comp.event_ids.includes(event)))
-    ));
-
+  const baseCompetitions = rawCompetitionData?.pages.flatMap((page) => page.data);
   const compIds = baseCompetitions?.map((comp) => comp.id) || [];
 
   const {

--- a/app/webpacker/components/CompetitionsOverview/queryUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/queryUtils.js
@@ -20,13 +20,22 @@ export function calculateQueryKey(filterState, canViewAdminDetails = false) {
     delegate: filterState?.delegate,
     search: filterState?.search,
     time: timeKey,
+    shouldIncludeCancelled: filterState?.shouldIncludeCancelled,
     adminStatus,
   };
 }
 
 export function createSearchParams(filterState, pageParam, canViewAdminDetails = false) {
   const {
-    region, delegate, search, timeOrder, selectedYear, customStartDate, customEndDate, adminStatus,
+    region,
+    delegate,
+    search,
+    timeOrder,
+    selectedYear,
+    customStartDate,
+    customEndDate,
+    adminStatus,
+    shouldIncludeCancelled,
   } = filterState;
 
   const dateNow = DateTime.now();
@@ -45,6 +54,7 @@ export function createSearchParams(filterState, pageParam, canViewAdminDetails =
   if (canViewAdminDetails && adminStatus && adminStatus !== 'all') {
     searchParams.append('admin_status', adminStatus);
   }
+  searchParams.append('include_cancelled', shouldIncludeCancelled);
 
   if (timeOrder === 'present') {
     searchParams.append('sort', 'start_date,end_date,name');

--- a/app/webpacker/components/CompetitionsOverview/queryUtils.js
+++ b/app/webpacker/components/CompetitionsOverview/queryUtils.js
@@ -17,6 +17,7 @@ export function calculateQueryKey(filterState, canViewAdminDetails = false) {
   return {
     timeOrder: filterState?.timeOrder,
     region: filterState?.region,
+    selectedEvents: filterState?.selectedEvents,
     delegate: filterState?.delegate,
     search: filterState?.search,
     time: timeKey,
@@ -28,6 +29,7 @@ export function calculateQueryKey(filterState, canViewAdminDetails = false) {
 export function createSearchParams(filterState, pageParam, canViewAdminDetails = false) {
   const {
     region,
+    selectedEvents,
     delegate,
     search,
     timeOrder,
@@ -44,6 +46,9 @@ export function createSearchParams(filterState, pageParam, canViewAdminDetails =
   if (region && region !== 'all') {
     const regionParam = isContinent(region) ? 'continent' : 'country_iso2';
     searchParams.append(regionParam, region);
+  }
+  if (selectedEvents && selectedEvents.length > 0) {
+    selectedEvents.forEach((eventId) => searchParams.append('event_ids[]', eventId));
   }
   if (delegate) {
     searchParams.append('delegate', delegate);


### PR DESCRIPTION
Previously, we still did events and cancelled filters in the frontend, and everything else in the backend.
With this change, everything should be backend-based for the overview page.