### PR TITLE
Migrate mysql to 8.4 in Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,11 +108,13 @@ services:
         condition: service_completed_successfully
 
   wca_db:
+    # You will have to run docker exec -it database mysql to connect to the database and then
+    # ALTER USER 'root'@'%' IDENTIFIED WITH caching_sha2_password BY '';
+    # To upgrade your DB from mysql8.0 to mysql8.4
     image: mysql:8.4
     container_name: "database"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-    command: --mysql-native-password=ON --authentication-policy=mysql_native_password
     ports:
       - "3306:3306"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,11 +108,11 @@ services:
         condition: service_completed_successfully
 
   wca_db:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: "database"
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-    command: --authentication-policy=mysql_native_password
+    command: --mysql-native-password=ON --authentication-policy=mysql_native_password
     ports:
       - "3306:3306"
     volumes:


### PR DESCRIPTION
Currently Upgrading staging but it seems to be working (staging replica already updated). Locally we need to add `--mysql-native-password=ON` as it's now deprecated and will be removed in version 9.

We can migrate to the new `caching_sha2_password` but that means every developer will need to recreate their database.