### PR TITLE
Show registrations even if competition is closed

### DIFF
--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -131,7 +131,7 @@
             }
           end
 
-          unless @competition.registration_not_yet_opened?
+          if @competition.any_registrations?
             event_icons = @competition.events.map do |event|
               { text: event.id, path: competition_psych_sheet_event_path(@competition, event.id), cubing_icon: event.id, title: event.name }
             end unless @competition.uses_new_registration_system?

--- a/app/webpacker/components/RegistrationsV2/Register/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/index.jsx
@@ -74,7 +74,7 @@ function Register({
     return <Loading />;
   }
 
-  if (userCanPreRegister || competitionInfo['registration_currently_open?'] || timerEnded) {
+  if (registration || userCanPreRegister || competitionInfo['registration_currently_open?'] || timerEnded) {
     return (
       <>
         <RegistrationMessage />


### PR DESCRIPTION
Shows the competitor panel and the registration overview even if the competition is closed by looking if there are registrations present or if the user has registered