### PR TITLE
Move Regional Records computation to Auxiliary table

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -327,6 +327,8 @@ class AdminController < ApplicationController
       competition_id: params[:competition_id] || nil,
       event_id: params[:event_id] || nil,
     )
+
+    @cad_timestamp = ComputeAuxiliaryData.successful_start_date&.to_fs || 'never'
   end
 
   def override_regional_records

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -323,9 +323,12 @@ class AdminController < ApplicationController
   end
 
   def check_regional_records
+    refresh_index_param = params[:refresh_index] || nil
+
     @check_records_request = CheckRegionalRecordsForm.new(
       competition_id: params[:competition_id] || nil,
       event_id: params[:event_id] || nil,
+      refresh_index: ActiveRecord::Type::Boolean.new.cast(refresh_index_param) || false,
     )
 
     @cad_timestamp = ComputeAuxiliaryData.successful_start_date&.to_fs || 'never'
@@ -333,7 +336,7 @@ class AdminController < ApplicationController
 
   def override_regional_records
     action_params = params.require(:check_regional_records_form)
-                          .permit(:competition_id, :event_id)
+                          .permit(:competition_id, :event_id, :refresh_index)
 
     @check_records_request = CheckRegionalRecordsForm.new(action_params)
     @check_results = @check_records_request.run_check

--- a/app/models/check_regional_records_form.rb
+++ b/app/models/check_regional_records_form.rb
@@ -10,8 +10,6 @@ class CheckRegionalRecordsForm
   end
 
   def run_check
-    ActiveRecord::Base.connected_to(role: :read_replica) do
-      CheckRegionalRecords.check_records(self.check_event_id, self.competition_id)
-    end
+    CheckRegionalRecords.check_records(self.check_event_id, self.competition_id)
   end
 end

--- a/app/models/check_regional_records_form.rb
+++ b/app/models/check_regional_records_form.rb
@@ -3,13 +3,17 @@
 class CheckRegionalRecordsForm
   include ActiveModel::Model
 
-  attr_accessor :competition_id, :event_id
+  attr_accessor :competition_id, :event_id, :refresh_index
 
   def check_event_id
     self.event_id == 'all' ? nil : self.event_id
   end
 
   def run_check
+    if self.refresh_index && self.competition_id.present?
+      CheckRegionalRecords.add_to_lookup_table(self.competition_id)
+    end
+
     CheckRegionalRecords.check_records(self.check_event_id, self.competition_id)
   end
 end

--- a/app/views/admin/_import_results_steps.html.erb
+++ b/app/views/admin/_import_results_steps.html.erb
@@ -37,10 +37,13 @@
       <% end %>
     <% else %>
       <p>All inbox data has been imported. You should consider the following steps next:</p>
-      <ul>
-        <li><%= link_to "Check record markers", admin_override_regional_records_path(check_regional_records_form: { competition_id: @competition.id, event_id: 'all' }), target: '_blank' %></li>
+      <ol>
         <li><%= link_to "Compute auxiliary data", admin_do_compute_auxiliary_data_path, target: '_blank' %></li>
-      </ul>
+        <li>
+          <%= link_to "Check record markers", admin_override_regional_records_path(check_regional_records_form: { competition_id: @competition.id, event_id: 'all' }), target: '_blank' %>
+          <p class="help-block">Note: The record markers script actually relies on CAD being run first</p>
+        </li>
+      </ol>
       <p>
         You can also visit the <%= link_to "public results page", competition_results_all_path(@competition, event: 'all'), target: '_blank' %> as an additional sanity check.
         Once you are sure, you can post the results using the button below:

--- a/app/views/admin/_import_results_steps.html.erb
+++ b/app/views/admin/_import_results_steps.html.erb
@@ -37,13 +37,10 @@
       <% end %>
     <% else %>
       <p>All inbox data has been imported. You should consider the following steps next:</p>
