### PR TITLE
Introduce registration version column instead of uses_v2_registrations

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -280,7 +280,7 @@ class CompetitionsController < ApplicationController
       competitor_limit_enabled: true,
       base_entry_fee_lowest_denomination: 0,
       guests_entry_fee_lowest_denomination: 0,
-      uses_v2_registrations: true,
+      registration_version: :v2,
     )
 
     assign_editing_user(@competition)

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -280,7 +280,6 @@ class CompetitionsController < ApplicationController
       competitor_limit_enabled: true,
       base_entry_fee_lowest_denomination: 0,
       guests_entry_fee_lowest_denomination: 0,
-      registration_version: :v2,
     )
 
     assign_editing_user(@competition)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -121,7 +121,7 @@ class RegistrationsController < ApplicationController
 
   def import
     @competition = competition_from_params
-    if @competition.uses_new_registration_service?
+    if @competition.uses_microservice_registrations?
       redirect_to Microservices::Registrations.registration_import_path(@competition.id)
     end
   end
@@ -210,7 +210,7 @@ class RegistrationsController < ApplicationController
     end
     ActiveRecord::Base.transaction do
       user, locked_account_created = user_for_registration!(params[:registration_data])
-      if @competition.uses_new_registration_service?
+      if @competition.uses_microservice_registrations?
         Microservices::Registrations.add_registration(@competition.id,
                                                       user.id,
                                                       params[:registration_data][:event_ids],

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -96,7 +96,7 @@ class Competition < ApplicationRecord
     restricted: 2,
   }, prefix: true
 
