### PR TITLE
Some fixes for edit profile form

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -38,7 +38,7 @@ class ContactsController < ApplicationController
 
   private def new_profile_data_key_to_value(new_profile_data, profile_data_to_change)
     if profile_data_to_change == 'country_iso2'
-      Country.find_by(iso2: new_profile_data).name
+      Country.find_by(iso2: new_profile_data).name_in(:en)
     else
       new_profile_data
     end

--- a/app/views/mail_form/contact_edit_profile.erb
+++ b/app/views/mail_form/contact_edit_profile.erb
@@ -15,6 +15,7 @@
     </tr>
   </body>
 </table>
+<p>Edit Reason: <%= @resource.edit_profile_reason %></p>
 <p>You can edit this person <%= link_to "here", panel_index_url(panel_id: 'wrt', wcaId: @resource.wca_id, anchor: User.panel_pages[:editPerson]) %>.</p>
 <% if @resource.document.present? %>
   <p>Note: There is a proof attachment to this email.</p>

--- a/app/webpacker/components/ContactEditProfilePage/EditProfileForm.jsx
+++ b/app/webpacker/components/ContactEditProfilePage/EditProfileForm.jsx
@@ -60,7 +60,9 @@ export default function EditProfileForm({
     formData.append('formValues', JSON.stringify({
       editedProfileDetails, editProfileReason, wcaId,
     }));
-    formData.append('attachment', proofAttachment);
+    if (proofAttachment) {
+      formData.append('attachment', proofAttachment);
+    }
 
     save(
       contactEditProfileActionUrl,
@@ -98,6 +100,7 @@ export default function EditProfileForm({
         name="name"
         value={editedProfileDetails?.name}
         onChange={handleFormChange}
+        required
       />
       <Form.Select
         options={countryOptions}


### PR DESCRIPTION
This PR aims at fixing some bugs of edit profile form noticed by WRT:

1. Edit reason was not there in the email - this was a big miss by me.
2. The email always mentioned there is a proof even if there wasn't. It was because of sending `undefined` from client.
3. Made name a required field.
4. Made country to english instead of user's locale