### PR TITLE
Custom schedule calendar event rendering

### DIFF
--- a/app/webpacker/components/Schedule/CalendarView.jsx
+++ b/app/webpacker/components/Schedule/CalendarView.jsx
@@ -1,7 +1,7 @@
-import luxonPlugin from '@fullcalendar/luxon3';
+import luxonPlugin, { toLuxonDateTime } from '@fullcalendar/luxon3';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
-import { DateTime } from 'luxon';
+import { DateTime, Interval } from 'luxon';
 import React from 'react';
 import {
   earliestTimeOfDayWithBuffer,
@@ -92,10 +92,54 @@ export default function CalendarView({
         locale={calendarLocale}
         timeZone={timeZone}
         events={fcActivities}
+        // custom rendering of event content
+        eventContent={(args) => (
+          <CalendarEventView {...args} />
+        )}
       />
       {fcActivities.length === 0 && (
         <em>{I18n.t('competitions.schedule.no_activities')}</em>
       )}
     </>
+  );
+}
+
+// TODO: check events crossing midnight
+function CalendarEventView({ event, timeText, view }) {
+  const startLuxon = toLuxonDateTime(event.start, view.calendar);
+  const endLuxon = toLuxonDateTime(event.end, view.calendar);
+  const interval = Interval.fromDateTimes(startLuxon, endLuxon);
+  const lengthInMin = interval.length('minutes');
+
+  return (
+    <div className='fc-event-main-frame' style={{ overflow: 'hidden' }}>
+      {lengthInMin < 15 && (
+        <div style={{ whiteSpace: 'nowrap', fontSize: '70%', lineHeight: '1.2em' }}>
+          {timeText} - {event.title}
+        </div>
+      )}
+      {15 <= lengthInMin && lengthInMin < 20 && (
+        <div style={{ whiteSpace: 'nowrap', fontSize: '90%' }}>
+          {timeText} - {event.title}
+        </div>
+      )}
+      {20 <= lengthInMin && lengthInMin < 25 && (
+        <div style={{ whiteSpace: 'nowrap' }}>
+          {timeText} - {event.title}
+        </div>
+      )}
+      {25 <= lengthInMin && lengthInMin < 30 && (
+        <div style={{ lineHeight: '1.4em' }}>
+          <div style={{ whiteSpace: 'nowrap' }}>{timeText}</div>
+          <div>{event.title}</div>
+        </div>
+      )}
+      {30 <= lengthInMin && (
+        <div>
+          <div style={{ whiteSpace: 'nowrap' }}>{timeText}</div>
+          <div>{event.title}</div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/app/webpacker/components/Schedule/CalendarView.jsx
+++ b/app/webpacker/components/Schedule/CalendarView.jsx
@@ -115,7 +115,7 @@ function CalendarEventView({ event, timeText, view }) {
   return (
     <div className='fc-event-main-frame' style={style}>
       <InnerEventContent
-        lengthInMin={lengthInMin}
+        onlyOneLine={lengthInMin < 25}
         title={event.title}
         timeText={timeText}
       />
@@ -123,8 +123,8 @@ function CalendarEventView({ event, timeText, view }) {
   );
 }
 
-function InnerEventContent({ lengthInMin, timeText, title }) {
-  if (lengthInMin < 25) {
+function InnerEventContent({ onlyOneLine, timeText, title }) {
+  if (onlyOneLine) {
     return (
       <>{timeText} - {title}</>
     );

--- a/app/webpacker/components/Schedule/CalendarView.jsx
+++ b/app/webpacker/components/Schedule/CalendarView.jsx
@@ -113,14 +113,12 @@ function CalendarEventView({ event, timeText, view }) {
   const style = getEventStyle(lengthInMin);
 
   return (
-    <div className='fc-event-main-frame' style={{ overflow: 'hidden' }}>
-      <div style={style}>
-        <InnerEventContent
-          lengthInMin={lengthInMin}
-          title={event.title}
-          timeText={timeText}
-        />
-      </div>
+    <div className='fc-event-main-frame' style={style}>
+      <InnerEventContent
+        lengthInMin={lengthInMin}
+        title={event.title}
+        timeText={timeText}
+      />
     </div>
   );
 }
@@ -142,14 +140,14 @@ function InnerEventContent({ lengthInMin, timeText, title }) {
 
 function getEventStyle(lengthInMin) {
   if (lengthInMin < 15) {
-    return { whiteSpace: 'nowrap', fontSize: '80%', lineHeight: '1.2em' };
+    return { overflow: 'hidden', whiteSpace: 'nowrap', fontSize: '80%', lineHeight: '1.2em' };
   } else if (lengthInMin < 20) {
-    return { whiteSpace: 'nowrap', fontSize: '90%' };
+    return { overflow: 'hidden', whiteSpace: 'nowrap', fontSize: '90%' };
   } else if (lengthInMin < 25) {
-    return { whiteSpace: 'nowrap' };
+    return { overflow: 'hidden', whiteSpace: 'nowrap' };
   } else if (lengthInMin < 30) {
-    return { lineHeight: '1.4em' };
+    return { overflow: 'hidden', lineHeight: '1.4em' };
   } else {
-    return {};
+    return { overflow: 'hidden' };
   }
 }

--- a/app/webpacker/components/Schedule/CalendarView.jsx
+++ b/app/webpacker/components/Schedule/CalendarView.jsx
@@ -104,42 +104,52 @@ export default function CalendarView({
   );
 }
 
-// TODO: check events crossing midnight
 function CalendarEventView({ event, timeText, view }) {
   const startLuxon = toLuxonDateTime(event.start, view.calendar);
   const endLuxon = toLuxonDateTime(event.end, view.calendar);
   const interval = Interval.fromDateTimes(startLuxon, endLuxon);
   const lengthInMin = interval.length('minutes');
 
+  const style = getEventStyle(lengthInMin);
+
   return (
     <div className='fc-event-main-frame' style={{ overflow: 'hidden' }}>
-      {lengthInMin < 15 && (
-        <div style={{ whiteSpace: 'nowrap', fontSize: '70%', lineHeight: '1.2em' }}>
-          {timeText} - {event.title}
-        </div>
-      )}
-      {15 <= lengthInMin && lengthInMin < 20 && (
-        <div style={{ whiteSpace: 'nowrap', fontSize: '90%' }}>
-          {timeText} - {event.title}
-        </div>
-      )}
-      {20 <= lengthInMin && lengthInMin < 25 && (
-        <div style={{ whiteSpace: 'nowrap' }}>
-          {timeText} - {event.title}
-        </div>
-      )}
-      {25 <= lengthInMin && lengthInMin < 30 && (
-        <div style={{ lineHeight: '1.4em' }}>
-          <div style={{ whiteSpace: 'nowrap' }}>{timeText}</div>
-          <div>{event.title}</div>
-        </div>
-      )}
-      {30 <= lengthInMin && (
-        <div>
-          <div style={{ whiteSpace: 'nowrap' }}>{timeText}</div>
-          <div>{event.title}</div>
-        </div>
-      )}
+      <div style={style}>
+        <InnerEventContent
+          lengthInMin={lengthInMin}
+          title={event.title}
+          timeText={timeText}
+        />
+      </div>
     </div>
   );
+}
+
+function InnerEventContent({ lengthInMin, timeText, title }) {
+  if (lengthInMin < 25) {
+    return (
+      <>{timeText} - {title}</>
+    );
+  } else {
+    return (
+      <>
+        <div style={{ whiteSpace: 'nowrap' }}>{timeText}</div>
+        <div>{title}</div>
+      </>
+    );
+  }
+}
+
+function getEventStyle(lengthInMin) {
+  if (lengthInMin < 15) {
+    return { whiteSpace: 'nowrap', fontSize: '80%', lineHeight: '1.2em' };
+  } else if (lengthInMin < 20) {
+    return { whiteSpace: 'nowrap', fontSize: '90%' };
+  } else if (lengthInMin < 25) {
+    return { whiteSpace: 'nowrap' };
+  } else if (lengthInMin < 30) {
+    return { lineHeight: '1.4em' };
+  } else {
+    return {};
+  }
 }

--- a/app/webpacker/components/Schedule/CalendarView.jsx
+++ b/app/webpacker/components/Schedule/CalendarView.jsx
@@ -140,9 +140,9 @@ function InnerEventContent({ onlyOneLine, timeText, title }) {
 
 function getEventStyle(lengthInMin) {
   if (lengthInMin < 15) {
-    return { overflow: 'hidden', whiteSpace: 'nowrap', fontSize: '80%', lineHeight: '1.2em' };
+    return { overflow: 'hidden', whiteSpace: 'nowrap', lineHeight: '1.2em', fontSize: '80%' };
   } else if (lengthInMin < 20) {
-    return { overflow: 'hidden', whiteSpace: 'nowrap', fontSize: '90%' };
+    return { overflow: 'hidden', whiteSpace: 'nowrap', lineHeight: '1.5em' };
   } else if (lengthInMin < 25) {
     return { overflow: 'hidden', whiteSpace: 'nowrap' };
   } else if (lengthInMin < 30) {


### PR DESCRIPTION
Customize the styling depending on the length of the event, rather than relying on full calendar to do everything. Made 10min font size smaller, and adjusted line heights and how many lines to use for other lengths. One size effect is that the time text is slightly bigger now, which seems good/fine to me.

If/when this is merged, it will be easy to implement a tool-tip on the events, so that people can hover/tap on events to see the full time/title/etc. if the box happens to be too small. (We didn't do this originally because we didn't want to do custom event rendering just to get a tool-tip; but now it's worth it.) The changes can also be applied to the edit schedule view (it would be nice to be able to read 10 minute events when creating a schedule, especially since a tutorial is often that long). And on a related note, it would be good for mobile view to use a separate calendar per day, so that the days can stack on top of each other instead of squishing way too much.

Before:
![image](https://github.com/user-attachments/assets/06aae179-153b-45ed-a8e9-b459895120da)

![image](https://github.com/user-attachments/assets/b7e2694e-4ed3-445e-b20b-f8e3e937447d)

After:
![image](https://github.com/user-attachments/assets/63a4908c-0137-47da-bbdd-62e758f3c7c4)

![image](https://github.com/user-attachments/assets/51ae0e02-fee9-42d9-855e-7eda9d2a6f04)

Examples of all event lengths:
![image](https://github.com/user-attachments/assets/c51e91a2-031d-4fa1-b30c-e3e6eb81dc95)

![image](https://github.com/user-attachments/assets/a4fbe1bf-dbee-404a-8bb4-8541a610ebb2)