-      <ol>
+      <ul>
+        <li><%= link_to "Check record markers", admin_override_regional_records_path(check_regional_records_form: { competition_id: @competition.id, event_id: 'all', refresh_index: true }), target: '_blank' %></li>
         <li><%= link_to "Compute auxiliary data", admin_do_compute_auxiliary_data_path, target: '_blank' %></li>
-        <li>
-          <%= link_to "Check record markers", admin_override_regional_records_path(check_regional_records_form: { competition_id: @competition.id, event_id: 'all' }), target: '_blank' %>
-          <p class="help-block">Note: The record markers script actually relies on CAD being run first</p>
-        </li>
-      </ol>
+      </ul>
       <p>
         You can also visit the <%= link_to "public results page", competition_results_all_path(@competition, event: 'all'), target: '_blank' %> as an additional sanity check.
         Once you are sure, you can post the results using the button below:

--- a/app/views/admin/check_regional_records.html.erb
+++ b/app/views/admin/check_regional_records.html.erb
@@ -31,7 +31,10 @@
 
     <%= alert :warning do %>
       This script relies on auxiliary tables which are computed as part of <%= link_to "running CAD", admin_compute_auxiliary_data_path, target: :_blank %>.
-      <b>It will not deliver accurate results for specific competitions if CAD hasn't been run after the results posting.</b>
+      <br/>
+      <b>The detected records will not automatically be up-to-date with the <code>Results</code> table by default.</b>
+      <br/>
+      Instead, they are up to date with CAD (last successful run: <%= @cad_timestamp %>)
     <% end %>
 
     <hr/>

--- a/app/views/admin/check_regional_records.html.erb
+++ b/app/views/admin/check_regional_records.html.erb
@@ -42,6 +42,7 @@
     <%= simple_form_for @check_records_request, url: admin_override_regional_records_path, method: :get do |f| %>
       <%= f.input :competition_id, as: :competition_id, only_one: true, label: "Competition ID", hint: "Leave blank to check for all competitions" %>
       <%= f.input :event_id, as: :events_picker, allowed_events: Event.all, only_one: true, include_all: true, label: "Event", hint: "First symbol means 'all events'" %>
+      <%= f.input :refresh_index, as: :boolean, label: "Refresh index for selected competition(s)", hint: "This will attempt to compute the lookup on-the-fly only if a specific competition has been selected above. It can lead to timeouts, please rely on CAD when that happens." %>
 
       <%= f.button :submit, value: "Run check", class: "btn-primary" %>
     <% end %>

--- a/app/views/admin/check_regional_records.html.erb
+++ b/app/views/admin/check_regional_records.html.erb
@@ -29,6 +29,11 @@
       huge).
     </p>
 
+    <%= alert :warning do %>
+      This script relies on auxiliary tables which are computed as part of <%= link_to "running CAD", admin_compute_auxiliary_data_path, target: :_blank %>.
+      <b>It will not deliver accurate results for specific competitions if CAD hasn't been run after the results posting.</b>
+    <% end %>
+
     <hr/>
 
     <%= simple_form_for @check_records_request, url: admin_override_regional_records_path, method: :get do |f| %>

--- a/app/views/admin/compute_auxiliary_data.html.erb
+++ b/app/views/admin/compute_auxiliary_data.html.erb
@@ -7,7 +7,7 @@
         <h4>This script:</h4>
         <ul class="list-group">
           <li class="list-group-item">Computes some auxiliary tables in the database (ConciseSingleResults, ConciseAverageResults, RanksSingle and RanksAverage).</li>
-          <li class="list-group-item">Clears some cache files (living on the PHP side)</li>
+          <li class="list-group-item">Computes the lookup for assigning record markers</li>
           <li class="list-group-item">Deletes cached results (so they can be cached again)</li>
         </ul>
       </div>

