### PR TITLE
Remove 2 unused routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -291,8 +291,6 @@ Rails.application.routes.draw do
   get '/admin/do_generate_public_export' => 'admin#do_generate_public_export'
   get '/admin/override_regional_records' => 'admin#override_regional_records'
   post '/admin/override_regional_records' => 'admin#do_override_regional_records'
-  get '/admin/finish_persons' => 'admin#finish_persons'
-  post '/admin/finish_persons' => 'admin#do_finish_persons'
   get '/admin/complete_persons' => 'admin#complete_persons'
   post '/admin/complete_persons' => 'admin#do_complete_persons'
   get '/admin/peek_unfinished_results' => 'admin#peek_unfinished_results'


### PR DESCRIPTION
These two routes were introduced in https://github.com/thewca/worldcubeassociation.org/pull/7726, but looks like they are not used anywhere (99%, leaving the remaining 1% to the reviewer 😬), so removing it.