### PR TITLE
Email delegates when a formerly-banned competitor registers

### DIFF
--- a/app/mailers/registrations_mailer.rb
+++ b/app/mailers/registrations_mailer.rb
@@ -84,10 +84,12 @@ class RegistrationsMailer < ApplicationMailer
   def notify_delegates_of_formerly_banned_user_registration(registration)
     @registration = registration
     to = registration.competition.competition_delegates.map(&:user).map(&:email)
-    mail(
-      to: to,
-      reply_to: UserGroup.teams_committees_group_wic.metadata.email,
-      subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
-      ) unless to.empty?
+    unless to.empty?
+      mail(
+        to: to,
+        reply_to: UserGroup.teams_committees_group_wic.metadata.email,
+        subject: "A formerly-banned competitor just registered for #{registration.competition.name}"
+      )
+    end
   end
 end

--- a/app/mailers/registrations_mailer.rb
+++ b/app/mailers/registrations_mailer.rb
@@ -88,7 +88,7 @@ class RegistrationsMailer < ApplicationMailer
       mail(
         to: to,
         reply_to: UserGroup.teams_committees_group_wic.metadata.email,
-        subject: "A formerly-banned competitor just registered for #{registration.competition.name}"
+        subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
       )
     end
   end

--- a/app/mailers/registrations_mailer.rb
+++ b/app/mailers/registrations_mailer.rb
@@ -88,12 +88,11 @@ class RegistrationsMailer < ApplicationMailer
     if to.empty?
       nil
     else
-    mail(
-      to: to,
-      reply_to: "integrity@worldcubeassociation.org",
-      subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
-    )
+      mail(
+        to: to,
+        reply_to: "integrity@worldcubeassociation.org",
+        subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
+      )
     end
   end
-
 end

--- a/app/mailers/registrations_mailer.rb
+++ b/app/mailers/registrations_mailer.rb
@@ -80,4 +80,20 @@ class RegistrationsMailer < ApplicationMailer
       subject: "Unlock your new account on the WCA website",
     )
   end
+
+  def notify_delegates_of_formerly_banned_user_registration(registration)
+    @registration = registration
+    delegate_ids = registration.competition.competition_delegates.map(&:delegate_id)
+    to = User.where(id: delegate_ids).map(&:email)
+    if to.empty?
+      nil
+    else
+    mail(
+      to: to,
+      reply_to: "integrity@worldcubeassociation.org",
+      subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
+    )
+    end
+  end
+
 end

--- a/app/mailers/registrations_mailer.rb
+++ b/app/mailers/registrations_mailer.rb
@@ -83,16 +83,11 @@ class RegistrationsMailer < ApplicationMailer
 
   def notify_delegates_of_formerly_banned_user_registration(registration)
     @registration = registration
-    delegate_ids = registration.competition.competition_delegates.map(&:delegate_id)
-    to = User.where(id: delegate_ids).map(&:email)
-    if to.empty?
-      nil
-    else
-      mail(
-        to: to,
-        reply_to: "integrity@worldcubeassociation.org",
-        subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
-      )
-    end
+    to = registration.competition.competition_delegates.map(&:user).map(&:email)
+    mail(
+      to: to,
+      reply_to: UserGroup.teams_committees_group_wic.metadata.email,
+      subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
+      ) unless to.empty?
   end
 end

--- a/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
+++ b/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
@@ -8,5 +8,5 @@
 
 <p>
 You can check the ban scope and reason
-  <%= link_to "here", panel_index_url(panel_id: :delegate, anchor: User.panel_pages[:bannedCompetitors]) %>
+  <%= link_to "here", panel_page_url(id: User.panel_pages[:bannedCompetitors]) %>
 </p>

--- a/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
+++ b/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
@@ -1,0 +1,12 @@
+<p>
+  <%= @registration.name %>
+  <% if @registration.user.wca_id %>
+    (<%= wca_id_link @registration.user.wca_id -%>)
+  <% end %>
+  just registered for <%= @registration.competition.name %>.
+</p>
+
+<p>
+You can check the ban scope and reason
+  <%= link_to "here", panel_index_url(panel_id: :delegate, anchor: User.panel_pages[:bannedCompetitors]) %>
+</p>

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -19,8 +19,7 @@ module Registrations
         registration.save!
         RegistrationsMailer.notify_organizers_of_new_registration(registration).deliver_later
         RegistrationsMailer.notify_registrant_of_new_registration(registration).deliver_later
-        user = User.find_by_id(user_id)
-        if user&.banned_in_past?
+        if registration.user.banned_in_past?
           RegistrationsMailer.notify_delegates_of_formerly_banned_user_registration(registration).deliver_later
         end
         registration.add_history_entry(changes, "worker", user_id, "Worker processed")

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -19,6 +19,10 @@ module Registrations
         registration.save!
         RegistrationsMailer.notify_organizers_of_new_registration(registration).deliver_later
         RegistrationsMailer.notify_registrant_of_new_registration(registration).deliver_later
+        user = User.find_by_id(user_id)
+        if user&.banned_in_past?
+          RegistrationsMailer.notify_delegates_of_formerly_banned_user_registration(registration).deliver_later
+        end
         registration.add_history_entry(changes, "worker", user_id, "Worker processed")
       end
 


### PR DESCRIPTION
Fixes: https://github.com/thewca/worldcubeassociation.org/issues/10562

Email look like this:
![image](https://github.com/user-attachments/assets/01e36969-6f15-42aa-bb47-0242cf48af20)

The red area is competitor name and WCA ID
