### PR TITLE
Precompute "popular" Records/Results pages in Sidekiq as part of CAD

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -25,7 +25,7 @@ class ResultsController < ApplicationController
   end
 
   private def params_for_cache
-    params.permit(:event_id, :region, :years, :show, :gender, :type)
+    params.permit(:event_id, :region, :years, :show, :gender, :type).to_h.symbolize_keys
   end
 
   def rankings

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -8,8 +8,11 @@ class ResultsController < ApplicationController
   GENDER_ALL = "All"
   EVENTS_ALL = "all events"
 
+  MODE_RANKINGS = "rankings"
+  MODE_RECORDS = "records"
+
   def self.compute_cache_key(
-    table,
+    mode,
     event_id: EVENTS_ALL,
     region: REGION_WORLD,
     years: YEARS_ALL,
@@ -18,7 +21,7 @@ class ResultsController < ApplicationController
     type: nil
   )
     # The specific order of the entries is determined by backwards compatibility with historical code.
-    [table, event_id, region, years, show, gender, type].compact
+    [mode, event_id, region, years, show, gender, type].compact
   end
 
   private def params_for_cache
@@ -55,7 +58,7 @@ class ResultsController < ApplicationController
     @is_results = splitted_show_param[1] == "results"
     limit_condition = "LIMIT #{@show}"
 
-    @cache_params = ResultsController.compute_cache_key('rankings', **params_for_cache)
+    @cache_params = ResultsController.compute_cache_key(MODE_RANKINGS, **params_for_cache)
 
     if @is_persons
       @query = <<-SQL
@@ -177,7 +180,7 @@ class ResultsController < ApplicationController
 
     shared_constants_and_conditions
 
-    @cache_params = ResultsController.compute_cache_key('records', **params_for_cache)
+    @cache_params = ResultsController.compute_cache_key(MODE_RECORDS, **params_for_cache)
 
     if @is_histories
       if @is_history

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,14 +1,38 @@
 # frozen_string_literal: true
 
 class ResultsController < ApplicationController
+  REGION_WORLD = "world"
+  YEARS_ALL = "all years"
+  SHOW_100_PERSONS = "100 persons"
+  SHOW_MIXED = "mixed"
+  GENDER_ALL = "All"
+  EVENTS_ALL = "all events"
+
+  def self.compute_cache_key(
+    table,
+    event_id: EVENTS_ALL,
+    region: REGION_WORLD,
+    years: YEARS_ALL,
+    gender: GENDER_ALL,
+    show: nil,
+    type: nil
+  )
+    # The specific order of the entries is determined by backwards compatibility with historical code.
+    [table, event_id, region, years, show, gender, type].compact
+  end
+
+  private def params_for_cache
+    params.permit(:event_id, :region, :years, :show, :gender, :type)
+  end
+
   def rankings
     support_old_links!
 
     # Default params
-    params[:region] ||= "world"
-    params[:years] = "all years" # FIXME: this is disabling years filters for now
-    params[:show] ||= "100 persons"
-    params[:gender] ||= "All"
+    params[:region] ||= REGION_WORLD
+    params[:years] = YEARS_ALL # FIXME: this is disabling years filters for now
+    params[:show] ||= SHOW_100_PERSONS
+    params[:gender] ||= GENDER_ALL
 
     params[:show] = params[:show].gsub(/\d+/, "100") # FIXME: this is disabling anything except show 100 for now
 
@@ -31,7 +55,7 @@ class ResultsController < ApplicationController
     @is_results = splitted_show_param[1] == "results"
     limit_condition = "LIMIT #{@show}"
 
-    @cache_params = ['rankings', params[:event_id], params[:region], params[:years], params[:show], params[:gender], params[:type]]
+    @cache_params = ResultsController.compute_cache_key('rankings', **params_for_cache)
 
     if @is_persons
       @query = <<-SQL
@@ -137,13 +161,13 @@ class ResultsController < ApplicationController
     support_old_links!
 
     # Default params
-    params[:event_id] ||= "all events"
-    params[:region] ||= "world"
-    params[:years] = "all years" # FIXME: this is disabling years filters for now
-    params[:show] ||= "mixed"
-    params[:gender] ||= "All"
+    params[:event_id] ||= EVENTS_ALL
+    params[:region] ||= REGION_WORLD
+    params[:years] = YEARS_ALL # FIXME: this is disabling years filters for now
+    params[:show] ||= SHOW_MIXED
+    params[:gender] ||= GENDER_ALL
 
-    @shows = ["mixed", "slim", "separate", "history", "mixed history"]
+    @shows = [SHOW_MIXED, "slim", "separate", "history", "mixed history"]
     @is_mixed = params[:show] == @shows[0]
     @is_slim = params[:show] == @shows[1]
     @is_separate = params[:show] == @shows[2]
