### PR TITLE
Fix link in Results/Reports nag email

### DIFF
--- a/app/views/competitions_mailer/submit_report_nag.html.erb
+++ b/app/views/competitions_mailer/submit_report_nag.html.erb
@@ -16,7 +16,7 @@
   @Senior Delegate: You can view the <%= "history".pluralize(@competition.delegates.count) %> of the <%= "Delegate".pluralize(@competition.delegates.count) %> here:
   <ul>
     <% @competition.delegates.each do |delegate| %>
-      <li><%= link_to "#{delegate.name}", competitions_url(display: "admin", years: "all", delegate: delegate.id), target: "_blank" %></li>
+      <li><%= link_to "#{delegate.name}", competitions_url(display: "admin", years: "all", state: "past", delegate: delegate.id), target: "_blank" %></li>
     <% end %>
   </ul>
 </p>

--- a/app/views/competitions_mailer/submit_results_nag.html.erb
+++ b/app/views/competitions_mailer/submit_results_nag.html.erb
@@ -18,7 +18,7 @@
   @Senior Delegate: You can view the <%= "history".pluralize(@competition.delegates.count) %> of the <%= "Delegate".pluralize(@competition.delegates.count) %> here:
   <ul>
     <% @competition.delegates.each do |delegate| %>
-      <li><%= link_to "#{delegate.name}", competitions_url(display: "admin", years: "all", delegate: delegate.id), target: "_blank" %></li>
+      <li><%= link_to "#{delegate.name}", competitions_url(display: "admin", years: "all", state: "past", delegate: delegate.id), target: "_blank" %></li>
     <% end %>
   </ul>
 </p>


### PR DESCRIPTION
Clicking the link set the `years` parameter to `all`, but didn't set the view to "Past".
This PR intends to fix that oversight.