### PR TITLE
Selector for rankings query (& mbf fix)

### DIFF
--- a/app/webpacker/components/Results/Rankings/RankingsTable.jsx
+++ b/app/webpacker/components/Results/Rankings/RankingsTable.jsx
@@ -48,55 +48,6 @@ function mapRankingsData(data, isByRegion) {
   }, []);
 }
 
-function CountryCell({ country }) {
-  return (
-    <Table.Cell textAlign="left">
-      {country.iso2 && <CountryFlag iso2={country.iso2} />}
-      {' '}
-      {country.name}
-    </Table.Cell>
-  );
-}
-
-function ResultRow({
-  result, competition, rank, isAverage, show, country,
-}) {
-  const attempts = [result.value1, result.value2, result.value3, result.value4, result.value5]
-    .filter(Boolean);
-
-  const bestResult = _.max(attempts);
-  const worstResult = _.min(attempts);
-  const bestResultIndex = attempts.indexOf(bestResult);
-  const worstResultIndex = attempts.indexOf(worstResult);
-
-  return (
-    <Table.Row>
-      {show === 'by region' ? <CountryCell country={country} />
-        : <Table.Cell textAlign="center">{rank}</Table.Cell> }
-      <Table.Cell>
-        <a href={personUrl(result.personId)}>{result.personName}</a>
-      </Table.Cell>
-      <Table.Cell>
-        {formatAttemptResult(result.value, result.eventId)}
-      </Table.Cell>
-      {show !== 'by region' && <CountryCell country={country} />}
-      <Table.Cell>
-        <CountryFlag iso2={countries.byId[competition.countryId].iso2} />
-        {' '}
-        <a href={competitionUrl(competition.id)}>{competition.cellName}</a>
-      </Table.Cell>
-      {isAverage && (attempts.map((a, i) => (
-        <Table.Cell>
-          { attempts.length === 5
-              && (i === bestResultIndex || i === worstResultIndex)
-            ? `(${formatAttemptResult(a, result.eventId)})` : formatAttemptResult(a, result.eventId)}
-        </Table.Cell>
-      ))
-      )}
-    </Table.Row>
-  );
-}
-
 export default function RankingsTable({ filterState }) {
   const {
     event, region, rankingType, gender, show,
@@ -196,5 +147,54 @@ export default function RankingsTable({ filterState }) {
         </Table.Body>
       </Table>
     </div>
+  );
+}
+
+function ResultRow({
+  result, competition, rank, isAverage, show, country,
+}) {
+  const attempts = [result.value1, result.value2, result.value3, result.value4, result.value5]
+    .filter(Boolean);
+
+  const bestResult = _.max(attempts);
+  const worstResult = _.min(attempts);
+  const bestResultIndex = attempts.indexOf(bestResult);
+  const worstResultIndex = attempts.indexOf(worstResult);
+
+  return (
+    <Table.Row>
+      {show === 'by region' ? <CountryCell country={country} />
+        : <Table.Cell textAlign="center">{rank}</Table.Cell> }
+      <Table.Cell>
+        <a href={personUrl(result.personId)}>{result.personName}</a>
+      </Table.Cell>
+      <Table.Cell>
+        {formatAttemptResult(result.value, result.eventId)}
+      </Table.Cell>
+      {show !== 'by region' && <CountryCell country={country} />}
+      <Table.Cell>
+        <CountryFlag iso2={countries.byId[competition.countryId].iso2} />
+        {' '}
+        <a href={competitionUrl(competition.id)}>{competition.cellName}</a>
+      </Table.Cell>
+      {isAverage && (attempts.map((a, i) => (
+        <Table.Cell>
+          { attempts.length === 5
+              && (i === bestResultIndex || i === worstResultIndex)
+            ? `(${formatAttemptResult(a, result.eventId)})` : formatAttemptResult(a, result.eventId)}
+        </Table.Cell>
+      ))
+      )}
+    </Table.Row>
+  );
+}
+
+function CountryCell({ country }) {
+  return (
+    <Table.Cell textAlign="left">
+      {country.iso2 && <CountryFlag iso2={country.iso2} />}
+      {' '}
+      {country.name}
+    </Table.Cell>
   );
 }

--- a/app/webpacker/components/Results/Rankings/RankingsTable.jsx
+++ b/app/webpacker/components/Results/Rankings/RankingsTable.jsx
@@ -58,7 +58,7 @@ export default function RankingsTable({ filterState }) {
   const { data, isFetching } = useQuery({
     queryKey: ['rankings', event, region, rankingType, gender, show],
     queryFn: () => getRankings(event, rankingType, region, gender, show),
-    select: (data) => mapRankingsData(data, show === 'by region'),
+    select: (rankingsData) => mapRankingsData(rankingsData, show === 'by region'),
   });
 
   const columns = useMemo(() => {

--- a/app/webpacker/components/Results/Rankings/RankingsTable.jsx
+++ b/app/webpacker/components/Results/Rankings/RankingsTable.jsx
@@ -102,7 +102,7 @@ export default function RankingsTable({ filterState }) {
   }, [show, isAverage]);
 
   const table = useReactTable({
-    data,
+    data: data || [],
     columns,
     getCoreRowModel: getCoreRowModel(),
   });

--- a/app/webpacker/components/Results/Rankings/index.jsx
+++ b/app/webpacker/components/Results/Rankings/index.jsx
@@ -45,9 +45,8 @@ function filterReducer(state, action) {
     case ActionTypes.SET_EVENT:
       if (action.payload === '333mbf') {
         return { ...state, event: action.payload, rankingType: 'single' };
-      } else {
-        return { ...state, event: action.payload };
       }
+      return { ...state, event: action.payload };
     case ActionTypes.SET_REGION:
       return { ...state, region: action.payload };
     case ActionTypes.SET_RANKING_TYPE:

--- a/app/webpacker/components/Results/Rankings/index.jsx
+++ b/app/webpacker/components/Results/Rankings/index.jsx
@@ -43,7 +43,11 @@ function parseInitialStateFromUrl(url) {
 function filterReducer(state, action) {
   switch (action.type) {
     case ActionTypes.SET_EVENT:
-      return { ...state, event: action.payload };
+      if (action.payload === '333mbf') {
+        return { ...state, event: action.payload, rankingType: 'single' };
+      } else {
+        return { ...state, event: action.payload };
+      }
     case ActionTypes.SET_REGION:
       return { ...state, region: action.payload };
     case ActionTypes.SET_RANKING_TYPE:


### PR DESCRIPTION
Theoretically this should fix the crash that most of us cannot reproduce.

Also, you could select, say, 333 average, then click 333mbf and it would show 333mbf average, even though the 'average' button was hidden So I fixed that.

Easiest to review the diff 1 commit at a time.