--- a/db/migrate/20241022093010_create_regional_records_lookup_table.rb
+++ b/db/migrate/20241022093010_create_regional_records_lookup_table.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateRegionalRecordsLookupTable < ActiveRecord::Migration[7.2]
+  def change
+    create_table :regional_records_lookup do |t|
+      t.string "countryId", null: false
+      t.string "eventId", null: false
+      t.date "competitionEndDate", null: false
+      t.integer "best", default: 0, null: false
+      t.integer "average", default: 0, null: false
+
+      t.index [:eventId, :countryId, :best, :competitionEndDate]
+      t.index [:eventId, :countryId, :average, :competitionEndDate]
+    end
+  end
+end

--- a/db/migrate/20241022093010_create_regional_records_lookup_table.rb
+++ b/db/migrate/20241022093010_create_regional_records_lookup_table.rb
@@ -3,6 +3,7 @@
 class CreateRegionalRecordsLookupTable < ActiveRecord::Migration[7.2]
   def change
     create_table :regional_records_lookup do |t|
+      t.references :Results, foreign_key: true, null: false, type: :int
       t.string "countryId", null: false
       t.string "eventId", null: false
       t.date "competitionEndDate", null: false
@@ -12,5 +13,9 @@ class CreateRegionalRecordsLookupTable < ActiveRecord::Migration[7.2]
       t.index [:eventId, :countryId, :best, :competitionEndDate]
       t.index [:eventId, :countryId, :average, :competitionEndDate]
     end
+
+    # Small hack because Rails doesn't support custom `t.references` names
+    #   but our Results tables have their own nomenclature
+    rename_column :regional_records_lookup, :Results_id, :resultId
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -961,6 +961,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_161404) do
   end
 
   create_table "regional_records_lookup", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "resultId", null: false
     t.string "countryId", null: false
     t.string "eventId", null: false
     t.date "competitionEndDate", null: false
@@ -968,6 +969,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_161404) do
     t.integer "average", default: 0, null: false
     t.index ["eventId", "countryId", "average", "competitionEndDate"], name: "idx_on_eventId_countryId_average_competitionEndDate_b424c59953"
     t.index ["eventId", "countryId", "best", "competitionEndDate"], name: "idx_on_eventId_countryId_best_competitionEndDate_4e01b1ae38"
+    t.index ["resultId"], name: "index_regional_records_lookup_on_resultId"
   end
 
   create_table "registration_competition_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1348,6 +1350,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_161404) do
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "payment_intents", "users", column: "initiated_by_id"
   add_foreign_key "paypal_records", "paypal_records", column: "parent_record_id"
+  add_foreign_key "regional_records_lookup", "Results", column: "resultId"
   add_foreign_key "registration_history_changes", "registration_history_entries"
   add_foreign_key "sanity_check_exclusions", "sanity_checks"
   add_foreign_key "sanity_checks", "sanity_check_categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -960,6 +960,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_161404) do
     t.index ["name"], name: "index_regional_organizations_on_name"
   end
 
+  create_table "regional_records_lookup", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "countryId", null: false
+    t.string "eventId", null: false
+    t.date "competitionEndDate", null: false
+    t.integer "best", default: 0, null: false
+    t.integer "average", default: 0, null: false
+    t.index ["eventId", "countryId", "average", "competitionEndDate"], name: "idx_on_eventId_countryId_average_competitionEndDate"
+    t.index ["eventId", "countryId", "best", "competitionEndDate"], name: "idx_on_eventId_countryId_best_competitionEndDate"
+  end
+
   create_table "registration_competition_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "registration_id"
     t.integer "competition_event_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -966,8 +966,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_161404) do
     t.date "competitionEndDate", null: false
     t.integer "best", default: 0, null: false
     t.integer "average", default: 0, null: false
