### PR TITLE
Give V3 Workers more juice

### DIFF
--- a/infra/wca_on_rails/production/worker.tf
+++ b/infra/wca_on_rails/production/worker.tf
@@ -59,7 +59,7 @@ resource "aws_ecs_service" "worker" {
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
   task_definition                    = data.aws_ecs_task_definition.worker.arn
-  desired_count                      = 0
+  desired_count                      = 1
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50

--- a/infra/wca_on_rails/production/worker.tf
+++ b/infra/wca_on_rails/production/worker.tf
@@ -13,16 +13,16 @@ resource "aws_ecs_task_definition" "worker" {
   execution_role_arn = aws_iam_role.task_execution_role.arn
   task_role_arn      = aws_iam_role.task_role.arn
 
-  cpu = "256"
-  memory = "256"
+  cpu = "1024"
+  memory = "3911"
 
   container_definitions = jsonencode([
 
     {
       name              = "sqs-worker-staging"
       image             = "${var.shared.ecr_repository.repository_url}:production-sqs-worker"
-      cpu    = 256
-      memory = 256
+      cpu    = 1024
+      memory = 3911
       portMappings = []
       logConfiguration = {
         logDriver = "awslogs"
@@ -34,7 +34,7 @@ resource "aws_ecs_task_definition" "worker" {
       }
       environment = local.rails_environment
       healthCheck       = {
-        command            = ["CMD-SHELL", "pgrep ruby || exit 1"]
+        command            = ["CMD-SHELL", "pgrep bundle || exit 1"]
         interval           = 30
         retries            = 3
         startPeriod        = 60
@@ -58,7 +58,7 @@ resource "aws_ecs_service" "worker" {
   # During deployment a new task revision is created with modified
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
-  task_definition                    = data.aws_ecs_task_definition.auxiliary.arn
+  task_definition                    = data.aws_ecs_task_definition.worker.arn
   desired_count                      = 0
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200

--- a/infra/wca_on_rails/staging/worker.tf
+++ b/infra/wca_on_rails/staging/worker.tf
@@ -59,7 +59,7 @@ resource "aws_ecs_service" "worker" {
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
   task_definition                    = data.aws_ecs_task_definition.worker.arn
-  desired_count                      = 0
+  desired_count                      = 1
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50

--- a/infra/wca_on_rails/staging/worker.tf
+++ b/infra/wca_on_rails/staging/worker.tf
@@ -13,16 +13,16 @@ resource "aws_ecs_task_definition" "worker" {
   execution_role_arn = aws_iam_role.task_execution_role.arn
   task_role_arn      = aws_iam_role.task_role.arn
 
-  cpu = "256"
-  memory = "256"
+  cpu = "1024"
+  memory = "3911"
 
   container_definitions = jsonencode([
 
     {
       name              = "sqs-worker-staging"
       image             = "${var.shared.ecr_repository.repository_url}:staging-sqs-worker"
-      cpu    = 256
-      memory = 256
+      cpu    = 1024
+      memory = 3911
       portMappings = []
       logConfiguration = {
         logDriver = "awslogs"
@@ -34,7 +34,7 @@ resource "aws_ecs_task_definition" "worker" {
       }
       environment = local.rails_environment
       healthCheck       = {
-        command            = ["CMD-SHELL", "pgrep ruby || exit 1"]
+        command            = ["CMD-SHELL", "pgrep bundle || exit 1"]
         interval           = 30
         retries            = 3
         startPeriod        = 60
@@ -58,8 +58,8 @@ resource "aws_ecs_service" "worker" {
   # During deployment a new task revision is created with modified
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
-  task_definition                    = data.aws_ecs_task_definition.auxiliary.arn
-  desired_count                      = 1
+  task_definition                    = data.aws_ecs_task_definition.worker.arn
+  desired_count                      = 0
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50


### PR DESCRIPTION
I set a weird RAM value (3.8GB) because we have a couple instances that have that amount left on them so we can use it without any extra cost