### PR TITLE
Improvements to formerly-banned competitor email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ApplicationRecord
   has_many :teams_committees_at_least_senior_roles, through: :teams_committees_at_least_senior_role_metadata, source: :user_role, class_name: "UserRole"
   has_many :teams_committees_at_least_senior_groups, through: :teams_committees_at_least_senior_roles, source: :group, class_name: "UserGroup"
   has_many :teams_committees_at_least_senior, through: :teams_committees_at_least_senior_groups, source: :metadata, source_type: "GroupsMetadataTeamsCommittees"
+  has_many :past_bans, through: :past_roles, source: :metadata, source_type: "RolesMetadataBannedCompetitors"
   has_many :active_groups, through: :active_roles, source: :group, class_name: "UserGroup"
   has_many :board_metadata, through: :active_groups, source: :metadata, source_type: "GroupsMetadataBoard"
   has_many :confirmed_users_claiming_wca_id, -> { confirmed_email }, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"

--- a/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
+++ b/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
@@ -17,4 +17,4 @@
   <% end %>
 </ul>
 
-<p>If you have any questions regarding the competitor's disciplinary history, please reach out to the WIC.</p>
+<p>If you have any questions regarding the competitor's disciplinary history, please reach out to the WIC by replying to this email.</p>

--- a/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
+++ b/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
@@ -7,7 +7,7 @@
 </p>
 
 <% user = @registration.user %>
-<% bans = user.past_roles.filter { |role| role.group == UserGroup.banned_competitors.first } %>
+<% bans = user.past_bans %>
 
 <p>User has been banned <%= bans.count %> time(s), with the following scopes and reasons:</p>
 

--- a/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
+++ b/app/views/registrations_mailer/notify_delegates_of_formerly_banned_user_registration.erb
@@ -6,7 +6,15 @@
   just registered for <%= @registration.competition.name %>.
 </p>
 
-<p>
-You can check the ban scope and reason
-  <%= link_to "here", panel_page_url(id: User.panel_pages[:bannedCompetitors]) %>
-</p>
+<% user = @registration.user %>
+<% bans = user.past_roles.filter { |role| role.group == UserGroup.banned_competitors.first } %>
+
+<p>User has been banned <%= bans.count %> time(s), with the following scopes and reasons:</p>
+
+<ul>
+  <% bans.each do |ban| %>
+    <li>Scope: <%= ban.metadata.scope %>, reason: <%= ban.metadata.ban_reason %></li>
+  <% end %>
+</ul>
+
+<p>If you have any questions regarding the competitor's disciplinary history, please reach out to the WIC.</p>


### PR DESCRIPTION
Addresses #10827 - screenshot of new email below: 

**(Note for the public: This user is not actually banned - just chosen at random for testing purposes)**

![image](https://github.com/user-attachments/assets/102e36b4-ac67-4f47-b5f6-adce9cea1355)

Copy-pasting the text for redundancy: 

> Feliks Chudzinski ([2024CHUD02](http://localhost:3000/persons/2024CHUD02)) just registered for Energy Cube Konin 2024.
> 
> User has been banned 2 time(s), with the following scopes and reasons:
> 
> * Scope: competing_and_attending, reason: derp
> * Scope: competing_only, reason: lfksjd
> 
> If you have any questions regarding the competitor's disciplinary history, please reach out to the WIC.