### PR TITLE
Fix dates in competitions admin view

### DIFF
--- a/app/webpacker/lib/utils/competition-table.js
+++ b/app/webpacker/lib/utils/competition-table.js
@@ -94,7 +94,7 @@ export function numberOfDaysAfter(competition, refDate) {
 
   const numberOfDays = parsedStartDate.diff(parsedRefDate, 'days').days;
 
-  return Math.ceil(Math.abs(numberOfDays));
+  return Math.floor(Math.abs(numberOfDays));
 }
 
 export function timeDifferenceAfter(competition, refDate) {


### PR DESCRIPTION
This fixes the bug with results submitted on the competition day and showed as submitted 1 day after.