### PR TITLE
Reg Admin: Also sort unpaid registrations on moving to waitlist & add info sentence

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -212,6 +212,9 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
       content: {
         content: (
           <>
+            <Header.Subheader>
+              {I18n.t('competitions.registration_v2.list.waitlist.information')}
+            </Header.Subheader>
             <Checkbox
               toggle
               value={waitlistEditModeEnabled}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1826,7 +1826,7 @@ en:
           information: "Pending should only be used for incomplete (eg, unpaid) registrations - please use the Waiting List if your competition is too full to accept new competitors."
         waitlist:
           title: "Waiting List Registrations"
-          information: "Competitors are added to the end of the Waiting List. If you add several at once, the paid competitors will be added to the end in the order that they paid, followed by the rest. You can manually adjust the order in Edit Mode if necessary."
+          information: "Competitors are added to the end of the Waiting List. If you add several at once, the paid competitors will be added to the end in the order that they paid, followed by the rest in the order that they registered. You can manually adjust the order in Edit Mode if necessary."
           skipped_warning: "You've skipped %{count} registration(s) on the Waiting List. Are you sure you want to approve the other registration(s) instead?"
         approved:
           title: "Approved Registrations"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1826,6 +1826,7 @@ en:
           information: "Pending should only be used for incomplete (eg, unpaid) registrations - please use the Waiting List if your competition is too full to accept new competitors."
         waitlist:
           title: "Waiting List Registrations"
+          information: "Competitors are added to the end of the Waiting List. If you add several at once, the paid competitors will be added to the end in the order that they paid, followed by the rest. You can manually adjust the order in Edit Mode if necessary."
           skipped_warning: "You've skipped %{count} registration(s) on the Waiting List. Are you sure you want to approve the other registration(s) instead?"
         approved:
           title: "Approved Registrations"


### PR DESCRIPTION
I also just noticed that when adding to the waitlist, we're not sorting the unpaid registrations (only the paid registrations). We definitely should be - or change the UI to make it clear that order of selection matters.

![Screenshot from 2025-03-08 18-46-31](https://github.com/user-attachments/assets/603c6e26-1cef-43bc-b38f-f83cd10a49de)
