### PR TITLE
Reg Admin warning when skipping waitlisted registrations

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -135,7 +135,7 @@ export default function RegistrationActions({
     if (skippedWaitlistRegistration) {
       const { name } = skippedWaitlistRegistration.user;
       confirm({
-        content: `You've skipped over ${name} on the waitlist. Are you sure you want to approve the other registration(s) instead?`,
+        content: I18n.t('competitions.registration_v2.list.waitlist.skipped_warning', { name }),
       }).then(
         () => changeStatus(idsToAccept, 'accepted'),
       ).catch(() => null);

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -133,7 +133,10 @@ export default function RegistrationActions({
     );
 
     if (skippedWaitlistRegistration) {
-      confirm().then(
+      const { name } = skippedWaitlistRegistration.user;
+      confirm({
+        content: `You've skipped over ${name} on the waitlist. Are you sure you want to approve the other registration(s) instead?`,
+      }).then(
         () => changeStatus(idsToAccept, 'accepted'),
       ).catch(() => null);
     } else if (idsToAccept.length > spotsRemaining) {

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -8,7 +8,7 @@ import { countries } from '../../../lib/wca-data.js.erb';
 import {
   APPROVED_COLOR, APPROVED_ICON,
   CANCELLED_COLOR, CANCELLED_ICON,
-  getSkippedWaitlistRegistration,
+  getSkippedWaitlistCount,
   PENDING_COLOR, PENDING_ICON,
   REJECTED_COLOR, REJECTED_ICON,
   WAITLIST_COLOR, WAITLIST_ICON,
@@ -127,15 +127,17 @@ export default function RegistrationActions({
 
   const attemptToApprove = () => {
     const idsToAccept = [...pending, ...cancelled, ...waiting, ...rejected];
-    const skippedWaitlistRegistration = getSkippedWaitlistRegistration(
+    const skippedWaitlistCount = getSkippedWaitlistCount(
       registrations,
       partitionedSelected,
     );
 
-    if (skippedWaitlistRegistration) {
-      const { name } = skippedWaitlistRegistration.user;
+    if (skippedWaitlistCount > 0) {
       confirm({
-        content: I18n.t('competitions.registration_v2.list.waitlist.skipped_warning', { name }),
+        content: I18n.t(
+          'competitions.registration_v2.list.waitlist.skipped_warning',
+          { count: skippedWaitlistCount },
+        ),
       }).then(
         () => changeStatus(idsToAccept, 'accepted'),
       ).catch(() => null);

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/index.jsx
@@ -5,6 +5,7 @@ import RegistrationMessage from '../Register/RegistrationMessage';
 import messageReducer from '../reducers/messageReducer';
 import StoreProvider from '../../../lib/providers/StoreProvider';
 import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvider';
+import ConfirmProvider from '../../../lib/providers/ConfirmProvider';
 
 export default function RegistrationEdit({ competitionInfo }) {
   const ref = useRef();
@@ -12,10 +13,12 @@ export default function RegistrationEdit({ competitionInfo }) {
     <div ref={ref}>
       <WCAQueryClientProvider>
         <StoreProvider reducer={messageReducer} initialState={{ messages: [] }}>
-          <Sticky context={ref} offset={60}>
-            <RegistrationMessage />
-          </Sticky>
-          <RegistrationAdministrationList competitionInfo={competitionInfo} />
+          <ConfirmProvider>
+            <Sticky context={ref} offset={60}>
+              <RegistrationMessage />
+            </Sticky>
+            <RegistrationAdministrationList competitionInfo={competitionInfo} />
+          </ConfirmProvider>
         </StoreProvider>
       </WCAQueryClientProvider>
     </div>

--- a/app/webpacker/lib/utils/registrationAdmin.js
+++ b/app/webpacker/lib/utils/registrationAdmin.js
@@ -9,3 +9,77 @@ export const WAITLIST_ICON = 'hourglass';
 export const APPROVED_ICON = 'check';
 export const CANCELLED_ICON = 'trash';
 export const REJECTED_ICON = 'x';
+
+function getSortedWaitlistRegistrations(registrations) {
+  return registrations.filter(
+    (reg) => reg.competing.registration_status === 'waiting_list',
+  ).toSorted(
+    (a, b) => a.competing.waiting_list_position - b.competing.waiting_list_position,
+  );
+}
+
+function getFirstUnselectedOnWaitlist(
+  registrations,
+  selectedWaitlistIds,
+) {
+  const waitlistRegistrations = getSortedWaitlistRegistrations(registrations);
+
+  return waitlistRegistrations.find(
+    (reg) => !selectedWaitlistIds.includes(reg.user_id),
+  );
+}
+
+function getLastSelectedOnWaitlist(
+  registrations,
+  selectedWaitlistIds,
+) {
+  const waitlistRegistrations = getSortedWaitlistRegistrations(registrations);
+
+  return waitlistRegistrations.findLast(
+    (reg) => selectedWaitlistIds.includes(reg.user_id),
+  );
+}
+
+export function getSkippedWaitlistRegistration(
+  registrations,
+  partitionedSelectedIds,
+) {
+  const {
+    pending, waiting, cancelled, rejected,
+  } = partitionedSelectedIds;
+
+  const waitlistRegistrations = getSortedWaitlistRegistrations(registrations);
+  if (waitlistRegistrations.length === 0) return null;
+
+  const firstUnselectedOnWaitlist = getFirstUnselectedOnWaitlist(
+    registrations,
+    waiting,
+  );
+  if (!firstUnselectedOnWaitlist) return null;
+
+  const notAllWaitlistIsSelected = waiting.length < waitlistRegistrations.length;
+  const aNonAcceptedNonWaitlistIsSelected = pending.length > 0
+    || cancelled.length > 0
+    || rejected.length > 0;
+  if (notAllWaitlistIsSelected && aNonAcceptedNonWaitlistIsSelected) {
+    return firstUnselectedOnWaitlist;
+  }
+
+  const lastSelectedOnWaitlist = getLastSelectedOnWaitlist(
+    registrations,
+    waiting,
+  );
+  // at this point the waitlist is non-empty and fully selected, so this exists
+  if (!lastSelectedOnWaitlist) {
+    console.error('lastSelectedOnWaitlist should exist');
+    return undefined;
+  }
+
+  const firstUnselectedPosition = firstUnselectedOnWaitlist.competing.waiting_list_position;
+  const lastSelectedPosition = lastSelectedOnWaitlist.competing.waiting_list_position;
+  if (firstUnselectedPosition < lastSelectedPosition) {
+    return firstUnselectedOnWaitlist;
+  }
+
+  return null;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1824,6 +1824,7 @@ en:
           information: "Pending should only be used for incomplete (eg, unpaid) registrations - please use the Waiting List if your competition is too full to accept new competitors."
         waitlist:
           title: "Waiting List Registrations"
+          skipped_warning: "You've skipped over %{name} on the waitlist. Are you sure you want to approve the other registration(s) instead?"
         approved:
           title: "Approved Registrations"
         cancelled:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1824,7 +1824,7 @@ en:
           information: "Pending should only be used for incomplete (eg, unpaid) registrations - please use the Waiting List if your competition is too full to accept new competitors."
         waitlist:
           title: "Waiting List Registrations"
-          skipped_warning: "You've skipped over %{name} on the waitlist. Are you sure you want to approve the other registration(s) instead?"
+          skipped_warning: "You've skipped %{count} registration(s) on the waitlist. Are you sure you want to approve the other registration(s) instead?"
         approved:
           title: "Approved Registrations"
         cancelled:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1824,7 +1824,7 @@ en:
           information: "Pending should only be used for incomplete (eg, unpaid) registrations - please use the Waiting List if your competition is too full to accept new competitors."
         waitlist:
           title: "Waiting List Registrations"
-          skipped_warning: "You've skipped %{count} registration(s) on the waitlist. Are you sure you want to approve the other registration(s) instead?"
+          skipped_warning: "You've skipped %{count} registration(s) on the Waiting List. Are you sure you want to approve the other registration(s) instead?"
         approved:
           title: "Approved Registrations"
         cancelled:


### PR DESCRIPTION
Initially I showed the name of the first person skipped over, but I think this is better.

It's purely a front-end warning, just click Ok to ignore it.

![image](https://github.com/user-attachments/assets/0c20b8bc-0045-484f-b62b-443469262bca)

Note: I changed the message slightly after recording the video below - see screenshot above. And the final time, I clicked Yes instead of cancel.

[Screencast from 2025-03-02 02:40:53 PM.webm](https://github.com/user-attachments/assets/f87bc4d1-8346-4e3c-8b9d-cab8d098356f)

I think an analogous warning for moving registrations to the waitlist would make sense? So, if there are unselected completed pending registrations with an earlier payment (or registered, if not using payments) timestamp, then show a warning.