### PR TITLE
Prevent user from registering if registration has passed

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   def validate_show_registration
     @user_id, @competition_id = show_params
     @competition = Competition.find(@competition_id)
-    render_error(:unauthorized, ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @current_user.id == @user_id.to_i || @current_user.can_manage_competition?(@competition)
+    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @current_user.id == @user_id.to_i || @current_user.can_manage_competition?(@competition)
   end
 
   def show
@@ -108,7 +108,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     # TODO: Do we set this as an instance variable here so we can use it below?
     @competition = Competition.find(competition_id)
     unless @current_user.can_manage_competition?(@competition)
-      render_error(:unauthorized, ErrorCodes::USER_INSUFFICIENT_PERMISSIONS)
+      render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS)
     end
   end
 
@@ -128,10 +128,12 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   def validate_payment_ticket_request
     competition_id = params[:competition_id]
     @competition = Competition.find(competition_id)
-    render_error(:forbidden, ErrorCodes::PAYMENT_NOT_ENABLED) unless @competition.using_payment_integrations?
+    return render_error(:forbidden, Registrations::ErrorCodes::PAYMENT_NOT_ENABLED) unless @competition.using_payment_integrations?
+
+    return render_error(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) if @competition.registration_past?
 
     @registration = Registration.find_by(user: @current_user, competition: @competition)
-    render_error(:forbidden, ErrorCodes::PAYMENT_NOT_READY) if @registration.nil?
+    return render_error(:forbidden, Registrations::ErrorCodes::PAYMENT_NOT_READY) if @registration.nil?
   end
 
   def payment_ticket

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -133,7 +133,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     return render_error(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) if @competition.registration_past?
 
     @registration = Registration.find_by(user: @current_user, competition: @competition)
-    return render_error(:forbidden, Registrations::ErrorCodes::PAYMENT_NOT_READY) if @registration.nil?
+    render_error(:forbidden, Registrations::ErrorCodes::PAYMENT_NOT_READY) if @registration.nil?
   end
 
   def payment_ticket

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1831,10 +1831,12 @@ class Competition < ApplicationRecord
                              reverse, field = part.match(/^(-)?(\w+)$/).captures
                              [field.to_sym, reverse ? :desc : :asc]
                            end
+                           # rubocop:disable Style/HashSlice
                            #   RuboCop suggests using `slice` here, which is a noble intention but breaks the order
                            #   of sort arguments. However, this order is crucial (sorting by "name then start_date"
                            #   is different from sorting by "start_date then name") so we insist on doing it our way.
                            .select { |field, _| orderable_fields.include?(field) }
+                           # rubocop:enable Style/HashSlice
                            .to_h
     else
       order = { start_date: :desc }

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1831,12 +1831,10 @@ class Competition < ApplicationRecord
                              reverse, field = part.match(/^(-)?(\w+)$/).captures
                              [field.to_sym, reverse ? :desc : :asc]
                            end
-                           # rubocop:disable Style/HashSlice
                            #   RuboCop suggests using `slice` here, which is a noble intention but breaks the order
                            #   of sort arguments. However, this order is crucial (sorting by "name then start_date"
                            #   is different from sorting by "start_date then name") so we insist on doing it our way.
                            .select { |field, _| orderable_fields.include?(field) }
