### PR TITLE
Add competing_status column to registration

### DIFF
--- a/app/jobs/add_registration_job.rb
+++ b/app/jobs/add_registration_job.rb
@@ -8,7 +8,7 @@ class AddRegistrationJob < ApplicationJob
     Rails.cache.write(CacheAccess.registration_processing_cache_key(competition_id, user_id), true)
   end
 
-  queue_as EnvConfig.REGISTRATION_QUEUE
+  queue_as EnvConfig.REGISTRATION_QUEUE unless Rails.env.local?
 
   def self.prepare_task(user_id, competition_id)
     message_deduplication_id = "competing-registration-#{competition_id}-#{user_id}"

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1173,7 +1173,7 @@ class Competition < ApplicationRecord
   def pending_competitors_count
     # TODO: V3-Reg Cleanup, we can go back to use registrations.pending when we are on v3
     if uses_microservice_registrations?
-      Microservices::Registrations.registrations_by_competition(@competition.id, 'pending', cache: true).length
+      Microservices::Registrations.registrations_by_competition(self.id, 'pending', cache: true).length
     elsif registration_version_v3?
       registrations.competing_status_pending.count
     else

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -451,7 +451,15 @@ class Competition < ApplicationRecord
   end
 
   def registration_full?
-    competitor_count = uses_microservice_registrations? ? Microservices::Registrations.competitor_count_by_competition(id) : registrations.accepted_and_paid_pending_count
+    # TODO: V3-Reg cleanup, move this to registrations.accepted_and_paid_pending_count again
+    competitor_count =
+      if uses_microservice_registrations?
+        Microservices::Registrations.competitor_count_by_competition(id)
+      elsif registration_version_v3?
+        registrations.competing_status_accepted.count + registrations.competing_status_pending.with_payments.count
+      else
+        registrations.accepted_and_paid_pending_count
+      end
     competitor_limit_enabled? && competitor_count >= competitor_limit
   end
 
@@ -1160,6 +1168,17 @@ class Competition < ApplicationRecord
 
   def some_guests_allowed?
     guest_entry_status_restricted?
+  end
+
+  def pending_competitors_count
+    # TODO: V3-Reg Cleanup, we can go back to use registrations.pending when we are on v3
+    if uses_microservice_registrations?
+      Microservices::Registrations.registrations_by_competition(@competition.id, 'pending', cache: true).length
+    elsif registration_version_v3?
+      registrations.competing_status_pending.count
+    else
+      registrations.pending.count
+    end
   end
 
   def registration_period_required?

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 class Registration < ApplicationRecord
-  scope :pending, -> {
-    where(accepted_at: nil, deleted_at: nil, is_competing: true)
-      .or(where(registration_version: :v3, competing_status: 'pending'))
-  }
+  scope :pending, -> { where(accepted_at: nil, deleted_at: nil, is_competing: true) }
   scope :accepted, -> { where.not(accepted_at: nil).where(deleted_at: nil) }
   scope :deleted, -> { where.not(deleted_at: nil) }
   scope :cancelled, -> { where(competing_status: 'cancelled') }

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -230,9 +230,9 @@ class Registration < ApplicationRecord
   end
 
   def add_history_entry(changes, actor_type, actor_id, action, timestamp = Time.now.utc)
-    new_entry = registration_history_entries.create(actor_type: actor_type, actor_id: actor_id, action: action)
+    new_entry = registration_history_entries.create(actor_type: actor_type, actor_id: actor_id, action: action, created_at: timestamp)
     changes.each_key do |key|
-      new_entry.registration_history_change.create(value: changes[key], key: key, created_at: timestamp)
+      new_entry.registration_history_change.create(value: changes[key], key: key)
     end
   end
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Registration < ApplicationRecord
-  scope :pending, -> { where(accepted_at: nil).where(deleted_at: nil).where(is_competing: true).or(competing_status: 'pending') }
+  scope :pending, -> {
+    where(accepted_at: nil, deleted_at: nil, is_competing: true)
+      .or(where(competing_status: 'pending'))
+  }
   scope :accepted, -> { where.not(accepted_at: nil).where(deleted_at: nil) }
   scope :deleted, -> { where.not(deleted_at: nil) }
   scope :cancelled, -> { where(competing_status: 'cancelled') }

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -3,7 +3,7 @@
 class Registration < ApplicationRecord
   scope :pending, -> {
     where(accepted_at: nil, deleted_at: nil, is_competing: true)
-      .or(where(competing_status: 'pending'))
+      .or(where(registration_version: :v3, competing_status: 'pending'))
   }
   scope :accepted, -> { where.not(accepted_at: nil).where(deleted_at: nil) }
   scope :deleted, -> { where.not(deleted_at: nil) }

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -22,6 +22,14 @@ class Registration < ApplicationRecord
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
   has_many :payment_intents, as: :holder, dependent: :delete_all
 
+  enum :competing_status, {
+    pending: Registrations::Helper::STATUS_PENDING,
+    accepted: Registrations::Helper::STATUS_ACCEPTED,
+    cancelled: Registrations::Helper::STATUS_CANCELLED,
+    rejected: Registrations::Helper::STATUS_REJECTED,
+    waiting_list: Registrations::Helper::STATUS_WAITING_LIST,
+  }, prefix: true
+
   serialize :roles, coder: YAML
 
   accepts_nested_attributes_for :registration_competition_events, allow_destroy: true
@@ -234,11 +242,11 @@ class Registration < ApplicationRecord
     end
   end
 
-  def competing_status
+  def compute_competing_status
     if accepted? || !is_competing?
       Registrations::Helper::STATUS_ACCEPTED
     elsif deleted?
-      Registrations::Helper::STATUS_DELETED
+      Registrations::Helper::STATUS_CANCELLED
     elsif rejected?
       Registrations::Helper::STATUS_REJECTED
     elsif pending?

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -225,10 +225,10 @@ class Registration < ApplicationRecord
     registration_competition_events.reject(&:marked_for_destruction?).map(&:event)
   end
 
-  def add_history_entry(changes, actor_type, actor_id, action)
+  def add_history_entry(changes, actor_type, actor_id, action, timestamp = Time.now.utc)
     new_entry = registration_history_entries.create(actor_type: actor_type, actor_id: actor_id, action: action)
     changes.each_key do |key|
-      new_entry.registration_history_change.create(value: changes[key], key: key)
+      new_entry.registration_history_change.create(value: changes[key], key: key, created_at: timestamp)
     end
   end
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -321,7 +321,7 @@ class Registration < ApplicationRecord
                          },
                        })
       if competing_status == "waiting_list"
-        base_json[:competing][:waiting_list_position] = competition.waiting_list.entries.find_index(user_id) + 1
+        base_json[:competing][:waiting_list_position] = waiting_list_position
       end
     end
     if history

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -273,7 +273,7 @@ class Registration < ApplicationRecord
   end
 
   def registration_history
-    registration_history_entries.map do |r|
+    registration_history_entries.includes([:registration_history_change]).map do |r|
       changed_attributes = r.registration_history_change.each_with_object({}) do |change, attrs|
         attrs[change.key] = if change.key == 'event_ids'
                               JSON.parse(change.value) # Assuming 'event_ids' is stored as JSON array in `to`

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -302,7 +302,7 @@ class Registration < ApplicationRecord
       if competition.using_payment_integrations?
         base_json.merge!({
                            payment: {
-                             has_paid: outstanding_entry_fees == 0,
+                             has_paid: outstanding_entry_fees <= 0,
                              payment_statuses: registration_payments.sort_by(&:created_at).reverse!.map { |p| p.payment_status },
                              payment_amount_iso: paid_entry_fees.cents,
                              payment_amount_human_readable: "#{paid_entry_fees.format} (#{paid_entry_fees.currency.name})",

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -24,6 +24,7 @@ class WaitingList < ActiveRecord::Base
     update_column :entries, entries.insert(new_position-1, entries.delete_at(old_index))
   end
 
+  # This is the position from the user/organizers perspective - ie, we start counting at 1
   def position(entry_id)
     return nil unless entries.include?(entry_id)
     entries.index(entry_id) + 1

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -25,6 +25,7 @@ class WaitingList < ActiveRecord::Base
   end
 
   def position(entry_id)
+    return nil unless entries.include?(entry_id)
     entries.index(entry_id) + 1
   end
 end

--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -50,11 +50,7 @@
               ] : [])
           }
           if @competition.use_wca_registration?
