### PR TITLE
Switch flag to disable Comp Overview React on demand

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -195,7 +195,7 @@ class CompetitionsController < ApplicationController
       @competitions = @competitions.select { |competition| competition.pending_results_or_report(days) }
     end
 
-    @enable_react = params[:legacy]&.to_s == 'off'
+    @disable_react = params[:legacy]&.to_s == 'on'
 
     respond_to do |format|
       format.html {}

--- a/app/views/competitions/index.html.erb
+++ b/app/views/competitions/index.html.erb
@@ -1,15 +1,13 @@
 <% provide(:title, t('.title')) %>
 
-<% if !@enable_react %>
+<% if @disable_react %>
   <div class="container">
 
       <h2>
         <%= yield(:title) %>
 
-        <% unless EnvConfig.WCA_LIVE_SITE? %>
-          <%= link_to competitions_path(**request.query_parameters.merge(legacy: 'off')), class: "btn btn-success" do %>
-            <%= ui_icon("magic") %> Go to new UI
-          <% end %>
+        <%= link_to competitions_path(**request.query_parameters.with_indifferent_access.except(:legacy)), class: "btn btn-success" do %>
+          <%= ui_icon("magic") %> Go to new UI
         <% end %>
       </h2>
 

--- a/spec/features/competitions_list_spec.rb
+++ b/spec/features/competitions_list_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Competitions list" do
+RSpec.feature "Competitions list", js: true do
   context "admin view" do
     before :each do
       sign_in FactoryBot.create(:admin)
@@ -13,18 +13,18 @@ RSpec.feature "Competitions list" do
       let(:delegate) { competition.delegates.first }
 
       before do
-        visit "/competitions?legacy=off&show_admin_details=yes"
+        visit "/competitions?show_admin_details=yes"
         within(:css, "#delegate") do
           find(".search").set(delegate.name)
           find(".search").send_keys(:enter)
         end
       end
 
-      it "the delegate is selected within the form", js: true do
+      it "the delegate is selected within the form" do
         expect(page.find("#competition-query-form #delegate")).to have_text(delegate.name)
       end
 
-      it "only competitions delegated by the given delegate are shown", js: true do
+      it "only competitions delegated by the given delegate are shown" do
         expect(page).to have_selector(".competition-info", count: 1)
       end
     end
@@ -33,11 +33,11 @@ RSpec.feature "Competitions list" do
       FactoryBot.create(:competition, :visible, starts: 2.days.ago, name: "Test Comp 2017")
       visit '/competitions?state=recent&display=admin'
       expect(page).to have_http_status(200)
+      expect(page).to have_text "Test Comp 2017"
       tr = page.find("tr", text: "Test Comp 2017")
 
-      results_td = tr.find("td:nth-child(6).admin-date")
-      expect(results_td.text).to eq "pending"
-      expect(results_td[:class].split).to match_array %w(admin-date)
+      results_td = tr.find("td:nth-child(7)")
+      expect(results_td.text).to eq "Pending"
     end
   end
 end


### PR DESCRIPTION
Effectively launching the new competition overview page

This is the least-intrusive-but-also-easy-to-understand diff that I could come up with (everything with even less changed lines would have been an awkwardly convoluted `if !@disabled_unless` blabla)