### PR TITLE
Can only update a competition's currency code if there are no unrefunded payments

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -353,6 +353,12 @@ class Competition < ApplicationRecord
     end
   end
 
+  validate :payments_nil_to_change_currency
+  private def payments_nil_to_change_currency
+    return unless currency_code_changed?
+    errors.add(:currency_code, I18n.t('competitions.errors.currency_cant_change')) if total_payment_amount != 0
+  end
+
   def has_any_round_per_event?
     competition_events.map(&:rounds).none?(&:empty?)
   end
@@ -2686,6 +2692,10 @@ class Competition < ApplicationRecord
 
   def disconnect_all_payment_integrations
     competition_payment_integrations.destroy_all
+  end
+
+  def total_payment_amount
+    registrations.joins(:registration_payments).sum('registration_payments.amount_lowest_denomination')
   end
 
   # Our React date picker unfortunately behaves weirdly in terms of backend data

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1933,6 +1933,7 @@ en:
         -6002: "You need to finish your registration before you can pay"
     #context: and when an error occured
     errors:
+      currency_cant_change: "You cannot change the currency until all outstanding payments have been refunded."
       invalid_name_message: "must end with a year and must contain only alphanumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )"
       cannot_manage: "Cannot manage competition."
       cannot_delete_public: "Cannot delete a competition that is publicly visible."


### PR DESCRIPTION
Addresses #1356 - in draft because I've asked WCAT if this is something that's still needed.

If this is needed, then I think this implementation _may_ be a bit thin. If we get the mega-edge-case of a user having been over-refunded, and another user still having a not-yet-refunded payment, the total amount paid for a competition will be $0 even though there are still two unresolved payments.

As such, it might be better to `find` a registration with a non-zero sum of its `registration_payments`

Also - it seems like we don't track the overall status of a payment (eg, whether it has been refunded) - we only infer this by summing registration_payments related to a given registration. 