### PR TITLE
Add backend methods to PayPal models and interfaces

### DIFF
--- a/lib/paypal_interface.rb
+++ b/lib/paypal_interface.rb
@@ -87,11 +87,44 @@ module PaypalInterface
     [payload, response.body]
   end
 
+  def self.retrieve_order(merchant_id, order_id)
+    url = "/v2/checkout/orders/#{order_id}"
+
+    response = paypal_connection.get(url) do |req|
+      req.headers['PayPal-Partner-Attribution-Id'] = AppSecrets.PAYPAL_ATTRIBUTION_CODE
+      req.headers['PayPal-Auth-Assertion'] = paypal_auth_assertion(merchant_id)
+    end
+
+    response.body
+  end
+
+  def self.retrieve_capture(merchant_id, capture_id)
+    url = "/v2/payments/captures/#{capture_id}"
+
+    response = paypal_connection.get(url) do |req|
+      req.headers['PayPal-Partner-Attribution-Id'] = AppSecrets.PAYPAL_ATTRIBUTION_CODE
+      req.headers['PayPal-Auth-Assertion'] = paypal_auth_assertion(merchant_id)
+    end
+
+    response.body
+  end
+
   # TODO: Update the status of the PaypalRecord object?
   def self.capture_payment(merchant_id, order_id)
     url = "/v2/checkout/orders/#{order_id}/capture"
 
     response = paypal_connection.post(url) do |req|
+      req.headers['PayPal-Partner-Attribution-Id'] = AppSecrets.PAYPAL_ATTRIBUTION_CODE
+      req.headers['PayPal-Auth-Assertion'] = paypal_auth_assertion(merchant_id)
+    end
+
+    response.body
+  end
+
+  def self.retrieve_refund(merchant_id, refund_id)
+    url = "/v2/payments/refunds/#{refund_id}"
+
+    response = paypal_connection.get(url) do |req|
       req.headers['PayPal-Partner-Attribution-Id'] = AppSecrets.PAYPAL_ATTRIBUTION_CODE
       req.headers['PayPal-Auth-Assertion'] = paypal_auth_assertion(merchant_id)
     end


### PR DESCRIPTION
No-op PR to fulfill the "interfaces" implied by previous payment gateway PRs.
Not used anywhere currently so will just merge as soon as tests pass.