### PR TITLE
Set DOB to 1954-12-04 during anonymization

### DIFF
--- a/app/models/anonymize_person.rb
+++ b/app/models/anonymize_person.rb
@@ -73,7 +73,7 @@ class AnonymizePerson
                                      name: ANONYMIZED_NAME,
                                      unconfirmed_wca_id: nil,
                                      delegate_id_to_handle_wca_id_claim: nil,
-                                     dob: nil,
+                                     dob: '1954-12-04',
                                      gender: "o",
                                      current_sign_in_ip: nil,
                                      last_sign_in_ip: nil)

--- a/spec/models/anonymize_person_spec.rb
+++ b/spec/models/anonymize_person_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe AnonymizePerson do
     expect(user.reload.wca_id).to eq nil
     expect(user.reload.email).to eq user.id.to_s + "@worldcubeassociation.org"
     expect(user.reload.name).to eq "Anonymous"
-    expect(user.reload.dob).to eq nil
+    expect(user.reload.dob).to eq Date.new(1954, 12, 4)
     expect(user.reload.gender).to eq "o"
   end
 end


### PR DESCRIPTION
Setting DOB to `nil` for accounts produces an error when trying to fetch WCIF.

For more information, refer to November sanity check email thread.