### PR TITLE
Index avatars by their own ID instead of user WCA ID

### DIFF
--- a/app/controllers/admin/avatars_controller.rb
+++ b/app/controllers/admin/avatars_controller.rb
@@ -8,10 +8,10 @@ module Admin
 
     def update_all
       avatars = params.require(:avatars)
+
       ActiveRecord::Base.transaction do
-        avatars.each do |wca_id, args|
-          user = User.find_by_wca_id!(wca_id)
-          avatar = user.pending_avatar
+        avatars.each do |avatar_id, args|
+          avatar = UserAvatar.pending.find(avatar_id)
 
           case args[:action]
           when "approve"
@@ -27,6 +27,7 @@ module Admin
             avatar.revoked_by_user = current_user
             avatar.revocation_reason = combined_reasons
 
+            user = avatar.pending_user
             AvatarsMailer.notify_user_of_avatar_rejection(user, combined_reasons).deliver_later
           when "defer"
             # do nothing!

--- a/app/views/admin/avatars/index.html.erb
+++ b/app/views/admin/avatars/index.html.erb
@@ -21,6 +21,8 @@
 
     <%= form_tag admin_avatars_path, class: 'are-you-sure' do |f| %>
       <% @users.each do |user| %>
+        <% pending_avatar = user.pending_avatar %>
+
         <div class="panel panel-default">
           <div class="panel-heading">
             <h3 class="panel-title">
@@ -35,9 +37,9 @@
 
               <div class="col-sm-6">
                 <div class="pending-avatar">
-                  <%= link_to image_tag(user.pending_avatar.url), user.pending_avatar.url, target: "_blank", class: "hide-new-window-icon" %>
+                  <%= link_to image_tag(pending_avatar.url), pending_avatar.url, target: "_blank", class: "hide-new-window-icon" %>
                   <div class="btn-group actions" data-toggle="buttons">
-                    <% name = "avatars[#{user.wca_id}][action]" %>
+                    <% name = "avatars[#{pending_avatar.id}][action]" %>
                     <label class="btn btn-default btn-success">
                       <%= radio_button_tag(name, "approve") %> Approve
                     </label>
@@ -53,6 +55,7 @@
 
               <div class="col-sm-6">
                 <% carousel_avatars = user.avatar_history %>
+
                 <% if carousel_avatars.empty? %>
                   <h3>This user has no previous pictures.</h3>
                 <% else %>
@@ -100,12 +103,12 @@
                 <% avatar_guidelines.each_with_index do |guideline, index| %>
                   <div class="checkbox">
                     <label>
-                      <%= check_box_tag "avatars[#{user.wca_id}][rejection_guidelines][]", guideline, false, id: "guideline_#{user.wca_id}_#{index}" %>
+                      <%= check_box_tag "avatars[#{pending_avatar.id}][rejection_guidelines][]", guideline, false, id: "guideline_#{pending_avatar.id}_#{index}" %>
                       <%= guideline %>
                     </label>
                   </div>
                 <% end %>
-                <%= text_area_tag "avatars[#{user.wca_id}][rejection_reason]", "",
+                <%= text_area_tag "avatars[#{pending_avatar.id}][rejection_reason]", "",
                       class: "form-control rejection-reason",
                       placeholder: "Provide additional reasons for rejection" %>
                 </div>


### PR DESCRIPTION
see title. Now that our storage mechanism doesn't depend on WCA ID anymore, we already have users uploading profile pictures which don't have an ID attached. This causes errors in the admin submission form because `null` WCA IDs get converted to the empty string, making the form part `avatars[2012BILL01][action] = :approve` look like `avatars[][action] = :reject`.