### PR TITLE
Display partial-refunds and include them in total paid

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -82,6 +82,8 @@ export default function TableRow({
     payment_statuses: paymentStatuses,
     has_paid: hasPaid,
   } = registration.payment ?? {};
+  {console.log("payment:")}
+  {console.log(registration.payment)}
 
   const copyEmail = () => {
     navigator.clipboard.writeText(emailAddress);
@@ -160,7 +162,7 @@ export default function TableRow({
 
             {competitionInfo['using_payment_integrations?'] && (
             <Table.Cell>
-              {hasPaid
+              {paymentAmount > 0
                 ? isoMoneyToHumanReadable(paymentAmount, competitionInfo.currency_code)
                 : ''}
             </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -82,8 +82,6 @@ export default function TableRow({
     payment_statuses: paymentStatuses,
     has_paid: hasPaid,
   } = registration.payment ?? {};
-  {console.log("payment:")}
-  {console.log(registration.payment)}
 
   const copyEmail = () => {
     navigator.clipboard.writeText(emailAddress);

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -160,7 +160,7 @@ export default function TableRow({
 
             {competitionInfo['using_payment_integrations?'] && (
             <Table.Cell>
-              {paymentAmount > 0
+              {paymentAmount != 0
                 ? isoMoneyToHumanReadable(paymentAmount, competitionInfo.currency_code)
                 : ''}
             </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -5,7 +5,7 @@ import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 
 const moneyCountHumanReadable = (registrations, competitionInfo) => {
   const moneyCount = _.sum(registrations.filter(
-    (r) => r.payment.has_paid,
+    (r) => r.payment.payment_amount_iso > 0,
   ).map((r) => r.payment.payment_amount_iso));
 
   return isoMoneyToHumanReadable(

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -4,9 +4,7 @@ import React from 'react';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 
 const moneyCountHumanReadable = (registrations, competitionInfo) => {
-  const moneyCount = _.sum(registrations.filter(
-    (r) => r.payment.payment_amount_iso > 0,
-  ).map((r) => r.payment.payment_amount_iso));
+  const moneyCount = _.sum(registrations.map((r) => r.payment.payment_amount_iso));
 
   return isoMoneyToHumanReadable(
     moneyCount,


### PR DESCRIPTION
Fixes 2 issues: 
- Partially-refunded payments weren't showing the amount which the user has paid in the "Amount" column
- Partially-refunded payments weren't being included in the total amount paid

Here's after the changes (note $74 total and $29 and $15 partial payments)
![image](https://github.com/user-attachments/assets/12f36021-00da-47d6-abce-b0411f1108f0)

Here's before (only the code branch has changed - the $15 and $29 should still show in amount paid, and the total is higher than $30):
![image](https://github.com/user-attachments/assets/447478a1-a90b-4403-b307-0f29ecb525e7)
