### PR TITLE
Attempt to fix test choke with Delegate selector

### DIFF
--- a/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
+++ b/app/webpacker/components/CompetitionsOverview/CompetitionsFilters.js
@@ -126,7 +126,7 @@ function DelegateSelector({ delegateId, dispatchFilter }) {
     <>
       <label htmlFor="delegate" style={{ display: 'inline-block' }}>
         {I18n.t('layouts.navigation.delegate')}
-        {delegatesLoading && <PulseLoader size="6px" cssOverride={{ marginLeft: '5px' }} />}
+        {delegatesLoading && <PulseLoader id="delegate-pulse" size="6px" cssOverride={{ marginLeft: '5px' }} />}
       </label>
       <Dropdown
         name="delegate"

--- a/spec/features/competitions_list_spec.rb
+++ b/spec/features/competitions_list_spec.rb
@@ -14,12 +14,12 @@ RSpec.feature "Competitions list", js: true do
 
       before do
         visit "/competitions?show_admin_details=yes"
+        # Wait until the Delegate index finished loading
+        expect(page).not_to have_selector("#delegate-pulse")
         within(:css, "#delegate") do
           find(".search").set(delegate.name)
           find(".search").send_keys(:enter)
         end
-        # Wait until the Delegate index finished loading
-        expect(page).not_to have_selector("#delegate-pulse")
       end
 
       it "the delegate is selected within the form" do

--- a/spec/features/competitions_list_spec.rb
+++ b/spec/features/competitions_list_spec.rb
@@ -18,6 +18,8 @@ RSpec.feature "Competitions list", js: true do
           find(".search").set(delegate.name)
           find(".search").send_keys(:enter)
         end
+        # Wait until the Delegate index finished loading
+        expect(page).not_to have_selector("#delegate-pulse")
       end
 
       it "the delegate is selected within the form" do


### PR DESCRIPTION
We got this occasional choke ever since merging the new Comp Overview page. It's not a real fail, it just means the browser engine hasn't finished fetching the Delegate information when the test already tries to check whether the Delegate is indeed correctly listed.