### PR TITLE
Fix the anonymization script issue for access grants

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1503,7 +1503,7 @@ class User < ApplicationRecord
 
   def anonymization_checks_with_message_args
     access_grants = oauth_access_grants
-                    .select { |access_grant| !access_grant.revoked_at.nil? }
+                    .where.not(revoked_at: nil)
                     .map do |access_grant|
                       access_grant.as_json(
                         include: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1502,7 +1502,22 @@ class User < ApplicationRecord
   end
 
   def anonymization_checks_with_message_args
-    access_grants = oauth_access_grants&.select { |access_grant| !access_grant.revoked_at.nil? }
+    access_grants = oauth_access_grants
+                    .select { |access_grant| !access_grant.revoked_at.nil? }
+                    .map do |access_grant|
+                      access_grant.as_json(
+                        include: {
+                          application: {
+                            only: [:name, :redirect_uri],
+                            include: {
+                              owner: {
+                                only: [:name, :email],
+                              },
+                            },
+                          },
+                        },
+                      )
+                    end
 
     [
       {
@@ -1513,6 +1528,7 @@ class User < ApplicationRecord
       },
       {
         access_grants: access_grants,
+        oauth_applications: oauth_applications,
       },
     ]
   end


### PR DESCRIPTION
This PR is to fix the issue where the anonymization script UI breaks as it was trying to access `application` of `access_grants` ([code link](https://github.com/thewca/worldcubeassociation.org/blob/a0ae42f8c3d51baf3da60af46b3a2e5d2fae8efb/app/webpacker/components/Tickets/TicketWorkbenches/AnonymizationTicketWorkbenchForWrt/index.jsx#L185C29-L185C40)).

I am not sure if this fix will work, I couldn't test it in local as I don't have any idea how to populate access grants.