### PR TITLE
Psych sheet/competitor list columns

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
@@ -155,6 +155,7 @@ function CompetitorsHeader({
           </Table.HeaderCell>
         ))}
         <Table.HeaderCell
+          textAlign="center"
           sorted={sortedColumn === 'total' ? sortedDirection : undefined}
           onClick={() => onSortableColumnClick('total')}
         >
@@ -210,7 +211,7 @@ function CompetitorsBody({
                   )}
                 </Table.Cell>
               ))}
-              <Table.Cell>
+              <Table.Cell textAlign="center">
                 {registration.competing.event_ids.length}
               </Table.Cell>
             </Table.Row>
@@ -256,7 +257,7 @@ function CompetitorsFooter({
             {eventCounts[evt]}
           </Table.Cell>
         ))}
-        <Table.Cell>{eventCountsSum}</Table.Cell>
+        <Table.Cell textAlign="center">{eventCountsSum}</Table.Cell>
       </Table.Row>
     </Table.Footer>
   );

--- a/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
@@ -147,6 +147,7 @@ function CompetitorsHeader({
         </Table.HeaderCell>
         {eventIds.map((id) => (
           <Table.HeaderCell
+            textAlign="center"
             key={`registration-table-header-${id}`}
             onClick={() => onEventColumnClick(id)}
           >
@@ -201,6 +202,7 @@ function CompetitorsBody({
               </Table.Cell>
               {eventIds.map((id) => (
                 <Table.Cell
+                  textAlign="center"
                   key={`registration-table-row-${registration.user.id}-${id}`}
                 >
                   {registration.competing.event_ids.includes(id) && (
@@ -250,7 +252,7 @@ function CompetitorsFooter({
           {`${I18n.t('registrations.list.country_plural', { count: countryCount })}`}
         </Table.Cell>
         {eventIds.map((evt) => (
-          <Table.Cell key={`footer-count-${evt}`}>
+          <Table.Cell textAlign="center" key={`footer-count-${evt}`}>
             {eventCounts[evt]}
           </Table.Cell>
         ))}

--- a/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
@@ -114,7 +114,6 @@ export default function PsychSheet({
         <PsychSheetBody
           registrations={rankings}
           selectedEvent={selectedEvent}
-          sortedColumn={sortedBy}
           userId={userId}
           userRowRef={userRowRef}
           hideAverage={eventIsMbf}
@@ -183,7 +182,6 @@ function PsychSheetHeader({
 function PsychSheetBody({
   registrations,
   selectedEvent,
-  sortedColumn,
   userId,
   userRowRef,
   hideAverage = false,

--- a/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
@@ -52,6 +52,8 @@ export default function PsychSheet({
   userRowRef,
   onScrollToMeClick,
 }) {
+  const eventIsMbf = selectedEvent === '333mbf';
+
   const { isLoading, data: rankings, isError } = useQuery({
     queryKey: [
       'psychSheet',
@@ -107,6 +109,7 @@ export default function PsychSheet({
           selectedEvent={selectedEvent}
           sortedColumn={sortedBy}
           onColumnClick={setSortedBy}
+          hideAverage={eventIsMbf}
         />
         <PsychSheetBody
           registrations={rankings}
@@ -114,9 +117,11 @@ export default function PsychSheet({
           sortedColumn={sortedBy}
           userId={userId}
           userRowRef={userRowRef}
+          hideAverage={eventIsMbf}
         />
         <PsychSheetFooter
           registrations={rankings}
+          hideAverage={eventIsMbf}
         />
       </Table>
     </>
@@ -127,6 +132,7 @@ function PsychSheetHeader({
   selectedEvent,
   sortedColumn,
   onColumnClick,
+  hideAverage = false,
 }) {
   return (
     <Table.Header>
@@ -149,21 +155,26 @@ function PsychSheetHeader({
           textAlign="right"
           sorted={sortedColumn === 'single' ? 'ascending' : undefined}
           onClick={() => onColumnClick('single')}
+          disabled={hideAverage}
         >
           {I18n.t('common.single')}
         </Table.HeaderCell>
-        <Table.HeaderCell
-          textAlign="right"
-          sorted={sortedColumn === 'average' ? 'ascending' : undefined}
-          onClick={() => onColumnClick('average')}
-        >
-          {I18n.t('common.average')}
-        </Table.HeaderCell>
-        <Table.HeaderCell textAlign="right" disabled>
-          <Icon name="trophy" />
-          {' '}
-          WR
-        </Table.HeaderCell>
+        {hideAverage || (
+          <>
+            <Table.HeaderCell
+              textAlign="right"
+              sorted={sortedColumn === 'average' ? 'ascending' : undefined}
+              onClick={() => onColumnClick('average')}
+            >
+              {I18n.t('common.average')}
+            </Table.HeaderCell>
+            <Table.HeaderCell textAlign="right" disabled>
+              <Icon name="trophy" />
+              {' '}
+              WR
+            </Table.HeaderCell>
+          </>
+        )}
       </Table.Row>
     </Table.Header>
   );
@@ -175,6 +186,7 @@ function PsychSheetBody({
   sortedColumn,
   userId,
   userRowRef,
+  hideAverage = false,
 }) {
   return (
     <Table.Body>
@@ -218,12 +230,16 @@ function PsychSheetBody({
               <Table.Cell textAlign="right">
                 {formatAttemptResult(registration.single_best, selectedEvent)}
               </Table.Cell>
-              <Table.Cell textAlign="right">
-                {formatAttemptResult(registration.average_best, selectedEvent)}
-              </Table.Cell>
-              <Table.Cell textAlign="right">
-                {registration.average_rank}
-              </Table.Cell>
+              {hideAverage || (
+                <>
+                  <Table.Cell textAlign="right">
+                    {formatAttemptResult(registration.average_best, selectedEvent)}
+                  </Table.Cell>
+                  <Table.Cell textAlign="right">
+                    {registration.average_rank}
+                  </Table.Cell>
+                </>
+              )}
             </Table.Row>
           );
         })
@@ -243,6 +259,7 @@ function PsychSheetBody({
 
 function PsychSheetFooter({
   registrations,
+  hideAverage = false,
 }) {
   const { registrationCount, countryCount } = getTotals(registrations);
 
@@ -264,8 +281,12 @@ function PsychSheetFooter({
         </Table.Cell>
         <Table.Cell key="single-world-rank" />
         <Table.Cell key="single" />
-        <Table.Cell key="average" />
-        <Table.Cell key="average-world-rank" />
+        {hideAverage || (
+          <>
+            <Table.Cell key="average" />
+            <Table.Cell key="average-world-rank" />
+          </>
+        )}
       </Table.Row>
     </Table.Footer>
   );

--- a/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
@@ -159,6 +159,11 @@ function PsychSheetHeader({
         >
           {I18n.t('common.average')}
         </Table.HeaderCell>
+        <Table.HeaderCell textAlign="right" disabled>
+          <Icon name="trophy" />
+          {' '}
+          WR
+        </Table.HeaderCell>
       </Table.Row>
     </Table.Header>
   );
@@ -208,15 +213,16 @@ function PsychSheetBody({
                 {countries.byIso2[registration.user.country.iso2].name}
               </Table.Cell>
               <Table.Cell textAlign="right">
-                {sortedColumn === 'single'
-                  ? registration.single_rank
-                  : registration.average_rank}
+                {registration.single_rank}
               </Table.Cell>
               <Table.Cell textAlign="right">
                 {formatAttemptResult(registration.single_best, selectedEvent)}
               </Table.Cell>
               <Table.Cell textAlign="right">
                 {formatAttemptResult(registration.average_best, selectedEvent)}
+              </Table.Cell>
+              <Table.Cell textAlign="right">
+                {registration.average_rank}
               </Table.Cell>
             </Table.Row>
           );
@@ -256,9 +262,10 @@ function PsychSheetFooter({
         <Table.Cell>
           {`${I18n.t('registrations.list.country_plural', { count: countryCount })}`}
         </Table.Cell>
-        <Table.Cell key="WR" />
+        <Table.Cell key="single-world-rank" />
         <Table.Cell key="single" />
         <Table.Cell key="average" />
+        <Table.Cell key="average-world-rank" />
       </Table.Row>
     </Table.Footer>
   );

--- a/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
@@ -140,18 +140,20 @@ function PsychSheetHeader({
         <Table.HeaderCell disabled>
           {I18n.t('activerecord.attributes.user.country_iso2')}
         </Table.HeaderCell>
-        <Table.HeaderCell disabled>
+        <Table.HeaderCell textAlign="right" disabled>
           <Icon name="trophy" />
           {' '}
           WR
         </Table.HeaderCell>
         <Table.HeaderCell
+          textAlign="right"
           sorted={sortedColumn === 'single' ? 'ascending' : undefined}
           onClick={() => onColumnClick('single')}
         >
           {I18n.t('common.single')}
         </Table.HeaderCell>
         <Table.HeaderCell
+          textAlign="right"
           sorted={sortedColumn === 'average' ? 'ascending' : undefined}
           onClick={() => onColumnClick('average')}
         >
@@ -205,15 +207,15 @@ function PsychSheetBody({
                 />
                 {countries.byIso2[registration.user.country.iso2].name}
               </Table.Cell>
-              <Table.Cell>
+              <Table.Cell textAlign="right">
                 {sortedColumn === 'single'
                   ? registration.single_rank
                   : registration.average_rank}
               </Table.Cell>
-              <Table.Cell>
+              <Table.Cell textAlign="right">
                 {formatAttemptResult(registration.single_best, selectedEvent)}
               </Table.Cell>
-              <Table.Cell>
+              <Table.Cell textAlign="right">
                 {formatAttemptResult(registration.average_best, selectedEvent)}
               </Table.Cell>
             </Table.Row>


### PR DESCRIPTION
It might have been more efficient to switch to using react table first, but oh well. I'll do that next.

1. Always* show world rank for both single and average, regardless of which sort is applied.
2. *Except: Don't show (empty) average value or world rank for mbf.
3. Right/center align various columns/cells.

Might also be worth moving the country to the end of the table in the psych sheet? Then people can see names and ranks together more easily.

[Screencast from 2025-01-29 10:36:34 PM.webm](https://github.com/user-attachments/assets/cabe2712-5492-40df-b33d-77b11f13de8a)

[Screencast from 2025-01-29 10:38:55 PM.webm](https://github.com/user-attachments/assets/5794b2a5-eff3-4a48-a153-c5f82c7e0fcc)
