### PR TITLE
Change `console.sh` command to `bash` not `rails c`

### DIFF
--- a/rel/console.sh
+++ b/rel/console.sh
@@ -106,5 +106,5 @@ aws ecs execute-command  \
   --cluster wca-on-rails \
   --task $task_arn \
   --container $container_name \
-  --command "/rails/bin/rails c" \
+  --command "bash" \
   --interactive


### PR DESCRIPTION
Tested locally and it works - this lets us run rake tasks etc using the same commands that we would locally