### PR TITLE
Disable event update button on register step after event update deadline

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -26,7 +26,7 @@ import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import { events, defaultGuestLimit } from '../../../lib/wca-data.js.erb';
 import { eventsNotQualifiedFor, isQualifiedForEvent } from '../../../lib/helpers/qualifications';
 import { eventQualificationToString } from '../../../lib/utils/wcif';
-import { hasNotPassed } from '../../../lib/utils/dates';
+import {hasNotPassed, hasPassed} from '../../../lib/utils/dates';
 import useSet from '../../../lib/hooks/useSet';
 
 const maxCommentLength = 240;
@@ -303,6 +303,10 @@ export default function CompetingStep({
     ? competitionInfo.guests_per_registration_limit
     : defaultGuestLimit;
 
+  const hasRegistrationEditDeadlinePassed = hasPassed(
+    competitionInfo.event_change_deadline_date ?? competitionInfo.start_date,
+  );
+
   const formWarnings = useMemo(() => potentialWarnings(competitionInfo), [competitionInfo]);
   return (
     <Segment basic loading={isUpdating}>
@@ -412,11 +416,11 @@ export default function CompetingStep({
                 <Button
                   primary
                   disabled={
-                        isUpdating || !hasChanges
+                        isUpdating || !hasChanges || hasRegistrationEditDeadlinePassed
                       }
                   type="submit"
                 >
-                  {I18n.t('registrations.update')}
+                  {I18n.t(hasRegistrationEditDeadlinePassed ? 'competitions.registration_v2.errors.-4001' : 'registrations.update')}
                 </Button>
                 <ButtonOr />
                 <Button secondary onClick={() => nextStep()}>

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -26,7 +26,7 @@ import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import { events, defaultGuestLimit } from '../../../lib/wca-data.js.erb';
 import { eventsNotQualifiedFor, isQualifiedForEvent } from '../../../lib/helpers/qualifications';
 import { eventQualificationToString } from '../../../lib/utils/wcif';
-import {hasNotPassed, hasPassed} from '../../../lib/utils/dates';
+import { hasNotPassed, hasPassed } from '../../../lib/utils/dates';
 import useSet from '../../../lib/hooks/useSet';
 
 const maxCommentLength = 240;

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -420,7 +420,7 @@ export default function CompetingStep({
                       }
                   type="submit"
                 >
-                  {I18n.t(hasRegistrationEditDeadlinePassed ? 'competitions.registration_v2.errors.-4001' : 'registrations.update')}
+                  {I18n.t(!hasRegistrationEditDeadlinePassed ? 'registrations.update' : 'competitions.registration_v2.errors.-4001')}
                 </Button>
                 <ButtonOr />
                 <Button secondary onClick={() => nextStep()}>


### PR DESCRIPTION
Users can send event update requests even after the deadline, and even after the competition, by using the register subtab
![image](https://github.com/user-attachments/assets/3c304adb-a0e6-4b12-99ba-3fa571f5e181)

This competition took place on 22-23rd of feb
![image](https://github.com/user-attachments/assets/306a0a2d-2ab5-485a-95c2-71deda2f1f83)
