### PR TITLE
Block unwanted file types from avatar upload

### DIFF
--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -32,8 +32,8 @@ class UserAvatar < ApplicationRecord
 
   MAX_UPLOAD_SIZE = 2.megabytes
 
-  validates :public_image, blob: { content_type: :web_image, size_range: ..MAX_UPLOAD_SIZE }
-  validates :private_image, blob: { content_type: :web_image, size_range: ..MAX_UPLOAD_SIZE }
+  validates :public_image, blob: { content_type: :web_image, size_range: 0..MAX_UPLOAD_SIZE }
+  validates :private_image, blob: { content_type: :web_image, size_range: 0..MAX_UPLOAD_SIZE }
 
   def url
     case self.backend

--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -30,6 +30,11 @@ class UserAvatar < ApplicationRecord
     local: 'local-fs',
   }, default: :active_storage, scopes: false
 
+  MAX_UPLOAD_SIZE = 2.megabytes
+
+  validates :public_image, blob: { content_type: :web_image, size_range: ..MAX_UPLOAD_SIZE }
+  validates :private_image, blob: { content_type: :web_image, size_range: ..MAX_UPLOAD_SIZE }
+
   def url
     case self.backend
     when 's3_legacy_cdn'

--- a/app/webpacker/components/EditAvatar/ImageUpload.js
+++ b/app/webpacker/components/EditAvatar/ImageUpload.js
@@ -9,6 +9,7 @@ import I18n from '../../lib/i18n';
 import useCheckboxState from '../../lib/hooks/useCheckboxState';
 import useInputState from '../../lib/hooks/useInputState';
 import useToggleButtonState from '../../lib/hooks/useToggleButtonState';
+import { avatarImageTypes } from '../../lib/wca-data.js.erb';
 
 function ImageUpload({
   uploadDisabled,
@@ -72,9 +73,8 @@ function ImageUpload({
           <Form.Input
             required
             label={I18n.t('activerecord.attributes.user.pending_avatar')}
-            disabled={uploadDisabled}
             type="file"
-            accept="image/*"
+            accept={avatarImageTypes.join(', ')}
             value={selectedFile}
             onChange={handleSelectedImage}
           />

--- a/app/webpacker/components/EditAvatar/index.js
+++ b/app/webpacker/components/EditAvatar/index.js
@@ -21,6 +21,7 @@ import Errored from '../Requests/Errored';
 import useSaveAction from '../../lib/hooks/useSaveAction';
 import UserAvatar from '../UserAvatar';
 import useCheckboxState from '../../lib/hooks/useCheckboxState';
+import { avatarImageTypes } from '../../lib/wca-data.js.erb';
 
 function EditAvatar({
   userId,
@@ -57,6 +58,12 @@ function EditAvatar({
 
     return workingAvatar?.url;
   }, [workingAvatar, userUploadedImage]);
+
+  const isValidContentType = useMemo(() => {
+    if (!userUploadedImage) return true;
+
+    return avatarImageTypes.includes(userUploadedImage.type);
+  }, [userUploadedImage]);
 
   const workingThumbnail = useMemo(() => ({
     x: workingAvatar?.thumbnail_crop_x,
@@ -176,7 +183,7 @@ function EditAvatar({
               )}
             </Message>
             <ImageUpload
-              uploadDisabled={uploadDisabled || isEditingPending}
+              uploadDisabled={uploadDisabled || isEditingPending || !isValidContentType}
               removalEnabled={canRemoveAvatar && !isEditingPending}
               onImageUploaded={uploadUserImage}
               onAvatarSaved={saveAvatar}

--- a/app/webpacker/lib/wca-data.js.erb
+++ b/app/webpacker/lib/wca-data.js.erb
@@ -217,3 +217,6 @@ export const banScopes = <%= RolesMetadataBannedCompetitors.scopes.to_json %>
 
 // ----- PANEL PAGES -----
 export const PANEL_PAGES = <%= User.panel_pages.to_json.html_safe %>;
+
+// ----- AVATAR CONFIG -----
+export const avatarImageTypes = <%= Rails.application.config.active_storage.web_image_content_types.to_json.html_safe %>;


### PR DESCRIPTION
One of the gazillion reasons to hate Apple! When switching to the new avatar backend, we introduced support for "web images" according to Rails -- which in turn basically just relies on MIME types and standards.

Apple's "High Efficiency Image Codec" somehow managed to get approved as "web image" in that standard, but those money-greedy bastards of course didn't release their codec properly. So while it's _technically_ adhering to the standard, in practice most browsers don't support it because they don't know how to decode the image stream client-side.

Now we have to fall back to hard-blocking HEIC files, sigh...