-            pending_registrations = if @competition.uses_microservice_registrations?
-                                      Microservices::Registrations.registrations_by_competition(@competition.id, 'pending', cache: true).length
-                                    else
-                                      @competition.registrations.pending.count
-                                    end
+            pending_registrations = @competition.pending_competitors_count
             nav_items << {
               text: t('.menu.registration'),
               path: competition_edit_registrations_path(@competition),

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationClosedMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationClosedMessage.jsx
@@ -28,6 +28,10 @@ export default function RegistrationClosedMessage({
     return () => clearInterval(intervalId); // Cleanup interval on unmount
   }, [registrationStart, onTimerEnd, start]);
 
+  if (timeLeft.seconds < 0) {
+    return null;
+  }
+
   return (
     <Message color="blue">
       { timeLeft.days < 1 && timeLeft.hours < 1

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -312,9 +312,9 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
           <Header>
             Payment status:
             {' '}
-            {registration.payment.payment_status}
+            {registration.payment.payment_statuses}
           </Header>
-          {(registration.payment.payment_status.includes('succeeded') || registration.payment.payment_status.includes('refund')) && (
+          {(registration.payment.payment_statuses.includes('succeeded') || registration.payment.payment_statuses.includes('refund')) && (
             <Refunds
               competitionId={competitionInfo.id}
               userId={competitor.id}

--- a/db/migrate/20241104161404_add_competing_status_enum.rb
+++ b/db/migrate/20241104161404_add_competing_status_enum.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 class AddCompetingStatusEnum < ActiveRecord::Migration[7.2]
-  def up
+  def change
     add_column :registrations, :competing_status, :string, default: Registrations::Helper::STATUS_PENDING, null: false
-
-    # Update values based on the old boolean column
-    Registration.all.each do |r|
-      r.update_column(:competing_status, r.compute_competing_status)
-    end
+    remove_column :registrations, :rejected_at
+    remove_column :registrations, :waitlisted_at
   end
 end

--- a/db/migrate/20241104161404_add_competing_status_enum.rb
+++ b/db/migrate/20241104161404_add_competing_status_enum.rb
@@ -5,7 +5,7 @@ class AddCompetingStatusEnum < ActiveRecord::Migration[7.2]
     add_column :registrations, :competing_status, :string, default: Registrations::Helper::STATUS_PENDING, null: false
 
     # Update values based on the old boolean column
-    Registration.all do |r|
+    Registration.all.each do |r|
       r.update_column(:competing_status, r.compute_competing_status)
     end
   end

--- a/db/migrate/20241104161404_add_competing_status_enum.rb
+++ b/db/migrate/20241104161404_add_competing_status_enum.rb
@@ -3,7 +3,7 @@
 class AddCompetingStatusEnum < ActiveRecord::Migration[7.2]
   def change
     add_column :registrations, :competing_status, :string, default: Registrations::Helper::STATUS_PENDING, null: false
-    remove_column :registrations, :rejected_at
-    remove_column :registrations, :waitlisted_at
+    remove_column :registrations, :rejected_at, :datetime
+    remove_column :registrations, :waitlisted_at, :datetime
   end
 end

--- a/db/migrate/20241104161404_add_competing_status_enum.rb
+++ b/db/migrate/20241104161404_add_competing_status_enum.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddCompetingStatusEnum < ActiveRecord::Migration[7.2]
+  def up
+    add_column :registrations, :competing_status, :string, default: Registrations::Helper::STATUS_PENDING, null: false
+
+    # Update values based on the old boolean column
+    Registration.all do |r|
+      r.update_column(:competing_status, r.compute_competing_status)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_31_120315) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_04_161404) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -1032,6 +1032,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_31_120315) do
     t.text "administrative_notes"
     t.datetime "rejected_at"
     t.datetime "waitlisted_at"
+    t.string "competing_status", default: "pending", null: false
     t.index ["competition_id", "user_id"], name: "index_registrations_on_competition_id_and_user_id", unique: true
     t.index ["competition_id"], name: "index_registrations_on_competition_id"
     t.index ["user_id"], name: "index_registrations_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1030,8 +1030,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_161404) do
     t.text "roles"
     t.boolean "is_competing", default: true
     t.text "administrative_notes"
-    t.datetime "rejected_at"
-    t.datetime "waitlisted_at"
     t.string "competing_status", default: "pending", null: false
     t.index ["competition_id", "user_id"], name: "index_registrations_on_competition_id_and_user_id", unique: true
     t.index ["competition_id"], name: "index_registrations_on_competition_id"

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -577,8 +577,6 @@ module DatabaseDumper
           created_at
           deleted_at
           deleted_by
-          rejected_at
-          waitlisted_at
           guests
           updated_at
           user_id

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -584,6 +584,7 @@ module DatabaseDumper
           user_id
           roles
           is_competing
+          competing_status
         ),
         db_default: %w(ip),
         fake_values: {

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -31,6 +31,10 @@ module Microservices
       "/api/internal/v1/#{attendee_id}"
     end
 
+    def self.get_history_path(attendee_id)
+      "/api/internal/v1/#{attendee_id}/history"
+    end
+
     def self.add_registration_path(competition_id)
       "/api/internal/v1/#{competition_id}/add"
     end
@@ -116,6 +120,11 @@ module Microservices
 
     def self.registration_by_id(attendee_id)
       response = self.registration_connection.get(self.get_registration_path(attendee_id))
+      response.body
+    end
+
+    def self.history_by_id(attendee_id)
+      response = self.registration_connection.get(self.get_history_path(attendee_id))
       response.body
     end
   end

--- a/lib/microservices/registrations.rb
+++ b/lib/microservices/registrations.rb
@@ -27,6 +27,10 @@ module Microservices
       "/api/internal/v1/#{competition_id}/registrations"
     end
 
+    def self.get_waiting_list_path(competition_id)
+      "/api/internal/v1/#{competition_id}/waiting_list"
+    end
+
     def self.get_registration_path(attendee_id)
       "/api/internal/v1/#{attendee_id}"
     end
@@ -125,6 +129,11 @@ module Microservices
 
     def self.history_by_id(attendee_id)
       response = self.registration_connection.get(self.get_history_path(attendee_id))
+      response.body
+    end
+
+    def self.waiting_list_by_id(competition_id)
+      response = self.registration_connection.get(self.get_waiting_list_path(competition_id))
       response.body
     end
   end

--- a/lib/registrations/helper.rb
+++ b/lib/registrations/helper.rb
@@ -7,6 +7,7 @@ module Registrations
     STATUS_WAITING_LIST = "waiting_list"
     STATUS_ACCEPTED = "accepted"
     STATUS_DELETED = "deleted"
+    STATUS_CANCELLED = "cancelled"
     STATUS_REJECTED = "rejected"
 
     REGISTRATION_STATES = [STATUS_ACCEPTED, STATUS_DELETED, STATUS_PENDING, STATUS_REJECTED, STATUS_WAITING_LIST].freeze # TODO: Change deleted to canceled when v1 is retired

--- a/lib/registrations/helper.rb
+++ b/lib/registrations/helper.rb
@@ -11,14 +11,14 @@ module Registrations
     STATUS_CANCELLED = "cancelled"
     STATUS_REJECTED = "rejected"
 
-    REGISTRATION_STATES = [STATUS_ACCEPTED, STATUS_DELETED, STATUS_CANCELLED, STATUS_PENDING, STATUS_REJECTED, STATUS_WAITING_LIST].freeze # TODO: Change deleted to canceled when v1 is retired
+    REGISTRATION_STATES = [STATUS_ACCEPTED, STATUS_CANCELLED, STATUS_PENDING, STATUS_REJECTED, STATUS_WAITING_LIST].freeze # TODO: Change deleted to canceled when v1 is retired
     ADMIN_ONLY_STATES = [STATUS_PENDING, STATUS_WAITING_LIST, STATUS_ACCEPTED, STATUS_REJECTED].freeze # Only admins are allowed to change registration state to one of these states
     MIGHT_ATTEND_STATES = [STATUS_PENDING, STATUS_WAITING_LIST, STATUS_ACCEPTED].freeze
 
     def self.action_type(request, current_user_id)
       self_updating = request[:user_id].to_i == current_user_id
       status = request.dig('competing', 'status')
-      if [STATUS_DELETED, STATUS_CANCELLED].include?(status)
+      if status == STATUS_CANCELLED
         return self_updating ? 'Competitor delete' : 'Admin delete'
       end
       if status == STATUS_REJECTED

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -76,7 +76,7 @@ module Registrations
 
       def self.update_status(registration, status)
         return unless status.present?
-        
+
         registration.competing_status = status
       end
 

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -64,23 +64,7 @@ module Registrations
       def self.update_status(registration, status)
         return unless status.present?
 
-        registration.accepted_at = nil
-        registration.deleted_at = nil
-        registration.rejected_at = nil
-        registration.waitlisted_at = nil
-
-        case status
-        when Registrations::Helper::STATUS_WAITING_LIST
-          registration.waitlisted_at = Time.now.utc
-        when Registrations::Helper::STATUS_ACCEPTED
-          registration.accepted_at = Time.now.utc
-        when Registrations::Helper::STATUS_DELETED
-          registration.deleted_at = Time.now.utc
-        when Registrations::Helper::STATUS_REJECTED
-          registration.rejected_at = Time.now.utc
-        else
-          raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_REQUEST_DATA)
-        end
+        registration.competing_status = status
       end
 
       def self.send_status_change_email(registration, status, user_id, current_user_id)

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -62,13 +62,13 @@ module Registrations
       end
 
       def self.update_waiting_list(competing_params, registration, waiting_list)
-        status = competing_params.dig('status')
-        waiting_list_position = competing_params.dig('waiting_list_position')
+        status = competing_params['status']
+        waiting_list_position = competing_params['waiting_list_position']
 
         should_add = status == Registrations::Helper::STATUS_WAITING_LIST # TODO: Add case where waiting_list status is present but that matches the old_status
         should_move = waiting_list_position.present? # TODO: Add case where waiting list pos is present but it matches the current position
         should_remove = status.present? && registration.competing_status == Registrations::Helper::STATUS_WAITING_LIST &&
-          status != Registrations::Helper::STATUS_WAITING_LIST # TODO: Consider adding cases for when not all of these are true?
+                        status != Registrations::Helper::STATUS_WAITING_LIST # TODO: Consider adding cases for when not all of these are true?
 
         waiting_list.add(registration.id) if should_add
         waiting_list.move_to_position(registration.id, competing_params[:waiting_list_position].to_i) if should_move

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -37,14 +37,14 @@ module Registrations
           registration.administrative_notes = admin_comment if admin_comment.present?
           registration.guests = guests if guests.present?
 
-          changes = registration.changes.transform_values { |change| change[1] }
-
           if old_status == Registrations::Helper::STATUS_WAITING_LIST || status == Registrations::Helper::STATUS_WAITING_LIST
             waiting_list = competition.waiting_list || competition.create_waiting_list(entries: [])
             update_waiting_list(update_params[:competing], registration, waiting_list)
           end
 
           update_status(registration, status) # Update status after updating waiting list so that can access the old_status
+
+          changes = registration.changes.transform_values { |change| change[1] }
 
           if waiting_list_position.present?
             changes[:waiting_list_position] = waiting_list_position

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -32,7 +32,6 @@ module Registrations
         old_status = registration.competing_status
 
         ActiveRecord::Base.transaction do
-          update_status(registration, status)
           update_event_ids(registration, event_ids)
           registration.comments = comment if comment.present?
           registration.administrative_notes = admin_comment if admin_comment.present?
@@ -44,6 +43,8 @@ module Registrations
             waiting_list = competition.waiting_list || competition.create_waiting_list(entries: [])
             update_waiting_list(update_params[:competing], registration, waiting_list)
           end
+
+          update_status(registration, status) # Update status after updating waiting list so that can access the old_status
 
           if waiting_list_position.present?
             changes[:waiting_list_position] = waiting_list_position

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -170,7 +170,7 @@ module Registrations
       # rubocop:disable Metrics/ParameterLists
       def validate_update_status!(new_status, competition, current_user, target_user, registration, events)
         raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_REQUEST_DATA) unless
-          Registrations::Helper::REGISTRATION_STATES.include?(new_status)
+          Registration.competing_statuses.include?(new_status)
         raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED) if
           new_status == Registrations::Helper::STATUS_ACCEPTED && competition.competitor_limit_enabled? &&
           competition.registrations.accepted.count >= competition.competitor_limit

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -65,7 +65,7 @@ namespace :registration_version do
           if competition.using_payment_integrations?
             payment_intents = registration.payment_intents
             if payment_intents.present?
-              payment_intents.update_all(holder_id: new_registration.id)
+              payment_intents.update_all(holder_id: new_registration.id, holder_type: 'Registration')
             end
           end
 

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+namespace :registration_version do
+  desc "Migrates a Competition from V1 to V3"
+  task :migrate_v1_v3, [:competition_id] => [:environment] do |_, args|
+    competition_id = args[:competition_id]
+
+    if competition_id.blank?
+      abort "Competition id is required"
+    end
+
+    competition = Competition.find(competition_id)
+
+    if competition.nil?
+      abort "Competition #{competition_id} not found"
+    end
+
+    unless competition.registration_version_v1?
+      abort "Competition #{competition_id} is not on version 1"
+    end
+
+    ActiveRecord::Base.transaction do
+      competition.registrations.each do |registration|
+        registration.update_column :competing_status, registration.compute_competing_status
+      end
+
+      competition.update_column :registration_version, :v3
+    end
+  end
+
+  task :migrate_v2_v3, [:competition_id] => [:environment] do |_, args|
+    competition_id = args[:competition_id]
+
+    if competition_id.blank?
+      abort "Competition id is required"
+    end
+
+    competition = Competition.find(competition_id)
+
+    if competition.nil?
+      abort "Competition #{competition_id} not found"
+    end
+
+    unless competition.registration_version_v2?
+      abort "Competition #{competition_id} is not on version 2"
+    end
+
+    ActiveRecord::Base.transaction do
+      competition.microservice_registrations.each do |registration|
+        # Create new registration
+        new_registration = Registration.create(competition_id: competition_id,
+                                               user_id: registration.user_id,
+                                               comments: registration.comments,
+                                               guests: registration.guests,
+                                               competing_status: registration.competing_status,
+                                               administrative_notes: registration.administrative_notes,
+                                               registration_competition_events: registration.event_ids do |event_id|
+                                                 competition_event = competition.competition_events.find { |ce| ce.event_id == event_id }
+                                                 { competition_event_id: competition_event.id }
+                                               end)
+
+        # Point any payments to the new holder
+        if competition.using_payment_integrations?
+          payment_intents = registration.payment_intents
+          payment_intents.update_all(holder_id: new_registration.id)
+        end
+
+        changes = new_registration.changes.transform_values { |change| change[1] }
+        changes[:event_ids] = registration.event_ids
+        new_registration.add_history_entry(changes, "rake task", user_id, "V2 -> V3 Migration")
+      end
+
+      competition.update_column :registration_version, :v3
+    end
+  end
+end

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -19,12 +19,15 @@ namespace :registration_version do
       abort "Competition #{competition_id} is not on version 1"
     end
 
-    ActiveRecord::Base.transaction do
-      competition.registrations.each do |registration|
-        registration.update_column :competing_status, registration.compute_competing_status
-      end
+    LogTask.log_task("Migrating Registrations for Competition #{competition_id}") do
+      ActiveRecord::Base.transaction do
+        competition.registrations.each do |registration|
+          registration.update_column :competing_status, registration.compute_competing_status
+          registration.add_history_entry(registration.attributes.to_h, "rake task", "WST", "V2 Migration")
+        end
 
-      competition.update_column :registration_version, :v3
+        competition.update_column :registration_version, :v3
+      end
     end
   end
 
@@ -45,32 +48,36 @@ namespace :registration_version do
       abort "Competition #{competition_id} is not on version 2"
     end
 
-    ActiveRecord::Base.transaction do
-      competition.microservice_registrations.each do |registration|
-        # Create new registration
-        new_registration = Registration.create(competition_id: competition_id,
-                                               user_id: registration.user_id,
-                                               comments: registration.comments,
-                                               guests: registration.guests,
-                                               competing_status: registration.competing_status,
-                                               administrative_notes: registration.administrative_notes,
-                                               registration_competition_events: registration.event_ids do |event_id|
-                                                 competition_event = competition.competition_events.find { |ce| ce.event_id == event_id }
-                                                 { competition_event_id: competition_event.id }
-                                               end)
+    LogTask.log_task("Migrating Registrations for Competition #{competition_id}") do
+      ActiveRecord::Base.transaction do
+        competition.microservice_registrations.each do |registration|
+          # Create new registration
+          new_registration = Registration.create(competition_id: competition_id,
+                                                 user_id: registration.user_id,
+                                                 comments: registration.comments,
+                                                 guests: registration.guests,
+                                                 competing_status: registration.competing_status,
+                                                 administrative_notes: registration.administrative_notes,
+                                                 registration_competition_events: registration.event_ids do |event_id|
+                                                   competition_event = competition.competition_events.find { |ce| ce.event_id == event_id }
+                                                   { competition_event_id: competition_event.id }
+                                                 end)
 
-        # Point any payments to the new holder
-        if competition.using_payment_integrations?
-          payment_intents = registration.payment_intents
-          payment_intents.update_all(holder_id: new_registration.id)
+          # Point any payments to the new holder
+          if competition.using_payment_integrations?
+            payment_intents = registration.payment_intents
+            if payment_intents.present?
+              payment_intents.update_all(holder_id: new_registration.id)
+            end
+          end
+
+          changes = new_registration.changes.transform_values { |change| change[1] }
+          changes[:event_ids] = new_registration.event_ids
+          new_registration.add_history_entry(new_registration.attributes.to_h, "rake task", "WST", "V2 Migration")
         end
 
-        changes = new_registration.changes.transform_values { |change| change[1] }
-        changes[:event_ids] = registration.event_ids
-        new_registration.add_history_entry(changes, "rake task", user_id, "V2 -> V3 Migration")
+        competition.update_column :registration_version, :v3
       end
-
-      competition.update_column :registration_version, :v3
     end
   end
 end

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -33,7 +33,7 @@ namespace :registration_version do
                                            competing_status: 'pending',
                                            event_ids: registration.event_ids,
                                            comments: registration.comments,
-                                           guests: registration.guests
+                                           guests: registration.guests,
                                          },
                                          "user", registration.user_id,
                                          "V2 Migration",

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -110,10 +110,16 @@ namespace :registration_version do
             end
           end
 
