### PR TITLE
Implement client-based resource access for Stripe API

### DIFF
--- a/app/models/stripe_record.rb
+++ b/app/models/stripe_record.rb
@@ -115,6 +115,13 @@ class StripeRecord < ApplicationRecord
     )
   end
 
+  def confirm_remote_for_test(payment_method)
+    raise "This method is only supposed to be called during testing!" unless Rails.env.test?
+    raise "Not a PaymentIntent, seems that you messed up your test case :P" unless self.payment_intent?
+
+    stripe_client.v1.payment_intents.confirm(self.stripe_id, { payment_method: payment_method })
+  end
+
   def money_amount
     ruby_amount = StripeRecord.amount_to_ruby(
       self.amount_stripe_denomination,

--- a/app/models/stripe_record.rb
+++ b/app/models/stripe_record.rb
@@ -80,11 +80,11 @@ class StripeRecord < ApplicationRecord
   def retrieve_stripe
     case self.stripe_record_type
     when StripeRecord.stripe_record_types[:payment_intent]
-      Stripe::PaymentIntent.retrieve(self.stripe_id, stripe_account: self.account_id)
+      stripe_client.v1.payment_intents.retrieve(self.stripe_id)
     when StripeRecord.stripe_record_types[:charge]
-      Stripe::Charge.retrieve(self.stripe_id, stripe_account: self.account_id)
+      stripe_client.v1.charges.retrieve(self.stripe_id)
     when StripeRecord.stripe_record_types[:refund]
-      Stripe::Refund.retrieve(self.stripe_id, stripe_account: self.account_id)
+      stripe_client.v1.refunds.retrieve(self.stripe_id)
     end
   end
 
@@ -100,10 +100,9 @@ class StripeRecord < ApplicationRecord
       currency: currency_iso,
     }
 
-    Stripe::PaymentIntent.update(
+    stripe_client.v1.payment_intents.update(
       self.stripe_id,
       update_intent_args,
-      stripe_account: self.account_id,
     )
 
     updated_parameters = self.parameters.deep_merge(update_intent_args)
@@ -187,5 +186,9 @@ class StripeRecord < ApplicationRecord
       account_id: account_id,
       parent_record: parent_record,
     )
+  end
+
+  private def stripe_client
+    Stripe::StripeClient.new(AppSecrets.STRIPE_API_KEY, stripe_account: self.account_id)
   end
 end

--- a/app/models/stripe_webhook_event.rb
+++ b/app/models/stripe_webhook_event.rb
@@ -19,7 +19,7 @@ class StripeWebhookEvent < ApplicationRecord
   has_one :canceled_intent, class_name: "PaymentIntent", as: :cancellation_source
 
   def retrieve_event
-    Stripe::Event.retrieve(self.stripe_id, stripe_account: self.account_id)
+    stripe_client.v1.events.retrieve(self.stripe_id)
   end
 
   def self.create_from_api(api_event, handled: false)
@@ -32,5 +32,9 @@ class StripeWebhookEvent < ApplicationRecord
       created_at_remote: created_at_remote,
       handled: handled,
     )
+  end
+
+  private def stripe_client
+    Stripe::StripeClient.new(AppSecrets.STRIPE_API_KEY, stripe_account: self.account_id)
   end
 end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -71,23 +71,23 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
       context "processes a payment" do
         before :each do
           sign_in organizer
+
           post :load_payment_intent, params: {
             id: registration.id,
             payment_integration: :stripe,
             amount: registration.outstanding_entry_fees.cents,
           }
+
           payment_intent = registration.reload.payment_intents.first
-          Stripe::PaymentIntent.confirm(
-            payment_intent.payment_record.stripe_id,
-            { payment_method: 'pm_card_visa' },
-            stripe_account: competition.payment_account_for(:stripe).account_id,
-          )
+          payment_intent.payment_record.confirm_remote_for_test("pm_card_visa")
+
           get :payment_completion, params: {
             competition_id: competition.id,
             payment_integration: :stripe,
             payment_intent: payment_intent.payment_record.stripe_id,
             payment_intent_client_secret: payment_intent.client_secret,
           }
+
           @payment = registration.reload.registration_payments.first
         end
 

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -582,11 +582,8 @@ RSpec.describe "registrations" do
           payment_intent = registration.reload.payment_intents.first
 
           # mimic the user clicking through the interface
-          Stripe::PaymentIntent.confirm(
-            payment_intent.payment_record.stripe_id,
-            { payment_method: 'pm_card_visa' },
-            stripe_account: competition.payment_account_for(:stripe).account_id,
-          )
+          payment_intent.payment_record.confirm_remote_for_test("pm_card_visa")
+
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
           get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
@@ -616,11 +613,7 @@ RSpec.describe "registrations" do
           stripe_account_id = competition.payment_account_for(:stripe).account_id
 
           # mimic the user clicking through the interface
