### PR TITLE
Unify flag components (& fix Finland)

### DIFF
--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -23,7 +23,7 @@ import {
 import { countries } from '../../lib/wca-data.js.erb';
 import { adminCompetitionUrl, competitionUrl } from '../../lib/requests/routes.js.erb';
 import { dateRange, toRelativeOptions } from '../../lib/utils/dates';
-import CountryFlag from '../wca/CountryFlag';
+import RegionFlag from '../wca/RegionFlag';
 
 function ListViewSection({
   competitions,
@@ -160,7 +160,7 @@ export function CompetitionsTable({
                 {dateRange(comp.start_date, comp.end_date)}
               </Table.Cell>
               <Table.Cell width={5}>
-                {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                {comp.country_iso2 && <RegionFlag iso2={comp.country_iso2} />}
                 {' '}
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
@@ -217,7 +217,7 @@ export function CompetitionsTabletTable({
                 {dateRange(comp.start_date, comp.end_date)}
               </Table.Cell>
               <Table.Cell width={6}>
-                {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                {comp.country_iso2 && <RegionFlag iso2={comp.country_iso2} />}
                 {' '}
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
@@ -264,7 +264,7 @@ export function CompetitionsMobileTable({
                   />
                   {dateRange(comp.start_date, comp.end_date)}
                 </Label>
-                {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                {comp.country_iso2 && <RegionFlag iso2={comp.country_iso2} />}
                 {' '}
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
@@ -345,7 +345,7 @@ function AdminCompetitionsTable({
                   />
                 </Table.Cell>
                 <Table.Cell width={4}>
-                  {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                  {comp.country_iso2 && <RegionFlag iso2={comp.country_iso2} />}
                   {' '}
                   <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
                   <br />

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Icon, Popup, Loader, Table, Flag, Label, Header, Container, Grid, List, Image, Button,
+  Icon, Popup, Loader, Table, Label, Header, Container, Grid, List, Image, Button,
 } from 'semantic-ui-react';
 
 import { BarLoader } from 'react-spinners';

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -23,6 +23,7 @@ import {
 import { countries } from '../../lib/wca-data.js.erb';
 import { adminCompetitionUrl, competitionUrl } from '../../lib/requests/routes.js.erb';
 import { dateRange, toRelativeOptions } from '../../lib/utils/dates';
+import CountryFlag from '../wca/CountryFlag';
 
 function ListViewSection({
   competitions,
@@ -159,7 +160,8 @@ export function CompetitionsTable({
                 {dateRange(comp.start_date, comp.end_date)}
               </Table.Cell>
               <Table.Cell width={5}>
-                <Flag className={comp.country_iso2?.toLowerCase()} />
+                {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                {' '}
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
               <Table.Cell width={4}>
@@ -215,7 +217,8 @@ export function CompetitionsTabletTable({
                 {dateRange(comp.start_date, comp.end_date)}
               </Table.Cell>
               <Table.Cell width={6}>
-                <Flag className={comp.country_iso2?.toLowerCase()} />
+                {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                {' '}
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
               <Table.Cell width={7}>
@@ -261,7 +264,8 @@ export function CompetitionsMobileTable({
                   />
                   {dateRange(comp.start_date, comp.end_date)}
                 </Label>
-                <Flag className={comp.country_iso2?.toLowerCase()} />
+                {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                {' '}
                 <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
               </Table.Cell>
               {
@@ -341,7 +345,8 @@ function AdminCompetitionsTable({
                   />
                 </Table.Cell>
                 <Table.Cell width={4}>
-                  <Flag className={comp.country_iso2?.toLowerCase()} />
+                  {comp.country_iso2 && <CountryFlag iso2={comp.country_iso2} />}
+                  {' '}
                   <a href={competitionUrl(comp.id)}>{comp.short_display_name}</a>
                   <br />
                   <strong>{countries.byIso2[comp.country_iso2].name}</strong>

--- a/app/webpacker/components/Live/Competitors/index.jsx
+++ b/app/webpacker/components/Live/Competitors/index.jsx
@@ -5,7 +5,7 @@ import {
 import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvider';
 import { liveUrls } from '../../../lib/requests/routes.js.erb';
 import useInputState from '../../../lib/hooks/useInputState';
-import CountryFlag from '../../wca/CountryFlag';
+import RegionFlag from '../../wca/RegionFlag';
 
 export default function Wrapper({
   competitionId, competitors,
@@ -33,7 +33,7 @@ function Competitors({
         <Table.Body>
           {competitors.filter((c) => c.user.name.includes(searchInput)).map((c) => (
             <Table.Row>
-              <Table.Cell><CountryFlag iso2={c.user.country_iso2} /></Table.Cell>
+              <Table.Cell><RegionFlag iso2={c.user.country_iso2} /></Table.Cell>
               <Table.Cell>
                 <a href={liveUrls.personResults(competitionId, c.id)}>{c.user.name}</a>
               </Table.Cell>

--- a/app/webpacker/components/PostingCompetitions/index.js
+++ b/app/webpacker/components/PostingCompetitions/index.js
@@ -9,7 +9,7 @@ import useLoadedData from '../../lib/hooks/useLoadedData';
 import useSaveAction from '../../lib/hooks/useSaveAction';
 import Loading from '../Requests/Loading';
 import Errored from '../Requests/Errored';
-import CountryFlag from '../wca/CountryFlag';
+import RegionFlag from '../wca/RegionFlag';
 import {
   adminCheckUploadedResults,
   adminPostingCompetitionsUrl,
@@ -75,7 +75,7 @@ function PostingCompetitionsIndex({
               <Header.Subheader>
                 {c.city}
                 {' '}
-                <CountryFlag iso2={c.country_iso2} />
+                <RegionFlag iso2={c.country_iso2} />
               </Header.Subheader>
               <Header.Subheader>
                 {`Submission Timestamp: ${DateTime.fromISO(c.results_submitted_at).toRelative()}`}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -1,5 +1,5 @@
 import {
-  Checkbox, Flag, Icon, Popup, Ref, Table,
+  Checkbox, Icon, Popup, Ref, Table,
 } from 'semantic-ui-react';
 import React from 'react';
 import { Draggable } from 'react-beautiful-dnd';

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -13,6 +13,7 @@ import EventIcon from '../../wca/EventIcon';
 import { editRegistrationUrl, editPersonUrl, personUrl } from '../../../lib/requests/routes.js.erb';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 import { countries } from '../../../lib/wca-data.js.erb';
+import CountryFlag from '../../wca/CountryFlag';
 
 // Semantic Table only allows truncating _all_ columns in a table in
 // single line fixed mode. As we only want to truncate the comment/admin notes
@@ -130,21 +131,9 @@ export default function TableRow({
             {dob && <Table.Cell>{dateOfBirth}</Table.Cell>}
 
             <Table.Cell>
-              {region ? (
-                <>
-                  <Flag className={country.iso2.toLowerCase()} />
-                  {region && countries.byIso2[country.iso2].name}
-                </>
-              ) : (
-                <Popup
-                  content={countries.byIso2[country.iso2].name}
-                  trigger={(
-                    <span>
-                      <Flag className={country.iso2.toLowerCase()} />
-                    </span>
-            )}
-                />
-              )}
+              <CountryFlag iso2={country.iso2} withoutTooltip={region} />
+              {' '}
+              {region && countries.byIso2[country.iso2].name}
             </Table.Cell>
 
             <Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -13,7 +13,7 @@ import EventIcon from '../../wca/EventIcon';
 import { editRegistrationUrl, editPersonUrl, personUrl } from '../../../lib/requests/routes.js.erb';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 import { countries } from '../../../lib/wca-data.js.erb';
-import CountryFlag from '../../wca/CountryFlag';
+import RegionFlag from '../../wca/RegionFlag';
 
 // Semantic Table only allows truncating _all_ columns in a table in
 // single line fixed mode. As we only want to truncate the comment/admin notes
@@ -131,7 +131,7 @@ export default function TableRow({
             {dob && <Table.Cell>{dateOfBirth}</Table.Cell>}
 
             <Table.Cell>
-              <CountryFlag iso2={country.iso2} withoutTooltip={region} />
+              <RegionFlag iso2={country.iso2} withoutTooltip={region} />
               {' '}
               {region && countries.byIso2[country.iso2].name}
             </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
@@ -19,7 +19,7 @@ import { getPeopleCounts, getTotals, getUserPositionInfo } from './utils';
 import PreTableInfo from './PreTableInfo';
 import Errored from '../../Requests/Errored';
 import Loading from '../../Requests/Loading';
-import CountryFlag from '../../wca/CountryFlag';
+import RegionFlag from '../../wca/RegionFlag';
 
 const sortReducer = createSortReducer(['name', 'country', 'total']);
 
@@ -197,7 +197,7 @@ function CompetitorsBody({
                 </div>
               </Table.Cell>
               <Table.Cell>
-                <CountryFlag iso2={registration.user.country.iso2} withoutTooltip />
+                <RegionFlag iso2={registration.user.country.iso2} withoutTooltip />
                 {' '}
                 {countries.byIso2[registration.user.country.iso2].name}
               </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
@@ -1,11 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import React, {
-  useMemo,
-  useReducer,
-} from 'react';
-import {
-  Flag, Segment, Table,
-} from 'semantic-ui-react';
+import React, { useMemo, useReducer } from 'react';
+import { Segment, Table } from 'semantic-ui-react';
 import _ from 'lodash';
 import {
   getConfirmedRegistrations,

--- a/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/Competitors.jsx
@@ -19,6 +19,7 @@ import { getPeopleCounts, getTotals, getUserPositionInfo } from './utils';
 import PreTableInfo from './PreTableInfo';
 import Errored from '../../Requests/Errored';
 import Loading from '../../Requests/Loading';
+import CountryFlag from '../../wca/CountryFlag';
 
 const sortReducer = createSortReducer(['name', 'country', 'total']);
 
@@ -196,9 +197,8 @@ function CompetitorsBody({
                 </div>
               </Table.Cell>
               <Table.Cell>
-                <Flag
-                  className={registration.user.country.iso2.toLowerCase()}
-                />
+                <CountryFlag iso2={registration.user.country.iso2} withoutTooltip />
+                {' '}
                 {countries.byIso2[registration.user.country.iso2].name}
               </Table.Cell>
               {eventIds.map((id) => (

--- a/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
@@ -15,7 +15,7 @@ import { getPeopleCounts, getTotals, getUserPositionInfo } from './utils';
 import PreTableInfo from './PreTableInfo';
 import Loading from '../../Requests/Loading';
 import Errored from '../../Requests/Errored';
-import CountryFlag from '../../wca/CountryFlag';
+import RegionFlag from '../../wca/RegionFlag';
 
 // for consistency with competitors table data, to reuse helper functions
 function mapPsychSheetDate(data) {
@@ -218,7 +218,7 @@ function PsychSheetBody({
                 </div>
               </Table.Cell>
               <Table.Cell>
-                <CountryFlag iso2={registration.user.country.iso2} withoutTooltip />
+                <RegionFlag iso2={registration.user.country.iso2} withoutTooltip />
                 {' '}
                 {countries.byIso2[registration.user.country.iso2].name}
               </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
@@ -15,6 +15,7 @@ import { getPeopleCounts, getTotals, getUserPositionInfo } from './utils';
 import PreTableInfo from './PreTableInfo';
 import Loading from '../../Requests/Loading';
 import Errored from '../../Requests/Errored';
+import CountryFlag from '../../wca/CountryFlag';
 
 // for consistency with competitors table data, to reuse helper functions
 function mapPsychSheetDate(data) {
@@ -217,9 +218,8 @@ function PsychSheetBody({
                 </div>
               </Table.Cell>
               <Table.Cell>
-                <Flag
-                  className={registration.user.country.iso2.toLowerCase()}
-                />
+                <CountryFlag iso2={registration.user.country.iso2} withoutTooltip />
+                {' '}
                 {countries.byIso2[registration.user.country.iso2].name}
               </Table.Cell>
               <Table.Cell textAlign="right">

--- a/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
+++ b/app/webpacker/components/RegistrationsV2/Registrations/PsychSheet.jsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 import {
-  Flag, Icon, Segment, Table,
+  Icon, Segment, Table,
 } from 'semantic-ui-react';
 import {
   getPsychSheetForEvent,

--- a/app/webpacker/components/Results/TableCells.jsx
+++ b/app/webpacker/components/Results/TableCells.jsx
@@ -4,11 +4,12 @@ import EventIcon from '../wca/EventIcon';
 import { competitionUrl, personUrl } from '../../lib/requests/routes.js.erb';
 import { formatAttemptResult } from '../../lib/wca-live/attempts';
 import { events } from '../../lib/wca-data.js.erb';
+import CountryFlag from '../wca/CountryFlag';
 
 export function CountryCell({ country }) {
   return (
     <>
-      {country.iso2 && <Flag name={country.iso2.toLowerCase()} />}
+      {country.iso2 && <CountryFlag iso2={country.iso2} withoutTooltip />}
       {' '}
       {country.name}
     </>
@@ -42,7 +43,7 @@ export function CompetitionCell({ competition, compatIso2 }) {
 
   return (
     <>
-      <Flag name={iso2.toLowerCase()} />
+      <CountryFlag iso2={iso2} />
       {' '}
       <a href={competitionUrl(competition.id)}>{competition.cellName}</a>
     </>

--- a/app/webpacker/components/Results/TableCells.jsx
+++ b/app/webpacker/components/Results/TableCells.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flag, Table } from 'semantic-ui-react';
+import { Table } from 'semantic-ui-react';
 import EventIcon from '../wca/EventIcon';
 import { competitionUrl, personUrl } from '../../lib/requests/routes.js.erb';
 import { formatAttemptResult } from '../../lib/wca-live/attempts';

--- a/app/webpacker/components/Results/TableCells.jsx
+++ b/app/webpacker/components/Results/TableCells.jsx
@@ -4,12 +4,12 @@ import EventIcon from '../wca/EventIcon';
 import { competitionUrl, personUrl } from '../../lib/requests/routes.js.erb';
 import { formatAttemptResult } from '../../lib/wca-live/attempts';
 import { events } from '../../lib/wca-data.js.erb';
-import CountryFlag from '../wca/CountryFlag';
+import RegionFlag from '../wca/RegionFlag';
 
 export function CountryCell({ country }) {
   return (
     <>
-      {country.iso2 && <CountryFlag iso2={country.iso2} withoutTooltip />}
+      {country.iso2 && <RegionFlag iso2={country.iso2} withoutTooltip />}
       {' '}
       {country.name}
     </>
@@ -43,7 +43,7 @@ export function CompetitionCell({ competition, compatIso2 }) {
 
   return (
     <>
-      <CountryFlag iso2={iso2} />
+      <RegionFlag iso2={iso2} />
       {' '}
       <a href={competitionUrl(competition.id)}>{competition.cellName}</a>
     </>

--- a/app/webpacker/components/ResultsData/Results/ResultRow.js
+++ b/app/webpacker/components/ResultsData/Results/ResultRow.js
@@ -3,7 +3,7 @@ import { Icon, Table } from 'semantic-ui-react';
 import cn from 'classnames';
 
 import { personUrl, editResultUrl } from '../../../lib/requests/routes.js.erb';
-import CountryFlag from '../../wca/CountryFlag';
+import RegionFlag from '../../wca/RegionFlag';
 import {
   formatAttemptResult,
   formatAttemptsForResult,
@@ -36,7 +36,7 @@ function ResultRow({
         {formatAttemptResult(result.average, result.event_id)}
       </Table.Cell>
       <Table.Cell>{result.regional_average_record}</Table.Cell>
-      <Table.Cell><CountryFlag iso2={result.country_iso2} /></Table.Cell>
+      <Table.Cell><RegionFlag iso2={result.country_iso2} /></Table.Cell>
       <Table.Cell className={(result.event_id === '333mbf' || result.event_id === '333mbo') ? 'table-cell-solves-mbf' : 'table-cell-solves'}>
         {formatAttemptsForResult(result, result.event_id)}
       </Table.Cell>

--- a/app/webpacker/components/SearchWidget/CompetitionItem.js
+++ b/app/webpacker/components/SearchWidget/CompetitionItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import CountryFlag from '../wca/CountryFlag';
+import RegionFlag from '../wca/RegionFlag';
 import '../../stylesheets/search_widget/CompetitionItem.scss';
 
 function CompetitionItem({
@@ -10,7 +10,7 @@ function CompetitionItem({
     <div className="multisearch-item-competition">
       <div>{item.name}</div>
       <div className="extra-details">
-        <CountryFlag iso2={item.country_iso2} />
+        <RegionFlag iso2={item.country_iso2} />
         {`${item.city} (${item.id})`}
       </div>
     </div>

--- a/app/webpacker/components/wca/CountryFlag.js
+++ b/app/webpacker/components/wca/CountryFlag.js
@@ -3,12 +3,12 @@ import { Popup } from 'semantic-ui-react';
 import classnames from 'classnames';
 import { countries } from '../../lib/wca-data.js.erb';
 
-export default function CountryFlag({ iso2, withTooltip = true }) {
-  if (withTooltip) {
-    return <CountryFlagWithTooltip iso2={iso2} />;
+export default function CountryFlag({ iso2, withoutTooltip = false }) {
+  if (withoutTooltip) {
+    return <CountryFlagWithoutTooltip iso2={iso2} />;
   }
 
-  return <CountryFlagWithoutTooltip iso2={iso2} />;
+  return <CountryFlagWithTooltip iso2={iso2} />;
 }
 
 function CountryFlagWithTooltip({ iso2 }) {

--- a/app/webpacker/components/wca/CountryFlag.js
+++ b/app/webpacker/components/wca/CountryFlag.js
@@ -3,19 +3,14 @@ import { Popup } from 'semantic-ui-react';
 import classnames from 'classnames';
 import { countries } from '../../lib/wca-data.js.erb';
 
-/* eslint react/jsx-props-no-spreading: "off" */
-function CountryFlag({
-  iso2,
-  className,
-  ...other
-}) {
+function CountryFlag({ iso2 }) {
   return (
     <Popup
       id="resultCountryFlagTooltip"
       position="top center"
       content={countries.byIso2[iso2].name}
       trigger={(
-        <span {...other} className={classnames('fi', `fi-${iso2.toLowerCase()}`, className)} />
+        <span className={classnames('fi', `fi-${iso2.toLowerCase()}`)} />
       )}
     />
   );

--- a/app/webpacker/components/wca/CountryFlag.js
+++ b/app/webpacker/components/wca/CountryFlag.js
@@ -3,17 +3,28 @@ import { Popup } from 'semantic-ui-react';
 import classnames from 'classnames';
 import { countries } from '../../lib/wca-data.js.erb';
 
-function CountryFlag({ iso2 }) {
+export default function CountryFlag({ iso2, withTooltip = true }) {
+  if (withTooltip) {
+    return <CountryFlagWithTooltip iso2={iso2} />;
+  }
+
+  return <CountryFlagWithoutTooltip iso2={iso2} />;
+}
+
+function CountryFlagWithTooltip({ iso2 }) {
   return (
     <Popup
       id="resultCountryFlagTooltip"
       position="top center"
       content={countries.byIso2[iso2].name}
-      trigger={(
-        <span className={classnames('fi', `fi-${iso2.toLowerCase()}`)} />
-      )}
+      // trigger <CountryFlagWithoutTooltip iso2={iso2} /> doesn't work (??)
+      trigger={<span className={classnames('fi', `fi-${iso2.toLowerCase()}`)} />}
     />
   );
 }
 
-export default CountryFlag;
+function CountryFlagWithoutTooltip({ iso2 }) {
+  return (
+    <span className={classnames('fi', `fi-${iso2.toLowerCase()}`)} />
+  );
+}

--- a/app/webpacker/components/wca/RegionFlag.js
+++ b/app/webpacker/components/wca/RegionFlag.js
@@ -3,27 +3,28 @@ import { Popup } from 'semantic-ui-react';
 import classnames from 'classnames';
 import { countries } from '../../lib/wca-data.js.erb';
 
-export default function CountryFlag({ iso2, withoutTooltip = false }) {
+/** Works with countries, continents, and world. */
+export default function RegionFlag({ iso2, withoutTooltip = false }) {
   if (withoutTooltip) {
-    return <CountryFlagWithoutTooltip iso2={iso2} />;
+    return <RegionFlagWithoutTooltip iso2={iso2} />;
   }
 
-  return <CountryFlagWithTooltip iso2={iso2} />;
+  return <RegionFlagWithTooltip iso2={iso2} />;
 }
 
-function CountryFlagWithTooltip({ iso2 }) {
+function RegionFlagWithTooltip({ iso2 }) {
   return (
     <Popup
       id="resultCountryFlagTooltip"
       position="top center"
       content={countries.byIso2[iso2].name}
-      // trigger <CountryFlagWithoutTooltip iso2={iso2} /> doesn't work (??)
+      // trigger <RegionFlagWithoutTooltip iso2={iso2} /> doesn't work (??)
       trigger={<span className={classnames('fi', `fi-${iso2.toLowerCase()}`)} />}
     />
   );
 }
 
-function CountryFlagWithoutTooltip({ iso2 }) {
+function RegionFlagWithoutTooltip({ iso2 }) {
   return (
     <span className={classnames('fi', `fi-${iso2.toLowerCase()}`)} />
   );


### PR DESCRIPTION
In particular, fixes Finland flag, and show flags with tooltip for multi-country instances.

Before:
![before](https://github.com/user-attachments/assets/e12cf704-e299-490a-899a-f0017bdb52e1) ![before2](https://github.com/user-attachments/assets/6503db19-6651-4a70-8fd5-145abc2c5dfe)
After: 
![after](https://github.com/user-attachments/assets/8fafbfdd-fe98-42f1-9e2e-85ab84ef4307) ![after2](https://github.com/user-attachments/assets/18c8b22a-514a-4d5b-b5b6-ad134b435e28)

![Screenshot from 2025-02-14 19-44-18](https://github.com/user-attachments/assets/1a50a374-315e-46a1-a4b4-5f10f7b237ee)

Formerly, half our flags were using our custom `RegionFlag` (formerly named `CountryFlag`), and half were using `Flag` from Semantic UI. The former were working well, the latter were smaller, messed up Finland, and didn't show anything for multi-country regions.

I'm not sure when `comp.country_iso2` would be `null`, but I included it since there were existing `?`s.