### PR TITLE
Circumvent cache in WIC->Ethics sync

### DIFF
--- a/app/jobs/sync_mailing_lists_job.rb
+++ b/app/jobs/sync_mailing_lists_job.rb
@@ -35,7 +35,7 @@ class SyncMailingListsJob < WcaCronjob
     # Special case: WIC is the first committee in our (recent) history that "absorbed" another team's duties:
     #   They are now a "mix" of WDC and WEC. The structures have been mapped so that WIC reuses WDC's groups,
     #   so they get WDC access "for free". But they _also_ need to be synced to ethics@ to view old conversations from there.
-    GsuiteMailingLists.sync_group("ethics@worldcubeassociation.org", GroupsMetadataTeamsCommittees.wic.user_group.active_users.map(&:email))
+    GsuiteMailingLists.sync_group("ethics@worldcubeassociation.org", GroupsMetadataTeamsCommittees.wic.user_group.active_users.pluck(:email))
 
     treasurers = UserGroup.officers.flat_map(&:active_roles).filter { |role| role.metadata.status == RolesMetadataOfficers.statuses[:treasurer] }
     GsuiteMailingLists.sync_group("treasurer@worldcubeassociation.org", treasurers.map(&:user).map(&:email))


### PR DESCRIPTION
This is (unfortunately) a very obscure fix, because the use-case is already a hack in itself.

WIC is the first team ever (to my knowledge) where two teams were merged into one (originally WDC and WEC). They want access to the historic records in both email groups, but we only support one-to-one sync.

When WIC was introduced, it was decided that they will become a rename of WDC. So they have automatic stuff to all WDC history. But they _also_ want and need to be synced to ethics@ which is the old WEC group. We do that sync manually with a hand-crafted line of code.

The problem is that this code directly accesses the `GroupsMetadataTeamsCommittees.wic` shorthand. These shorthands are cached, so if the leader adds new members the list sync will not consider them until the next deploy (or reboot) which can sometimes be days apart.

This PR fixes that small inconvenience by using `pluck` which forces Rails to directly fire an SQL query every single time.