### PR TITLE
Give more competition permissions to Regional Delegates

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -836,6 +836,7 @@ class User < ApplicationRecord
       competition.organizers.include?(self) ||
       competition.delegates.include?(self) ||
       competition.delegates.flat_map(&:senior_delegates).compact.include?(self) ||
+      competition.delegates.flat_map(&:regional_delegates).compact.include?(self) ||
       wic_team?
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -492,6 +492,10 @@ class User < ApplicationRecord
     senior_delegate_roles.any?
   end
 
+  def regional_delegate?
+    regional_delegate_roles.any?
+  end
+
   def staff_or_any_delegate?
     staff? || any_kind_of_delegate?
   end
@@ -535,6 +539,10 @@ class User < ApplicationRecord
 
   private def senior_delegate_roles
     delegate_roles.select { |role| role.metadata.status == RolesMetadataDelegateRegions.statuses[:senior_delegate] }
+  end
+
+  private def regional_delegate_roles
+    delegate_roles.select { |role| role.metadata.status == RolesMetadataDelegateRegions.statuses[:regional_delegate] }
   end
 
   private def can_view_current_banned_competitors?
@@ -939,7 +947,7 @@ class User < ApplicationRecord
   end
 
   def can_see_admin_competitions?
-    can_admin_competitions? || senior_delegate? || quality_assurance_committee? || weat_team?
+    can_admin_competitions? || senior_delegate? || regional_delegate? || quality_assurance_committee? || weat_team?
   end
 
   def can_issue_refunds?(competition)


### PR DESCRIPTION
With this PR, Regional Delegates will have permission to...
1. Access the 'Admin' part of the Competitions Overview page (which Senior Delegates already have access to)
2. Manage competitions of their subordinate Delegates (most notably, the "Edit Competition" form) the same way that Senior Delegates already can

In short, this PR gives Regional Delegates some access rights which Senior Delegates already have.

Fixes https://github.com/thewca/worldcubeassociation.org/issues/10073
Fixes https://github.com/thewca/worldcubeassociation.org/issues/10072