-    t.index ["eventId", "countryId", "average", "competitionEndDate"], name: "idx_on_eventId_countryId_average_competitionEndDate"
-    t.index ["eventId", "countryId", "best", "competitionEndDate"], name: "idx_on_eventId_countryId_best_competitionEndDate"
+    t.index ["eventId", "countryId", "average", "competitionEndDate"], name: "idx_on_eventId_countryId_average_competitionEndDate_b424c59953"
+    t.index ["eventId", "countryId", "best", "competitionEndDate"], name: "idx_on_eventId_countryId_best_competitionEndDate_4e01b1ae38"
   end
 
   create_table "registration_competition_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/lib/auxiliary_data_computation.rb
+++ b/lib/auxiliary_data_computation.rb
@@ -4,6 +4,7 @@ module AuxiliaryDataComputation
   def self.compute_everything
     self.compute_concise_results
     self.compute_rank_tables
+    self.insert_regional_records_lookup
   end
 
   ## Build 'concise results' tables.
@@ -102,6 +103,18 @@ module AuxiliaryDataComputation
           end
         end
       end
+    end
+  end
+
+  def self.insert_regional_records_lookup
+    DbHelper.with_temp_table("regional_records_lookup") do |temp_table_name|
+      ActiveRecord::Base.connection.execute <<-SQL
+        INSERT INTO #{temp_table_name}
+        (countryId, eventId, competitionEndDate, best, average)
+        SELECT Results.countryId, Results.eventId, Competitions.end_date, Results.best, Results.average
+        FROM Results
+        INNER JOIN Competitions ON Results.competitionId = Competitions.id
+      SQL
     end
   end
 end

--- a/lib/auxiliary_data_computation.rb
+++ b/lib/auxiliary_data_computation.rb
@@ -108,13 +108,7 @@ module AuxiliaryDataComputation
 
   def self.insert_regional_records_lookup
     DbHelper.with_temp_table("regional_records_lookup") do |temp_table_name|
-      ActiveRecord::Base.connection.execute <<-SQL
-        INSERT INTO #{temp_table_name}
-        (countryId, eventId, competitionEndDate, best, average)
-        SELECT Results.countryId, Results.eventId, Competitions.end_date, Results.best, Results.average
-        FROM Results
-        INNER JOIN Competitions ON Results.competitionId = Competitions.id
-      SQL
+      CheckRegionalRecords.add_to_lookup_table(table_name: temp_table_name)
     end
   end
 end

--- a/lib/auxiliary_data_computation.rb
+++ b/lib/auxiliary_data_computation.rb
@@ -12,10 +12,8 @@ module AuxiliaryDataComputation
       %w(best ConciseSingleResults),
       %w(average ConciseAverageResults),
     ].each do |field, table_name|
-      temp_table_name = "#{table_name}_temp"
-      ActiveRecord::Base.connection.execute("CREATE TABLE #{temp_table_name} LIKE #{table_name}")
-      ActiveRecord::Base.connection.execute("ALTER TABLE #{temp_table_name} AUTO_INCREMENT = 1")
-      ActiveRecord::Base.connection.execute <<-SQL
+      DbHelper.with_temp_table(table_name) do |temp_table_name|
+        ActiveRecord::Base.connection.execute <<-SQL
           INSERT INTO #{temp_table_name} (id, #{field}, valueAndId, personId, eventId, countryId, continentId, year, month, day)
           SELECT
             result.id,
@@ -39,15 +37,8 @@ module AuxiliaryDataComputation
             JOIN Competitions competition ON competition.id = competitionId
             JOIN Countries country ON country.id = result.countryId
             JOIN Events event ON event.id = eventId
-      SQL
-
-      # Atomically swap the tables
-      ActiveRecord::Base.connection.execute("RENAME TABLE #{table_name} TO #{table_name}_old, #{temp_table_name} TO #{table_name}")
-
-      # Drop the old table
-      ActiveRecord::Base.connection.execute("DROP TABLE #{table_name}_old")
-    ensure
-      ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{temp_table_name}")
+        SQL
+      end
     end
   end
 
