### PR TITLE
Few cleanups in contact edit profile form

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -36,25 +36,13 @@ class ContactsController < ApplicationController
     )
   end
 
-  private def new_profile_data_key_to_value(new_profile_data, profile_data_to_change)
-    if profile_data_to_change == 'country_iso2'
-      Country.find_by(iso2: new_profile_data).name_in(:en)
-    else
-      new_profile_data
-    end
-  end
-
   private def contact_wrt(requestor_details, contact_params, attachment)
-    profile_data_to_change = contact_params[:profileDataToChange]
     maybe_send_contact_email(
       ContactWrt.new(
         name: requestor_details[:name],
         your_email: requestor_details[:email],
         wca_id: User.find_by(email: requestor_details[:email])&.wca_id || 'None',
         query_type: contact_params[:queryType].titleize,
-        profile_data_to_change: profile_data_to_change&.titleize,
-        new_profile_data: new_profile_data_key_to_value(contact_params[:newProfileData], profile_data_to_change),
-        edit_profile_reason: contact_params[:editProfileReason],
         message: contact_params[:message],
         document: attachment,
         request: request,
@@ -118,9 +106,9 @@ class ContactsController < ApplicationController
                               .reject { |field| profile_to_edit[field].to_s == edited_profile_details[field].to_s }
                               .map { |field|
                                 ContactEditProfile::EditProfileChange.new(
-                                  field: field.to_s.humanize,
-                                  from: (new_profile_data_key_to_value(profile_to_edit[field], field.to_s) || "Unknown").to_s,
-                                  to: new_profile_data_key_to_value(edited_profile_details[field], field.to_s),
+                                  field: field,
+                                  from: profile_to_edit[field],
+                                  to: edited_profile_details[field],
                                 )
                               }
 

--- a/app/models/contact_wrt.rb
+++ b/app/models/contact_wrt.rb
@@ -3,9 +3,6 @@
 class ContactWrt < ContactForm
   attribute :query_type
   attribute :wca_id
-  attribute :profile_data_to_change
-  attribute :new_profile_data
-  attribute :edit_profile_reason
   attribute :message
   attribute :document, attachment: true
 

--- a/app/views/mail_form/contact_edit_profile.erb
+++ b/app/views/mail_form/contact_edit_profile.erb
@@ -6,8 +6,15 @@
   <body>
     <% @resource.changes_requested.each do |change| %>
       <tr>
-        <td><%= change[:field] %></td>
-        <td><%= change[:from] %> -> <%= change[:to] %></td>
+        <td><%= change[:field].to_s.humanize %></td>
+        <% case change[:field] %>
+          <% when :country_iso2 %>
+            <td><%= Country.find_by(iso2: change[:from]).name_in(:en) %> -> <%= Country.find_by(iso2: change[:to]).name_in(:en) %></td>
+          <% when :gender %>
+            <td><%= User::GENDER_LABEL_METHOD.call(change[:from].to_sym) %> -> <%= User::GENDER_LABEL_METHOD.call(change[:to].to_sym) %></td>
+          <% else %>
+            <td><%= change[:from] %> -> <%= change[:to] %></td>
+        <% end %>
       </tr>
     <% end %>
     <tr style="height: 1em">


### PR DESCRIPTION
This PR aims at few cleanups and a minor change which will be needed for first PR of tickets.

The cleanups include removal of few fields from `ContactWrt` class, which was missed in one of the previous PR.

The minor change is that the "changes" was pushed to an array after converting to human readable format. But now that logic is moved to the email body because tickets need the raw format bit early.