### PR TITLE
Select stakeholder if a user is part of multiple stakeholders

### DIFF
--- a/app/webpacker/components/Tickets/TicketWorkbench.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbench.jsx
@@ -2,12 +2,18 @@ import React from 'react';
 import { ticketTypes } from '../../lib/wca-data.js.erb';
 import EditPersonTicketWorkbench from './TicketWorkbenches/EditPersonTicketWorkbench';
 
-export default function TicketWorkbench({ ticketDetails, sync }) {
+export default function TicketWorkbench({ ticketDetails, sync, currentStakeholder }) {
   const { ticket } = ticketDetails;
 
   switch (ticket.metadata_type) {
     case ticketTypes.edit_person:
-      return <EditPersonTicketWorkbench ticketDetails={ticketDetails} sync={sync} />;
+      return (
+        <EditPersonTicketWorkbench
+          ticketDetails={ticketDetails}
+          sync={sync}
+          currentStakeholder={currentStakeholder}
+        />
+      );
     default: return null;
   }
 }

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonTicketWorkbench.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonTicketWorkbench.jsx
@@ -31,23 +31,19 @@ function EditPersonTicketWorkbenchForWrt({ ticketDetails, actingStakeholderId, s
   );
 }
 
-export default function EditPersonTicketWorkbench({ ticketDetails, sync }) {
-  const { requester_stakeholders: requesterStakeholders, ticket } = ticketDetails;
-
-  if (ticket.metadata.status === ticketStatuses.edit_person.closed) {
+export default function EditPersonTicketWorkbench({ ticketDetails, sync, currentStakeholder }) {
+  if (ticketDetails.ticket.metadata.status === ticketStatuses.edit_person.closed) {
     return null;
   }
 
-  return requesterStakeholders.map((requesterStakeholder) => {
-    if (requesterStakeholder.stakeholder?.metadata?.friendly_id === 'wrt') {
-      return (
-        <EditPersonTicketWorkbenchForWrt
-          ticketDetails={ticketDetails}
-          actingStakeholderId={requesterStakeholder.id}
-          sync={sync}
-        />
-      );
-    }
-    return null;
-  });
+  if (currentStakeholder.stakeholder?.metadata?.friendly_id === 'wrt') {
+    return (
+      <EditPersonTicketWorkbenchForWrt
+        ticketDetails={ticketDetails}
+        actingStakeholderId={currentStakeholder.id}
+        sync={sync}
+      />
+    );
+  }
+  return null;
 }

--- a/app/webpacker/components/Tickets/index.jsx
+++ b/app/webpacker/components/Tickets/index.jsx
@@ -37,6 +37,20 @@ function SkateholderSelector({ stakeholderList, setUserSelectedStakeholder }) {
   );
 }
 
+function TicketContent({ ticketDetails, currentStakeholder, sync }) {
+  return (
+    <>
+      <TicketHeader ticketDetails={ticketDetails} />
+      <TicketWorkbench
+        ticketDetails={ticketDetails}
+        sync={sync}
+        currentStakeholder={currentStakeholder}
+      />
+      <TicketLogs logs={ticketDetails.ticket.ticket_logs} />
+    </>
+  );
+}
+
 export default function Tickets({ id }) {
   const {
     data: ticketDetails, sync, loading, error,
@@ -56,16 +70,21 @@ export default function Tickets({ id }) {
       <Container fluid>
         {userSelectedStakeholder && (
           <Message>
-            {`You are currently viewing the ticket as stakeholder "${userSelectedStakeholder.stakeholder.name}". If you wish to change, please refresh the page.`}
+            {`You are currently viewing the ticket as stakeholder "${userSelectedStakeholder.stakeholder.name}".`}
+            <Button
+              onClick={() => setUserSelectedStakeholder(false)}
+            >
+              Click here to change
+            </Button>
           </Message>
         )}
-        <TicketHeader ticketDetails={ticketDetails} />
-        <TicketWorkbench
-          ticketDetails={ticketDetails}
-          sync={sync}
-          currentStakeholder={currentStakeholder}
-        />
-        <TicketLogs logs={ticketDetails.ticket.ticket_logs} />
+        {!shouldUserSelectStakeholder && (
+          <TicketContent
+            ticketDetails={ticketDetails}
+            currentStakeholder={currentStakeholder}
+            sync={sync}
+          />
+        )}
       </Container>
       <Modal open={shouldUserSelectStakeholder}>
         <Modal.Header>Select stakeholder</Modal.Header>

--- a/app/webpacker/components/Tickets/index.jsx
+++ b/app/webpacker/components/Tickets/index.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { Container } from 'semantic-ui-react';
+import React, { useState } from 'react';
+import {
+  Button, Container, Dropdown, Message, Modal,
+} from 'semantic-ui-react';
 import useLoadedData from '../../lib/hooks/useLoadedData';
 import { actionUrls } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
@@ -8,19 +10,72 @@ import TicketHeader from './TicketHeader';
 import TicketWorkbench from './TicketWorkbench';
 import TicketLogs from './TicketLogs';
 
+function SkateholderSelector({ stakeholderList, setUserSelectedStakeholder }) {
+  const [selectedOption, setSelectedOption] = useState(stakeholderList[0]);
+  return (
+    <>
+      <p>
+        You are part of more than one stakeholder, please select the stakeholder as which you want
+        to visit the ticket page.
+      </p>
+      <Dropdown
+        options={stakeholderList.map((requesterStakeholder) => ({
+          key: requesterStakeholder.id,
+          text: requesterStakeholder.stakeholder.name,
+          value: requesterStakeholder,
+        }))}
+        value={selectedOption}
+        onChange={(__, { value }) => setSelectedOption(value)}
+      />
+      <Button
+        disabled={!selectedOption}
+        onClick={() => setUserSelectedStakeholder(selectedOption)}
+      >
+        Select
+      </Button>
+    </>
+  );
+}
+
 export default function Tickets({ id }) {
   const {
     data: ticketDetails, sync, loading, error,
   } = useLoadedData(actionUrls.tickets.show(id));
 
+  const [userSelectedStakeholder, setUserSelectedStakeholder] = useState();
+  const currentStakeholder = userSelectedStakeholder || ticketDetails?.requester_stakeholders[0];
+  const shouldUserSelectStakeholder = (
+    !userSelectedStakeholder
+    && ticketDetails?.requester_stakeholders?.length > 1);
+
   if (loading) return <Loading />;
   if (error) return <Errored />;
 
   return (
-    <Container fluid>
-      <TicketHeader ticketDetails={ticketDetails} />
-      <TicketWorkbench ticketDetails={ticketDetails} sync={sync} />
-      <TicketLogs logs={ticketDetails.ticket.ticket_logs} />
-    </Container>
+    <>
+      <Container fluid>
+        {userSelectedStakeholder && (
+          <Message>
+            {`You are currently viewing the ticket as stakeholder "${userSelectedStakeholder.stakeholder.name}". If you wish to change, please refresh the page.`}
+          </Message>
+        )}
+        <TicketHeader ticketDetails={ticketDetails} />
+        <TicketWorkbench
+          ticketDetails={ticketDetails}
+          sync={sync}
+          currentStakeholder={currentStakeholder}
+        />
+        <TicketLogs logs={ticketDetails.ticket.ticket_logs} />
+      </Container>
+      <Modal open={shouldUserSelectStakeholder}>
+        <Modal.Header>Select stakeholder</Modal.Header>
+        <Modal.Content>
+          <SkateholderSelector
+            stakeholderList={ticketDetails?.requester_stakeholders}
+            setUserSelectedStakeholder={setUserSelectedStakeholder}
+          />
+        </Modal.Content>
+      </Modal>
+    </>
   );
 }


### PR DESCRIPTION
There are different cases where the user needs to represent a single stakeholder - for example, once we have the feature to change status, the person who change should represent one stakeholder so that we can add that in the logs.

In this PR, if the user is part of multiple stakeholders in a ticket, we will ask the user to select one of them.