-          Stripe::PaymentIntent.confirm(
-            payment_intent.payment_record.stripe_id,
-            { payment_method: 'pm_card_visa' },
-            stripe_account: stripe_account_id,
-          )
+          payment_intent.payment_record.confirm_remote_for_test("pm_card_visa")
 
           # mimic the response that Stripe sends to our webhook upon payment completion
           post registration_stripe_webhook_path, params: payment_confirmation_webhook_as_json(
@@ -650,11 +643,8 @@ RSpec.describe "registrations" do
           payment_intent = registration.reload.payment_intents.first
 
           # mimic the user clicking through the interface
-          Stripe::PaymentIntent.confirm(
-            payment_intent.payment_record.stripe_id,
-            { payment_method: 'pm_card_visa' },
-            stripe_account: competition.payment_account_for(:stripe).account_id,
-          )
+          payment_intent.payment_record.confirm_remote_for_test("pm_card_visa")
+
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
           get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
@@ -683,11 +673,8 @@ RSpec.describe "registrations" do
           expect(payment_intent.wca_status).not_to eq('succeeded')
 
           # mimic the user clicking through the interface
-          Stripe::PaymentIntent.confirm(
-            payment_intent.payment_record.stripe_id,
-            { payment_method: 'pm_card_visa' },
-            stripe_account: competition.payment_account_for(:stripe).account_id,
-          )
+          payment_intent.payment_record.confirm_remote_for_test("pm_card_visa")
+
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
           get registration_payment_completion_path(competition.id, :stripe), params: {
             payment_intent: payment_intent.payment_record.stripe_id,
@@ -718,11 +705,8 @@ RSpec.describe "registrations" do
           # but we cannot do that programmatically. So we just take the status quo as "stuck in SCA". (See also comment below)
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_authenticationRequired' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_authenticationRequired")
+
             # mimic the response that Stripe sends to our return_url after completing the checkout UI
             get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
@@ -751,11 +735,7 @@ RSpec.describe "registrations" do
           expect(payment_intent.confirmed_at).to be_nil
 
           # mimic the user clicking through the interface
-          Stripe::PaymentIntent.confirm(
-            payment_intent.payment_record.stripe_id,
-            { payment_method: 'pm_card_authenticationRequired' },
-            stripe_account: competition.payment_account_for(:stripe).account_id,
-          )
+          payment_intent.payment_record.confirm_remote_for_test("pm_card_authenticationRequired")
 
           # mimic the response that Stripe sends to our return_url after completing the checkout UI
           get registration_payment_completion_path(competition.id, :stripe), params: {
@@ -786,11 +766,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_visa_chargeDeclined' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_visa_chargeDeclined")
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           expect {
@@ -816,11 +792,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_visa_chargeDeclinedExpiredCard' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_visa_chargeDeclinedExpiredCard")
           }.to raise_error(Stripe::StripeError, "Your card has expired.")
 
           expect {
@@ -846,11 +818,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_visa_chargeDeclinedIncorrectCvc' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_visa_chargeDeclinedIncorrectCvc")
           }.to raise_error(Stripe::StripeError, "Your card's security code is incorrect.")
 
           expect {
@@ -876,11 +844,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_radarBlock' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_radarBlock")
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           expect {
@@ -906,11 +870,8 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_authenticationRequiredChargeDeclinedInsufficientFunds' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_authenticationRequiredChargeDeclinedInsufficientFunds")
+
             # mimick the response that Stripe sends to our return_url after completing the checkout UI
             get registration_payment_completion_path(competition.id, :stripe), params: {
               payment_intent: payment_intent.payment_record.stripe_id,
@@ -940,11 +901,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_visa_chargeDeclined' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_visa_chargeDeclined")
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
@@ -982,11 +939,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_visa_chargeDeclined' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_visa_chargeDeclined")
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
@@ -1029,11 +982,7 @@ RSpec.describe "registrations" do
 
           expect {
             # mimic the user clicking through the interface
-            Stripe::PaymentIntent.confirm(
-              payment_intent.payment_record.stripe_id,
-              { payment_method: 'pm_card_visa_chargeDeclined' },
-              stripe_account: competition.payment_account_for(:stripe).account_id,
-            )
+            payment_intent.payment_record.confirm_remote_for_test("pm_card_visa_chargeDeclined")
           }.to raise_error(Stripe::StripeError, "Your card was declined.")
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
@@ -1076,11 +1025,7 @@ RSpec.describe "registrations" do
           first_pi_parameters = payment_intent.payment_record.parameters
 
           # mimic the user clicking through the interface
-          Stripe::PaymentIntent.confirm(
-            payment_intent.payment_record.stripe_id,
-            { payment_method: 'pm_card_visa' },
-            stripe_account: competition.payment_account_for(:stripe).account_id,
-          )
+          payment_intent.payment_record.confirm_remote_for_test("pm_card_visa")
 
           # mimick the response that Stripe sends to our return_url after completing the checkout UI
           get registration_payment_completion_path(competition.id, :stripe), params: {


### PR DESCRIPTION
As per https://github.com/stripe/stripe-ruby/wiki/Migration-guide-for-v13

I also opted to introduce a test helper for the numerous occasions of `Stripe::PaymentIntent.confirm` in our code.