@@ -153,7 +177,7 @@ class ResultsController < ApplicationController
 
     shared_constants_and_conditions
 
-    @cache_params = ['records', params[:event_id], params[:region], params[:years], params[:show], params[:gender]]
+    @cache_params = ResultsController.compute_cache_key('records', **params_for_cache)
 
     if @is_histories
       if @is_history
@@ -263,7 +287,7 @@ class ResultsController < ApplicationController
     @years = Competition.non_future_years
     @types = ["single", "average"]
 
-    if params[:event_id] == "all events"
+    if params[:event_id] == EVENTS_ALL
       @event_condition = ""
     else
       event = Event.c_find!(params[:event_id])
@@ -293,7 +317,7 @@ class ResultsController < ApplicationController
       @gender_condition = ""
     end
 
-    @is_all_years = params[:years] == "all years"
+    @is_all_years = params[:years] == YEARS_ALL
     splitted_years_param = params[:years].split
     @is_only = splitted_years_param[0] == "only"
     @is_until = splitted_years_param[0] == "until"

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -105,14 +105,4 @@ module ResultsHelper
     end
     record_class
   end
-
-  def execute_cached_query(cache_key, sql_query)
-    # As we are using the native Rails cache we set the expiry date to 7 days
-    # as CAD is ran usually before that
-    Rails.cache.fetch(cache_key, expires_in: 7.days) do
-      ActiveRecord::Base.connected_to(role: :read_replica) do
-        ActiveRecord::Base.connection.exec_query(sql_query)
-      end
-    end
-  end
 end

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -10,4 +10,10 @@ class ComputeAuxiliaryData < WcaCronjob
   def perform
     AuxiliaryDataComputation.compute_everything
   end
+
+  def recompute_popular_rankings
+    Event::OFFICIAL_IDS.each do |event_id|
+
+    end
+  end
 end

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -135,7 +135,7 @@ class ComputeAuxiliaryData < WcaCronjob
           WHERE 1
             #{event_condition}
           GROUP BY eventId) record,
-        Results result
+        Results result,
         Events event,
         Countries country,
         Competitions competition

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -28,7 +28,7 @@ class ComputeAuxiliaryData < WcaCronjob
         column_value = result_type.gsub('single', 'best')
 
         rankings_query = self.rankings_query(result_type, column_value, event_id)
-        rankings_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RANKINGS, event_id: event_id, type: result_type)
+        rankings_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RANKINGS, event_id: event_id, type: result_type, show: ResultsController::SHOW_100_PERSONS)
 
         DbHelper.execute_cached_query(
           rankings_cache_key,
@@ -41,7 +41,7 @@ class ComputeAuxiliaryData < WcaCronjob
       # The records page by default shows a "mixed" view which contains both single and average at once,
       #   so there's no need to do this inside the small single/average loop like the rankings above.
       records_query = self.mixed_records_query(event_id: event_id)
-      records_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RECORDS, event_id: event_id)
+      records_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RECORDS, event_id: event_id, show: ResultsController::SHOW_MIXED)
 
       DbHelper.execute_cached_query(
         records_cache_key,
@@ -54,7 +54,7 @@ class ComputeAuxiliaryData < WcaCronjob
     # Lastly, compute the "All events" default view for mixed records.
     #   Again, this only applies to Records because Rankings must specify an event.
     all_records_query = self.mixed_records_query
-    all_records_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RECORDS)
+    all_records_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RECORDS, show: ResultsController::SHOW_MIXED)
 
     DbHelper.execute_cached_query(
       all_records_cache_key,

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -9,6 +9,10 @@ class ComputeAuxiliaryData < WcaCronjob
 
   def perform
     AuxiliaryDataComputation.compute_everything
+
+    # Trigger rankings computation based on the just-now-computed ranks,
+    #   but insert them into the cache _before_ committing the "CAD has finished" timestamp to the DB
+    self.recompute_popular_rankings
   end
 
   def recompute_popular_rankings

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -113,7 +113,7 @@ class ComputeAuxiliaryData < WcaCronjob
   end
 
   private def current_records_query(value, type, event_id: nil)
-    event_condition = event_id.present? ? "AND eventId = #{event_id}" : ""
+    event_condition = event_id.present? ? "AND eventId = '#{event_id}'" : ""
 
     <<-SQL
       SELECT

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -12,8 +12,133 @@ class ComputeAuxiliaryData < WcaCronjob
   end
 
   def recompute_popular_rankings
-    Event::OFFICIAL_IDS.each do |event_id|
+    # In the future, after this current run of the CAD job successfully finishes,
+    #   the `start_date` will be written / copied over to `successful_start_date`, so we predict that
+    #   the Records/Rankings pages will try and use that timestamp in the future once CAD has been completed.
+    predicted_timestamp = self.class.start_date
 
+    Event::OFFICIAL_IDS.each do |event_id|
+      %w[single average].each do |result_type|
+        # For averages, there's a column also called 'average'.
+        #   But for singles, the column to look up is called 'best'.
+        column_value = result_type.gsub('single', 'best')
+
+        rankings_query = self.rankings_query(result_type, column_value, event_id)
+        rankings_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RANKINGS, event_id: event_id, type: result_type)
+
+        DbHelper.execute_cached_query(
+          rankings_cache_key,
+          predicted_timestamp,
+          rankings_query,
+        )
+      end
+
+      # The records page by default shows a "mixed" view which contains both single and average at once,
+      #   so there's no need to do this inside the small single/average loop like the rankings above.
+      records_query = self.mixed_records_query(event_id: event_id)
+      records_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RECORDS, event_id: event_id)
+
+      DbHelper.execute_cached_query(
+        records_cache_key,
+        predicted_timestamp,
+        records_query,
+      )
     end
