### PR TITLE
Unify update_status_and_charges for generic provider support

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -331,7 +331,7 @@ class RegistrationsController < ApplicationController
     connected_account = ConnectedStripeAccount.find_by(account_id: stored_record.account_id)
 
     unless connected_account.present?
-      logger.error "Stripe webhook reported event for account #{stored_record.account_id} but we are not connected to that account."
+      logger.error "Stripe webhook reported event for account '#{stored_record.account_id}' but we are not connected to that account."
       return head :not_found
     end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -314,6 +314,7 @@ class RegistrationsController < ApplicationController
 
     # Create a default audit that marks the event as "unhandled".
     audit_event = StripeWebhookEvent.create_from_api(event)
+    audit_remote_timestamp = audit_event.created_at_remote
 
     stripe_intent = event.data.object # contains a polymorphic type that depends on the event
     stored_record = StripeRecord.find_by(stripe_id: stripe_intent.id)
@@ -327,6 +328,13 @@ class RegistrationsController < ApplicationController
       end
     end
 
+    connected_account = ConnectedStripeAccount.find_by(account_id: stored_record.account_id)
+
+    unless connected_account.present?
+      logger.error "Stripe webhook reported event for account #{stored_record.account_id} but we are not connected to that account."
+      return head :not_found
+    end
+
     # Handle the event
     case event.type
     when StripeWebhookEvent::PAYMENT_INTENT_SUCCEEDED
@@ -334,7 +342,7 @@ class RegistrationsController < ApplicationController
 
       stored_intent = stored_record.payment_intent
 
-      stored_intent.update_status_and_charges(stripe_intent, audit_event, audit_event.created_at_remote) do |charge_transaction|
+      stored_intent.update_status_and_charges(connected_account, stripe_intent, audit_event, audit_remote_timestamp) do |charge_transaction|
         ruby_money = charge_transaction.money_amount
         stored_holder = stored_intent.holder
 
@@ -350,14 +358,14 @@ class RegistrationsController < ApplicationController
           # Context: When our servers die due to traffic spikes, the Stripe webhook cannot be processed
           #   and Stripe tries again after an exponential backoff. So we (erroneously!) record the creation timestamp
           #   in our DB _after_ the backed-off event has been processed. This can lead to a wrong registration order :(
-          stored_payment.update!(created_at: audit_event.created_at_remote)
+          stored_payment.update!(created_at: audit_remote_timestamp)
         end
       end
     when StripeWebhookEvent::PAYMENT_INTENT_CANCELED
       # stripe_intent contains a Stripe::PaymentIntent as per Stripe documentation
 
       stored_intent = stored_record.payment_intent
-      stored_intent.update_status_and_charges(stripe_intent, audit_event, audit_event.created_at_remote)
+      stored_intent.update_status_and_charges(connected_account, stripe_intent, audit_event, audit_remote_timestamp)
     else
       logger.info "Unhandled Stripe event type: #{event.type}"
     end
@@ -412,7 +420,7 @@ class RegistrationsController < ApplicationController
 
     registration = stored_intent.holder
 
-    stored_intent.update_status_and_charges(remote_intent, current_user) do |charge_transaction|
+    stored_intent.update_status_and_charges(payment_account, remote_intent, current_user) do |charge_transaction|
       ruby_money = charge_transaction.money_amount
 
       registration.record_payment(

--- a/app/models/connected_stripe_account.rb
+++ b/app/models/connected_stripe_account.rb
@@ -78,9 +78,9 @@ class ConnectedStripeAccount < ApplicationRecord
     )
   end
 
-  def retrieve_payments(payment_intent)
+  def retrieve_payments(intent_record)
     intent_charges = Stripe::Charge.list(
-      { payment_intent: payment_intent.payment_record.stripe_id },
+      { payment_intent: intent_record.stripe_id },
       stripe_account: self.account_id,
     )
 
@@ -90,7 +90,7 @@ class ConnectedStripeAccount < ApplicationRecord
       if stripe_record.present?
         stripe_record.update_status(charge)
       else
-        stripe_record = StripeRecord.create_from_api(charge, {}, self.account_id, payment_intent.payment_record)
+        stripe_record = StripeRecord.create_from_api(charge, {}, self.account_id, intent_record)
         yield stripe_record if block_given?
       end
 

--- a/app/models/connected_stripe_account.rb
+++ b/app/models/connected_stripe_account.rb
@@ -78,6 +78,26 @@ class ConnectedStripeAccount < ApplicationRecord
     )
   end
 
+  def retrieve_payments(payment_intent)
+    intent_charges = Stripe::Charge.list(
+      { payment_intent: payment_intent.payment_record.stripe_id },
+      stripe_account: self.account_id,
+    )
+
+    intent_charges.data.map do |charge|
+      stripe_record = StripeRecord.find_by(stripe_id: charge.id)
+
+      if stripe_record.present?
+        stripe_record.update_status(charge)
+      else
+        stripe_record = StripeRecord.create_from_api(charge, {}, self.account_id, payment_intent.payment_record)
+        yield stripe_record if block_given?
+      end
+
+      stripe_record
+    end
+  end
+
   def find_payment(record_id)
     StripeRecord.charge.find(record_id)
   end

