### PR TITLE
Fix Person trying to serialize non-existing methods in User

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -314,7 +314,7 @@ class Person < ApplicationRecord
 
     # If there's a user for this Person, merge in all their data,
     # the Person's data takes priority, though.
-    user_override_options = USER_COMMON_SERIALIZE_OPTIONS.merge_union(options)
+    user_override_options = USER_COMMON_SERIALIZE_OPTIONS.merge_union(options&.stringify_keys)
     (user || User.new).serializable_hash(user_override_options).merge(json)
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -281,7 +281,9 @@ class Person < ApplicationRecord
   USER_COMMON_SERIALIZE_OPTIONS = {
     only: ["name", "gender"],
     methods: ["country_iso2"],
-    include: [],
+    # grrr… some tests (and apparently also API endpoints) rely on serializing teams _through_ person.
+    #   Not a good code design decision, but very cumbersome to properly refactor. Signed GB 2025-01-09
+    include: ["teams"],
   }.freeze
 
   def personal_records

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -278,6 +278,12 @@ class Person < ApplicationRecord
     methods: ["url", "country_iso2"],
   }.freeze
 
+  USER_COMMON_SERIALIZE_OPTIONS = {
+    only: ["name", "gender"],
+    methods: ["country_iso2"],
+    include: [],
+  }.freeze
+
   def personal_records
     [self.ranksAverage, self.ranksSingle].compact.flatten
   end
@@ -308,6 +314,7 @@ class Person < ApplicationRecord
 
     # If there's a user for this Person, merge in all their data,
     # the Person's data takes priority, though.
-    (user || User.new).serializable_hash(options).merge(json)
+    user_override_options = USER_COMMON_SERIALIZE_OPTIONS.merge_union(options)
+    (user || User.new).serializable_hash(user_override_options).merge(json)
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -281,9 +281,9 @@ class Person < ApplicationRecord
   USER_COMMON_SERIALIZE_OPTIONS = {
     only: ["name", "gender"],
     methods: ["country_iso2"],
-    # grrr… some tests (and apparently also API endpoints) rely on serializing teams _through_ person.
+    # grrr… some tests (and apparently also API endpoints) rely on serializing this data _through_ person.
     #   Not a good code design decision, but very cumbersome to properly refactor. Signed GB 2025-01-09
-    include: ["teams"],
+    include: User::DEFAULT_SERIALIZE_OPTIONS[:include],
   }.freeze
 
   def personal_records
@@ -314,9 +314,17 @@ class Person < ApplicationRecord
       json[:incorrect_wca_id_claim_count] = incorrect_wca_id_claim_count
     end
 
+    # Passing down options from Person to User (which are completely different models in the DB!)
+    #   is a horrible idea. Unfortunately, our external APIs have come to rely on it,
+    #   so we need to hack around it.
+    #   - `merge_union` makes sure that only values specified in USER_COMMON_SERIALIZE_OPTIONS kick in
+    #   - `filter` makes sure that when the result of `merge_union` are empty, the defaults from
+    #       User::DEFAULT_SERIALIZE_OPTIONS can override.
+    user_override_options = USER_COMMON_SERIALIZE_OPTIONS.merge_union(options&.stringify_keys)
+                                                         .filter { |_, v| v.present? }
+
     # If there's a user for this Person, merge in all their data,
     # the Person's data takes priority, though.
-    user_override_options = USER_COMMON_SERIALIZE_OPTIONS.merge_union(options&.stringify_keys)
     (user || User.new).serializable_hash(user_override_options).merge(json)
   end
 end

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -51,6 +51,14 @@ Rails.configuration.to_prepare do
     end
   end
 
+  Hash.class_eval do
+    def merge_union(other = nil)
+      self.to_h do |key, value|
+        [key, value & (other&.fetch(key.to_s, []) || [])]
+      end
+    end
+  end
+
   ActiveSupport::Duration.class_eval do
     def in_seconds
       self.to_i


### PR DESCRIPTION
For some reason, we have the following code snippet in the `serializable_hash` method of `Person`:

```
# If there's a user for this Person, merge in all their data,
# the Person's data takes priority, though.
(user || User.new).serializable_hash(user_override_options).merge(json)
```

The code comment explains what the intention is, but the implementation is problematic because it directly passes down the serialization options from Person down to User. But `Person` has plenty of methods and properties (which the developer might want to serialize) that don't exist on `User` at all.

The only reason why this didn't break so far is because nobody ever happened to request (i.e. try and serialize) a property of `Person` that isn't available from `User`.

The monkey-patched method is essentially a short-hand for:
```
{
  only: USER_PERSON_COMMON_OPTIONS[:only] & options[:only],
  methods: USER_PERSON_COMMON_OPTIONS[:methods] & options[:methods],
  includes: USER_PERSON_COMMON_OPTIONS[:includes] & options[:includes],
}
```
with a little bit of null-safety built in. The intention is to merge these two arrays together, but only keep the union (i.e. common values shared between two arrays) of the value params. That way, we can effectively restrict which params should be passed down to `User`.