### PR TITLE
Fix weird but necessary edge case in serializable_opts monkey-patch

### DIFF
--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -52,9 +52,16 @@ Rails.configuration.to_prepare do
   end
 
   Hash.class_eval do
-    def merge_union(other = nil)
+    def merge_serialization_opts(other = nil)
       self.to_h do |key, value|
-        [key, value & (other&.fetch(key.to_s, []) || [])]
+        # Try to read `key` from the other hash, fall back to empty array.
+        other_value = (other&.fetch(key.to_s, []) || [])
+
+        # Merge arrays together, making sure to respect the difference between symbols and strings.
+        merged_value = value.map(&:to_sym) & other_value.map(&:to_sym)
+
+        # Return the merged result associated with the original (common) key
+        [key, merged_value]
       end
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/thewca/worldcubeassociation.org/pull/10575 to cover an edge-case where nested options are passed down as hash instead of array.

As noted in that other PR, it is a horrible, _horrible_ idea to squeeze-merge two different ORM models together, and it's an even worse idea to pass around serialization options from one to the other. But our APIs have grown to expect this behavior, so we cannot remove this serialization nightmare without breaking API contracts.

I don't expect anybody to review or even understand this patch, I really just need to see whether the CI passes.