### PR TITLE
Fixed the wrong page in WFC panel

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -697,7 +697,7 @@ class User < ApplicationRecord
           panel_pages[:countryBands],
           panel_pages[:xeroUsers],
           panel_pages[:duesRedirect],
-          panel_pages[:bannedCompetitors],
+          panel_pages[:delegateProbations],
         ],
       },
       wrt: {


### PR DESCRIPTION
During https://github.com/thewca/worldcubeassociation.org/pull/10583, I accidentally replaced probation page with banned competitors page. This PR aims at reverting to the correct page.