### PR TITLE
Expose announced_at in non-admin view

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -25,11 +25,11 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
 
     competitions = competitions_scope.search(params[:q], params: params)
 
-    serial_methods = ["short_display_name", "city", "country_iso2", "event_ids", "latitude_degrees", "longitude_degrees"]
+    serial_methods = ["short_display_name", "city", "country_iso2", "event_ids", "latitude_degrees", "longitude_degrees", "announced_at"]
     serial_includes = {}
 
     serial_includes["delegates"] = { only: ["id", "name"], methods: [], include: ["avatar"] } if admin_mode
-    serial_methods |= ["announced_at", "results_submitted_at", "report_posted_at"] if admin_mode
+    serial_methods |= ["results_submitted_at", "report_posted_at"] if admin_mode
 
     paginate json: competitions,
              only: ["id", "name", "start_date", "end_date", "registration_open", "registration_close", "venue"],

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -4,6 +4,7 @@ import {
 } from 'semantic-ui-react';
 
 import { BarLoader } from 'react-spinners';
+import { DateTime } from 'luxon';
 import I18n from '../../lib/i18n';
 import {
   computeAnnouncementStatus,
@@ -515,7 +516,10 @@ function StatusIcon({
   } else if (shouldShowRegStatus) {
     return <RegistrationStatus comp={comp} isLoading={regStatusLoading} />;
   } else if (isSortedByAnnouncement) {
-    tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.announced_on', { announcement_date: comp.announced_at });
+    const announcedAtLuxon = DateTime.fromISO(comp.announced_at);
+    const announcedAtFormatted = announcedAtLuxon.toLocaleString(DateTime.DATETIME_MED);
+
+    tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.announced_on', { announcement_date: announcedAtFormatted });
     iconClass = 'hourglass start';
   } else {
     tooltipInfo = I18n.t('competitions.index.tooltips.hourglass.starts_in', { days: I18n.t('common.days', { count: dayDifferenceFromToday(comp.start_date) }) });


### PR DESCRIPTION
Otherwise, the return value is `null` and the I18N library interprets this as "variable missing in translation string".