### PR TITLE
Fix psych sheet crash when selecting event while loading

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -70,7 +70,7 @@ export default function RegistrationList({ competitionInfo, userId }) {
   const registrationsWithPsychSheet = useMemo(() => {
     if (psychSheet !== undefined) {
       return psychSheet.sorted_rankings.map((p) => {
-        const registrationEntry = registrations.find((r) => p.user_id === r.user_id);
+        const registrationEntry = registrations?.find((r) => p.user_id === r.user_id) || {};
         return { ...p, ...registrationEntry };
       });
     }


### PR DESCRIPTION
I think it would be a lot cleaner to have separate components for the registrations list and the psych sheet, now that they're significantly different (originally, it was just contracting a bunch of columns in the middle into one column, basically). I'll do that in a follow-up PR, unless anybody raises a concern.

Edit: to reproduce crash, go to worlds competitor list and click an event in the event selector before the initial data finishes loading.