### PR TITLE
WCA Live: Create a Live Attempt History

### DIFF
--- a/app/controllers/live_controller.rb
+++ b/app/controllers/live_controller.rb
@@ -41,13 +41,7 @@ class LiveController < ApplicationController
         if previous_attempts[i].present?
           previous_attempts[i].update_with_history_entry(r, current_user)
         else
-          LiveAttempt.build(attempt_number: i,
-                            result: r,
-                            live_attempt_history_entries: [LiveAttemptHistoryEntry.build(
-                              result: r,
-                              entered_at: Time.now.utc,
-                              entered_by: current_user,
-                            )])
+          LiveAttempt.build_with_history_entry(r, i, current_user)
         end
       end
     end

--- a/app/controllers/live_controller.rb
+++ b/app/controllers/live_controller.rb
@@ -35,14 +35,16 @@ class LiveController < ApplicationController
     previous_attempts = result.live_attempts.index_by(&:attempt_number)
 
     new_attempts = results.map.with_index(1) do |r, i|
-      if previous_attempts[i]&.result == r
-        previous_attempts[i]
-      else
-        if previous_attempts[i].present?
-          previous_attempts[i].update_with_history_entry(r, current_user)
+      previous_attempt = previous_attempts[i]
+
+      if previous_attempt.present?
+        if previous_attempt.result == r
+          previous_attempt
         else
-          LiveAttempt.build_with_history_entry(r, i, current_user)
+          previous_attempt.update_with_history_entry(r, current_user)
         end
+      else
+        LiveAttempt.build_with_history_entry(r, i, current_user)
       end
     end
 

--- a/app/controllers/live_controller.rb
+++ b/app/controllers/live_controller.rb
@@ -40,15 +40,21 @@ class LiveController < ApplicationController
       else
         if previous_attempts[i].present?
           previous_attempts[i].update_with_history_entry(r, current_user)
-          previous_attempts[i]
         else
-          LiveAttempt.create(registration_id: registration_id, attempt_number: i, result: r)
+          LiveAttempt.build(attempt_number: i,
+                            result: r,
+                            current_user: current_user,
+                            live_attempt_history_entries: [LiveAttemptHistoryEntry.build(
+                                                             result: r,
+                                                             entered_at: Time.now.utc,
+                                                             entered_by: current_user
+                            )])
         end
       end
     end
 
     # TODO: What is the best way to do this?
-    r = Result.build({ value1: results[0], value2: results[1], value3: results[2], value4: results[3] || 0, value5: results[4] || 0, event_id: round.event.id, round_type_id: round.round_type_id, format_id: round.format_id })
+    r = Result.new( value1: results[0], value2: results[1], value3: results[2], value4: results[3] || 0, value5: results[4] || 0, event_id: round.event.id, round_type_id: round.round_type_id, format_id: round.format_id)
 
     result.update(average: r.compute_correct_average, best: r.compute_correct_best, live_attempts: new_attempts, last_attempt_entered_at: Time.now.utc)
 

--- a/app/controllers/live_controller.rb
+++ b/app/controllers/live_controller.rb
@@ -43,18 +43,17 @@ class LiveController < ApplicationController
         else
           LiveAttempt.build(attempt_number: i,
                             result: r,
-                            current_user: current_user,
                             live_attempt_history_entries: [LiveAttemptHistoryEntry.build(
-                                                             result: r,
-                                                             entered_at: Time.now.utc,
-                                                             entered_by: current_user
+                              result: r,
+                              entered_at: Time.now.utc,
+                              entered_by: current_user,
                             )])
         end
       end
     end
 
     # TODO: What is the best way to do this?
-    r = Result.new( value1: results[0], value2: results[1], value3: results[2], value4: results[3] || 0, value5: results[4] || 0, event_id: round.event.id, round_type_id: round.round_type_id, format_id: round.format_id)
+    r = Result.new(value1: results[0], value2: results[1], value3: results[2], value4: results[3] || 0, value5: results[4] || 0, event_id: round.event.id, round_type_id: round.round_type_id, format_id: round.format_id)
 
     result.update(average: r.compute_correct_average, best: r.compute_correct_best, live_attempts: new_attempts, last_attempt_entered_at: Time.now.utc)
 

--- a/app/jobs/add_live_result_job.rb
+++ b/app/jobs/add_live_result_job.rb
@@ -10,13 +10,18 @@ class AddLiveResultJob < ApplicationJob
     event = round.event
     format = round.format
 
