### PR TITLE
Update scrambles page for 2025 regs

### DIFF
--- a/app/views/regulations/scrambles.html.erb
+++ b/app/views/regulations/scrambles.html.erb
@@ -14,7 +14,7 @@
   </center>
   <h2>Important Notes for Delegates</h2>
   <ul>
-    <li>Official competitions must always use a current version of the official scramble program (see <%= link_to "Regulation 4f", "/regulations#4f" %>).</li>
+    <li>Official competitions must always use a current version of the official scramble program (see <%= link_to "Regulation 4b", "/regulations#4b" %>).</li>
     <li>Delegates should download TNoodle to run it on a computer. They should not use TNoodle running on a public server (for security reasons).</li>
     <li>Delegates must save all scramble sequences generated for an official competition, and send them with the results (see the <%= link_to "WCA Competition Requirements Policy", "https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf" %>).</li>
   </ul>
@@ -44,7 +44,7 @@
     <li>4x4x4 scramble sequences <strong>may take a few minutes</strong> to initialize and generate. If you are generating 4x4x4 scramble sequences, be patient while the loading bar may appear to be stuck.</li>
     <li>TNoodle creates a <code>tnoodle_resources</code> folder with a few MB of files (mostly cached tables) in the same folder it is run.<br />
       Keep this folder if you want to generate more 4x4x4 scramble sequences more quickly in the future, but feel free to delete it if you need to reclaim disk space.</li>
-    <li>TNoodle performs scramble filtering according to regulation <a href="https://www.worldcubeassociation.org/regulations/#4b3">4b3</a>.</li>
+    <li>TNoodle performs scramble filtering according to <a href="https://www.worldcubeassociation.org/regulations/#4b3">Regulation 4b3</a>.</li>
   </ul>
   <h2>About TNoodle</h2>
   <p>TNoodle uses code developed or adapted by Jeremy Fleischman, Ryan Zheng, Cl&#233;ment Gallet, Shuang Chen, Bruce Norskog, and Lucas Garron. View the <%= link_to "TNoodle project on GitHub", "https://github.com/thewca/tnoodle" %> to view the source, report an issue, or contribute to its development.</p>


### PR DESCRIPTION
- Change the existing reference to Regulation 4f to 4b to align with 2025 Regulations.
- Change the presentation of the reference to Regulation 4b3 for consistency.

~~Not to be deployed until 2025 Regulations have been deployed.~~ Now ready