### PR TITLE
Fix recompute_timestamps not setting the other timestamp to nil

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -64,8 +64,10 @@ class Registration < ApplicationRecord
       self.deleted_at = nil
     when Registrations::Helper::STATUS_ACCEPTED
       self.accepted_at = DateTime.now
+      self.deleted_at = nil
     when Registrations::Helper::STATUS_CANCELLED
     when Registrations::Helper::STATUS_REJECTED
+      self.accepted_at = nil
       self.deleted_at = DateTime.now
     end
   end


### PR DESCRIPTION
This isn't entirely needed, because you usually don't go from deleted -> accepted, but if an organizer accidentally deleted someone and puts them back to accepted the registration will still be marked as deleted