-    r = Result.build({ value1: results[0], value2: results[1] || 0, value3: results[2] || 0, value4: results[3] || 0, value5: results[4] || 0, event_id: event.id, round_type_id: round.round_type_id, format_id: format.id })
+    r = Result.new(value1: results[0], value2: results[1] || 0, value3: results[2] || 0, value4: results[3] || 0, value5: results[4] || 0, event_id: event.id, round_type_id: round.round_type_id, format_id: format.id)
 
     LiveResult.create!(registration_id: registration_id,
                        round: round,
                        live_attempts: attempts,
                        last_attempt_entered_at: Time.now.utc,
                        best: r.compute_correct_best,
-                       average: r.compute_correct_average)
+                       average: r.compute_correct_average,
+                       live_attempt_history_entries: [LiveAttemptHistoryEntry.build(
+                         result: r,
+                         entered_at: Time.now.utc,
+                         entered_by: current_user
+                       )])
   end
 end

--- a/app/jobs/add_live_result_job.rb
+++ b/app/jobs/add_live_result_job.rb
@@ -6,12 +6,7 @@ class AddLiveResultJob < ApplicationJob
 
   def perform(results, round_id, registration_id, entered_by)
     attempts = results.map.with_index(1) { |r, i|
-      LiveAttempt.build(result: r, attempt_number: i,
-                        live_attempt_history_entries: [LiveAttemptHistoryEntry.build(
-                          result: r,
-                          entered_at: Time.now.utc,
-                          entered_by: entered_by,
-                        )])
+      LiveAttempt.build_with_history_entry(r, i, entered_by)
     }
     round = Round.find(round_id)
     event = round.event

--- a/app/models/live_attempt.rb
+++ b/app/models/live_attempt.rb
@@ -4,7 +4,6 @@ class LiveAttempt < ApplicationRecord
   include Comparable
 
   belongs_to :live_result
-  validate :needs_live_result_or_replaced_by
   has_many :live_attempt_history_entries, dependent: :destroy
 
   validates :result, presence: true
@@ -21,5 +20,14 @@ class LiveAttempt < ApplicationRecord
 
   def <=>(other)
     result <=> other.result
+  end
+
+  def update_with_history_entry(r, current_user)
+    update(result: r)
+    live_attempt_history_entries.create({
+                                          result: r,
+                                          entered_at: Time.current.utc,
+                                          entered_by: current_user
+                                        })
   end
 end

--- a/app/models/live_attempt.rb
+++ b/app/models/live_attempt.rb
@@ -3,6 +3,8 @@
 class LiveAttempt < ApplicationRecord
   include Comparable
 
+  default_scope { order(:attempt_number) }
+
   belongs_to :live_result
   has_many :live_attempt_history_entries, dependent: :destroy
 

--- a/app/models/live_attempt.rb
+++ b/app/models/live_attempt.rb
@@ -24,13 +24,27 @@ class LiveAttempt < ApplicationRecord
     result <=> other.result
   end
 
-  def update_with_history_entry(r, current_user)
-    update(result: r)
-    live_attempt_history_entries.create({
-                                          result: r,
-                                          entered_at: Time.now.utc,
-                                          entered_by: current_user,
-                                        })
+  def self.build_with_history_entry(r, i, acting_user)
+    LiveAttempt.build(
+      result: r,
+      attempt_number: i,
+      live_attempt_history_entries: [
+        LiveAttemptHistoryEntry.build(
+          result: r,
+          entered_at: Time.now.utc,
+          entered_by: acting_user,
+        ),
+      ],
+    )
+  end
+
+  def update_with_history_entry(result, acting_user)
+    update(result: result)
+    live_attempt_history_entries.create(
+      result: r,
+      entered_at: Time.now.utc,
+      entered_by: acting_user,
+    )
     self
   end
 end

--- a/app/models/live_attempt.rb
+++ b/app/models/live_attempt.rb
@@ -3,13 +3,9 @@
 class LiveAttempt < ApplicationRecord
   include Comparable
 
-  # If the Attempt has been replaced, it no longer points to a live_result, but instead is being pointed to
-  # by another Attempt
-  belongs_to :live_result, optional: true
-  belongs_to :replaced_by, class_name: "LiveAttempt", optional: true
+  belongs_to :live_result
   validate :needs_live_result_or_replaced_by
-
-  belongs_to :entered_by, class_name: 'User'
+  has_many :live_attempt_history_entries, dependent: :destroy
 
   validates :result, presence: true
   validates :result, numericality: { only_integer: true }
