### PR TITLE
Distinguish between V1 and V2 competitions for Competition ID changes

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -614,7 +614,14 @@ class Competition < ApplicationRecord
   end
 
   def user_can_pre_register?(user)
-    (delegates.include?(user) || trainee_delegates.include?(user) || organizers.include?(user)) && self.confirmed_or_visible?
+    # The user has to be either a registered Delegate or organizer of the competition
+    is_competition_manager = delegates.include?(user) || trainee_delegates.include?(user) || organizers.include?(user)
+    # We allow pre-registration at any time for the old registration system (because we have control over the foreign keys there)
+    #   Otherwise, if it's using the new system, we only allow registrations when it's announced
+    #   because the probability of an ID change is pretty low in that case and when it does happen, WST can handle it
+    system_compatible = !uses_new_registration_service? || announced?
+
+    is_competition_manager && system_compatible
   end
 
   attr_accessor :being_cloned_from_id

--- a/app/views/competitions/_competition_form.html.erb
+++ b/app/views/competitions/_competition_form.html.erb
@@ -2,7 +2,6 @@
 
 <%= react_component("CompetitionForm", {
   competition: @competition.to_form_data,
-  usesV2Registrations: @competition.uses_v2_registrations,
   canChangeRegistrationSystem: @competition.can_change_registration_system?,
   hasAnyRegistrations: @competition.any_registrations?,
   storedEvents: @competition.events,

--- a/app/webpacker/components/CompetitionForm/FormSections/EventRestrictions.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/EventRestrictions.js
@@ -14,7 +14,6 @@ import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider
 
 export default function EventRestrictions() {
   const {
-    usesV2Registrations,
     isCloning,
     isPersisted,
     storedEvents,
@@ -26,6 +25,9 @@ export default function EventRestrictions() {
       earlyPuzzleSubmission,
       qualificationResults,
       eventLimitation,
+    },
+    admin: {
+      usesV2Registrations,
     },
   } = useFormObject();
 

--- a/app/webpacker/components/CompetitionForm/FormSections/NameDetails.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/NameDetails.js
@@ -8,14 +8,18 @@ import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider
 export default function NameDetails() {
   const { hasAnyRegistrations, isPersisted, isAdminView } = useStore();
 
-  const { name } = useFormObject();
+  const { name, admin: { usesV2Registrations } } = useFormObject();
 
   const nameAlreadyShort = !name || name.length <= competitionMaxShortNameLength;
   const disableIdAndShortName = !isAdminView && nameAlreadyShort;
 
+  // ID change on V1 is always possible, because we have control over the Foreign Keys.
+  // Otherwise, only competitions without registrations can change their ID.
+  const regSystemSupportsIdChange = !usesV2Registrations || !hasAnyRegistrations;
+
   return (
     <>
-      {isPersisted && <InputString id="competitionId" disabled={disableIdAndShortName || hasAnyRegistrations} />}
+      {isPersisted && <InputString id="competitionId" disabled={disableIdAndShortName || !regSystemSupportsIdChange} />}
       <InputString id="name" required />
       {isPersisted && (
         <InputString

--- a/app/webpacker/components/CompetitionForm/index.js
+++ b/app/webpacker/components/CompetitionForm/index.js
@@ -75,7 +75,6 @@ function CompetitionForm() {
 
 export default function Wrapper({
   competition = null,
-  usesV2Registrations = false,
   canChangeRegistrationSystem = false,
   hasAnyRegistrations = false,
   storedEvents = [],
@@ -104,7 +103,6 @@ export default function Wrapper({
     <StoreProvider
       reducer={_.identity}
       initialState={{
-        usesV2Registrations,
         canChangeRegistrationSystem,
         hasAnyRegistrations,
         storedEvents,


### PR DESCRIPTION
Follow-up to https://github.com/thewca/worldcubeassociation.org/pull/10059.

Makes it so that V1 competitions can change IDs freely, just as they used to.
The "don't change ID when V2" limitation now actually checks for V2 reg system. If yes, then registrations are allowed only after announcement of the competition.