### PR TITLE
Replace redirect with panel-page

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -51,11 +51,11 @@ class PanelController < ApplicationController
     }
   end
 
-  def redirect
-    @panel_page = params.require(:panel_page)
-    panel_with_panel_page = current_user.panels_with_access&.find { |panel| User.panel_list[panel][:pages].include?(@panel_page) }
+  def panel_page
+    panel_page_id = params.require(:id)
+    panel_with_panel_page = current_user.panels_with_access&.find { |panel| User.panel_list[panel][:pages].include?(panel_page_id) }
 
     return head :unauthorized if panel_with_panel_page.nil?
-    redirect_to panel_index_path(panel_id: panel_with_panel_page, anchor: @panel_page)
+    redirect_to panel_index_path(panel_id: panel_with_panel_page, anchor: panel_page_id)
   end
 end

--- a/app/webpacker/components/RolesTab/ActiveRoles.jsx
+++ b/app/webpacker/components/RolesTab/ActiveRoles.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Header, List, Icon } from 'semantic-ui-react';
-import { panelRedirectUrl } from '../../lib/requests/routes.js.erb';
+import { panelPageUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
 import useLoggedInUserPermissions from '../../lib/hooks/useLoggedInUserPermissions';
 import { groupTypes, delegateRegionsStatus, PANEL_PAGES } from '../../lib/wca-data.js.erb';
@@ -12,17 +12,17 @@ function hyperlink(role) {
       delegateRegionsStatus.senior_delegate,
       delegateRegionsStatus.regional_delegate,
     ].includes(role.metadata.status)) {
-      return panelRedirectUrl(PANEL_PAGES.regionsManager);
+      return panelPageUrl(PANEL_PAGES.regionsManager);
     }
-    return panelRedirectUrl(PANEL_PAGES.regions);
+    return panelPageUrl(PANEL_PAGES.regions);
   }
   if (role.group.group_type === groupTypes.teams_committees) {
     // FIXME: Redirect to correct dropdown in groupsManager. Currently it only goes to the
     // groupsManager page without selecting the group of the user.
-    return panelRedirectUrl(PANEL_PAGES.groupsManager);
+    return panelPageUrl(PANEL_PAGES.groupsManager);
   }
   if (role.group.group_type === groupTypes.translators) {
-    return panelRedirectUrl(PANEL_PAGES.translators);
+    return panelPageUrl(PANEL_PAGES.translators);
   }
   return null;
 }

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -254,7 +254,7 @@ export const panelUrls = {
   },
 }
 
-export const panelRedirectUrl = (panelPage) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_redirect_path(panel_page: "${panelPage}")) %>`;
+export const panelPageUrl = (panelPage) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_page_path(id: "${panelPage}")) %>`;
 
 export const viewUrls = {
   tickets: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,7 +191,7 @@ Rails.application.routes.draw do
     get 'generate_db_token' => 'panel#generate_db_token', as: :panel_generate_db_token
   end
   get 'panel/:panel_id' => 'panel#index', as: :panel_index
-  get 'panel/redirect/:panel_page' => 'panel#redirect', as: :panel_redirect
+  get 'panel-page/:id' => 'panel#panel_page', as: :panel_page
   resources :tickets, only: [:index, :show] do
     post 'update_status' => 'tickets#update_status', as: :update_status
     get 'edit_person_validators' => 'tickets#edit_person_validators', as: :edit_person_validators


### PR DESCRIPTION
This is slightly a continuation of https://github.com/thewca/worldcubeassociation.org/pull/9671. In that PR, I've introduced `redirect` to redirect panel pages to the right panel. In this PR, I'm renaming `redirect` with `panel-page` so that the URL can stay for long term. The current feature is still to redirect, but in future, the panel pages can come under the "panel-page/" path.

For example, if somebody opens worldcubeassociation.org/panel-page/dues-export, if they have access to dues-export page, then:
1. after this PR is merged - it will redirect to the correct panel
2. in long term - it won't get redirected, instead will open the dues-export page and in the left side, the panel options will be shown.