### PR TITLE
Remove obsolete route in payments

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -679,13 +679,6 @@ class RegistrationsController < ApplicationController
     render json: { client_secret: intent.client_secret }
   end
 
-  # TODO: This can be removed after deployment, this is so we don't have any users error out if they click on pay
-  # while the deployment happens
-  def payment_completion_legacy
-    registration = Registration.find(params[:id])
-    redirect_to action: :payment_completion, competition_id: registration.competition_id, params: params.permit(:payment_intent, :payment_intent_client_secret)
-  end
-
   def refund_payment
     competition_id = params[:competition_id]
     competition = Competition.find(competition_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,10 +41,6 @@ Rails.application.routes.draw do
     delete 'users/sign-out-other' => 'sessions#destroy_other', as: :destroy_other_user_sessions
   end
 
-  # TODO: This can be removed after deployment, this is so we don't have any users error out if they click on pay
-  # while the deployment happens
-  get 'registration/:id/payment-completion' => 'registrations#payment_completion_legacy', as: :registration_payment_completion_legacy
-
   post 'registration/:id/load-payment-intent/:payment_integration' => 'registrations#load_payment_intent', as: :registration_payment_intent
   post 'competitions/:competition_id/refund/:payment_integration/:payment_id' => 'registrations#refund_payment', as: :registration_payment_refund
   get 'competitions/:competition_id/payment-completion' => 'registrations#payment_completion', as: :registration_payment_completion


### PR DESCRIPTION
This was originally a part of #9425, where we had to change the format and parameters of the Stripe return URL.

We wanted to make sure that people who initiated Stripe before deployment started (with the "legacy" return URL format) and then entered their payment details _right as deployment happened_ would not end up with a 404 when Stripe sends them back to the (then-outdated) return URL.

Seeing that the other PR has been merged for well over 5 months now, this is definitely safe to remove