### PR TITLE
Update WRT email nag wording

### DIFF
--- a/app/views/competitions_mailer/submit_results_nag.html.erb
+++ b/app/views/competitions_mailer/submit_results_nag.html.erb
@@ -6,8 +6,8 @@
   This is an automated reminder. Over a week has passed since <%= @competition.name %> took
   place and the results of the competition are still not available as required by the <a href="https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf">WCA Competition Requirements Policy</a>.
   There might be valid reasons for this, but nonetheless you are requested to reply to this mail
-  to inform the results team about the state of the competition results as soon as possible
-  (if not already done).
+  to inform the results team about the state of the competition results, and reason for the
+  delay, as soon as possible (if not already done).
 </p>
 
 <p>


### PR DESCRIPTION
To avoid the Delegate basically saying "Results are already submitted, thanks." and getting to the _why_ they were not submitted issue.