### PR TITLE
Set RuboCop detection to 3.4 language level

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 require: rubocop-thread_safety
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   DisplayCopNames: true
   NewCops: enable
   Exclude:

--- a/spec/lib/results_validators/scrambles_validator_spec.rb
+++ b/spec/lib/results_validators/scrambles_validator_spec.rb
@@ -170,9 +170,9 @@ RSpec.describe SV do
     end
   end
 
-  def create_scramble_set(n, **kwargs)
+  def create_scramble_set(n, **)
     1.upto(n) do |i|
-      FactoryBot.create(:scramble, scrambleNum: i, **kwargs)
+      FactoryBot.create(:scramble, scrambleNum: i, **)
     end
   end
 end


### PR DESCRIPTION
Forgot this when upgrading to Ruby 3.4