### PR TITLE
More cleanly transition to mandatory :payment_integration parameter in URL

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -65,7 +65,7 @@ export default function PaymentStep({
       elements,
       clientSecret,
       confirmParams: {
-        return_url: paymentFinishUrl(competitionInfo.id),
+        return_url: paymentFinishUrl(competitionInfo.id, 'stripe'),
       },
     });
 

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -92,7 +92,7 @@ export const adminFixResultsUrl = (personId, competition_id = undefined, event_i
   return `<%= CGI.unescape(Rails.application.routes.url_helpers.admin_fix_results_path) %>?${searchParams.toString()}`
 };
 
-export const paymentFinishUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_payment_completion_url("${competitionId}", host: EnvConfig.ROOT_URL)) %>`
+export const paymentFinishUrl = (competitionId, paymentIntegration) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_payment_completion_url("${competitionId}", "${paymentIntegration}", host: EnvConfig.ROOT_URL)) %>`
 
 export const availableRefundsUrl = (competitionId, userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refunds_path) %>?attendee_id=${competitionId}-${userId}`
 

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
           )
           get :payment_completion, params: {
             competition_id: competition.id,
+            payment_integration: :stripe,
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -587,7 +587,7 @@ RSpec.describe "registrations" do
             stripe_account: competition.payment_account_for(:stripe).account_id,
           )
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
@@ -655,7 +655,7 @@ RSpec.describe "registrations" do
             stripe_account: competition.payment_account_for(:stripe).account_id,
           )
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
@@ -688,7 +688,7 @@ RSpec.describe "registrations" do
             stripe_account: competition.payment_account_for(:stripe).account_id,
           )
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
@@ -723,7 +723,7 @@ RSpec.describe "registrations" do
               stripe_account: competition.payment_account_for(:stripe).account_id,
             )
             # mimic the response that Stripe sends to our return_url after completing the checkout UI
-            get registration_payment_completion_path(competition.id), params: {
+            get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
@@ -757,7 +757,7 @@ RSpec.describe "registrations" do
           )
 
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
@@ -794,7 +794,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimick the response that Stripe sends to our return_url after completing the checkout UI
-            get registration_payment_completion_path(competition.id), params: {
+            get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
@@ -824,7 +824,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimick the response that Stripe sends to our return_url after completing the checkout UI
-            get registration_payment_completion_path(competition.id), params: {
+            get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
@@ -854,7 +854,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimick the response that Stripe sends to our return_url after completing the checkout UI
-            get registration_payment_completion_path(competition.id), params: {
+            get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
@@ -884,7 +884,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimick the response that Stripe sends to our return_url after completing the checkout UI
-            get registration_payment_completion_path(competition.id), params: {
+            get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
@@ -911,7 +911,7 @@ RSpec.describe "registrations" do
               stripe_account: competition.payment_account_for(:stripe).account_id,
             )
             # mimick the response that Stripe sends to our return_url after completing the checkout UI
-            get registration_payment_completion_path(competition.id), params: {
+            get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
@@ -947,7 +947,7 @@ RSpec.describe "registrations" do
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
@@ -989,7 +989,7 @@ RSpec.describe "registrations" do
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
@@ -1036,7 +1036,7 @@ RSpec.describe "registrations" do
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
@@ -1082,7 +1082,7 @@ RSpec.describe "registrations" do
           )
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
-          get registration_payment_completion_path(competition.id), params: {
+          get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }


### PR DESCRIPTION
Basically a copy-cat of #10458, except that the parameter in the URL is not marked as required yet.

This will make it so that if anybody starts a Stripe session with the old (paremeter-less, because optional) URL _during deployment_, the route would still resolve after coming back to the newly deployed server.

Highly unlikely circumstance anyways (somebody would need to perform their 3DS authorization _exactly_ during the time window that AWS swaps out our ECS instances and switches over the traffic) but with payments you can never be safe enough.

Since the original #10458 is already reviewed and approved, I will merge this as soon as tests pass.