### PR TITLE
Updated qualification explainer to 'on or before'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2037,7 +2037,7 @@ en:
         format_html: "The format describes how to determine the ranking of competitors based on their results. The list of allowed formats per event is described in %{link_to_9b}. See %{link_to_9f} for a description of each format."
         qualification_html: "Qualification times must be set in other WCA competitions in order to compete."
         qualification_all_events_html: "Qualification times must be set on or before <b>%{date}</b>."
-        qualification_some_events_html: "Qualification times in %{events} must be set before <b>%{date}</b>."
+        qualification_some_events_html: "Qualification times in %{events} must be set on or before <b>%{date}</b>."
       format: "Format"
       time_limit: "Time limit"
       cutoff: "Cutoff"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2036,7 +2036,7 @@ en:
         cutoff_html: "The result to beat to proceed to the second phase of a cutoff round (see %{regulation_link})."
         format_html: "The format describes how to determine the ranking of competitors based on their results. The list of allowed formats per event is described in %{link_to_9b}. See %{link_to_9f} for a description of each format."
         qualification_html: "Qualification times must be set in other WCA competitions in order to compete."
-        qualification_all_events_html: "Qualification times must be set before <b>%{date}</b>."
+        qualification_all_events_html: "Qualification times must be set on or before <b>%{date}</b>."
         qualification_some_events_html: "Qualification times in %{events} must be set before <b>%{date}</b>."
       format: "Format"
       time_limit: "Time limit"


### PR DESCRIPTION
@timreyn this addresses one of your comments on the PR where we changed the qualification logic. Your full comment was: 

> Can you also update the text on https://www.worldcubeassociation.org/competitions/WC2025#competition-events ? Under "Qualification" it says "by DATE_MINUS_ONE", and at the bottom it says "before".

As far as I can see, we are now showing the date itself, not date-minus-one - can you confirm this is the case? 

![image](https://github.com/user-attachments/assets/a0430818-4c21-4d73-91a7-1b396635ef65)

![image](https://github.com/user-attachments/assets/b7f7ab9b-ba34-4e2f-9f20-1780b52691c1)