-  enum :registration_version, { v1: 'v1', v2: 'v2', v3: 'v3' }
+  enum :registration_version, [:v1, :v2, :v3], prefix: true
 
   CLONEABLE_ATTRIBUTES = %w(
     cityName
@@ -745,7 +745,7 @@ class Competition < ApplicationRecord
   end
 
   def uses_new_registration_service?
-    self.registration_version == 'v2'
+    self.registration_version_v2?
   end
 
   def should_render_register_v2?(user)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2409,7 +2409,7 @@ class Competition < ApplicationRecord
       "admin" => {
         "isConfirmed" => confirmed?,
         "isVisible" => showAtAll?,
-        "usesV2Registrations" => uses_new_registration_service?,
+        "registrationVersion" => registration_version.to_s,
       },
       "cloning" => {
         "fromId" => being_cloned_from_id,
@@ -2616,7 +2616,7 @@ class Competition < ApplicationRecord
       showAtAll: form_data.dig('admin', 'isVisible'),
       being_cloned_from_id: form_data.dig('cloning', 'fromId'),
       clone_tabs: form_data.dig('cloning', 'cloneTabs'),
-      uses_v2_registrations: form_data.dig('admin', 'usesV2Registrations'),
+      registration_version: form_data.dig('admin', 'registrationVersion'),
     }
   end
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -171,7 +171,7 @@ class Competition < ApplicationRecord
     waiting_list_deadline_date
     event_change_deadline_date
     competition_series_id
-    uses_v2_registrations
+    registration_version
   ).freeze
   VALID_NAME_RE = /\A([-&.:' [:alnum:]]+) (\d{4})\z/
   VALID_ID_RE = /\A[a-zA-Z0-9]+\Z/

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -96,6 +96,8 @@ class Competition < ApplicationRecord
     restricted: 2,
   }, prefix: true
 
+  enum :registration_version, { v1: 'v1', v2: 'v2', v3: 'v3' }
+
   CLONEABLE_ATTRIBUTES = %w(
     cityName
     countryId
@@ -739,11 +741,11 @@ class Competition < ApplicationRecord
   end
 
   def enable_v2_registrations!
-    update_column :uses_v2_registrations, true
+    update_column :registration_version, 'v2'
   end
 
   def uses_new_registration_service?
-    self.uses_v2_registrations
+    self.registration_version == 'v2'
   end
 
   def should_render_register_v2?(user)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -432,7 +432,7 @@ class Competition < ApplicationRecord
   end
 
   def registration_full?
-    competitor_count = uses_new_registration_service? ? Microservices::Registrations.competitor_count_by_competition(id) : registrations.accepted_and_paid_pending_count
+    competitor_count = uses_microservice_registrations? ? Microservices::Registrations.competitor_count_by_competition(id) : registrations.accepted_and_paid_pending_count
     competitor_limit_enabled? && competitor_count >= competitor_limit
   end
 
@@ -570,7 +570,7 @@ class Competition < ApplicationRecord
 
   def reg_warnings
     warnings = {}
-    warnings[:uses_v2_registrations] = I18n.t('competitions.messages.uses_v2_registrations') if uses_new_registration_service?
+    warnings[:uses_v2_registrations] = I18n.t('competitions.messages.uses_v2_registrations') if uses_new_registration_system?
     if registration_range_specified? && !registration_past?
       if self.announced?
         if (self.registration_open - self.announced_at) < REGISTRATION_OPENING_EARLIEST
@@ -623,7 +623,7 @@ class Competition < ApplicationRecord
     # We allow pre-registration at any time for the old registration system (because we have control over the foreign keys there)
     #   Otherwise, if it's using the new system, we only allow registrations when it's announced
     #   because the probability of an ID change is pretty low in that case and when it does happen, WST can handle it
-    system_compatible = !uses_new_registration_service? || announced?
+    system_compatible = !uses_microservice_registrations? || announced?
 
     is_competition_manager && system_compatible
   end
@@ -741,16 +741,16 @@ class Competition < ApplicationRecord
     @trainee_delegate_ids || trainee_delegates.map(&:id).join(",")
   end
 
-  def enable_v2_registrations!
-    update_column :registration_version, NEW_REG_SYSTEM_DEFAULT
+  def uses_microservice_registrations?
+    self.registration_version_v2?
   end
 
-  def uses_new_registration_service?
-    self.registration_version_v2? || self.registration_version_v3?
+  def uses_new_registration_system?
+    self.uses_microservice_registrations? || self.registration_version_v3?
   end
 
   def should_render_register_v2?(user)
-    uses_new_registration_service? && user.cannot_register_for_competition_reasons(self).empty?
+    uses_new_registration_system? && user.cannot_register_for_competition_reasons(self).empty?
   end
 
   before_validation :unpack_delegate_organizer_ids
@@ -1003,7 +1003,7 @@ class Competition < ApplicationRecord
   end
 
   def any_registrations?
-    if uses_new_registration_service?
+    if uses_microservice_registrations?
       Microservices::Registrations.competitor_count_by_competition(id) > 0
     else
       self.registrations.any?
@@ -1605,7 +1605,7 @@ class Competition < ApplicationRecord
         raise "Unknown 'sort_by' in psych sheet computation: #{sort_by}"
       end
 
-      if self.uses_new_registration_service?
+      if self.uses_microservice_registrations?
         # We deliberately don't go through the cached `microservice_registrations` table here, because then we
         # would need to separately check which of the cached registrations are accepted
         # and which of those are registered for the specified event. Querying the MS directly is much more efficient.
@@ -1896,9 +1896,9 @@ class Competition < ApplicationRecord
       :wcif_extensions,
     ]
     # V2 registrations store the event IDs in the microservice data, not in the monolith
-    includes_associations << :events unless self.uses_new_registration_service?
+    includes_associations << :events unless self.uses_microservice_registrations?
 
-    registrations_relation = self.uses_new_registration_service? ? self.microservice_registrations : self.registrations
+    registrations_relation = self.uses_microservice_registrations? ? self.microservice_registrations : self.registrations
 
     # NOTE: we're including non-competing registrations so that they can have job
     # assignments as well. These registrations don't have accepted?, but they
@@ -2050,13 +2050,13 @@ class Competition < ApplicationRecord
 
   # Takes an array of partial Person WCIF and updates the fields that are not immutable.
   def update_persons_wcif!(wcif_persons, current_user)
-    registrations_relation = self.uses_new_registration_service? ? self.microservice_registrations : self.registrations
+    registrations_relation = self.uses_microservice_registrations? ? self.microservice_registrations : self.registrations
     registration_includes = [
       { assignments: [:schedule_activity] },
       :user,
       :wcif_extensions,
     ]
-    registration_includes << :registration_competition_events unless self.uses_new_registration_service?
+    registration_includes << :registration_competition_events unless self.uses_microservice_registrations?
     registrations = registrations_relation.includes(registration_includes)
     competition_activities = all_activities
     new_assignments = []
@@ -2410,7 +2410,7 @@ class Competition < ApplicationRecord
       "admin" => {
         "isConfirmed" => confirmed?,
         "isVisible" => showAtAll?,
-        "usesNewRegistrationSystem" => uses_new_registration_service?,
+        "usesNewRegistrationSystem" => uses_new_registration_system?,
       },
       "cloning" => {
         "fromId" => being_cloned_from_id,
@@ -2680,7 +2680,7 @@ class Competition < ApplicationRecord
   end
 
   def can_change_registration_system?
-    registration_not_yet_opened? && (uses_new_registration_service? || self.registrations.empty?)
+    registration_not_yet_opened? && (uses_microservice_registrations? || self.registrations.empty?)
   end
 
   # Our React date picker unfortunately behaves weirdly in terms of backend data

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -96,7 +96,7 @@ class Competition < ApplicationRecord
     restricted: 2,
   }, prefix: true
 
-  enum :registration_version, [:v1, :v2, :v3], prefix: true
+  enum :registration_version, [:v1, :v2, :v3], prefix: true, default: :v2
 
   CLONEABLE_ATTRIBUTES = %w(
     cityName
@@ -634,7 +634,7 @@ class Competition < ApplicationRecord
   def build_clone
     Competition.new(attributes.slice(*CLONEABLE_ATTRIBUTES)).tap do |clone|
       clone.being_cloned_from_id = id
-      clone.uses_v2_registrations = true
+      clone.registration_version = :v2
 
       Competition.reflections.each_key do |association_name|
         case association_name
@@ -741,7 +741,7 @@ class Competition < ApplicationRecord
   end
 
   def enable_v2_registrations!
-    update_column :registration_version, 'v2'
+    update_column :registration_version, :v2
   end
 
   def uses_new_registration_service?

--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -50,7 +50,7 @@
               ] : [])
           }
           if @competition.use_wca_registration?
