### PR TITLE
Avoid showing EditPersonTicketWorkbench if the ticket is closed

### DIFF
--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonTicketWorkbench.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonTicketWorkbench.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import EditPersonForm from '../../Panel/pages/EditPersonPage/EditPersonForm';
 import useSaveAction from '../../../lib/hooks/useSaveAction';
 import { actionUrls } from '../../../lib/requests/routes.js.erb';
+import { ticketStatuses } from '../../../lib/wca-data.js.erb';
 import Loading from '../../Requests/Loading';
 
 function EditPersonTicketWorkbenchForWrt({ ticketDetails, actingStakeholderId, sync }) {
@@ -12,7 +13,7 @@ function EditPersonTicketWorkbenchForWrt({ ticketDetails, actingStakeholderId, s
     save(
       actionUrls.tickets.updateStatus(ticket.id),
       {
-        ticket_status: 'closed',
+        ticket_status: ticketStatuses.edit_person.closed,
         acting_stakeholder_id: actingStakeholderId,
       },
       sync,
@@ -31,7 +32,11 @@ function EditPersonTicketWorkbenchForWrt({ ticketDetails, actingStakeholderId, s
 }
 
 export default function EditPersonTicketWorkbench({ ticketDetails, sync }) {
-  const { requester_stakeholders: requesterStakeholders } = ticketDetails;
+  const { requester_stakeholders: requesterStakeholders, ticket } = ticketDetails;
+
+  if (ticket.metadata.status === ticketStatuses.edit_person.closed) {
+    return null;
+  }
 
   return requesterStakeholders.map((requesterStakeholder) => {
     if (requesterStakeholder.stakeholder?.metadata?.friendly_id === 'wrt') {

--- a/app/webpacker/lib/wca-data.js.erb
+++ b/app/webpacker/lib/wca-data.js.erb
@@ -223,4 +223,5 @@ export const avatarImageTypes = <%= Rails.application.config.active_storage.web_
 
 // ----- TICKETS -----
 export const ticketTypes = <%= Ticket::TICKET_TYPES.to_json %>;
+export const ticketStatuses = <%= Ticket::TICKET_TYPES.transform_values { |value| value.constantize.statuses }.to_json %>;
 export const ticketLogActionTypes = <%= TicketLog.action_types.to_json %>;

--- a/app/webpacker/lib/wca-data.js.erb
+++ b/app/webpacker/lib/wca-data.js.erb
@@ -223,5 +223,5 @@ export const avatarImageTypes = <%= Rails.application.config.active_storage.web_
 
 // ----- TICKETS -----
 export const ticketTypes = <%= Ticket::TICKET_TYPES.to_json %>;
-export const ticketStatuses = <%= Ticket::TICKET_TYPES.transform_values { |value| value.constantize.statuses }.to_json %>;
+export const ticketStatuses = <%= Ticket::TICKET_TYPES.transform_values { |value| value.safe_constantize&.statuses }.to_json %>;
 export const ticketLogActionTypes = <%= TicketLog.action_types.to_json %>;


### PR DESCRIPTION
Currently the edit form is visible in ticket even for closed tickets. It will be good if we avoid showing the edit form (which is there inside the workbench) if the ticket is already closed.