### PR TITLE
WCA Live: Add small pulse loader icon for WebSocket connection status

### DIFF
--- a/app/webpacker/components/Live/RoundResults/index.jsx
+++ b/app/webpacker/components/Live/RoundResults/index.jsx
@@ -1,7 +1,9 @@
 import React, { useCallback } from 'react';
 import {
-  Button, Container,
-  Grid, Header,
+  Button,
+  Container,
+  Grid,
+  Header,
 } from 'semantic-ui-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { events } from '../../../lib/wca-data.js.erb';
@@ -11,6 +13,7 @@ import { liveUrls } from '../../../lib/requests/routes.js.erb';
 import Loading from '../../Requests/Loading';
 import getRoundResults, { insertNewResult, roundResultsKey } from '../api/getRoundResults';
 import useResultsSubscription from '../hooks/useResultsSubscription';
+import ConnectionPulse from '../components/ConnectionPulse';
 
 export default function Wrapper({
   roundId, eventId, competitionId, competitors, canAdminResults,
@@ -46,7 +49,7 @@ function ResultPage({
     );
   }, [roundId, queryClient]);
 
-  useResultsSubscription(roundId, updateResults);
+  const connectionState = useResultsSubscription(roundId, updateResults);
 
   const event = events.byId[eventId];
 
@@ -58,6 +61,7 @@ function ResultPage({
     <Container fluid>
       <Header>
         {event.name}
+        <ConnectionPulse connectionState={connectionState} />
         {canAdminResults && <a href={liveUrls.roundResultsAdmin(competitionId, roundId)}><Button floated="right">Admin</Button></a>}
       </Header>
       <Grid>

--- a/app/webpacker/components/Live/components/ConnectionPulse.jsx
+++ b/app/webpacker/components/Live/components/ConnectionPulse.jsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from 'react';
+import { Label, Transition } from 'semantic-ui-react';
+import { CONNECTION_COLORS, CONNECTION_STATE_CONNECTED } from '../hooks/useResultsSubscription';
+import usePerpetualState from '../../RegistrationsV2/hooks/usePerpetualState';
+
+const PULSE_DURATION = 2000;
+
+export default function ConnectionPulse({ connectionState, animationDuration = PULSE_DURATION }) {
+  const animationPulse = usePerpetualState((prev) => !prev, animationDuration * 1.5);
+
+  const connectionColor = useMemo(() => CONNECTION_COLORS[connectionState], [connectionState]);
+
+  const isConnected = useMemo(
+    () => connectionState === CONNECTION_STATE_CONNECTED,
+    [connectionState],
+  );
+
+  return (
+    <Transition animation="flash" duration={animationDuration} visible={!isConnected || animationPulse}>
+      <Label circular empty color={connectionColor} />
+    </Transition>
+  );
+}

--- a/app/webpacker/components/Live/hooks/useResultsSubscription.js
+++ b/app/webpacker/components/Live/hooks/useResultsSubscription.js
@@ -1,15 +1,34 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { createConsumer } from '@rails/actioncable';
 
+export const CONNECTION_STATE_INITIALIZED = 'initialized';
+export const CONNECTION_STATE_CONNECTED = 'connected';
+export const CONNECTION_STATE_DISCONNECTED = 'disconnected';
+
+export const CONNECTION_COLORS = {
+  [CONNECTION_STATE_INITIALIZED]: 'yellow',
+  [CONNECTION_STATE_CONNECTED]: 'green',
+  [CONNECTION_STATE_DISCONNECTED]: 'red',
+};
+
 export default function useResultsSubscription(roundId, onReceived) {
-  return useEffect(() => {
+  const [connectionState, setConnectionState] = useState();
+
+  useEffect(() => {
     const cable = createConsumer();
 
     const subscription = cable.subscriptions.create(
       { channel: 'LiveResultsChannel', round_id: roundId },
-      { received: onReceived },
+      {
+        received: onReceived,
+        initialized: () => setConnectionState(CONNECTION_STATE_INITIALIZED),
+        connected: () => setConnectionState(CONNECTION_STATE_CONNECTED),
+        disconnected: () => setConnectionState(CONNECTION_STATE_DISCONNECTED),
+      },
     );
 
     return () => subscription.unsubscribe();
   }, [roundId, onReceived]);
+
+  return connectionState;
 }


### PR DESCRIPTION
A little late night fun :D
[Bildschirmaufnahme_20250214_215900.webm](https://github.com/user-attachments/assets/3574730a-2509-43a6-a8e5-3bfa65f3ae5c)

The circle actually changes color and stops pulsating when the Socket gets disconnected for any reason:
[Bildschirmaufnahme_20250214_220235.webm](https://github.com/user-attachments/assets/175f1d86-8f18-401c-89a0-a6311906ab31)

Unfortunately ActionCable does not expose any actual error information, that means we cannot show the user _why_ the connection broke away. But the transition itself is fully automatic!

In terms of reviewing, there is a boolean toggle looping between true and false. That is because in SemUI, unidirectional transitions (transitions that do not make a clear distinction between "on" and "off", they "just play") do not differentiate between `true` and `false`. They just play the animation whenever the `visible` value changes: https://react.semantic-ui.com/modules/transition/#explorers-transition-explorer