@@ -57,70 +48,60 @@ module AuxiliaryDataComputation
       %w(best RanksSingle ConciseSingleResults),
       %w(average RanksAverage ConciseAverageResults),
     ].each do |field, table_name, concise_table_name|
-      temp_table_name = "#{table_name}_temp"
-      ActiveRecord::Base.connection.execute("CREATE TABLE #{temp_table_name} LIKE #{table_name}")
-      ActiveRecord::Base.connection.execute("ALTER TABLE #{temp_table_name} AUTO_INCREMENT = 1")
-
-      current_country_by_wca_id = Person.current.pluck(:wca_id, :countryId).to_h
-      # Get all personal records (note: people that changed their country appear once for each country).
-      personal_records_with_event = ActiveRecord::Base.connection.execute <<-SQL
+      DbHelper.with_temp_table(table_name) do |temp_table_name|
+        current_country_by_wca_id = Person.current.pluck(:wca_id, :countryId).to_h
+        # Get all personal records (note: people that changed their country appear once for each country).
+        personal_records_with_event = ActiveRecord::Base.connection.execute <<-SQL
           SELECT eventId, personId, countryId, continentId, min(#{field}) value
           FROM #{concise_table_name}
           GROUP BY personId, countryId, continentId, eventId
           ORDER BY eventId, value
-      SQL
-      personal_records_with_event.group_by(&:first).each do |event_id, personal_records|
-        personal_rank = Hash.new { |h, k| h[k] = {} }
-        ranked = Hash.new { |h, k| h[k] = {} }
-        counter = Hash.new(0)
-        current_rank = Hash.new(0)
-        previous_value = {}
-        personal_records.each do |_, person_id, country_id, continent_id, value|
-          # Update the region states (unless we have ranked this person already,
-          # e.g. 2008SEAR01 twice in North America and World because of his two countries).
-          ["World", continent_id, country_id].each do |region|
-            next if ranked[region][person_id]
-            counter[region] += 1
-            # As we ordered by value it can either be greater or tie the previous one.
-            current_rank[region] = counter[region] if previous_value[region].nil? || value > previous_value[region]
-            previous_value[region] = value
-            ranked[region][person_id] = true
+        SQL
+        personal_records_with_event.group_by(&:first).each do |event_id, personal_records|
+          personal_rank = Hash.new { |h, k| h[k] = {} }
+          ranked = Hash.new { |h, k| h[k] = {} }
+          counter = Hash.new(0)
+          current_rank = Hash.new(0)
+          previous_value = {}
+          personal_records.each do |_, person_id, country_id, continent_id, value|
+            # Update the region states (unless we have ranked this person already,
+            # e.g. 2008SEAR01 twice in North America and World because of his two countries).
+            ["World", continent_id, country_id].each do |region|
+              next if ranked[region][person_id]
+              counter[region] += 1
+              # As we ordered by value it can either be greater or tie the previous one.
+              current_rank[region] = counter[region] if previous_value[region].nil? || value > previous_value[region]
+              previous_value[region] = value
+              ranked[region][person_id] = true
+            end
+            cached_country = Country.c_find(current_country_by_wca_id[person_id])
+            # The only known case where this happens if current_country_by_wca_id[person_id] is nil,
+            # in other words, the personId from the Concise*Results table is not found in the Persons table.
+            # In the past, this has occurred when temporary results have been inserted for newcomers.
+            next if cached_country.nil?
+            # Set the person's data (first time the current location is matched).
+            personal_rank[person_id][:best] ||= value
+            personal_rank[person_id][:world_rank] ||= current_rank["World"]
+            if continent_id == cached_country.continentId
+              personal_rank[person_id][:continent_rank] ||= current_rank[continent_id]
+            end
+            if country_id == cached_country.id
+              personal_rank[person_id][:country_rank] ||= current_rank[country_id]
+            end
           end
-          cached_country = Country.c_find(current_country_by_wca_id[person_id])
-          # The only known case where this happens if current_country_by_wca_id[person_id] is nil,
-          # in other words, the personId from the Concise*Results table is not found in the Persons table.
-          # In the past, this has occurred when temporary results have been inserted for newcomers.
-          next if cached_country.nil?
-          # Set the person's data (first time the current location is matched).
-          personal_rank[person_id][:best] ||= value
-          personal_rank[person_id][:world_rank] ||= current_rank["World"]
-          if continent_id == cached_country.continentId
-            personal_rank[person_id][:continent_rank] ||= current_rank[continent_id]
+          values = personal_rank.map do |person_id, rank_data|
+            # NOTE: continent_rank and country_rank may be not present because of a country change, in such case we default to 0.
+            "('#{person_id}', '#{event_id}', #{rank_data[:best]}, #{rank_data[:world_rank]}, #{rank_data[:continent_rank] || 0}, #{rank_data[:country_rank] || 0})"
           end
-          if country_id == cached_country.id
-            personal_rank[person_id][:country_rank] ||= current_rank[country_id]
-          end
-        end
-        values = personal_rank.map do |person_id, rank_data|
-          # NOTE: continent_rank and country_rank may be not present because of a country change, in such case we default to 0.
-          "('#{person_id}', '#{event_id}', #{rank_data[:best]}, #{rank_data[:world_rank]}, #{rank_data[:continent_rank] || 0}, #{rank_data[:country_rank] || 0})"
-        end
-        # Insert 500 rows at once to avoid running into too long query.
-        values.each_slice(500) do |values_subset|
-          ActiveRecord::Base.connection.execute <<-SQL
+          # Insert 500 rows at once to avoid running into too long query.
+          values.each_slice(500) do |values_subset|
+            ActiveRecord::Base.connection.execute <<-SQL
               INSERT INTO #{temp_table_name} (personId, eventId, best, worldRank, continentRank, countryRank) VALUES
               #{values_subset.join(",\n")}
-          SQL
+            SQL
+          end
         end
       end
-
-      # Atomically swap the tables
-      ActiveRecord::Base.connection.execute("RENAME TABLE #{table_name} TO #{table_name}_old, #{temp_table_name} TO #{table_name}")
-
-      # Drop the old table
-      ActiveRecord::Base.connection.execute("DROP TABLE #{table_name}_old")
-    ensure
-      ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{temp_table_name}")
     end
   end
 end

--- a/lib/check_regional_records.rb
+++ b/lib/check_regional_records.rb
@@ -120,28 +120,14 @@ module CheckRegionalRecords
 
       if competition_id.present?
         model_comp = Competition.find(competition_id)
+        event_filter = event_id || model_comp.event_ids
 
-        non_zero_results = Result.select(:eventId, :competitionId, :countryId, value_column.to_sym)
-                                 .where.not(value_column => ..0)
-
-        if event_id.present?
-          non_zero_results = non_zero_results.where(eventId: event_id)
-        end
-
-        earlier_competitions = Competition.select(:id)
-                                          .where(end_date: ...model_comp.start_date)
-
-        previous_min_results = Result.select("r.eventId, r.countryId, MIN(r.#{value_column}) AS `value`")
-                                     .from("(#{non_zero_results.to_sql}) AS r")
-                                     .joins("INNER JOIN (#{earlier_competitions.to_sql}) c ON c.id = r.competitionId")
-                                     .group("r.eventId, r.countryId")
-
-        unless event_id.present?
-          competition_events = CompetitionEvent.select(:event_id)
-                                               .where(competition_id: model_comp.id)
-
-          previous_min_results = previous_min_results.joins("INNER JOIN (#{competition_events.to_sql}) ce ON ce.event_id = r.eventId")
-        end
+        previous_min_results = Result.select("eventId, countryId, MIN(#{value_column}) AS `value`")
+                                     .from("regional_records_lookup AS Results")
+                                     .where.not(value_column => ..0)
+                                     .where(competitionEndDate: ...model_comp.start_date)
+                                     .where(eventId: event_filter)
+                                     .group(:eventId, :countryId)
 
         previous_min_results.each do |r|
           event_records = base_records[r.event_id] || {}

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -555,6 +555,7 @@ module DatabaseDumper
         },
       ),
     }.freeze,
