### PR TITLE
Added method competition_list_from_string back (hotfix)

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -382,6 +382,10 @@ class AdminController < ApplicationController
     Competition.includes(associations).find_by_id!(params[:competition_id])
   end
 
+  private def competition_list_from_string(competition_ids_string)
+    competition_ids_string.split(',').uniq.compact
+  end
+
   def complete_persons
     @competition_ids_string = params.fetch(:competition_ids, "")
     @competition_ids = competition_list_from_string(@competition_ids_string)


### PR DESCRIPTION
I added this method in https://github.com/thewca/worldcubeassociation.org/pull/10732 but accidentally removed in https://github.com/thewca/worldcubeassociation.org/pull/10654 during rebase. 