### PR TITLE
Added mapping for cancelled status in v2

### DIFF
--- a/app/models/microservice_registration.rb
+++ b/app/models/microservice_registration.rb
@@ -107,7 +107,9 @@ class MicroserviceRegistration < ApplicationRecord
   end
 
   def deleted?
-    self.status == Registrations::Helper::STATUS_DELETED || self.status == Registrations::Helper::STATUS_REJECTED
+    self.status == Registrations::Helper::STATUS_DELETED ||
+      self.status == Registrations::Helper::STATUS_REJECTED ||
+      self.status == Registrations::Helper::STATUS_CANCELLED
   end
 
   def pending?


### PR DESCRIPTION
This fixes an issue in production where `cancelled` statuses from v2 aren't mapped to `deleted` in wcif