### PR TITLE
Teams page: Remove side effect from const & simplify/rename

### DIFF
--- a/app/webpacker/components/TeamsCommitteesCouncils/index.jsx
+++ b/app/webpacker/components/TeamsCommitteesCouncils/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   Container, Dropdown, Grid, Header, Menu, Segment,
 } from 'semantic-ui-react';
@@ -24,32 +24,41 @@ export default function TeamsCommitteesCouncils({ canViewPastRoles }) {
     error: councilsError,
   } = useLoadedData(apiV0Urls.userGroups.list(groupTypes.councils, 'name', { isActive: true, isHidden: false }));
 
-  const [hash, setHash] = useHash();
-  const loading = teamsCommitteesLoading || councilsLoading;
+  const isLoading = teamsCommitteesLoading || councilsLoading;
 
-  const groupList = useMemo(() => (loading ? [] : [
+  const groups = useMemo(() => (isLoading ? [] : [
     ...(teamsCommittees || []),
     ...(councils || []),
-  ]), [loading, teamsCommittees, councils]);
+  ]), [isLoading, teamsCommittees, councils]);
 
-  const menuOptions = useMemo(() => groupList.map((group) => ({
+  const menuOptions = useMemo(() => groups.map((group) => ({
     id: group.id,
     text: I18n.t(`page.teams_committees_councils.groups_name.${group.metadata.friendly_id}`),
     friendlyId: group.metadata.friendly_id,
-  })), [groupList]);
+  })), [groups]);
 
-  const activeGroup = React.useMemo(() => {
-    const selectedGroupIndex = groupList.findIndex(
-      (group) => group.metadata.friendly_id === hash,
-    );
-    if (selectedGroupIndex === -1 && groupList.length > 0) {
-      setHash(groupList[0]?.metadata.friendly_id);
-      return null;
-    }
-    return groupList[selectedGroupIndex];
-  }, [groupList, hash, setHash]);
+  const [hash, setHash] = useHash();
 
-  if (loading || !activeGroup) return <Loading />;
+  const activeGroup = useMemo(() => groups.find(
+    (group) => group.metadata.friendly_id === hash,
+  ), [groups, hash]);
+
+  const hashIsValid = Boolean(activeGroup);
+
+  useEffect(
+    function sanitizeHash() {
+      if (!isLoading && !hashIsValid) {
+        if (groups.length > 0) {
+          setHash(groups[0].metadata.friendly_id);
+        } else {
+          setHash(null)
+        }
+      }
+    },
+    [isLoading, hashIsValid, groups, setHash],
+  );
+
+  if (isLoading || !activeGroup) return <Loading />;
   if (teamsCommitteesError || councilsError) return <Errored />;
 
   return (


### PR DESCRIPTION
I was looking into #10594, and saw the `setHash` side effect inside a constant's definition, which is not the proper way to do a side effect (for various reasons, such as no guarantees about when `useMemo` will run, potential infinite loops, and clarity), so I moved it out and did some simplifying (work directly with the group, rather than the index) and renamed some things. (I think I reviewed the code before it was merged, so my bad for not seeing it then.)

This doesn't fix the bug, which I documented in the issue mentioned above.

Edit: test failures seem unrelated to changes?