### PR TITLE
Fix countries being displayed in random languages for V2 Lists

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -12,6 +12,7 @@ import {
 import EventIcon from '../../wca/EventIcon';
 import { editRegistrationUrl, editPersonUrl, personUrl } from '../../../lib/requests/routes.js.erb';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
+import { countries } from "../../../lib/wca-data.js.erb";
 
 // Semantic Table only allows truncating _all_ columns in a table in
 // single line fixed mode. As we only want to truncate the comment/admin notes
@@ -130,11 +131,11 @@ export default function TableRow({
               {region ? (
                 <>
                   <Flag name={country.iso2.toLowerCase()} />
-                  {region && country.name}
+                  {region && countries.byIso2[country.iso2].name}
                 </>
               ) : (
                 <Popup
-                  content={country.name}
+                  content={countries.byIso2[country.iso2].name}
                   trigger={(
                     <span>
                       <Flag name={country.iso2.toLowerCase()} />

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -17,6 +17,7 @@ import useWithUserData from '../hooks/useWithUserData';
 import { bulkUpdateRegistrations } from '../api/registration/patch/update_registration';
 import RegistrationAdministrationTable from './RegistrationsAdministrationTable';
 import useCheckboxState from '../../../lib/hooks/useCheckboxState';
+import {countries} from "../../../lib/wca-data.js.erb";
 
 const selectedReducer = (state, action) => {
   let newState = [...state];
@@ -204,7 +205,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
             return a.user.wca_id.localeCompare(b.user.wca_id);
           }
           case 'country':
-            return a.user.country.name.localeCompare(b.user.country.name);
+            return countries.byIso2[a.user.country.iso2].name.localeCompare(countries.byIso2[b.user.country.iso2].name);
           case 'events':
             return a.competing.event_ids.length - b.competing.event_ids.length;
           case 'guests':

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -20,6 +20,7 @@ import { personUrl } from '../../../lib/requests/routes.js.erb';
 import Errored from '../../Requests/Errored';
 import { formatAttemptResult } from '../../../lib/wca-live/attempts';
 import i18n from '../../../lib/i18n';
+import { countries } from "../../../lib/wca-data.js.erb";
 
 const sortReducer = createSortReducer(['name', 'country', 'total']);
 
@@ -135,7 +136,7 @@ export default function RegistrationList({ competitionInfo }) {
           return a.user.name.localeCompare(b.user.name);
         }
         if (sortColumn === 'country') {
-          return a.user.country.name.localeCompare(b.user.country.name);
+          return countries.byIso2[a.user.country.iso2].name.localeCompare(countries.byIso2[b.user.country.iso2].name);
         }
         if (sortColumn === 'total') {
           return a.competing.event_ids.length - b.competing.event_ids.length;
@@ -255,7 +256,7 @@ export default function RegistrationList({ competitionInfo }) {
                   <Flag
                     name={registration.user.country.iso2.toLowerCase()}
                   />
-                  {registration.user.country.name}
+                  {countries.byIso2[registration.user.country.iso2].name}
                 </Table.Cell>
                 {psychSheetEvent === undefined ? (
                   <>


### PR DESCRIPTION
Same issue as we had with the activity names. Hope this is the last spot we use i18n strings generated from the backend in API calls