### PR TITLE
Set v3 registrations as default for newly-created comps

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -96,7 +96,7 @@ class Competition < ApplicationRecord
     restricted: 2,
   }, prefix: true
 
-  NEW_REG_SYSTEM_DEFAULT = :v2
+  NEW_REG_SYSTEM_DEFAULT = :v3
 
   enum :registration_version, [:v1, :v2, :v3], prefix: true, default: NEW_REG_SYSTEM_DEFAULT
 


### PR DESCRIPTION
Is it this easy? Have tested locally and it seems to work.