-            pending_registrations = if @competition.uses_new_registration_service?
+            pending_registrations = if @competition.uses_microservice_registrations?
                                       Microservices::Registrations.registrations_by_competition(@competition.id, 'pending', cache: true).length
                                       else
                                         @competition.registrations.pending.count
@@ -138,7 +138,7 @@
           unless @competition.registration_not_yet_opened?
             event_icons = @competition.events.map do |event|
               { text: event.id, path: competition_psych_sheet_event_path(@competition, event.id), cubing_icon: event.id, title: event.name }
-            end unless @competition.uses_new_registration_service?
+            end unless @competition.uses_new_registration_system?
             nav_items << {
               text: t('.menu.competitors'),
               path: competition_registrations_path(@competition),

--- a/app/views/registrations/edit_registrations.html.erb
+++ b/app/views/registrations/edit_registrations.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, I18n.t('registrations.list.title', comp: @competition.name)) %>
 
 <%= render layout: 'nav' do %>
-  <% if @competition.uses_new_registration_service? %>
+  <% if @competition.uses_new_registration_system? %>
     <%= react_component('RegistrationsV2/RegistrationAdministration', { competitionInfo: @competition.to_competition_info }) %>
   <% else %>
     <p>

--- a/app/views/registrations/index.html.erb
+++ b/app/views/registrations/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, I18n.t('registrations.list.title', comp: @competition.name)) %>
 
 <%= render layout: "nav" do %>
