### PR TITLE
Reg admin column sorting

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
@@ -64,7 +64,12 @@ export default function TableHeader({
             >
               {I18n.t('registrations.list.registered.with_stripe')}
             </Table.HeaderCell>
-            <Table.HeaderCell disabled>{I18n.t('competitions.registration_v2.update.amount')}</Table.HeaderCell>
+            <Table.HeaderCell
+              sorted={sortColumn === 'amount' ? sortDirection : undefined}
+              onClick={() => changeSortColumn('amount')}
+            >
+              {I18n.t('competitions.registration_v2.update.amount')}
+            </Table.HeaderCell>
           </>
         ) : (
           <Table.HeaderCell

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
@@ -81,7 +81,11 @@ export default function TableHeader({
         )}
         {eventsAreExpanded ? (
           competitionInfo.event_ids.map((eventId) => (
-            <Table.HeaderCell key={`event-${eventId}`} disabled>
+            <Table.HeaderCell
+              key={`event-${eventId}`}
+              sorted={sortColumn === eventId ? sortDirection : undefined}
+              onClick={() => changeSortColumn(eventId)}
+            >
               <EventIcon id={eventId} size="1em" />
             </Table.HeaderCell>
           ))

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
@@ -21,15 +21,15 @@ export default function TableHeader({
   return (
     <Table.Header>
       <Table.Row>
-        <Table.HeaderCell>
+        <Table.HeaderCell disabled>
           {withCheckbox && (
             <Checkbox checked={isChecked} onChange={onCheckboxChanged} />
           )}
         </Table.HeaderCell>
         {withPosition && (
-          <Table.HeaderCell>#</Table.HeaderCell>
+          <Table.HeaderCell disabled>#</Table.HeaderCell>
         )}
-        <Table.HeaderCell />
+        <Table.HeaderCell disabled />
         <Table.HeaderCell
           sorted={sortColumn === 'wca_id' ? sortDirection : undefined}
           onClick={() => changeSortColumn('wca_id')}
@@ -64,7 +64,7 @@ export default function TableHeader({
             >
               {I18n.t('registrations.list.registered.with_stripe')}
             </Table.HeaderCell>
-            <Table.HeaderCell>{I18n.t('competitions.registration_v2.update.amount')}</Table.HeaderCell>
+            <Table.HeaderCell disabled>{I18n.t('competitions.registration_v2.update.amount')}</Table.HeaderCell>
           </>
         ) : (
           <Table.HeaderCell
@@ -76,7 +76,7 @@ export default function TableHeader({
         )}
         {eventsAreExpanded ? (
           competitionInfo.event_ids.map((eventId) => (
-            <Table.HeaderCell key={`event-${eventId}`}>
+            <Table.HeaderCell key={`event-${eventId}`} disabled>
               <EventIcon id={eventId} size="1em" />
             </Table.HeaderCell>
           ))
@@ -104,12 +104,12 @@ export default function TableHeader({
             >
               {I18n.t('activerecord.attributes.registration.comments')}
             </Table.HeaderCell>
-            <Table.HeaderCell>
+            <Table.HeaderCell disabled>
               {I18n.t('activerecord.attributes.registration.administrative_notes')}
             </Table.HeaderCell>
           </>
         )}
-        <Table.HeaderCell>{I18n.t('registrations.list.email')}</Table.HeaderCell>
+        <Table.HeaderCell disabled>{I18n.t('registrations.list.email')}</Table.HeaderCell>
       </Table.Row>
     </Table.Header>
   );

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -32,6 +32,7 @@ const sortReducer = createSortReducer([
   'country',
   'paid_on_with_registered_on_fallback',
   'registered_on',
+  'amount',
   'events',
   'guests',
   'paid_on',
@@ -166,6 +167,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
         switch (sortColumn) {
           case 'name':
             return a.user.name.localeCompare(b.user.name);
+
           case 'wca_id': {
             const aHasAccount = a.user.wca_id !== null;
             const bHasAccount = b.user.wca_id !== null;
@@ -180,23 +182,29 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
             }
             return a.user.wca_id.localeCompare(b.user.wca_id);
           }
+
           case 'country':
             return countries.byIso2[a.user.country.iso2].name
               .localeCompare(countries.byIso2[b.user.country.iso2].name);
+
           case 'events':
             return a.competing.event_ids.length - b.competing.event_ids.length;
+
           case 'guests':
             return a.guests - b.guests;
+
           case 'dob':
             return DateTime.fromISO(a.user.dob).toMillis()
               - DateTime.fromISO(b.user.dob).toMillis();
+
           case 'comment':
             return a.competing.comment.localeCompare(b.competing.comment);
+
           case 'registered_on':
             return DateTime.fromISO(a.competing.registered_on).toMillis()
               - DateTime.fromISO(b.competing.registered_on).toMillis();
-          case 'paid_on_with_registered_on_fallback':
-          {
+
+          case 'paid_on_with_registered_on_fallback': {
             const hasAPaid = a.payment?.has_paid;
             const hasBPaid = b.payment?.has_paid;
 
@@ -213,8 +221,13 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
             return DateTime.fromISO(a.competing.registered_on).toMillis()
               - DateTime.fromISO(b.competing.registered_on).toMillis();
           }
+
+          case 'amount':
+            return a.payment.payment_amount_iso - b.payment.payment_amount_iso;
+
           case 'waiting_list_position':
             return a.competing.waiting_list_position - b.competing.waiting_list_position;
+
           default:
             return 0;
         }

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -234,13 +234,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
               const aHasEvent = a.competing.event_ids.includes(sortColumn);
               const bHasEvent = b.competing.event_ids.includes(sortColumn);
 
-              if (aHasEvent && !bHasEvent) {
-                return -1;
-              }
-              if (!aHasEvent && bHasEvent) {
-                return 1;
-              }
-              return 0;
+              return Number(bHasEvent) - Number(aHasEvent);
             }
 
             return 0;

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -16,7 +16,7 @@ import Loading from '../../Requests/Loading';
 import { bulkUpdateRegistrations } from '../api/registration/patch/update_registration';
 import RegistrationAdministrationTable from './RegistrationsAdministrationTable';
 import useCheckboxState from '../../../lib/hooks/useCheckboxState';
-import { countries } from '../../../lib/wca-data.js.erb';
+import { countries, WCA_EVENT_IDS } from '../../../lib/wca-data.js.erb';
 import useOrderedSet from '../../../lib/hooks/useOrderedSet';
 import {
   APPROVED_COLOR, APPROVED_ICON,
@@ -38,6 +38,7 @@ const sortReducer = createSortReducer([
   'paid_on',
   'comment',
   'dob',
+  ...WCA_EVENT_IDS,
 ]);
 
 const partitionRegistrations = (registrations) => registrations.reduce(
@@ -228,8 +229,22 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
           case 'waiting_list_position':
             return a.competing.waiting_list_position - b.competing.waiting_list_position;
 
-          default:
+          default: {
+            if (WCA_EVENT_IDS.includes(sortColumn)) {
+              const aHasEvent = a.competing.event_ids.includes(sortColumn);
+              const bHasEvent = b.competing.event_ids.includes(sortColumn);
+
+              if (aHasEvent && !bHasEvent) {
+                return -1;
+              }
+              if (!aHasEvent && bHasEvent) {
+                return 1;
+              }
+              return 0;
+            }
+
             return 0;
+          }
         }
       });
       if (sortDirection === 'descending') {


### PR DESCRIPTION
- Allow sorting by amount paid, and by event (it's not useless, I would have liked this functionality when creating groups for a favourites competition).
- Disable other columns.

Currently we sort registrations, then partition them into tables, then pass the data to tables. One awkward consequence is that all tables share the same sort state. In a follow-up PR, I'll change this to partition -> pass to tables -> sort individually.