### PR TITLE
Fix date format for DatePicker component parser

### DIFF
--- a/app/webpacker/components/ContactEditProfilePage/EditProfileForm.jsx
+++ b/app/webpacker/components/ContactEditProfilePage/EditProfileForm.jsx
@@ -122,7 +122,7 @@ export default function EditProfileForm({
         name="dob"
         control={UtcDatePicker}
         showYearDropdown
-        dateFormatOverride="YYYY-MM-dd"
+        dateFormatOverride="yyyy-MM-dd"
         dropdownMode="select"
         isoDate={editedProfileDetails?.dob}
         onChange={handleDobChange}

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitorForm.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitorForm.jsx
@@ -80,7 +80,7 @@ export default function BanendCompetitorForm({
         name="endDate"
         control={UtcDatePicker}
         showYearDropdown
-        dateFormatOverride="YYYY-MM-dd"
+        dateFormatOverride="yyyy-MM-dd"
         dropdownMode="select"
         isoDate={formValues?.endDate}
         onChange={(date) => handleFormChange(null, {

--- a/app/webpacker/components/Panel/pages/EditPersonPage/EditPersonForm.jsx
+++ b/app/webpacker/components/Panel/pages/EditPersonPage/EditPersonForm.jsx
@@ -157,7 +157,7 @@ export default function EditPersonForm({ wcaId, onSuccess }) {
           name="dob"
           control={UtcDatePicker}
           showYearDropdown
-          dateFormatOverride="YYYY-MM-dd"
+          dateFormatOverride="yyyy-MM-dd"
           dropdownMode="select"
           disabled={!editedUserDetails}
           isoDate={editedUserDetails?.dob}


### PR DESCRIPTION
It seems that our DatePicker library wants the "year" part to be specified as lowercase `yyyy` rather than standard JS uppercase `YYYY`.

I could not find a precise documentation explaining why (or what the difference is). I just noticed locally that uppercase throws errors in the console while lowercase works without any flaws. Also, the examples at https://reactdatepicker.com/ all use lowercase `yyyy`, I couldn't find any uppercase `YYYY` at all in there. 