### PR TITLE
Use wca_status instead of Stripe's native status in payment_completion message

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -415,15 +415,14 @@ class RegistrationsController < ApplicationController
       #   this behavior differs and we overwrite created_at manually, see #stripe_webhook above.
     end
 
-    # Payment Intent lifecycle as per https://stripe.com/docs/payments/intents#intent-statuses
-    case stored_intent.payment_record.stripe_status
+    case stored_intent.wca_status
     when 'succeeded'
       flash[:success] = t("registrations.payment_form.payment_successful")
-    when 'requires_action'
+    when 'pending'
       # Customer did not complete the payment
       # For example, 3DSecure could still be pending.
       flash[:warning] = t("registrations.payment_form.errors.payment_pending")
-    when 'requires_payment_method'
+    when 'created'
       # Payment failed. If a payment fails, it is "reset" by Stripe,
       # so from our end it looks like it never even started (i.e. the customer didn't choose a payment method yet)
       flash[:error] = t("registrations.payment_form.errors.payment_reset")

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -415,19 +415,16 @@ class RegistrationsController < ApplicationController
       #   this behavior differs and we overwrite created_at manually, see #stripe_webhook above.
     end
 
+    # For details on what the individual statuses mean, please refer to the comments
+    #   of the `enum :wca_status` declared in the `payment_intent.rb` model
     case stored_intent.wca_status
     when 'succeeded'
       flash[:success] = t("registrations.payment_form.payment_successful")
     when 'pending'
-      # Customer did not complete the payment
-      # For example, 3DSecure could still be pending.
       flash[:warning] = t("registrations.payment_form.errors.payment_pending")
     when 'created'
-      # Payment failed. If a payment fails, it is "reset" by Stripe,
-      # so from our end it looks like it never even started (i.e. the customer didn't choose a payment method yet)
       flash[:error] = t("registrations.payment_form.errors.payment_reset")
     when 'processing'
-      # The payment can be pending, for example bank transfers can take multiple days to be fulfilled.
       flash[:warning] = t("registrations.payment_form.payment_processing")
     when 'partial'
       flash[:warning] = t("registrations.payment_form.payment_partial")

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -418,19 +418,19 @@ class RegistrationsController < ApplicationController
     # For details on what the individual statuses mean, please refer to the comments
     #   of the `enum :wca_status` declared in the `payment_intent.rb` model
     case stored_intent.wca_status
-    when 'succeeded'
+    when PaymentIntent.wca_statuses[:succeeded]
       flash[:success] = t("registrations.payment_form.payment_successful")
-    when 'pending'
+    when PaymentIntent.wca_statuses[:pending]
       flash[:warning] = t("registrations.payment_form.errors.payment_pending")
-    when 'created'
+    when PaymentIntent.wca_statuses[:created]
       flash[:error] = t("registrations.payment_form.errors.payment_reset")
-    when 'processing'
+    when PaymentIntent.wca_statuses[:processing]
       flash[:warning] = t("registrations.payment_form.payment_processing")
-    when 'partial'
+    when PaymentIntent.wca_statuses[:partial]
       flash[:warning] = t("registrations.payment_form.payment_partial")
-    when 'failed'
+    when PaymentIntent.wca_statuses[:failed]
       flash[:error] = t("registrations.payment_form.errors.payment_failed")
-    when 'canceled'
+    when PaymentIntent.wca_statuses[:canceled]
       flash[:error] = t("registrations.payment_form.errors.payment_canceled")
     else
       # Invalid status

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -429,6 +429,12 @@ class RegistrationsController < ApplicationController
     when 'processing'
       # The payment can be pending, for example bank transfers can take multiple days to be fulfilled.
       flash[:warning] = t("registrations.payment_form.payment_processing")
+    when 'partial'
+      flash[:warning] = t("registrations.payment_form.payment_partial")
+    when 'failed'
+      flash[:error] = t("registrations.payment_form.errors.payment_failed")
+    when 'canceled'
+      flash[:error] = t("registrations.payment_form.errors.payment_canceled")
     else
       # Invalid status
       flash[:error] = "Invalid PaymentIntent status"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1273,6 +1273,7 @@ en:
       title: "Registration fees"
       payment_successful: "Your payment was successful, and your registration should show up as paid below."
       payment_processing: "Your payment has been confirmed, but the transaction is still pending."
+      payment_partial: "Your payment has been confirmed, but it does not cover the full amount. Please pay the remaining fee as well."
       button_text: "Pay now!"
       hints:
         donation: "Optional donation that will go only to the organization team"
@@ -1300,6 +1301,8 @@ en:
         stripe_not_an_intent: "Stripe reported back a transaction ID that is not actually a payment intent."
         payment_reset: "The payment was rejected by Stripe."
         payment_pending: "The payment has not been completed yet."
+        payment_failed: "The payment was not successful. Please check your payment details and try again."
+        payment_canceled: "The payment was canceled and will not be completed."
     preferred_events_prompt_html: "To speed up registration in the future, you can set your preferred events %{link}."
     preferred_events_populated_html: "We autopopulated this with your preferred events, which you can edit %{link}."
     registration_requirements: "Registration requirements for the competition:"


### PR DESCRIPTION
Small part of https://github.com/thewca/worldcubeassociation.org/pull/9208, should be pretty self-explanatory.
We already have and use `wca_status` since a long while, so let's use it in places where it makes sense.