### PR TITLE
Allow creating 'rejected' registrations for banned competitors

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -376,7 +376,7 @@ class Registration < ApplicationRecord
   # to invalidate all the corresponding registrations (e.g. if the user gets banned).
   # Instead the validations should be placed such that they ensure that a user
   # change doesn't lead to an invalid state.
-  validate :user_can_register_for_competition, on: :create
+  validate :user_can_register_for_competition, on: :create, unless: :rejected?
   private def user_can_register_for_competition
     cannot_register_reasons = user&.cannot_register_for_competition_reasons(competition, is_competing: self.is_competing?)
     if cannot_register_reasons.present?


### PR DESCRIPTION
We need this for migrating the registration system of certain competitions where banned competitors have tried to register.

Their registration exists in the microservice backend as `rejected`, but when migrating them to V3, the monolith sees "Oh a new `Registration` is created so let's definitely run this `on: :create` validation` and the ban causes the validation to trip.