### PR TITLE
Removed some pages (basically hyperlinks) from old admin panel and added to panels wherever necessary

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -720,6 +720,7 @@ class User < ApplicationRecord
           panel_pages[:officersEditor],
           panel_pages[:regionsAdmin],
           panel_pages[:bannedCompetitors],
+          panel_pages[:downloadVoters],
         ],
       },
       leader: {
@@ -778,6 +779,9 @@ class User < ApplicationRecord
       },
       can_edit_delegate_report: {
         scope: can_admin_results? ? "*" : delegated_competition_ids,
+      },
+      can_edit_results: {
+        scope: results_team? || admin? ? "*" : [],
       },
       can_create_groups: {
         scope: groups_with_create_access,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -780,9 +780,6 @@ class User < ApplicationRecord
       can_edit_delegate_report: {
         scope: can_admin_results? ? "*" : delegated_competition_ids,
       },
-      can_edit_results: {
-        scope: can_edit_results? ? "*" : [],
-      },
       can_create_groups: {
         scope: groups_with_create_access,
       },
@@ -840,10 +837,6 @@ class User < ApplicationRecord
 
   def can_admin_results?
     admin? || board_member? || results_team?
-  end
-
-  private def can_edit_results?
-    admin? || results_team?
   end
 
   def can_admin_finances?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -648,6 +648,7 @@ class User < ApplicationRecord
       :approveAvatars,
       :editPersonRequests,
       :anonymizationScript,
+      :serverStatus,
     ].index_with { |panel_page| panel_page.to_s.underscore.dasherize }
   end
 
@@ -706,6 +707,7 @@ class User < ApplicationRecord
         name: 'WST panel',
         pages: [
           panel_pages[:translators],
+          panel_pages[:serverStatus],
         ],
       },
       board: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -781,7 +781,7 @@ class User < ApplicationRecord
         scope: can_admin_results? ? "*" : delegated_competition_ids,
       },
       can_edit_results: {
-        scope: results_team? || admin? ? "*" : [],
+        scope: can_edit_results? ? "*" : [],
       },
       can_create_groups: {
         scope: groups_with_create_access,
@@ -840,6 +840,10 @@ class User < ApplicationRecord
 
   def can_admin_results?
     admin? || board_member? || results_team?
+  end
+
+  private def can_edit_results?
+    admin? || results_team?
   end
 
   def can_admin_finances?

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -4,8 +4,6 @@
       <% competitions_view = "/competitions"
          competitions_view += "?display=admin" if current_user.can_see_admin_competitions? %>
       <% [
-        { text: "List competitions", path: competitions_view, fa_icon: "list" },
-        { text: "Delegates", path: delegates_path(anchor: "all"), fa_icon: "sitemap" },
         { text: "Run validators", path: admin_check_results_path, fa_icon: "check double" },
         { text: "Create newcomers", path: admin_finish_unfinished_persons_path, fa_icon: "user plus" },
         { text: "Check records", path: admin_check_regional_records_path, fa_icon: "trophy" },
@@ -15,7 +13,6 @@
         { text: "Merge people", path: admin_merge_people_path, fa_icon: "code branch" },
         { text: "Anonymize person", path: admin_anonymize_person_path, fa_icon: "id card" },
         { text: "Reassign connected wca id", path: admin_reassign_wca_id_path, fa_icon: "code branch" },
-        { text: "Server status", path: server_status_path, fa_icon: "info" },
       ].each do |nav_item| %>
         <%= link_to nav_item[:path], class: "list-group-item" + (current_page?(nav_item[:path]) ? ' active' : '') do %>
           <%= ui_icon(nav_item[:fa_icon]) %> <%= nav_item[:text] %>

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -15,8 +15,6 @@
         { text: "Merge people", path: admin_merge_people_path, fa_icon: "code branch" },
         { text: "Anonymize person", path: admin_anonymize_person_path, fa_icon: "id card" },
         { text: "Reassign connected wca id", path: admin_reassign_wca_id_path, fa_icon: "code branch" },
-        { text: "WCA all voting members", path: eligible_voters_path, fa_icon: "download" },
-        { text: "WCA leaders and seniors", path: leader_senior_voters_path, fa_icon: "download" },
         { text: "Server status", path: server_status_path, fa_icon: "info" },
       ].each do |nav_item| %>
         <%= link_to nav_item[:path], class: "list-group-item" + (current_page?(nav_item[:path]) ? ' active' : '') do %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -249,7 +249,7 @@
               <li><%= link_to t('.new_competition'), new_competition_path if current_user.can_create_competitions? %></li>
             <% end %>
 
-            <% if current_user.has_permission?(:can_edit_results) %>
+            <% if current_user.can_admin_results? %>
               <li class="divider"></li>
               <li role="presentation" class="dropdown-header">
                 <%= t '.results_team' %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -249,7 +249,7 @@
               <li><%= link_to t('.new_competition'), new_competition_path if current_user.can_create_competitions? %></li>
             <% end %>
 
-            <% if current_user.can_admin_results? %>
+            <% if current_user.has_permission?(:can_edit_results) %>
               <li class="divider"></li>
               <li role="presentation" class="dropdown-header">
                 <%= t '.results_team' %>

--- a/app/webpacker/components/Panel/PanelPages.jsx
+++ b/app/webpacker/components/Panel/PanelPages.jsx
@@ -4,6 +4,7 @@ import {
   subordinateDelegateClaimsUrl,
   subordinateUpcomingCompetitionsUrl,
   generateDbTokenUrl,
+  serverStatusPageUrl,
 } from '../../lib/requests/routes.js.erb';
 import PostingCompetitionsTable from '../PostingCompetitions';
 import EditPersonPage from './pages/EditPersonPage';
@@ -148,5 +149,9 @@ export default {
   [PANEL_PAGES.anonymizationScript]: {
     name: 'Anonymization Script',
     component: AnonymizationScriptPage,
+  },
+  [PANEL_PAGES.serverStatus]: {
+    name: 'Server Status',
+    link: serverStatusPageUrl,
   },
 };

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -305,3 +305,5 @@ export const updateRegistrationUrl = `<%= CGI.unescape(Rails.application.routes.
 export const bulkUpdateRegistrationUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v1_registrations_bulk_update_path) %>`;
 
 export const paymentTicketUrl = (competitionId, donationIso) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v1_registrations_payment_ticket_path(competition_id: "${competitionId}", donation_iso: "${donationIso}")) %>`;
+
+export const serverStatusPageUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.server_status_path) %>`;


### PR DESCRIPTION
The Board doesn't use admin panel, and even if they the max they want is voters page. So moved it to board panel, and removed board access to admin panel. The access to admin panel is removed for board, so that now it is accessible only by WRT and WST, and this will help to move closer towards removal of old admin panel completely.