### PR TITLE
Only disable qualification button if qualifications are enforced

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -297,6 +297,8 @@ export default function CompetingStep({
             warning
             list={formWarnings}
           />
+          {console.log("comp info")}
+          {console.log(competitionInfo)}
           <Form.Field required error={hasInteracted && selectedEvents.length === 0}>
             <EventSelector
               onEventSelection={handleEventSelection}
@@ -304,11 +306,15 @@ export default function CompetingStep({
               selectedEvents={selectedEvents}
               id="event-selection"
               maxEvents={maxEvents}
-              eventsDisabled={eventsNotQualifiedFor(
-                competitionInfo.event_ids,
-                qualifications.wcif,
-                qualifications.personalRecords,
-              )}
+              eventsDisabled={
+                competitionInfo.allow_registration_without_qualification
+                ? []
+                : eventsNotQualifiedFor(
+                  competitionInfo.event_ids,
+                  qualifications.wcif,
+                  qualifications.personalRecords,
+                )
+              }
               disabledText={(event) => eventQualificationToString(
                 { id: event },
                 qualifications.wcif[event],

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -297,8 +297,6 @@ export default function CompetingStep({
             warning
             list={formWarnings}
           />
-          {console.log("comp info")}
-          {console.log(competitionInfo)}
           <Form.Field required error={hasInteracted && selectedEvents.length === 0}>
             <EventSelector
               onEventSelection={handleEventSelection}


### PR DESCRIPTION
[Austrlian Nationals](https://www.worldcubeassociation.org/competitions/AustralianNationals2025/register) allows registration without meeting the qualification requirements, and this is allowed by our backend, but the event buttons are disabled in the frontend in all cases, meaning users can't register even if qualifications aren't enforced

Fixes #10593 