+          # Migrate History
           ms_history = Microservices::Registrations.history_by_id(registration.attendee_id)
           ms_history['entries'].each do |entry|
             new_registration.add_history_entry(entry['changed_attributes'], entry['actor_type'], entry['actor_id'], entry['action'], entry['timestamp'])
           end
+
+          # Migrate Waiting List
+          waitlisted_competitors = competition.registrations.waitlisted
+          ms_waiting_list = Microservices::Registrations.waiting_list_by_id(competition_id)
+          competition.create_waiting_list(entries: ms_waiting_list.map { |user_id| waitlisted_competitors.find_by!(user_id: user_id).id })
         end
 
         competition.registration_version_v3!

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -120,7 +120,8 @@ namespace :registration_version do
         # Migrate Waiting List
         waitlisted_competitors = competition.registrations.waitlisted
         ms_waiting_list = Microservices::Registrations.waiting_list_by_id(competition_id)
-        competition.create_waiting_list(entries: ms_waiting_list.map { |user_id| waitlisted_competitors.find_by!(user_id: user_id).id })
+        reg_lookup = waitlisted_competitors.pluck(:user_id, :id).to_h
+        competition.create_waiting_list(entries: ms_waiting_list.map { |user_id| reg_lookup[user_id] })
 
         competition.registration_version_v3!
       end

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -115,12 +115,12 @@ namespace :registration_version do
           ms_history['entries'].each do |entry|
             new_registration.add_history_entry(entry['changed_attributes'], entry['actor_type'], entry['actor_id'], entry['action'], entry['timestamp'])
           end
