### PR TITLE
Only run SubmitResultsNagJob in Prod

### DIFF
--- a/app/jobs/submit_report_nag_job.rb
+++ b/app/jobs/submit_report_nag_job.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class SubmitReportNagJob < WcaCronjob
+  before_enqueue do
+    # We only need to do this in prod
+    throw :abort unless Rails.env.production?
+  end
+
   def nag_needed?(competition)
     (competition.delegate_report.nag_sent_at || competition.end_date) <= 8.days.ago
   end

--- a/app/jobs/submit_results_nag_job.rb
+++ b/app/jobs/submit_results_nag_job.rb
@@ -3,7 +3,7 @@
 class SubmitResultsNagJob < WcaCronjob
   before_enqueue do
     # We only need to do this in prod
-    throw :abort unless EnvConfig.WCA_LIVE_SITE?
+    throw :abort unless Rails.env.production?
   end
 
   def nag_needed(competition)

--- a/app/jobs/submit_results_nag_job.rb
+++ b/app/jobs/submit_results_nag_job.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class SubmitResultsNagJob < WcaCronjob
+  before_enqueue do
+    # We only need to do this in prod
+    throw :abort unless EnvConfig.WCA_LIVE_SITE?
+  end
+
   def nag_needed(competition)
     (competition.results_nag_sent_at || competition.end_date) <= 8.days.ago
   end


### PR DESCRIPTION
Just had to wait 10 minutes until sidekiq send 50000 nags so I think it's fair to say we don't need to run this unless we are on prod