### PR TITLE
Show notification bubble in new approveAvatars panel

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -22,6 +22,10 @@ class PanelController < ApplicationController
     panel_details = User.panel_list[@panel_id.to_sym]
     @pages = panel_details[:pages]
     @title = panel_details[:name]
+    # This awkward mapping is necessary because `panel_notifications` returns callables
+    #   which compute the value _if needed_. The point is to reduce workload, not every time
+    #   that `User.panel_notifications` is called should trigger an actual computation.
+    @notifications = User.panel_notifications.slice(*@pages).transform_values(&:call)
   end
 
   def generate_db_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -643,6 +643,12 @@ class User < ApplicationRecord
     ].index_with { |panel_page| panel_page.to_s.underscore.dasherize }
   end
 
+  def self.panel_notifications
+    {
+      self.panel_pages[:approveAvatars] => lambda { User.where.not(pending_avatar: nil).count },
+    }
+  end
+
   def self.panel_list
     panel_pages = User.panel_pages
     {

--- a/app/views/panel/index.html.erb
+++ b/app/views/panel/index.html.erb
@@ -3,4 +3,5 @@
   loggedInUserId: current_user.id,
   heading: @title,
   pages: @pages,
+  pageNotifications: @notifications,
 }) %>

--- a/app/webpacker/components/Panel/PanelTemplate.jsx
+++ b/app/webpacker/components/Panel/PanelTemplate.jsx
@@ -2,13 +2,18 @@ import React from 'react';
 import {
   Container,
   Dropdown,
-  Grid, Header, Icon, Menu, Segment,
+  Grid, Header, Icon, Label, Menu, Segment,
 } from 'semantic-ui-react';
 import useHash from '../../lib/hooks/useHash';
 import ConfirmProvider from '../../lib/providers/ConfirmProvider';
 import PanelPages from './PanelPages';
 
-export default function PanelTemplate({ heading, pages, loggedInUserId }) {
+export default function PanelTemplate({
+  heading,
+  pages,
+  pageNotifications,
+  loggedInUserId,
+}) {
   const [hash, setHash] = useHash();
 
   const SelectedComponent = React.useMemo(() => {
@@ -28,9 +33,10 @@ export default function PanelTemplate({ heading, pages, loggedInUserId }) {
   const menuOptions = React.useMemo(() => (pages.map(
     (page) => ({
       id: page,
+      notification: pageNotifications?.[page],
       ...PanelPages[page],
     }),
-  )), [pages]);
+  )), [pages, pageNotifications]);
 
   return (
     <Container fluid>
@@ -48,6 +54,11 @@ export default function PanelTemplate({ heading, pages, loggedInUserId }) {
                 )}
               >
                 {!menuOption.component && <Icon name="external alternate" />}
+                {menuOption.notification !== undefined && (
+                  <Label color={menuOption.notification === 0 ? 'green' : 'red'}>
+                    {menuOption.notification}
+                  </Label>
+                )}
                 {menuOption.name}
               </Menu.Item>
             ))}
@@ -65,6 +76,7 @@ export default function PanelTemplate({ heading, pages, loggedInUserId }) {
                     text: menuOption.name,
                     value: menuOption.id,
                     icon: !menuOption.component && 'external alternate',
+                    label: menuOption.notification && ({ color: 'red', content: menuOption.notification }),
                   }))}
                   value={hash}
                   onChange={(_, { value }) => setHash(value)}


### PR DESCRIPTION
Porting over the small "bubble" that showed how many were pending.

The backend code looks a bit complicated, but the idea is this: There should be a method generating "notification count" for a given panel page. But if I do this like `{page1: User.count, page2: Competition.count, page5: AwesomeStuff.joins(...).where(...).count}`, it means a lot of useless things will be computed when the user only has access to `page1`.
So instead of returning the counts, I will return the _instruction_ how to compute the count, then filter that for the panels which the user has access to, then compute.

I'm all ears for better ideas @danieljames-dj 