### PR TITLE
Always display guest limit input if `guestsEnabled`

### DIFF
--- a/app/webpacker/components/CompetitionForm/FormSections/RegistrationDetails.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/RegistrationDetails.js
@@ -41,7 +41,7 @@ export default function RegistrationDetails() {
       <ConditionalSection showIf={guestsGoFree}>
         <InputSelect id="guestEntryStatus" options={guestMessageOptions} required={guestsGoFree} />
       </ConditionalSection>
-      <ConditionalSection showIf={guestsRestricted}>
+      <ConditionalSection showIf={registration?.guestsEnabled}>
         <InputNumber id="guestsPerRegistration" required={guestsRestricted} />
       </ConditionalSection>
       <InputMarkdown id="extraRequirements" />


### PR DESCRIPTION
This one is a bit of a long story. 

- For some competitions (eg, https://www.worldcubeassociation.org/competitions/BattleforBelgrade2025/register), the user can't enter any guest amount > 0
- This is because organizers can only change the guest limit in 1/3 cases where guestsEnabled is true in the competition form - `restricted` ("Guests are only permitted as guests of competitors"). In the other cases (`free` and `unclear`) we don't display the guest limit setting at all - despite the organizer having selected "Ask about guests"
- This leads to a situation where a competitor is asked how many guests they want to bring, but isn't able to set a non-zero value for this field (as the organizer can't set a non-zero limit) 

I believe this is an inconsistency in the Competition Form, and we should instead _always_ display the guest limit if the organizer selects "Ask about guests".

There are two levels of solution here: 
1. **Fix for new competitions: ** Always show the guest limit if "Ask about guests" is selected 
2. **Fix for existing competitions: ** We'll still have the issue of existing competitions asking about guests where no non-zero value is allowed. To resolve this, I think we have a few options:
  1. Consider a guest_limit of 0 equivalent to NULL if `guests_enabled` is true
    1. If we're not going to consider guest_limit == 0 as NULL, then we should change the competition form to allow a user to leave a numeric field blank (currently it can start off blank, but they can't replace the 0 once they've put any number in there - ie, an organizer couldn't _remove_ a guest limit once it is set)  
  3. Write a SQL query that sets all `guest_limit` to NULL for all open comps with `guests_enabled` == true AND `guest_limit` == 0