### PR TITLE
Add ticket comment email notification

### DIFF
--- a/app/controllers/ticket_comments_controller.rb
+++ b/app/controllers/ticket_comments_controller.rb
@@ -28,8 +28,6 @@ class TicketCommentsController < ApplicationController
       acting_stakeholder_id: acting_stakeholder_id,
     )
 
-    ticket.ticket_stakeholders.each { |stakeholder| stakeholder.notify_new_comment(comment) }
-
     render json: comment
   end
 end

--- a/app/controllers/ticket_comments_controller.rb
+++ b/app/controllers/ticket_comments_controller.rb
@@ -28,6 +28,8 @@ class TicketCommentsController < ApplicationController
       acting_stakeholder_id: acting_stakeholder_id,
     )
 
+    ticket.ticket_stakeholders.each { |stakeholder| stakeholder.notify_new_comment(comment) }
+
     render json: comment
   end
 end

--- a/app/mailers/tickets_mailer.rb
+++ b/app/mailers/tickets_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class TicketsMailer < ApplicationMailer
+  def notify_create_ticket_comment(ticket_comment, stakeholder)
+    @recipient_name = stakeholder.name
+    @ticket_id = ticket_comment.ticket.id
+    @ticket_comment = ticket_comment
+
+    mail(
+      to: [stakeholder.email],
+      subject: "[Ticket #{ticket_comment.ticket.id}] New comment added",
+    )
+  end
+end

--- a/app/mailers/tickets_mailer.rb
+++ b/app/mailers/tickets_mailer.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class TicketsMailer < ApplicationMailer
-  def notify_create_ticket_comment(ticket_comment, stakeholder)
-    @recipient_name = stakeholder.name
-    @ticket_id = ticket_comment.ticket.id
+  def notify_create_ticket_comment(ticket_comment, recipient_emails)
     @ticket_comment = ticket_comment
 
     mail(
-      to: [stakeholder.email],
+      bcc: recipient_emails,
       subject: "[Ticket #{ticket_comment.ticket.id}] New comment added",
     )
   end

--- a/app/models/ticket_comment.rb
+++ b/app/models/ticket_comment.rb
@@ -3,10 +3,19 @@
 class TicketComment < ApplicationRecord
   belongs_to :ticket
   belongs_to :acting_user, class_name: 'User'
+  belongs_to :acting_stakeholder, class_name: 'TicketStakeholder'
 
   DEFAULT_SERIALIZE_OPTIONS = {
     include: %w[acting_user],
   }.freeze
+
+  def author_text
+    if acting_stakeholder.user_group_stakeholder?
+      "#{acting_user.name} (#{acting_stakeholder.stakeholder.name})"
+    else
+      acting_user.name
+    end
+  end
 
   def serializable_hash(options = nil)
     super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))

--- a/app/models/ticket_stakeholder.rb
+++ b/app/models/ticket_stakeholder.rb
@@ -25,8 +25,8 @@ class TicketStakeholder < ApplicationRecord
     stakeholder_type == "UserGroup"
   end
 
-  def notify_new_comment(comment)
-    TicketsMailer.notify_create_ticket_comment(comment, stakeholder).deliver_later
+  def user_stakeholder?
+    stakeholder_type == "User"
   end
 
   def serializable_hash(options = nil)

--- a/app/models/ticket_stakeholder.rb
+++ b/app/models/ticket_stakeholder.rb
@@ -21,6 +21,14 @@ class TicketStakeholder < ApplicationRecord
     methods: %w[stakeholder],
   }.freeze
 
+  def user_group_stakeholder?
+    stakeholder_type == "UserGroup"
+  end
+
+  def notify_new_comment(comment)
+    TicketsMailer.notify_create_ticket_comment(comment, stakeholder).deliver_later
+  end
+
   def serializable_hash(options = nil)
     json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
     json[:class] = self.class.to_s.downcase

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -350,6 +350,10 @@ class UserGroup < ApplicationRecord
     group_changes.join("<br>")
   end
 
+  def email
+    metadata&.email
+  end
+
   DEFAULT_SERIALIZE_OPTIONS = {
     include: %w[metadata],
     methods: %w[lead_user],

--- a/app/views/tickets_mailer/notify_create_ticket_comment.erb
+++ b/app/views/tickets_mailer/notify_create_ticket_comment.erb
@@ -1,11 +1,11 @@
-<p>Hi <%= @recipient_name %>,</p>
+<p>Hi,</p>
 
-<p>A new comment has been added to ticket <%= @ticket_id %>.</p>
+<p>A new comment has been added to ticket <%= @ticket_comment.ticket_id %>.</p>
 
 <b>Ticket Details:</b>
 <ul>
-  <li>Ticket ID: <%= @ticket_id %></li>
-  <li>Link to Ticket: <%= ticket_url(@ticket_id) %></li>
+  <li>Ticket ID: <%= @ticket_comment.ticket_id %></li>
+  <li>Link to Ticket: <%= ticket_url(@ticket_comment.ticket_id) %></li>
 </ul>
 
 <b>Comment Details:</b>

--- a/app/views/tickets_mailer/notify_create_ticket_comment.erb
+++ b/app/views/tickets_mailer/notify_create_ticket_comment.erb
@@ -1,0 +1,22 @@
+<p>Hi <%= @recipient_name %>,</p>
+
+<p>A new comment has been added to ticket <%= @ticket_id %>.</p>
+
+<b>Ticket Details:</b>
+<ul>
+  <li>Ticket ID: <%= @ticket_id %></li>
+  <li>Link to Ticket: <%= ticket_url(@ticket_id) %></li>
+</ul>
+
+<b>Comment Details:</b>
+<ul>
+  <li>Author: <%= @ticket_comment.author_text %></li>
+  <li>Timestamp: <%= @ticket_comment.created_at %></li>
+</ul>
+
+<b>Comment:</b>
+<blockquote><%= md @ticket_comment.comment %></blockquote>
+
+<p>You can view the full ticket and respond to the comment by clicking the link above.</p>
+
+<p>Please do not reply directly to this email. Replies to this address are not monitored. To respond to the comment, please use the provided link to access the ticket within our system.</p>


### PR DESCRIPTION
This PR implements comments email notification for tickets. A sample email screenshot is attached below:

<img width="1279" alt="Screenshot 2025-03-07 at 09 06 49" src="https://github.com/user-attachments/assets/ec773f78-38ef-496f-9e4c-9e2b340d6f61" />
