### PR TITLE
Reg admin toggles: 2 per row on mobile

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -501,17 +501,16 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
   return (
     <Segment loading={isMutating} style={{ overflowX: 'scroll' }}>
       <Form>
-        <Form.Group widths="equal">
+        <Form.Group unstackable widths="2">
           {Object.entries(expandableColumns).map(([id, name]) => (
-            <Form.Field key={id}>
-              <Checkbox
-                name={id}
-                label={name}
-                toggle
-                checked={expandedColumns[id]}
-                onChange={() => dispatchColumns({ column: id })}
-              />
-            </Form.Field>
+            <Form.Checkbox
+              key={id}
+              name={id}
+              label={name}
+              toggle
+              checked={expandedColumns[id]}
+              onChange={() => dispatchColumns({ column: id })}
+            />
           ))}
         </Form.Group>
       </Form>


### PR DESCRIPTION
I can't figure out how to make it dynamic - 3 would fit in landscape (but not portrait). Before/after:

![b1](https://github.com/user-attachments/assets/3b82707c-f3f5-45c6-86ca-a13ac2563b0a) ![a1](https://github.com/user-attachments/assets/9f501a1a-ffa5-4904-84ad-e380cff418f7)

![b2](https://github.com/user-attachments/assets/e8e4e36a-68f5-4ebf-9590-9f3045040edc) ![a2](https://github.com/user-attachments/assets/a1b94bba-eeca-4130-8a47-d4c69a6b3f78)

![b3](https://github.com/user-attachments/assets/99041bda-7468-4a76-bbe4-a2bc03e7fcdd) ![a3](https://github.com/user-attachments/assets/e5d5a623-1c53-4b4c-83f9-21acb2a2582f)

Alternatively, switch to checkboxes and do 3 per row - I don't like it:
![alt](https://github.com/user-attachments/assets/42ba6f98-965c-4c16-9e95-044c7f7c10c5)

You can also make them `inline`, but then there's 0 padding/margin and they're way too close - but they do take up much less space. (Didn't take a screenshot.)

