### PR TITLE
Fix error from large partial refunds

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Button, Header, Message, Table,
 } from 'semantic-ui-react';
@@ -77,6 +77,14 @@ function RefundRow({
   refund, refundMutation, isMutating, userId, competitionId,
 }) {
   const [amountToRefund, setAmountToRefund] = useInputState(refund.ruby_amount_refundable);
+
+  // React state persists across rerenders, so `amountToRefund` would keep old values
+  // which is problematic when refunding more than 50% of the original
+  // (because then the input exceeds the new max, leading to a whole new tragedy with AN)
+  useEffect(() => {
+    setAmountToRefund((prevAmount) => Math.min(prevAmount, refund.ruby_amount_refundable));
+  }, [refund.ruby_amount_refundable, setAmountToRefund]);
+
   const confirm = useConfirm();
 
   const attemptRefund = () => confirm({

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   Button, Header, Message, Table,
 } from 'semantic-ui-react';
@@ -78,10 +78,6 @@ function RefundRow({
 }) {
   const [amountToRefund, setAmountToRefund] = useInputState(refund.ruby_amount_refundable);
   const confirm = useConfirm();
-
-  useEffect(() => {
-    setAmountToRefund(refund.ruby_amount_refundable);
-  }, [refund.ruby_amount_refundable, setAmountToRefund]);
 
   const attemptRefund = () => confirm({
     content: I18n.t('registrations.refund_confirmation'),

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Button, Header, Message, Table,
 } from 'semantic-ui-react';
@@ -78,6 +78,10 @@ function RefundRow({
 }) {
   const [amountToRefund, setAmountToRefund] = useInputState(refund.ruby_amount_refundable);
   const confirm = useConfirm();
+
+  useEffect(() => {
+    setAmountToRefund(refund.ruby_amount_refundable);
+  }, [refund.ruby_amount_refundable, setAmountToRefund]);
 
   const attemptRefund = () => confirm({
     content: I18n.t('registrations.refund_confirmation'),

--- a/app/webpacker/components/wca/FormBuilder/input/AutonumericField.js
+++ b/app/webpacker/components/wca/FormBuilder/input/AutonumericField.js
@@ -79,8 +79,16 @@ export default function AutonumericField({
   useEffect(() => {
     if (!autoNumeric) return;
 
+    // When setting values, we don't know whether this hook or the `options` hook below
+    // triggers first. Unfortunately for us, AN throws hard errors when setting some value
+    // greater than the defined max, so we have to manually work around the situation
+    // where the `max` option updates first, by just capping the value.
+    if (autoNumericOptions.maximumValue) {
+      autoNumeric.set(Math.min(autoNumericValue, autoNumericOptions.maximumValue));
+    }
+
     autoNumeric.update(autoNumericOptions);
-  }, [autoNumeric, autoNumericOptions]);
+  }, [autoNumeric, autoNumericOptions, autoNumericValue]);
 
   const onChangeAutonumeric = (event) => {
     onChange(event, { value: getCurrentUiValue() });


### PR DESCRIPTION
## Overview 

Currently, issuing a partial refund which exceeds the remainder value after the refund[1] causes an error that blocks rendering of the Refund page until refresh.

This is because the refund amount is not being updated with the refetch of the new refund data - so the new `max` value is less than the original refund value, causing an error.

```javascript
<AutonumericField
  currency={refund.currency_code.toUpperCase()}
  value={amountToRefund}
  onChange={setAmountToRefund}
  max={refund.ruby_amount_refundable}
/>
```

[1] ie, Refund amount $12 on $22 total leaves $10 remaining afterwards - $12 > $10, causing the error

## Trial and Error

First, I tried a useEffect to update the `amountToRefund` with a useEffect as follows: 
```javascript
useEffect(() => {
    setAmountToRefund(refund.ruby_amount_refundable);
  }, [refund.ruby_amount_refundable, setAmountToRefund]);
```

That hasn't worked. I'm now experimenting with "watching" other values in the useEffect to see if that might do anything