### PR TITLE
Include ImageMagick in GitHub CI runner

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: fregante/setup-git-user@v2 # set up dummy user.name and user.email in git so that Overcommit doesn't explode
+      - name: Set up ImageMagick # This is not included in GitHub runners by default anymore
+        uses: mfinelli/setup-imagemagick@v6
+        with:
+          cache: true
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Because GH threw it out without clearly announcing it. Yay!

(Note that this makes our tests fail. I merged #10086 *after tests passed* because it was still on the old 22.04 runner. But that CI run happened a few weeks ago already. Now after the merge the `main` CI ran on the new 24.04 runner and suddenly failed on the exact same code because ImageMagick was missing)