+
+    # Lastly, compute the "All events" default view for mixed records.
+    #   Again, this only applies to Records because Rankings must specify an event.
+    all_records_query = self.mixed_records_query
+    all_records_cache_key = ResultsController.compute_cache_key(ResultsController::MODE_RECORDS)
+
+    DbHelper.execute_cached_query(
+      all_records_cache_key,
+      predicted_timestamp,
+      all_records_query,
+    )
+  end
+
+  ######
+  # WARNING: Shameless copy-paste ahead!
+  #
+  # These queries originate from results_controller.rb. The cleanest solution would be to provide a method
+  #   which -- given an event ID, a region, a gender, etc. -- returns the SQL query string to the caller.
+  #   Both the controller as well as this job could then use that method.
+  # However, coming up with that method would require significant refactoring because of how all the
+  #   SQL `AND` conditions are currently glued together in different formats and different places,
+  #   and because of how deeply intertwined the query build process is with the `@var` global variables in the controller.
+  # Since we're only ever using the `event_id` filter here, and all other filters that the results_controller supports
+  #   are obsolete for this job, we would end up with an overblown solution that isn't really used except in one
+  #   place to its full potential (and here in a very, very trimmed-down version).
+  # So this shameless copy-pasta is the most time-efficient way I could come up with (and the next time we need to
+  #   touch these queries we will most likely redesign the schema so fundamentally that we can get rid of the current
+  #   caching approach anyways, so maintenance is at a minimum here.)
+  ######
+
+  private def rankings_query(type, column, event_id)
+    <<-SQL
+      SELECT
+        result.*,
+        result.#{column} value
+      FROM (
+        SELECT MIN(valueAndId) valueAndId
+        FROM Concise#{type.capitalize}Results result
+        WHERE #{column} > 0
+          AND eventId = '#{event_id}'
+        GROUP BY personId
+        ORDER BY valueAndId
+        LIMIT 100
+      ) top
+      JOIN Results result ON result.id = valueAndId % 1000000000
+      ORDER BY value, personName
+    SQL
+  end
+
+  private def mixed_records_query(event_id: nil)
+    <<-SQL
+      SELECT *
+      FROM
+        (#{self.current_records_query("best", "single", event_id: event_id)}
+        UNION
+        #{self.current_records_query("average", "average", event_id: event_id)}) helper
+      ORDER BY
+        `rank`, type DESC, start_date, roundTypeId, personName
+    SQL
+  end
+
+  private def current_records_query(value, type, event_id: nil)
+    event_condition = event_id.present? ? "AND eventId = #{event_id}" : ""
+
+    <<-SQL
+      SELECT
+        '#{type}'            type,
+                             result.*,
+                             value,
+        event.name           eventName,
+                             format,
+        country.name         countryName,
+        competition.cellName competitionName,
+                             `rank`,
+        competition.start_date,
+        YEAR(competition.start_date)  year,
+        MONTH(competition.start_date) month,
+        DAY(competition.start_date)   day
+      FROM
+        (SELECT eventId recordEventId, MIN(valueAndId) DIV 1000000000 value
+          FROM Concise#{type.capitalize}Results result
+          WHERE 1
+            #{event_condition}
+          GROUP BY eventId) record,
+        Results result
+        Events event,
+        Countries country,
+        Competitions competition
+      WHERE result.#{value} = value
+        #{event_condition}
+        AND result.eventId = recordEventId
+        AND event.id       = result.eventId
+        AND country.id     = result.countryId
+        AND competition.id = result.competitionId
+        AND event.`rank` < 990
+    SQL
   end
 end

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -30,6 +30,7 @@ class ComputeAuxiliaryData < WcaCronjob
           rankings_cache_key,
           predicted_timestamp,
           rankings_query,
+          db_role: :writing,
         )
       end
 
@@ -42,6 +43,7 @@ class ComputeAuxiliaryData < WcaCronjob
         records_cache_key,
         predicted_timestamp,
         records_query,
