### PR TITLE
Switch to V2 upload for Slack error notifications

### DIFF
--- a/lib/slack_bot.rb
+++ b/lib/slack_bot.rb
@@ -8,8 +8,9 @@ module SlackBot
   end
 
   def self.send_error_report(message, exception)
-    self.client.files_upload(
-      channels: ALARMS_CHANNEL_ID,
+    self.client.files_upload_v2(
+      channel: ALARMS_CHANNEL_ID,
+      filename: 'backtrace.txt',
       content: exception.backtrace.join("\n"),
       title: exception.message,
       initial_comment: message,


### PR DESCRIPTION
This handles a long-standing deprecation in the public Slack API, now that the underlying client library has finally been updated (cf. https://github.com/thewca/worldcubeassociation.org/pull/10796)