### PR TITLE
Refactor messages

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -19,7 +19,7 @@ import Processing from './Processing';
 import { contactCompetitionUrl, userPreferencesRoute } from '../../../lib/requests/routes.js.erb';
 import EventSelector from '../../wca/EventSelector';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
-import { setMessage } from './RegistrationMessage';
+import { showMessage } from './RegistrationMessage';
 import I18n from '../../../lib/i18n';
 import I18nHTMLTranslate from '../../I18nHTMLTranslate';
 import { useConfirm } from '../../../lib/providers/ConfirmProvider';
@@ -97,7 +97,7 @@ export default function CompetingStep({
     mutationFn: updateRegistration,
     onError: (data) => {
       const { error } = data.json;
-      dispatch(setMessage(
+      dispatch(showMessage(
         `competitions.registration_v2.errors.${error}`,
         'negative',
       ));
@@ -113,11 +113,11 @@ export default function CompetingStep({
       // Going from cancelled -> pending
       if (registration.competing.registration_status === 'cancelled') {
         // i18n-tasks-use t('registrations.flash.registered')
-        dispatch(setMessage('registrations.flash.registered', 'positive'));
+        dispatch(showMessage('registrations.flash.registered', 'positive'));
         // Not changing status
       } else {
         // i18n-tasks-use t('registrations.flash.updated')
-        dispatch(setMessage('registrations.flash.updated', 'positive'));
+        dispatch(showMessage('registrations.flash.updated', 'positive'));
       }
       nextStep();
     },
@@ -127,7 +127,7 @@ export default function CompetingStep({
     mutationFn: submitEventRegistration,
     onError: (data) => {
       const { error } = data.json;
-      dispatch(setMessage(
+      dispatch(showMessage(
         `competitions.registration_v2.errors.${error}`,
         'negative',
       ));
@@ -135,7 +135,7 @@ export default function CompetingStep({
     onSuccess: () => {
       // We can't update the registration yet, because there might be more steps needed
       // And the Registration might still be processing
-      dispatch(setMessage('registrations.flash.registered', 'positive'));
+      dispatch(showMessage('registrations.flash.registered', 'positive'));
       setProcessing(true);
     },
   });
@@ -153,10 +153,10 @@ export default function CompetingStep({
   const attemptAction = useCallback(
     (action, options = {}) => {
       if (options.checkForChanges && !hasChanges) {
-        dispatch(setMessage('competitions.registration_v2.update.no_changes', 'basic'));
+        dispatch(showMessage('competitions.registration_v2.update.no_changes', 'basic'));
       } else if (!eventsAreValid) {
         // i18n-tasks-use t('registrations.errors.exceeds_event_limit')
-        dispatch(setMessage(
+        dispatch(showMessage(
           maxEvents === Infinity
             ? 'registrations.errors.must_register'
             : 'registrations.errors.exceeds_event_limit.other',
@@ -196,7 +196,7 @@ export default function CompetingStep({
       content: I18n.t(competitionInfo.allow_registration_edits ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
     }).then(() => {
       if (competitionInfo.allow_registration_edits) {
-        dispatch(setMessage('competitions.registration_v2.update.being_updated', 'basic'));
+        dispatch(showMessage('competitions.registration_v2.update.being_updated', 'basic'));
         updateRegistrationMutation({
           user_id: registration.user_id,
           competition_id: competitionInfo.id,

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -13,7 +13,7 @@ import {
 } from 'semantic-ui-react';
 import { paymentFinishUrl } from '../../../lib/requests/routes.js.erb';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
-import { setMessage } from './RegistrationMessage';
+import { showMessage } from './RegistrationMessage';
 import Loading from '../../Requests/Loading';
 import I18n from '../../../lib/i18n';
 import useCheckboxState from '../../../lib/hooks/useCheckboxState';
@@ -78,7 +78,7 @@ export default function PaymentStep({
     // redirected to the `return_url`.
     if (error) {
       // i18n-tasks-use t('registrations.payment_form.errors.generic.failed')
-      dispatch(setMessage('registrations.payment_form.errors.generic.failed', 'error', {
+      dispatch(showMessage('registrations.payment_form.errors.generic.failed', 'error', {
         provider: I18n.t('payments.payment_providers.stripe'),
       }));
 

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -3,6 +3,10 @@ import React, { useEffect } from 'react';
 import { useDispatch, useStore } from '../../../lib/providers/StoreProvider';
 import I18n from '../../../lib/i18n';
 
+/**
+ * You may pass an array of keys - if so, also pass an
+ * array of params of the same length.
+ */
 export const setMessage = (key, type, params) => ({
   payload: {
     key,
@@ -33,12 +37,13 @@ export default function RegistrationMessage() {
   if (!message?.key) return null;
 
   if (Array.isArray(message.key)) {
-    return message.key.map((key) => (
+    return message.key.map((key, index) => (
       <Message
+        key={key}
         positive={message.type === 'positive'}
         negative={message.type === 'negative'}
       >
-        {I18n.t(key, message.params)}
+        {I18n.t(key, (message.params ?? [])[index] ?? {})}
       </Message>
     ));
   }

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -41,7 +41,7 @@ export default function RegistrationMessage() {
       style={{ margin: messages.length === 1 ? 0 : undefined }}
       positive={type === 'positive'}
       negative={type === 'negative'}
-      onDismiss={() => dispatch(clearMessage(id))}
+      onDismiss={type === 'negative' && (() => dispatch(clearMessage(id)))}
     >
       {I18n.t(key, params)}
     </Message>

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -12,7 +12,7 @@ export const showMessages = (messages) => ({ newMessages: messages });
 
 export const clearAllMessages = () => ({ messages: [] });
 
-// const clearMessage = (id) => ({ toClear: [id] });
+const clearMessage = (id) => ({ toClear: [id] });
 
 const clearMessages = (ids) => ({ toClear: ids });
 
@@ -33,13 +33,13 @@ export default function RegistrationMessage() {
 
   if (messages.length === 0) return null;
 
-  // TODO: allow clearing message
   return messages.map(({ id, key, type, params }) => (
     <Message
       key={id}
       style={{ margin: messages.length === 1 ? 0 : undefined }}
       positive={type === 'positive'}
       negative={type === 'negative'}
+      onDismiss={() => dispatch(clearMessage(id))}
     >
       {I18n.t(key, params)}
     </Message>

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -33,7 +33,9 @@ export default function RegistrationMessage() {
 
   if (messages.length === 0) return null;
 
-  return messages.map(({ id, key, type, params }) => (
+  return messages.map(({
+    id, key, type, params,
+  }) => (
     <Message
       key={id}
       style={{ margin: messages.length === 1 ? 0 : undefined }}

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -3,58 +3,45 @@ import React, { useEffect } from 'react';
 import { useDispatch, useStore } from '../../../lib/providers/StoreProvider';
 import I18n from '../../../lib/i18n';
 
-/**
- * You may pass an array of keys - if so, also pass an
- * array of params of the same length.
- */
-export const setMessage = (key, type, params) => ({
-  payload: {
-    key,
-    type,
-    params,
-  },
+/** To show multiple messages, use `showMessages` instead. */
+export const showMessage = (key, type, params) => ({
+  newMessages: [{ key, type, params }],
 });
 
-export const clearMessage = () => ({
-  payload: {
-    message: null,
-  },
-});
+export const showMessages = (messages) => ({ newMessages: messages });
+
+export const clearAllMessages = () => ({ messages: [] });
+
+// const clearMessage = (id) => ({ toClear: [id] });
+
+const clearMessages = (ids) => ({ toClear: ids });
 
 export default function RegistrationMessage() {
-  const { message } = useStore();
+  const { messages } = useStore();
   const dispatch = useDispatch();
 
+  const positiveMessages = messages.filter(({ type }) => type === 'positive');
+
   useEffect(() => {
-    // Don't clear negative Messages automatically
-    if (message?.key && message.type !== 'negative') {
+    if (positiveMessages.length > 0) {
       setTimeout(() => {
-        dispatch({ payload: { message: null } });
+        // some may already be cleared by an earlier timeout; that's fine
+        dispatch(clearMessages(positiveMessages.map(({ id }) => id)));
       }, 4000);
     }
-  }, [dispatch, message]);
+  }, [dispatch, positiveMessages]);
 
-  if (!message?.key) return null;
+  if (messages.length === 0) return null;
 
-  if (Array.isArray(message.key)) {
-    return message.key.map((key, index) => (
-      <Message
-        key={key}
-        positive={message.type === 'positive'}
-        negative={message.type === 'negative'}
-      >
-        {I18n.t(key, (message.params ?? [])[index] ?? {})}
-      </Message>
-    ));
-  }
-
-  return (
+  // TODO: allow clearing message
+  return messages.map(({ id, key, type, params }) => (
     <Message
-      style={{ margin: 0 }}
-      positive={message.type === 'positive'}
-      negative={message.type === 'negative'}
+      key={id}
+      style={{ margin: messages.length === 1 ? 0 : undefined }}
+      positive={type === 'positive'}
+      negative={type === 'negative'}
     >
-      {I18n.t(message.key, message.params)}
+      {I18n.t(key, params)}
     </Message>
-  );
+  ));
 }

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationMessage.jsx
@@ -20,16 +20,16 @@ export default function RegistrationMessage() {
   const { messages } = useStore();
   const dispatch = useDispatch();
 
-  const positiveMessages = messages.filter(({ type }) => type === 'positive');
+  const nonNegativeMessages = messages.filter(({ type }) => type !== 'negative');
 
   useEffect(() => {
-    if (positiveMessages.length > 0) {
+    if (nonNegativeMessages.length > 0) {
       setTimeout(() => {
         // some may already be cleared by an earlier timeout; that's fine
-        dispatch(clearMessages(positiveMessages.map(({ id }) => id)));
+        dispatch(clearMessages(nonNegativeMessages.map(({ id }) => id)));
       }, 4000);
     }
-  }, [dispatch, positiveMessages]);
+  }, [dispatch, nonNegativeMessages]);
 
   if (messages.length === 0) return null;
 

--- a/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/RegistrationOverview.jsx
@@ -8,7 +8,7 @@ import EventIcon from '../../wca/EventIcon';
 import { hasPassed } from '../../../lib/utils/dates';
 import { events } from '../../../lib/wca-data.js.erb';
 import updateRegistration from '../api/registration/patch/update_registration';
-import { setMessage } from './RegistrationMessage';
+import { showMessage } from './RegistrationMessage';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import { contactCompetitionUrl } from '../../../lib/requests/routes.js.erb';
@@ -41,7 +41,7 @@ export default function RegistrationOverview({
     }),
     onError: (data) => {
       const { error } = data.json;
-      dispatch(setMessage(
+      dispatch(showMessage(
         `competitions.registration_v2.errors.${error}`,
         'negative',
       ));
@@ -55,7 +55,7 @@ export default function RegistrationOverview({
           payment: registration.payment,
         },
       );
-      dispatch(setMessage('competitions.registration_v2.register.registration_status.cancelled', 'positive'));
+      dispatch(showMessage('competitions.registration_v2.register.registration_status.cancelled', 'positive'));
     },
   });
 

--- a/app/webpacker/components/RegistrationsV2/Register/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/index.jsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import StepPanel from './StepPanel';
 import { getSingleRegistration } from '../api/registration/get/get_registrations';
 import Loading from '../../Requests/Loading';
-import RegistrationMessage, { setMessage } from './RegistrationMessage';
+import RegistrationMessage, { showMessage } from './RegistrationMessage';
 import StoreProvider, { useDispatch } from '../../../lib/providers/StoreProvider';
 import messageReducer from '../reducers/messageReducer';
 import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvider';
@@ -30,7 +30,7 @@ export default function Index({
 }) {
   return (
     <WCAQueryClientProvider>
-      <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
+      <StoreProvider reducer={messageReducer} initialState={{ messages: [] }}>
         <ConfirmProvider>
           <Register
             competitionInfo={competitionInfo}
@@ -69,7 +69,7 @@ function Register({
     queryFn: () => getSingleRegistration(userInfo.id, competitionInfo),
     onError: (data) => {
       const { error } = data.json;
-      dispatch(setMessage(
+      dispatch(showMessage(
         `competitions.registration_v2.errors.${error}`,
         'negative',
       ));

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -3,7 +3,7 @@ import {
 } from 'semantic-ui-react';
 import React from 'react';
 import { Draggable } from 'react-beautiful-dnd';
-import { setMessage } from '../Register/RegistrationMessage';
+import { showMessage } from '../Register/RegistrationMessage';
 import I18n from '../../../lib/i18n';
 import {
   getRegistrationTimestamp,
@@ -85,7 +85,7 @@ export default function TableRow({
 
   const copyEmail = () => {
     navigator.clipboard.writeText(emailAddress);
-    setMessage('Copied email address to clipboard.', 'positive');
+    showMessage('Copied email address to clipboard.', 'positive');
   };
   /* eslint-disable react/jsx-props-no-spreading */
   return (

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Icon } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
-import { setMessage } from '../Register/RegistrationMessage';
+import { showMessage } from '../Register/RegistrationMessage';
 import I18n from '../../../lib/i18n';
 import { countries } from '../../../lib/wca-data.js.erb';
 
@@ -80,7 +80,7 @@ export default function RegistrationActions({
       },
       {
         onSuccess: () => {
-          dispatch(setMessage('registrations.flash.updated', 'positive'));
+          dispatch(showMessage('registrations.flash.updated', 'positive'));
           refresh();
         },
       },
@@ -108,7 +108,7 @@ export default function RegistrationActions({
   const attemptToApprove = () => {
     const idsToAccept = [...pending, ...cancelled, ...waiting, ...rejected];
     if (idsToAccept.length > spotsRemaining) {
-      dispatch(setMessage(
+      dispatch(showMessage(
         'competitions.registration_v2.update.too_many',
         'negative',
         {
@@ -122,7 +122,7 @@ export default function RegistrationActions({
 
   const copyEmails = (emails) => {
     navigator.clipboard.writeText(emails);
-    dispatch(setMessage('competitions.registration_v2.update.email_message', 'positive'));
+    dispatch(showMessage('competitions.registration_v2.update.email_message', 'positive'));
   };
 
   return (

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -87,12 +87,6 @@ const partitionRegistrations = (registrations) => registrations.reduce(
   },
 );
 
-const getUserName = (registrations, userId) => {
-  const registration = registrations.find(({ user_id: id }) => id === userId);
-  if (!registration) return null;
-  return registration.user.name;
-};
-
 const expandableColumns = {
   dob: I18n.t('activerecord.attributes.user.dob'),
   region: I18n.t('activerecord.attributes.user.region'),
@@ -169,11 +163,10 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
     onError: (data) => {
       const { error } = data.json;
       dispatchStore(showMessages(
-        Object.entries(error).map(([userId, err]) => (
+        Object.values(error).map((err) => (
           {
             key: `competitions.registration_v2.errors.${err}`,
             type: 'negative',
-            params: { name: getUserName(registrations, Number(userId)) ?? userId },
           }
         )),
       ));

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -87,6 +87,12 @@ const partitionRegistrations = (registrations) => registrations.reduce(
   },
 );
 
+const getUserName = (registrations, userId) => {
+  const registration = registrations.find(({ user_id }) => user_id === userId);
+  if (!registration) return null;
+  return registration.user.name;
+}
+
 const expandableColumns = {
   dob: I18n.t('activerecord.attributes.user.dob'),
   region: I18n.t('activerecord.attributes.user.region'),
@@ -165,6 +171,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
       dispatchStore(setMessage(
         Object.values(error).map((err) => `competitions.registration_v2.errors.${err}`),
         'negative',
+        Object.keys(error).map((userId) => ({ name: getUserName(registrations, Number(userId)) ?? userId })),
       ));
     },
     onSuccess: async () => {

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -9,7 +9,7 @@ import { DateTime } from 'luxon';
 import { getAllRegistrations } from '../api/registration/get/get_registrations';
 import createSortReducer from '../reducers/sortReducer';
 import RegistrationActions from './RegistrationActions';
-import { setMessage } from '../Register/RegistrationMessage';
+import { showMessage, showMessages } from '../Register/RegistrationMessage';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import I18n from '../../../lib/i18n';
 import Loading from '../../Requests/Loading';
@@ -155,7 +155,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
     retry: false,
     onError: (err) => {
       const { errorCode } = err;
-      dispatchStore(setMessage(
+      dispatchStore(showMessage(
         errorCode
           ? `competitions.registration_v2.errors.${errorCode}`
           : 'registrations.flash.failed',
@@ -168,10 +168,14 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
     mutationFn: bulkUpdateRegistrations,
     onError: (data) => {
       const { error } = data.json;
-      dispatchStore(setMessage(
-        Object.values(error).map((err) => `competitions.registration_v2.errors.${err}`),
-        'negative',
-        Object.keys(error).map((userId) => ({ name: getUserName(registrations, Number(userId)) ?? userId })),
+      dispatchStore(showMessages(
+        Object.entries(error).map(([userId, err]) => (
+          {
+            key: `competitions.registration_v2.errors.${err}`,
+            type: 'negative',
+            params: { name: getUserName(registrations, Number(userId)) ?? userId },
+          }
+        ))
       ));
     },
     onSuccess: async () => {

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -88,10 +88,10 @@ const partitionRegistrations = (registrations) => registrations.reduce(
 );
 
 const getUserName = (registrations, userId) => {
-  const registration = registrations.find(({ user_id }) => user_id === userId);
+  const registration = registrations.find(({ user_id: id }) => id === userId);
   if (!registration) return null;
   return registration.user.name;
-}
+};
 
 const expandableColumns = {
   dob: I18n.t('activerecord.attributes.user.dob'),
@@ -175,7 +175,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
             type: 'negative',
             params: { name: getUserName(registrations, Number(userId)) ?? userId },
           }
-        ))
+        )),
       ));
     },
     onSuccess: async () => {

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
@@ -11,7 +11,7 @@ export default function RegistrationEdit({ competitionInfo }) {
   return (
     <div ref={ref}>
       <WCAQueryClientProvider>
-        <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
+        <StoreProvider reducer={messageReducer} initialState={{ messages: [] }}>
           <Sticky context={ref} offset={60}>
             <RegistrationMessage />
           </Sticky>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -15,7 +15,7 @@ import {
 import { getSingleRegistration } from '../api/registration/get/get_registrations';
 import updateRegistration from '../api/registration/patch/update_registration';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
-import { setMessage } from '../Register/RegistrationMessage';
+import { showMessage } from '../Register/RegistrationMessage';
 import Loading from '../../Requests/Loading';
 import EventSelector from '../../wca/EventSelector';
 import Refunds from './Refunds';
@@ -59,7 +59,7 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
     mutationFn: updateRegistration,
     onError: (data) => {
       const { error } = data.json;
-      dispatch(setMessage(
+      dispatch(showMessage(
         `competitions.registration_v2.errors.${error}`,
         'negative',
       ));
@@ -74,10 +74,10 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
       );
       // Going from cancelled -> pending
       if (registration.competing.registration_status === 'cancelled') {
-        dispatch(setMessage('registrations.flash.registered', 'positive'));
+        dispatch(showMessage('registrations.flash.registered', 'positive'));
         // Not changing status
       } else {
-        dispatch(setMessage('registrations.flash.updated', 'positive'));
+        dispatch(showMessage('registrations.flash.updated', 'positive'));
       }
     },
   });
@@ -115,20 +115,20 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
 
   const handleRegisterClick = useCallback(() => {
     if (!hasChanges) {
-      dispatch(setMessage('competitions.registration_v2.update.no_changes', 'basic'));
+      dispatch(showMessage('competitions.registration_v2.update.no_changes', 'basic'));
     } else if (!commentIsValid) {
       // i18n-tasks-use t('registrations.errors.cannot_register_without_comment')
-      dispatch(setMessage('registrations.errors.cannot_register_without_comment', 'negative'));
+      dispatch(showMessage('registrations.errors.cannot_register_without_comment', 'negative'));
     } else if (!eventsAreValid) {
       // i18n-tasks-use t('registrations.errors.must_register')
-      dispatch(setMessage(
+      dispatch(showMessage(
         maxEvents === Infinity
           ? 'registrations.errors.must_register'
           : 'registrations.errors.exceeds_event_limit.other',
         'negative',
       ));
     } else {
-      dispatch(setMessage('competitions.registration_v2.update.being_updated', 'positive'));
+      dispatch(showMessage('competitions.registration_v2.update.being_updated', 'positive'));
       // Only send changed values
       const body = {
         user_id: competitor.id,

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
@@ -12,7 +12,7 @@ export default function RegistrationEdit({ competitionInfo, user }) {
   return (
     <div ref={ref}>
       <WCAQueryClientProvider>
-        <StoreProvider reducer={messageReducer} initialState={{ message: null }}>
+        <StoreProvider reducer={messageReducer} initialState={{ messages: [] }}>
           <ConfirmProvider>
             <Sticky context={ref}>
               <RegistrationMessage />

--- a/app/webpacker/components/RegistrationsV2/reducers/messageReducer.jsx
+++ b/app/webpacker/components/RegistrationsV2/reducers/messageReducer.jsx
@@ -1,5 +1,6 @@
 const messageReducer = (state, { messages, newMessages, toClear }) => {
-  const nextId = state.nextId ?? 0
+  const nextId = state.nextId ?? 0;
+
   // overwrite existing messages
   if (messages) {
     const messagesWithId = messages.map((message, index) => (
@@ -16,7 +17,7 @@ const messageReducer = (state, { messages, newMessages, toClear }) => {
   if (newMessages) {
     const newMessagesWithId = newMessages.map((message, index) => (
       { ...message, id: nextId + index }
-    ))
+    ));
     return {
       ...state,
       messages: [...state.messages, ...newMessagesWithId],

--- a/app/webpacker/components/RegistrationsV2/reducers/messageReducer.jsx
+++ b/app/webpacker/components/RegistrationsV2/reducers/messageReducer.jsx
@@ -1,6 +1,36 @@
-const messageReducer = (state, { payload }) => ({
-  ...state,
-  message: { key: payload.key, type: payload.type, params: payload.params },
-});
+const messageReducer = (state, { messages, newMessages, toClear }) => {
+  const nextId = state.nextId ?? 0
+  // overwrite existing messages
+  if (messages) {
+    const messagesWithId = messages.map((message, index) => (
+      { ...message, id: nextId + index }
+    ));
+    return {
+      ...state,
+      messages: messagesWithId,
+      nextId: nextId + messages.length,
+    };
+  }
+
+  // append new messages to existing messages
+  if (newMessages) {
+    const newMessagesWithId = newMessages.map((message, index) => (
+      { ...message, id: nextId + index }
+    ))
+    return {
+      ...state,
+      messages: [...state.messages, ...newMessagesWithId],
+      nextId: nextId + newMessages.length,
+    };
+  }
+
+  // clear certain messages
+  if (toClear) {
+    const filteredMessages = state.messages.filter(({ id }) => !toClear.includes(id));
+    return { ...state, messages: filteredMessages };
+  }
+
+  return state;
+};
 
 export default messageReducer;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1909,7 +1909,7 @@ en:
         -2003: "You don't have the permissions to complete this action"
         -2004: "You are not allowed to register, as the organizers have rejected your registration. Please contact them if you think there has been a mistake."
         -3000: "Registration does not exist"
-        -3001: "You have already registered for another Competition in the series"
+        -3001: "%{name} has already registered for another Competition in the series."
         -4000: "The Request contains invalid data"
         -4001: "The event edit deadline has passed"
         -4002: "The number of guests are over the allowed limit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1909,7 +1909,7 @@ en:
         -2003: "You don't have the permissions to complete this action"
         -2004: "You are not allowed to register, as the organizers have rejected your registration. Please contact them if you think there has been a mistake."
         -3000: "Registration does not exist"
-        -3001: "%{name} has already registered for another Competition in the series."
+        -3001: "You have already registered for another Competition in the series"
         -4000: "The Request contains invalid data"
         -4001: "The event edit deadline has passed"
         -4002: "The number of guests are over the allowed limit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1079,7 +1079,7 @@ en:
         failure: "Couldn't verify your identity"
         confirm_proceed: "Confirm and proceed"
         identity_error: "Cannot edit your data. Please confirm your identity below before trying again."
-    #context: when an error occured during the edition
+    #context: when an error occurred during the edition
     errors:
       not_found: "not found"
       already_assigned: "already assigned to a different user"
@@ -1799,7 +1799,7 @@ en:
             allow_registration_without:
               "true": "Competitors will be allowed to register for events they're not qualified for (I'll remove them later)"
               "false": "Competitors MUST be qualified to register for an event"
-        #context: new registration system
+    #context: new registration system
     registration_v2:
       pdf:
         #context: <0> indicates an html tag for internationalizing in React, see https://docs.worldcubeassociation.org/guides/translating_the_website.html#using-react
@@ -1926,7 +1926,7 @@ en:
         -4014: "You are already registered for this competition."
         -6001: "WCA Payment is not enabled for this competition"
         -6002: "You need to finish your registration before you can pay"
-    #context: and when an error occured
+    #context: and when an error occurred
     errors:
       invalid_name_message: "must end with a year and must contain only alphanumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )"
       cannot_manage: "Cannot manage competition."


### PR DESCRIPTION
~**I've marked this as a draft, and need input from people who are more familiar with the back-end/error messages.**~

The main work here is refactoring the message reducer/UI to be more general: when a new message is shown it's added to the existing messages instead of replacing them, positive messages are cleared after 4 seconds (regardless of new messages appearing), and messages are dismissable.

~Using this, in the registration admin lists I added the user's name to the error message. I'm not very confident in this part as I changed an error message - I don't know if that error message might show up somewhere else and would no longer make sense, and I don't know if/which other messages might show up here and will also need adjusting. But hopefully this is the right direction to go.~

Edit: Note that all of the error messages are written as if being shown directly to a competitor registering - e.g. use "you" - but many also appear when an organizer/delegate is handling registrations, in which case this doesn't make sense. Hopefully this can also be cleared up in this PR.

If modifying the error messages to include the name is not appropriate, then I could instead modify the message reducer to consume a string instead of an id, and add the name in manually (i.e. `'${I18n.t(errorMessage)} (${userName})'` or something.

Edit: Done. ~Edit: If this is going to take time, I could remove showing the user name/string edits, and just make this PR be the message logic refactoring.~

[Screencast from 2025-02-17 09:48:02 PM.webm](https://github.com/user-attachments/assets/c31474ea-cad1-4839-84f2-bcadab483ce8)
