### PR TITLE
Reorganize Delegate panel links

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -637,7 +637,6 @@ class User < ApplicationRecord
       :leaderForms,
       :groupsManager,
       :importantLinks,
-      :delegateHandbook,
       :seniorDelegatesList,
       :leadersAdmin,
       :boardEditor,
@@ -682,7 +681,6 @@ class User < ApplicationRecord
         name: 'Delegate panel',
         pages: [
           panel_pages[:importantLinks],
-          panel_pages[:delegateHandbook],
           panel_pages[:bannedCompetitors],
         ],
       },

--- a/app/webpacker/components/Panel/PanelPages.jsx
+++ b/app/webpacker/components/Panel/PanelPages.jsx
@@ -40,8 +40,6 @@ import ApprovePictures from './pages/ApprovePictures';
 import EditPersonRequestsPage from './pages/EditPersonRequestsPage';
 import AnonymizationScriptPage from './pages/AnonymizationScriptPage';
 
-const DELEGATE_HANDBOOK_LINK = 'https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf';
-
 export default {
   [PANEL_PAGES.postingDashboard]: {
     name: 'Posting Dashboard',
@@ -114,10 +112,6 @@ export default {
   [PANEL_PAGES.importantLinks]: {
     name: 'Important Links',
     component: ImportantLinks,
-  },
-  [PANEL_PAGES.delegateHandbook]: {
-    name: 'Delegate Handbook',
-    link: DELEGATE_HANDBOOK_LINK,
   },
   [PANEL_PAGES.seniorDelegatesList]: {
     name: 'Senior Delegates List',

--- a/app/webpacker/components/Panel/pages/ImportantLinks/index.jsx
+++ b/app/webpacker/components/Panel/pages/ImportantLinks/index.jsx
@@ -1,50 +1,57 @@
 import React from 'react';
 import { Header, List } from 'semantic-ui-react';
-import { allDelegatePageUrl, countryBandsUrl } from '../../../../lib/requests/routes.js.erb';
 
 const IMPORTANT_LINKS = [
   {
-    title: 'Guidelines for Disciplinary Incidents',
-    link: 'https://documents.worldcubeassociation.org/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.pdf',
+    section: 'Guides',
+    links: [
+      {
+        title: 'Delegate Handbook',
+        link: 'https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf',
+      },
+      {
+        title: 'Guidelines for Disciplinary Incidents',
+        link: 'https://documents.worldcubeassociation.org/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.pdf',
+      },
+      {
+        title: 'Visual Guide for Regulation 3j',
+        link: 'https://drive.google.com/file/d/1m6THsA8fXRN7QFM4ApJbm6eVODKGbMLx/view',
+      },
+      {
+        title: 'Visual Guide for Regulation 5b5f',
+        link: 'https://drive.google.com/file/d/15XszaCGNvy3Dk6X6qERzZWZaDH1RH04z/view',
+      },
+    ],
   },
   {
-    title: 'All Delegates',
-    link: allDelegatePageUrl,
-  },
-  {
-    title: 'WR Submission Form',
-    link: 'https://docs.google.com/forms/d/e/1FAIpQLSeLrkLhFnIy1QNGoWoZT4jsOIibNJ_xc9qTd_YKBpcuMIq-LA/viewform',
-  },
-  {
-    title: 'Gear Order Form',
-    link: 'https://forms.gle/owX3ppZahYkoq9s48',
-  },
-  {
-    title: 'Travel Reimbursement Form',
-    link: 'https://docs.google.com/forms/d/12tz2I_EeBORm14kQO6ZB5TOp321YbXkIXvrxUNIHxN0/viewform',
-  },
-  {
-    title: 'Equipment Funding Form',
-    link: 'https://docs.google.com/forms/d/e/1FAIpQLSebkWMyG2kRzR3cDm3jXFVMFCwd5u4XI6Yt35givu0SOidpHg/viewform',
-  },
-  {
-    title: 'Bands for WCA Dues',
-    link: countryBandsUrl,
-  },
-  {
-    title: 'Visual Guide for Regulation 3j',
-    link: 'https://drive.google.com/file/d/1m6THsA8fXRN7QFM4ApJbm6eVODKGbMLx/view',
-  },
-  {
-    title: 'Visual Guide for Regulation 5b5f',
-    link: 'https://drive.google.com/file/d/15XszaCGNvy3Dk6X6qERzZWZaDH1RH04z/view',
+    section: 'Forms',
+    links: [
+      {
+        title: 'Gear Order Form',
+        link: 'https://forms.gle/owX3ppZahYkoq9s48',
+      },
+      {
+        title: 'Equipment Funding Form',
+        link: 'https://docs.google.com/forms/d/e/1FAIpQLSebkWMyG2kRzR3cDm3jXFVMFCwd5u4XI6Yt35givu0SOidpHg/viewform',
+      },
+      {
+        title: 'Travel Reimbursement Form',
+        link: 'https://docs.google.com/forms/d/12tz2I_EeBORm14kQO6ZB5TOp321YbXkIXvrxUNIHxN0/viewform',
+      },
+      {
+        title: 'WR Submission Form',
+        link: 'https://docs.google.com/forms/d/e/1FAIpQLSeLrkLhFnIy1QNGoWoZT4jsOIibNJ_xc9qTd_YKBpcuMIq-LA/viewform',
+      },
+    ],
   },
 ];
 
 function ListItemLink({ title, link }) {
   return (
     <List.Item>
-      <a href={link} target="_blank" rel="noreferrer">{title}</a>
+      <a href={link} target="_blank" rel="noreferrer">
+        {title}
+      </a>
     </List.Item>
   );
 }
@@ -53,11 +60,16 @@ export default function ImportantLinks() {
   return (
     <>
       <Header as="h2">Important Links</Header>
-      <List>
-        {IMPORTANT_LINKS.map(({ title, link }) => (
-          <ListItemLink key={link} title={title} link={link} />
-        ))}
-      </List>
+      {IMPORTANT_LINKS.map(({ section, links }) => (
+        <List key={section}>
+          <Header as="h3">{section}</Header>
+          <List>
+            {links.map(({ title, link }) => (
+              <ListItemLink key={link} title={title} link={link} />
+            ))}
+          </List>
+        </List>
+      ))}
     </>
   );
 }


### PR DESCRIPTION
This commit:
1. Moves the Delegate Handbook link to the Important Links section
2. Removes the "All Delegates" link from the Delegate panel, because it is not necessary or useful here
3. Adds sections to the Important Links so that they are better organized

There's still some jank with the CSS but this page wasn't pretty anyway and I don't want to mess with the styling rn

Desktop View:

<img width="1025" alt="Screenshot 2025-01-18 at 1 31 44 PM" src="https://github.com/user-attachments/assets/f79f43a9-e7f0-41ca-b507-a1261cb86066" />

Mobile View:

<img width="836" alt="Screenshot 2025-01-18 at 1 31 58 PM" src="https://github.com/user-attachments/assets/5a5d4c6a-f1c2-49df-8bfa-52cf5a205997" />