-
-          # Migrate Waiting List
-          waitlisted_competitors = competition.registrations.waitlisted
-          ms_waiting_list = Microservices::Registrations.waiting_list_by_id(competition_id)
-          competition.create_waiting_list(entries: ms_waiting_list.map { |user_id| waitlisted_competitors.find_by!(user_id: user_id).id })
         end
+
+        # Migrate Waiting List
+        waitlisted_competitors = competition.registrations.waitlisted
+        ms_waiting_list = Microservices::Registrations.waiting_list_by_id(competition_id)
+        competition.create_waiting_list(entries: ms_waiting_list.map { |user_id| waitlisted_competitors.find_by!(user_id: user_id).id })
 
         competition.registration_version_v3!
       end

--- a/spec/controllers/api_competitions_controller_spec.rb
+++ b/spec/controllers/api_competitions_controller_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Api::V0::CompetitionsController do
         get_wcif_and_compare_persons_to(competition.id, user_competitor_ids + [[competition.organizers.first.id, nil], [competition.delegates.first.id, nil]])
 
         # Move last registration to deleted
-        last_registration.touch :deleted_at
+        last_registration.competing_status = Registrations::Helper::STATUS_CANCELLED
         # Create and register one new user
         user = FactoryBot.create(:user)
         last_registration = FactoryBot.create(:registration, :accepted, competition: competition, user: user)

--- a/spec/controllers/competitions_controller_spec.rb
+++ b/spec/controllers/competitions_controller_spec.rb
@@ -1109,14 +1109,14 @@ RSpec.describe CompetitionsController do
       end
 
       it 'does not show past competitions they have a rejected registration for' do
-        FactoryBot.create(:registration, :deleted, competition: past_competition2, user: registered_user)
+        FactoryBot.create(:registration, :rejected, competition: past_competition2, user: registered_user)
         get :my_competitions
         expect(assigns(:not_past_competitions)).to eq [future_competition1, future_competition3]
         expect(assigns(:past_competitions)).to eq [past_competition1]
       end
 
       it 'does not show upcoming competitions they have a rejected registration for' do
-        FactoryBot.create(:registration, :deleted, competition: future_competition2, user: registered_user)
+        FactoryBot.create(:registration, :cancelled, competition: future_competition2, user: registered_user)
         get :my_competitions
         expect(assigns(:not_past_competitions)).to eq [future_competition1, future_competition3]
         expect(assigns(:past_competitions)).to eq [past_competition1]

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
     it "doesn't allow accepting a banned user" do
       registration.update!(accepted_at: Time.now)
       registration2 = FactoryBot.create(:registration, :pending, competition: competition)
-      deleted_registration = FactoryBot.create(:registration, :deleted, competition: competition)
-      banned_deleted_registration = FactoryBot.create(:registration, :deleted, competition: competition)
+      deleted_registration = FactoryBot.create(:registration, :cancelled, competition: competition)
+      banned_deleted_registration = FactoryBot.create(:registration, :cancelled, competition: competition)
       banned_user = FactoryBot.create(:user, :banned)
       banned_deleted_registration.update!(user: banned_user)
 
@@ -185,8 +185,8 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
     it "doesn't allow rejecting a banned user" do
       registration.update!(accepted_at: Time.now)
       registration2 = FactoryBot.create(:registration, :pending, competition: competition)
