### PR TITLE
Set disabled state on save button of edit activity modal

### DIFF
--- a/app/webpacker/components/EditSchedule/EditActivities/EditActivityModal.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/EditActivityModal.js
@@ -103,6 +103,7 @@ function EditActivityModal({
           icon="save"
           content="Save"
           positive
+          disabled={!activityCode || !activityName?.trim()}
           onClick={() => {
             onModalSave({ activityCode, activityName });
             closeModalAndCleanUp();


### PR DESCRIPTION
Currently, you can click 'save' without filling in the activity type or name. This appears to save successfully, but nothing new shows up in the schedule UI (I think because we're filtering out 'orphaned' activities?).