### PR TITLE
Mount apt-relevant folders in Docker Compose

### DIFF
--- a/bundle-install.dev.sh
+++ b/bundle-install.dev.sh
@@ -25,10 +25,3 @@ fi
 
 # Symlink the versioned directory to a common 'current' path
 ln -sfn "$BUNDLE_PATH" "$CURRENT_SYMLINK"
-BUNDLE_PATH="$CURRENT_SYMLINK"
-
-# Set the BUNDLE_PATH to the symlink for all processes
-export BUNDLE_PATH
-
-# Run the main command (e.g., rails server or sidekiq)
-exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-app: &app
     - .:/app
     - gems_volume:/usr/local/bundle
     - node_modules_volume:/app/node_modules
-    - usr_volume:/usr
+    - apt_package_volume:/usr
   networks:
     - wca-main
 
@@ -150,7 +150,7 @@ volumes:
     driver: local
   cache_volume:
     driver: local
-  usr_volume:
+  apt_package_volume:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ x-app: &app
     - .:/app
     - gems_volume:/usr/local/bundle
     - node_modules_volume:/app/node_modules
+    - usr_volume:/usr
   networks:
     - wca-main
 
@@ -148,6 +149,8 @@ volumes:
   wca_db_volume:
     driver: local
   cache_volume:
+    driver: local
+  usr_volume:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ x-app: &app
     - gems_volume:/usr/local/bundle
     - node_modules_volume:/app/node_modules
     - apt_package_volume:/usr
+    - apt_cache_volume:/var/cache/apt
+    - dpkg_cache_volume:/var/lib/dpkg
   networks:
     - wca-main
 
@@ -151,6 +153,10 @@ volumes:
   cache_volume:
     driver: local
   apt_package_volume:
+    driver: local
+  apt_cache_volume:
+    driver: local
+  dpkg_cache_volume:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ x-app: &app
     dockerfile: Dockerfile.dev
     context: .
   working_dir: /app
-  entrypoint: ./entrypoint.dev.sh
   environment:
     <<: *env
   volumes:
@@ -32,7 +31,8 @@ services:
       <<: *env
       DISABLE_SPRING: 1
     command: >
-      bash -c './package-install.dev.sh packages.dev.txt &&
+      bash -c './bundle-install.dev.sh &&
+      ./package-install.dev.sh packages.dev.txt &&
       rm -f .db-inited &&
       bin/setup &&
       touch .db-inited'

--- a/package-install.dev.sh
+++ b/package-install.dev.sh
@@ -6,6 +6,7 @@ corepack install
 
 # Make sure all sources are up-to-date
 apt-get update -qq
+apt-get upgrade -y
 
 # Install the packages from a line-separated package list,
 #   making sure that one failure doesn't affect the other packages.


### PR DESCRIPTION
The packages themselves all live in `/usr`, but the information about which packages are installed live in separate directories.
In other words, if you only mount `/usr` as shared volume, the package contents will be there but the images don't know that they are there...