-      deleted_registration = FactoryBot.create(:registration, :deleted, competition: competition)
-      banned_deleted_registration = FactoryBot.create(:registration, :deleted, competition: competition)
+      deleted_registration = FactoryBot.create(:registration, :cancelled, competition: competition)
+      banned_deleted_registration = FactoryBot.create(:registration, :cancelled, competition: competition)
       banned_user = FactoryBot.create(:user, :banned)
       banned_deleted_registration.update!(user: banned_user)
 
@@ -317,7 +317,7 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
     end
 
     it "can re-create registration after it was deleted" do
-      registration = FactoryBot.create :registration, :accepted, :deleted, competition: competition, user_id: user.id
+      registration = FactoryBot.create :registration, :accepted, :cancelled, competition: competition, user_id: user.id
       registration_competition_event = registration.registration_competition_events.first
       expect(registration.reload.deleted?).to eq true
 
@@ -383,7 +383,7 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
     end
 
     it "can re-create registration after it was deleted" do
-      registration = FactoryBot.create :registration, :accepted, :deleted, competition: competition, user_id: user.id
+      registration = FactoryBot.create :registration, :cancelled, competition: competition, user_id: user.id
       registration_competition_event = registration.registration_competition_events.first
       expect(registration.reload.pending?).to eq false
       expect(registration.reload.accepted?).to eq false

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe UsersController do
     end
 
     context "after having a registration deleted" do
-      let!(:registration) { FactoryBot.create(:registration, :deleted, user: user) }
+      let!(:registration) { FactoryBot.create(:registration, :cancelled, user: user) }
       it "user can change name" do
         sign_in user
         patch :update, params: { id: user.id, user: { name: "Johnny 5" } }

--- a/spec/factories/registration_request_factory.rb
+++ b/spec/factories/registration_request_factory.rb
@@ -90,7 +90,7 @@ FactoryBot.define do
 
     requests do
       user_ids.map do |user_id|
-        FactoryBot.build(:update_request, user_id: user_id, competing: { 'status' => 'deleted' })
+        FactoryBot.build(:update_request, user_id: user_id, competing: { 'status' => 'cancelled' })
       end
     end
 

--- a/spec/factories/registration_request_factory.rb
+++ b/spec/factories/registration_request_factory.rb
@@ -12,13 +12,13 @@ FactoryBot.define do
     user_id { nil }
     submitted_by { user_id }
     competition_id { nil }
-    competing { { 'event_ids' => events, 'lane_state' => 'pending' } }
+    competing { { 'event_ids' => events, 'competing_status' => 'pending' } }
 
     jwt_token { fetch_jwt_token(submitted_by) }
     guests { 0 }
 
     trait :comment do
-      competing { { 'event_ids' => events, 'comment' => raw_comment, 'lane_state' => 'pending' } }
+      competing { { 'event_ids' => events, 'comment' => raw_comment, 'competing_status' => 'pending' } }
     end
 
     trait :impersonation do

--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -33,14 +33,6 @@ FactoryBot.define do
       accepted_at { nil }
     end
 
-    trait :waiting_list do
-      waitlisted_at { Time.now }
-    end
-
-    trait :rejected do
-      rejected_at { Time.now }
-    end
-
     trait :newcomer do
       association :user, factory: [:user]
     end

--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -15,6 +15,8 @@ FactoryBot.define do
     end
     competition_events { competition.competition_events.where(event: events) }
 
+    competing_status { "pending" }
+
     trait :skip_validations do
       to_create { |instance| instance.save(validate: false) }
     end

--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -17,7 +17,6 @@ FactoryBot.define do
 
     competing_status { Registrations::Helper::STATUS_PENDING }
 
-
     trait :skip_validations do
       to_create { |instance| instance.save(validate: false) }
     end

--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
 
     competing_status { Registrations::Helper::STATUS_PENDING }
 
+
     trait :skip_validations do
       to_create { |instance| instance.save(validate: false) }
     end
@@ -24,11 +25,6 @@ FactoryBot.define do
     trait :accepted do
       accepted_at { Time.now }
       competing_status { Registrations::Helper::STATUS_ACCEPTED }
-    end
-
-    trait :deleted do
-      deleted_at { Time.now }
-      competing_status { Registrations::Helper::STATUS_DELETED }
     end
 
     trait :cancelled do

--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     end
     competition_events { competition.competition_events.where(event: events) }
 
-    competing_status { "pending" }
+    competing_status { Registrations::Helper::STATUS_PENDING }
 
     trait :skip_validations do
       to_create { |instance| instance.save(validate: false) }
@@ -23,18 +23,27 @@ FactoryBot.define do
 
     trait :accepted do
       accepted_at { Time.now }
+      competing_status { Registrations::Helper::STATUS_ACCEPTED }
     end
 
     trait :deleted do
       deleted_at { Time.now }
+      competing_status { Registrations::Helper::STATUS_DELETED }
     end
 
     trait :cancelled do
       deleted_at { Time.now }
+      competing_status { Registrations::Helper::STATUS_CANCELLED }
     end
 
     trait :pending do
       accepted_at { nil }
+      competing_status { Registrations::Helper::STATUS_PENDING }
+    end
+
+    trait :waiting_list do
+      accepted_at { nil }
+      competing_status { Registrations::Helper::STATUS_WAITING_LIST }
     end
 
     trait :newcomer do
@@ -57,6 +66,10 @@ FactoryBot.define do
     trait :paid_pending do
       accepted_at { nil }
       paid
+    end
+
+    after(:create) do |registration|
+      registration.competition.waiting_list.add(registration.id) if registration.competing_status == Registrations::Helper::STATUS_WAITING_LIST
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -254,7 +254,7 @@ FactoryBot.define do
     trait :with_deleted_registration_in_future_comps do
       after(:create) do |user|
         competition = FactoryBot.create(:competition, :future)
-        FactoryBot.create(:registration, :deleted, user: user, competition: competition, events: %w(333))
+        FactoryBot.create(:registration, :cancelled, user: user, competition: competition, events: %w(333))
       end
     end
 

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1354,7 +1354,7 @@ RSpec.describe Registrations::RegistrationChecker do
           :update_request,
           user_id: default_registration.user_id,
           competition_id: default_registration.competition.id,
-          competing: { 'status' => 'deleted' },
+          competing: { 'status' => 'cancelled' },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, Competition.find(update_request['competition_id']), User.find(update_request['submitted_by'])) }
@@ -1366,7 +1366,7 @@ RSpec.describe Registrations::RegistrationChecker do
           :update_request,
           user_id: default_registration.user_id,
           competition_id: default_registration.competition.id,
-          competing: { 'status' => 'deleted', 'event_ids' => ['333'] },
+          competing: { 'status' => 'cancelled', 'event_ids' => ['333'] },
         )
 
         expect {
@@ -1401,7 +1401,7 @@ RSpec.describe Registrations::RegistrationChecker do
           :update_request,
           user_id: accepted_reg.user_id,
           competition_id: accepted_reg.competition.id,
-          competing: { 'status' => 'deleted' },
+          competing: { 'status' => 'cancelled' },
         )
 
         expect {
@@ -1422,7 +1422,7 @@ RSpec.describe Registrations::RegistrationChecker do
           :update_request,
           user_id: not_accepted_reg.user_id,
           competition_id: not_accepted_reg.competition.id,
-          competing: { 'status' => 'deleted' },
+          competing: { 'status' => 'cancelled' },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, Competition.find(update_request['competition_id']), User.find(update_request['submitted_by'])) }
@@ -1439,7 +1439,7 @@ RSpec.describe Registrations::RegistrationChecker do
           :update_request,
           user_id: registration.user_id,
           competition_id: registration.competition.id,
-          competing: { 'status' => 'deleted' },
+          competing: { 'status' => 'cancelled' },
         )
 
         expect {
@@ -1461,7 +1461,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: registration.user_id,
           competition_id: registration.competition.id,
           submitted_by: editing_over.organizers.first.id,
-          competing: { 'status' => 'deleted' },
+          competing: { 'status' => 'cancelled' },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, Competition.find(update_request['competition_id']), User.find(update_request['submitted_by'])) }
@@ -1501,9 +1501,9 @@ RSpec.describe Registrations::RegistrationChecker do
         { initial_status: :accepted, new_status: 'waiting_list' },
         { initial_status: :accepted, new_status: 'accepted' },
         { initial_status: :accepted, new_status: 'rejected' },
