### PR TITLE
Psych sheet: Move wide info out of footer

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -379,7 +379,7 @@ function FooterContent({
           } ${
             I18n.t('registrations.registration_info_people.person', { count: registrationCount })
           }`
-          }
+        }
       </Table.Cell>
       <Table.Cell>{`${I18n.t('registrations.list.country_plural', { count: countryCount })}`}</Table.Cell>
       {isAllCompetitors ? (

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -142,8 +142,8 @@ export default function RegistrationList({ competitionInfo, userId }) {
         eventList={competitionInfo.event_ids}
         selectedEvents={[psychSheetEvent].filter(Boolean)}
       />
-      {userIsInTable && (
-        <Message>
+      <Message>
+        {userIsInTable && (
           <Button
             size="mini"
             onClick={
@@ -152,32 +152,32 @@ export default function RegistrationList({ competitionInfo, userId }) {
           >
             {I18n.t('competitions.registration_v2.list.psychsheets.show_me')}
           </Button>
-          {' '}
-          {(userPosition || isPsychSheet) && (
-            `${
-              I18n.t(
-                'competitions.registration_v2.list.psychsheets.rank',
-                { userPosition: userPosition ?? '-' },
-              )
-            }; `
-          )}
-          {
-            `${
-              newcomerCount
-            } ${
-              I18n.t('registrations.registration_info_people.newcomer', { count: newcomerCount })
-            } + ${
-              returnerCount
-            } ${
-              I18n.t('registrations.registration_info_people.returner', { count: returnerCount })
-            } = ${
-              registrationCount
-            } ${
-              I18n.t('registrations.registration_info_people.person', { count: registrationCount })
-            }`
-          }
-        </Message>
-      )}
+        )}
+        {' '}
+        {userIsInTable && (userPosition || isPsychSheet) && (
+          `${
+            I18n.t(
+              'competitions.registration_v2.list.psychsheets.rank',
+              { userPosition: userPosition ?? '-' },
+            )
+          }; `
+        )}
+        {
+          `${
+            newcomerCount
+          } ${
+            I18n.t('registrations.registration_info_people.newcomer', { count: newcomerCount })
+          } + ${
+            returnerCount
+          } ${
+            I18n.t('registrations.registration_info_people.returner', { count: returnerCount })
+          } = ${
+            registrationCount
+          } ${
+            I18n.t('registrations.registration_info_people.person', { count: registrationCount })
+          }`
+        }
+      </Message>
       <Table striped sortable unstackable compact singleLine textAlign="left">
         <Table.Header>
           <Table.Row>

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -129,8 +129,8 @@ export default function RegistrationList({ competitionInfo, userId }) {
     );
   }
 
-  const registrationCount = registrations.length;
-  const newcomerCount = registrations?.filter(
+  const registrationCount = registrationsWithPsychSheet.length;
+  const newcomerCount = registrationsWithPsychSheet.filter(
     (reg) => !reg.user.wca_id,
   ).length;
   const returnerCount = registrationCount - newcomerCount;

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -129,6 +129,12 @@ export default function RegistrationList({ competitionInfo, userId }) {
     );
   }
 
+  const registrationCount = registrations.length;
+  const newcomerCount = registrations?.filter(
+    (reg) => !reg.user.wca_id,
+  ).length;
+  const returnerCount = registrationCount - newcomerCount;
+
   return (
     <Segment style={{ overflowX: 'scroll' }}>
       <PsychSheetEventSelector
@@ -148,11 +154,28 @@ export default function RegistrationList({ competitionInfo, userId }) {
           </Button>
           {' '}
           {(userPosition || isPsychSheet) && (
-            I18n.t(
-              'competitions.registration_v2.list.psychsheets.rank',
-              { userPosition: userPosition ?? '-' },
-            )
+            `${
+              I18n.t(
+                'competitions.registration_v2.list.psychsheets.rank',
+                { userPosition: userPosition ?? '-' },
+              )
+            }; `
           )}
+          {
+            `${
+              newcomerCount
+            } ${
+              I18n.t('registrations.registration_info_people.newcomer', { count: newcomerCount })
+            } + ${
+              returnerCount
+            } ${
+              I18n.t('registrations.registration_info_people.returner', { count: returnerCount })
+            } = ${
+              registrationCount
+            } ${
+              I18n.t('registrations.registration_info_people.person', { count: registrationCount })
+            }`
+          }
         </Message>
       )}
       <Table striped sortable unstackable compact singleLine textAlign="left">

--- a/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/RegistrationList.jsx
@@ -348,9 +348,7 @@ function FooterContent({
 
   const isPsychSheet = !isAllCompetitors;
 
-  const newcomerCount = registrations.filter(
-    (reg) => !reg.user.wca_id,
-  ).length;
+  const registrationCount = registrations.length;
 
   const countryCount = new Set(
     registrations.map((reg) => reg.user.country.iso2),
@@ -375,10 +373,13 @@ function FooterContent({
         <Table.Cell />
       )}
       <Table.Cell>
-        {`${newcomerCount} ${I18n.t('registrations.registration_info_people.newcomer', { count: newcomerCount })} + ${
-          registrations.length - newcomerCount
-        } ${I18n.t('registrations.registration_info_people.returner', { count: registrations.length - newcomerCount })} =
-         ${registrations.length} ${I18n.t('registrations.registration_info_people.person', { count: registrations.length })}`}
+        {
+          `${
+            registrationCount
+          } ${
+            I18n.t('registrations.registration_info_people.person', { count: registrationCount })
+          }`
+          }
       </Table.Cell>
       <Table.Cell>{`${I18n.t('registrations.list.country_plural', { count: countryCount })}`}</Table.Cell>
       {isAllCompetitors ? (


### PR DESCRIPTION
This addresses two problems: stop making the name column unnecessarily wide, and allow users to see the information without scrolling down to the bottom.

I didn't modify the string at all. I don't really like how it looks. Something like "Rank: 5, People: 8 (2 first-timers + 6 returners)" would be better, but that requires adding a new "People" string to capitalize it (the existing string is also used in the footer and is consistent with the uncapitalized "regions" in the adjacent column, so changing it would not work (unless we also change regions to be capitalized)). Thoughts? Other suggestions? Design is not my strong point.

A related issue is to somehow show the per-event competitor totals at the top of the page to avoid scrolling, but I don't know where to nicely display that information, and it's less of a problem now that clicking on an event shows the total competitors at the top.

![image](https://github.com/user-attachments/assets/4ae3143f-7aad-4226-9054-b01ba8ac68b6)
![image](https://github.com/user-attachments/assets/8a55a69a-7949-4799-b86a-84609db4e97b)
![image](https://github.com/user-attachments/assets/c7c3d9fe-06b9-4439-854e-587c535f922b)

![image](https://github.com/user-attachments/assets/150c5da7-5fbd-4cc8-bbac-ac8f7f8672ab)
![image](https://github.com/user-attachments/assets/11fce750-096e-4417-80be-c7f4aa00128e)
![image](https://github.com/user-attachments/assets/13ee6f99-8808-4f31-91de-91c31c5f6885)


Wasting horizontal space before vs after:
![image](https://github.com/user-attachments/assets/47b56f04-acca-4297-90d2-81bc5adc01f6) ![image](https://github.com/user-attachments/assets/f2046250-256b-4b17-b8b4-e38bdb877b45)

(Side note: why are the header icons orange on the site, but black locally?)