### PR TITLE
Default datepicker to iso-8601 date format

### DIFF
--- a/app/webpacker/components/wca/UtcDatePicker.js
+++ b/app/webpacker/components/wca/UtcDatePicker.js
@@ -65,7 +65,7 @@ function UtcDatePicker({
   // weird quirk in the 3rd party datepicker implementation: The "dateFormat" field actually means
   //  "format for the whole input row, which may or may not include time". The field "timeFormat"
   //  is only considered for time-specific inputs *within* the dropdown parts of the picker.
-  const dateOnlyFormat = dateFormatOverride || 'P';
+  const dateOnlyFormat = dateFormatOverride || "yyyy-MM-dd";
   const dateFormat = showTimeInput ? (dateOnlyFormat + timeFormat) : dateOnlyFormat;
 
   return (


### PR DESCRIPTION
It seems that react-datepicker internally defaults to en-US locale if no dateFormatOverride is given. Given that we have an international userbase and date formats can be ambiguous, I believe iso8601 is a more appropriate default.

I've taken the simplest approach - manually replacing the fallback to datepicker's default with a fallback to "yyyy-MM-dd". There are other options: 
- always pass the user's locale to datepicker
- change datepicker's internal default 