### PR TITLE
Use jbuilder to optimize v3 json output

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Api::V1::ApiController < ActionController::API
+  # https://github.com/rails/jbuilder/pull/575
+  helper_method :combined_fragment_cache_key
+  helper_method :view_cache_dependencies
   prepend_before_action :validate_jwt_token
 
   # Manually include new Relic because we don't derive from ActionController::Base

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -34,8 +34,10 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   end
 
   def show
-    registration = Registration.find_by!(user_id: @user_id, competition_id: @competition_id)
-    render json: registration.to_v2_json(admin: true, history: true)
+    @registration = Registration.find_by!(user_id: @user_id, competition_id: @competition_id)
+    @admin = true
+    @history = true
+    render "registrations/show", formats: :json
   end
 
   def create
@@ -60,8 +62,10 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
   def update
     if params[:competing]
-      updated_registration = Registrations::Lanes::Competing.update!(params, @competition, @current_user.id)
-      return render json: { status: 'ok', registration: updated_registration.to_v2_json(admin: true, history: true) }, status: :ok
+      @registration = Registrations::Lanes::Competing.update!(params, @competition, @current_user.id)
+      @admin = true
+      @history = true
+      return render "registrations/update", formats: :json
     end
     render json: { status: 'bad request', message: 'You need to supply at least one lane' }, status: :bad_request
   end

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -89,8 +89,8 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
   def list
     competition_id = list_params
-    registrations = Registration.where(competition_id: competition_id)
-    render json: registrations.map { |r| r.to_v2_json }
+    @registrations = Registration.where(competition_id: competition_id).competing_status_accepted
+    render "registrations/index", formats: :json
   end
 
   # To list Registrations in the admin view you need to be able to administer the competition
@@ -104,8 +104,10 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   end
 
   def list_admin
-    registrations = Registration.where(competition: @competition)
-    render json: registrations.map { |r| r.to_v2_json(admin: true, history: true, pii: true) }
+    @registrations = Registration.where(competition: @competition)
+    @admin = true
+    @pii = true
+    render "registrations/index", formats: :json
   end
 
   def validate_payment_ticket_request

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -37,6 +37,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     @registration = Registration.find_by!(user_id: @user_id, competition_id: @competition_id)
     @admin = true
     @history = true
+    @payment = @competition.using_payment_integrations?
     render "registrations/show", formats: :json
   end
 
@@ -65,6 +66,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
       @registration = Registrations::Lanes::Competing.update!(params, @competition, @current_user.id)
       @admin = true
       @history = true
+      @payment = @competition.using_payment_integrations?
       return render "registrations/update", formats: :json
     end
     render json: { status: 'bad request', message: 'You need to supply at least one lane' }, status: :bad_request
@@ -111,6 +113,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     @registrations = Registration.where(competition: @competition)
     @admin = true
     @pii = true
+    @payment = @competition.using_payment_integrations?
     render "registrations/index", formats: :json
   end
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -44,9 +44,9 @@ class Registration < ApplicationRecord
 
   validate :registration_cannot_be_deleted_and_accepted_simultaneously
   private def registration_cannot_be_deleted_and_accepted_simultaneously
-    # if deleted? && accepted?
-    #   errors.add(:registration_competition_events, I18n.t('registrations.errors.cannot_be_deleted_and_accepted'))
-    # end
+    if deleted? && accepted?
+      errors.add(:registration_competition_events, I18n.t('registrations.errors.cannot_be_deleted_and_accepted'))
+    end
   end
 
   after_save :mark_registration_processing_as_done
@@ -383,7 +383,7 @@ class Registration < ApplicationRecord
     end
   end
 
-  # validate :cannot_be_undeleted_when_banned, if: :deleted_at_changed?
+  validate :cannot_be_undeleted_when_banned, if: :deleted_at_changed?
   private def cannot_be_undeleted_when_banned
     if user.banned? && deleted_at.nil?
       errors.add(:user_id, I18n.t('registrations.errors.undelete_banned'))

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -44,9 +44,9 @@ class Registration < ApplicationRecord
 
   validate :registration_cannot_be_deleted_and_accepted_simultaneously
   private def registration_cannot_be_deleted_and_accepted_simultaneously
-    if deleted? && accepted?
-      errors.add(:registration_competition_events, I18n.t('registrations.errors.cannot_be_deleted_and_accepted'))
-    end
+    # if deleted? && accepted?
+    #   errors.add(:registration_competition_events, I18n.t('registrations.errors.cannot_be_deleted_and_accepted'))
+    # end
   end
 
   after_save :mark_registration_processing_as_done
