### PR TITLE
Move COPY to the end of the build step for better caching in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,13 +53,16 @@ RUN apt-get update -qq && \
 COPY Gemfile Gemfile.lock ./
 RUN gem update --system && gem install bundler
 
-COPY . .
+COPY ./bin/bundle ./bin/bundle
 RUN ./bin/bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 
 # Install node dependencies
 COPY package.json yarn.lock .yarnrc.yml ./
+COPY ./bin/yarn ./bin/yarn
 RUN ./bin/yarn install --immutable
+
+COPY . .
 
 RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 ./bin/bundle exec i18n export
 RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 ./bin/rake assets:precompile


### PR DESCRIPTION
Everything after the `COPY . .` gets invalidated whenever any files change, which caused the bundle or yarn build step not to be cached even if the gemfile/package.json didn't change.
It would be nice to do the same with the asset compilation, but as it requires a full rails stack to be running, there isn't really a better way that doesn't involve a full copy (or a very long manually curated list of files which is bad)

This also fixed the issue locally for me that running
```
docker build --target sidekiq .
docker build --target monolith-api .
```
like the github action does, did not reuse the cache. I am not 100% sure though if this will translate to it working better in github actions. There could be some files generated by the action that could invalidate it. I think we just need to try it out.