### PR TITLE
Dues estimator to reduce currencylayer usage

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -370,11 +370,15 @@ class CompetitionsController < ApplicationController
   end
 
   def calculate_dues
-    country_iso2 = Country.find_by(id: params[:country_id])&.iso2
-    multiplier = ActiveRecord::Type::Boolean.new.cast(params[:competitor_limit_enabled]) ? params[:competitor_limit].to_i : 1
-    total_dues = DuesCalculator.dues_for_n_competitors(country_iso2, params[:base_entry_fee_lowest_denomination].to_i, params[:currency_code], multiplier)
+    country_iso2 = Country.find_by(id: params[:countryId])&.iso2
+    per_competitor_dues = DuesCalculator.dues_per_competitor(
+      country_iso2,
+      params[:baseEntryFee].to_i,
+      params[:currencyCode],
+    )
+
     render json: {
-      dues_value: total_dues.present? ? total_dues.format : nil,
+      dues_value: per_competitor_dues.to_f,
     }
   end
 

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -376,9 +376,10 @@ class CompetitionsController < ApplicationController
       params[:baseEntryFee].to_i,
       params[:currencyCode],
     )
+    per_competitor_dues_in_lowest_denomination = per_competitor_dues.cents
 
     render json: {
-      dues_value: per_competitor_dues.to_f,
+      dues_value: per_competitor_dues_in_lowest_denomination,
     }
   end
 

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -376,7 +376,7 @@ class CompetitionsController < ApplicationController
       params[:baseEntryFee].to_i,
       params[:currencyCode],
     )