@@ -383,7 +383,7 @@ class Registration < ApplicationRecord
     end
   end
 
-  validate :cannot_be_undeleted_when_banned, if: :deleted_at_changed?
+  # validate :cannot_be_undeleted_when_banned, if: :deleted_at_changed?
   private def cannot_be_undeleted_when_banned
     if user.banned? && deleted_at.nil?
       errors.add(:user_id, I18n.t('registrations.errors.undelete_banned'))

--- a/app/views/registrations/_registration.json.jbuilder
+++ b/app/views/registrations/_registration.json.jbuilder
@@ -1,6 +1,10 @@
-json.cache! ['registration-user', registration, @admin] do
+json.cache! ['registration-user', registration, @pii] do
   json.user do
-    json.extract! registration.user, :id, :wca_id, :name, :gender, :country_iso2, :email, :dob
+    if @pii
+      json.extract! registration.user, :id, :wca_id, :name, :gender, :country_iso2, :email, :dob
+    else
+      json.extract! registration.user, :id, :wca_id, :name, :gender, :country_iso2
+    end
     json.country registration.user.country
   end
 end

--- a/app/views/registrations/_registration.json.jbuilder
+++ b/app/views/registrations/_registration.json.jbuilder
@@ -20,7 +20,7 @@ json.competing do
 end
 
 if @admin
-  if @competition.using_payment_integrations?
+  if @payment
     json.payment do
       json.has_paid registration.outstanding_entry_fees <= 0
       json.payment_statuses registration.registration_payments.sort_by(&:created_at).reverse.map(&:payment_status)

--- a/app/views/registrations/_registration.json.jbuilder
+++ b/app/views/registrations/_registration.json.jbuilder
@@ -1,0 +1,43 @@
+json.user do
+  json.extract! registration.user, :id, :wca_id, :name, :gender, :country_iso2
+  json.country registration.user.country
+end
+
+json.user_id registration.user_id
+
+json.competing do
+  json.event_ids registration.event_ids
+  if @admin
+    json.registration_status registration.competing_status
+    json.registered_on registration.created_at
+    json.comment registration.comments
+    json.admin_comment registration.administrative_notes
+
+    if registration.competing_status == "waiting_list"
+      json.waiting_list_position registration.waiting_list_position
+    end
+  end
+end
+
+if @admin
+  if @competition.using_payment_integrations?
+    json.payment do
+      json.has_paid registration.outstanding_entry_fees <= 0
+      json.payment_statuses registration.registration_payments.sort_by(&:created_at).reverse.map(&:payment_status)
+      json.payment_amount_iso registration.paid_entry_fees.cents
+      json.payment_amount_human_readable "#{registration.paid_entry_fees.format} (#{registration.paid_entry_fees.currency.name})"
+      json.updated_at registration.last_payment_date
+    end
+  end
+
+  json.guests registration.guests
+end
+
+if @history
+  json.history registration.registration_history || []
+end
+
+if @pii
+  json.email registration.user.email
+  json.dob registration.user.dob
+end

--- a/app/views/registrations/_registration.json.jbuilder
+++ b/app/views/registrations/_registration.json.jbuilder
@@ -1,43 +1,43 @@
-json.user do
-  json.extract! registration.user, :id, :wca_id, :name, :gender, :country_iso2
-  json.country registration.user.country
+json.cache! ['registration-user', registration, @admin] do
+  json.user do
+    json.extract! registration.user, :id, :wca_id, :name, :gender, :country_iso2, :email, :dob
+    json.country registration.user.country
+  end
 end
 
 json.user_id registration.user_id
 
-json.competing do
-  json.event_ids registration.event_ids
-  if @admin
-    json.registration_status registration.competing_status
-    json.registered_on registration.created_at
-    json.comment registration.comments
-    json.admin_comment registration.administrative_notes
+json.cache! ['registration-competing', registration, @admin] do
+  json.competing do
+    json.event_ids registration.event_ids
+    if @admin
+      json.registration_status registration.competing_status
+      json.registered_on registration.created_at
+      json.comment registration.comments
+      json.admin_comment registration.administrative_notes
 
-    if registration.competing_status == "waiting_list"
-      json.waiting_list_position registration.waiting_list_position
+      if registration.competing_status == "waiting_list"
+        json.waiting_list_position registration.waiting_list_position
+      end
     end
   end
 end
 
 if @admin