-                           # rubocop:enable Style/HashSlice
                            .to_h
     else
       order = { start_date: :desc }

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -1,5 +1,4 @@
 import { PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
-import I18nHTMLTranslate from '../../I18nHTMLTranslate';
 import React, { useEffect, useState } from 'react';
 import {
   Button,
@@ -12,6 +11,7 @@ import {
   Message,
   Segment,
 } from 'semantic-ui-react';
+import I18nHTMLTranslate from '../../I18nHTMLTranslate';
 import { paymentFinishUrl } from '../../../lib/requests/routes.js.erb';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { setMessage } from './RegistrationMessage';
@@ -61,8 +61,6 @@ export default function PaymentStep({
     // Create the PaymentIntent and obtain clientSecret
     const data = await getPaymentTicket(competitionInfo, donationAmount);
 
-
-
     const { client_secret: clientSecret } = data;
 
     const { error } = await stripe.confirmPayment({
@@ -93,7 +91,7 @@ export default function PaymentStep({
   if (!competitionInfo['registration_currently_open?']) {
     return (
       <Message color="red">
-        <I18nHTMLTranslate i18nKey="registrations.payment_form.errors.registration_closed" options={{ days: 3, time: 4 }} />
+        <I18nHTMLTranslate i18nKey="registrations.payment_form.errors.registration_closed"/>
       </Message>
     );
   }

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -11,7 +11,6 @@ import {
   Message,
   Segment,
 } from 'semantic-ui-react';
-import I18nHTMLTranslate from '../../I18nHTMLTranslate';
 import { paymentFinishUrl } from '../../../lib/requests/routes.js.erb';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { setMessage } from './RegistrationMessage';

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -1,4 +1,5 @@
 import { PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
+import I18nHTMLTranslate from '../../I18nHTMLTranslate';
 import React, { useEffect, useState } from 'react';
 import {
   Button,
@@ -8,6 +9,7 @@ import {
   FormField,
   Header,
   Label,
+  Message,
   Segment,
 } from 'semantic-ui-react';
 import { paymentFinishUrl } from '../../../lib/requests/routes.js.erb';
@@ -59,6 +61,8 @@ export default function PaymentStep({
     // Create the PaymentIntent and obtain clientSecret
     const data = await getPaymentTicket(competitionInfo, donationAmount);
 
+
+
     const { client_secret: clientSecret } = data;
 
     const { error } = await stripe.confirmPayment({
@@ -85,6 +89,14 @@ export default function PaymentStep({
 
     setIsLoading(false);
   };
+
+  if (!competitionInfo['registration_currently_open?']) {
+    return (
+      <Message color="red">
+        <I18nHTMLTranslate i18nKey="registrations.payment_form.errors.registration_closed" options={{ days: 3, time: 4 }} />
+      </Message>
+    );
+  }
 
   return (
     <Segment>

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -90,9 +90,7 @@ export default function PaymentStep({
 
   if (!competitionInfo['registration_currently_open?']) {
     return (
-      <Message color="red">
-        <I18nHTMLTranslate i18nKey="registrations.payment_form.errors.registration_closed" />
-      </Message>
+      <Message color="red">{I18n.t('registrations.payment_form.errors.registration_closed')}</Message>
     );
   }
 

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -91,7 +91,7 @@ export default function PaymentStep({
   if (!competitionInfo['registration_currently_open?']) {
     return (
       <Message color="red">
-        <I18nHTMLTranslate i18nKey="registrations.payment_form.errors.registration_closed"/>
+        <I18nHTMLTranslate i18nKey="registrations.payment_form.errors.registration_closed" />
       </Message>
     );
   }

--- a/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
@@ -52,7 +52,7 @@ const shouldBeDisabled = (hasPaid, key, activeIndex, index, competitionInfo, isR
   }
 
   if (key === paymentStepConfig.key) {
-    return !hasPaid && index > activeIndex;
+    return (!hasPaid && index > activeIndex) || !competitionInfo['registration_currently_open?'];
   }
   if (key === competingStepConfig.key) {
     return index > activeIndex;
@@ -77,7 +77,7 @@ export default function StepPanel({
   const isAccepted = isRegistered && registration.competing.registration_status === 'accepted';
   const isRejected = isRegistered && registration.competing.registration_status === 'rejected';
   const hasPaid = registration?.payment?.has_paid;
-  const registrationFinished = (isRegistered && hasPaid) || (isRegistered && !competitionInfo['using_payment_integrations?']);
+  const registrationFinished = (isRegistered && hasPaid) || (isRegistered && !competitionInfo['using_payment_integrations?']) || !competitionInfo['registration_currently_open?'];
 
   const steps = useMemo(() => {
     const stepList = [requirementsStepConfig, competingStepConfig];

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1291,6 +1291,7 @@ en:
         amount_too_low: "The total amount must be at least the registration fees to be paid."
         amount_rather_high: "You are about to pay at least double the required amount for your registration to proceed."
       errors:
+        registration_closed: "Registration has closed - no further payments are allowed."
         already_paid: "The charge was not placed because the registration fees are already paid."
         not_allowed: "You can't pay for that registration."
         cpi_disconnected: "Tried to confirm a payment but the payment integration was disabled. Please contact the organizers of the competition."

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe 'API Registrations' do
 
       body = JSON.parse(response.body)
       expect(response.status).to eq(403)
-      expect(body).to eq({error: Registrations::ErrorCodes::REGISTRATION_CLOSED}.with_indifferent_access)
+      expect(body).to eq({ error: Registrations::ErrorCodes::REGISTRATION_CLOSED }.with_indifferent_access)
     end
   end
 end

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -386,4 +386,18 @@ RSpec.describe 'API Registrations' do
       end
     end
   end
+
+  describe 'GET #payment_ticket' do
+    it 'refuses ticket create request if registration is closed' do
+      closed_comp = FactoryBot.create(:competition, :registration_closed, :with_organizer, :stripe_connected)
+      reg = FactoryBot.create(:registration, :pending, competition: closed_comp)
+
+      headers = { 'Authorization' => fetch_jwt_token(reg.user_id) }
+      get api_v1_registrations_payment_ticket_path(competition_id: closed_comp.id), headers: headers
+
+      body = JSON.parse(response.body)
+      expect(response.status).to eq(403)
+      expect(body).to eq({error: Registrations::ErrorCodes::REGISTRATION_CLOSED}.with_indifferent_access)
+    end
+  end
 end


### PR DESCRIPTION
Prevents payment after registration close in 3 ways: 
1. Disables and marks inactive the payment window - so that the user can't access the payment UI 
2. Renders a "can't pay" message instead of the payment panel - in case the user gets to the payment panel, they can't use it
3. Rejects payment_ticket endpoint requests `if registration_past?` - so that if the user does somehow submit a request, it won't work