-  <% if @competition.uses_new_registration_service? %>
+  <% if @competition.uses_new_registration_system? %>
     <%= react_component('RegistrationsV2/Registrations', { competitionInfo: @competition.to_competition_info }) %>
   <% else %>
     <% cache [

--- a/app/views/registrations/register.html.erb
+++ b/app/views/registrations/register.html.erb
@@ -10,7 +10,7 @@
   <% opens_in_days = distance_of_time_in_words_to_now(@competition.registration_open) %>
   <% closes_in_days = distance_of_time_in_words_to_now(@competition.registration_close) %>
 
-  <% if !@competition.uses_new_registration_service? && @competition.registration_not_yet_opened? %>
+  <% if !@competition.uses_new_registration_system? && @competition.registration_not_yet_opened? %>
     <%= alert :info, t('registrations.will_open_html', days: opens_in_days, time: wca_local_time(@competition.registration_open)) %>
   <%# Don't show this alert if we're showing the registration's details: this message is included in it! %>
   <% elsif @competition.registration_past? && !@registration&.show_details?(current_user) %>

--- a/app/views/registrations_mailer/notify_organizers_of_new_registration.html.erb
+++ b/app/views/registrations_mailer/notify_organizers_of_new_registration.html.erb
@@ -16,7 +16,7 @@
 
 <p>
   You can approve or delete this registration
-  <%= link_to "here", @registration.competition.uses_new_registration_service? ?
+  <%= link_to "here", @registration.competition.uses_new_registration_system? ?
                         edit_registration_v2_url(competition_id: @registration.competition.id, user_id: @registration.user.id) :
                         edit_registration_url(@registration) %>.
 </p>

--- a/app/webpacker/components/CompetitionForm/FormSections/Admin.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/Admin.js
@@ -1,25 +1,17 @@
 import React from 'react';
-import { InputBoolean, InputSelect } from '../../wca/FormBuilder/input/FormInputs';
+import { InputBoolean } from '../../wca/FormBuilder/input/FormInputs';
 import { useStore } from '../../../lib/providers/StoreProvider';
 import SubSection from '../../wca/FormBuilder/SubSection';
-import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider';
-
-const registrationVersions = [{
-  key: 'v1', value: 'v1', text: 'Version 1',
-}, {
-  key: 'v2', value: 'v2', text: 'Version 2',
-}];
 
 export default function Admin() {
   const { isAdminView, isPersisted, canChangeRegistrationSystem } = useStore();
-  const { admin: { registrationVersion } } = useFormObject();
   if (!isPersisted || !isAdminView) return null;
 
   return (
     <SubSection section="admin">
       <InputBoolean id="isConfirmed" />
       <InputBoolean id="isVisible" />
-      <InputSelect id="registrationVersion" options={registrationVersions} value={registrationVersions.find((x) => x.value === registrationVersion)} disabled={!canChangeRegistrationSystem} />
+      <InputBoolean id="usesNewRegistrationSystem" disabled={!canChangeRegistrationSystem} />
     </SubSection>
   );
 }

--- a/app/webpacker/components/CompetitionForm/FormSections/Admin.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/Admin.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { InputBoolean, InputSelect } from '../../wca/FormBuilder/input/FormInputs';
 import { useStore } from '../../../lib/providers/StoreProvider';
 import SubSection from '../../wca/FormBuilder/SubSection';
-import { useFormObject } from "../../wca/FormBuilder/provider/FormObjectProvider";
+import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider';
 
 const registrationVersions = [{
   key: 'v1', value: 'v1', text: 'Version 1',
-},{
+}, {
   key: 'v2', value: 'v2', text: 'Version 2',
 }];
 

--- a/app/webpacker/components/CompetitionForm/FormSections/Admin.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/Admin.js
@@ -1,18 +1,25 @@
 import React from 'react';
-import { InputBoolean } from '../../wca/FormBuilder/input/FormInputs';
+import { InputBoolean, InputSelect } from '../../wca/FormBuilder/input/FormInputs';
 import { useStore } from '../../../lib/providers/StoreProvider';
 import SubSection from '../../wca/FormBuilder/SubSection';
+import { useFormObject } from "../../wca/FormBuilder/provider/FormObjectProvider";
+
+const registrationVersions = [{
+  key: 'v1', value: 'v1', text: "Version 1",
+},{
+  key: 'v2', value: 'v2', text: "Version 2",
+}]
 
 export default function Admin() {
   const { isAdminView, isPersisted, canChangeRegistrationSystem } = useStore();
-
+  const { admin: { registrationVersion } } = useFormObject();
   if (!isPersisted || !isAdminView) return null;
 
   return (
     <SubSection section="admin">
       <InputBoolean id="isConfirmed" />
       <InputBoolean id="isVisible" />
-      <InputBoolean id="usesV2Registrations" disabled={!canChangeRegistrationSystem} />
+      <InputSelect id="registrationVersion" options={registrationVersions} value={registrationVersions.find((x) => x.value === registrationVersion)} disabled={!canChangeRegistrationSystem}/>
     </SubSection>
   );
 }

--- a/app/webpacker/components/CompetitionForm/FormSections/Admin.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/Admin.js
@@ -5,10 +5,10 @@ import SubSection from '../../wca/FormBuilder/SubSection';
 import { useFormObject } from "../../wca/FormBuilder/provider/FormObjectProvider";
 
 const registrationVersions = [{
-  key: 'v1', value: 'v1', text: "Version 1",
+  key: 'v1', value: 'v1', text: 'Version 1',
 },{
-  key: 'v2', value: 'v2', text: "Version 2",
-}]
+  key: 'v2', value: 'v2', text: 'Version 2',
+}];
 
 export default function Admin() {
   const { isAdminView, isPersisted, canChangeRegistrationSystem } = useStore();
@@ -19,7 +19,7 @@ export default function Admin() {
     <SubSection section="admin">
       <InputBoolean id="isConfirmed" />
       <InputBoolean id="isVisible" />
-      <InputSelect id="registrationVersion" options={registrationVersions} value={registrationVersions.find((x) => x.value === registrationVersion)} disabled={!canChangeRegistrationSystem}/>
+      <InputSelect id="registrationVersion" options={registrationVersions} value={registrationVersions.find((x) => x.value === registrationVersion)} disabled={!canChangeRegistrationSystem} />
     </SubSection>
   );
 }

