### PR TITLE
Show 'My Results' button in 'my competitions' page only when the user has a WCA ID

### DIFF
--- a/app/webpacker/components/MyCompetitions/index.jsx
+++ b/app/webpacker/components/MyCompetitions/index.jsx
@@ -20,7 +20,16 @@ export default function MyCompetitions({ permissions, competitions, wcaId }) {
   return (
     <>
       <Header>
-        <Button as="a" href={personUrl(wcaId)} secondary floated="right">{I18n.t('layouts.navigation.my_results')}</Button>
+        {wcaId && (
+          <Button
+            as="a"
+            href={personUrl(wcaId)}
+            secondary
+            floated="right"
+          >
+            {I18n.t('layouts.navigation.my_results')}
+          </Button>
+        )}
         {I18n.t('competitions.my_competitions.title')}
       </Header>
       <p>


### PR DESCRIPTION
Currently 'My Results' button in ['my competitions' page](https://www.worldcubeassociation.org/competitions/mine) is shown every time, it should be shown only if user has a WCA ID associated with it.