### PR TITLE
Revert "Bump stripe from 12.6.0 to 13.3.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -755,7 +755,7 @@ GEM
     stringio (3.1.2)
     strip_attributes (1.14.1)
       activemodel (>= 3.0, < 9.0)
-    stripe (13.3.1)
+    stripe (12.6.0)
     superconfig (2.1.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)


### PR DESCRIPTION
Reverts thewca/worldcubeassociation.org#10669

Note to self: Don't merge too many Dependabot PRs in a row