### PR TITLE
Allow user to re-register a cancelled registration if edits are disabled

### DIFF
--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1395,12 +1395,13 @@ RSpec.describe Registrations::RegistrationChecker do
       end
 
       it 'user can change state from cancelled to pending' do
-        deleted_reg = FactoryBot.create(:registration, :cancelled, competition: default_competition)
+        no_edits_comp = FactoryBot.create(:competition, :registration_open)
+        cancelled_reg = FactoryBot.create(:registration, :cancelled, competition: no_edits_comp)
 
         update_request = FactoryBot.build(
           :update_request,
-          user_id: deleted_reg.user_id,
-          competition_id: deleted_reg.competition.id,
+          user_id: cancelled_reg.user_id,
+          competition_id: cancelled_reg.competition.id,
           competing: { 'status' => 'pending' },
         )
 


### PR DESCRIPTION
This was previously not possible because submitting a registration for a previously cancelled reg is viewed as an update by our system, and so was blocked by the `registration_edits_allowed?` check