### PR TITLE
Psych sheet navigation improvement

### DIFF
--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -68,6 +68,8 @@ export function EventSelector({
   maxEvents = Infinity,
   shouldErrorOnEmpty = false,
   showBreakBeforeButtons = true,
+  hideAllButton = false,
+  hideClearButton = false,
   eventButtonsCompact = false,
   eventsDisabled = [],
   // Listing event as an argument here to indicate to developers that it's needed
@@ -79,17 +81,19 @@ export function EventSelector({
       <label htmlFor="events">
         {`${I18n.t('competitions.competition_form.events')}`}
         {showBreakBeforeButtons ? (<br />) : (' ')}
-        <Popup
-          disabled={!Number.isFinite(maxEvents)}
-          trigger={
-            <span><Button disabled={disabled || eventList.length >= maxEvents} primary type="button" size="mini" id="select-all-events" onClick={() => onEventSelection({ type: 'select_all_events' })}>{I18n.t('competitions.index.all_events')}</Button></span>
-        }
-        >
-          {I18n.t('competitions.registration_v2.register.event_limit', {
-            max_events: maxEvents,
-          })}
-        </Popup>
-        <Button disabled={disabled} type="button" size="mini" id="clear-all-events" onClick={() => onEventSelection({ type: 'clear_events' })}>{I18n.t('competitions.index.clear')}</Button>
+        {hideAllButton || (
+          <Popup
+            disabled={!Number.isFinite(maxEvents)}
+            trigger={
+              <span><Button disabled={disabled || eventList.length >= maxEvents} primary type="button" size="mini" id="select-all-events" onClick={() => onEventSelection({ type: 'select_all_events' })}>{I18n.t('competitions.index.all_events')}</Button></span>
+            }
+          >
+            {I18n.t('competitions.registration_v2.register.event_limit', {
+              max_events: maxEvents,
+            })}
+          </Popup>
+        )}
+        {hideClearButton || <Button disabled={disabled} type="button" size="mini" id="clear-all-events" onClick={() => onEventSelection({ type: 'clear_events' })}>{I18n.t('competitions.index.clear')}</Button>}
       </label>
       <Popup
         open={selectedEvents.length === 0}

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -20,6 +20,7 @@ import Errored from '../../Requests/Errored';
 import { formatAttemptResult } from '../../../lib/wca-live/attempts';
 import I18n from '../../../lib/i18n';
 import { countries } from '../../../lib/wca-data.js.erb';
+import { EventSelector } from '../../CompetitionsOverview/CompetitionsFilters';
 
 const sortReducer = createSortReducer(['name', 'country', 'total']);
 
@@ -72,7 +73,6 @@ function FooterContent({
           <Table.Cell />
           <Table.Cell />
           <Table.Cell />
-          <Table.Cell />
         </>
       )}
     </Table.Row>
@@ -96,6 +96,9 @@ export default function RegistrationList({ competitionInfo }) {
 
   const [psychSheetEvent, setPsychSheetEvent] = useState();
   const [psychSheetSortBy, setPsychSheetSortBy] = useState('single');
+  const handleEventSelection = ({ type, eventId }) => {
+    setPsychSheetEvent(type === 'toggle_event' ? eventId : undefined);
+  };
 
   const { isLoading: isLoadingPsychSheet, data: psychSheet } = useQuery({
     queryKey: [
@@ -161,6 +164,11 @@ export default function RegistrationList({ competitionInfo }) {
   if (registrationsLoading || isLoadingPsychSheet) {
     return (
       <Segment>
+        <PsychSheetEventSelector
+          handleEventSelection={handleEventSelection}
+          eventList={competitionInfo.event_ids}
+          selectedEvents={[psychSheetEvent].filter(Boolean)}
+        />
         <Loading />
       </Segment>
     );
@@ -168,6 +176,11 @@ export default function RegistrationList({ competitionInfo }) {
 
   return (
     <Segment style={{ overflowX: 'scroll' }}>
+      <PsychSheetEventSelector
+        handleEventSelection={handleEventSelection}
+        eventList={competitionInfo.event_ids}
+        selectedEvents={[psychSheetEvent].filter(Boolean)}
+      />
       <Table sortable unstackable singleLine textAlign="left">
         <Table.Header>
           <Table.Row>
@@ -188,7 +201,6 @@ export default function RegistrationList({ competitionInfo }) {
                 {competitionInfo.event_ids.map((id) => (
                   <Table.HeaderCell
                     key={`registration-table-header-${id}`}
-                    onClick={() => setPsychSheetEvent(id)}
                   >
                     <EventIcon id={id} size="1em" className="selected" />
                   </Table.HeaderCell>
@@ -202,14 +214,6 @@ export default function RegistrationList({ competitionInfo }) {
               </>
             ) : (
               <>
-                <Table.HeaderCell
-                  collapsing
-                  onClick={() => setPsychSheetEvent(undefined)}
-                >
-                  <Icon name="backward" />
-                  {' '}
-                  {I18n.t('competitions.registration_v2.list.psychsheets.go_back')}
-                </Table.HeaderCell>
                 <Table.HeaderCell>
                   <EventIcon id={psychSheetEvent} className="selected" size="1em" />
                 </Table.HeaderCell>
@@ -276,7 +280,6 @@ export default function RegistrationList({ competitionInfo }) {
                   </>
                 ) : (
                   <>
-                    <Table.Cell />
                     <Table.Cell
                       collapsing
                       textAlign="right"
@@ -325,4 +328,20 @@ export default function RegistrationList({ competitionInfo }) {
       </Table>
     </Segment>
   );
+}
+
+function PsychSheetEventSelector({
+  handleEventSelection,
+  eventList,
+  selectedEvents,
+}) {
+  return (
+    <EventSelector
+      onEventSelection={handleEventSelection}
+      eventList={eventList}
+      selectedEvents={selectedEvents}
+      showBreakBeforeButtons={false}
+      id="event-selection"
+    />
+  )
 }

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -341,6 +341,7 @@ function PsychSheetEventSelector({
       eventList={eventList}
       selectedEvents={selectedEvents}
       showBreakBeforeButtons={false}
+      hideAllButton
       id="event-selection"
     />
   )

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -181,7 +181,7 @@ export default function RegistrationList({ competitionInfo }) {
         eventList={competitionInfo.event_ids}
         selectedEvents={[psychSheetEvent].filter(Boolean)}
       />
-      <Table sortable unstackable singleLine textAlign="left">
+      <Table striped sortable unstackable singleLine textAlign="left">
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -116,7 +116,7 @@ export default function RegistrationList({ competitionInfo }) {
     enabled: psychSheetEvent !== undefined,
   });
 
-  const registrationsWithPsychsheet = useMemo(() => {
+  const registrationsWithPsychSheet = useMemo(() => {
     if (psychSheet !== undefined) {
       setPsychSheetSortBy(psychSheet.sort_by);
       return psychSheet.sorted_rankings.map((p) => {
@@ -128,7 +128,7 @@ export default function RegistrationList({ competitionInfo }) {
   }, [psychSheet, registrations]);
 
   const data = useMemo(() => {
-    if (registrationsWithPsychsheet) {
+    if (registrationsWithPsychSheet) {
       let orderBy = [];
       if (psychSheetEvent === undefined) {
         switch (sortColumn) {
@@ -150,10 +150,10 @@ export default function RegistrationList({ competitionInfo }) {
       }
       const direction = sortDirection === 'descending' ? 'desc' : 'asc';
 
-      return _.orderBy(registrationsWithPsychsheet, orderBy, [direction]);
+      return _.orderBy(registrationsWithPsychSheet, orderBy, [direction]);
     }
     return [];
-  }, [registrationsWithPsychsheet, sortColumn, sortDirection, psychSheetEvent]);
+  }, [registrationsWithPsychSheet, sortColumn, sortDirection, psychSheetEvent]);
 
   if (isError) {
     return (


### PR DESCRIPTION
See commit list.

[Screencast from 2025-01-03 04:27:10 PM.webm](https://github.com/user-attachments/assets/7a62e27e-444c-4767-8477-73802f9eab4e)

![image](https://github.com/user-attachments/assets/ca7432d9-64bd-49b0-bae3-181cd14c24be)

![image](https://github.com/user-attachments/assets/c736e876-c9a0-4930-8c24-725ec1ad7a07)

![image](https://github.com/user-attachments/assets/336d1037-9146-4a34-8451-4b92c1266126)

Next steps (future PRs): fix footer; adjust some columns (e.g. move rank to the left); highlight user when logged in; move EventSelector out of CompetitionsOverview