### PR TITLE
Disable frontend competitor limit check if no competitor limit is enforced

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -69,7 +69,7 @@ export default function RegistrationActions({
 
   const attemptToApprove = () => {
     const idsToAccept = [...pending, ...cancelled, ...waiting, ...rejected];
-    if (idsToAccept.length > spotsRemaining && competitionInfo.competitor_limit > 0) {
+    if (idsToAccept.length > spotsRemaining) {
       dispatch(setMessage(
         'competitions.registration_v2.update.too_many',
         'negative',

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -69,7 +69,7 @@ export default function RegistrationActions({
 
   const attemptToApprove = () => {
     const idsToAccept = [...pending, ...cancelled, ...waiting, ...rejected];
-    if (idsToAccept.length > spotsRemaining && competitionInfo.competitorLimit > 0) {
+    if (idsToAccept.length > spotsRemaining && competitionInfo.competitor_limit > 0) {
       dispatch(setMessage(
         'competitions.registration_v2.update.too_many',
         'negative',

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -69,7 +69,7 @@ export default function RegistrationActions({
 
   const attemptToApprove = () => {
     const idsToAccept = [...pending, ...cancelled, ...waiting, ...rejected];
-    if (idsToAccept.length > spotsRemaining) {
+    if (idsToAccept.length > spotsRemaining && competitionInfo.competitorLimit > 0) {
       dispatch(setMessage(
         'competitions.registration_v2.update.too_many',
         'negative',

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -273,7 +273,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
 
   // some sticky/floating bar somewhere with totals/info would be better
   // than putting this in the table headers which scroll out of sight
-  const spotsRemaining = (competitionInfo.competitor_limit ?? Infinity) - accepted.length;
+  const spotsRemaining = (competitionInfo.competitor_limit || Infinity) - accepted.length;
   const spotsRemainingText = i18n.t(
     'competitions.registration_v2.list.spots_remaining_plural',
     { count: spotsRemaining },

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -366,7 +366,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           {' '}
           (
           {accepted.length}
-          {competitionInfo.competitor_limit && (
+          { spotsRemaining !== Infinity && (
             <>
               {`/${competitionInfo.competitor_limit}; `}
               {spotsRemainingText}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -366,7 +366,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           {' '}
           (
           {accepted.length}
-          { spotsRemaining !== Infinity && (
+          {spotsRemaining !== Infinity && (
             <>
               {`/${competitionInfo.competitor_limit}; `}
               {spotsRemainingText}


### PR DESCRIPTION
This mirrors the change pushed to the registration microservice - tested locally and works as expected in cases where a competitor limit is and isn't set.