### PR TITLE
Fix for users self-deleting their avatar

### DIFF
--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -78,7 +78,7 @@ class UserAvatar < ApplicationRecord
 
   def using_cdn?
     # Approved avatars are actively being used and should therefor be served by our CDN
-    self.approved? && self.attached?
+    self.approved? && self.attached? && !Rails.env.local?
   end
 
   def filename

--- a/app/webpacker/components/EditAvatar/ImageUpload.js
+++ b/app/webpacker/components/EditAvatar/ImageUpload.js
@@ -45,7 +45,10 @@ function ImageUpload({
   const removeAvatar = (evt) => {
     evt.preventDefault();
 
-    onAvatarDeleted(reasonForDeletion);
+    onAvatarDeleted(reasonForDeletion, () => {
+      setIsRemoving(false);
+      setReasonForDeletion(null);
+    });
   };
 
   const handleSelectedImage = (evt, { value }) => {

--- a/app/webpacker/components/EditAvatar/index.js
+++ b/app/webpacker/components/EditAvatar/index.js
@@ -115,10 +115,10 @@ function EditAvatar({
     });
   };
 
-  const deleteAvatar = (reasonForDeletion) => {
+  const deleteAvatar = (reasonForDeletion, cleanupFn) => {
     save(avatarDataUrl, { avatarId: workingAvatar?.id, reason: reasonForDeletion }, () => {
-      setUserUploadedImage(undefined);
       sync();
+      cleanupFn();
     }, {
       method: 'DELETE',
     });

--- a/app/webpacker/components/EditAvatar/index.js
+++ b/app/webpacker/components/EditAvatar/index.js
@@ -116,7 +116,12 @@ function EditAvatar({
   };
 
   const deleteAvatar = (reasonForDeletion) => {
-    save(avatarDataUrl, { avatarId: workingAvatar?.id, reason: reasonForDeletion }, sync);
+    save(avatarDataUrl, { avatarId: workingAvatar?.id, reason: reasonForDeletion }, () => {
+      setUserUploadedImage(undefined);
+      sync();
+    }, {
+      method: 'DELETE',
+    });
   };
 
   /* eslint-disable react/no-array-index-key */


### PR DESCRIPTION
Was accidentally fired against the wrong endpoint, resulting in a silent error.
Now using the correct endpoint and also a bit of cleanup convenience.