### PR TITLE
Display waitlisted competitions in My Competitions

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -839,7 +839,8 @@ class CompetitionsController < ApplicationController
     ActiveRecord::Base.connected_to(role: :read_replica) do
       competition_ids = current_user.organized_competitions.pluck(:competition_id)
       competition_ids.concat(current_user.delegated_competitions.pluck(:competition_id))
-      registrations = current_user.registrations.includes(:competition).active.reject { |r| r.competition.results_posted? }
+      registrations = current_user.registrations.includes(:competition).accepted.reject { |r| r.competition.results_posted? }
+      registrations.concat(current_user.registrations.includes(:competition).waitlisted.select { |r| r.competition.upcoming? })
       registrations.concat(current_user.registrations.includes(:competition).pending.select { |r| r.competition.upcoming? })
       @registered_for_by_competition_id = registrations.uniq.to_h do |r|
         [r.competition.id, r]

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -839,7 +839,7 @@ class CompetitionsController < ApplicationController
     ActiveRecord::Base.connected_to(role: :read_replica) do
       competition_ids = current_user.organized_competitions.pluck(:competition_id)
       competition_ids.concat(current_user.delegated_competitions.pluck(:competition_id))
-      registrations = current_user.registrations.includes(:competition).accepted.reject { |r| r.competition.results_posted? }
+      registrations = current_user.registrations.includes(:competition).active.reject { |r| r.competition.results_posted? }
       registrations.concat(current_user.registrations.includes(:competition).pending.select { |r| r.competition.upcoming? })
       @registered_for_by_competition_id = registrations.uniq.to_h do |r|
         [r.competition.id, r]

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class Registration < ApplicationRecord
-  scope :pending, -> { where(competing_status: Registrations::Helper::STATUS_PENDING) }
-  scope :accepted, -> { where(competing_status: Registrations::Helper::STATUS_ACCEPTED) }
-  scope :cancelled, -> { where(competing_status: Registrations::Helper::STATUS_CANCELLED) }
-  scope :rejected, -> { where(competing_status: Registrations::Helper::STATUS_REJECTED) }
-  scope :waitlisted, -> { where(competing_status: Registrations::Helper::STATUS_WAITING_LIST) }
+  # TODO: Reg-V3 Cleanup: Remove all these and use the competing_status_{status} scopes
+  scope :pending, -> { where(competing_status: 'pending') }
+  scope :accepted, -> { where(competing_status: 'accepted') }
+  scope :cancelled, -> { where(competing_status: 'cancelled') }
+  scope :rejected, -> { where(competing_status: 'rejected') }
+  scope :waitlisted, -> { where(competing_status: 'waiting_list') }
   scope :non_competing, -> { where(is_competing: false) }
-  scope :active, -> { where.not(competing_status: [Registrations::Helper::STATUS_CANCELLED, Registrations::Helper::STATUS_REJECTED]) }
+  scope :not_cancelled, -> { where.not(competing_status: 'cancelled') }
   scope :with_payments, -> { joins(:registration_payments).distinct }
   scope :wcif_ordered, -> { order(:id) }
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 class Registration < ApplicationRecord
-  # TODO: Reg-V3 Cleanup: Remove all these and use the competing_status_{status} scopes
-  scope :pending, -> { where(competing_status: 'pending') }
-  scope :accepted, -> { where(competing_status: 'accepted') }
-  scope :cancelled, -> { where(competing_status: 'cancelled') }
-  scope :rejected, -> { where(competing_status: 'rejected') }
-  scope :waitlisted, -> { where(competing_status: 'waiting_list') }
+  scope :pending, -> { where(competing_status: Registrations::Helper::STATUS_PENDING) }
+  scope :accepted, -> { where(competing_status: Registrations::Helper::STATUS_ACCEPTED) }
+  scope :cancelled, -> { where(competing_status: Registrations::Helper::STATUS_CANCELLED) }
+  scope :rejected, -> { where(competing_status: Registrations::Helper::STATUS_REJECTED) }
+  scope :waitlisted, -> { where(competing_status: Registrations::Helper::STATUS_WAITING_LIST) }
   scope :non_competing, -> { where(is_competing: false) }
-  scope :not_cancelled, -> { where.not(competing_status: 'cancelled') }
+  scope :active, -> { where.not(competing_status: [Registrations::Helper::STATUS_CANCELLED, Registrations::Helper::STATUS_REJECTED]) }
   scope :with_payments, -> { joins(:registration_payments).distinct }
   scope :wcif_ordered, -> { order(:id) }
 


### PR DESCRIPTION
We could add a separate scope for pending_and_waitlisted, (perhaps `active_not_accepted` or similar?), but
- I figured that Rails might be smart enough to combine all this concatenation into one SQL statement 
- I realized the requirements for the My Competitions page aren't trivial and didn't want to get in over my head with what I might be changing so keeping it simple/stupid