### PR TITLE
More dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN useradd rails --create-home --shell /bin/bash
 USER rails:rails
 
 # Copy built artifacts: gems, application
-COPY --from=build /rails .
+COPY --chown=rails:rails --from=build  /rails .
 
 FROM runtime AS sidekiq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,9 @@ RUN apt-get update -qq && \
       libyaml-dev \
       tzdata
 
-# Install application gems
 COPY bin ./bin
+
+# Install application gems
 
 COPY Gemfile Gemfile.lock ./
 RUN gem update --system && gem install bundler

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV RAILS_LOG_TO_STDOUT="1" \
     BUILD_TAG=$BUILD_TAG \
     WCA_LIVE_SITE=$WCA_LIVE_SITE \
     SHAKAPACKER_ASSET_HOST=$SHAKAPACKER_ASSET_HOST
+ENV BUNDLE_JOBS=4 BUNDLE_RETRY=3
 
 # Add dependencies necessary to install nodejs.
 # From: https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
@@ -50,56 +51,24 @@ RUN apt-get update -qq && \
       tzdata
 
 # Install application gems
-COPY Gemfile Gemfile.lock ./
-RUN gem update --system && gem install bundler
+COPY bin ./bin
 
-COPY ./bin/bundle ./bin/bundle
-RUN ./bin/bundle install && \
-    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+COPY Gemfile Gemfile.lock ./
+RUN gem update --system && gem install bundler && ./bin/bundle install && \
+                                                      rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 
 # Install node dependencies
 COPY package.json yarn.lock .yarnrc.yml ./
-COPY ./bin/yarn ./bin/yarn
 RUN ./bin/yarn install --immutable
 
 COPY . .
 
-RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 ./bin/bundle exec i18n export
-RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 ./bin/rake assets:precompile
+RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 RAILS_MAX_THREADS=4 NODE_OPTIONS="--max_old_space_size=4096" ./bin/bundle exec i18n export
+RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 RAILS_MAX_THREADS=4 NODE_OPTIONS="--max_old_space_size=4096" ./bin/rake assets:precompile
 
 RUN rm -rf node_modules
 
 FROM base AS runtime
-
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y \
-      mariadb-client \
-      zip \
-      python-is-python3
-
-# Copy built artifacts: gems, application
-COPY --from=build /rails .
-
-# Run and own only the runtime files as a non-root user for security
-RUN useradd rails --create-home --shell /bin/bash && \
-    chown -R rails:rails vendor db log tmp public app pids
-
-FROM runtime AS sidekiq
-
-USER rails:rails
-RUN gem install mailcatcher
-
-ENTRYPOINT ["/rails/bin/docker-entrypoint-sidekiq"]
-
-FROM runtime AS shoryuken
-
-USER rails:rails
-
-ENTRYPOINT ["/rails/bin/docker-entrypoint-shoryuken"]
-
-FROM runtime AS monolith
-
-EXPOSE 3000
 
 # Install fonts for rendering PDFs (mostly competition summary PDFs)
 # dejavu = Hebrew, Arabic, Greek
@@ -108,15 +77,37 @@ EXPOSE 3000
 # ipafont = Japanese
 # thai-tlwg = Thai (as the name suggests)
 # lmodern = Random accents and special symbols for Latin script
+
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
+      mariadb-client \
+      zip \
+      python-is-python3 \
       fonts-dejavu \
       fonts-unfonts-core \
       fonts-wqy-microhei \
       fonts-ipafont \
       fonts-thai-tlwg \
       fonts-lmodern
+
+RUN useradd rails --create-home --shell /bin/bash
 USER rails:rails
+
+# Copy built artifacts: gems, application
+COPY --from=build /rails .
+
+FROM runtime AS sidekiq
+
+ENTRYPOINT ["/rails/bin/docker-entrypoint-sidekiq"]
+
+FROM runtime AS shoryuken
+
+ENTRYPOINT ["/rails/bin/docker-entrypoint-shoryuken"]
+
+FROM runtime AS monolith
+
+EXPOSE 3000
+
 # Regenerate the font cache so WkHtmltopdf can find them
 # per https://dalibornasevic.com/posts/76-figuring-out-missing-fonts-for-wkhtmltopdf
 RUN fc-cache -f -v
@@ -132,6 +123,5 @@ FROM runtime AS monolith-api
 
 EXPOSE 3000
 
