### PR TITLE
Show DOB validations for registered users

### DIFF
--- a/lib/results_validators/validator_data.rb
+++ b/lib/results_validators/validator_data.rb
@@ -6,7 +6,7 @@ module ResultsValidators
 
     BACKOFF_INT_MAX = 2_147_483_648
 
-    attr_accessor :competition, :results, :persons
+    attr_accessor :competition, :results, :persons, :registered_users
 
     def self.from_competitions(validator, competition_ids, check_real_results, batch_size: nil)
       associations = self.load_associations(validator, check_real_results: check_real_results)
@@ -86,6 +86,9 @@ module ResultsValidators
 
       if validator.include_persons?
         data.persons = check_real_results ? competition.competitors : competition.inbox_persons
+        if data.persons.empty?
+          data.registered_users = competition.registrations.map(&:user)
+        end
       end
 
       data


### PR DESCRIPTION
Currently delegates need to wait till the competition is over to know the persons related warnings and errors. The reason is that the persons will be fetched only from InboxPerons or Persons and before the delegate uploads json, it won't be available in neither of the tables.

In this PR, if the Persons and InboxPersons is empty, it will populate a new field `registered_users` with the list of registered users. Hence, if the delegate runs the `PersonValidators` before the competition, they will be able to see the name and DOB warnings much earlier.

Currently, there are many cases where the delegate has to inform the WRT that they will contact the competitor and get back, and in many cases, the delegates find it really difficult to contact the competitors after the competition. If the warnings & errors are available in advance, it will be really helpful for the delegates.

PS: For now, only DOB validations will be shown, for name validations there are some more cleanups required, which I'll be doing at a later stage in a separate PR.