### PR TITLE
Do not show the main event warning if competition has only one event

### DIFF
--- a/lib/results_validators/events_rounds_validator.rb
+++ b/lib/results_validators/events_rounds_validator.rb
@@ -49,7 +49,7 @@ module ResultsValidators
 
       def check_main_event(competition)
         if competition.main_event
-          if competition.main_event_id != "333"
+          if competition.main_event_id != "333" && competition.events.size > 1
             @warnings << ValidationWarning.new(:events, competition.id,
                                                NOT_333_MAIN_EVENT_WARNING,
                                                main_event_id: competition.main_event_id)


### PR DESCRIPTION
See title. It's quite clearly that if the event is the only event, it was treated in a special way and there is no need to show this warning.