### PR TITLE
Add safeguards for production avatars that aren't exported to local environments

### DIFF
--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -43,6 +43,8 @@ class UserAvatar < ApplicationRecord
 
       URI::HTTPS.build(host: host, path: path).to_s
     when 'active_storage'
+      return UserAvatar.default_avatar(self.user).url unless self.image.attached?
+
       if self.using_cdn?
         URI.join(EnvConfig.S3_AVATARS_ASSET_HOST, self.image.key).to_s
       else
@@ -65,6 +67,8 @@ class UserAvatar < ApplicationRecord
 
       URI::HTTPS.build(host: host, path: path).to_s
     when 'active_storage'
+      return UserAvatar.default_avatar(self.user).thumbnail_url unless self.image.attached?
+
       if self.using_cdn?
         URI.join(EnvConfig.S3_AVATARS_ASSET_HOST, self.thumbnail_image.processed.key).to_s
       else
@@ -87,7 +91,7 @@ class UserAvatar < ApplicationRecord
   end
 
   def filename
-    self.active_storage? ? self.image.blob.filename.to_s : super
+    self.active_storage? ? self.image.blob&.filename.to_s : super
   end
 
   def image
@@ -111,7 +115,7 @@ class UserAvatar < ApplicationRecord
   end
 
   def default_avatar?
-    self.filename == DEFAULT_AVATAR_FILE && self.local?
+    self.local? && self.filename == DEFAULT_AVATAR_FILE
   end
 
   alias_method :is_default, :default_avatar?


### PR DESCRIPTION
A potential long-term solution would be to export `active_record_attachments` in the dev export. But to be honest, that doesn't quite feel right. They're uploaded to production for a reason, and we had nasty incidents in the past (uploading derogatory and/or anti-semitic profile pictures via staging) when sharing assets between environments.

Of course, nothing goes against _reading_ prod avatars on local, but that requires a more sophisticated solution and think-through. This one here is an intermediate fix so that people with newer avatars can log in on local and staging again in the first place.