### PR TITLE
Speed up records precompute query

### DIFF
--- a/db/migrate/20241021145709_add_results_country_event_index.rb
+++ b/db/migrate/20241021145709_add_results_country_event_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddResultsCountryEventIndex < ActiveRecord::Migration[7.2]
+  def change
+    add_index :Results, [:eventId, :countryId]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_09_111904) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_21_145709) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -256,6 +256,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_111904) do
     t.index ["eventId", "best"], name: "Results_eventAndBest"
     t.index ["eventId", "competitionId", "roundTypeId", "countryId", "average"], name: "Results_regionalAverageRecordCheckSpeedup"
     t.index ["eventId", "competitionId", "roundTypeId", "countryId", "best"], name: "Results_regionalSingleRecordCheckSpeedup"
+    t.index ["eventId", "countryId"], name: "index_Results_on_eventId_and_countryId"
     t.index ["eventId", "value1"], name: "index_Results_on_eventId_and_value1"
     t.index ["eventId", "value2"], name: "index_Results_on_eventId_and_value2"
     t.index ["eventId", "value3"], name: "index_Results_on_eventId_and_value3"

--- a/lib/check_regional_records.rb
+++ b/lib/check_regional_records.rb
@@ -122,11 +122,11 @@ module CheckRegionalRecords
         model_comp = Competition.includes(:events).find(competition_id)
         event_filter = event_id || model_comp.event_ids
 
-        previous_min_results = Result.select("eventId, countryId, MIN(#{value_column}) AS `value`")
+        previous_min_results = Result.select(:eventId, :countryId, "MIN(#{value_column}) AS `value`")
                                      .where.not(value_column => ..0)
+                                     .where(eventId: event_filter)
                                      .joins(:competition)
                                      .where(competition: { end_date: ...model_comp.start_date })
-                                     .where(event: event_filter)
                                      .group(:eventId, :countryId)
 
         previous_min_results.each do |r|

--- a/lib/check_regional_records.rb
+++ b/lib/check_regional_records.rb
@@ -119,29 +119,15 @@ module CheckRegionalRecords
       base_records = {}
 
       if competition_id.present?
-        model_comp = Competition.find(competition_id)
+        model_comp = Competition.includes(:events).find(competition_id)
+        event_filter = event_id || model_comp.event_ids
 
-        non_zero_results = Result.select(:eventId, :competitionId, :countryId, value_column.to_sym)
-                                 .where.not(value_column => ..0)
-
-        if event_id.present?
-          non_zero_results = non_zero_results.where(eventId: event_id)
-        end
-
-        earlier_competitions = Competition.select(:id)
-                                          .where(end_date: ...model_comp.start_date)
-
-        previous_min_results = Result.select("r.eventId, r.countryId, MIN(r.#{value_column}) AS `value`")
-                                     .from("(#{non_zero_results.to_sql}) AS r")
-                                     .joins("INNER JOIN (#{earlier_competitions.to_sql}) c ON c.id = r.competitionId")
-                                     .group("r.eventId, r.countryId")
-
-        unless event_id.present?
-          competition_events = CompetitionEvent.select(:event_id)
-                                               .where(competition_id: model_comp.id)
-
-          previous_min_results = previous_min_results.joins("INNER JOIN (#{competition_events.to_sql}) ce ON ce.event_id = r.eventId")
-        end
+        previous_min_results = Result.select("eventId, countryId, MIN(#{value_column}) AS `value`")
+                                     .where.not(value_column => ..0)
+                                     .joins(:competition)
+                                     .where(competition: { end_date: ...model_comp.start_date })
+                                     .where(event: event_filter)
+                                     .group(:eventId, :countryId)
 
         previous_min_results.each do |r|
           event_records = base_records[r.event_id] || {}


### PR DESCRIPTION
I feel a little bit sorry for Eleanor after she spent so much time on much more sophisticated optimizations...

But it turns out that this plain and simple restructuring speeds up the query by factor ~3 on my local system. So I'll take that as a win for the time being, and continue to work on a proper table caching mechanism while this PR buys us a few days time.

# Before
```sql
SELECT r.eventId, r.countryId, MIN(r.best) AS `value`
FROM (
  SELECT `Results`.`eventId`, `Results`.`competitionId`, `Results`.`countryId`, `Results`.`best`
  FROM `Results`
  WHERE `Results`.`best` > 0
) AS r
INNER JOIN (
  SELECT `Competitions`.`id`
  FROM `Competitions`
  WHERE `Competitions`.`end_date` < '2013-06-01' # This seemingly hard-coded value is read directly from the `Competitions` table one step before
) AS c
  ON c.id = r.competitionId
INNER JOIN (
  SELECT `competition_events`.`event_id`
  FROM `competition_events`
  WHERE `competition_events`.`competition_id` = 'ErfurtOpen2013'
) AS ce
  ON ce.event_id = r.eventId
GROUP BY r.eventId, r.countryId
```

Runtime on my local machine: `2301.3ms`

# After
```sql
SELECT eventId, Results.countryId, MIN(best) AS `value`
FROM `Results`
INNER JOIN `Competitions` `competition`
  ON `competition`.`id` = `Results`.`competitionId`
WHERE `Results`.`best` > 0
  # The following two values are both fetched directly from the `Competitions` table immediately before this query is being executed
  AND `Results`.`eventId` IN ('333', '222', '444', '555', '666', '777', '333bf', '333fm', '333oh', 'clock', 'minx', 'pyram', 'sq1')
  AND `competition`.`end_date` < '2013-06-01'
GROUP BY `Results`.`eventId`, `Results`.`countryId`
```

Runtime on my local machine: `756.6ms`