### PR TITLE
Fix Delegate's edit profile contact form

### DIFF
--- a/app/webpacker/components/ContactEditProfilePage/index.jsx
+++ b/app/webpacker/components/ContactEditProfilePage/index.jsx
@@ -45,7 +45,7 @@ export default function ContactEditProfilePage({ loggedInUserId, recaptchaPublic
       </Message>
     );
   }
-  if (loggedInUserData && !wcaId) {
+  if (!editOthersProfileMode && loggedInUserData && !wcaId) {
     return (
       <Message error>
         <I18nHTMLTranslate i18nKey="page.contact_edit_profile.no_profile_error" />


### PR DESCRIPTION
I somehow missed this because of which delegates were seeing error when the "edit others profile" page is opened.