--- a/app/models/connected_stripe_account.rb
+++ b/app/models/connected_stripe_account.rb
@@ -78,7 +78,9 @@ class ConnectedStripeAccount < ApplicationRecord
     )
   end
 
-  def retrieve_payments(intent_record)
+  def retrieve_payments(payment_intent)
+    intent_record = payment_intent.payment_record
+
     intent_charges = Stripe::Charge.list(
       { payment_intent: intent_record.stripe_id },
       stripe_account: self.account_id,

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -46,7 +46,7 @@ class PaymentIntent < ApplicationRecord
         # The payment didn't need any additional actions and is completed!
 
         # Record the success timestamp if not already done
-        unless self.confirmed_at.present?
+        unless self.succeeded?
           self.update!(
             confirmed_at: source_datetime,
             confirmation_source: action_source,
@@ -65,7 +65,7 @@ class PaymentIntent < ApplicationRecord
         # Canceled by the gateway
 
         # Record the cancellation timestamp if not already done
-        unless self.canceled_at.present?
+        unless self.canceled?
           self.update!(
             canceled_at: source_datetime,
             cancellation_source: action_source,

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -54,7 +54,7 @@ class PaymentIntent < ApplicationRecord
           )
         end
 
-        payment_account.retrieve_payments(self) do |payment|
+        payment_account.retrieve_payments(self.payment_record) do |payment|
           # Only trigger outer update blocks for charges that are actually successful. This is reasonable
           # because we only ever trigger this block for PIs that are marked "successful" in the first place
           charge_successful = payment.determine_wca_status == PaymentIntent.wca_statuses[:succeeded]

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -72,8 +72,8 @@ class PaymentIntent < ApplicationRecord
             wca_status: updated_wca_status,
           )
         end
-      when PaymentIntent.wca_statuses[:created]
-      when PaymentIntent.wca_statuses[:pending]
+      when PaymentIntent.wca_statuses[:created],
+        PaymentIntent.wca_statuses[:pending]
         # Reset by the gateway
         self.update!(
           confirmed_at: nil,

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -39,7 +39,7 @@ class PaymentIntent < ApplicationRecord
       # The order of operations here is critical:
       #   We need to update the underlying raw record first, so that `determine_wca_status` works correctly
       self.payment_record.update_status(api_intent)
-      updated_wca_status = self.determine_wca_status
+      updated_wca_status = self.determine_wca_status.to_s
 
       case updated_wca_status
       when PaymentIntent.wca_statuses[:succeeded]
@@ -57,7 +57,7 @@ class PaymentIntent < ApplicationRecord
         payment_account.retrieve_payments(self) do |payment|
           # Only trigger outer update blocks for charges that are actually successful. This is reasonable
           # because we only ever trigger this block for PIs that are marked "successful" in the first place
-          charge_successful = payment.determine_wca_status == PaymentIntent.wca_statuses[:succeeded]
+          charge_successful = payment.determine_wca_status.to_s == PaymentIntent.wca_statuses[:succeeded]
 
           yield payment if block_given? && charge_successful
         end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -54,7 +54,7 @@ class PaymentIntent < ApplicationRecord
           )
         end
 
-        payment_account.retrieve_payments(self.payment_record) do |payment|
+        payment_account.retrieve_payments(self) do |payment|
           # Only trigger outer update blocks for charges that are actually successful. This is reasonable
           # because we only ever trigger this block for PIs that are marked "successful" in the first place
           charge_successful = payment.determine_wca_status == PaymentIntent.wca_statuses[:succeeded]

--- a/app/models/stripe_record.rb
+++ b/app/models/stripe_record.rb
@@ -65,9 +65,9 @@ class StripeRecord < ApplicationRecord
     stripe_error = nil
 
     case self.stripe_record_type
-    when 'payment_intent'
+    when StripeRecord.stripe_record_types[:payment_intent]
       stripe_error = api_transaction.last_payment_error&.code
-    when 'charge'
+    when StripeRecord.stripe_record_types[:charge]
       stripe_error = api_transaction.failure_message
     end
 
@@ -79,11 +79,11 @@ class StripeRecord < ApplicationRecord
 
   def retrieve_stripe
     case self.stripe_record_type
-    when 'payment_intent'
+    when StripeRecord.stripe_record_types[:payment_intent]
       Stripe::PaymentIntent.retrieve(self.stripe_id, stripe_account: self.account_id)
-    when 'charge'
+    when StripeRecord.stripe_record_types[:charge]
       Stripe::Charge.retrieve(self.stripe_id, stripe_account: self.account_id)
-    when 'refund'
+    when StripeRecord.stripe_record_types[:refund]
       Stripe::Refund.retrieve(self.stripe_id, stripe_account: self.account_id)
     end
   end


### PR DESCRIPTION
Partial implementation of #9208 

The idea is to pull out all platform-specific behavior from `update_stripe_status_and_charges`, and implement that in the CPI instead. The payment intent's `update_status_and_charges` then gets the CPI as an additional param, which it can use to call the platform-specific functionality as sort of like an "interface"

Edit: For review, I recommend the "Hide Whitespace" feature in the diff settings