### PR TITLE
Allow 5 minutes for sidekiq to finish when redeploying

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,3 +6,4 @@
 development:
   :concurrency: 5
   :verbose: true
+:timeout: 300

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,4 +6,5 @@
 development:
   :concurrency: 5
   :verbose: true
+# The time that Sidekiq waits after a TERM for jobs to finish see https://github.com/sidekiq/sidekiq/blob/11e23346a719fbed5052cf8c058845e13ce14808/lib/sidekiq/launcher.rb#L58
 :timeout: 300

--- a/infra/wca_on_rails/production/auxiliary_services.tf
+++ b/infra/wca_on_rails/production/auxiliary_services.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "auxiliary" {
           awslogs-stream-prefix = var.name_prefix
         }
       }
-      environment = local.rails_environment
+      environment = concat(local.rails_environment, local.sidekiq_environment)
       healthCheck       = {
         command            = ["CMD-SHELL", "pgrep ruby || exit 1"]
         interval           = 30

--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -6,7 +6,7 @@ locals {
   sidekiq_environment = [
     {
       "name" = "ECS_CONTAINER_STOP_TIMEOUT"
-      "value" = "300"
+      "value" = "305"
     },
   ]
   rails_environment = [

--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -3,6 +3,12 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 locals {
+  sidekiq_environment = [
+    {
+      "name" = "ECS_CONTAINER_STOP_TIMEOUT"
+      "value" = "300"
+    },
+  ]
   rails_environment = [
     {
       name  = "WCA_LIVE_SITE"


### PR DESCRIPTION
Will need to force a long running job on local to test, but it seems to work?
I made up the 5 minutes, but sounds reasonable