### PR TITLE
Remove i18n-country-translations as it is not used anywhere

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,6 @@ gem 'blocks'
 gem 'rack-cors', require: 'rack/cors'
 gem 'api-pagination'
 gem 'daemons'
-gem 'i18n-country-translations', github: 'thewca/i18n-country-translations'
 gem 'http_accept_language'
 gem 'twitter_cldr'
 # version explicitly specified because Shakapacker wants to keep Gemfile and package.json in sync

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,14 +12,6 @@ GIT
     selectize-rails (0.12.1)
 
 GIT
-  remote: https://github.com/thewca/i18n-country-translations.git
-  revision: e6706abe0eaa65729c1acb698be08b91dd2b6fde
-  specs:
-    i18n-country-translations (1.4.1)
-      i18n (>= 0.9.3, < 2)
-      railties (>= 5.0)
-
-GIT
   remote: https://github.com/thewca/ruby-iso.git
   revision: 3782e23f5c913434e71120cfc358d5539a70265e
   specs:
@@ -867,7 +859,6 @@ DEPENDENCIES
   guard-rspec
   hiredis
   http_accept_language
-  i18n-country-translations!
   i18n-js
   i18n-spec
   i18n-tasks


### PR DESCRIPTION
I'm not 100% sure about this change, I couldn't find any usage like given in [README of the gem](https://github.com/thewca/i18n-country-translations). I searched for `I18n.t(:` and couldn't find any relevant details, so I believe this is no longer needed.

The reason why I want this to be removed is, when I install `currencylayer` gem, I got the following error:

```
Could not find compatible versions



Because every version of i18n-country-translations depends on i18n >= 0.9.3, < 2

  and money >= 6.5.0, < 6.8.2 depends on i18n >= 0.6.4, <= 0.7.0,

  every version of i18n-country-translations is incompatible with money >= 6.5.0, < 6.8.2.

And because every version of currencylayer depends on money ~> 6.5.0,

  every version of i18n-country-translations is incompatible with currencylayer >= 0.

So, because Gemfile depends on currencylayer >= 0

  and Gemfile depends on i18n-country-translations >= 0,

  version solving has failed.
```

I believe the problem is that `i18n-country-translations` requires old version of `money` while `currencylayer` requires newer version of `money`. Removing `i18n-country-translations` (if not used) will allow to upgrade money to newer version and hence allow to install `currencylayer`.

