### PR TITLE
Construct payment history on v1->v3 migration

### DIFF
--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -23,8 +23,7 @@ namespace :registration_version do
       ActiveRecord::Base.transaction do
         competition.registrations.includes(:registration_payments, :registration_history_entries).each do |registration|
           registration.update_column :competing_status, registration.compute_competing_status
-
-          if registration.paid_entry_fees > 0 && registration.registration_history_entries.empty?
+          if registration.paid_entry_fees > 0
             registration.registration_payments.each do |payment|
               # If the payments were made after November 6th we already have history entries for it
               if payment.created_at < Time.new(year: 2024, month: 11, day: 6)

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -27,7 +27,7 @@ namespace :registration_version do
             registration.registration_payments.each do |payment|
               # If the payments were made after November 6th we already have history entries for it
               if payment.created_at < Time.new(2024, 11, 6)
-                registration.add_history_entry({ payment_status: payment.payment_status, iso_amount: payment.amount }, "user", payment.receipt.initiated_by, "V2 Migration", payment.created_at)
+                registration.add_history_entry({ payment_status: payment.payment_status, iso_amount: payment.amount_lowest_denomination }, "user", payment.user_id, "V2 Migration", payment.created_at)
               end
             end
           end

--- a/lib/tasks/registration_version.rake
+++ b/lib/tasks/registration_version.rake
@@ -26,8 +26,8 @@ namespace :registration_version do
           if registration.paid_entry_fees > 0
             registration.registration_payments.each do |payment|
               # If the payments were made after November 6th we already have history entries for it
-              if payment.created_at < Time.new(year: 2024, month: 11, day: 6)
-                registration.add_history_entry({ payment_status: payment.payment_status, payment_amount_iso: payment.amount }, "user", payment.receipt.initiated_by, "V2 Migration", payment.created_at)
+              if payment.created_at < Time.new(2024, 11, 6)
+                registration.add_history_entry({ payment_status: payment.payment_status, iso_amount: payment.amount }, "user", payment.receipt.initiated_by, "V2 Migration", payment.created_at)
               end
             end
           end


### PR DESCRIPTION
We added payments to v1 history on November 5th so the easiest way was just saying we only add the payments made before that (choosing november 6th to be safe which will have just a few duplicates)