### PR TITLE
Order items moved to waiting list by payment timestamp

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -104,13 +104,13 @@ export default function RegistrationActions({
     const unpaid = attendeesWithRegistrations.filter(({ paymentUpdatedAt }) => !paymentUpdatedAt);
 
     paid.sort((a, b) => {
-      if (!a.paymentUpdatedAt) return 1; // Push entries without payment to the end
+      if (!a.paymentUpdatedAt) return 1;
       if (!b.paymentUpdatedAt) return -1;
       return new Date(a.paymentUpdatedAt) - new Date(b.paymentUpdatedAt);
     });
 
     const combined = paid.concat(unpaid);
-    changeStatus(combined.map(({ userId }) => userId ), 'waiting_list');
+    changeStatus(combined.map(({ userId }) => userId), 'waiting_list');
   };
 
   const attemptToApprove = () => {
@@ -191,8 +191,8 @@ export default function RegistrationActions({
             <Button
               color="yellow"
               onClick={() => moveToWaitingList(
-                  [...pending, ...cancelled, ...accepted, ...rejected],
-                )}
+                [...pending, ...cancelled, ...accepted, ...rejected],
+              )}
             >
               <Icon name="hourglass" />
               {I18n.t('competitions.registration_v2.update.move_waiting')}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, Icon } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
@@ -100,11 +100,11 @@ export default function RegistrationActions({
         };
       });
 
-    const [paid, unpaid] = _.partition(attendeesWithRegistrations, ({ paymentUpdatedAt }) => paymentUpdatedAt);
+    const [paid, unpaid] = _.partition(
+      attendeesWithRegistrations, ({ paymentUpdatedAt }) => paymentUpdatedAt
+    );
 
-    paid.sort((a, b) => {
-      return new Date(a.paymentUpdatedAt) - new Date(b.paymentUpdatedAt);
-    });
+    paid.sort((a, b) => new Date(a.paymentUpdatedAt) - new Date(b.paymentUpdatedAt));
 
     const combined = paid.concat(unpaid);
     changeStatus(combined.map(({ userId }) => userId), 'waiting_list');

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -100,8 +100,8 @@ export default function RegistrationActions({
         };
       });
 
-    const [paid, unpaid] = _.partition(
-      attendeesWithRegistrations, ({ paymentUpdatedAt }) => paymentUpdatedAt
+    const [paid, unpaid] = _.partition(attendeesWithRegistrations, ({ paymentUpdatedAt }) =>
+      paymentUpdatedAt
     );
 
     paid.sort((a, b) => new Date(a.paymentUpdatedAt) - new Date(b.paymentUpdatedAt));

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -68,8 +68,6 @@ export default function RegistrationActions({
     .join(',');
 
   const changeStatus = useCallback((attendees, status) => {
-    console.log("attendees")
-    console.log(attendees)
     updateRegistrationMutation(
       {
         requests: attendees.map((attendee) => (

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -100,9 +100,8 @@ export default function RegistrationActions({
         };
       });
 
-    const [paid, unpaid] = _.partition(attendeesWithRegistrations, ({ paymentUpdatedAt }) =>
-      paymentUpdatedAt
-    );
+    const hasPayment = ({ paymentUpdatedAt }) => paymentUpdatedAt;
+    const [paid, unpaid] = _.partition(attendeesWithRegistrations, hasPayment);
 
     paid.sort((a, b) => new Date(a.paymentUpdatedAt) - new Date(b.paymentUpdatedAt));
 

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Button, Icon } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
@@ -67,7 +67,7 @@ export default function RegistrationActions({
     .map((userId) => userEmailMap[userId])
     .join(',');
 
-  const changeStatus = useCallback((attendees, status) => {
+  const changeStatus = (attendees, status) => {
     updateRegistrationMutation(
       {
         requests: attendees.map((attendee) => (
@@ -85,9 +85,9 @@ export default function RegistrationActions({
         },
       },
     );
-  }, [competitionInfo.id]);
+  };
 
-  const moveToWaitingList = useCallback((attendees) => {
+  const moveToWaitingList = (attendees) => {
     const registrationsByUserId = _.groupBy(registrations, 'user_id');
 
     const [paid, unpaid] = _.partition(
@@ -103,7 +103,7 @@ export default function RegistrationActions({
 
     const combined = paid.concat(unpaid);
     changeStatus(combined, 'waiting_list');
-  }, [registrations, changeStatus]);
+  };
 
   const attemptToApprove = () => {
     const idsToAccept = [...pending, ...cancelled, ...waiting, ...rejected];

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -90,8 +90,9 @@ export default function RegistrationActions({
   const moveToWaitingList = useCallback((attendees) => {
     const registrationsByUserId = _.groupBy(registrations, 'user_id');
 
-    const [paid, unpaid] = _.partition(attendees, (userId) =>
-      registrationsByUserId[userId]?.[0]?.payment?.updated_at
+    const [paid, unpaid] = _.partition(
+      attendees,
+      (userId) => registrationsByUserId[userId]?.[0]?.payment?.updated_at,
     );
 
     paid.sort((a, b) => {


### PR DESCRIPTION
Initially, users were added to the waiting list in the order they were selected (ticked) by the organizer. Now, when items users are added in Waiting List, they are sorted according to the following rules: 
- paid registrations before unpaid registrations
- paid registrations sorted by payment timestamp
- unpaid registrations sorted by when they were selected (this behaviour still makes sense in cases where payment is handled off-site, and registration timestamp has no bearing on who should be approved in what order) 

Finn and I also discussed 'previewing' the new state of the waiting list - but that's hard to do, and there isn't user support for it, so I think this change is sufficient for now.

User feedback informing these changes: 
![image](https://github.com/user-attachments/assets/3ff6d7c3-f52d-4522-8804-4233fe1b0871)

![image](https://github.com/user-attachments/assets/1c86cbca-652a-4fe4-9e19-2e53142e61a0)
