### PR TITLE
Fixed grammatically incorrect message while accessing pages without permission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,7 +96,7 @@ class ApplicationController < ActionController::Base
       if redirecting
         flash[:danger] = case action
                          when :has_permission?
-                           t("errors.messages.no_permission.no_permission")
+                           t("errors.messages.no_permission")
                          else
                            "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"
                          end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,7 +96,7 @@ class ApplicationController < ActionController::Base
       if redirecting
         flash[:danger] = case action
                          when :has_permission?
-                           t("application.no_permission")
+                           t("errors.messages.no_permission.no_permission")
                          else
                            "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"
                          end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,7 +94,12 @@ class ApplicationController < ActionController::Base
     def redirect_to_root_unless_user(action, *)
       redirecting = !current_user&.send(action, *)
       if redirecting
-        flash[:danger] = "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"
+        flash[:danger] = case action
+                         when :has_permission?
+                           t("application.no_permission")
+                         else
+                           "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"
+                         end
         redirect_to root_url
       end
       redirecting

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,8 +94,7 @@ class ApplicationController < ActionController::Base
     def redirect_to_root_unless_user(action, *)
       redirecting = !current_user&.send(action, *)
       if redirecting
-        flash[:danger] = case action
-                         when :has_permission?
+        flash[:danger] = if action == :has_permission?
                            t("errors.messages.no_permission")
                          else
                            "You are not allowed to #{action.to_s.sub(/^can_/, '').chomp('?').humanize.downcase}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,6 +586,7 @@ en:
       wrong_size: "is the wrong size (should be %{file_size})"
       size_too_small: "is too small (should be at least %{file_size})"
       size_too_big: "is too big (should be at most %{file_size})"
+      no_permission: "You do not have the required permissions to access this page."
   devise:
     #context: Overridden key for sign in
     passwords:
@@ -2879,5 +2880,3 @@ en:
       missing_scrambles_for_multi_error: "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
       multiple_fmc_groups_warning: "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
       wrong_number_of_scramble_sets_error: "[%{round_id}] This round has a different number of scramble sets than specified on the Manage Events tab. Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
-  application:
-    no_permission: "You do not have the required permissions to access this page."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2879,3 +2879,5 @@ en:
       missing_scrambles_for_multi_error: "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
       multiple_fmc_groups_warning: "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
       wrong_number_of_scramble_sets_error: "[%{round_id}] This round has a different number of scramble sets than specified on the Manage Events tab. Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
+  application:
+    no_permission: "You do not have the required permissions to access this page."


### PR DESCRIPTION
Fixes: https://github.com/thewca/worldcubeassociation.org/issues/10409

![image](https://github.com/user-attachments/assets/af078256-12ae-42e8-9f7b-f8cf254a7186)