-    per_competitor_dues_in_lowest_denomination = per_competitor_dues.cents
+    per_competitor_dues_in_lowest_denomination = per_competitor_dues&.cents
 
     render json: {
       dues_value: per_competitor_dues_in_lowest_denomination,

--- a/app/webpacker/components/CompetitionForm/FormSections/DuesEstimate.jsx
+++ b/app/webpacker/components/CompetitionForm/FormSections/DuesEstimate.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Input, Modal } from 'semantic-ui-react';
+import { QueryClient, useQuery } from '@tanstack/react-query';
+import useInputState from '../../../lib/hooks/useInputState';
+import { calculateDuesUrl } from '../../../lib/requests/routes.js.erb';
+import { currenciesData } from '../../../lib/wca-data.js.erb';
+import Loading from '../../Requests/Loading';
+import Errored from '../../Requests/Errored';
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+
+const CALCULATE_DUES_QUERY_CLIENT = new QueryClient();
+
+export default function DuesEstimate({
+  close, countryId, currencyCode, baseEntryFee, competitorLimit,
+}) {
+  const [competitorCount, setCompetitorCount] = useInputState(competitorLimit || 0);
+  const currencyInfo = currenciesData.byIso[currencyCode] || currenciesData.byIso.USD;
+
+  const {
+    data, isLoading, isError,
+  } = useQuery({
+    queryKey: [countryId, currencyCode, baseEntryFee],
+    queryFn: () => fetchJsonOrError(calculateDuesUrl(countryId, currencyCode, baseEntryFee)),
+  }, CALCULATE_DUES_QUERY_CLIENT);
+
+  const { dues_value: duesValue } = data?.data || {};
+
+  if (isLoading) return <Loading />;
+  if (isError) return <Errored error="Dues fetching failed..." />;
+
+  return (
+    <Modal
+      open
+      onClose={close}
+      closeIcon
+    >
+      <Modal.Header>Dues Estimate</Modal.Header>
+      <Modal.Content>
+        <Input
+          label="Competitor count"
+          type="number"
+          value={competitorCount}
+          onChange={setCompetitorCount}
+        />
+        <p>
+          {`Dues for ${competitorCount} competitors (approximately): ${currencyInfo?.symbol || ''}${(duesValue * competitorCount).toFixed(2)}`}
+        </p>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/app/webpacker/components/CompetitionForm/FormSections/DuesEstimate.jsx
+++ b/app/webpacker/components/CompetitionForm/FormSections/DuesEstimate.jsx
@@ -19,7 +19,7 @@ export default function DuesEstimate({
   const {
     data, isLoading, isError,
   } = useQuery({
-    queryKey: [countryId, currencyCode, baseEntryFee],
+    queryKey: ['dues-estimate', countryId, currencyCode, baseEntryFee],
     queryFn: () => fetchJsonOrError(calculateDuesUrl(countryId, currencyCode, baseEntryFee)),
   }, CALCULATE_DUES_QUERY_CLIENT);
 

--- a/app/webpacker/components/CompetitionForm/FormSections/DuesEstimate.jsx
+++ b/app/webpacker/components/CompetitionForm/FormSections/DuesEstimate.jsx
@@ -24,6 +24,7 @@ export default function DuesEstimate({
   }, CALCULATE_DUES_QUERY_CLIENT);
 
   const { dues_value: duesValue } = data?.data || {};
+  const totalDues = (duesValue * competitorCount || 0) / currencyInfo.subunitToUnit;
 
   if (isLoading) return <Loading />;
   if (isError) return <Errored error="Dues fetching failed..." />;
@@ -43,7 +44,12 @@ export default function DuesEstimate({
           onChange={setCompetitorCount}
         />
         <p>
-          {`Dues for ${competitorCount} competitors (approximately): ${currencyInfo?.symbol || ''}${(duesValue * competitorCount).toFixed(2)}`}
+          {`Dues for ${competitorCount} competitors (approximately): ${
+            totalDues.toLocaleString(
+              undefined, // undefined will use the browser's default locale
+              { style: 'currency', currency: currencyCode },
+            )
+          }`}
         </p>
       </Modal.Content>
     </Modal>

--- a/app/webpacker/components/CompetitionForm/FormSections/RegistrationFees.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/RegistrationFees.js
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { useState } from 'react';
+import { Button } from 'semantic-ui-react';
 import {
   InputBoolean,
   InputCurrencyAmount,
@@ -7,12 +8,10 @@ import {
   InputSelect,
 } from '../../wca/FormBuilder/input/FormInputs';
 import { currenciesData } from '../../../lib/wca-data.js.erb';
-import I18n from '../../../lib/i18n';
-import { calculateDuesUrl } from '../../../lib/requests/routes.js.erb';
-import useLoadedData from '../../../lib/hooks/useLoadedData';
 import ConditionalSection from './ConditionalSection';
 import SubSection from '../../wca/FormBuilder/SubSection';
 import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider';
+import DuesEstimate from './DuesEstimate';
 
 const currenciesOptions = Object.keys(currenciesData.byIso).map((iso) => ({
   key: iso,
@@ -29,59 +28,26 @@ export default function RegistrationFees() {
     competitorLimit,
     registration,
   } = useFormObject();
+  const [showDuesEstimate, setShowDuesEstimate] = useState(false);
 
   const currency = entryFees.currencyCode;
 
   const canRegOnSite = registration && registration.allowOnTheSpot;
 
-  const savedParams = useMemo(() => {
-    const params = new URLSearchParams();
-
-    params.append('competitor_limit_enabled', competitorLimit.enabled);
-    params.append('competitor_limit', competitorLimit.count);
-    params.append('currency_code', entryFees.currencyCode);
-    params.append('base_entry_fee_lowest_denomination', entryFees.baseEntryFee);
-    params.append('country_id', country);
-
-    return params;
-  }, [competitorLimit, country, entryFees]);
-
-  const entryFeeDuesUrl = useMemo(
-    () => `${calculateDuesUrl}?${savedParams.toString()}`,
-    [savedParams],
-  );
-
-  const {
-    data: duesJson,
-    error,
-  } = useLoadedData(entryFeeDuesUrl);
-
-  const duesText = useMemo(() => {
-    if (error || !duesJson?.dues_value) {
-      return I18n.t('competitions.competition_form.dues_estimate.ajax_error');
-    }
-
-    if (competitorLimit.enabled) {
-      return `${I18n.t('competitions.competition_form.dues_estimate.calculated', {
-        limit: competitorLimit.count,
-        estimate: duesJson?.dues_value,
-      })} (${currency})`;
-    }
-
-    return `${I18n.t('competitions.competition_form.dues_estimate.per_competitor', {
-      estimate: duesJson?.dues_value,
-    })} (${currency})`;
-  }, [competitorLimit, currency, duesJson, error]);
-
   return (
     <SubSection section="entryFees">
       <InputSelect id="currencyCode" options={currenciesOptions} required />
       <InputCurrencyAmount id="baseEntryFee" currency={currency} required />
-      <p className="help-block">
-        <b>
-          {duesText}
-        </b>
-      </p>
+      <Button onClick={() => setShowDuesEstimate(true)}>Show Dues Estimate</Button>
+      {showDuesEstimate && (
+        <DuesEstimate
+          close={() => setShowDuesEstimate(false)}
+          countryId={country}
+          currencyCode={entryFees.currencyCode}
+          baseEntryFee={entryFees.baseEntryFee}
+          competitorLimit={competitorLimit.count}
+        />
+      )}
       <ConditionalSection showIf={canRegOnSite}>
         <InputCurrencyAmount id="onTheSpotEntryFee" currency={currency} required={canRegOnSite} />
       </ConditionalSection>

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -137,7 +137,7 @@ export const seriesEligibleCompetitionsJsonUrl = `<%= CGI.unescape(Rails.applica
 
 export const registrationCollisionsJsonUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_collisions_json_path)%>`;
 
-export const calculateDuesUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.calculate_dues_path)%>`;
+export const calculateDuesUrl = (countryId, currencyCode, baseEntryFee) => `<%= CGI.unescape(Rails.application.routes.url_helpers.calculate_dues_path)%>?${jsonToQueryString({ countryId, currencyCode, baseEntryFee })}`;
 
 export const adminPostingCompetitionsUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.results_posting_dashboard_path(format: "json")) %>`;
 

--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -3,7 +3,9 @@
 module DuesCalculator
   def self.dues_per_competitor(country_iso2, base_entry_fee_lowest_denomination, currency_code)
     dues_per_competitor_in_usd_money = dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)
-    dues_per_competitor_in_usd_money.exchange_to(currency_code)
+    dues_per_competitor_in_usd_money&.exchange_to(currency_code)
+  rescue CurrencyUnavailable
+    nil
   end
 
   def self.dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)

--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
 module DuesCalculator
-  def self.dues_for_n_competitors(country_iso2, base_entry_fee_lowest_denomination, currency_code, n)
+  def self.dues_per_competitor(country_iso2, base_entry_fee_lowest_denomination, currency_code)
     dues_per_competitor_in_usd_money = dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)
-    if dues_per_competitor_in_usd_money.present?
-      (dues_per_competitor_in_usd_money * n).exchange_to(currency_code)
-    else
-      nil
-    end
-  rescue CurrencyUnavailable
-    nil
+    dues_per_competitor_in_usd_money.exchange_to(currency_code)
   end
 
   def self.dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)


### PR DESCRIPTION
For getting currency details, we moved to currencylayer API which is paid. Currently, the dues is shown on competition edit page, but it may not be noticed every time by the user. So it has been replaced with a button now as shown below:

<img width="1249" alt="Screenshot 2025-02-04 at 06 33 28" src="https://github.com/user-attachments/assets/493837e2-06c2-44af-af31-b78fb5c6403f" />

When the user clicks the button, they will be able to see the dues estimate. This view not only shows the dues estimate, but also allows user to change the competitor count temporarily and see what is the dues for that competitor count:

<img width="996" alt="Screenshot 2025-02-04 at 06 35 50" src="https://github.com/user-attachments/assets/bea6313d-0373-4e2a-a45c-274ca8630d4b" />

The future plan of this component will be to explain the dues calculation method used in this component, so that delegate can easily understand it from here, and hence reduce queries to WFC on 'why is the dues xyz for n competitors'.