--- a/app/webpacker/components/CompetitionForm/FormSections/EventRestrictions.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/EventRestrictions.js
@@ -27,7 +27,7 @@ export default function EventRestrictions() {
       eventLimitation,
     },
     admin: {
-      usesV2Registrations,
+      usesNewRegistrationSystem,
     },
   } = useFormObject();
 
@@ -52,7 +52,7 @@ export default function EventRestrictions() {
 
   return (
     <SubSection section="eventRestrictions">
-      { usesV2Registrations && (
+      { usesNewRegistrationSystem && (
         <SubSection section="forbidNewcomers">
           <InputBoolean id="enabled" />
           <ConditionalSection showIf={newcomers}>

--- a/app/webpacker/components/CompetitionForm/FormSections/NameDetails.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/NameDetails.js
@@ -8,14 +8,14 @@ import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider
 export default function NameDetails() {
   const { hasAnyRegistrations, isPersisted, isAdminView } = useStore();
 
-  const { name, admin: { usesV2Registrations } } = useFormObject();
+  const { name, admin: { usesNewRegistrationSystem } } = useFormObject();
 
   const nameAlreadyShort = !name || name.length <= competitionMaxShortNameLength;
   const disableIdAndShortName = !isAdminView && nameAlreadyShort;
 
   // ID change on V1 is always possible, because we have control over the Foreign Keys.
   // Otherwise, only competitions without registrations can change their ID.
-  const regSystemSupportsIdChange = !usesV2Registrations || !hasAnyRegistrations;
+  const regSystemSupportsIdChange = !usesNewRegistrationSystem || !hasAnyRegistrations;
 
   return (
     <>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1619,7 +1619,7 @@ en:
         admin:
           is_confirmed: "Do not let organizers edit this competition"
           is_visible: "Make competition visible to the public"
-          uses_v_2_registrations: "Use the new Registration System"
+          registration_version: "Which registration service version is used"
         competition_id: "ID"
         name: "Name"
         short_name: "Competition short name"
@@ -1700,7 +1700,7 @@ en:
         admin:
           is_confirmed: ""
           is_visible: ""
-          uses_v_2_registrations: "If this is disabled, changing the registration system will cause technical issues. Please contact WST for assistance if you still need to change the registration system."
+          registration_version: "If this is disabled, changing the registration system will cause technical issues. Please contact WST for assistance if you still need to change the registration system."
         competition_id: ""
         name: "The full name of the competition including the year at the end (e.g., Danish Open 2016). Be sure to capitalize. The name must contain only alphanumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )."
         short_name: "A short name for displaying. If the name of the competition is below %{short_name_limit} characters this should not be edited and should be the same as the normal name."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1619,7 +1619,7 @@ en:
         admin:
           is_confirmed: "Do not let organizers edit this competition"
           is_visible: "Make competition visible to the public"
-          registration_version: "Which registration service version is used"
+          uses_new_registration_system: "Use the new Registration System"
         competition_id: "ID"
         name: "Name"
         short_name: "Competition short name"
@@ -1700,7 +1700,7 @@ en:
         admin:
           is_confirmed: ""
           is_visible: ""
-          registration_version: "If this is disabled, changing the registration system will cause technical issues. Please contact WST for assistance if you still need to change the registration system."
+          uses_new_registration_system: "If this is disabled, changing the registration system will cause technical issues. Please contact WST for assistance if you still need to change the registration system."
         competition_id: ""
         name: "The full name of the competition including the year at the end (e.g., Danish Open 2016). Be sure to capitalize. The name must contain only alphanumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )."
         short_name: "A short name for displaying. If the name of the competition is below %{short_name_limit} characters this should not be edited and should be the same as the normal name."

--- a/db/migrate/20241025161404_make_registration_version_an_enum.rb
+++ b/db/migrate/20241025161404_make_registration_version_an_enum.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MakeRegistrationVersionAnEnum < ActiveRecord::Migration[7.2]
+  def up
+    add_column :Competitions, :registration_version, :string, default: 'v1', null: false
+
+    # Update values based on the old boolean column
+    Competition.where(uses_v2_registrations: true).update_all(registration_version: 'v2')
+    Competition.where(uses_v2_registrations: false).update_all(registration_version: 'v1')
+
+    # Remove the old column
+    remove_column :Competitions, :uses_v2_registrations
+  end
+
+  def down
+    # Add back the original boolean column
+    add_column :Competitions, :uses_v2_registrations, :boolean, default: false, null: false
+
+    # Map back enum values to the boolean
+    Competition.where(registration_version: 'v2').update_all(uses_v2_registrations: true)
+
+    # Remove the enum column and rename the boolean column back
+    remove_column :Competitions, :registration_version
+  end
+end
+

--- a/db/migrate/20241025161404_make_registration_version_an_enum.rb
+++ b/db/migrate/20241025161404_make_registration_version_an_enum.rb
@@ -23,4 +23,3 @@ class MakeRegistrationVersionAnEnum < ActiveRecord::Migration[7.2]
     remove_column :Competitions, :registration_version
   end
 end
-

--- a/db/migrate/20241025161404_make_registration_version_an_enum.rb
+++ b/db/migrate/20241025161404_make_registration_version_an_enum.rb
@@ -2,11 +2,10 @@
 
 class MakeRegistrationVersionAnEnum < ActiveRecord::Migration[7.2]
   def up
-    add_column :Competitions, :registration_version, :string, default: 'v1', null: false
+    add_column :Competitions, :registration_version, :integer, default: 0, null: false
 
     # Update values based on the old boolean column
-    Competition.where(uses_v2_registrations: true).update_all(registration_version: 'v2')
-    Competition.where(uses_v2_registrations: false).update_all(registration_version: 'v1')
+    Competition.where(uses_v2_registrations: true).update_all(registration_version: 1)
 
     # Remove the old column
     remove_column :Competitions, :uses_v2_registrations
@@ -17,7 +16,7 @@ class MakeRegistrationVersionAnEnum < ActiveRecord::Migration[7.2]
     add_column :Competitions, :uses_v2_registrations, :boolean, default: false, null: false
 
     # Map back enum values to the boolean
-    Competition.where(registration_version: 'v2').update_all(uses_v2_registrations: true)
+    Competition.where(registration_version: 1).update_all(uses_v2_registrations: true)
 
     # Remove the enum column and rename the boolean column back
     remove_column :Competitions, :registration_version

--- a/db/migrate/20241025161404_make_registration_version_an_enum.rb
+++ b/db/migrate/20241025161404_make_registration_version_an_enum.rb
@@ -5,7 +5,7 @@ class MakeRegistrationVersionAnEnum < ActiveRecord::Migration[7.2]
     add_column :Competitions, :registration_version, :integer, default: 0, null: false
 
     # Update values based on the old boolean column
-    Competition.where(uses_v2_registrations: true).update_all(registration_version: 1)
+    Competition.where(uses_v2_registrations: true).update_all(registration_version: Competition.registration_versions[:v2])
 
     # Remove the old column
     remove_column :Competitions, :uses_v2_registrations
@@ -16,7 +16,7 @@ class MakeRegistrationVersionAnEnum < ActiveRecord::Migration[7.2]
     add_column :Competitions, :uses_v2_registrations, :boolean, default: false, null: false
 
     # Map back enum values to the boolean
-    Competition.where(registration_version: 1).update_all(uses_v2_registrations: true)
+    Competition.where(registration_version: Competition.registration_versions[:v2]).update_all(uses_v2_registrations: true)
 
     # Remove the enum column and rename the boolean column back
     remove_column :Competitions, :registration_version

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_09_111904) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_25_161404) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -79,9 +79,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_111904) do
     t.integer "events_per_registration_limit"
     t.boolean "force_comment_in_registration"
     t.integer "posting_by"
-    t.boolean "uses_v2_registrations", default: false, null: false
     t.boolean "forbid_newcomers", default: false, null: false
     t.string "forbid_newcomers_reason"
+    t.string "registration_version", default: "v1", null: false
     t.index ["cancelled_at"], name: "index_Competitions_on_cancelled_at"
     t.index ["countryId"], name: "index_Competitions_on_countryId"
     t.index ["end_date"], name: "index_Competitions_on_end_date"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,7 +81,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_161404) do
     t.integer "posting_by"
     t.boolean "forbid_newcomers", default: false, null: false
     t.string "forbid_newcomers_reason"
-    t.string "registration_version", default: "v1", null: false
+    t.integer "registration_version", default: 0, null: false
     t.index ["cancelled_at"], name: "index_Competitions_on_cancelled_at"
     t.index ["countryId"], name: "index_Competitions_on_countryId"
     t.index ["end_date"], name: "index_Competitions_on_end_date"

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -107,7 +107,7 @@ module DatabaseDumper
           competition_series_id
           use_wca_live_for_scoretaking
           allow_registration_without_qualification
-          uses_v2_registrations
+          registration_version
           forbid_newcomers
           forbid_newcomers_reason
         ),

--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -109,6 +109,7 @@ FactoryBot.define do
     use_wca_registration { false }
     registration_open { 54.weeks.ago.change(usec: 0) }
     registration_close { 1.weeks.from_now.change(usec: 0) }
+    registration_version { :v1 }
 
     trait :with_valid_submitted_results do
       announced


### PR DESCRIPTION
To allow us to switch over to 'v3' in stages