### PR TITLE
Configure sidekiq-cron in its own file

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -36,3 +36,4 @@ STAGING_OAUTH_SECRET=example-secret
 AVATARS_PUBLIC_STORAGE=local
 AVATARS_PRIVATE_STORAGE=local_private
 DUMP_HOST=https://assets.worldcubeassociation.org
+CRONJOB_POLLING_SECONDS=0

--- a/config/initializers/sidekiq_cron.rb
+++ b/config/initializers/sidekiq_cron.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Sidekiq::Cron.configure do |config|
+  config.cron_poll_interval = EnvConfig.CRONJOB_POLLING_SECONDS
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,6 +6,3 @@
 development:
   :concurrency: 5
   :verbose: true
-  # We cannot use EnvConfig here because the Sidekiq server is booted outside of the Rails pipeline.
-  # Setting the value to zero (as a default) *disables* cronjobs entirely as per sidekiq-cron documentation.
-  :cron_poll_interval: <%= ENV.fetch('CRONJOB_POLLING_SECONDS', 0) %>

--- a/env_config.rb
+++ b/env_config.rb
@@ -102,6 +102,10 @@ EnvConfig = SuperConfig.new(raise_exception: !is_compiling_assets) do
 
   # For API Only Server
   optional :API_ONLY, :bool, false
+
+  # For cronjob fine-tuning. Default value is recommended by sidekiq-cron.
+  # Setting this value to 0 disables cron jobs altogether (for example, very useful to have on local)
+  optional :CRONJOB_POLLING_SECONDS, :int, 30
 end
 
 # Require Asset Specific ENV variables


### PR DESCRIPTION
Was not explicitly mentioned in the `CHANGELOG.md` of sidekiq-cron when we migrated to RCv2: https://github.com/thewca/worldcubeassociation.org/pull/10163