### PR TITLE
Replace manual stringified query parts by Rails ORM

### DIFF
--- a/app/controllers/wfc_controller.rb
+++ b/app/controllers/wfc_controller.rb
@@ -19,10 +19,10 @@ class WfcController < ApplicationController
     response.headers["Content-Disposition"] = "attachment; filename=\"wfc-competitions-export-#{from}-#{to}.tsv\""
     @competitions = Competition
                     .select(select_attributes)
-                    .includes(:delegates, :championships, :organizers, :events)
+                    .includes(:delegates, :championships, :organizers, :events, organizers: [:wfc_dues_redirect])
                     .left_joins(:competitors)
-                    .group("Competitions.id")
-                    .where("results_posted_at >= ? and results_posted_at <= ?", from, to)
+                    .group(:id)
+                    .where(results_posted_at: from..to)
                     .order(:results_posted_at, :name)
   end
 end

--- a/spec/controllers/wfc_controller_spec.rb
+++ b/spec/controllers/wfc_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WfcController do
+  let(:competitions) { FactoryBot.create_list(:competition, 3) }
+
+  context "logged in as WFC member" do
+    let!(:wfc_member) { FactoryBot.create :user, :wfc_member }
+    before :each do
+      sign_in wfc_member
+    end
+
+    it "renders a valid export CSV" do
+      start_date = competitions.min_by(&:start_date).start_date
+      end_date = competitions.max_by(&:end_date).end_date
+
+      post :competition_export, params: { from_date: start_date, to_date: end_date }, as: :csv
+
+      expect(response).to be_successful
+      expect(response.headers["Content-Type"]).to eq "text/csv; charset=utf-8"
+    end
+  end
+end


### PR DESCRIPTION
Hotfix because WFC currently cannot download Dues exports.

The stack trace is very cryptic: `ActionView::Template::Error (undefined method `instantiate' for nil)`

During my investigation, I found out by trial and error that the problem goes away when removing certain parts of the query that fetches competitions from the DB in the controller. Upon closer inspection, it was exactly those parts that contained manual, stringified statements.

Rails 7.2.2 must have done something :tm: to these styles of (admittedly old) queries without properly communicating it.

The "new" version is functionally exactly identical to the existing one, except that it lets the ORM fully handle gluing the raw SQL together. Instead of `posted_at  >= ? AND posted_at <= ?` it now uses `posted_at BETWEEN ? AND ?` under the hood, which is semantically identical (`BETWEEN` is inclusive in MySQL)