### PR TITLE
Make `payment_integration` a required parameter in the payment completion route

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -378,11 +378,8 @@ class RegistrationsController < ApplicationController
     competition_id = params[:competition_id]
     competition = Competition.find(competition_id)
 
-    # Historically, Stripe was our only payment provider and thus is the implicit default here.
-    #   This can be deleted (and the currently optional parameter in `routes.rb` can be changed
-    #   to become a mandatory parameter) a week or so after deployment.
-    payment_integration = params.fetch(:payment_integration, 'stripe')
-    payment_account = competition.payment_account_for(payment_integration.to_sym)
+    payment_integration = params[:payment_integration].to_sym
+    payment_account = competition.payment_account_for(payment_integration)
 
     unless payment_account.present?
       flash[:danger] = t("registrations.payment_form.errors.cpi_disconnected")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
 
   post 'registration/:id/load-payment-intent/:payment_integration' => 'registrations#load_payment_intent', as: :registration_payment_intent
   post 'competitions/:competition_id/refund/:payment_integration/:payment_id' => 'registrations#refund_payment', as: :registration_payment_refund
-  get 'competitions/:competition_id/payment-completion(/:payment_integration)' => 'registrations#payment_completion', as: :registration_payment_completion
+  get 'competitions/:competition_id/payment-completion/:payment_integration' => 'registrations#payment_completion', as: :registration_payment_completion
   post 'registration/stripe-webhook' => 'registrations#stripe_webhook', as: :registration_stripe_webhook
   get 'registration/payment-denomination' => 'registrations#payment_denomination', as: :registration_payment_denomination
   resources :users, only: [:index, :edit, :update]


### PR DESCRIPTION
Follow-up to #10234

The optional URL parameter that was in that PR (to maintain backwards compatibility) now becomes a required parameter.
All usages throughout the code have been adjusted to pass `'stripe'` (or the functionally equivalent `:stripe`) when calling the URL helpers