### PR TITLE
Don't overwrite host for local in new Avatar model

### DIFF
--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -42,7 +42,7 @@ class UserAvatar < ApplicationRecord
         Rails.application.routes.url_helpers.rails_representation_url(self.image)
       end
     when 'local'
-      ActionController::Base.helpers.asset_url(self.filename, host: EnvConfig.ROOT_URL)
+      ActionController::Base.helpers.asset_url(self.filename)
     end
   end
 


### PR DESCRIPTION
This should fix the issue of the default avatar not showing, as it was written before we had the CDN