### PR TITLE
Move timeout to ECS instance

### DIFF
--- a/infra/templates/user_data.sh.tftpl
+++ b/infra/templates/user_data.sh.tftpl
@@ -1,3 +1,4 @@
 #!/bin/bash
 # Make the EC2 Instance join the cluster on startup
 echo "ECS_CLUSTER=${ecs_cluster_name}" >> /etc/ecs/ecs.config
+echo "ECS_CONTAINER_STOP_TIMEOUT=305" >> /etc/ecs/ecs.config

--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -4,10 +4,6 @@ resource "aws_cloudwatch_log_group" "this" {
 
 locals {
   sidekiq_environment = [
-    {
-      "name" = "ECS_CONTAINER_STOP_TIMEOUT"
-      "value" = "305"
-    },
   ]
   rails_environment = [
     {


### PR DESCRIPTION
This will not make our overall deployment slower as this is a maximum value, if the server stops before that, it will not affect anything.