### PR TITLE
Show Registration status in comp overview page by default

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -25,7 +25,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
     competitions = competitions_scope.search(params[:q], params: params)
 
-    serial_methods = ["short_display_name", "city", "country_iso2", "event_ids", "date_range", "latitude_degrees", "longitude_degrees"]
+    serial_methods = ["short_display_name", "city", "country_iso2", "event_ids", "date_range", "latitude_degrees", "longitude_degrees", "registration_status"]
     serial_includes = {}
 
     serial_includes["delegates"] = { only: ["id", "name"], methods: [], include: ["avatar"] } if admin_mode

--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -16,6 +16,7 @@ import UtcDatePicker from '../wca/UtcDatePicker';
 function CompetitionsFilters({
   filterState,
   dispatchFilter,
+  displayMode,
   shouldShowAdminDetails,
   canViewAdminDetails,
 }) {
@@ -48,6 +49,16 @@ function CompetitionsFilters({
       <Form.Field>
         <TimeOrderButtonGroup filterState={filterState} dispatchFilter={dispatchFilter} />
       </Form.Field>
+
+      <Form.Group inline>
+        <CompDisplayCheckboxes
+          shouldIncludeCancelled={filterState.shouldIncludeCancelled}
+          dispatchFilter={dispatchFilter}
+          shouldShowAdminDetails={shouldShowAdminDetails}
+          canViewAdminDetails={canViewAdminDetails}
+          displayMode={displayMode}
+        />
+      </Form.Group>
 
       {canViewAdminDetails && shouldShowAdminDetails && (
         <Form.Group>
@@ -428,8 +439,6 @@ function CustomDateSelector({ filterState, dispatchFilter }) {
 export function CompDisplayCheckboxes({
   shouldIncludeCancelled,
   dispatchFilter,
-  shouldShowRegStatus,
-  setShouldShowRegStatus,
   shouldShowAdminDetails,
   canViewAdminDetails,
   displayMode,
@@ -449,32 +458,19 @@ export function CompDisplayCheckboxes({
       </div>
 
       {
-        displayMode === 'list' && (
-          <>
-            <div id="registration-status" className="registration-status-selector">
-              <Form.Checkbox
-                label={I18n.t('competitions.index.show_registration_status')}
-                name="show_registration_status"
-                id="show_registration_status"
-                checked={shouldShowRegStatus}
-                onChange={() => setShouldShowRegStatus(!shouldShowRegStatus)}
-              />
-            </div>
-            {canViewAdminDetails && (
-              <div id="admin-data" className="admin-data-selector">
-                <Form.Checkbox
-                  toggle
-                  label={I18n.t('competitions.index.use_admin_view')}
-                  name="show_admin_data"
-                  id="show_admin_data"
-                  checked={shouldShowAdminDetails}
-                  onChange={() => dispatchFilter(
-                    { shouldShowAdminDetails: !shouldShowAdminDetails },
-                  )}
-                />
-              </div>
-            )}
-          </>
+        displayMode === 'list' && canViewAdminDetails && (
+          <div id="admin-data" className="admin-data-selector">
+            <Form.Checkbox
+              toggle
+              label={I18n.t('competitions.index.use_admin_view')}
+              name="show_admin_data"
+              id="show_admin_data"
+              checked={shouldShowAdminDetails}
+              onChange={() => dispatchFilter(
+                { shouldShowAdminDetails: !shouldShowAdminDetails },
+              )}
+            />
+          </div>
         )
       }
     </>

--- a/app/webpacker/components/CompetitionsOverview/ListView.js
+++ b/app/webpacker/components/CompetitionsOverview/ListView.js
@@ -11,10 +11,8 @@ import { isInProgress, isProbablyOver } from '../../lib/utils/competition-table'
 function ListView({
   competitions,
   filterState,
-  shouldShowRegStatus,
   shouldShowAdminDetails,
   isLoading,
-  regStatusLoading,
   fetchMoreCompetitions,
   hasMoreCompsToLoad,
 }) {
@@ -39,10 +37,8 @@ function ListView({
             <ListViewSection
               competitions={competitions}
               title={I18n.t('competitions.index.titles.ongoing_and_upcoming')}
-              shouldShowRegStatus={shouldShowRegStatus}
               shouldShowAdminDetails={shouldShowAdminDetails}
               selectedDelegate={filterState.delegate}
-              regStatusLoading={regStatusLoading}
               isLoading={isLoading}
               hasMoreCompsToLoad={hasMoreCompsToLoad}
             />
@@ -68,9 +64,7 @@ function ListView({
             <ListViewSection
               competitions={inProgressComps}
               title={I18n.t('competitions.index.titles.in_progress')}
-              shouldShowRegStatus={shouldShowRegStatus}
               selectedDelegate={filterState.delegate}
-              regStatusLoading={regStatusLoading}
               isLoading={isLoading && !upcomingComps?.length}
               hasMoreCompsToLoad={hasMoreCompsToLoad && !upcomingComps?.length}
             />
@@ -78,9 +72,7 @@ function ListView({
           <ListViewSection
             competitions={upcomingComps}
             title={I18n.t('competitions.index.titles.upcoming')}
-            shouldShowRegStatus={shouldShowRegStatus}
             selectedDelegate={filterState.delegate}
-            regStatusLoading={regStatusLoading}
             isLoading={isLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
@@ -99,11 +91,9 @@ function ListView({
           <ListViewSection
             competitions={competitions}
             title={I18n.t('competitions.index.titles.recent', { count: competitionConstants.competitionRecentDays })}
-            shouldShowRegStatus={shouldShowRegStatus}
             shouldShowAdminDetails={shouldShowAdminDetails}
             selectedDelegate={filterState.delegate}
             isLoading={isLoading}
-            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
           <ListViewFooter
@@ -120,11 +110,9 @@ function ListView({
           <ListViewSection
             competitions={competitions}
             title={filterState.selectedYear === 'all_years' ? I18n.t('competitions.index.titles.past_all') : I18n.t('competitions.index.titles.past', { year: filterState.selectedYear })}
-            shouldShowRegStatus={shouldShowRegStatus}
             shouldShowAdminDetails={shouldShowAdminDetails}
             selectedDelegate={filterState.delegate}
             isLoading={isLoading}
-            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
           <ListViewFooter
@@ -141,11 +129,9 @@ function ListView({
           <ListViewSection
             competitions={competitions}
             title={I18n.t('competitions.index.titles.by_announcement')}
-            shouldShowRegStatus={shouldShowRegStatus}
             shouldShowAdminDetails={shouldShowAdminDetails}
             selectedDelegate={filterState.delegate}
             isLoading={isLoading}
-            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
             isSortedByAnnouncement
           />
@@ -163,11 +149,9 @@ function ListView({
           <ListViewSection
             competitions={competitions}
             title={I18n.t('competitions.index.titles.custom')}
-            shouldShowRegStatus={shouldShowRegStatus}
             shouldShowAdminDetails={shouldShowAdminDetails}
             selectedDelegate={filterState.delegate}
             isLoading={isLoading}
-            regStatusLoading={regStatusLoading}
             hasMoreCompsToLoad={hasMoreCompsToLoad}
           />
           <ListViewFooter

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Icon, Popup, Loader, Table, Flag, Label, Header, Container, Grid, List, Image, Button,
+  Icon, Popup, Table, Flag, Label, Header, Container, Grid, List, Image, Button,
 } from 'semantic-ui-react';
 
 import { BarLoader } from 'react-spinners';
@@ -25,11 +25,9 @@ import { adminCompetitionUrl, competitionUrl } from '../../lib/requests/routes.j
 function ListViewSection({
   competitions,
   title,
-  shouldShowRegStatus,
   shouldShowAdminDetails,
   selectedDelegate,
   isLoading,
-  regStatusLoading,
   hasMoreCompsToLoad,
   isSortedByAnnouncement = false,
 }) {
@@ -49,9 +47,7 @@ function ListViewSection({
           competitions={competitions}
           isLoading={isLoading}
           hasMoreCompsToLoad={hasMoreCompsToLoad}
-          shouldShowRegStatus={shouldShowRegStatus}
           selectedDelegate={selectedDelegate}
-          regStatusLoading={regStatusLoading}
           isSortedByAnnouncement={isSortedByAnnouncement}
         />
       ) : (
@@ -59,8 +55,6 @@ function ListViewSection({
           competitions={competitions}
           isLoading={isLoading}
           hasMoreCompsToLoad={hasMoreCompsToLoad}
-          shouldShowRegStatus={shouldShowRegStatus}
-          regStatusLoading={regStatusLoading}
           isSortedByAnnouncement={isSortedByAnnouncement}
         />
       )}
@@ -73,8 +67,6 @@ function ResponsiveCompetitionsTables({
   competitions,
   isLoading,
   hasMoreCompsToLoad,
-  shouldShowRegStatus,
-  regStatusLoading,
   isSortedByAnnouncement,
 }) {
   const noCompetitions = !competitions || competitions.length === 0;
@@ -91,8 +83,6 @@ function ResponsiveCompetitionsTables({
         <CompetitionsTable
           competitions={competitions}
           isLoading={isLoading}
-          shouldShowRegStatus={shouldShowRegStatus}
-          regStatusLoading={regStatusLoading}
           isSortedByAnnouncement={isSortedByAnnouncement}
         />
       </Grid.Row>
@@ -100,8 +90,6 @@ function ResponsiveCompetitionsTables({
         <CompetitionsTabletTable
           competitions={competitions}
           isLoading={isLoading}
-          shouldShowRegStatus={shouldShowRegStatus}
-          regStatusLoading={regStatusLoading}
           isSortedByAnnouncement={isSortedByAnnouncement}
         />
       </Grid.Row>
@@ -109,8 +97,6 @@ function ResponsiveCompetitionsTables({
         <CompetitionsMobileTable
           competitions={competitions}
           isLoading={isLoading}
-          shouldShowRegStatus={shouldShowRegStatus}
-          regStatusLoading={regStatusLoading}
           isSortedByAnnouncement={isSortedByAnnouncement}
         />
       </Grid.Row>
@@ -120,8 +106,6 @@ function ResponsiveCompetitionsTables({
 
 export function CompetitionsTable({
   competitions,
-  shouldShowRegStatus,
-  regStatusLoading,
   isSortedByAnnouncement = false,
 }) {
   return (
@@ -148,9 +132,7 @@ export function CompetitionsTable({
               <Table.Cell collapsing>
                 <StatusIcon
                   comp={comp}
-                  shouldShowRegStatus={shouldShowRegStatus}
                   isSortedByAnnouncement={isSortedByAnnouncement}
-                  regStatusLoading={regStatusLoading}
                 />
               </Table.Cell>
               <Table.Cell textAlign="right" width={2}>
@@ -177,8 +159,6 @@ export function CompetitionsTable({
 
 export function CompetitionsTabletTable({
   competitions,
-  shouldShowRegStatus,
-  regStatusLoading,
   isSortedByAnnouncement = false,
 }) {
   return (
@@ -204,9 +184,7 @@ export function CompetitionsTabletTable({
               <Table.Cell collapsing>
                 <StatusIcon
                   comp={comp}
-                  shouldShowRegStatus={shouldShowRegStatus}
                   isSortedByAnnouncement={isSortedByAnnouncement}
-                  regStatusLoading={regStatusLoading}
                 />
               </Table.Cell>
               <Table.Cell textAlign="right" width={3}>
@@ -233,8 +211,6 @@ export function CompetitionsTabletTable({
 
 export function CompetitionsMobileTable({
   competitions,
-  shouldShowRegStatus,
-  regStatusLoading,
   isSortedByAnnouncement = false,
 }) {
   return (
@@ -253,9 +229,7 @@ export function CompetitionsMobileTable({
                 <Label ribbon="right" size="small">
                   <StatusIcon
                     comp={comp}
-                    shouldShowRegStatus={shouldShowRegStatus}
                     isSortedByAnnouncement={isSortedByAnnouncement}
-                    regStatusLoading={regStatusLoading}
                   />
                   {comp.date_range}
                 </Label>
@@ -288,9 +262,7 @@ function AdminCompetitionsTable({
   competitions,
   isLoading,
   hasMoreCompsToLoad,
-  shouldShowRegStatus,
   selectedDelegate,
-  regStatusLoading,
   isSortedByAnnouncement,
 }) {
   const noCompetitions = !competitions || competitions.length === 0;
@@ -333,9 +305,7 @@ function AdminCompetitionsTable({
                 <Table.Cell collapsing>
                   <StatusIcon
                     comp={comp}
-                    shouldShowRegStatus={shouldShowRegStatus}
                     isSortedByAnnouncement={isSortedByAnnouncement}
-                    regStatusLoading={regStatusLoading}
                   />
                 </Table.Cell>
                 <Table.Cell width={4}>
@@ -437,14 +407,7 @@ function ConditionalYearHeader({
   }
 }
 
-function RegistrationStatus({ comp, isLoading }) {
-  // It is important that we check both conditions, because the query hook
-  //   uses a `keepPreviousData` trick that holds existing data in-memory while
-  //   also executing the query for the next batch of rows in the background.
-  if (isLoading && !comp.registration_status) {
-    return (<Loader active inline size="mini" />);
-  }
-
+function RegistrationStatus({ comp }) {
   if (comp.registration_status === 'not_yet_opened') {
     return (
       <Popup
@@ -493,9 +456,7 @@ function RegistrationStatus({ comp, isLoading }) {
 
 function StatusIcon({
   comp,
-  shouldShowRegStatus,
   isSortedByAnnouncement,
-  regStatusLoading,
 }) {
   let tooltipInfo = '';
   let iconClass = '';
@@ -511,14 +472,11 @@ function StatusIcon({
   } else if (isInProgress(comp)) {
     tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.in_progress');
     iconClass = 'hourglass half';
-  } else if (shouldShowRegStatus) {
-    return <RegistrationStatus comp={comp} isLoading={regStatusLoading} />;
   } else if (isSortedByAnnouncement) {
     tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.announced_on', { announcement_date: comp.announced_at });
     iconClass = 'hourglass start';
   } else {
-    tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.starts_in', { days: I18n.t('common.days', { count: dayDifferenceFromToday(comp.start_date) }) });
-    iconClass = 'hourglass start';
+    return <RegistrationStatus comp={comp} />;
   }
 
   return (


### PR DESCRIPTION
Promised follow-up to #10461

Only feature we're losing now is the "hydrated caching" in Redis. Registration values are now always pulled from the database freshly, and TBH I'm not sure whether that's a good thing.