-        { initial_status: :deleted, new_status: 'accepted' },
-        { initial_status: :deleted, new_status: 'waiting_list' },
-        { initial_status: :deleted, new_status: 'rejected' },
+        { initial_status: :cancelled, new_status: 'accepted' },
+        { initial_status: :cancelled, new_status: 'waiting_list' },
+        { initial_status: :cancelled, new_status: 'rejected' },
       ].each do |params|
         it_behaves_like 'invalid user status updates', params[:initial_status], params[:new_status]
       end
@@ -1529,7 +1529,7 @@ RSpec.describe Registrations::RegistrationChecker do
       end
 
       [
-        { initial_status: :rejected, new_status: 'deleted' },
+        { initial_status: :rejected, new_status: 'cancelled' },
         { initial_status: :rejected, new_status: 'accepted' },
         { initial_status: :rejected, new_status: 'waiting_list' },
         { initial_status: :rejected, new_status: 'pending' },
@@ -1589,28 +1589,28 @@ RSpec.describe Registrations::RegistrationChecker do
       [
         { initial_status: :pending, new_status: 'accepted' },
         { initial_status: :pending, new_status: 'waiting_list' },
-        { initial_status: :pending, new_status: 'deleted' },
+        { initial_status: :pending, new_status: 'cancelled' },
         { initial_status: :pending, new_status: 'pending' },
         { initial_status: :pending, new_status: 'rejected' },
         { initial_status: :waiting_list, new_status: 'pending' },
-        { initial_status: :waiting_list, new_status: 'deleted' },
+        { initial_status: :waiting_list, new_status: 'cancelled' },
         { initial_status: :waiting_list, new_status: 'waiting_list' },
         { initial_status: :waiting_list, new_status: 'accepted' },
         { initial_status: :waiting_list, new_status: 'rejected' },
         { initial_status: :accepted, new_status: 'pending' },
-        { initial_status: :accepted, new_status: 'deleted' },
+        { initial_status: :accepted, new_status: 'cancelled' },
         { initial_status: :accepted, new_status: 'waiting_list' },
         { initial_status: :accepted, new_status: 'accepted' },
         { initial_status: :accepted, new_status: 'rejected' },
-        { initial_status: :deleted, new_status: 'accepted' },
-        { initial_status: :deleted, new_status: 'pending' },
-        { initial_status: :deleted, new_status: 'waiting_list' },
-        { initial_status: :deleted, new_status: 'rejected' },
-        { initial_status: :deleted, new_status: 'deleted' },
+        { initial_status: :cancelled, new_status: 'accepted' },
+        { initial_status: :cancelled, new_status: 'pending' },
+        { initial_status: :cancelled, new_status: 'waiting_list' },
+        { initial_status: :cancelled, new_status: 'rejected' },
+        { initial_status: :cancelled, new_status: 'cancelled' },
         { initial_status: :rejected, new_status: 'accepted' },
         { initial_status: :rejected, new_status: 'pending' },
         { initial_status: :rejected, new_status: 'waiting_list' },
-        { initial_status: :rejected, new_status: 'deleted' },
+        { initial_status: :rejected, new_status: 'cancelled' },
       ].each do |params|
         it_behaves_like 'valid organizer status updates', params[:initial_status], params[:new_status]
       end

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1510,7 +1510,7 @@ RSpec.describe Registrations::RegistrationChecker do
 
       RSpec.shared_examples 'user cant update rejected registration' do |initial_status, new_status|
         it "user cant change 'status' => #{initial_status} to: #{new_status}" do
-          registration = FactoryBot.create(:registration, initial_status, competition: default_competition)
+          registration = FactoryBot.create(:registration, competing_status: initial_status.to_s, competition: default_competition)
 
           update_request = FactoryBot.build(
             :update_request,
@@ -1539,7 +1539,7 @@ RSpec.describe Registrations::RegistrationChecker do
 
       RSpec.shared_examples 'valid organizer status updates' do |initial_status, new_status|
         it "organizer can change 'status' => #{initial_status} to: #{new_status} before close" do
-          registration = FactoryBot.create(:registration, initial_status, competition: default_competition)
+          registration = FactoryBot.create(:registration, competing_status: initial_status.to_s, competition: default_competition)
 
           update_request = FactoryBot.build(
             :update_request,

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe Registrations::RegistrationChecker do
       end
 
       it 'can register if they have a cancelled registration for another series comp' do
-        registration = FactoryBot.create(:registration, :deleted) # TODO: We need to bring in the new registration statuses
+        registration = FactoryBot.create(:registration, :cancelled) # TODO: We need to bring in the new registration statuses
 
         series = FactoryBot.create(:competition_series)
         competitionA = registration.competition
@@ -1378,7 +1378,7 @@ RSpec.describe Registrations::RegistrationChecker do
       end
 
       it 'user can change state from cancelled to pending' do
-        deleted_reg = FactoryBot.create(:registration, :deleted, competition: default_competition)
+        deleted_reg = FactoryBot.create(:registration, :cancelled, competition: default_competition)
 
         update_request = FactoryBot.build(
           :update_request,
@@ -2225,7 +2225,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
       }
 
-      let(:registrationB) { FactoryBot.create(:registration, :deleted, competition: competitionB, user_id: registrationA.user.id) }
+      let(:registrationB) { FactoryBot.create(:registration, :cancelled, competition: competitionB, user_id: registrationA.user.id) }
 
       before do
         competitionA.update!(competition_series: series)

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -415,26 +415,10 @@ RSpec.describe Registration do
         { initial_status: Registrations::Helper::STATUS_REJECTED, input_status: Registrations::Helper::STATUS_WAITING_LIST },
         { initial_status: Registrations::Helper::STATUS_REJECTED, input_status: Registrations::Helper::STATUS_ACCEPTED },
         { initial_status: Registrations::Helper::STATUS_REJECTED, input_status: Registrations::Helper::STATUS_REJECTED },
-        { initial_status: 'deleted', input_status: Registrations::Helper::STATUS_ACCEPTED },
-        { initial_status: 'deleted', input_status: Registrations::Helper::STATUS_CANCELLED },
-        { initial_status: 'deleted', input_status: Registrations::Helper::STATUS_WAITING_LIST },
-        { initial_status: 'deleted', input_status: Registrations::Helper::STATUS_PENDING },
-        { initial_status: 'deleted', input_status: Registrations::Helper::STATUS_REJECTED },
-      ]
-
-      # TODO: 1. Do we want to have backwards compatibility with 'deleted' status?
-      # 2. If yes, do we want to only support the string, or keep it defined as a constant?
-      deleted_competing_status_updates = [
-        { initial_status: Registrations::Helper::STATUS_PENDING, input_status: 'deleted' },
-        { initial_status: Registrations::Helper::STATUS_ACCEPTED, input_status: 'deleted' },
-        { initial_status: Registrations::Helper::STATUS_WAITING_LIST, input_status: 'deleted' },
-        { initial_status: Registrations::Helper::STATUS_CANCELLED, input_status: 'deleted' },
-        { initial_status: Registrations::Helper::STATUS_REJECTED, input_status: 'deleted' },
-        { initial_status: 'deleted', input_status: 'deleted' },
       ]
 
       it 'tests cover all possible status update combinations' do
-        combined_updates = (competing_status_updates << deleted_competing_status_updates).flatten
+        combined_updates = (competing_status_updates).flatten
         expect(combined_updates).to match_array(REGISTRATION_TRANSITIONS)
       end
 
@@ -457,10 +441,6 @@ RSpec.describe Registration do
 
       competing_status_updates.each do |params|
         it_behaves_like 'update competing status', params[:initial_status], params[:input_status]
-      end
-
-      deleted_competing_status_updates.each do |params|
-        it_behaves_like 'update competing status: deleted cases', params[:initial_status], params[:input_status]
       end
     end
 

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -479,38 +479,28 @@ RSpec.describe Registration do
       let(:competition) { FactoryBot.create(:competition, :registration_open, :editable_registrations, :with_organizer) }
       let(:waiting_list) { competition.waiting_list }
 
-      let(:reg1) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-      let(:reg2) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-      let(:reg3) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-      let(:reg4) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-      let(:reg5) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-
-      before do
-        # If we don't reload they don't show up on the waiting list
-        reg1.reload
-        reg2.reload
-        reg3.reload
-        reg4.reload
-        reg5.reload
-      end
+      let!(:reg1) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+      let!(:reg2) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+      let!(:reg3) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+      let!(:reg4) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+      let!(:reg5) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
 
       it 'adds to waiting list' do
         reg = FactoryBot.create(:registration, competition: competition)
         reg.update_lanes!({ user_id: reg.user.id, competing: { status: 'waiting_list' } }.with_indifferent_access, reg.user)
-        reg.reload
+
         expect(reg.waiting_list_position).to eq(6)
       end
 
       it 'removes from waiting list' do
         reg4.update_lanes!({ user_id: reg4.user.id, competing: { status: 'pending' } }.with_indifferent_access, reg4.user)
-        reg4.reload
+
         expect(reg4.waiting_list_position).to eq(nil)
-        expect(waiting_list.reload.entries.count).to eq(4)
+        expect(waiting_list.entries.count).to eq(4)
       end
 
       it 'moves backwards in waiting list' do
         reg2.update_lanes!({ user_id: reg2.user.id, competing: { waiting_list_position: 5 } }.with_indifferent_access, reg2.user)
-        reg2.reload
 
         expect(reg1.waiting_list_position).to eq(1)
         expect(reg2.waiting_list_position).to eq(5)
@@ -523,7 +513,6 @@ RSpec.describe Registration do
 
       it 'moves forwards in waiting list' do
         reg5.update_lanes!({ user_id: reg5.user.id, competing: { waiting_list_position: 1 } }.with_indifferent_access, reg5.user)
-        reg5.reload
 
         expect(reg1.waiting_list_position).to eq(2)
         expect(reg2.waiting_list_position).to eq(3)

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -486,11 +486,12 @@ RSpec.describe Registration do
       let(:reg5) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
 
       before do
-        waiting_list.add(reg1.id)
-        waiting_list.add(reg2.id)
-        waiting_list.add(reg3.id)
-        waiting_list.add(reg4.id)
-        waiting_list.add(reg5.id)
+        # If we don't reload they don't show up on the waiting list
+        reg1.reload
+        reg2.reload
+        reg3.reload
+        reg4.reload
+        reg5.reload
       end
 
       it 'adds to waiting list' do
@@ -504,7 +505,7 @@ RSpec.describe Registration do
         reg4.update_lanes!({ user_id: reg4.user.id, competing: { status: 'pending' } }.with_indifferent_access, reg4.user)
         reg4.reload
         expect(reg4.waiting_list_position).to eq(nil)
-        expect(waiting_list.entries.count).to eq(4)
+        expect(waiting_list.reload.entries.count).to eq(4)
       end
 
       it 'moves backwards in waiting list' do

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe Registration do
 
   describe '#to_wcif' do
     it 'deleted state returns deleted status' do
-      registration = FactoryBot.create(:registration, :deleted)
+      registration = FactoryBot.create(:registration, :cancelled)
 
       expect(registration.deleted?).to eq(true)
       expect(registration.to_wcif['status']).to eq('deleted')

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe WaitingList do
   let(:competition) { FactoryBot.create(:competition, :registration_open, :editable_registrations, :with_organizer) }
   let(:waiting_list) { competition.waiting_list }
 
+
+  it 'position is nil when registration not on waiting list' do
+    registration = FactoryBot.create(:registration)
+    expect(registration.waiting_list_position).to eq(nil)
+  end
+
   describe 'add to waiting list' do
     it 'first competitor in the waiting list gets set to position 1' do
       registration = FactoryBot.create(:registration, :waiting_list, competition: competition)
@@ -60,6 +66,7 @@ RSpec.describe WaitingList do
       expect(reg3.waiting_list_position).to eq(2)
       expect(reg4.waiting_list_position).to eq(3)
       expect(reg5.waiting_list_position).to eq(5)
+      byebug
     end
 
     it 'can be moved to the last position in the list' do

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -14,14 +14,12 @@ RSpec.describe WaitingList do
   describe 'add to waiting list' do
     it 'first competitor in the waiting list gets set to position 1' do
       registration = FactoryBot.create(:registration, :waiting_list, competition: competition)
-      waiting_list.add(registration.id)
       expect(competition.waiting_list.entries[0]).to eq(registration.id)
     end
 
     it 'second competitor gets set to position 2' do
-      waiting_list.add(FactoryBot.create(:registration, :waiting_list, competition: competition).id)
+      FactoryBot.create(:registration, :waiting_list, competition: competition).id
       registration = FactoryBot.create(:registration, :waiting_list, competition: competition)
-      waiting_list.add(registration.id)
       expect(competition.waiting_list.entries[1]).to eq(registration.id)
     end
   end
@@ -34,16 +32,16 @@ RSpec.describe WaitingList do
     let(:reg5) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
 
     before do
-      waiting_list.add(reg1.id)
-      waiting_list.add(reg2.id)
-      waiting_list.add(reg3.id)
-      waiting_list.add(reg4.id)
-      waiting_list.add(reg5.id)
+      # If we don't reload the registrations, they don't show up on the waiting list until they're accessed
+      reg1.reload
+      reg2.reload
+      reg3.reload
+      reg4.reload
+      reg5.reload
     end
 
     it 'waiting list position gives position, not index' do
       registration = FactoryBot.create(:registration, :waiting_list, competition: competition)
-      waiting_list.add(registration.id)
       expect(registration.waiting_list_position).to eq(6)
     end
 

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -25,20 +25,11 @@ RSpec.describe WaitingList do
   end
 
   describe 'with populated waiting list' do
-    let(:reg1) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-    let(:reg2) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-    let(:reg3) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-    let(:reg4) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-    let(:reg5) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
-
-    before do
-      # If we don't reload the registrations, they don't show up on the waiting list until they're accessed
-      reg1.reload
-      reg2.reload
-      reg3.reload
-      reg4.reload
-      reg5.reload
-    end
+    let!(:reg1) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+    let!(:reg2) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+    let!(:reg3) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+    let!(:reg4) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
+    let!(:reg5) { FactoryBot.create(:registration, :waiting_list, competition: competition) }
 
     it 'waiting list position gives position, not index' do
       registration = FactoryBot.create(:registration, :waiting_list, competition: competition)

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe WaitingList do
   let(:competition) { FactoryBot.create(:competition, :registration_open, :editable_registrations, :with_organizer) }
   let(:waiting_list) { competition.waiting_list }
 
-
   it 'position is nil when registration not on waiting list' do
     registration = FactoryBot.create(:registration)
     expect(registration.waiting_list_position).to eq(nil)
@@ -66,7 +65,6 @@ RSpec.describe WaitingList do
       expect(reg3.waiting_list_position).to eq(2)
       expect(reg4.waiting_list_position).to eq(3)
       expect(reg5.waiting_list_position).to eq(5)
-      byebug
     end
 
     it 'can be moved to the last position in the list' do

--- a/spec/requests/api_competitions_spec.rb
+++ b/spec/requests/api_competitions_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "API Competitions" do
       end
 
       it "returns people with all registrations statues" do
-        FactoryBot.create(:registration, :deleted, competition: competition)
+        FactoryBot.create(:registration, :cancelled, competition: competition)
         FactoryBot.create(:registration, :pending, competition: competition)
         get api_v0_competition_wcif_path(competition)
         response_json = JSON.parse(response.body)
@@ -150,7 +150,7 @@ RSpec.describe "API Competitions" do
     end
 
     it "returns people with accepted registrations only" do
-      FactoryBot.create(:registration, :deleted, competition: competition)
+      FactoryBot.create(:registration, :cancelled, competition: competition)
       FactoryBot.create(:registration, :pending, competition: competition)
       get api_v0_competition_wcif_public_path(competition)
       response_json = JSON.parse(response.body)

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'API Registrations' do
         :update_request,
         user_id: registration.user_id,
         competition_id: registration.competition.id,
-        competing: { 'status' => 'deleted' },
+        competing: { 'status' => 'cancelled' },
         guests: 3,
       )
       headers = { 'Authorization' => update_request['jwt_token'] }
@@ -122,12 +122,12 @@ RSpec.describe 'API Registrations' do
       registration = Registration.find_by(user_id: user.id)
 
       expect(registration.guests).to eq(3)
-      expect(registration.competing_status).to eq('deleted')
+      expect(registration.competing_status).to eq('cancelled')
 
       history = registration.registration_history
       expect(history.length).to eq(1)
       expect(history.first[:changed_attributes]['guests']).to eq('3')
-      expect(history.first[:changed_attributes]['deleted_at']).to be_present
+      expect(history.first[:changed_attributes]['competing_status']).to be_present
       expect(history.first[:action]).to eq('Competitor delete')
     end
   end
@@ -158,11 +158,11 @@ RSpec.describe 'API Registrations' do
 
       registration = Registration.find_by(user_id: user1.id)
 
-      expect(registration.competing_status).to eq('deleted')
+      expect(registration.competing_status).to eq('cancelled')
 
       history = registration.registration_history
       expect(history.length).to eq(1)
-      expect(history.first[:changed_attributes]['deleted_at']).to be_present
+      expect(history.first[:changed_attributes]['competing_status']).to be_present
       expect(history.first[:action]).to eq('Admin delete')
     end
 
@@ -171,7 +171,7 @@ RSpec.describe 'API Registrations' do
         :update_request,
         user_id: registration1.user_id,
         competition_id: registration1.competition.id,
-        competing: { 'status' => 'deleted' },
+        competing: { 'status' => 'cancelled' },
       )
 
       update_request2 = FactoryBot.build(
@@ -204,7 +204,7 @@ RSpec.describe 'API Registrations' do
       body = JSON.parse(response.body)
       expect(body['updated_registrations'].count).to eq(3)
 
-      expect(Registration.find_by(user_id: update_request1['user_id']).competing_status).to eq('deleted')
+      expect(Registration.find_by(user_id: update_request1['user_id']).competing_status).to eq('cancelled')
       expect(Registration.find_by(user_id: update_request2['user_id']).guests).to eq(3)
       expect(Registration.find_by(user_id: update_request3['user_id']).events.pluck(:id)).to eq(['333', '444'])
     end
@@ -214,7 +214,7 @@ RSpec.describe 'API Registrations' do
         :update_request,
         user_id: registration1.user_id,
         competition_id: registration1.competition.id,
-        competing: { 'status' => 'deleted' },
+        competing: { 'status' => 'cancelled' },
       )
 
       update_request2 = FactoryBot.build(
@@ -320,12 +320,12 @@ RSpec.describe 'API Registrations' do
     let(:user5) { FactoryBot.create :user }
     let(:user6) { FactoryBot.create :user }
 
-    let!(:registration1) { FactoryBot.create(:registration, :accepted, competition: competition, user: user1) }
-    let!(:registration2) { FactoryBot.create(:registration, :accepted, competition: competition, user: user2) }
-    let!(:registration3) { FactoryBot.create(:registration, :accepted, competition: competition, user: user3) }
-    let!(:registration4) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user4) }
-    let!(:registration5) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user5) }
-    let!(:registration6) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user6) }
+    let!(:registration1) { FactoryBot.create(:registration, competing_status: 'accepted', competition: competition, user: user1) }
+    let!(:registration2) { FactoryBot.create(:registration, competing_status: 'accepted', competition: competition, user: user2) }
+    let!(:registration3) { FactoryBot.create(:registration, competing_status: 'accepted', competition: competition, user: user3) }
+    let!(:registration4) { FactoryBot.create(:registration, competing_status: 'waiting_list', competition: competition, user: user4) }
+    let!(:registration5) { FactoryBot.create(:registration, competing_status: 'waiting_list', competition: competition, user: user5) }
+    let!(:registration6) { FactoryBot.create(:registration, competing_status: 'waiting_list', competition: competition, user: user6) }
 
     before do
       FactoryBot.create(:waiting_list, holder: competition)

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -151,12 +151,14 @@ RSpec.describe 'API Registrations' do
         competition_id: competition.id,
       )
 
