### PR TITLE
Update browserslist and caniuse-lite definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,11 @@
     "whatwg-fetch": "^3.6.20"
   },
   "browserslist": [
-    "defaults"
+    "> 0.2%",
+    "last 5 versions",
+    "Firefox ESR",
+    "not dead",
+    "not op_mini all"
   ],
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,14 +3912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001699
-  resolution: "caniuse-lite@npm:1.0.30001699"
-  checksum: 10c0/e87b3a0602c3124131f6a21f1eb262378e17a2ee3089e3c472ac8b9caa85cf7d6a219655379302c29c6f10a74051f2a712639d7f98ee0444c73fefcbaf25d519
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001702":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
   version: 1.0.30001703
   resolution: "caniuse-lite@npm:1.0.30001703"
   checksum: 10c0/ed88e318da28e9e59c4ac3a2e3c42859558b7b713aebf03696a1f916e4ed4b70734dda82be04635e2b62ec355b8639bbed829b7b12ff528d7f9cc31a3a5bea91


### PR DESCRIPTION
Attempt to fix the occasional error that users have been reporting about "not seeing anything on the competitions overview page". From our investigation so far, this is due to old browsers not having `toSorted()` on arrays.

We can make reasonable effort by polyfilling, although I'm not going to polyfill everything down to Chrome 90. We have to draw a reasonable line somewhere instead of blowing up our bundle size meaninglessly. Since JSON does not support comments, I will explain my suggestion here:

```
// Support every browser with > 0.2% market share, according to `caniuse`. 
"> 0.2%",
// Support all 5 last versions of (major) browsers
"last 5 versions",
// Support Firefox long-term releases
"Firefox ESR",
// Do NOT support dead browsers, even if they have a big market share (Sorry IE11)
"not dead",
// Do NOT bother supporting Opera Mini, which has a horrible ECMA implementation
"not op_mini all"
```

See https://browsersl.ist/#q=%3E+0.2%25%2C+last+5+versions%2C+Firefox+ESR%2C+not+dead%2C+not+op_mini+all