### PR TITLE
tried out a validation for the image

### DIFF
--- a/app/models/delegate_report.rb
+++ b/app/models/delegate_report.rb
@@ -61,6 +61,15 @@ class DelegateReport < ApplicationRecord
     end
   end
 
+  validate :setup_image_format, if: -> { setup_images.attached? }
+  private def setup_image_format
+    setup_images.each do |image|
+      if !image.content_type.in?(%w[image/png image/jpeg image/jpg image/gif])
+        errors.add(:setup_images, "must be a valid image format (JPG, PNG, GIF)")
+      end
+    end
+  end
+
   def schedule_and_discussion_urls_required?
     posted? && created_at > Date.new(2019, 7, 21)
   end

--- a/app/models/delegate_report.rb
+++ b/app/models/delegate_report.rb
@@ -61,14 +61,7 @@ class DelegateReport < ApplicationRecord
     end
   end
 
-  validate :setup_image_format, if: -> { setup_images.attached? }
-  private def setup_image_format
-    setup_images.each do |image|
-      if !image.content_type.in?(%w[image/png image/jpeg image/jpg image/gif])
-        errors.add(:setup_images, "must be a valid image format (JPG, PNG, GIF)")
-      end
-    end
-  end
+  validates :setup_images, blob: { content_type: :web_image }
 
   def schedule_and_discussion_urls_required?
     posted? && created_at > Date.new(2019, 7, 21)


### PR DESCRIPTION
We had an issue in a comp where a PDF file was accidentally uploaded to a delegate report in the Setup Images section, breaking the page. ChatGPT guided me to try and add a validation for the image type, but doing so yields the following error. My suspicion is that we should handle this in the frontend, which ChatGPT didn't have any inspiringly good ideas for. 

My suspicion is this is a "React will fix" issue, but posting in case the code is a useful starting point, and because we don't want to need to manually delete _too_ many images via the console
 
![image](https://github.com/user-attachments/assets/a18cbe09-e75d-4c7d-a83e-efe397627aa1)
