### PR TITLE
Optimize React competition overview page spacing on mobile

### DIFF
--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -29,31 +29,28 @@ function CompetitionsFilters({
         <EventSelector
           selectedEvents={filterState.selectedEvents}
           onEventSelection={dispatchFilter}
+          showBreakBeforeButtons={false}
         />
       </Form.Field>
 
       <Form.Group>
-        <Form.Field width={6}>
+        <Form.Field width={8}>
           <RegionSelector region={filterState.region} dispatchFilter={dispatchFilter} />
         </Form.Field>
-        <Form.Field width={6}>
+        <Form.Field width={8}>
           <SearchBar text={filterState.search} dispatchFilter={dispatchFilter} />
         </Form.Field>
       </Form.Group>
 
       {shouldShowAdminDetails && (
-        <Form.Group>
-          <Form.Field width={8}>
-            <DelegateSelector delegateId={filterState.delegate} dispatchFilter={dispatchFilter} />
-          </Form.Field>
-        </Form.Group>
+        <Form.Field width={16}>
+          <DelegateSelector delegateId={filterState.delegate} dispatchFilter={dispatchFilter} />
+        </Form.Field>
       )}
 
-      <Form.Group>
-        <Form.Field>
-          <TimeOrderButtonGroup filterState={filterState} dispatchFilter={dispatchFilter} />
-        </Form.Field>
-      </Form.Group>
+      <Form.Field>
+        <TimeOrderButtonGroup filterState={filterState} dispatchFilter={dispatchFilter} />
+      </Form.Field>
 
       <Form.Group inline>
         <CompDisplayCheckboxes
@@ -76,10 +73,6 @@ function CompetitionsFilters({
       )}
 
       <Form.Group>
-        <ResetFilters dispatchFilter={dispatchFilter} />
-      </Form.Group>
-
-      <Form.Group>
         <ToggleListOrMapDisplay
           displayMode={displayMode}
           setDisplayMode={setDisplayMode}
@@ -96,6 +89,7 @@ export function EventSelector({
   disabled = false,
   maxEvents = Infinity,
   shouldErrorOnEmpty = false,
+  showBreakBeforeButtons = true,
   eventsDisabled = [],
   // Listing event as an argument here to indicate to developers that it's needed
   // eslint-disable-next-line no-unused-vars
@@ -105,7 +99,7 @@ export function EventSelector({
     <>
       <label htmlFor="events">
         {`${I18n.t('competitions.competition_form.events')}`}
-        <br />
+        {showBreakBeforeButtons ? (<br />) : (' ')}
         <Popup
           disabled={!Number.isFinite(maxEvents)}
           trigger={
@@ -231,10 +225,10 @@ function DelegateSelector({ delegateId, dispatchFilter }) {
 
   return (
     <>
-      <div style={{ display: 'inline-block' }}>
-        <label htmlFor="delegate">{I18n.t('layouts.navigation.delegate')}</label>
-        {delegatesLoading && <PulseLoader size="10px" cssOverride={{ marginLeft: '5px' }} />}
-      </div>
+      <label htmlFor="delegate" style={{ display: 'inline-block' }}>
+        {I18n.t('layouts.navigation.delegate')}
+        {delegatesLoading && <PulseLoader size="6px" cssOverride={{ marginLeft: '5px' }} />}
+      </label>
       <Dropdown
         name="delegate"
         id="delegate"
@@ -538,9 +532,18 @@ function ToggleListOrMapDisplay({ displayMode, setDisplayMode }) {
   );
 }
 
-function ResetFilters({ dispatchFilter }) {
+export function ResetFilters({ dispatchFilter, floated = null }) {
   return (
-    <Button type="reset" size="mini" id="reset" onClick={() => dispatchFilter({ type: 'reset' })}>
+    <Button
+      type="reset"
+      floated={floated}
+      size="mini"
+      id="reset"
+      icon
+      labelPosition="left"
+      onClick={() => dispatchFilter({ type: 'reset' })}
+    >
+      <Icon name="repeat" />
       {I18n.t('competitions.index.reset_filters')}
     </Button>
   );

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -30,6 +30,7 @@ function CompetitionsFilters({
           selectedEvents={filterState.selectedEvents}
           onEventSelection={dispatchFilter}
           showBreakBeforeButtons={false}
+          eventButtonsCompact
         />
       </Form.Field>
 
@@ -90,6 +91,7 @@ export function EventSelector({
   maxEvents = Infinity,
   shouldErrorOnEmpty = false,
   showBreakBeforeButtons = true,
+  eventButtonsCompact = false,
   eventsDisabled = [],
   // Listing event as an argument here to indicate to developers that it's needed
   // eslint-disable-next-line no-unused-vars
@@ -134,6 +136,7 @@ export function EventSelector({
                         || eventsDisabled.includes(eventId)
                     }
                       basic
+                      compact={eventButtonsCompact}
                       icon
                       toggle
                       type="button"

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsView.js
@@ -8,7 +8,7 @@ import I18n from '../../lib/i18n';
 import { apiV0Urls, WCA_API_PAGINATION } from '../../lib/requests/routes.js.erb';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 
-import CompetitionsFilters from './CompetitionsFilters';
+import CompetitionsFilters, { ResetFilters } from './CompetitionsFilters';
 import ListView from './ListView';
 import MapView from './MapView';
 import {
@@ -113,7 +113,10 @@ function CompetitionsView({ canViewAdminDetails = false }) {
 
   return (
     <Container>
-      <Header as="h2">{I18n.t('competitions.index.title')}</Header>
+      <Header as="h2">
+        {I18n.t('competitions.index.title')}
+        <ResetFilters dispatchFilter={dispatchFilter} floated="right" />
+      </Header>
       <CompetitionsFilters
         filterState={filterState}
         dispatchFilter={dispatchFilter}

--- a/app/webpacker/components/CompetitionsOverview/ListView.js
+++ b/app/webpacker/components/CompetitionsOverview/ListView.js
@@ -64,15 +64,17 @@ function ListView({
 
       return (
         <>
-          <ListViewSection
-            competitions={inProgressComps}
-            title={I18n.t('competitions.index.titles.in_progress')}
-            shouldShowRegStatus={shouldShowRegStatus}
-            selectedDelegate={filterState.delegate}
-            regStatusLoading={regStatusLoading}
-            isLoading={isLoading && !upcomingComps?.length}
-            hasMoreCompsToLoad={hasMoreCompsToLoad && !upcomingComps?.length}
-          />
+          {inProgressComps?.length > 0 && (
+            <ListViewSection
+              competitions={inProgressComps}
+              title={I18n.t('competitions.index.titles.in_progress')}
+              shouldShowRegStatus={shouldShowRegStatus}
+              selectedDelegate={filterState.delegate}
+              regStatusLoading={regStatusLoading}
+              isLoading={isLoading && !upcomingComps?.length}
+              hasMoreCompsToLoad={hasMoreCompsToLoad && !upcomingComps?.length}
+            />
+          )}
           <ListViewSection
             competitions={upcomingComps}
             title={I18n.t('competitions.index.titles.upcoming')}

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -156,7 +156,7 @@ export function CompetitionsTable({
               <Table.Cell textAlign="right" width={2}>
                 {comp.date_range}
               </Table.Cell>
-              <Table.Cell width={6}>
+              <Table.Cell width={5}>
                 <Flag name={comp.country_iso2?.toLowerCase()} />
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
@@ -164,7 +164,7 @@ export function CompetitionsTable({
                 <strong>{countries.byIso2[comp.country_iso2].name}</strong>
                 {`, ${comp.city}`}
               </Table.Cell>
-              <Table.Cell width={4}>
+              <Table.Cell width={5}>
                 <PseudoLinkMarkdown text={comp.venue} />
               </Table.Cell>
             </Table.Row>

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -217,8 +217,10 @@ export function CompetitionsTabletTable({
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
               <Table.Cell width={7}>
-                <strong>{countries.byIso2[comp.country_iso2].name}</strong>
-                {`, ${comp.city}`}
+                <span>
+                  <strong>{countries.byIso2[comp.country_iso2].name}</strong>
+                  {`, ${comp.city}`}
+                </span>
                 <PseudoLinkMarkdown text={comp.venue} />
               </Table.Cell>
             </Table.Row>
@@ -248,7 +250,7 @@ export function CompetitionsMobileTable({
             />
             <Table.Row error={isCancelled(comp)} className="competition-info mobile-compact">
               <Table.Cell>
-                <Label ribbon="right">
+                <Label ribbon="right" size="small">
                   <StatusIcon
                     comp={comp}
                     shouldShowRegStatus={shouldShowRegStatus}
@@ -262,9 +264,12 @@ export function CompetitionsMobileTable({
                 {' '}
               </Table.Cell>
               <Table.Cell>
-                <strong>{countries.byIso2[comp.country_iso2].name}</strong>
-                {`, ${comp.city}`}
-                <PseudoLinkMarkdown text={comp.venue} />
+                <span>
+                  <strong>{countries.byIso2[comp.country_iso2].name}</strong>
+                  {`, ${comp.city}`}
+                </span>
+                {' '}
+                <PseudoLinkMarkdown text={comp.venue} RenderAs="span" />
               </Table.Cell>
             </Table.Row>
           </React.Fragment>

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -261,9 +261,14 @@ export function CompetitionsMobileTable({
                 </Label>
                 <Flag name={comp.country_iso2?.toLowerCase()} />
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
-                {' '}
               </Table.Cell>
-              <Table.Cell>
+              {
+                /* This "magical" 1px is necessary so that the long text from the venue
+                *   "clears" the floating date indicator from above. Otherwise, the text
+                *   would break too early. SemUI doesn't support "nicely" padding cells,
+                *   if anyone has a better idea then please shout. */
+              }
+              <Table.Cell style={{ marginTop: '1px' }}>
                 <span>
                   <strong>{countries.byIso2[comp.country_iso2].name}</strong>
                   {`, ${comp.city}`}

--- a/app/webpacker/lib/utils/competition-table.js
+++ b/app/webpacker/lib/utils/competition-table.js
@@ -132,7 +132,7 @@ export function computeReportsAndResultsStatus(comp, refDate) {
 
 // Currently, the venue attribute of a competition object can be written as markdown,
 // and using third party libraries like react-markdown to parse it requires too much work
-export function PseudoLinkMarkdown({ text }) {
+export function PseudoLinkMarkdown({ text, RenderAs = 'p' }) {
   const openBracketIndex = text.indexOf('[');
   const closeBracketIndex = text.indexOf(']', openBracketIndex);
   const openParenIndex = text.indexOf('(', closeBracketIndex);
@@ -140,14 +140,14 @@ export function PseudoLinkMarkdown({ text }) {
 
   if (openBracketIndex === -1 || closeBracketIndex === -1
     || openParenIndex === -1 || closeParenIndex === -1) {
-    return <p>{text}</p>;
+    return <RenderAs>{text}</RenderAs>;
   }
 
   return (
-    <p>
+    <RenderAs>
       <a href={text.slice(openParenIndex + 1, closeParenIndex)} target="_blank" rel="noreferrer">
         {text.slice(openBracketIndex + 1, closeBracketIndex)}
       </a>
-    </p>
+    </RenderAs>
   );
 }


### PR DESCRIPTION
Tries to squeeze out even more room for folks who get very excited at the notion of squishing one more competition on their phone screen.

# Tablet
![localhost_3000_competitions](https://github.com/user-attachments/assets/a789e95f-6206-47bf-9483-a3874d8872ef)
![localhost_3000_competitions_legacy=off](https://github.com/user-attachments/assets/8b70a830-5ed6-4d39-bbdf-462bdebdd765)

# Mobile
![localhost_3000_competitions](https://github.com/user-attachments/assets/a3e08bf0-4ac3-4373-915b-7281fa00bc81)
![localhost_3000_competitions_legacy=off](https://github.com/user-attachments/assets/2834ebe1-bacb-41ba-a608-c623fd674818)

The legacy view can still barely squeeze one more competition, but I feel that with the layout improvements of the table and the information generally being quite "dense" in the old view, this is a good trade-off