-USER rails:rails
 ENV API_ONLY="true"
 CMD ["./bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ RUN apt-get update -qq && \
 COPY bin ./bin
 
 # Install application gems
-
 COPY Gemfile Gemfile.lock ./
 RUN gem update --system && gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN useradd rails --create-home --shell /bin/bash
 USER rails:rails
 
 # Copy built artifacts: gems, application
-COPY --chown=rails:rails --from=build  /rails .
+COPY --chown=rails:rails --from=build /rails .
 
 FROM runtime AS sidekiq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ENV RAILS_LOG_TO_STDOUT="1" \
     BUILD_TAG=$BUILD_TAG \
     WCA_LIVE_SITE=$WCA_LIVE_SITE \
     SHAKAPACKER_ASSET_HOST=$SHAKAPACKER_ASSET_HOST
-ENV BUNDLE_JOBS=4 BUNDLE_RETRY=3
 
 # Add dependencies necessary to install nodejs.
 # From: https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions

--- a/bin/docker-entrypoint-sidekiq
+++ b/bin/docker-entrypoint-sidekiq
@@ -1,3 +1,8 @@
 #!/bin/bash -e
-mailcatcher --http-ip=0.0.0.0 --no-quit
+
+if [ "$WCA_LIVE_SITE" == "false" ]; then
+  gem install mailcatcher
+  mailcatcher --http-ip=0.0.0.0 --no-quit
+fi
+
 ./bin/bundle exec sidekiq

--- a/bin/docker-entrypoint-sidekiq
+++ b/bin/docker-entrypoint-sidekiq
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-if [ "$WCA_LIVE_SITE" == "false" ]; then
+if [ "$WCA_LIVE_SITE" = "0" ]; then
   gem install mailcatcher
   mailcatcher --http-ip=0.0.0.0 --no-quit
 fi


### PR DESCRIPTION
This saves almost 5 minutes on my local machine (from 10 to 5:30). 

- Added `RAILS_MAX_THREADS=4 NODE_OPTIONS="--max_old_space_size=4096"` to speed up compiling which saves like a minute?
- Remove the chown to the rails user and just assume the user earlier (saves about 2 minutes)
   - This means we have to install the fonts in the runtime layer already (as we don't have access to apt install as the rails user), but that is adding minimal size
- Only install mailcatcher in staging (saves another 2 minutes for building sidekiq)

This non -cached build now has this timeline:
```
Building 342.6s (23/23) FINISHED                                                                                                                                                                                                                  docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                            0.0s
 => => transferring dockerfile: 3.78kB                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/ruby:3.4.1                                                                                                                                                                                                   0.9s
 => [internal] load .dockerignore                                                                                                                                                                                                                               0.0s
 => => transferring context: 542B                                                                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                                               0.1s
 => => transferring context: 217.29kB                                                                                                                                                                                                                           0.1s
 => [base 1/4] FROM docker.io/library/ruby:3.4.1@sha256:f78dc1bba60f85d40d6dc6d6722ca2cda0b5273fc179119badd0f7654d5d1d6e                                                                                                                                        0.0s
 => [base 2/4] WORKDIR /rails                                                                                                                                                                                                                            0.0s
 => [base 3/4] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y       ca-certificates       curl       gnupg                                                                                                                            3.7s
 => [base 4/4] RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash &&     apt-get install -y nodejs                                                                                                                                                    10.1s
 => [build  1/11] RUN corepack enable                                                                                                                                                                                                                           0.4s 
 => [runtime 1/3] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y       mariadb-client       zip       python-is-python3                                                                                                               3.9s 
 => [build  2/11] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y       build-essential       software-properties-common       git       clang       pkg-config       libvips       libssl-dev       libyaml-dev       tzdata         26.6s
 => [runtime 2/3] RUN useradd rails --create-home --shell /bin/bash                                                                                                                                                                                             0.4s
 => [build  3/11] COPY bin ./bin                                                                                                                                                                                                                                0.1s
 => [build  4/11] COPY Gemfile Gemfile.lock ./                                                                                                                                                                                                                  0.1s
 => [build  5/11] RUN gem update --system && gem install bundler && ./bin/bundle install &&                                                       rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git                 172.9s
 => [build  6/11] COPY package.json yarn.lock .yarnrc.yml ./                                                                                                                                                                                                    0.1s
 => [build  7/11] RUN ./bin/yarn install --immutable                                                                                                                                                                                                           14.0s
 => [build  8/11] COPY . .                                                                                                                                                                                                                                      0.5s
 => [build  9/11] RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 RAILS_MAX_THREADS=4 NODE_OPTIONS="--max_old_space_size=4096" ./bin/bundle exec i18n export                                                                                                     13.6s
 => [build 10/11] RUN ASSETS_COMPILATION=true SECRET_KEY_BASE=1 RAILS_MAX_THREADS=4 NODE_OPTIONS="--max_old_space_size=4096" ./bin/rake assets:precompile                                                                                                      81.0s
 => [build 11/11] RUN rm -rf node_modules                                                                                                                                                                                                                       3.4s
 => [runtime 3/3] COPY --from=build /rails .                                                                                                                                                                                                                    5.6s
 => exporting to image                                                                                                                                                                                                                                          5.3s
 => => exporting layers                                                                                                                                                                                                                                         5.3s
```
Now the biggest slice of the pie is bundling. I tried setting `BUNDLE_JOBS` to a higher value, but bundler seems to be already setting this to the number of CPUs ([see docs](https://bundler.io/man/bundle-install.1.html#OPTIONS)). I also tried using the [MAKE environment variable trick](https://build.betterup.com/one-weird-trick-that-will-speed-up-your-bundle-install/ ) but that caused the compilation to crash with some weird rust error.

I then deep dived into how to cache bundle packages between builds and found [this](https://github.com/moby/buildkit/issues/1173#issuecomment-2242055616) which causes the bundle time to go down to a couple of seconds if it isn't cached (but doesn't need to install new packages).

I also found [this](https://qiita.com/k_kind/items/836bc7ba2e33dc2ed3e7) japanese post that uses it for asset compilation and yarn install as well. I did not get it to work for yarn (because the --node_modules options doesn't exist anymore), but our yarn install is a very small slice of the pie anyway