@@ -25,11 +21,5 @@ class LiveAttempt < ApplicationRecord
 
   def <=>(other)
     result <=> other.result
-  end
-
-  def needs_live_result_or_replaced_by
-    if replaced_by.nil? && live_result.nil?
-      errors.add(:replaced_by, "When unlinking an attempt from a live result you need to set replaced_by")
-    end
   end
 end

--- a/app/models/live_attempt.rb
+++ b/app/models/live_attempt.rb
@@ -27,7 +27,7 @@ class LiveAttempt < ApplicationRecord
     live_attempt_history_entries.create({
                                           result: r,
                                           entered_at: Time.now.utc,
-                                          entered_by: current_user
+                                          entered_by: current_user,
                                         })
     self
   end

--- a/app/models/live_attempt.rb
+++ b/app/models/live_attempt.rb
@@ -26,8 +26,9 @@ class LiveAttempt < ApplicationRecord
     update(result: r)
     live_attempt_history_entries.create({
                                           result: r,
-                                          entered_at: Time.current.utc,
+                                          entered_at: Time.now.utc,
                                           entered_by: current_user
                                         })
+    self
   end
 end

--- a/app/models/live_attempt.rb
+++ b/app/models/live_attempt.rb
@@ -24,13 +24,13 @@ class LiveAttempt < ApplicationRecord
     result <=> other.result
   end
 
-  def self.build_with_history_entry(r, i, acting_user)
+  def self.build_with_history_entry(result, attempt_number, acting_user)
     LiveAttempt.build(
-      result: r,
-      attempt_number: i,
+      result: result,
+      attempt_number: attempt_number,
       live_attempt_history_entries: [
         LiveAttemptHistoryEntry.build(
-          result: r,
+          result: result,
           entered_at: Time.now.utc,
           entered_by: acting_user,
         ),
@@ -39,12 +39,14 @@ class LiveAttempt < ApplicationRecord
   end
 
   def update_with_history_entry(result, acting_user)
-    update(result: result)
-    live_attempt_history_entries.create(
-      result: r,
+    self.update(result: result)
+    self.live_attempt_history_entries.create(
+      result: result,
       entered_at: Time.now.utc,
       entered_by: acting_user,
     )
+
+    # Return `self` for method chaining
     self
   end
 end

--- a/app/models/live_attempt_history_entry.rb
+++ b/app/models/live_attempt_history_entry.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LiveAttemptHistoryEntry < ApplicationRecord
+  belongs_to :live_attempt
+
+  validates :entered_at, presence: true
+  validates :entered_by, presence: true
+  validates :value, presence: true
+end

--- a/app/models/live_attempt_history_entry.rb
+++ b/app/models/live_attempt_history_entry.rb
@@ -5,5 +5,5 @@ class LiveAttemptHistoryEntry < ApplicationRecord
 
   validates :entered_at, presence: true
   validates :entered_by, presence: true
-  validates :value, presence: true
+  validates :result, presence: true
 end

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -2,7 +2,7 @@
 
 class LiveResult < ApplicationRecord
   has_many :live_attempts
-  alias_attribute :attempts, :live_attempts
+  alias_method :attempts, :live_attempts
 
   after_create :recompute_ranks
   after_update :recompute_ranks, if: :should_recompute?

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class LiveResult < ApplicationRecord
-  has_many :live_attempts, -> { order(:attempt_number) }
+  has_many :live_attempts
+  alias_attribute :attempts, :live_attempts
 
   after_create :recompute_ranks
   after_update :recompute_ranks, if: :should_recompute?
@@ -28,10 +29,6 @@ class LiveResult < ApplicationRecord
 
   def event_id
     event.id
-  end
-
-  def attempts
-    live_attempts.order(:attempt_number)
   end
 
   def potential_score

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LiveResult < ApplicationRecord
-  has_many :live_attempts, -> { where(replaced_by: nil).order(:attempt_number) }
+  has_many :live_attempts, -> { order(:attempt_number) }
 
   after_create :recompute_ranks
   after_update :recompute_ranks, if: :should_recompute?

--- a/db/migrate/20250212142508_create_live_attempt_history_entries.rb
+++ b/db/migrate/20250212142508_create_live_attempt_history_entries.rb
@@ -11,8 +11,8 @@ class CreateLiveAttemptHistoryEntries < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    remove_column :live_attempts, :entered_at
-    remove_column :live_attempts, :entered_by
-    remove_column :live_attempts, :replaced_by
+    remove_column :live_attempts, :entered_at, :datetime
+    remove_column :live_attempts, :entered_by_id, :integer
+    remove_column :live_attempts, :replaced_by_id, :integer
   end
 end

--- a/db/migrate/20250212142508_create_live_attempt_history_entries.rb
+++ b/db/migrate/20250212142508_create_live_attempt_history_entries.rb
@@ -6,7 +6,7 @@ class CreateLiveAttemptHistoryEntries < ActiveRecord::Migration[7.2]
       t.datetime :entered_at, null: false
       t.string :entered_by, null: false
       t.references :live_attempt, null: false, foreign_key: true
-      t.integer :value, null: false
+      t.integer :result, null: false
 
       t.timestamps
     end

--- a/db/migrate/20250212142508_create_live_attempt_history_entries.rb
+++ b/db/migrate/20250212142508_create_live_attempt_history_entries.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateLiveAttemptHistoryEntries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :live_attempt_history_entries do |t|
+      t.datetime :entered_at, null: false
+      t.string :entered_by, null: false
+      t.references :live_attempt, null: false, foreign_key: true
+      t.integer :value, null: false
+
+      t.timestamps
+    end
+
+    remove_column :live_attempts, :entered_at
+    remove_column :live_attempts, :entered_by
+    remove_column :live_attempts, :replaced_by
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1133,7 +1133,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_12_142508) do
     t.text "round_results", size: :medium
     t.integer "total_number_of_rounds", null: false
     t.string "old_type", limit: 1
-    t.boolean "is_open", default: false, null: false
     t.index ["competition_event_id", "number"], name: "index_rounds_on_competition_event_id_and_number", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_12_082508) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_12_142508) do
   create_table "Competitions", id: { type: :string, limit: 32, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 50, default: "", null: false
     t.string "cityName", limit: 50, default: "", null: false
@@ -795,18 +795,23 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_12_082508) do
     t.index ["jti"], name: "index_jwt_denylist_on_jti"
   end
 
