### PR TITLE
Add hook to compute backwards-compatible V3->V1 timestamps

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -50,6 +50,17 @@ class Registration < ApplicationRecord
     end
   end
 
+  # Automatically compute the competing_status, unless it has been explicitly assigned.
+  #   This is a poor-man's backwards compatibility so that V1 registrations get their competing status
+  #   set to whatever V3 expects, and we can just globally use V3 scopes when querying for "accepted registrations".
+  # TODO V3: Remove this hook once V1 is completely gone.
+  before_save :assign_auto_competing_status, unless: :competing_status_changed?
+
+  private def assign_auto_competing_status
+    comp_using_v3 = self.competition.uses_new_registration_system?
+    self.competing_status = self.compute_competing_status unless comp_using_v3
+  end
+
   after_save :mark_registration_processing_as_done
 
   private def mark_registration_processing_as_done

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -50,11 +50,11 @@ class Registration < ApplicationRecord
     end
   end
 
-  # Automatically compute the V1 timestamps, for competitions that just got a new competing_status.
+  # Automatically compute the V1 timestamps, for competitions that already have a competing_status.
   #   This is a poor-man's backwards compatibility so that V3 registrations can be used by the V1 scopes
-  #   for `accepted` and `pending`, which .
+  #   for `accepted` and `pending`, which rely on these timestamps having some non-nil value.
   # TODO V3: Remove this hook once V1 is completely gone.
-  before_save :recompute_timestamps, if: [:competing_status?, :competing_status_changed?]
+  before_save :recompute_timestamps, if: :competing_status?
 
   def recompute_timestamps
     case self.competing_status

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -50,11 +50,11 @@ class Registration < ApplicationRecord
     end
   end
 
-  # Automatically compute the V1 timestamps, for competitions that already have a competing_status.
+  # Automatically compute the V1 timestamps, for competitions that just changed their competing_status.
   #   This is a poor-man's backwards compatibility so that V3 registrations can be used by the V1 scopes
   #   for `accepted` and `pending`, which rely on these timestamps having some non-nil value.
   # TODO V3: Remove this hook once V1 is completely gone.
-  before_save :recompute_timestamps, if: :competing_status?
+  before_save :recompute_timestamps, if: :competing_status_changed?
 
   def recompute_timestamps
     case self.competing_status
@@ -63,10 +63,8 @@ class Registration < ApplicationRecord
       self.deleted_at = nil
     when Registrations::Helper::STATUS_ACCEPTED
       self.accepted_at = DateTime.now
-      self.deleted_at = nil
     when Registrations::Helper::STATUS_CANCELLED
     when Registrations::Helper::STATUS_REJECTED
-      self.accepted_at = nil
       self.deleted_at = DateTime.now
     end
   end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -59,6 +59,7 @@ class Registration < ApplicationRecord
   def recompute_timestamps
     case self.competing_status
     when Registrations::Helper::STATUS_PENDING
+    when Registrations::Helper::STATUS_WAITING_LIST
       self.accepted_at = nil
       self.deleted_at = nil
     when Registrations::Helper::STATUS_ACCEPTED


### PR DESCRIPTION
This hook writes the legacy `accepted_at` and `deleted_at` timestamps, so that the "old" `Registration.accepted` and `Registration.pending` scopes will work as intended.

The hook is only fired if there is a `competing_status` to use. That's basically a poor-man's version of detecting "is this registration for V3?" without having to check the relation to the `Competitions` table constantly.