### PR TITLE
Reg Admin: Make individual tables scrollable instead of whole panel

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -499,7 +499,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
   );
 
   return (
-    <Segment loading={isMutating} style={{ overflowX: 'scroll' }}>
+    <Segment loading={isMutating}>
       <Form>
         <Form.Group widths="equal">
           {Object.entries(expandableColumns).map(([id, name]) => (

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationsAdministrationTable.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationsAdministrationTable.jsx
@@ -43,59 +43,61 @@ export default function RegistrationAdministrationTable({
   // TODO: use native ref= when we switch to semantic v3
   /* eslint-disable react/jsx-props-no-spreading */
   return (
-    <Table
-      sortable={sortable}
-      striped
-      unstackable
-      compact
-      singleLine
-      textAlign="left"
-      color={color}
-    >
-      <TableHeader
-        columnsExpanded={columnsExpanded}
-        isChecked={registrations.length === selected.length}
-        onCheckboxChanged={handleHeaderCheck}
-        sortDirection={sortDirection}
-        sortColumn={sortColumn}
-        changeSortColumn={changeSortColumn}
-        competitionInfo={competitionInfo}
-        withCheckbox={!draggable}
-        withPosition={withPosition}
-      />
-
-      <DragDropContext onDragEnd={handleOnDragEnd}>
-        <Droppable droppableId="droppable-table">
-          {(providedDroppable) => (
-            <Ref innerRef={providedDroppable.innerRef}>
-              <Table.Body {...providedDroppable.droppableProps}>
-                {registrations.map((w, i) => (
-                  <TableRow
-                    competitionInfo={competitionInfo}
-                    columnsExpanded={columnsExpanded}
-                    registration={w}
-                    onCheckboxChange={() => onToggle(w.user.id)}
-                    index={i}
-                    draggable={draggable}
-                    isSelected={selected.includes(w.user.id)}
-                    withPosition={withPosition}
-                    color={color}
-                  />
-                ))}
-                {providedDroppable.placeholder}
-              </Table.Body>
-            </Ref>
-          )}
-        </Droppable>
-      </DragDropContext>
-      <TableFooter>
-        <RegistrationAdministrationTableFooter
+    <div style={{ overflowX: 'scroll' }}>
+      <Table
+        sortable={sortable}
+        striped
+        unstackable
+        compact
+        singleLine
+        textAlign="left"
+        color={color}
+      >
+        <TableHeader
           columnsExpanded={columnsExpanded}
-          registrations={registrations}
+          isChecked={registrations.length === selected.length}
+          onCheckboxChanged={handleHeaderCheck}
+          sortDirection={sortDirection}
+          sortColumn={sortColumn}
+          changeSortColumn={changeSortColumn}
           competitionInfo={competitionInfo}
+          withCheckbox={!draggable}
           withPosition={withPosition}
         />
-      </TableFooter>
-    </Table>
+
+        <DragDropContext onDragEnd={handleOnDragEnd}>
+          <Droppable droppableId="droppable-table">
+            {(providedDroppable) => (
+              <Ref innerRef={providedDroppable.innerRef}>
+                <Table.Body {...providedDroppable.droppableProps}>
+                  {registrations.map((w, i) => (
+                    <TableRow
+                      competitionInfo={competitionInfo}
+                      columnsExpanded={columnsExpanded}
+                      registration={w}
+                      onCheckboxChange={() => onToggle(w.user.id)}
+                      index={i}
+                      draggable={draggable}
+                      isSelected={selected.includes(w.user.id)}
+                      withPosition={withPosition}
+                      color={color}
+                    />
+                  ))}
+                  {providedDroppable.placeholder}
+                </Table.Body>
+              </Ref>
+            )}
+          </Droppable>
+        </DragDropContext>
+        <TableFooter>
+          <RegistrationAdministrationTableFooter
+            columnsExpanded={columnsExpanded}
+            registrations={registrations}
+            competitionInfo={competitionInfo}
+            withPosition={withPosition}
+          />
+        </TableFooter>
+      </Table>
+    </div>
   );
 }


### PR DESCRIPTION
### Reviewers: Use the "Hide Whitespace" feature please. It will make it 1000x more obvious what's going on

I noticed this while playing around with https://github.com/thewca/worldcubeassociation.org/pull/10921. On mobile, the reg tables are (almost) always too wide, but the `overflowX` property is set on the parent `Segment` component of the whole panel.

## Before
https://github.com/user-attachments/assets/a11850af-c9a0-46d8-b571-5d10b03a28ce

## After
https://github.com/user-attachments/assets/7cad2fbf-0c94-4e03-bbc1-6c53c0f20c05