+        db_role: :writing,
       )
     end
 
@@ -54,6 +56,7 @@ class ComputeAuxiliaryData < WcaCronjob
       all_records_cache_key,
       predicted_timestamp,
       all_records_query,
+      db_role: :writing,
     )
   end
 

--- a/app/views/results/rankings.html.erb
+++ b/app/views/results/rankings.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, t(".title")) %>
 
 <% ranking_timestamp = ComputeAuxiliaryData.successful_run_start || Date.current %>
-<% @rows = execute_cached_query([*@cache_params, ranking_timestamp], @query) %>
+<% @rows = DbHelper.execute_cached_query(@cache_params, ranking_timestamp, @query) %>
 
 <div class="container">
   <h1><%= yield(:title) %></h1>

--- a/app/views/results/rankings.html.erb
+++ b/app/views/results/rankings.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t(".title")) %>
 
-<% ranking_timestamp = ComputeAuxiliaryData.successful_run_start || Date.current %>
+<% ranking_timestamp = ComputeAuxiliaryData.successful_start_date || Date.current %>
 <% @rows = DbHelper.execute_cached_query(@cache_params, ranking_timestamp, @query) %>
 
 <div class="container">

--- a/app/views/results/rankings.html.erb
+++ b/app/views/results/rankings.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t(".title")) %>
 
-<% ranking_timestamp = ComputeAuxiliaryData.end_date || Date.current %>
+<% ranking_timestamp = ComputeAuxiliaryData.successful_run_start || Date.current %>
 <% @rows = execute_cached_query([*@cache_params, ranking_timestamp], @query) %>
 
 <div class="container">

--- a/app/views/results/records.html.erb
+++ b/app/views/results/records.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t(".title")) %>
 
-<% record_timestamp = ComputeAuxiliaryData.successful_run_start || Date.current %>
+<% record_timestamp = ComputeAuxiliaryData.successful_start_date || Date.current %>
 <% @rows = DbHelper.execute_cached_query(@cache_params, record_timestamp, @query) %>
 
 <div class="container">

--- a/app/views/results/records.html.erb
+++ b/app/views/results/records.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, t(".title")) %>
 
 <% record_timestamp = ComputeAuxiliaryData.successful_run_start || Date.current %>
-<% @rows = execute_cached_query([*@cache_params, record_timestamp], @query) %>
+<% @rows = DbHelper.execute_cached_query(@cache_params, record_timestamp, @query) %>
 
 <div class="container">
   <h1><%= yield(:title) %></h1>

--- a/app/views/results/records.html.erb
+++ b/app/views/results/records.html.erb
@@ -1,7 +1,6 @@
 <% provide(:title, t(".title")) %>
 
-<% record_timestamp = ComputeAuxiliaryData.end_date || Date.current %>
-
+<% record_timestamp = ComputeAuxiliaryData.successful_run_start || Date.current %>
 <% @rows = execute_cached_query([*@cache_params, record_timestamp], @query) %>
 
 <div class="container">

--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -32,11 +32,11 @@ module DbHelper
     ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{old_table_name}")
   end
 
-  def self.execute_cached_query(cache_params, timestamp, sql_query)
+  def self.execute_cached_query(cache_params, timestamp, sql_query, db_role: :read_replica)
     # As we are using the native Rails cache we set the expiry date to 7 days
     #   as CAD is usually ran much more frequently than that
     Rails.cache.fetch([*cache_params, timestamp], expires_in: 7.days) do
-      ActiveRecord::Base.connected_to(role: :read_replica) do
+      ActiveRecord::Base.connected_to(role: db_role) do
         ActiveRecord::Base.connection.exec_query(sql_query)
       end
     end

--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -31,4 +31,14 @@ module DbHelper
     ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{temp_table_name}")
     ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{old_table_name}")
   end
+
+  def self.execute_cached_query(cache_params, timestamp, sql_query)
+    # As we are using the native Rails cache we set the expiry date to 7 days
+    #   as CAD is usually ran much more frequently than that
+    Rails.cache.fetch([*cache_params, timestamp], expires_in: 7.days) do
+      ActiveRecord::Base.connected_to(role: :read_replica) do
+        ActiveRecord::Base.connection.exec_query(sql_query)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Basically to remedy the issue that several threads get fried when people try to access Records pages directly after CAD has been run.

We pre-compute and insert the most popular pages (i.e. the default filter selection that you would see by just opening "Records", but not sophisticated queries like "Female Pyraminx Average History for Guatemala") and insert those into the cache using the same key which the page is expected to fetch just a moment later.

As an additional optimization, we could outsource this new "CAD part" into a separate job so that CAD runtimes aren't skewed. But then the cache timestamp is already invalid and we might not be fast enough with pre-computing until the statistics fetischists out there start bombarding us