### PR TITLE
Psych sheet columns and headers

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -31,13 +31,12 @@ export default function RegistrationList({ competitionInfo }) {
     retry: false,
   });
 
-  const [state, dispatch] = useReducer(sortReducer, {
+  const [{ sortColumn, sortDirection }, sortDispatch] = useReducer(sortReducer, {
     sortColumn: 'name',
     sortDirection: undefined,
   });
 
-  const { sortColumn, sortDirection } = state;
-  const changeSortColumn = (name) => dispatch({ type: 'CHANGE_SORT', sortColumn: name });
+  const changeSortColumn = (name) => sortDispatch({ type: 'CHANGE_SORT', sortColumn: name });
 
   const [psychSheetEvent, setPsychSheetEvent] = useState();
   const [psychSheetSortBy, setPsychSheetSortBy] = useState('single');

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -33,7 +33,7 @@ export default function RegistrationList({ competitionInfo }) {
 
   const [{ sortColumn, sortDirection }, sortDispatch] = useReducer(sortReducer, {
     sortColumn: 'name',
-    sortDirection: undefined,
+    sortDirection: 'ascending',
   });
 
   const changeSortColumn = (name) => sortDispatch({ type: 'CHANGE_SORT', sortColumn: name });

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -287,6 +287,8 @@ function FooterContent({
 }) {
   if (!registrations) return null;
 
+  const isPsychSheet = !isAllCompetitors
+
   const newcomerCount = registrations.filter(
     (reg) => !reg.user.wca_id,
   ).length;
@@ -309,7 +311,7 @@ function FooterContent({
 
   return (
     <Table.Row>
-      {!isAllCompetitors && (
+      {isPsychSheet && (
         // psych sheet position
         <Table.Cell />
       )}

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -154,6 +154,7 @@ export default function RegistrationList({ competitionInfo }) {
                 {competitionInfo.event_ids.map((id) => (
                   <Table.HeaderCell
                     key={`registration-table-header-${id}`}
+                    onClick={() => setPsychSheetEvent(id)} // 3
                   >
                     <EventIcon id={id} size="1em" className="selected" />
                   </Table.HeaderCell>

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -130,6 +130,11 @@ export default function RegistrationList({ competitionInfo }) {
       <Table striped sortable unstackable compact singleLine textAlign="left">
         <Table.Header>
           <Table.Row>
+            {isPsychSheet && (
+              <Table.HeaderCell disabled>
+                <EventIcon id={psychSheetEvent} className="selected" size="1em" />
+              </Table.HeaderCell>
+            )}
             <Table.HeaderCell
               sorted={isAllCompetitors && sortColumn === 'name' ? sortDirection : undefined}
               onClick={isAllCompetitors ? () => changeSortColumn('name') : undefined}
@@ -162,9 +167,6 @@ export default function RegistrationList({ competitionInfo }) {
               </>
             ) : (
               <>
-                <Table.HeaderCell>
-                  <EventIcon id={psychSheetEvent} className="selected" size="1em" />
-                </Table.HeaderCell>
                 <Table.HeaderCell disabled>
                   <Icon name="trophy" />
                   {' '}
@@ -194,6 +196,15 @@ export default function RegistrationList({ competitionInfo }) {
           {data.length > 0 ? (
             data.map((registration) => (
               <Table.Row key={`registration-table-row-${registration.user.id}`}>
+                {isPsychSheet && (
+                  <Table.Cell
+                    collapsing
+                    textAlign="right"
+                    disabled={registration.tied_previous}
+                  >
+                    {registration.pos}
+                  </Table.Cell>
+                )}
                 <Table.Cell>
                   {registration.user.wca_id ? (
                     <a
@@ -228,13 +239,6 @@ export default function RegistrationList({ competitionInfo }) {
                   </>
                 ) : (
                   <>
-                    <Table.Cell
-                      collapsing
-                      textAlign="right"
-                      disabled={registration.tied_previous}
-                    >
-                      {registration.pos}
-                    </Table.Cell>
                     <Table.Cell>
                       {psychSheetSortBy === 'single'
                         ? registration.single_rank
@@ -304,6 +308,10 @@ function FooterContent({
 
   return (
     <Table.Row>
+      {!isAllCompetitors && (
+        // psych sheet position
+        <Table.Cell />
+      )}
       <Table.Cell>
         {`${newcomerCount} ${I18n.t('registrations.registration_info_people.newcomer', { count: newcomerCount })} + ${
           registrations.length - newcomerCount
@@ -321,8 +329,8 @@ function FooterContent({
           <Table.Cell>{totalEvents}</Table.Cell>
         </>
       ) : (
+        // WR, single, average
         <>
-          <Table.Cell />
           <Table.Cell />
           <Table.Cell />
           <Table.Cell />

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -40,6 +40,8 @@ export default function RegistrationList({ competitionInfo }) {
 
   const [psychSheetEvent, setPsychSheetEvent] = useState();
   const [psychSheetSortBy, setPsychSheetSortBy] = useState('single');
+  const isPsychSheet = psychSheetEvent !== undefined
+  const isAllCompetitors = !isPsychSheet
   const handleEventSelection = ({ type, eventId }) => {
     setPsychSheetEvent(type === 'toggle_event' ? eventId : undefined);
   };
@@ -57,7 +59,7 @@ export default function RegistrationList({ competitionInfo }) {
       psychSheetSortBy,
     ),
     retry: false,
-    enabled: psychSheetEvent !== undefined,
+    enabled: isPsychSheet,
   });
 
   const registrationsWithPsychSheet = useMemo(() => {
@@ -74,7 +76,7 @@ export default function RegistrationList({ competitionInfo }) {
   const data = useMemo(() => {
     if (registrationsWithPsychSheet) {
       let orderBy = [];
-      if (psychSheetEvent === undefined) {
+      if (isAllCompetitors) {
         switch (sortColumn) {
           case 'country':
             orderBy = [
@@ -97,7 +99,7 @@ export default function RegistrationList({ competitionInfo }) {
       return _.orderBy(registrationsWithPsychSheet, orderBy, [direction]);
     }
     return [];
-  }, [registrationsWithPsychSheet, sortColumn, sortDirection, psychSheetEvent]);
+  }, [isAllCompetitors, registrationsWithPsychSheet, sortColumn, sortDirection]);
 
   if (isError) {
     return (
@@ -129,18 +131,20 @@ export default function RegistrationList({ competitionInfo }) {
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell
-              sorted={sortColumn === 'name' ? sortDirection : undefined}
-              onClick={() => changeSortColumn('name')}
+              sorted={isAllCompetitors && sortColumn === 'name' ? sortDirection : undefined}
+              onClick={isAllCompetitors ? () => changeSortColumn('name') : undefined}
+              disabled={isPsychSheet}
             >
               {I18n.t('activerecord.attributes.registration.name')}
             </Table.HeaderCell>
             <Table.HeaderCell
-              sorted={sortColumn === 'country' ? sortDirection : undefined}
-              onClick={() => changeSortColumn('country')}
+              sorted={isAllCompetitors && sortColumn === 'country' ? sortDirection : undefined}
+              onClick={isAllCompetitors ? () => changeSortColumn('country') : undefined}
+              disabled={isPsychSheet}
             >
               {I18n.t('activerecord.attributes.user.country_iso2')}
             </Table.HeaderCell>
-            {psychSheetEvent === undefined ? (
+            {isAllCompetitors ? (
               <>
                 {competitionInfo.event_ids.map((id) => (
                   <Table.HeaderCell
@@ -161,7 +165,7 @@ export default function RegistrationList({ competitionInfo }) {
                 <Table.HeaderCell>
                   <EventIcon id={psychSheetEvent} className="selected" size="1em" />
                 </Table.HeaderCell>
-                <Table.HeaderCell>
+                <Table.HeaderCell disabled>
                   <Icon name="trophy" />
                   {' '}
                   WR
@@ -207,7 +211,7 @@ export default function RegistrationList({ competitionInfo }) {
                   />
                   {countries.byIso2[registration.user.country.iso2].name}
                 </Table.Cell>
-                {psychSheetEvent === undefined ? (
+                {isAllCompetitors ? (
                   <>
                     {competitionInfo.event_ids.map((id) => (
                       <Table.Cell
@@ -251,12 +255,12 @@ export default function RegistrationList({ competitionInfo }) {
               <Table.Cell
                 textAlign="center"
                 colSpan={
-                  psychSheetEvent === undefined
+                  isAllCompetitors
                     ? competitionInfo.event_ids.length + 3
                     : 7
                 }
               >
-                {psychSheetEvent && I18n.t('competitions.registration_v2.list.empty')}
+                {isPsychSheet && I18n.t('competitions.registration_v2.list.empty')}
               </Table.Cell>
             </Table.Row>
           )}
@@ -264,7 +268,7 @@ export default function RegistrationList({ competitionInfo }) {
         <Table.Footer>
           <FooterContent
             registrations={registrationsWithPsychSheet}
-            psychSheetEvent={psychSheetEvent}
+            isAllCompetitors={isAllCompetitors}
             competitionInfo={competitionInfo}
           />
         </Table.Footer>
@@ -274,7 +278,7 @@ export default function RegistrationList({ competitionInfo }) {
 }
 
 function FooterContent({
-  registrations, psychSheetEvent, competitionInfo,
+  registrations, isAllCompetitors, competitionInfo,
 }) {
   if (!registrations) return null;
 
@@ -307,7 +311,7 @@ function FooterContent({
          ${registrations.length} ${I18n.t('registrations.registration_info_people.person', { count: registrations.length })}`}
       </Table.Cell>
       <Table.Cell>{`${I18n.t('registrations.list.country_plural', { count: countryCount })}`}</Table.Cell>
-      {psychSheetEvent === undefined ? (
+      {isAllCompetitors ? (
         <>
           {competitionInfo.event_ids.map((evt) => (
             <Table.Cell key={`footer-count-${evt}`}>


### PR DESCRIPTION
Partially resolves 10552.

Move rank to first column, mark columns as disabled (cannot be clicked (to sort)) when applicable, and re-introduce ability to click an event column to open the psych sheet for that event.

![image](https://github.com/user-attachments/assets/d1785c78-6e9a-4e86-9417-8cedc8c1f957)


[Screencast from 2025-01-09 05:18:46 PM.webm](https://github.com/user-attachments/assets/eb31292b-8814-47c2-893a-d4333c214846)

Future PR: Given a particular event, it might be good to have a single call to get the psych sheet data, and then have the front end handle sorting by single vs average?

Also, ties are not currently shown as the same rank:

![image](https://github.com/user-attachments/assets/513d6e10-edd3-4edf-85ad-7cc1415d399e)
