### PR TITLE
Default to `en` locale for dates in competition pages

### DIFF
--- a/app/views/competitions/_competition_info.html.erb
+++ b/app/views/competitions/_competition_info.html.erb
@@ -3,7 +3,7 @@
     <dl class="dl-horizontal compact">
       <dt><%= t '.date' %></dt>
       <dd>
-        <%= wca_date_range(competition.start_date, competition.end_date) %>
+        <%= wca_date_range(competition.start_date, competition.end_date, locale: :en) %>
         <%= link_to(ui_icon("calendar plus"), competition_path(competition, format: :ics),
                     title: t('.add_to_calendar'),
                     data: {

--- a/app/views/competitions/_index_table.html.erb
+++ b/app/views/competitions/_index_table.html.erb
@@ -24,7 +24,7 @@
         <% else %>
           <%= ui_icon('hourglass start', title: t('competitions.index.tooltips.hourglass.starts_in', days: t('common.days', count:(competition.start_date - Date.today).to_i)), data: { toggle: "tooltip" }) %>
         <% end %>
-        <%= wca_date_range(competition.start_date, competition.end_date) %>
+        <%= wca_date_range(competition.start_date, competition.end_date, locale: :en) %>
       </span>
       <span class="competition-info">
         <div class="competition-link">

--- a/app/views/competitions/_my_competitions_table.html.erb
+++ b/app/views/competitions/_my_competitions_table.html.erb
@@ -51,7 +51,7 @@
               <% end %>
             </td>
             <td><%= competition.city_and_country %></td>
-            <td><%= wca_date_range(competition.start_date, competition.end_date) %></td>
+            <td><%= wca_date_range(competition.start_date, competition.end_date, locale: :en) %></td>
             <td>
               <% if registration %>
                 <%= ui_icon(registration.accepted? ? "calendar check" : "hourglass half") %>


### PR DESCRIPTION
Corresponding issue: #10601 