+      puts "registration status: #{registration1.competing_status}"
+
       headers = { 'Authorization' => bulk_update_request['jwt_token'] }
       patch api_v1_registrations_bulk_update_path, params: bulk_update_request, headers: headers
 
       expect(response.status).to eq(200)
 
-      registration = Registration.find_by(user_id: user1.id)
+      registration = Registration.find_by(user_id: registration1.user_id)
 
       expect(registration.competing_status).to eq('cancelled')
 

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -320,12 +320,12 @@ RSpec.describe 'API Registrations' do
     let(:user5) { FactoryBot.create :user }
     let(:user6) { FactoryBot.create :user }
 
-    let!(:registration1) { FactoryBot.create(:registration, competing_status: 'accepted', competition: competition, user: user1) }
-    let!(:registration2) { FactoryBot.create(:registration, competing_status: 'accepted', competition: competition, user: user2) }
-    let!(:registration3) { FactoryBot.create(:registration, competing_status: 'accepted', competition: competition, user: user3) }
-    let!(:registration4) { FactoryBot.create(:registration, competing_status: 'waiting_list', competition: competition, user: user4) }
-    let!(:registration5) { FactoryBot.create(:registration, competing_status: 'waiting_list', competition: competition, user: user5) }
-    let!(:registration6) { FactoryBot.create(:registration, competing_status: 'waiting_list', competition: competition, user: user6) }
+    let!(:registration1) { FactoryBot.create(:registration, :accepted, competition: competition, user: user1) }
+    let!(:registration2) { FactoryBot.create(:registration, :accepted, competition: competition, user: user2) }
+    let!(:registration3) { FactoryBot.create(:registration, :accepted, competition: competition, user: user3) }
+    let!(:registration4) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user4) }
+    let!(:registration5) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user5) }
+    let!(:registration6) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user6) }
 
     before do
       FactoryBot.create(:waiting_list, holder: competition)

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -327,13 +327,6 @@ RSpec.describe 'API Registrations' do
     let!(:registration5) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user5) }
     let!(:registration6) { FactoryBot.create(:registration, :waiting_list, competition: competition, user: user6) }
 
