### PR TITLE
Remove destroy button from ticket page

### DIFF
--- a/app/webpacker/components/Panel/pages/EditPersonPage/EditPersonForm.jsx
+++ b/app/webpacker/components/Panel/pages/EditPersonPage/EditPersonForm.jsx
@@ -24,7 +24,7 @@ const countryOptions = _.map(countries.byIso2, (country) => ({
   value: country.iso2,
 }));
 
-export default function EditPersonForm({ wcaId, onSuccess }) {
+export default function EditPersonForm({ wcaId, onSuccess, showDestroyButton = false }) {
   const {
     data: personFetchData, loading, error: personError,
   } = useLoadedData(
@@ -180,10 +180,12 @@ export default function EditPersonForm({ wcaId, onSuccess }) {
           <Icon name="clone" />
           Update
         </Button>
-        <Button disabled={!editedUserDetails} onClick={handleDestroy}>
-          <Icon name="trash" />
-          Destroy
-        </Button>
+        {showDestroyButton && (
+          <Button disabled={!editedUserDetails} onClick={handleDestroy}>
+            <Icon name="trash" />
+            Destroy
+          </Button>
+        )}
         {incorrectClaimCount > 0 && (
           <Button onClick={handleResetClaimCount}>
             <Icon name="redo" />

--- a/app/webpacker/components/Panel/pages/EditPersonPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/EditPersonPage/index.jsx
@@ -36,7 +36,10 @@ export default function EditPersonPage() {
                 </Item.Description>
               </Item.Content>
             </Item>
-            <EditPersonForm wcaId={wcaId} />
+            <EditPersonForm
+              wcaId={wcaId}
+              showDestroyButton
+            />
           </>
         )
         : (


### PR DESCRIPTION
This is a request from WRT - showing destroy button in tickets UI is confusing the team a bit, and sometimes even misunderstand it as deleting ticket button. So to avoid confusion, it's removed from tickets page - or rather it is shown only from 'edit person panel page'.