-  if @payment
-    json.payment do
-      json.has_paid registration.outstanding_entry_fees <= 0
-      json.payment_statuses registration.registration_payments.sort_by(&:created_at).reverse.map(&:payment_status)
-      json.payment_amount_iso registration.paid_entry_fees.cents
-      json.payment_amount_human_readable "#{registration.paid_entry_fees.format} (#{registration.paid_entry_fees.currency.name})"
-      json.updated_at registration.last_payment_date
+  json.cache! ['registration-payment', registration.registration_payments] do
+    if @payment
+      json.payment do
+        json.has_paid registration.outstanding_entry_fees <= 0
+        json.payment_statuses registration.registration_payments.sort_by(&:created_at).reverse.map(&:payment_status)
+        json.payment_amount_iso registration.paid_entry_fees.cents
+        json.payment_amount_human_readable "#{registration.paid_entry_fees.format} (#{registration.paid_entry_fees.currency.name})"
+        json.updated_at registration.last_payment_date
+      end
     end
   end
-
   json.guests registration.guests
 end
 
 if @history
   json.history registration.registration_history || []
-end
-
-if @pii
-  json.email registration.user.email
-  json.dob registration.user.dob
 end

--- a/app/views/registrations/index.json.jbuilder
+++ b/app/views/registrations/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @registrations do |registration|
+  json.partial! "registrations/registration", registration: registration
+end

--- a/app/views/registrations/show.json.jbuilder
+++ b/app/views/registrations/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "registrations/registration", registration: @registration

--- a/app/views/registrations/update.json.jbuilder
+++ b/app/views/registrations/update.json.jbuilder
@@ -1,0 +1,3 @@
+json.registration do
+  json.partial! "registrations/registration", registration: @registration
+end

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -71,12 +71,11 @@ export default function TableRow({
     dob, region, events, comments, email, timestamp,
   } = columnsExpanded;
   const {
-    id, wca_id: wcaId, name, country,
+    id, wca_id: wcaId, name, country, dob: dateOfBirth, email: emailAddress,
   } = registration.user;
   const {
     registered_on: registeredOn, event_ids: eventIds, comment, admin_comment: adminComment,
   } = registration.competing;
-  const { dob: dateOfBirth, email: emailAddress } = registration;
   const {
     payment_amount_iso: paymentAmount,
     updated_at: updatedAt,

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -62,7 +62,6 @@ function csvExport(selected, registrations, competition) {
 
 export default function RegistrationActions({
   partitionedSelected,
-  userEmailMap,
   refresh,
   registrations,
   spotsRemaining,
@@ -86,7 +85,7 @@ export default function RegistrationActions({
   const anyRejectable = rejected.length < selectedCount;
 
   const selectedEmails = [...pending, ...accepted, ...cancelled, ...waiting]
-    .map((userId) => userEmailMap[userId])
+    .map((userId) => registrations.find((r) => userId === r.user_id).user.email)
     .join(',');
 
   const changeStatus = (attendees, status) => {

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -20,7 +20,7 @@ import { personUrl } from '../../../lib/requests/routes.js.erb';
 import Errored from '../../Requests/Errored';
 import { formatAttemptResult } from '../../../lib/wca-live/attempts';
 import i18n from '../../../lib/i18n';
-import { countries } from "../../../lib/wca-data.js.erb";
+import { countries } from '../../../lib/wca-data.js.erb';
 
 const sortReducer = createSortReducer(['name', 'country', 'total']);
 
@@ -317,7 +317,7 @@ export default function RegistrationList({ competitionInfo }) {
           <FooterContent
             registrations={registrations}
             psychSheetEvent={psychSheetEvent}
-            dataWithUser={registrations}
+            dataWithUser={dataWithUser}
             competitionInfo={competitionInfo}
           />
         </Table.Footer>

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -317,7 +317,7 @@ export default function RegistrationList({ competitionInfo }) {
           <FooterContent
             registrations={registrations}
             psychSheetEvent={psychSheetEvent}
-            dataWithUser={dataWithUser}
+            dataWithUser={registrations}
             competitionInfo={competitionInfo}
           />
         </Table.Footer>


### PR DESCRIPTION
This is an implementation of the 'old' v2 json output optimized by using fragment caching jbuilder. If we want to keep the json API schema the same, this is probably the most optimized way of doing it. Definitely open to change the json output though.