### PR TITLE
Add person DOB to anonymization dashboard

### DIFF
--- a/app/controllers/api/v0/persons_controller.rb
+++ b/app/controllers/api/v0/persons_controller.rb
@@ -17,14 +17,8 @@ class Api::V0::PersonsController < Api::V0::ApiController
   def show
     wca_id = params[:wca_id]
     person = Person.current.includes(:user, :ranksSingle, :ranksAverage).find_by_wca_id!(wca_id)
-    private_attributes = []
-    if current_user
-      if current_user.wca_id == wca_id || current_user.any_kind_of_delegate?
-        private_attributes = %w[dob]
-      elsif current_user.can_admin_results?
-        private_attributes = %w[incorrect_wca_id_claim_count dob]
-      end
-    end
+    private_attributes = person.private_attributes_for_user(current_user)
+
     render json: person_to_json(person, private_attributes)
   end
 

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -142,6 +142,8 @@ class TicketsController < ApplicationController
     user, person = user_and_person_from_params
     return if check_errors(user, person)
 
+    person_private_attributes = person&.private_attributes_for_user(current_user)
+
     user_anonymization_checks, user_message_args = user&.anonymization_checks_with_message_args
     person_anonymization_checks, person_message_args = person&.anonymization_checks_with_message_args
 
@@ -154,7 +156,7 @@ class TicketsController < ApplicationController
 
     render json: {
       user: user,
-      person: person,
+      person: person&.serializable_hash(private_attributes: person_private_attributes),
       action_items: action_items,
       non_action_items: non_action_items,
       message_args: message_args,

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -156,7 +156,7 @@ class TicketsController < ApplicationController
 
     render json: {
       user: user,
-      person: person&.serializable_hash(private_attributes: person_private_attributes),
+      person: person&.as_json(private_attributes: person_private_attributes),
       action_items: action_items,
       non_action_items: non_action_items,
       message_args: message_args,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -365,6 +365,16 @@ class Person < ApplicationRecord
     new_wca_id
   end
 
+  def private_attributes_for_user(user)
+    if user&.wca_id == wca_id || user&.any_kind_of_delegate?
+      %w[dob]
+    elsif user&.can_admin_results?
+      %w[incorrect_wca_id_claim_count dob]
+    else
+      []
+    end
+  end
+
   def serializable_hash(options = nil)
     json = super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
     json.merge!(

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -366,9 +366,11 @@ class Person < ApplicationRecord
   end
 
   def private_attributes_for_user(user)
-    if user&.wca_id == wca_id || user&.any_kind_of_delegate?
+    return [] if user.nil?
+
+    if user.wca_id == wca_id || user.any_kind_of_delegate?
       %w[dob]
-    elsif user&.can_admin_results?
+    elsif user.can_admin_results?
       %w[incorrect_wca_id_claim_count dob]
     else
       []

--- a/app/webpacker/components/Tickets/TicketWorkbenches/AnonymizationTicketWorkbenchForWrt/VerifyAnonymizeDetails.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/AnonymizationTicketWorkbenchForWrt/VerifyAnonymizeDetails.jsx
@@ -16,7 +16,7 @@ export default function VerifyAnonymizeDetails({ data }) {
   return (
     <List bulleted>
       <List.Item>{`Anonymization type: ${anonymizationType(data)}`}</List.Item>
-      <List.Item>{`DOB: ${data.user?.dob || 'N/A'}`}</List.Item>
+      <List.Item>{`DOB: ${data.user?.dob || data.person?.dob || 'N/A'}`}</List.Item>
       <List.Item>{`Email: ${data.user?.email || 'N/A'}`}</List.Item>
       <Message>
         Before processing any anonymization requests, WRT must receive verification with a


### PR DESCRIPTION
This was a bug in the previous anonymization dashboard migration because of which the DOB of persons is not shown. I've fixed it now.

There was a similar case in another UI earlier, so I have attempted to reuse the logic.