### PR TITLE
Only show competing registrations in Competitor list

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -90,7 +90,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   def list
     competition_id = list_params
     competition = Competition.find(competition_id)
-    registrations = competition.registrations.accepted
+    registrations = competition.registrations.accepted.competing
     payload = Rails.cache.fetch([
                                   "registrations_v2_list",
                                   competition.id,

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -3,7 +3,7 @@
 class Registration < ApplicationRecord
   # TODO: Reg-V3 Cleanup: Remove all these and use the competing_status_{status} scopes
   scope :pending, -> { where(competing_status: 'pending') }
-  scope :accepted, -> { where(competing_status: 'accepted') }
+  scope :accepted, -> { where(competing_status: 'accepted', is_competing: true) }
   scope :cancelled, -> { where(competing_status: 'cancelled') }
   scope :rejected, -> { where(competing_status: 'rejected') }
   scope :waitlisted, -> { where(competing_status: 'waiting_list') }

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -3,11 +3,12 @@
 class Registration < ApplicationRecord
   # TODO: Reg-V3 Cleanup: Remove all these and use the competing_status_{status} scopes
   scope :pending, -> { where(competing_status: 'pending') }
-  scope :accepted, -> { where(competing_status: 'accepted', is_competing: true) }
+  scope :accepted, -> { where(competing_status: 'accepted') }
   scope :cancelled, -> { where(competing_status: 'cancelled') }
   scope :rejected, -> { where(competing_status: 'rejected') }
   scope :waitlisted, -> { where(competing_status: 'waiting_list') }
   scope :non_competing, -> { where(is_competing: false) }
+  scope :competing, -> { where(is_competing: true) }
   scope :not_cancelled, -> { where.not(competing_status: 'cancelled') }
   scope :with_payments, -> { joins(:registration_payments).distinct }
   scope :wcif_ordered, -> { order(:id) }


### PR DESCRIPTION
TL;DR - I'm operating on the assumption that devs should explicitly _request_ the presence of non-competing registrations when working with registration data, which seems much less likely to lead to issues than non-competing registrations being returned when they don't realize they've implicitly requested them

Currently, we show non-competing registrations in the Competitor list - eg, Amanda Campbell in [Warm Up Seattle 2025](https://www.worldcubeassociation.org/competitions/WarmUpSeattle2025/registrations).

This is because our `accepted` scope doesn't check whether a user `is_competing` or not. This is technically correct, as non-competing lanes will also have registration_statuses, but in practice I'm concerned that most developers (myself included) wouldn't realize that calling the `accepted` scope is also returning non-competing registrations.

Based on this, I think the **best** solution would be to:
- Renamed `accepted` scope to `accepted_registrations`
- Add an `accepted_competitors` scope which returns `competing_status: 'accepted', is_competing: true`

However, that would mean
- renaming ~40 instances where the `accepted` scope is used, which carries some risk and will take time
- that we should also consider changing the other scopes to match this new naming convention
- we are preparing for a future (more formal support for non-competing registrations) that isn't here yet - so perhaps we're over-engineering

Thus, the actually-submitted PR returns all accepted & competing registrations in the `accepted` scope - which is what I think developers expect when they use that scope. (Because if they want non-competing registrations, they'll access them directly using the `non-competing` scope)