-    before do
-      FactoryBot.create(:waiting_list, holder: competition)
-      competition.waiting_list.add(registration4.user_id)
-      competition.waiting_list.add(registration5.user_id)
-      competition.waiting_list.add(registration6.user_id)
-    end
-
     it 'returns multiple registrations' do
       headers = { 'Authorization' => fetch_jwt_token(competition.organizers.first.id) }
       get api_v1_registrations_list_admin_path(competition_id: competition.id), headers: headers

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe "registrations" do
 
         context "CSV registrant already in the database, but deleted" do
           it "acceptes the registration again" do
-            registration = FactoryBot.create(:registration, :deleted, competition: competition)
+            registration = FactoryBot.create(:registration, :cancelled, competition: competition)
             user = registration.user
             file = csv_file [
               ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
@@ -387,7 +387,7 @@ RSpec.describe "registrations" do
 
         context "registrant deleted in the database, but not in the CSV file" do
           it "leaves the registration unchanged" do
-            registration = FactoryBot.create(:registration, :deleted, competition: competition)
+            registration = FactoryBot.create(:registration, :cancelled, competition: competition)
             file = csv_file [
               ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
             ]


### PR DESCRIPTION
This just adds the column and does nothing with it as this would generate a lot of conflicts with #10127 . So either we merge this first and then change it in  #10127 or we merge  #10127 and then I do the changes here