### PR TITLE
Order registration_history_entries by timestamp

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -16,7 +16,7 @@ class Registration < ApplicationRecord
   belongs_to :user, optional: true # A user may be deleted later. We only enforce validation directly on creation further down below.
   belongs_to :accepted_user, foreign_key: "accepted_by", class_name: "User", optional: true
   belongs_to :deleted_user, foreign_key: "deleted_by", class_name: "User", optional: true
-  has_many :registration_history_entries, dependent: :destroy
+  has_many :registration_history_entries, -> { order(:created_at) }, dependent: :destroy
   has_many :registration_competition_events
   has_many :registration_payments
   has_many :competition_events, through: :registration_competition_events


### PR DESCRIPTION
in most cases id order will be time order, but especially for some of our data migrations that isn't true. This makes sure we always get them in the correct order