### PR TITLE
Clean up avatar inclusion in new competition overview backend

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -182,7 +182,7 @@ class Api::V0::ApiController < ApplicationController
   def delegates_search_index
     # TODO: There is a `uniq` call at the end which I feel shouldn't be necessary?!
     #   Postponing investigation until the Roles system migration is complete.
-    all_delegates = UserGroup.includes(:active_users).delegate_regions.flat_map(&:active_users).uniq
+    all_delegates = UserGroup.includes(active_users: [:current_avatar]).delegate_regions.flat_map(&:active_users).uniq
 
     search_index = all_delegates.map do |delegate|
       delegate.slice(:id, :name, :wca_id).merge({ thumb_url: delegate.avatar.thumbnail_url })

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -18,17 +18,17 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def competition_index
-    competitions = Competition.includes(:events)
-                              .search(params[:q], params: params)
+    admin_mode = current_user&.can_see_admin_competitions?
+
+    competitions_scope = Competition.includes(:events)
+    competitions_scope = competitions_scope.includes(:delegate_report, delegates: [:current_avatar]) if admin_mode
+
+    competitions = competitions_scope.search(params[:q], params: params)
 
     serial_methods = ["short_display_name", "city", "country_iso2", "event_ids", "date_range", "latitude_degrees", "longitude_degrees"]
     serial_includes = {}
 
-    admin_mode = current_user&.can_see_admin_competitions?
-
-    competitions = competitions.includes(:delegate_report, delegates: [:current_avatar]) if admin_mode
-
-    serial_includes["delegates"] = { only: ["id", "name"], methods: ["avatar"] } if admin_mode
+    serial_includes["delegates"] = { only: ["id", "name"], methods: [], include: ["avatar"] } if admin_mode
     serial_methods |= ["announced_at", "results_submitted_at", "report_posted_at"] if admin_mode
 
     paginate json: competitions,

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -26,9 +26,9 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
     admin_mode = current_user&.can_see_admin_competitions?
 
-    competitions = competitions.includes(:delegate_report) if admin_mode
+    competitions = competitions.includes(:delegate_report, delegates: [:current_avatar]) if admin_mode
 
-    serial_includes["delegates"] = { only: ["id", "name"], include: ["avatar"] } if admin_mode
+    serial_includes["delegates"] = { only: ["id", "name"], methods: ["avatar"] } if admin_mode
     serial_methods |= ["announced_at", "results_submitted_at", "report_posted_at"] if admin_mode
 
     paginate json: competitions,

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1807,7 +1807,10 @@ class Competition < ApplicationRecord
       order = { start_date: :desc }
     end
 
-    competitions.includes(:delegates, :organizers).order(**order)
+    # Respect other `includes` associations that might have been specified ahead of time
+    previous_includes = competitions.includes_values
+
+    competitions.includes(:delegates, :organizers, *previous_includes).order(**order)
   end
 
   def all_activities


### PR DESCRIPTION
This is a follow-up of the avatars migration which went by unnoticed because the page isn't actively used in prod and only in "preview" state.

Avatars used to be directly attached to the `user` class, now they are a separate DB entity which we have to preload.