### PR TITLE
Allowing Incedent log visible to staff/public or editors

### DIFF
--- a/app/assets/stylesheets/incidents.scss
+++ b/app/assets/stylesheets/incidents.scss
@@ -39,19 +39,3 @@
 #wrc-data {
   @extend #competition-data;
 }
-
-.incident-visibility {
-  margin-bottom: 10px;
-  
-  .text-warning {
-    color: #f0ad4e;  //  warning color
-  }
-  
-  .text-info {
-    color: #5bc0de;  //  info color
-  }
-  
-  .text-success {
-    color: #5cb85c;  //  success color
-  }
-}

--- a/app/assets/stylesheets/incidents.scss
+++ b/app/assets/stylesheets/incidents.scss
@@ -39,3 +39,19 @@
 #wrc-data {
   @extend #competition-data;
 }
+
+.incident-visibility {
+  margin-bottom: 10px;
+  
+  .text-warning {
+    color: #f0ad4e;  //  warning color
+  }
+  
+  .text-info {
+    color: #5bc0de;  //  info color
+  }
+  
+  .text-success {
+    color: #5cb85c;  //  success color
+  }
+}

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -38,8 +38,16 @@ class IncidentsController < ApplicationController
 
   def show
     set_incident
-    unless @incident.visible_to?(current_user)
+
+    # Check visibility and redirect based on user role
+    if @incident.visibility == 'draft' && !current_user&.can_manage_incidents?
       redirect_to_root_unless_user(:can_manage_incidents?)
+      return
+    end
+
+    if @incident.visibility == 'staff' && !current_user&.staff?
+      redirect_to_root_unless_user(:staff?)
+      nil
     end
   end
 
@@ -88,12 +96,6 @@ class IncidentsController < ApplicationController
 
   def update
     set_incident
-    if @incident.update(incident_params)
-      flash[:success] = "Incident was successfully updated."
-      redirect_to @incident
-    else
-      render :edit
-    end
   end
 
   def destroy

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -7,7 +7,7 @@ class Incident < ApplicationRecord
 
   accepts_nested_attributes_for :incident_competitions, allow_destroy: true
 
-  attribute :visibility, :integer, default: 1
+  attribute :visibility, :integer, default: 2
 
   enum visibility: {
     draft: 0,          # Only visible to WRC members

--- a/app/views/incidents/_form.html.erb
+++ b/app/views/incidents/_form.html.erb
@@ -4,6 +4,10 @@
 
   <div class="form-inputs">
     <%= f.input :title %>
+    <% if current_user.can_manage_incidents? %>
+      <%= f.input :visibility, collection: Incident.visibilities.keys.map { |v| [v.titleize, v] },
+                              include_blank: false %>
+    <% end %>
     <%= f.input :digest_worthy, disabled: @incident.digest_sent? %>
     <% if @incident.digest_sent? %>
       <div class="form-group"><div class="col-sm-10 col-sm-offset-2">Digest marked as sent on <%= wca_local_time(@incident.digest_sent_at) %></div></div>

--- a/app/views/incidents/_form.html.erb
+++ b/app/views/incidents/_form.html.erb
@@ -5,8 +5,11 @@
   <div class="form-inputs">
     <%= f.input :title %>
     <% if current_user.can_manage_incidents? %>
-      <%= f.input :visibility, collection: Incident.visibilities.keys.map { |v| [v.titleize, v] },
-                              include_blank: false %>
+      <%= f.input :visibility, collection: [
+        ['Draft (WRC only)', 'draft'],
+        ['Staff only', 'staff'],
+        ['Public', 'visible']
+      ], include_blank: false, hint: "Select who can view this incident" %>
     <% end %>
     <%= f.input :digest_worthy, disabled: @incident.digest_sent? %>
     <% if @incident.digest_sent? %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -13,15 +13,15 @@
   </div>
 
   <% if current_user&.can_manage_incidents? %>
-    <div>
-      <strong>Visibility:</strong>
-      <% case @incident.visibility %>
-      <% when "draft" %>
-        <span class="text-warning">Draft (WRC only)</span>
-      <% when "staff" %>
-        <span class="text-info">Staff only</span>
-      <% when "visible" %>
-        <span class="text-success">Public</span>
+    <div style="margin-top: 10px; display: flex; align-items: center;">
+      <strong style="margin-right: 10px;">Visibility:</strong>
+      <%= form_for @incident, html: { style: 'display: inline-flex; align-items: center;' } do |f| %>
+        <%= f.select :visibility, 
+            Incident.visibilities.map { |k, _| [k.titleize, k] },
+            { selected: @incident.visibility },
+            { class: 'ui dropdown',
+              style: 'min-width: 80px; max-height: 40px;',
+              onchange: 'this.form.submit()' } %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -12,6 +12,20 @@
     <% end %>
   </div>
 
+  <% if current_user&.can_manage_incidents? %>
+    <div>
+      <strong>Visibility:</strong>
+      <% case @incident.visibility %>
+      <% when "draft" %>
+        <span class="text-warning">Draft (WRC only)</span>
+      <% when "staff" %>
+        <span class="text-info">Staff only</span>
+      <% when "visible" %>
+        <span class="text-success">Public</span>
+      <% end %>
+    </div>
+  <% end %>
+
   <p>
     <% @incident.tags_array.each do |t| %>
       <%= render "incident_tag", tag: t %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_18_145843) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_04_012633) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -777,6 +777,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_18_145843) do
     t.datetime "resolved_at", precision: nil
     t.boolean "digest_worthy", default: false
     t.datetime "digest_sent_at", precision: nil
+    t.integer "visibility", default: 0, null: false
+    t.index ["visibility"], name: "index_incidents_on_visibility"
   end
 
   create_table "jwt_denylist", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_04_012633) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_18_145843) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -506,7 +506,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_04_012633) do
     t.integer "user_allow_viewonline", limit: 1, default: 1, null: false, unsigned: true
     t.integer "user_allow_viewemail", limit: 1, default: 1, null: false, unsigned: true
     t.integer "user_allow_massemail", limit: 1, default: 1, null: false, unsigned: true
-    t.integer "user_options", default: 230271, null: false, unsigned: true
+    t.integer "user_options", default: 230_271, null: false, unsigned: true
     t.string "user_avatar", limit: 255, default: "", null: false
     t.string "user_avatar_type", limit: 255, default: "", null: false
     t.integer "user_avatar_width", limit: 2, default: 0, null: false, unsigned: true
@@ -777,8 +777,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_04_012633) do
     t.datetime "resolved_at", precision: nil
     t.boolean "digest_worthy", default: false
     t.datetime "digest_sent_at", precision: nil
-    t.integer "visibility", default: 0, null: false
-    t.index ["visibility"], name: "index_incidents_on_visibility"
   end
 
   create_table "jwt_denylist", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Added a drop-down menu to each incident log, allowing you to set its permissions to be either public (all can see), draft (WCA members and those with permission to edit the log can see), or staff (only staff can see). 