### PR TITLE
Making comps visible after announcing

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -769,7 +769,7 @@ class CompetitionsController < ApplicationController
       return render json: { error: "Already announced" }
     end
 
-    competition.update!(announced_at: Time.now, announced_by: current_user.id)
+    competition.update!(announced_at: Time.now, announced_by: current_user.id, showAtAll: true)
 
     competition.organizers.each do |organizer|
       CompetitionsMailer.notify_organizer_of_announced_competition(competition, organizer).deliver_later

--- a/app/webpacker/components/CompetitionForm/AnnouncementActions.js
+++ b/app/webpacker/components/CompetitionForm/AnnouncementActions.js
@@ -24,6 +24,7 @@ import {
   useFormErrorHandler,
   useFormInitialObject,
 } from '../wca/FormBuilder/provider/FormObjectProvider';
+import { useFormCommitAction, useFormUpdateAction } from '../wca/FormBuilder/EditForm';
 
 function AnnounceAction({
   competitionId,
@@ -39,11 +40,19 @@ function AnnounceAction({
   const { save } = useSaveAction();
   const confirm = useConfirm();
 
+  const updateFormObject = useFormUpdateAction();
+  const commitFormObject = useFormCommitAction();
+
   const postAnnouncement = () => {
     confirm({
       content: I18n.t('competitions.announce_confirm'),
     }).then(() => {
-      save(announceCompetitionUrl(competitionId), null, sync, {
+      save(announceCompetitionUrl(competitionId), null, () => {
+        sync();
+
+        updateFormObject('isVisible', true, ['admin']); // Automatically make the competition visible.
+        commitFormObject();
+      }, {
         body: null,
         method: 'PUT',
       });


### PR DESCRIPTION
Making competitions visible after announcing. Saves a step for WCAT
solves issue : https://github.com/thewca/worldcubeassociation.org/issues/8884

Demo: https://youtu.be/97qNRyvvTiA