### PR TITLE
Edit Registration: Display name of acting user and typo fix

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -213,8 +213,7 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
         )}
         {registrationEditDeadlinePassed && (
           <Message>
-            The Registration Edit Deadline has passed!
-            <strong>Changes should only be made in extraordinary circumstances</strong>
+            The Registration Edit Deadline has passed! <strong>Changes should only be made in extraordinary circumstances</strong>
           </Message>
         )}
         <Header>{competitor.name}</Header>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -50,7 +50,9 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
 
   const { isLoading, data: competitorsInfo } = useQuery({
     queryKey: ['history-user', serverRegistration?.history],
-    queryFn: () => getUsersInfo(_.uniq(serverRegistration.history.flatMap((e) => (e.actor_type === 'user' ? Number(e.actor_id) : [])))),
+    queryFn: () => getUsersInfo(_.uniq(serverRegistration.history.flatMap((e) => (
+      (e.actor_type === 'user' || e.actor_type === 'worker') ? Number(e.actor_id) : [])
+    ))),
     enabled: Boolean(serverRegistration),
   });
 

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'API Registrations' do
           post api_v1_registrations_register_path, params: registration_request, headers: headers
         }.to have_enqueued_job(AddRegistrationJob)
       end
+
       it 'creates a registration when job is worked off' do
         perform_enqueued_jobs do
           post api_v1_registrations_register_path, params: registration_request, headers: headers
@@ -35,6 +36,18 @@ RSpec.describe 'API Registrations' do
           registration = Registration.find_by(user_id: user.id)
           expect(registration).to be_present
           expect(registration.events.map(&:id).sort).to eq(['333', '333oh'])
+        end
+      end
+
+      it 'creates a registration history' do
+        perform_enqueued_jobs do
+          post api_v1_registrations_register_path, params: registration_request, headers: headers
+
+          registration = Registration.find_by(user_id: user.id)
+          reg_history = registration.registration_history.first
+
+          expect(reg_history[:actor_id]).to eq(user.id.to_s)
+          expect(reg_history[:action]).to eq("Worker processed")
         end
       end
     end


### PR DESCRIPTION
We weren't retrieving user data when the worker processed a change, meaning that we only displayed the user_id in the "Acting User" column, not their name.

Other changes:
- added a test to assert that registration history gets created (did this before I realized it was a frontend issue, but it's a worthwhile test so left it in)
- minor text fixes (the newline got condensed to there being no space between the two sentences)

After:
![image](https://github.com/user-attachments/assets/a29eeb16-1406-4565-820d-572af9ca8953)

Before:
![image](https://github.com/user-attachments/assets/d78b59dc-04e8-4317-857b-af94d1ef3b73)

