### PR TITLE
Replace invert_where to where.not

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -15,7 +15,7 @@ class UserRole < ApplicationRecord
 
   delegate :group_type, to: :group
 
-  scope :active, -> { where(end_date: nil).or(inactive.invert_where) }
+  scope :active, -> { where(end_date: nil).or(where.not(end_date: ..Date.today)) }
   scope :inactive, -> { where(end_date: ..Date.today) }
 
   # We need this for creating new roles that would otherwise be instantiated with an out-of-date group reference


### PR DESCRIPTION
This issue was noted while working on https://github.com/thewca/worldcubeassociation.org/pull/10476.

If we use `invert_where`, all the `where` before that is getting inverted. For example:

```
UserRole.where(group_id: 3)
```
This will return all roles which are part of group with group_id `3`.

```
UserRole.where(group_id: 3).active
```
We expect this to return all the active roles, but it is internally getting converted to `UserRole.where(group_id: 3).where(end_date: nil).or(inactive.invert_where)` and `inactive` here is `where(end_date: ..Date.today)`. So it is becoming `UserRole.where(...).where(...).invert_where` and the `invert_where` is inverting all the previous `where` resulting in unexpected results.

Thanks to @gregorbg for helping to find out this problem.