+  create_table "live_attempt_history_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "entered_at", null: false
+    t.string "entered_by", null: false
+    t.bigint "live_attempt_id", null: false
+    t.integer "result", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["live_attempt_id"], name: "index_live_attempt_history_entries_on_live_attempt_id"
+  end
+
   create_table "live_attempts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "result", null: false
     t.integer "attempt_number", null: false
-    t.bigint "replaced_by_id"
-    t.datetime "entered_at", null: false
-    t.integer "entered_by_id", null: false
     t.bigint "live_result_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["entered_by_id"], name: "index_live_attempts_on_entered_by_id"
     t.index ["live_result_id"], name: "index_live_attempts_on_live_result_id"
-    t.index ["replaced_by_id"], name: "index_live_attempts_on_replaced_by_id"
   end
 
   create_table "live_results", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1128,6 +1133,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_12_082508) do
     t.text "round_results", size: :medium
     t.integer "total_number_of_rounds", null: false
     t.string "old_type", limit: 1
+    t.boolean "is_open", default: false, null: false
     t.index ["competition_event_id", "number"], name: "index_rounds_on_competition_event_id_and_number", unique: true
   end
 
@@ -1438,8 +1444,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_12_082508) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "live_attempts", "live_attempts", column: "replaced_by_id"
-  add_foreign_key "live_attempts", "users", column: "entered_by_id"
+  add_foreign_key "live_attempt_history_entries", "live_attempts"
   add_foreign_key "microservice_registrations", "Competitions", column: "competition_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "microservice_registrations", "users"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -438,6 +438,7 @@ module DatabaseDumper
     }.freeze,
     "live_results" => :skip_all_rows,
     "live_attempts" => :skip_all_rows,
+    "live_attempt_history_entries" => :skip_all_rows,
     "schedule_activities" => {
       where_clause: "WHERE (holder_type=\"ScheduleActivity\" AND holder_id IN (#{VISIBLE_ACTIVITY_IDS}) or id in (#{VISIBLE_ACTIVITY_IDS}))",
       column_sanitizers: actions_to_column_sanitizers(

--- a/spec/factories/live_attempts.rb
+++ b/spec/factories/live_attempts.rb
@@ -2,9 +2,6 @@
 
 FactoryBot.define do
   factory :live_attempt do
-    association :entered_by, factory: [:user, :wca_id]
-    entered_at { Time.now.utc }
-
     result { 3000 }
     attempt_number { 1 }
 


### PR DESCRIPTION
moving from a replaced_by strategy to keep a history instead. I wish we could do adding a new entry as an `after_save` hook, but you need `current_user`