### PR TITLE
Fixed 'Registrations' button on my comp page to redirect to correct page

### DIFF
--- a/app/webpacker/components/MyCompetitions/UpcomingCompetitionTable.jsx
+++ b/app/webpacker/components/MyCompetitions/UpcomingCompetitionTable.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { DateTime } from 'luxon';
 import I18n from '../../lib/i18n';
 import { competitionStatusText } from '../../lib/utils/competition-table';
-import { competitionRegistrationsUrl, editCompetitionsUrl } from '../../lib/requests/routes.js.erb';
+import { competitionEditRegistrationsUrl, editCompetitionsUrl } from '../../lib/requests/routes.js.erb';
 import {
   DateTableCell, LocationTableCell, NameTableCell, ReportTableCell,
 } from './TableCells';
@@ -126,7 +126,7 @@ export default function UpcomingCompetitionTable({
                   )}
                   {(permissions.can_organize_competitions.scope === '*' || permissions.can_organize_competitions.scope.includes(competition.id)) && (
                     <Table.Cell>
-                      <a href={competitionRegistrationsUrl(competition.id)}>
+                      <a href={competitionEditRegistrationsUrl(competition.id)}>
                         {I18n.t('competitions.my_competitions_table.registrations')}
                       </a>
                     </Table.Cell>

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -47,7 +47,7 @@ export const homepageUrl = `<%= CGI.unescape(Rails.application.routes.url_helper
 export const createCompetitionUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.competitions_path)%>`;
 export const competitionReportEditUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.delegate_report_edit_path("${id}"))%>`;
 export const editCompetitionsUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_competition_path("${id}"))%>`;
-export const competitionRegistrationsUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_registrations_path("${id}"))%>`;
+export const competitionEditRegistrationsUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_edit_registrations_path("${id}"))%>`;
 export const competitionUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_path("${id}"))%>`;
 export const adminCompetitionUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_edit_path("${id}"))%>`;
 


### PR DESCRIPTION
'Registrations' button on my competitions page was redirecting to the registrations page instead of edit/registrations page.