+    "regional_records_lookup" => :skip_all_rows,
     "registration_competition_events" => {
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w(

--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -10,4 +10,25 @@ module DbHelper
     raw_connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
     raw_connection.abandon_results!
   end
+
+  def self.with_temp_table(table_name)
+    temp_table_name = "#{table_name}_temp"
+    old_table_name = "#{table_name}_old"
+
+    ActiveRecord::Base.connection.execute("CREATE TABLE #{temp_table_name} LIKE #{table_name}")
+    ActiveRecord::Base.connection.execute("ALTER TABLE #{temp_table_name} AUTO_INCREMENT = 1")
+
+    ActiveRecord::Base.transaction do
+      yield temp_table_name
+    end
+
+    # Atomically swap the tables
+    ActiveRecord::Base.connection.execute("RENAME TABLE #{table_name} TO #{old_table_name}, #{temp_table_name} TO #{table_name}")
+
+    # Drop the old table
+    ActiveRecord::Base.connection.execute("DROP TABLE #{old_table_name}")
+  ensure
+    ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{temp_table_name}")
+    ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{old_table_name}")
+  end
 end


### PR DESCRIPTION
Supersedes https://github.com/thewca/worldcubeassociation.org/pull/10089, although I'm very grateful for the initial inspiration :smile: 
Supersedes https://github.com/thewca/worldcubeassociation.org/pull/10120

The basic problem is that the query to pre-load existing records was breaking our necks. The simple solution of this PR is to combine `Results` data and `Competitions` data into one common, `JOIN`ed table which can be indexed.
That way, we can essentially reuse the same queries as before (with minor modifications to the table name etc.) but the indexes will make them reasonably fast.

# Before
```sql
SELECT r.eventId, r.countryId, MIN(r.best) AS `value`
FROM (
  SELECT `Results`.`eventId`, `Results`.`competitionId`, `Results`.`countryId`, `Results`.`best`
  FROM `Results`
  WHERE `Results`.`best` > 0
) AS r
INNER JOIN (
  SELECT `Competitions`.`id`
  FROM `Competitions`
  WHERE `Competitions`.`end_date` < '2024-08-10' # This seemingly hard-coded value is read directly from the `Competitions` table one step before
) AS c
  ON c.id = r.competitionId
INNER JOIN (
  SELECT `competition_events`.`event_id`
  FROM `competition_events`
  WHERE `competition_events`.`competition_id` = 'StevenageAugust2024'
) AS ce
  ON ce.event_id = r.eventId
GROUP BY r.eventId, r.countryId
```

Benchmark on my local machine: 11390.9ms

# After

:warning: Please do not be confused by the table being referenced as `Results`. This is a necessary hack because otherwise the Rails model engine gets confused! It is only an alias that is freely choosable, and in terms of understanding the contents of this query, you can mentally replace `Results` with `pancake`.

```sql
SELECT eventId, countryId, MIN(best) AS `value`
FROM regional_records_lookup AS Results # This alias is here only to make sure that Ruby doesn't get confused
WHERE `Results`.`best` > 0
  AND `Results`.`competitionEndDate` < '2024-08-10'
  AND `Results`.`eventId` IN ('333', '222', '444', '555', '666', '777', '333bf', '333fm', '333oh', 'clock', 'minx', 'pyram', 'sq1')
GROUP BY `Results`.`eventId`, `Results`.`countryId`
```

The relevant index is on `(eventId, countryId, competitionEndDate, best)` (as well as `(eventId, countryId, competitionEndDate, average)` respectively for averages)

Benchmark on my local machine: 1804.1ms