### PR TITLE
Ensure auxiliary services are redeployed after migrations are run

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -29,8 +29,3 @@ jobs:
           environment: production
           build_tag: ${{ env.SHORT_SHA }}
           registry: ${{ steps.login-ecr.outputs.registry }}/wca-on-rails
-        # Replace the old sidekiq image with the new one
-      - name: Deploy Sidekiq and sqs worker
-        run: |
-          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-prod-auxiliary-services --force-new-deployment
-          aws ecs update-service --cluster wca-on-rails --service wca-on-rails-prod-sqs-worker --force-new-deployment

--- a/infra/wca_on_rails/production/pipeline.tf
+++ b/infra/wca_on_rails/production/pipeline.tf
@@ -287,7 +287,61 @@ resource "aws_codepipeline" "this" {
       }
     }
   }
+
+  stage {
+    name = "Trigger Auxiliary Service Update"
+
+    action {
+      name     = "update-ecs-services"
+      category = "Build"
+      owner    = "AWS"
+      provider = "CodeBuild"
+      version  = "1"
+
+      input_artifacts = []
+
+      configuration = {
+        ProjectName = aws_codebuild_project.ecs_update_services.name
+      }
+    }
+  }
 }
+
+resource "aws_codebuild_project" "ecs_update_services" {
+  name          = "${var.name_prefix}-ecs-update-services"
+  service_role  = aws_iam_role.codepipeline_role.arn
+  build_timeout = "5"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:6.0"
+    type                        = "LINUX_CONTAINER"
+    privileged_mode             = false
+
+    environment_variable {
+      name  = "CLUSTER_NAME"
+      value = "wca-on-rails"
+    }
+  }
+
+  source {
+    type     = "NO_SOURCE"
+    buildspec = <<EOF
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - aws ecs update-service --cluster $CLUSTER_NAME --service wca-on-rails-prod-auxiliary-services --force-new-deployment
+      - aws ecs update-service --cluster $CLUSTER_NAME --service wca-on-rails-prod-sqs-worker --force-new-deployment
+EOF
+  }
+}
+
 
 resource "aws_cloudwatch_event_rule" "ecr_image_push" {
   name     = "${var.name_prefix}-ecr-image-push"


### PR DESCRIPTION
My idea to fix any race conditions between the main rails server and our auxiliary services that rely on the same database (but don't run migrations themselves as they only run purpose build processes).

Another solution would be to actually run migrations on sidekiq or the sqs worker as part of a docker entrypoint, but not sure if that could be risky 