### PR TITLE
Activate Rspec format cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -465,9 +465,6 @@ RSpec/DescribeClass:
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/BeEq:
-  Enabled: false
-
 RSpec/EmptyLineAfterHook:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -435,9 +435,6 @@ Rails/ActiveRecordCallbacksOrder:
 
 # Rspec
 
-RSpec/NotToNot:
- Enabled: false
-
 RSpec/MultipleExpectations:
  Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -465,16 +465,7 @@ RSpec/DescribeClass:
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/EmptyLineAfterHook:
-  Enabled: false
-
-RSpec/EmptyLineAfterExampleGroup:
-  Enabled: false
-
 RSpec/ExpectChange:
-  Enabled: false
-
-RSpec/EmptyLineAfterFinalLet:
   Enabled: false
 
 RSpec/SpecFilePathFormat:

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         default_avatar = UserAvatar.default_avatar(nil)
         expect(json['result'][0]['avatar']['url']).to eq default_avatar.url
         expect(json['result'][0]['avatar']['thumb_url']).to eq default_avatar.thumbnail_url
-        expect(json['result'][0]['avatar']['is_default']).to eq true
+        expect(json['result'][0]['avatar']['is_default']).to be true
       end
 
       it "can find by name" do
@@ -208,7 +208,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
       json = JSON.parse(response.body)
       expect(json["current"]["name"]).to eq "TNoodle-WCA-1.2.2"
       # the actual key resides in regulations-data, so in the test environment it will simply prompt "false"
-      expect(json["publicKeyBytes"]).to eq false
+      expect(json["publicKeyBytes"]).to be false
     end
   end
 
@@ -235,7 +235,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         expect(json['me']['teams'].length).to eq 1
         team = json['me']['teams'].first
         expect(team['friendly_id']).to eq 'board'
-        expect(team['leader']).to eq false
+        expect(team['leader']).to be false
       end
     end
 
@@ -278,10 +278,10 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
 
-        expect(json['me']['delegate_status']).to eq nil
+        expect(json['me']['delegate_status']).to be nil
         expect(json['me']['teams'].length).to eq 2
         team = json['me']['teams'].find { |t| t['friendly_id'] == 'wrc' }
-        expect(team['leader']).to eq false
+        expect(team['leader']).to be false
         expect(team['friendly_id']).to eq 'wrc'
         expect(team['avatar']['url']).to be_a String
         expect(team['id']).to be_a Numeric
@@ -324,10 +324,10 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         expect(json['me']['country_iso2']).to eq("US")
         expect(json['me']['gender']).to eq("m")
 
-        expect(json['me']['dob']).to eq(nil)
-        expect(json['me']['email']).to eq(nil)
+        expect(json['me']['dob']).to be(nil)
+        expect(json['me']['email']).to be(nil)
 
-        expect(json['me']['delegate_status']).to eq(nil)
+        expect(json['me']['delegate_status']).to be(nil)
         expect(json['me']['teams']).to eq([])
       end
 
@@ -338,7 +338,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json['me']['dob']).to eq("1987-12-04")
-        expect(json['me']['email']).to eq(nil)
+        expect(json['me']['email']).to be(nil)
       end
 
       it 'can request email scope' do
@@ -385,7 +385,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         default_avatar = UserAvatar.default_avatar(user)
         expect(json['me']['avatar']['url']).to eq default_avatar.url
         expect(json['me']['avatar']['thumb_url']).to eq default_avatar.thumbnail_url
-        expect(json['me']['avatar']['is_default']).to eq true
+        expect(json['me']['avatar']['is_default']).to be true
 
         expect(json['me']['country_iso2']).to eq "US"
         expect(json['me']['gender']).to eq "m"
@@ -413,7 +413,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         default_avatar = UserAvatar.default_avatar(user)
         expect(json['me']['avatar']['url']).to eq default_avatar.url
         expect(json['me']['avatar']['thumb_url']).to eq default_avatar.thumbnail_url
-        expect(json['me']['avatar']['is_default']).to eq true
+        expect(json['me']['avatar']['is_default']).to be true
 
         expect(json['me']['country_iso2']).to eq "US"
         expect(json['me']['gender']).to eq "m"

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
     let!(:user) { FactoryBot.create(:delegate, name: "Jeremy Fleischman") }
     let!(:comp) { FactoryBot.create(:competition, :confirmed, :visible, name: "jeremy Jfly's Competition 2015", delegates: [user]) }
     let!(:post) { FactoryBot.create(:post, title: "jeremy post title", body: "post body", author: user) }
+
     s3 = Aws::S3::Client.new(stub_responses: true)
     s3.stub_responses(:get_object, ->(_) { { body: "{}" } })
     Regulation.reload_regulations(Aws::S3::Resource.new(client: s3))
@@ -307,6 +308,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
         )
       end
       let(:scopes) { Doorkeeper::OAuth::Scopes.new }
+
       before :each do
         api_sign_in_as(user, scopes: scopes)
       end
@@ -369,6 +371,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
       end
       let(:scopes) { Doorkeeper::OAuth::Scopes.new }
       let(:token) { double acceptable?: true, accessible?: true, resource_owner_id: user.id, scopes: scopes }
+
       before :each do
         allow(controller).to receive(:doorkeeper_token) { token }
       end
@@ -397,6 +400,7 @@ RSpec.describe Api::V0::ApiController, clean_db_with_truncation: true do
       let(:user) { FactoryBot.create :user, country_iso2: "US" }
       let(:scopes) { Doorkeeper::OAuth::Scopes.new }
       let(:token) { double acceptable?: true, accessible?: true, resource_owner_id: user.id, scopes: scopes }
+
       before :each do
         allow(controller).to receive(:doorkeeper_token) { token }
       end

--- a/spec/controllers/api_users_controller_spec.rb
+++ b/spec/controllers/api_users_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Api::V0::UsersController do
       expect(response.status).to eq 200
       json = JSON.parse(response.body)
       expect(json["user"]).to eq competed_user.serializable_hash(private_attributes: ['email']).as_json
-      expect(json.key?("rankings")).to eq true
+      expect(json.key?("rankings")).to be true
     end
   end
 

--- a/spec/controllers/competitions_controller_spec.rb
+++ b/spec/controllers/competitions_controller_spec.rb
@@ -221,9 +221,9 @@ RSpec.describe CompetitionsController do
         expect(new_comp.name).to eq ""
         # When cloning a competition, we don't want to clone its showAtAll,
         # confirmed, and results_posted_at attributes.
-        expect(new_comp.showAtAll).to eq false
-        expect(new_comp.confirmed?).to eq false
-        expect(new_comp.results_posted_at).to eq nil
+        expect(new_comp.showAtAll).to be false
+        expect(new_comp.confirmed?).to be false
+        expect(new_comp.results_posted_at).to be nil
         # We don't want to clone its dates.
         expect(new_comp.start_date).to be_nil
         expect(new_comp.end_date).to be_nil
@@ -237,13 +237,13 @@ RSpec.describe CompetitionsController do
         # the delegate doing the cloning.
         expect(new_comp.delegates.sort_by(&:id)).to eq((competition.delegates + [delegate]).sort_by(&:id))
         # Assert competition has guest limit
-        expect(competition.guests_per_registration_limit_enabled?).to eq true
+        expect(competition.guests_per_registration_limit_enabled?).to be true
         # Guest limit is cloned
         expect(new_comp.guests_enabled).to eq competition.guests_enabled
         expect(new_comp.guest_entry_status).to eq competition.guest_entry_status
         expect(new_comp.guests_per_registration_limit).to eq competition.guests_per_registration_limit
         # Source competition has event limit
-        expect(competition.events_per_registration_limit_enabled?).to eq true
+        expect(competition.events_per_registration_limit_enabled?).to be true
         # Event limit is NOT cloned
         expect(new_comp.event_restrictions).not_to eq competition.event_restrictions
         expect(new_comp.event_restrictions_reason).not_to eq competition.event_restrictions_reason
@@ -273,7 +273,7 @@ RSpec.describe CompetitionsController do
       it 'can confirm competition' do
         put :confirm, params: { competition_id: competition }
         expect(response).to be_successful
-        expect(competition.reload.confirmed?).to eq true
+        expect(competition.reload.confirmed?).to be true
       end
 
       it 'saves staff_delegate_ids' do
@@ -358,7 +358,7 @@ RSpec.describe CompetitionsController do
       it 'cannot confirm competition' do
         put :confirm, params: { competition_id: competition }
         expect(response).to have_http_status(:forbidden)
-        expect(competition.reload.confirmed?).to eq false
+        expect(competition.reload.confirmed?).to be false
       end
 
       it "who is also the delegate can remove oneself as delegate" do
@@ -495,14 +495,14 @@ RSpec.describe CompetitionsController do
           put :confirm, params: { competition_id: competition }
         end.to change { enqueued_jobs.size }.by(2)
         expect(response).to be_successful
-        expect(competition.reload.confirmed?).to eq true
+        expect(competition.reload.confirmed?).to be true
       end
 
       it "cannot confirm a competition that is not at least 28 days in the future" do
         competition.update(start_date: 26.day.from_now, end_date: 26.day.from_now)
         put :confirm, params: { competition_id: competition }
         expect(response).to have_http_status(:bad_request)
-        expect(competition.reload.confirmed?).to eq false
+        expect(competition.reload.confirmed?).to be false
       end
 
       it "can confirm a competition that is having advancement conditions" do
@@ -532,7 +532,7 @@ RSpec.describe CompetitionsController do
         )
         put :confirm, params: { competition_id: competition }
         expect(response).to be_successful
-        expect(competition.reload.confirmed?).to eq true
+        expect(competition.reload.confirmed?).to be true
       end
 
       it "cannot confirm a competition that is not having advancement conditions" do
@@ -549,7 +549,7 @@ RSpec.describe CompetitionsController do
           scramble_set_count: 1,
         )
         put :confirm, params: { competition_id: competition }
-        expect(competition.reload.confirmed?).to eq false
+        expect(competition.reload.confirmed?).to be false
       end
 
       it "cannot delete not confirmed, but visible competition" do
@@ -661,7 +661,7 @@ RSpec.describe CompetitionsController do
         competition.update(start_date: 5.week.from_now, end_date: 5.week.from_now)
         put :confirm, params: { competition_id: competition }
         expect(response).to have_http_status(:forbidden)
-        expect(competition.reload.confirmed?).to eq false
+        expect(competition.reload.confirmed?).to be false
       end
 
       it "cannot delete not confirmed, but visible competition" do
@@ -775,27 +775,27 @@ RSpec.describe CompetitionsController do
         comp = FactoryBot.create(:competition, :announced)
         put :cancel_or_uncancel, params: { competition_id: comp }
         expect(response).to have_http_status(:bad_request)
-        expect(comp.reload.cancelled?).to eq false
+        expect(comp.reload.cancelled?).to be false
       end
 
       it "cannot cancel unannounced competition" do
         comp = FactoryBot.create(:competition, :confirmed)
         put :cancel_or_uncancel, params: { competition_id: comp }
         expect(response).to have_http_status(:bad_request)
-        expect(comp.reload.cancelled?).to eq false
+        expect(comp.reload.cancelled?).to be false
       end
 
       it "can cancel competition" do
         put :cancel_or_uncancel, params: { competition_id: competition }
         expect(response).to be_successful
-        expect(competition.reload.cancelled?).to eq true
+        expect(competition.reload.cancelled?).to be true
       end
 
       it "can uncancel competition" do
         cancelled_competition = FactoryBot.create(:competition, :cancelled, :future)
         put :cancel_or_uncancel, params: { competition_id: cancelled_competition, undo: true }
         expect(response).to be_successful
-        expect(cancelled_competition.reload.cancelled?).to eq false
+        expect(cancelled_competition.reload.cancelled?).to be false
       end
     end
 
@@ -809,14 +809,14 @@ RSpec.describe CompetitionsController do
         competition.organizers << orga
         put :cancel_or_uncancel, params: { competition_id: competition }
         expect(response).to have_http_status(:forbidden)
-        expect(competition.reload.cancelled?).to eq false
+        expect(competition.reload.cancelled?).to be false
       end
 
       it 'cannot uncancel competition' do
         cancelled_competition = FactoryBot.create(:competition, :cancelled, organizers: [orga])
         put :cancel_or_uncancel, params: { competition_id: cancelled_competition }
         expect(response).to have_http_status(:forbidden)
-        expect(cancelled_competition.reload.cancelled?).to eq true
+        expect(cancelled_competition.reload.cancelled?).to be true
       end
     end
   end
@@ -1085,16 +1085,16 @@ RSpec.describe CompetitionsController do
       end
 
       it 'bookmarks a competition' do
-        expect(user.is_bookmarked?(competition)).to eq false
+        expect(user.is_bookmarked?(competition)).to be false
         post :bookmark, params: { id: competition.id }
-        expect(user.is_bookmarked?(competition)).to eq true
+        expect(user.is_bookmarked?(competition)).to be true
       end
 
       it 'unbookmarks a competition' do
         post :bookmark, params: { id: competition.id }
-        expect(user.is_bookmarked?(competition)).to eq true
+        expect(user.is_bookmarked?(competition)).to be true
         post :unbookmark, params: { id: competition.id }
-        expect(user.is_bookmarked?(competition)).to eq false
+        expect(user.is_bookmarked?(competition)).to be false
       end
     end
   end

--- a/spec/controllers/competitions_controller_spec.rb
+++ b/spec/controllers/competitions_controller_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe CompetitionsController do
 
     context 'when signed in as a delegate' do
       let(:delegate) { FactoryBot.create :delegate }
+
       before :each do
         sign_in delegate
       end
@@ -328,6 +329,7 @@ RSpec.describe CompetitionsController do
 
     context 'when signed in as organizer' do
       let(:organizer) { FactoryBot.create(:delegate) }
+
       before :each do
         competition.organizers << organizer
         future_competition.organizers << organizer
@@ -453,6 +455,7 @@ RSpec.describe CompetitionsController do
       let(:delegate) { FactoryBot.create(:delegate) }
       let(:organizer1) { FactoryBot.create(:user) }
       let(:organizer2) { FactoryBot.create(:user) }
+
       before :each do
         competition.delegates << delegate
         sign_in delegate
@@ -621,6 +624,7 @@ RSpec.describe CompetitionsController do
       let(:trainee_delegate) { FactoryBot.create(:trainee_delegate) }
       let(:organizer1) { FactoryBot.create(:user) }
       let(:organizer2) { FactoryBot.create(:user) }
+
       before :each do
         competition.delegates << delegate
         competition.delegates << trainee_delegate
@@ -729,6 +733,7 @@ RSpec.describe CompetitionsController do
 
     context "when signed in as delegate for a different competition" do
       let(:delegate) { FactoryBot.create(:delegate) }
+
       before :each do
         sign_in delegate
       end
@@ -765,8 +770,10 @@ RSpec.describe CompetitionsController do
 
   describe 'PUT #cancel_or_uncancel' do
     let(:competition) { FactoryBot.create(:competition, :confirmed, :announced, :future) }
+
     context 'when signed in as WCAT' do
       let(:wcat_member) { FactoryBot.create(:user, :wcat_member) }
+
       before :each do
         sign_in wcat_member
       end
@@ -801,6 +808,7 @@ RSpec.describe CompetitionsController do
 
     context 'when signed in as orga' do
       let(:orga) { FactoryBot.create(:user) }
+
       before :each do
         sign_in orga
       end
@@ -824,6 +832,7 @@ RSpec.describe CompetitionsController do
   describe 'POST #orga_close_reg_when_full_limit' do
     context 'organiser trying to close registration via button' do
       let(:orga) { FactoryBot.create(:user) }
+
       before :each do
         sign_in orga
       end

--- a/spec/controllers/delegate_reports_controller_spec.rb
+++ b/spec/controllers/delegate_reports_controller_spec.rb
@@ -64,17 +64,17 @@ RSpec.describe DelegateReportsController do
       comp.start_date = 1.day.from_now.strftime("%F")
       comp.end_date = 1.day.from_now.strftime("%F")
       comp.save!
-      expect(comp.is_probably_over?).to eq false
+      expect(comp.is_probably_over?).to be false
 
       post :update, params: { competition_id: comp.id, delegate_report: { remarks: "My new remarks", posted: false } }
       comp.reload
       expect(comp.delegate_report.remarks).to eq "My new remarks"
-      expect(comp.delegate_report.posted?).to eq false
+      expect(comp.delegate_report.posted?).to be false
 
       post :update, params: { competition_id: comp.id, delegate_report: { remarks: "My newer remarks", posted: true } }
       comp.reload
       expect(comp.delegate_report.remarks).to eq "My newer remarks"
-      expect(comp.delegate_report.posted?).to eq true
+      expect(comp.delegate_report.posted?).to be true
     end
 
     it "can post report and cannot edit report if it's posted" do
@@ -90,7 +90,7 @@ RSpec.describe DelegateReportsController do
       expect(flash[:info]).to eq "Your report has been posted and emailed!"
       comp.reload
       expect(comp.delegate_report.remarks).to eq "My newer remarks"
-      expect(comp.delegate_report.posted?).to eq true
+      expect(comp.delegate_report.posted?).to be true
       expect(comp.delegate_report.posted_by_user_id).to eq user.id
 
       # Try to update the report when it's posted.
@@ -141,7 +141,7 @@ RSpec.describe DelegateReportsController do
     it "cannot post the report" do
       post :update, params: { competition_id: comp.id, delegate_report: { remarks: "My newer remarks", posted: true } }
       comp.reload
-      expect(comp.delegate_report.posted?).to eq false
+      expect(comp.delegate_report.posted?).to be false
       expect(response).to redirect_to(root_url)
     end
   end

--- a/spec/controllers/delegate_reports_controller_spec.rb
+++ b/spec/controllers/delegate_reports_controller_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe DelegateReportsController do
 
   context "logged in as THE delegate" do
     let!(:user) { comp.delegates.first }
+
     before :each do
       sign_in user
     end
@@ -122,6 +123,7 @@ RSpec.describe DelegateReportsController do
 
   context "logged in as THE trainee delegate" do
     let!(:user) { comp.trainee_delegates.first }
+
     before :each do
       sign_in user
     end

--- a/spec/controllers/panel_controller_spec.rb
+++ b/spec/controllers/panel_controller_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe PanelController do
   describe "signed in as senior delegate" do
     let!(:senior_delegate_role) { FactoryBot.create :senior_delegate_role }
+
     before :each do
       sign_in senior_delegate_role.user
     end
@@ -17,6 +18,7 @@ RSpec.describe PanelController do
 
   describe "signed in as board member" do
     let!(:board_member) { FactoryBot.create :user, :board_member }
+
     before :each do
       sign_in board_member
     end

--- a/spec/controllers/polls_controller_spec.rb
+++ b/spec/controllers/polls_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe PollsController do
         post :update, params: { id: poll.id, poll: { question: "Pedro", multiple: true, deadline: '2016-03-15' } }
         poll.reload
         expect(poll.question).to eq "Pedro"
-        expect(poll.multiple?).to eq true
+        expect(poll.multiple?).to be true
         expect(poll.deadline).to eq '2016-03-15'.to_date
       end
 
@@ -78,7 +78,7 @@ RSpec.describe PollsController do
 
         post :update, params: { id: poll.id, poll: { question: poll.question }, commit: "Confirm" }
         poll.reload
-        expect(poll.confirmed?).to eq true
+        expect(poll.confirmed?).to be true
       end
 
       it "removes an option and try to confirm" do
@@ -94,7 +94,7 @@ RSpec.describe PollsController do
 
         post :update, params: { id: poll.id, poll: { question: poll.question }, commit: "Confirm" }
         poll.reload
-        expect(poll.confirmed?).to eq false
+        expect(poll.confirmed?).to be false
       end
 
       it "can't edit a confirmed poll, except for deadline" do
@@ -102,7 +102,7 @@ RSpec.describe PollsController do
         post :update, params: { id: poll.id, poll: { multiple: true } }
         invalid_poll = assigns :poll
         poll.reload
-        expect(poll.multiple).to eq false
+        expect(poll.multiple).to be false
         expect(invalid_poll.errors[:deadline]).to eq ["you can only change the deadline"]
       end
 
@@ -117,13 +117,13 @@ RSpec.describe PollsController do
       it "can delete an unconfirmed poll" do
         poll = FactoryBot.create(:poll)
         post :destroy, params: { id: poll.id }
-        expect(Poll.find_by_id(poll.id)).to eq nil
+        expect(Poll.find_by_id(poll.id)).to be nil
       end
 
       it "can't delete a confirmed poll" do
         poll = FactoryBot.create(:poll, :confirmed)
         post :destroy, params: { id: poll.id }
-        expect(Poll.find_by_id(poll.id)).not_to eq nil
+        expect(Poll.find_by_id(poll.id)).not_to be nil
       end
 
       it "deadline defaults to now if you don't change it" do

--- a/spec/controllers/polls_controller_spec.rb
+++ b/spec/controllers/polls_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe PollsController do
 
   context "logged in as board member" do
     let!(:board_member) { FactoryBot.create :user, :board_member }
+
     before :each do
       sign_in board_member
     end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RegistrationsController, clean_db_with_truncation: true do
 
     it "works when not logged in" do
       get :register, params: { competition_id: competition.id }
-      expect(assigns(:registration)).to eq nil
+      expect(assigns(:registration)).to be nil
     end
   end
 

--- a/spec/controllers/tickets_controller_spec.rb
+++ b/spec/controllers/tickets_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe TicketsController do
 
       expect(response).to be_successful
       user.reload
-      expect(user.wca_id).to eq nil
+      expect(user.wca_id).to be nil
       expect(user.email).to eq user.id.to_s + User::ANONYMOUS_ACCOUNT_EMAIL_ID_SUFFIX
       expect(user.name).to eq User::ANONYMOUS_NAME
       expect(user.dob).to eq User::ANONYMOUS_DOB.to_date

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -114,12 +114,12 @@ RSpec.describe UsersController do
     context "recently authenticated" do
       it "user can change email" do
         sign_in user
-        expect(user.confirmation_sent_at).to eq nil
+        expect(user.confirmation_sent_at).to be nil
         post :authenticate_user_for_sensitive_edit, params: { user: { password: "wca" } }
         patch :update, params: { id: user.id, user: { email: "newEmail@newEmail.com" } }
         user.reload
         expect(user.unconfirmed_email).to eq "newemail@newemail.com"
-        expect(user.confirmation_sent_at).not_to eq nil
+        expect(user.confirmation_sent_at).not_to be nil
       end
     end
 
@@ -128,8 +128,8 @@ RSpec.describe UsersController do
         sign_in user
         patch :update, params: { id: user.id, user: { email: "newEmail@newEmail.com" } }
         user.reload
-        expect(user.unconfirmed_email).to eq nil
-        expect(user.confirmation_sent_at).to eq nil
+        expect(user.unconfirmed_email).to be nil
+        expect(user.confirmation_sent_at).to be nil
         expect(flash[:danger]).to eq I18n.t("users.edit.sensitive.identity_error")
       end
     end
@@ -148,6 +148,7 @@ RSpec.describe UsersController do
 
     context "after creating a pending registration" do
       let!(:registration) { FactoryBot.create(:registration, :pending, user: user) }
+
       it "user can change name" do
         sign_in user
         patch :update, params: { id: user.id, user: { name: "Johnny 5" } }
@@ -157,6 +158,7 @@ RSpec.describe UsersController do
 
     context "after having a registration deleted" do
       let!(:registration) { FactoryBot.create(:registration, :cancelled, user: user) }
+
       it "user can change name" do
         sign_in user
         patch :update, params: { id: user.id, user: { name: "Johnny 5" } }
@@ -189,7 +191,7 @@ RSpec.describe UsersController do
       get :index, params: { format: :json, sort: "country", order: "ASC -- HMM" }
       users = assigns(:users)
       sql = users.to_sql
-      expect(sql).to_not match "HMM"
+      expect(sql).not_to match "HMM"
       expect(sql).to match(/order by .+ desc/i)
     end
   end
@@ -200,7 +202,7 @@ RSpec.describe UsersController do
         post :acknowledge_cookies
         expect(response.status).to eq 401
         response_json = response.parsed_body
-        expect(response_json['ok']).to eq false
+        expect(response_json['ok']).to be false
       end
     end
 
@@ -215,14 +217,14 @@ RSpec.describe UsersController do
         expect(admin.reload.cookies_acknowledged).to be false
         post :acknowledge_cookies
         response_json = response.parsed_body
-        expect(response_json['ok']).to eq true
+        expect(response_json['ok']).to be true
         expect(admin.reload.cookies_acknowledged).to be true
 
         # Do the same thing again. This shouldn't clear their cookies acknowledged
         # state.
         post :acknowledge_cookies
         response_json = response.parsed_body
-        expect(response_json['ok']).to eq true
+        expect(response_json['ok']).to be true
         expect(admin.reload.cookies_acknowledged).to be true
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe UsersController do
       get :index, params: { format: :json, sort: "country", order: "ASC -- HMM" }
       users = assigns(:users)
       sql = users.to_sql
-      expect(sql).to_not match "HMM"
+      expect(sql).not_to match "HMM"
       expect(sql).to match(/order by .+ desc/i)
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe UsersController do
 
     context "after creating a pending registration" do
       let!(:registration) { FactoryBot.create(:registration, :pending, user: user) }
+
       it "user can change name" do
         sign_in user
         patch :update, params: { id: user.id, user: { name: "Johnny 5" } }
@@ -157,6 +158,7 @@ RSpec.describe UsersController do
 
     context "after having a registration deleted" do
       let!(:registration) { FactoryBot.create(:registration, :cancelled, user: user) }
+
       it "user can change name" do
         sign_in user
         patch :update, params: { id: user.id, user: { name: "Johnny 5" } }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -114,12 +114,12 @@ RSpec.describe UsersController do
     context "recently authenticated" do
       it "user can change email" do
         sign_in user
-        expect(user.confirmation_sent_at).to eq nil
+        expect(user.confirmation_sent_at).to be nil
         post :authenticate_user_for_sensitive_edit, params: { user: { password: "wca" } }
         patch :update, params: { id: user.id, user: { email: "newEmail@newEmail.com" } }
         user.reload
         expect(user.unconfirmed_email).to eq "newemail@newemail.com"
-        expect(user.confirmation_sent_at).not_to eq nil
+        expect(user.confirmation_sent_at).not_to be nil
       end
     end
 
@@ -128,8 +128,8 @@ RSpec.describe UsersController do
         sign_in user
         patch :update, params: { id: user.id, user: { email: "newEmail@newEmail.com" } }
         user.reload
-        expect(user.unconfirmed_email).to eq nil
-        expect(user.confirmation_sent_at).to eq nil
+        expect(user.unconfirmed_email).to be nil
+        expect(user.confirmation_sent_at).to be nil
         expect(flash[:danger]).to eq I18n.t("users.edit.sensitive.identity_error")
       end
     end
@@ -200,7 +200,7 @@ RSpec.describe UsersController do
         post :acknowledge_cookies
         expect(response.status).to eq 401
         response_json = JSON.parse(response.body)
-        expect(response_json['ok']).to eq false
+        expect(response_json['ok']).to be false
       end
     end
 
@@ -215,14 +215,14 @@ RSpec.describe UsersController do
         expect(admin.reload.cookies_acknowledged).to be false
         post :acknowledge_cookies
         response_json = JSON.parse(response.body)
-        expect(response_json['ok']).to eq true
+        expect(response_json['ok']).to be true
         expect(admin.reload.cookies_acknowledged).to be true
 
         # Do the same thing again. This shouldn't clear their cookies acknowledged
         # state.
         post :acknowledge_cookies
         response_json = JSON.parse(response.body)
-        expect(response_json['ok']).to eq true
+        expect(response_json['ok']).to be true
         expect(admin.reload.cookies_acknowledged).to be true
       end
     end

--- a/spec/controllers/votes_controller_spec.rb
+++ b/spec/controllers/votes_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe VotesController do
 
   context "logged in as delegate" do
     let!(:delegate) { FactoryBot.create :delegate }
+
     before :each do
       sign_in delegate
     end
@@ -55,6 +56,7 @@ RSpec.describe VotesController do
 
   context "logged in as staff member" do
     let!(:staff_member) { FactoryBot.create :user, :wrt_member }
+
     before :each do
       sign_in staff_member
     end

--- a/spec/controllers/wfc_controller_spec.rb
+++ b/spec/controllers/wfc_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe WfcController do
 
   context "logged in as WFC member" do
     let!(:wfc_member) { FactoryBot.create :user, :wfc_member }
+
     before :each do
       sign_in wfc_member
     end

--- a/spec/features/claim_wca_id_spec.rb
+++ b/spec/features/claim_wca_id_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Claim WCA ID" do
 
       # They have not selected a valid WCA ID yet, so don't show the birthdate verification
       # field.
-      expect(page.find("div.user_dob_verification", visible: false).visible?).to eq false
+      expect(page.find("div.user_dob_verification", visible: false).visible?).to be false
 
       # Fill in WCA ID.
       fill_in_selectize "WCA ID", with: person.wca_id
@@ -27,7 +27,7 @@ RSpec.feature "Claim WCA ID" do
 
       # Now that they've selected a valid WCA ID, make sure the birthdate
       # verification field is visible.
-      expect(page.find("div.user_dob_verification", visible: true).visible?).to eq true
+      expect(page.find("div.user_dob_verification", visible: true).visible?).to be true
 
       delegate = person.competitions.first.delegates.first
       choose("user_delegate_id_to_handle_wca_id_claim_#{delegate.id}")
@@ -91,8 +91,8 @@ RSpec.feature "Claim WCA ID" do
       # the expected message for this is users.errors.wca_id_no_birthdate_html
       expect(page.find(".alert.alert-danger")).to have_content("We do not have a birthdate recorded for this WCA ID. Please contact the WCA Results Team")
       user.reload
-      expect(user.unconfirmed_wca_id).to eq nil
-      expect(user.delegate_to_handle_wca_id_claim).to eq nil
+      expect(user.unconfirmed_wca_id).to be nil
+      expect(user.delegate_to_handle_wca_id_claim).to be nil
     end
   end
 end

--- a/spec/features/competition_manage_schedule_spec.rb
+++ b/spec/features/competition_manage_schedule_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Competition events management" do
 
   context "unconfirmed competition without schedule" do
     let!(:competition) { FactoryBot.create(:competition, :with_delegate, :registration_open, event_ids: ["333", "444"], with_rounds: true) }
+
     background do
       sign_in competition.delegates.first
       visit "/competitions/#{competition.id}/schedule/edit"
@@ -42,6 +43,7 @@ RSpec.feature "Competition events management" do
 
   context "unconfirmed competition with schedule" do
     let!(:competition) { FactoryBot.create(:competition, :with_delegate, :registration_open, :with_valid_schedule, event_ids: ["333", "444"]) }
+
     background do
       sign_in competition.delegates.first
       visit "/competitions/#{competition.id}/schedule/edit"

--- a/spec/features/competition_management_spec.rb
+++ b/spec/features/competition_management_spec.rb
@@ -276,7 +276,7 @@ RSpec.feature "Competition management", js: true, retry: 10 do
       visit edit_competition_path(comp)
       # patch :update, params: { id: comp, competition: { name: comp.name }, commit: "Confirm" }
       click_button "Confirm"
-      expect(comp.reload.confirmed?).to eq false
+      expect(comp.reload.confirmed?).to be false
     end
 
     scenario 'clone competition', js: true do
@@ -295,8 +295,8 @@ RSpec.feature "Competition management", js: true, retry: 10 do
       expect(new_competition.name).to eq "New Comp 2015"
       expect(new_competition.delegates).to eq [delegate, cloned_delegate]
       expect(new_competition.venue).to eq competition_to_clone.venue
-      expect(new_competition.showAtAll).to eq false
-      expect(new_competition.confirmed?).to eq false
+      expect(new_competition.showAtAll).to be false
+      expect(new_competition.confirmed?).to be false
       expect(new_competition.cityName).to eq 'Melbourne, Victoria'
     end
 

--- a/spec/features/competition_management_spec.rb
+++ b/spec/features/competition_management_spec.rb
@@ -42,6 +42,7 @@ end
 RSpec.feature "Competition management", js: true, retry: 10 do
   context "when signed in as admin" do
     let!(:admin) { FactoryBot.create :admin }
+
     before :each do
       sign_in admin
     end

--- a/spec/features/cookie_law_spec.rb
+++ b/spec/features/cookie_law_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature "cookie law" do
 
   context "signed in" do
     let!(:admin) { FactoryBot.create(:admin, cookies_acknowledged: false) }
+
     background do
       sign_in admin
     end

--- a/spec/features/create_competition_tabs_spec.rb
+++ b/spec/features/create_competition_tabs_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "create competition tabs" do
     visit competition_path(competition)
     expect(page).to have_content "Travel!"
     expect(page).to have_content "Travel informations."
-    expect(page).to_not have_content "Accomodation"
-    expect(page).to_not have_content "On your own."
+    expect(page).not_to have_content "Accomodation"
+    expect(page).not_to have_content "On your own."
   end
 end

--- a/spec/features/incident_management_spec.rb
+++ b/spec/features/incident_management_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Incident Management", js: true do
 
   context "when signed in as a WRC member" do
     let!(:wrc_member) { FactoryBot.create(:user, :wrc_member) }
+
     before(:each) do
       sign_in wrc_member
     end
@@ -77,6 +78,7 @@ RSpec.feature "Incident Management", js: true do
 
   context "when signed in as a Delegate" do
     let!(:delegate) { FactoryBot.create(:delegate) }
+
     before(:each) do
       sign_in delegate
     end
@@ -111,6 +113,7 @@ RSpec.feature "Incident Management", js: true do
 
   context "when signed in as a User" do
     let!(:user) { FactoryBot.create(:user) }
+
     before(:each) do
       sign_in user
     end

--- a/spec/features/register_for_competition_spec.rb
+++ b/spec/features/register_for_competition_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Registering for a competition", js: true do
       click_button "Continue to next Step"
       expect(find("#checkbox-444")).to match_selector(".active")
       expect(find("#checkbox-555")).to match_selector(".active")
-      expect(find("#checkbox-666")).to_not match_selector(".active")
+      expect(find("#checkbox-666")).not_to match_selector(".active")
     end
 
     context "editing registration" do

--- a/spec/features/register_for_competition_spec.rb
+++ b/spec/features/register_for_competition_spec.rb
@@ -181,7 +181,7 @@ RSpec.feature "Registering for a competition", js: true do
       end
 
       expect(page).to have_text("Updated registration")
-      expect(Registration.find_by_id(registration.id).cancelled?).to eq true
+      expect(Registration.find_by_id(registration.id).cancelled?).to be true
     end
   end
 end

--- a/spec/features/register_for_competition_spec.rb
+++ b/spec/features/register_for_competition_spec.rb
@@ -131,6 +131,7 @@ RSpec.feature "Registering for a competition", js: true do
   context "signed in as delegate" do
     let!(:registration) { FactoryBot.create(:registration, user: user, competition: competition) }
     let(:delegate_registration) { FactoryBot.create(:registration, :accepted, user: delegate, competition: competition) }
+
     before :each do
       sign_in delegate
     end

--- a/spec/helpers/persons_helper_spec.rb
+++ b/spec/helpers/persons_helper_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe PersonsHelper do
       it "when country rank is missing" do
         rank_single = FactoryBot.create :ranks_single, countryRank: 0
         rank_average = FactoryBot.create :ranks_average
-        expect(odd_rank_reason_needed?(rank_single, rank_average)).to eq true
+        expect(odd_rank_reason_needed?(rank_single, rank_average)).to be true
       end
 
       it "when continent rank is missing" do
         rank_single = FactoryBot.create :ranks_single
         rank_average = FactoryBot.create :ranks_average, continentRank: 0
-        expect(odd_rank_reason_needed?(rank_single, rank_average)).to eq true
+        expect(odd_rank_reason_needed?(rank_single, rank_average)).to be true
       end
 
       it "when country rank is greater than continent rank" do
         rank_single = FactoryBot.create :ranks_single, continentRank: 10, countryRank: 1
         rank_average = FactoryBot.create :ranks_single, continentRank: 10, countryRank: 50
-        expect(odd_rank_reason_needed?(rank_single, rank_average)).to eq true
+        expect(odd_rank_reason_needed?(rank_single, rank_average)).to be true
       end
     end
   end

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ResultsHelper do
       results << FactoryBot.create(:result, person: person, best: 1000, average: 1300)
 
       pb_markers = helper.historical_pb_markers results
-      expect(pb_markers[results[1].id][:single]).to eq true
+      expect(pb_markers[results[1].id][:single]).to be true
     end
 
     it "doesn't mark uncompleted solves as PB" do

--- a/spec/i18n_locale_files_spec.rb
+++ b/spec/i18n_locale_files_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Locale files content" do
     describe locale_file.to_s do
       it { is_expected.to be_parseable }
       it { is_expected.to have_valid_pluralization_keys }
-      it { is_expected.to_not have_missing_pluralization_keys }
+      it { is_expected.not_to have_missing_pluralization_keys }
       it { is_expected.to have_one_top_level_namespace }
-      it { is_expected.to_not have_legacy_interpolations }
+      it { is_expected.not_to have_legacy_interpolations }
       it { is_expected.to have_a_valid_locale }
     end
   end

--- a/spec/jobs/wca_cronjob_spec.rb
+++ b/spec/jobs/wca_cronjob_spec.rb
@@ -54,43 +54,43 @@ RSpec.describe WcaCronjob, type: :job do
   end
 
   it "stores timestamps in cronjob_statistics table" do
-    expect(SuccessfulJob.scheduled?).to eq false
-    expect(SuccessfulJob.in_progress?).to eq false
-    expect(SuccessfulJob.finished?).to eq false
+    expect(SuccessfulJob.scheduled?).to be false
+    expect(SuccessfulJob.in_progress?).to be false
+    expect(SuccessfulJob.finished?).to be false
 
     SuccessfulJob.perform_later
 
-    expect(SuccessfulJob.scheduled?).to eq true
-    expect(SuccessfulJob.in_progress?).to eq false
-    expect(SuccessfulJob.finished?).to eq false
+    expect(SuccessfulJob.scheduled?).to be true
+    expect(SuccessfulJob.in_progress?).to be false
+    expect(SuccessfulJob.finished?).to be false
 
     perform_enqueued_jobs
 
-    expect(SuccessfulJob.last_run_successful?).to eq true
+    expect(SuccessfulJob.last_run_successful?).to be true
 
-    expect(SuccessfulJob.scheduled?).to eq false
-    expect(SuccessfulJob.in_progress?).to eq false
-    expect(SuccessfulJob.finished?).to eq true
+    expect(SuccessfulJob.scheduled?).to be false
+    expect(SuccessfulJob.in_progress?).to be false
+    expect(SuccessfulJob.finished?).to be true
   end
 
   it "doesn't delete failed jobs, and notifies on failure" do
-    expect(FailingJob.scheduled?).to eq false
-    expect(FailingJob.in_progress?).to eq false
-    expect(FailingJob.finished?).to eq false
+    expect(FailingJob.scheduled?).to be false
+    expect(FailingJob.in_progress?).to be false
+    expect(FailingJob.finished?).to be false
 
     FailingJob.perform_later
 
-    expect(FailingJob.scheduled?).to eq true
-    expect(FailingJob.in_progress?).to eq false
-    expect(FailingJob.finished?).to eq false
+    expect(FailingJob.scheduled?).to be true
+    expect(FailingJob.in_progress?).to be false
+    expect(FailingJob.finished?).to be false
 
     expect(JobFailureMailer).to receive(:notify_admin_of_job_failure).and_call_original
     expect { perform_enqueued_jobs }.to raise_error(RuntimeError).and change { ActionMailer::Base.deliveries.length }.by(1)
 
-    expect(FailingJob.last_run_successful?).to eq false
+    expect(FailingJob.last_run_successful?).to be false
 
-    expect(FailingJob.scheduled?).to eq false
-    expect(FailingJob.in_progress?).to eq false
-    expect(FailingJob.finished?).to eq true
+    expect(FailingJob.scheduled?).to be false
+    expect(FailingJob.in_progress?).to be false
+    expect(FailingJob.finished?).to be true
   end
 end

--- a/spec/lib/database_dumper_spec.rb
+++ b/spec/lib/database_dumper_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "DatabaseDumper" do
 
       expect(Competition.count).to eq 1
       expect(visible_competition.reload.remarks).to eq "remarks to the board here"
-      expect(CompetitionDelegate.find_by_competition_id(not_visible_competition.id)).to eq nil
+      expect(CompetitionDelegate.find_by_competition_id(not_visible_competition.id)).to be nil
       expect(user.reload.dob).to eq Date.new(1954, 12, 4)
       expect(ServerSetting.find_by_name(DatabaseDumper::DEV_TIMESTAMP_NAME).as_datetime).to be >= before_dump
 

--- a/spec/lib/results_validators/positions_validator_spec.rb
+++ b/spec/lib/results_validators/positions_validator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ResultsValidators::PositionsValidator do
       it "validates results correctly ordered on given competitions" do
         validator_args.each do |arg|
           pv = ResultsValidators::PositionsValidator.new.validate(**arg)
-          expect(pv.has_errors?).to eq false
+          expect(pv.has_errors?).to be false
         end
       end
 
@@ -88,7 +88,7 @@ RSpec.describe ResultsValidators::PositionsValidator do
           arg[:model].where(pos: 1, eventId: "333oh").update(pos: 2)
           arg[:model].where(pos: 5, eventId: "222").update(pos: 7)
           pv = ResultsValidators::PositionsValidator.new(apply_fixes: true).validate(**arg)
-          expect(pv.has_errors?).to eq false
+          expect(pv.has_errors?).to be false
           expect(pv.infos).to match_array(expected_infos[arg[:model].to_s])
         end
       end
@@ -100,7 +100,7 @@ RSpec.describe ResultsValidators::PositionsValidator do
         create_correct_tied_results(competition1, "333oh", kind: :inbox_result)
         validator_args.each do |arg|
           pv = ResultsValidators::PositionsValidator.new.validate(**arg)
-          expect(pv.has_errors?).to eq false
+          expect(pv.has_errors?).to be false
         end
       end
       it "invalidates incorrectly tied results" do
@@ -128,7 +128,7 @@ RSpec.describe ResultsValidators::PositionsValidator do
         FactoryBot.create(:result, :blind_mo3, competition: competition1, pos: 1, best: 1000)
         FactoryBot.create(:result, :blind_mo3, competition: competition1, pos: 3, best: 2000)
         pv = ResultsValidators::PositionsValidator.new.validate(competition_ids: competition1.id, model: Result)
-        expect(pv.has_errors?).to eq false
+        expect(pv.has_errors?).to be false
       end
 
       it "invalidates incorrectly ordered results" do

--- a/spec/lib/results_validators/positions_validator_spec.rb
+++ b/spec/lib/results_validators/positions_validator_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe ResultsValidators::PositionsValidator do
           ],
         }
       }
+
       it "validates results correctly ordered on given competitions" do
         validator_args.each do |arg|
           pv = ResultsValidators::PositionsValidator.new.validate(**arg)

--- a/spec/lib/solve_time_spec.rb
+++ b/spec/lib/solve_time_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "SolveTime" do
   end
 
   it "skipped?" do
-    expect(solve_time(0).skipped?).to eq true
+    expect(solve_time(0).skipped?).to be true
     expect(solve_time(0).clock_format).to eq ""
     expect(solve_time(0).clock_format_with_units).to eq ""
   end
@@ -36,22 +36,22 @@ RSpec.describe "SolveTime" do
 
   describe "ordering" do
     it "orders regular solves" do
-      expect(solve_time(100) < solve_time(1000)).to eq true
+      expect(solve_time(100) < solve_time(1000)).to be true
     end
 
     it "treats skipped as worst" do
-      expect(solve_time(SolveTime::SKIPPED_VALUE) > solve_time(SolveTime::DNF_VALUE)).to eq true
-      expect(solve_time(SolveTime::SKIPPED_VALUE) > solve_time(SolveTime::DNS_VALUE)).to eq true
-      expect(solve_time(SolveTime::SKIPPED_VALUE) > solve_time(30)).to eq true
+      expect(solve_time(SolveTime::SKIPPED_VALUE) > solve_time(SolveTime::DNF_VALUE)).to be true
+      expect(solve_time(SolveTime::SKIPPED_VALUE) > solve_time(SolveTime::DNS_VALUE)).to be true
+      expect(solve_time(SolveTime::SKIPPED_VALUE) > solve_time(30)).to be true
     end
 
     it "treats DNS as worse than DNF" do
-      expect(solve_time(SolveTime::DNS_VALUE) > solve_time(SolveTime::DNF_VALUE)).to eq true
-      expect(solve_time(SolveTime::DNS_VALUE) > solve_time(30)).to eq true
+      expect(solve_time(SolveTime::DNS_VALUE) > solve_time(SolveTime::DNF_VALUE)).to be true
+      expect(solve_time(SolveTime::DNS_VALUE) > solve_time(30)).to be true
     end
 
     it "treats DNS as worse than a finished solve" do
-      expect(solve_time(SolveTime::DNF_VALUE) > solve_time(30)).to eq true
+      expect(solve_time(SolveTime::DNF_VALUE) > solve_time(30)).to be true
     end
   end
 

--- a/spec/mailers/competitions_mailer_spec.rb
+++ b/spec/mailers/competitions_mailer_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe CompetitionsMailer, type: :mailer do
 
       it "renders the body" do
         expect(mail.body.encoded).to match(/This is a reminder that registration/)
-        expect(mail.body.encoded).to_not match(/You have registered/)
+        expect(mail.body.encoded).not_to match(/You have registered/)
         expect(mail.body.encoded).to include(competition_url(competition))
       end
     end

--- a/spec/models/competition_series_spec.rb
+++ b/spec/models/competition_series_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CompetitionSeries do
     competition.reload
 
     expect(competition.id).to eq previous_competition_id
-    expect(competition.destroyed?).to eq false
+    expect(competition.destroyed?).to be false
   end
 
   it "deletes the series when it is orphaned" do
@@ -43,6 +43,6 @@ RSpec.describe CompetitionSeries do
     competition.reload
 
     expect(competition.id).to eq previous_competition_id
-    expect(competition.destroyed?).to eq false
+    expect(competition.destroyed?).to be false
   end
 end

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -260,12 +260,12 @@ RSpec.describe Competition do
 
     it "start_date" do
       competition.start_date = "i am not a date"
-      expect(competition.start_date).to eq nil
+      expect(competition.start_date).to be nil
     end
 
     it "end_date" do
       competition.end_date = "i am also not a date"
-      expect(competition.end_date).to eq nil
+      expect(competition.end_date).to be nil
     end
   end
 
@@ -414,7 +414,7 @@ RSpec.describe Competition do
     it "warns for unposted reports" do
       competition = FactoryBot.create :competition, :visible, :with_delegate, starts: 2.days.ago
       delegate = competition.delegates.first
-      expect(competition.user_should_post_delegate_report?(delegate)).to eq true
+      expect(competition.user_should_post_delegate_report?(delegate)).to be true
     end
 
     it "does not warn for posted reports" do
@@ -422,19 +422,19 @@ RSpec.describe Competition do
       posted_dummy_dr = FactoryBot.create :delegate_report, :posted, competition: competition
       competition.delegate_report.update!(schedule_url: "http://example.com", posted: true, setup_images: posted_dummy_dr.setup_images_blobs)
       delegate = competition.delegates.first
-      expect(competition.user_should_post_delegate_report?(delegate)).to eq false
+      expect(competition.user_should_post_delegate_report?(delegate)).to be false
     end
 
     it "does not warn for upcoming competitions" do
       competition = FactoryBot.create :competition, :visible, :with_delegate, starts: 1.days.from_now
       delegate = competition.delegates.first
-      expect(competition.user_should_post_delegate_report?(delegate)).to eq false
+      expect(competition.user_should_post_delegate_report?(delegate)).to be false
     end
 
     it "does not warn board members" do
       competition = FactoryBot.create :competition, :visible, :with_delegate, starts: 2.days.ago
       board_member = FactoryBot.create :user, :board_member
-      expect(competition.user_should_post_delegate_report?(board_member)).to eq false
+      expect(competition.user_should_post_delegate_report?(board_member)).to be false
     end
   end
 
@@ -450,7 +450,7 @@ RSpec.describe Competition do
     it "does not warn about name greater than 32 when competition is publicly visible" do
       competition = FactoryBot.build :competition, :confirmed, :visible, name: "A really long competition name 2016"
       expect(competition).to be_valid
-      expect(competition.warnings_for(nil)[:name]).to eq nil
+      expect(competition.warnings_for(nil)[:name]).to be nil
     end
 
     it "warns if competition is not visible" do
@@ -489,7 +489,7 @@ RSpec.describe Competition do
 
       competition = FactoryBot.create :competition, starts: Date.new(2019, 10, 1), championship_types: ["world"]
       expect(competition).to be_valid
-      expect(competition.warnings_for(nil)["world"]).to eq nil
+      expect(competition.warnings_for(nil)["world"]).to be nil
     end
 
     it "warns if championship already exists" do
@@ -509,7 +509,7 @@ RSpec.describe Competition do
     it "do not warn if competition id starts with a number" do
       competition = FactoryBot.build :competition, id: "1stNumberedComp2021"
       expect(competition).to be_valid
-      expect(competition.warnings_for(nil)[:id]).to eq nil
+      expect(competition.warnings_for(nil)[:id]).to be nil
     end
 
     it "warns if advancement condition isn't present for a non final round" do
@@ -577,7 +577,7 @@ RSpec.describe Competition do
       competition.results_posted_at = Time.now
       competition.results_posted_by = FactoryBot.create(:user, :wrt_member).id
       expect(competition.in_progress?).to be false
-      expect(competition.info_for(nil)[:in_progress]).to eq nil
+      expect(competition.info_for(nil)[:in_progress]).to be nil
     end
   end
 
@@ -593,14 +593,14 @@ RSpec.describe Competition do
     end
 
     it "not_over scope does not include the competition" do
-      expect(Competition.not_over.find_by_id(competition.id)).to eq nil
+      expect(Competition.not_over.find_by_id(competition.id)).to be nil
     end
   end
 
   it "knows the calendar" do
     competition = FactoryBot.create :competition
     competition.start_date = "1987-0-04"
-    expect(competition.start_date).to eq nil
+    expect(competition.start_date).to be nil
   end
 
   it "gracefully handles multiyear competitions" do
@@ -738,9 +738,9 @@ RSpec.describe Competition do
       expect(CompetitionOrganizer.where(organizer_id: organizer.id).count).to eq 1
 
       cd = CompetitionDelegate.find_by_delegate_id(delegate.id)
-      expect(cd).not_to eq nil
+      expect(cd).not_to be nil
       co = CompetitionOrganizer.find_by_organizer_id(organizer.id)
-      expect(co).not_to eq nil
+      expect(co).not_to be nil
 
       c = Competition.find(competition.id)
       c.id = "NewID2015"
@@ -853,57 +853,57 @@ RSpec.describe Competition do
     let(:delegate_enabled) { FactoryBot.create :delegate, registration_notifications_enabled: true }
 
     it "computes receiving_registration_emails? via OR" do
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq false
+      expect(competition.receiving_registration_emails?(delegate.id)).to be false
 
       competition.delegates << delegate
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq false
+      expect(competition.receiving_registration_emails?(delegate.id)).to be false
 
       competition.delegates << delegate_enabled
-      expect(competition.receiving_registration_emails?(delegate_enabled.id)).to eq true
+      expect(competition.receiving_registration_emails?(delegate_enabled.id)).to be true
 
       cd = competition.competition_delegates.find_by_delegate_id(delegate.id)
       cd.update_column(:receive_registration_emails, true)
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq true
+      expect(competition.receiving_registration_emails?(delegate.id)).to be true
 
       competition.organizers << delegate
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq true
+      expect(competition.receiving_registration_emails?(delegate.id)).to be true
 
       co = competition.competition_organizers.find_by_organizer_id(delegate.id)
       co.update_column(:receive_registration_emails, true)
-      expect(competition.receiving_registration_emails?(delegate.id)).to eq true
+      expect(competition.receiving_registration_emails?(delegate.id)).to be true
     end
 
     it "setting receive_registration_emails" do
       competition.delegates << delegate
       cd = competition.competition_delegates.find_by_delegate_id(delegate.id)
-      expect(cd.receive_registration_emails).to eq false
+      expect(cd.receive_registration_emails).to be false
 
       competition.receive_registration_emails = false
       competition.editing_user_id = delegate.id
       competition.save!
       competition.receive_registration_emails = nil
-      expect(cd.reload.receive_registration_emails).to eq false
+      expect(cd.reload.receive_registration_emails).to be false
 
       competition.organizers << delegate
       co = competition.competition_organizers.find_by_organizer_id(delegate.id)
-      expect(co.receive_registration_emails).to eq false
+      expect(co.receive_registration_emails).to be false
 
       competition.receive_registration_emails = false
       competition.editing_user_id = delegate.id
       competition.save!
 
-      expect(cd.reload.receive_registration_emails).to eq false
-      expect(co.reload.receive_registration_emails).to eq false
+      expect(cd.reload.receive_registration_emails).to be false
+      expect(co.reload.receive_registration_emails).to be false
 
       # Test we can change the setting for a delegate with notifications
       # enabled by default.
       competition.delegates << delegate_enabled
       cde = competition.competition_delegates.find_by_delegate_id(delegate_enabled.id)
-      expect(cde.receive_registration_emails).to eq true
+      expect(cde.receive_registration_emails).to be true
       competition.receive_registration_emails = false
       competition.editing_user_id = delegate_enabled.id
       competition.save!
-      expect(cde.reload.receive_registration_emails).to eq false
+      expect(cde.reload.receive_registration_emails).to be false
     end
   end
 
@@ -964,11 +964,11 @@ RSpec.describe Competition do
       expect(result.map(&:first)).to eq [person_four, person_one, person_three, person_two].map(&:wca_id)
       expect(result.second.last.map(&:roundTypeId)).to eq %w(f 1 c)
 
-      expect(result[1][1][1].muted).to eq true
-      expect(result[1][1][2].muted).to eq false
+      expect(result[1][1][1].muted).to be true
+      expect(result[1][1][2].muted).to be false
 
-      expect(result[2][1][1].muted).to eq true
-      expect(result[3][1][1].muted).to eq true
+      expect(result[2][1][1].muted).to be true
+      expect(result[3][1][1].muted).to be true
     end
 
     it "events_with_round_types_with_results" do
@@ -1075,9 +1075,9 @@ RSpec.describe Competition do
     it "searching with two words" do
       expect(Competition.contains('eso').contains('aci').first).to eq search_comp
       expect(Competition.contains('awesome').contains('comp').first).to eq search_comp
-      expect(Competition.contains('abc').contains('def').first).to eq nil
-      expect(Competition.contains('ped').contains('aci').first).to eq nil
-      expect(Competition.contains('wes').contains('blah').first).to eq nil
+      expect(Competition.contains('abc').contains('def').first).to be nil
+      expect(Competition.contains('ped').contains('aci').first).to be nil
+      expect(Competition.contains('wes').contains('blah').first).to be nil
     end
   end
 
@@ -1223,12 +1223,12 @@ RSpec.describe Competition do
   describe "has_defined_dates" do
     it "is false when no start and end date" do
       competition = FactoryBot.create(:competition, start_date: nil, end_date: nil)
-      expect(competition.has_defined_dates?).to eq false
+      expect(competition.has_defined_dates?).to be false
     end
 
     it "is true when has start and end date" do
       competition = FactoryBot.create(:competition)
-      expect(competition.has_defined_dates?).to eq true
+      expect(competition.has_defined_dates?).to be true
     end
   end
 
@@ -1245,42 +1245,42 @@ RSpec.describe Competition do
 
     it "is false when competition has no championships" do
       competition = FactoryBot.create(:competition, events: [four_by_four], championship_types: [], countryId: "Canada", cityName: "Vancouver, British Columbia")
-      expect(competition.exempt_from_wca_dues?).to eq false
+      expect(competition.exempt_from_wca_dues?).to be false
     end
 
     it "is false when competition is a national championship" do
       competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["CA"], countryId: "Canada", cityName: "Vancouver, British Columbia")
-      expect(competition.exempt_from_wca_dues?).to eq false
+      expect(competition.exempt_from_wca_dues?).to be false
     end
 
     it "is false when 333fm is the only event and competition is in a single country" do
       competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "Canada", cityName: "Vancouver, British Columbia")
-      expect(competition.exempt_from_wca_dues?).to eq false
+      expect(competition.exempt_from_wca_dues?).to be false
     end
 
     it "is true when 333fm is the only event and competition is in multiple countries" do
       competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XN")
-      expect(competition.exempt_from_wca_dues?).to eq true
+      expect(competition.exempt_from_wca_dues?).to be true
     end
 
     it "is true when 333fm is the only event and competition is in multiple continents" do
       competition = FactoryBot.create(:competition, events: [fmc], championship_types: [], countryId: "XW")
-      expect(competition.exempt_from_wca_dues?).to eq true
+      expect(competition.exempt_from_wca_dues?).to be true
     end
 
     it "is true when competition is a national championship and a world championship" do
       competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["AU", "world"], countryId: "Australia", cityName: "Melbourne, Victoria")
-      expect(competition.exempt_from_wca_dues?).to eq true
+      expect(competition.exempt_from_wca_dues?).to be true
     end
 
     it "is true when competition is a continental championship" do
       competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["_North America"], countryId: "Canada", cityName: "Vancouver, British Columbia")
-      expect(competition.exempt_from_wca_dues?).to eq true
+      expect(competition.exempt_from_wca_dues?).to be true
     end
 
     it "is true when competition is a world championship" do
       competition = FactoryBot.create(:competition, events: Event.official, championship_types: ["world"], countryId: "Korea")
-      expect(competition.exempt_from_wca_dues?).to eq true
+      expect(competition.exempt_from_wca_dues?).to be true
     end
   end
 
@@ -1445,63 +1445,63 @@ RSpec.describe Competition do
 
       it 'returns nil if no matching account is found' do
         competition = FactoryBot.create(:competition)
-        expect(competition.payment_account_for(:paypal)).to eq(nil)
+        expect(competition.payment_account_for(:paypal)).to be(nil)
       end
     end
 
     describe '#payments_enabled?' do
       it 'returns true when stripe is connected' do
         competition = FactoryBot.create(:competition, :stripe_connected)
-        expect(competition.payments_enabled?).to eq(true)
+        expect(competition.payments_enabled?).to be(true)
       end
 
       it 'returns true when paypal is connected' do
         competition = FactoryBot.create(:competition, :paypal_connected)
-        expect(competition.payments_enabled?).to eq(true)
+        expect(competition.payments_enabled?).to be(true)
       end
 
       it 'returns true when multiple integrations are connected' do
         competition = FactoryBot.create(:competition, :stripe_connected, :paypal_connected)
-        expect(competition.payments_enabled?).to eq(true)
+        expect(competition.payments_enabled?).to be(true)
       end
 
       it 'returns false when no integrations are connected' do
         competition = FactoryBot.create(:competition)
-        expect(competition.payments_enabled?).to eq(false)
+        expect(competition.payments_enabled?).to be(false)
       end
     end
 
     describe '#stripe_connected?' do
       it 'returns true when stripe is connected' do
         competition = FactoryBot.create(:competition, :stripe_connected)
-        expect(competition.stripe_connected?).to eq(true)
+        expect(competition.stripe_connected?).to be(true)
       end
 
       it 'returns false when paypal is connected' do
         competition = FactoryBot.create(:competition, :paypal_connected)
-        expect(competition.stripe_connected?).to eq(false)
+        expect(competition.stripe_connected?).to be(false)
       end
 
       it 'returns false when no integrations are connected' do
         competition = FactoryBot.create(:competition)
-        expect(competition.stripe_connected?).to eq(false)
+        expect(competition.stripe_connected?).to be(false)
       end
     end
 
     describe '#paypal_connected?' do
       it 'returns false when stripe is connected' do
         competition = FactoryBot.create(:competition, :stripe_connected)
-        expect(competition.paypal_connected?).to eq(false)
+        expect(competition.paypal_connected?).to be(false)
       end
 
       it 'returns true when paypal is connected' do
         competition = FactoryBot.create(:competition, :paypal_connected)
-        expect(competition.paypal_connected?).to eq(true)
+        expect(competition.paypal_connected?).to be(true)
       end
 
       it 'returns false when no integrations are connected' do
         competition = FactoryBot.create(:competition)
-        expect(competition.paypal_connected?).to eq(false)
+        expect(competition.paypal_connected?).to be(false)
       end
     end
 
@@ -1524,16 +1524,16 @@ RSpec.describe Competition do
         competition = FactoryBot.create(:competition, :payment_disconnect_delay_elapsed, :paypal_connected, :stripe_connected)
 
         competition.disconnect_payment_integration(:paypal)
-        expect(competition.paypal_connected?).to eq(false)
-        expect(competition.stripe_connected?).to eq(true)
+        expect(competition.paypal_connected?).to be(false)
+        expect(competition.stripe_connected?).to be(true)
       end
 
       it 'disconnecting stripe leaves paypal connected' do
         competition = FactoryBot.create(:competition, :payment_disconnect_delay_elapsed, :paypal_connected, :stripe_connected)
 
         competition.disconnect_payment_integration(:stripe)
-        expect(competition.paypal_connected?).to eq(true)
-        expect(competition.stripe_connected?).to eq(false)
+        expect(competition.paypal_connected?).to be(true)
+        expect(competition.stripe_connected?).to be(false)
       end
 
       it 'fails silently on a competition with no payment integrations' do
@@ -1546,8 +1546,8 @@ RSpec.describe Competition do
     describe '#disconnect_all' do
       it 'disconnects both integrations on a comp with two integrations' do
         competition = FactoryBot.create(:competition, :payment_disconnect_delay_elapsed, :stripe_connected, :paypal_connected)
-        expect(competition.paypal_connected?).to eq(true)
-        expect(competition.stripe_connected?).to eq(true)
+        expect(competition.paypal_connected?).to be(true)
+        expect(competition.stripe_connected?).to be(true)
 
         competition.disconnect_all_payment_integrations
         expect(competition.competition_payment_integrations).to eq([])
@@ -1644,29 +1644,29 @@ RSpec.describe Competition do
     let(:comp) { FactoryBot.create(:competition, :registration_open, :with_competitor_limit, competitor_limit: 3) }
 
     it 'attempt auto close returns false when it fails' do
-      expect(auto_close_comp.attempt_auto_close!).to eq(false)
+      expect(auto_close_comp.attempt_auto_close!).to be(false)
     end
 
     it 'attempt auto close returns true when it succeeds' do
       FactoryBot.create_list(:registration, 4, :paid_no_hooks, competition: auto_close_comp)
       FactoryBot.create(:registration, :paid_no_hooks, competition: auto_close_comp)
 
-      expect(auto_close_comp.attempt_auto_close!).to eq(true)
+      expect(auto_close_comp.attempt_auto_close!).to be(true)
     end
 
     it 'wont auto-close if threshold not reached' do
       FactoryBot.create(:registration, :paid_no_hooks, competition: auto_close_comp)
-      expect(auto_close_comp.attempt_auto_close!).to eq(false)
+      expect(auto_close_comp.attempt_auto_close!).to be(false)
     end
 
     it 'doesnt auto-close if threshold is null' do
       FactoryBot.create(:registration, :paid_no_hooks, competition: comp)
-      expect(comp.attempt_auto_close!).to eq(false)
+      expect(comp.attempt_auto_close!).to be(false)
     end
 
     it 'closes registrations when the close threshold is reached' do
       FactoryBot.create_list(:registration, 5, :paid_no_hooks, competition: auto_close_comp)
-      expect(auto_close_comp.attempt_auto_close!).to eq(true)
+      expect(auto_close_comp.attempt_auto_close!).to be(true)
     end
 
     it 'closes registrations when the close threshold is exceeded' do
@@ -1675,12 +1675,12 @@ RSpec.describe Competition do
       comp.update_column(:auto_close_threshold, 5)
       FactoryBot.create(:registration, :paid_no_hooks, competition: comp)
 
-      expect(comp.attempt_auto_close!).to eq(true)
+      expect(comp.attempt_auto_close!).to be(true)
     end
 
     it 'only auto-closes if the registrations are fully registrations' do
       FactoryBot.create_list(:registration, 5, :partially_paid, competition: auto_close_comp)
-      expect(auto_close_comp.attempt_auto_close!).to eq(false)
+      expect(auto_close_comp.attempt_auto_close!).to be(false)
     end
 
     context 'validations' do

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -1072,6 +1072,7 @@ RSpec.describe Competition do
   describe "#contains" do
     let!(:delegate) { FactoryBot.create :delegate, name: 'Pedro' }
     let!(:search_comp) { FactoryBot.create :competition, name: "Awesome Comp 2016", cityName: "Piracicaba, São Paulo", countryId: "Brazil", delegates: [delegate] }
+
     it "searching with two words" do
       expect(Competition.contains('eso').contains('aci').first).to eq search_comp
       expect(Competition.contains('awesome').contains('comp').first).to eq search_comp

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -1003,7 +1003,7 @@ RSpec.describe Competition do
 
     expect do
       competition.update_attribute(:id, "NewName2016")
-    end.to_not change {
+    end.not_to change {
       [:results, :organizers, :delegates, :tabs, :registrations, :delegate_report].map do |associated|
         competition.send(associated)
       end
@@ -1028,7 +1028,7 @@ RSpec.describe Competition do
         clone.save
       end.to change(CompetitionTab, :count).by(1)
       cloned_tab = clone.reload.tabs.first
-      expect(cloned_tab).to_not eq tab
+      expect(cloned_tab).not_to eq tab
       expect(cloned_tab.name).to eq tab.name
       expect(cloned_tab.content).to eq tab.content
     end

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Competition WCIF" do
   let!(:round333fm_1) { FactoryBot.create(:round, competition: competition, event_id: "333fm", number: 1, format_id: "m") }
   let!(:round333mbf_1) { FactoryBot.create(:round, competition: competition, event_id: "333mbf", number: 1, format_id: "3") }
   let!(:round333mbf_1_extension) { round333mbf_1.wcif_extensions.create!(extension_id: "com.third.party", spec_url: "https://example.com", data: { "tables" => 5 }) }
+
   before :each do
     # Load all the rounds we just created.
     competition.reload

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe "Competition WCIF" do
     it "rendered WCIF matches JSON Schema definition" do
       expect {
         JSON::Validator.validate!(Competition.wcif_json_schema, competition.to_wcif)
-      }.to_not raise_error
+      }.not_to raise_error
     end
   end
 

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe "Competition WCIF" do
 
       competition.set_wcif_competitor_limit!(competitor_limit_wcif, delegate)
 
-      expect(competition.competitor_limit_enabled?).to eq(true)
+      expect(competition.competitor_limit_enabled?).to be(true)
       expect(competition.to_wcif["competitorLimit"]).to eq(competitor_limit_wcif)
     end
 

--- a/spec/models/delegate_report_spec.rb
+++ b/spec/models/delegate_report_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe DelegateReport do
 
   it "wrc_feedback_requested is set false on creation" do
     dr = FactoryBot.create :delegate_report
-    expect(dr.wrc_feedback_requested).to eq false
+    expect(dr.wrc_feedback_requested).to be false
   end
 
   it "wrc_incidents is required when wrc_feedback_requested is true" do
@@ -52,7 +52,7 @@ RSpec.describe DelegateReport do
 
   it "wic_feedback_requested is set false on creation" do
     dr = FactoryBot.create :delegate_report
-    expect(dr.wic_feedback_requested).to eq false
+    expect(dr.wic_feedback_requested).to be false
   end
 
   it "wic_incidents is required when wic_feedback_requested is true" do
@@ -75,22 +75,22 @@ RSpec.describe DelegateReport do
       let(:delegate) { competition.delegates.first }
 
       it "cannot view delegate report with unposted report" do
-        expect(other_delegate.can_view_delegate_report?(competition.delegate_report)).to eq false
+        expect(other_delegate.can_view_delegate_report?(competition.delegate_report)).to be false
       end
 
       it "can view delegate report with posted report" do
         posted_dummy_dr = FactoryBot.create :delegate_report, :posted, competition: competition
         competition.delegate_report.update!(schedule_url: "http://example.com", posted: true, setup_images: posted_dummy_dr.setup_images_blobs)
 
-        expect(other_delegate.can_view_delegate_report?(competition.delegate_report)).to eq true
+        expect(other_delegate.can_view_delegate_report?(competition.delegate_report)).to be true
       end
 
       it "can view own delegate report for unposted report" do
-        expect(delegate.can_view_delegate_report?(competition.delegate_report)).to eq true
+        expect(delegate.can_view_delegate_report?(competition.delegate_report)).to be true
       end
 
       it "board member can view delegate report for unposted report" do
-        expect(board_member.can_view_delegate_report?(competition.delegate_report)).to eq true
+        expect(board_member.can_view_delegate_report?(competition.delegate_report)).to be true
       end
     end
 
@@ -99,15 +99,15 @@ RSpec.describe DelegateReport do
       let(:delegate) { competition.delegates.first }
 
       it "cannot view delegate report with unposted report" do
-        expect(other_delegate.can_view_delegate_report?(competition.delegate_report)).to eq false
+        expect(other_delegate.can_view_delegate_report?(competition.delegate_report)).to be false
       end
 
       it "can view own delegate report for unposted report" do
-        expect(delegate.can_view_delegate_report?(competition.delegate_report)).to eq true
+        expect(delegate.can_view_delegate_report?(competition.delegate_report)).to be true
       end
 
       it "board member can view delegate report for unposted report" do
-        expect(board_member.can_view_delegate_report?(competition.delegate_report)).to eq true
+        expect(board_member.can_view_delegate_report?(competition.delegate_report)).to be true
       end
     end
   end

--- a/spec/models/live_result_spec.rb
+++ b/spec/models/live_result_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe LiveResult do
       round = FactoryBot.create(:round, competition: competition, event_id: "666", format_id: 'm')
 
       complete_mean_result = FactoryBot.create(:live_result, :mo3, round: round, registration: registration)
-      expect(complete_mean_result.complete?).to eq true
+      expect(complete_mean_result.complete?).to be true
     end
 
     it "if less than 5 attempts are entered for an average of 5 round" do
       round = FactoryBot.create(:round, competition: competition, event_id: "333", format_id: 'a')
 
       incomplete_ao5_result = FactoryBot.create(:live_result, :incomplete, round: round, registration: registration)
-      expect(incomplete_ao5_result.complete?).to eq false
+      expect(incomplete_ao5_result.complete?).to be false
     end
   end
 end

--- a/spec/models/merge_people_spec.rb
+++ b/spec/models/merge_people_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe MergePeople do
     decoy_result = FactoryBot.create(:result)
 
     old_decoy_personId = decoy_result.personId
-    expect(merge_people.do_merge).to eq true
+    expect(merge_people.do_merge).to be true
     expect(result1.reload.personId).to eq person1.wca_id
     expect(result2.reload.personId).to eq person1.wca_id
     expect(decoy_result.reload.personId).to eq old_decoy_personId

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Person, type: :model do
       expect do
         FactoryBot.create :result, :blind_dnf_mo3, person: us_competitor, competition: us_nationals2017,
                                                    pos: 2, eventId: "555bf", best: SolveTime::DNF_VALUE
-      end.to_not change { us_competitor.championship_podiums[:national] }
+      end.not_to change { us_competitor.championship_podiums[:national] }
     end
 
     context "when a person changed nationality and continent" do
@@ -167,7 +167,7 @@ RSpec.describe Person, type: :model do
         expect do
           fr_nationals2017 = FactoryBot.create :competition, championship_types: ["FR"], starts: Date.new(2017, 1, 1)
           FactoryBot.create :result, person: fr_competitor, competition: fr_nationals2017, pos: 1, eventId: "333"
-        end.to_not change { fr_competitor.championship_podiums[:national] }
+        end.not_to change { fr_competitor.championship_podiums[:national] }
       end
 
       it "is eligible for championship title of the current continent" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Post do
       post.update!(tags: "wic")
       expect(Post.find(post.id).tags_array).to match_array %w(wic)
 
-      expect(post.update(tags: "wic,test tag with spaces")).to eq false
+      expect(post.update(tags: "wic,test tag with spaces")).to be false
       expect(post).to be_invalid_with_errors('post_tags.tag': ["only allows English letters, numbers, hyphens, and '+'"])
 
       expect(Post.find(post.id).tags_array).to match_array %w(wic)

--- a/spec/models/reassign_wca_id_spec.rb
+++ b/spec/models/reassign_wca_id_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe ReassignWcaId do
     wca_id = account1.wca_id
     delegate_status = account1.delegate_status
 
-    expect(reassign_wca_id.do_reassign_wca_id).to eq true
-    expect(account1.reload.wca_id).to eq nil
+    expect(reassign_wca_id.do_reassign_wca_id).to be true
+    expect(account1.reload.wca_id).to be nil
     expect(account2.reload.wca_id).to eq wca_id
-    expect(account1.reload.delegate_status).to eq nil
+    expect(account1.reload.delegate_status).to be nil
     expect(account2.reload.delegate_status).to eq delegate_status
     expect(team_member.reload.user_id).to eq account2.id
     expect(organized_competition.reload.organizers[0].id).to eq account2.id

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -353,35 +353,35 @@ RSpec.describe Registration do
     it 'deleted state returns deleted status' do
       registration = FactoryBot.create(:registration, :cancelled)
 
-      expect(registration.cancelled?).to eq(true)
+      expect(registration.cancelled?).to be(true)
       expect(registration.to_wcif['status']).to eq('deleted')
     end
 
     it 'rejected state returns deleted status' do
       registration = FactoryBot.create(:registration, :rejected)
 
-      expect(registration.rejected?).to eq(true)
+      expect(registration.rejected?).to be(true)
       expect(registration.to_wcif['status']).to eq('deleted')
     end
 
     it 'accepted state returns accepted status' do
       registration = FactoryBot.create(:registration, :accepted)
 
-      expect(registration.accepted?).to eq(true)
+      expect(registration.accepted?).to be(true)
       expect(registration.to_wcif['status']).to eq('accepted')
     end
 
     it 'pending state returns pending status' do
       registration = FactoryBot.create(:registration, :pending)
 
-      expect(registration.pending?).to eq(true)
+      expect(registration.pending?).to be(true)
       expect(registration.to_wcif['status']).to eq('pending')
     end
 
     it 'waitlisted state returns pending status' do
       registration = FactoryBot.create(:registration, :waiting_list)
 
-      expect(registration.waitlisted?).to eq(true)
+      expect(registration.waitlisted?).to be(true)
       expect(registration.to_wcif['status']).to eq('pending')
     end
   end
@@ -524,7 +524,7 @@ RSpec.describe Registration do
       it 'removes from waiting list' do
         reg4.update_lanes!({ user_id: reg4.user.id, competing: { status: 'pending' } }.with_indifferent_access, reg4.user)
 
-        expect(reg4.waiting_list_position).to eq(nil)
+        expect(reg4.waiting_list_position).to be(nil)
         expect(waiting_list.entries.count).to eq(4)
       end
 
@@ -568,7 +568,7 @@ RSpec.describe Registration do
         reg = FactoryBot.create(:registration, competition: competition)
         reg.update_lanes!({ user_id: reg.user.id, competing: { waiting_list_position: 3 } }.with_indifferent_access, reg.user)
 
-        expect(reg.waiting_list_position).to eq(nil)
+        expect(reg.waiting_list_position).to be(nil)
 
         expect(reg1.waiting_list_position).to eq(1)
         expect(reg2.waiting_list_position).to eq(2)

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Result do
 
           it "missing solves" do
             result = build_result(value1: 42, value2: 43, value3: 44, value4: 0, value5: 0, best: 42, average: 44)
-            expect(result.average_is_not_computable_reason).to eq nil
+            expect(result.average_is_not_computable_reason).to be nil
             expect(result.compute_correct_average).to eq 0
             expect(result).to be_invalid(average: ["should be 0"])
           end

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Round do
       let(:round) { FactoryBot.create :round, event_id: "333" }
 
       it "defaults to nil" do
-        expect(round.cutoff).to eq nil
+        expect(round.cutoff).to be nil
         expect(round.cutoff_to_s).to eq ""
       end
 
@@ -87,7 +87,7 @@ RSpec.describe Round do
       let(:round) { FactoryBot.create :round, event_id: "333fm", format_id: "m" }
 
       it "defaults to nil" do
-        expect(round.cutoff).to eq nil
+        expect(round.cutoff).to be nil
         expect(round.cutoff_to_s).to eq ""
       end
 
@@ -101,7 +101,7 @@ RSpec.describe Round do
       let(:round) { FactoryBot.create :round, event_id: "333mbf", format_id: "3" }
 
       it "defaults to nil" do
-        expect(round.cutoff).to eq nil
+        expect(round.cutoff).to be nil
         expect(round.cutoff_to_s).to eq ""
       end
 
@@ -115,7 +115,7 @@ RSpec.describe Round do
   context "advance to next round requirement" do
     it "defaults to nil" do
       first_round = create_rounds("333", count: 1)[0]
-      expect(first_round.advancement_condition).to eq nil
+      expect(first_round.advancement_condition).to be nil
       expect(first_round.advancement_condition_to_s).to eq ""
     end
 

--- a/spec/models/server_setting_spec.rb
+++ b/spec/models/server_setting_spec.rb
@@ -16,29 +16,29 @@ RSpec.describe ServerSetting do
   context "parses booleans" do
     it "casts truthy values into actual boolean" do
       server_setting = ServerSetting.create!(name: 'dummy_true', value: '1')
-      expect(server_setting.as_boolean).to eq(true)
+      expect(server_setting.as_boolean).to be(true)
 
       server_setting.update!(value: 'true')
-      expect(server_setting.as_boolean).to eq(true)
+      expect(server_setting.as_boolean).to be(true)
 
       server_setting.update!(value: 'TRUE')
-      expect(server_setting.as_boolean).to eq(true)
+      expect(server_setting.as_boolean).to be(true)
     end
 
     it "casts false-y values into actual boolean" do
       server_setting = ServerSetting.create!(name: 'dummy_true', value: '0')
-      expect(server_setting.as_boolean).to eq(false)
+      expect(server_setting.as_boolean).to be(false)
 
       server_setting.update!(value: 'false')
-      expect(server_setting.as_boolean).to eq(false)
+      expect(server_setting.as_boolean).to be(false)
 
       server_setting.update!(value: 'FALSE')
-      expect(server_setting.as_boolean).to eq(false)
+      expect(server_setting.as_boolean).to be(false)
     end
 
     it "casts false-y values as being truthy" do
       server_setting = ServerSetting.create!(name: 'dummy_true', value: 'lol')
-      expect(server_setting.as_boolean).to eq(true)
+      expect(server_setting.as_boolean).to be(true)
     end
   end
 end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Ticket, type: :model do
 
     it "user_stakeholders returns WRT stakeholder if user is a WRT member" do
       wrt_member = FactoryBot.create(:wrt_member_role).user
-      expect(edit_name_ticket.ticket.user_stakeholders(wrt_member).any? { |stakeholder| stakeholder.stakeholder == UserGroup.teams_committees_group_wrt }).to eq(true)
+      expect(edit_name_ticket.ticket.user_stakeholders(wrt_member).any? { |stakeholder| stakeholder.stakeholder == UserGroup.teams_committees_group_wrt }).to be(true)
     end
 
     it "user_stakeholders returns nil if user is a normal user" do
       normal_user = FactoryBot.create(:user)
-      expect(edit_name_ticket.ticket.user_stakeholders(normal_user).any? { |stakeholder| stakeholder.stakeholder == UserGroup.teams_committees_group_wrt }).to eq(false)
+      expect(edit_name_ticket.ticket.user_stakeholders(normal_user).any? { |stakeholder| stakeholder.stakeholder == UserGroup.teams_committees_group_wrt }).to be(false)
     end
   end
 
@@ -25,22 +25,22 @@ RSpec.describe Ticket, type: :model do
     let(:edit_name_ticket) { FactoryBot.create(:edit_name_ticket) }
 
     it "can_user_access? returns false if user is nil" do
-      expect(edit_name_ticket.ticket.can_user_access?(nil)).to eq(false)
+      expect(edit_name_ticket.ticket.can_user_access?(nil)).to be(false)
     end
 
     it "can_user_access? returns true if user is a WRT member" do
       wrt_member = FactoryBot.create(:wrt_member_role).user
-      expect(edit_name_ticket.ticket.can_user_access?(wrt_member)).to eq(true)
+      expect(edit_name_ticket.ticket.can_user_access?(wrt_member)).to be(true)
     end
 
     it "can_user_access? returns true if user is a direct stakeholder" do
       direct_stakeholder = edit_name_ticket.ticket.ticket_stakeholders.find_by(stakeholder_type: "User")
-      expect(edit_name_ticket.ticket.can_user_access?(direct_stakeholder.stakeholder)).to eq(true)
+      expect(edit_name_ticket.ticket.can_user_access?(direct_stakeholder.stakeholder)).to be(true)
     end
 
     it "can_user_access? returns false if user is a normal user" do
       normal_user = FactoryBot.create(:user)
-      expect(edit_name_ticket.ticket.can_user_access?(normal_user)).to eq(false)
+      expect(edit_name_ticket.ticket.can_user_access?(normal_user)).to be(false)
     end
   end
 end

--- a/spec/models/upload_json_spec.rb
+++ b/spec/models/upload_json_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe UploadJson do
 
     upload_json = FactoryBot.build(:upload_json, competition_id: competition.id, results_json_str: results_json)
 
-    expect(upload_json.import_to_inbox).to eq true
+    expect(upload_json.import_to_inbox).to be true
     expect(InboxResult.count).to eq 1
     inbox_result = InboxResult.first
     # There is no cutoff, so the incoming roundTypeId "c" should be converted to "f"

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -144,11 +144,11 @@ RSpec.describe UserGroup, type: :model do
   end
 
   it "is_root_group? returns true for root group" do
-    expect(asia_region.is_root_group?).to eq(true)
+    expect(asia_region.is_root_group?).to be(true)
   end
 
   it "is_root_group? returns false for non-root group" do
-    expect(india_region.is_root_group?).to eq(false)
+    expect(india_region.is_root_group?).to be(false)
   end
 
   context "Monthly digest changes" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -498,7 +498,7 @@ RSpec.describe User, type: :model do
 
     it "doesn't send the notification if the user has it disabled" do
       user = FactoryBot.build(:user_with_wca_id, results_notifications_enabled: false)
-      expect(CompetitionsMailer).to_not receive(:notify_users_of_results_presence).with(user, competition).and_call_original
+      expect(CompetitionsMailer).not_to receive(:notify_users_of_results_presence).with(user, competition).and_call_original
       user.notify_of_results_posted(competition)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -430,20 +430,20 @@ RSpec.describe User, type: :model do
     it "when empty, is set to nil" do
       user = FactoryBot.create :user, unconfirmed_wca_id: nil
       user.update! unconfirmed_wca_id: ""
-      expect(user.reload.unconfirmed_wca_id).to eq nil
+      expect(user.reload.unconfirmed_wca_id).to be nil
     end
   end
 
   it 'banned? returns true for users who are actively banned' do
     banned_user = FactoryBot.create :user, :banned
 
-    expect(banned_user.banned?).to eq true
+    expect(banned_user.banned?).to be true
   end
 
   it 'banned? returns false for users who are banned in past' do
     formerly_banned_user = FactoryBot.create :user, :formerly_banned
 
-    expect(formerly_banned_user.banned?).to eq false
+    expect(formerly_banned_user.banned?).to be false
   end
 
   it 'current_ban returns data of current banned role' do
@@ -472,12 +472,12 @@ RSpec.describe User, type: :model do
 
       it "updates the password if the password_confirmation matches" do
         user.update(password: "new", password_confirmation: "new")
-        expect(user.reload.valid_password?("new")).to eq true
+        expect(user.reload.valid_password?("new")).to be true
       end
 
       it "does not update the password if the password_confirmation does not match" do
         user.update(password: "new", password_confirmation: "wrong")
-        expect(user.reload.valid_password?("new")).to eq false
+        expect(user.reload.valid_password?("new")).to be false
       end
 
       it "does not allow blank password" do
@@ -508,17 +508,17 @@ RSpec.describe User, type: :model do
 
     it "returns false if the user is an organizer of an upcoming comp using registration system" do
       organizer = competition.organizers.first
-      expect(organizer.can_view_all_users?).to eq false
+      expect(organizer.can_view_all_users?).to be false
     end
 
     it "returns true for board" do
       board_member = FactoryBot.create :user, :board_member
-      expect(board_member.can_view_all_users?).to eq true
+      expect(board_member.can_view_all_users?).to be true
     end
 
     it "returns false for normal user" do
       normal_user = FactoryBot.create :user
-      expect(normal_user.can_view_all_users?).to eq false
+      expect(normal_user.can_view_all_users?).to be false
     end
   end
 
@@ -527,12 +527,12 @@ RSpec.describe User, type: :model do
 
     it "returns true for board" do
       board_member = FactoryBot.create :user, :board_member
-      expect(board_member.can_edit_user?(user)).to eq true
+      expect(board_member.can_edit_user?(user)).to be true
     end
 
     it "returns false for normal user" do
       normal_user = FactoryBot.create :user
-      expect(normal_user.can_edit_user?(user)).to eq false
+      expect(normal_user.can_edit_user?(user)).to be false
     end
   end
 
@@ -542,14 +542,14 @@ RSpec.describe User, type: :model do
 
     it "allows organizers of upcoming competitions to edit first-timer names" do
       organizer = competition.organizers.first
-      expect(organizer.can_edit_user?(registration.user)).to eq true
+      expect(organizer.can_edit_user?(registration.user)).to be true
       expect(organizer.editable_fields_of_user(registration.user).to_a).to eq [:name]
     end
 
     it "disallows delegates to edit WCA IDs of special accounts" do
       board_member = FactoryBot.create :user, :board_member
       delegate = FactoryBot.create :delegate
-      expect(delegate.can_edit_user?(board_member)).to eq true
+      expect(delegate.can_edit_user?(board_member)).to be true
       expect(delegate.editable_fields_of_user(board_member).to_a).not_to include(:wca_id)
     end
   end
@@ -557,19 +557,19 @@ RSpec.describe User, type: :model do
   describe "#is_special_account" do
     it "returns false for a normal user" do
       user = FactoryBot.create :user
-      expect(user.is_special_account?).to eq false
+      expect(user.is_special_account?).to be false
     end
 
     it "returns true for users on a team" do
       board_member = FactoryBot.create :user, :board_member
       banned_person = FactoryBot.create :user, :banned
-      expect(board_member.is_special_account?).to eq true
-      expect(banned_person.is_special_account?).to eq true
+      expect(board_member.is_special_account?).to be true
+      expect(banned_person.is_special_account?).to be true
     end
 
     it "returns true for users that are delegates" do
       senior_delegate_role = FactoryBot.create :senior_delegate_role
-      expect(senior_delegate_role.user.is_special_account?).to eq true
+      expect(senior_delegate_role.user.is_special_account?).to be true
     end
 
     it "returns true for users who organized or delegated a competition" do
@@ -577,9 +577,9 @@ RSpec.describe User, type: :model do
       delegate = FactoryBot.create :user # Intentionally not assigning a Delegate role as it is possible to Delegate a competition without being a current Delegate
       trainee_delegate = FactoryBot.create :user
       FactoryBot.create :competition, organizers: [organizer], delegates: [delegate, trainee_delegate]
-      expect(organizer.is_special_account?).to eq true
-      expect(delegate.is_special_account?).to eq true
-      expect(trainee_delegate.is_special_account?).to eq true
+      expect(organizer.is_special_account?).to be true
+      expect(delegate.is_special_account?).to be true
+      expect(trainee_delegate.is_special_account?).to be true
     end
   end
 
@@ -605,8 +605,8 @@ RSpec.describe User, type: :model do
     it "gets cleared if user is not eligible anymore" do
       former_staff_member = FactoryBot.create :user, receive_delegate_reports: true
       User.clear_receive_delegate_reports_if_not_eligible
-      expect(former_staff_member.reload.receive_delegate_reports).to eq false
-      expect(staff_member1.reload.receive_delegate_reports).to eq true
+      expect(former_staff_member.reload.receive_delegate_reports).to be false
+      expect(staff_member1.reload.receive_delegate_reports).to be true
     end
 
     it "adds to reports@ only current staff members who want to receive reports" do

--- a/spec/models/waiting_list_spec.rb
+++ b/spec/models/waiting_list_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WaitingList do
 
   it 'position is nil when registration not on waiting list' do
     registration = FactoryBot.create(:registration)
-    expect(registration.waiting_list_position).to eq(nil)
+    expect(registration.waiting_list_position).to be(nil)
   end
 
   describe 'add to waiting list' do

--- a/spec/requests/api_competitions_spec.rb
+++ b/spec/requests/api_competitions_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe "API Competitions" do
 
     context "when signed in as not a competition manager" do
       let(:competition) { FactoryBot.create(:competition, :visible) }
+
       sign_in { FactoryBot.create :user }
 
       it "does not allow access" do
@@ -459,6 +460,7 @@ RSpec.describe "API Competitions" do
 
     describe "extensions" do
       let!(:competition) { FactoryBot.create(:competition, :with_organizer, :visible) }
+
       context "when signed in as a competition manager" do
         before { sign_in competition.organizers.first }
 

--- a/spec/requests/api_competitions_spec.rb
+++ b/spec/requests/api_competitions_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe "API Competitions" do
     it "does not return confidential person data" do
       get api_v0_competition_wcif_public_path(competition)
       response_json = JSON.parse(response.body)
-      expect(response_json["persons"][0].keys).to_not include "email"
-      expect(response_json["persons"][0].keys).to_not include "birthdate"
+      expect(response_json["persons"][0].keys).not_to include "email"
+      expect(response_json["persons"][0].keys).not_to include "birthdate"
     end
 
     it "returns people with accepted registrations only" do
@@ -345,7 +345,7 @@ RSpec.describe "API Competitions" do
           }]
           expect {
             patch api_v0_competition_update_wcif_path(competition), params: { persons: persons }.to_json, headers: headers
-          }.to_not change { competition.reload.to_wcif["persons"] }
+          }.not_to change { competition.reload.to_wcif["persons"] }
         end
       end
     end
@@ -363,7 +363,7 @@ RSpec.describe "API Competitions" do
             competition.competition_venues.destroy_all
             # Reconstruct everything from the saved WCIF
             patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
-          }.to_not change { competition.reload.to_wcif["schedule"] }
+          }.not_to change { competition.reload.to_wcif["schedule"] }
         end
 
         it "can update venues and rooms" do
@@ -452,7 +452,7 @@ RSpec.describe "API Competitions" do
           wcif["schedule"]["startDate"] = nil
           expect {
             patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
-          }.to_not change { competition.reload.competition_venues.size }
+          }.not_to change { competition.reload.competition_venues.size }
         end
       end
     end

--- a/spec/requests/api_competitions_spec.rb
+++ b/spec/requests/api_competitions_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe "API Competitions" do
     it "does not return confidential person data" do
       get api_v0_competition_wcif_public_path(competition)
       response_json = response.parsed_body
-      expect(response_json["persons"][0].keys).to_not include "email"
-      expect(response_json["persons"][0].keys).to_not include "birthdate"
+      expect(response_json["persons"][0].keys).not_to include "email"
+      expect(response_json["persons"][0].keys).not_to include "birthdate"
     end
 
     it "returns people with accepted registrations only" do
@@ -173,6 +173,7 @@ RSpec.describe "API Competitions" do
 
     context "when signed in as not a competition manager" do
       let(:competition) { FactoryBot.create(:competition, :visible) }
+
       sign_in { FactoryBot.create :user }
 
       it "does not allow access" do
@@ -345,7 +346,7 @@ RSpec.describe "API Competitions" do
           }]
           expect {
             patch api_v0_competition_update_wcif_path(competition), params: { persons: persons }.to_json, headers: headers
-          }.to_not change { competition.reload.to_wcif["persons"] }
+          }.not_to change { competition.reload.to_wcif["persons"] }
         end
       end
     end
@@ -363,7 +364,7 @@ RSpec.describe "API Competitions" do
             competition.competition_venues.destroy_all
             # Reconstruct everything from the saved WCIF
             patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
-          }.to_not change { competition.reload.to_wcif["schedule"] }
+          }.not_to change { competition.reload.to_wcif["schedule"] }
         end
 
         it "can update venues and rooms" do
@@ -452,13 +453,14 @@ RSpec.describe "API Competitions" do
           wcif["schedule"]["startDate"] = nil
           expect {
             patch api_v0_competition_update_wcif_path(competition), params: wcif.to_json, headers: headers
-          }.to_not change { competition.reload.competition_venues.size }
+          }.not_to change { competition.reload.competition_venues.size }
         end
       end
     end
 
     describe "extensions" do
       let!(:competition) { FactoryBot.create(:competition, :with_organizer, :visible) }
+
       context "when signed in as a competition manager" do
         before { sign_in competition.organizers.first }
 

--- a/spec/requests/api_persons_spec.rb
+++ b/spec/requests/api_persons_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe "API Persons" do
 
   describe "GET #results" do
     let!(:result) { FactoryBot.create :result, person: person }
+
     it "renders properly" do
       get api_v0_person_results_path(person.wca_id)
       expect(response).to be_successful

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -410,10 +410,10 @@ RSpec.describe 'API Registrations' do
 
       user_ids = [user1.id, user2.id, user3.id, user4.id, user5.id, user6.id]
       body.each do |data|
-        expect(user_ids.include?(data['user_id'])).to eq(true)
+        expect(user_ids.include?(data['user_id'])).to be(true)
         if data['user_id'] == registration1[:user_id] || data['user_id'] == registration2[:user_id] ||data['user_id'] == registration3[:user_id]
           expect(data.dig('competing', 'registration_status')).to eq('accepted')
-          expect(data.dig('competing', 'waiting_list_position')).to eq(nil)
+          expect(data.dig('competing', 'waiting_list_position')).to be(nil)
         elsif data['user_id'] == registration4[:user_id]
           expect(data.dig('competing', 'waiting_list_position')).to eq(1)
         elsif data['user_id'] == registration5[:user_id]

--- a/spec/requests/competitions_spec.rb
+++ b/spec/requests/competitions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "competitions" do
         put competition_confirm_path(competition)
         expect(response).to be_successful
 
-        expect(competition.reload.confirmed?).to eq true
+        expect(competition.reload.confirmed?).to be true
       end
 
       context "when handling unconfirmed competitions" do
@@ -46,7 +46,7 @@ RSpec.describe "competitions" do
             competition.reload
             series.reload
 
-            expect(competition.part_of_competition_series?).to eq true
+            expect(competition.part_of_competition_series?).to be true
             expect(competition.series_sibling_competitions.count).to eq 1
             expect(series.competitions.count).to eq 2
           end
@@ -67,7 +67,7 @@ RSpec.describe "competitions" do
 
             competition.reload
 
-            expect(competition.part_of_competition_series?).to eq true
+            expect(competition.part_of_competition_series?).to be true
             expect(competition.series_sibling_competitions.count).to eq 1
             expect(competition.competition_series.id).not_to eq series.id
           end
@@ -88,7 +88,7 @@ RSpec.describe "competitions" do
 
               competition.reload
 
-              expect(competition.part_of_competition_series?).to eq false
+              expect(competition.part_of_competition_series?).to be false
               expect(competition.series_sibling_competitions.count).to eq 0
 
               persisted_series_id = series.id
@@ -109,7 +109,7 @@ RSpec.describe "competitions" do
 
               competition.reload
 
-              expect(competition.part_of_competition_series?).to eq false
+              expect(competition.part_of_competition_series?).to be false
               expect(competition.series_sibling_competitions.count).to eq 0
 
               expect { series.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -148,7 +148,7 @@ RSpec.describe "competitions" do
 
             expect(response).to be_successful
 
-            expect(competition.reload.part_of_competition_series?).to eq true
+            expect(competition.reload.part_of_competition_series?).to be true
             expect(competition.reload.series_sibling_competitions.count).to eq 1
             expect(series.reload.competitions.count).to eq 2
           end
@@ -169,7 +169,7 @@ RSpec.describe "competitions" do
 
             competition.reload
 
-            expect(competition.part_of_competition_series?).to eq true
+            expect(competition.part_of_competition_series?).to be true
             expect(competition.series_sibling_competitions.count).to eq 1
             expect(competition.competition_series.id).not_to eq series.id
           end
@@ -190,7 +190,7 @@ RSpec.describe "competitions" do
 
               competition.reload
 
-              expect(competition.part_of_competition_series?).to eq false
+              expect(competition.part_of_competition_series?).to be false
               expect(competition.series_sibling_competitions.count).to eq 0
 
               persisted_series_id = series.id
@@ -211,7 +211,7 @@ RSpec.describe "competitions" do
 
               competition.reload
 
-              expect(competition.part_of_competition_series?).to eq false
+              expect(competition.part_of_competition_series?).to be false
               expect(competition.series_sibling_competitions.count).to eq 0
 
               expect { series.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -257,7 +257,7 @@ RSpec.describe "competitions" do
             competition.reload
             series.reload
 
-            expect(competition.part_of_competition_series?).to eq true
+            expect(competition.part_of_competition_series?).to be true
             expect(competition.series_sibling_competitions.count).to eq 1
             expect(series.competitions.count).to eq 2
           end
@@ -278,7 +278,7 @@ RSpec.describe "competitions" do
 
             competition.reload
 
-            expect(competition.part_of_competition_series?).to eq true
+            expect(competition.part_of_competition_series?).to be true
             expect(competition.series_sibling_competitions.count).to eq 1
             expect(competition.competition_series.id).not_to eq series.id
           end
@@ -299,7 +299,7 @@ RSpec.describe "competitions" do
 
               competition.reload
 
-              expect(competition.part_of_competition_series?).to eq false
+              expect(competition.part_of_competition_series?).to be false
               expect(competition.series_sibling_competitions.count).to eq 0
 
               persisted_series_id = series.id
@@ -320,7 +320,7 @@ RSpec.describe "competitions" do
 
               competition.reload
 
-              expect(competition.part_of_competition_series?).to eq false
+              expect(competition.part_of_competition_series?).to be false
               expect(competition.series_sibling_competitions.count).to eq 0
 
               expect { series.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -361,7 +361,7 @@ RSpec.describe "competitions" do
 
             competition.reload
 
-            expect(competition.part_of_competition_series?).to eq false
+            expect(competition.part_of_competition_series?).to be false
             expect(competition.series_sibling_competitions.count).to eq 0
           end
 
@@ -381,7 +381,7 @@ RSpec.describe "competitions" do
 
             competition.reload
 
-            expect(competition.part_of_competition_series?).to eq false
+            expect(competition.part_of_competition_series?).to be false
             expect(competition.series_sibling_competitions.count).to eq 0
           end
 
@@ -397,7 +397,7 @@ RSpec.describe "competitions" do
             competition.reload
             series.reload
 
-            expect(competition.part_of_competition_series?).to eq true
+            expect(competition.part_of_competition_series?).to be true
             expect(competition.series_sibling_competitions.count).to eq 1
             expect(series.competitions.count).to eq 2
             expect(series.competitions).to include(competition, partner_competition)

--- a/spec/requests/incidents_spec.rb
+++ b/spec/requests/incidents_spec.rb
@@ -230,28 +230,28 @@ RSpec.describe "Incidents management", type: :request do
 
       it "can mark as resolved" do
         unresolved_incident = FactoryBot.create(:incident)
-        expect(unresolved_incident.resolved?).to eq false
+        expect(unresolved_incident.resolved?).to be false
         patch incident_mark_as_path(incident_id: unresolved_incident.id, kind: "resolved")
         unresolved_incident.reload
-        expect(unresolved_incident.resolved?).to eq true
+        expect(unresolved_incident.resolved?).to be true
         expect(response).to redirect_to(unresolved_incident)
       end
 
       it "can mark as digest sent" do
         resolved_incident = FactoryBot.create(:incident, :resolved, :digest_worthy)
-        expect(resolved_incident.digest_missing?).to eq true
+        expect(resolved_incident.digest_missing?).to be true
         patch incident_mark_as_path(incident_id: resolved_incident.id, kind: "sent")
         resolved_incident.reload
-        expect(resolved_incident.digest_sent?).to eq true
+        expect(resolved_incident.digest_sent?).to be true
         expect(response).to redirect_to(resolved_incident)
       end
 
       it "does not mark as digest sent when incident is not resolved" do
         unresolved_incident = FactoryBot.create(:incident)
-        expect(unresolved_incident.resolved?).to eq false
+        expect(unresolved_incident.resolved?).to be false
         patch incident_mark_as_path(incident_id: unresolved_incident.id, kind: "sent")
         unresolved_incident.reload
-        expect(unresolved_incident.digest_sent?).to eq false
+        expect(unresolved_incident.digest_sent?).to be false
       end
     end
   end

--- a/spec/requests/incidents_spec.rb
+++ b/spec/requests/incidents_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe "Incidents management", type: :request do
       before do
         sign_in wrc_member
       end
+
       it "shows the incident creation form" do
         get new_incident_path
         expect(response).to be_successful
@@ -105,6 +106,7 @@ RSpec.describe "Incidents management", type: :request do
       before do
         sign_in wrc_member
       end
+
       it "renders the edit page" do
         get edit_incident_path(incident)
         expect(response).to be_successful
@@ -150,6 +152,7 @@ RSpec.describe "Incidents management", type: :request do
 
   describe "PUT #update" do
     let!(:competition) { FactoryBot.create(:competition, :confirmed) }
+
     before :each do
       sign_in wrc_member
     end

--- a/spec/requests/oauth/oauth_spec.rb
+++ b/spec/requests/oauth/oauth_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe "oauth api" do
     post oauth_token_path, params: { grant_type: "password", client_id: oauth_app.uid, client_secret: oauth_app.secret, username: user.email, password: user.password, scope: "public email" }
     expect(response).to be_successful
     json = response.parsed_body
-    expect(json['error']).to eq(nil)
+    expect(json['error']).to be(nil)
     access_token = json['access_token']
-    expect(access_token).to_not eq(nil)
+    expect(access_token).not_to be(nil)
     verify_access_token access_token
   end
 
@@ -61,9 +61,9 @@ RSpec.describe "oauth api" do
       post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: oauth_authorization_url }
       expect(response).to be_successful
       json = response.parsed_body
-      expect(json['error']).to eq(nil)
+      expect(json['error']).to be(nil)
       access_token = json['access_token']
-      expect(access_token).to_not eq(nil)
+      expect(access_token).not_to be(nil)
       verify_access_token access_token
     end
 
@@ -108,21 +108,21 @@ RSpec.describe "oauth api" do
       post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: oauth_authorization_url }
       expect(response).to be_successful
       json = response.parsed_body
-      expect(json['error']).to eq(nil)
+      expect(json['error']).to be(nil)
       access_token = json['access_token']
-      expect(access_token).to_not eq(nil)
+      expect(access_token).not_to be(nil)
       verify_access_token access_token
       refresh_token = json['refresh_token']
-      expect(refresh_token).to_not eq(nil)
+      expect(refresh_token).not_to be(nil)
 
       # Since we now have a refresh token, we should be able to get a new access
       # token.
       post oauth_token_path, params: { grant_type: "refresh_token", client_id: oauth_app.uid, client_secret: oauth_app.secret, redirect_uri: oauth_authorization_url, refresh_token: refresh_token }
       expect(response).to be_successful
       json = response.parsed_body
-      expect(json['error']).to eq(nil)
+      expect(json['error']).to be(nil)
       access_token = json['access_token']
-      expect(access_token).to_not eq(nil)
+      expect(access_token).not_to be(nil)
       verify_access_token access_token
     end
 
@@ -156,9 +156,9 @@ RSpec.describe "oauth api" do
         post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: different_redirect_uri }
         expect(response).to be_successful
         json = response.parsed_body
-        expect(json['error']).to eq(nil)
+        expect(json['error']).to be(nil)
         access_token = json['access_token']
-        expect(access_token).to_not eq(nil)
+        expect(access_token).not_to be(nil)
         verify_access_token access_token
       end
     end
@@ -183,7 +183,7 @@ RSpec.describe "oauth api" do
 
     query = Rack::Utils.parse_query(URI.parse(current_url).query)
     access_token = query["access_token"]
-    expect(access_token).to_not eq(nil)
+    expect(access_token).not_to be(nil)
     verify_access_token access_token
   end
 
@@ -195,7 +195,7 @@ RSpec.describe "oauth api" do
     # We just do a sanity check of the /me route here. There is a more
     # complete test in api_controller_spec.
     expect(json['me']['id']).to eq(user.id)
-    expect(json['me']['dob']).to eq(nil)
+    expect(json['me']['dob']).to be(nil)
     expect(json['me']['email']).to eq(user.email)
   end
 end

--- a/spec/requests/oauth/oauth_spec.rb
+++ b/spec/requests/oauth/oauth_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe "oauth api" do
     post oauth_token_path, params: { grant_type: "password", client_id: oauth_app.uid, client_secret: oauth_app.secret, username: user.email, password: user.password, scope: "public email" }
     expect(response).to be_successful
     json = JSON.parse(response.body)
-    expect(json['error']).to eq(nil)
+    expect(json['error']).to be(nil)
     access_token = json['access_token']
-    expect(access_token).not_to eq(nil)
+    expect(access_token).not_to be(nil)
     verify_access_token access_token
   end
 
@@ -61,9 +61,9 @@ RSpec.describe "oauth api" do
       post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: oauth_authorization_url }
       expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['error']).to eq(nil)
+      expect(json['error']).to be(nil)
       access_token = json['access_token']
-      expect(access_token).not_to eq(nil)
+      expect(access_token).not_to be(nil)
       verify_access_token access_token
     end
 
@@ -108,21 +108,21 @@ RSpec.describe "oauth api" do
       post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: oauth_authorization_url }
       expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['error']).to eq(nil)
+      expect(json['error']).to be(nil)
       access_token = json['access_token']
-      expect(access_token).not_to eq(nil)
+      expect(access_token).not_to be(nil)
       verify_access_token access_token
       refresh_token = json['refresh_token']
-      expect(refresh_token).not_to eq(nil)
+      expect(refresh_token).not_to be(nil)
 
       # Since we now have a refresh token, we should be able to get a new access
       # token.
       post oauth_token_path, params: { grant_type: "refresh_token", client_id: oauth_app.uid, client_secret: oauth_app.secret, redirect_uri: oauth_authorization_url, refresh_token: refresh_token }
       expect(response).to be_successful
       json = JSON.parse(response.body)
-      expect(json['error']).to eq(nil)
+      expect(json['error']).to be(nil)
       access_token = json['access_token']
-      expect(access_token).not_to eq(nil)
+      expect(access_token).not_to be(nil)
       verify_access_token access_token
     end
 
@@ -156,9 +156,9 @@ RSpec.describe "oauth api" do
         post oauth_token_path, params: { grant_type: "authorization_code", client_id: oauth_app.uid, client_secret: oauth_app.secret, code: authorization_code, redirect_uri: different_redirect_uri }
         expect(response).to be_successful
         json = JSON.parse(response.body)
-        expect(json['error']).to eq(nil)
+        expect(json['error']).to be(nil)
         access_token = json['access_token']
-        expect(access_token).not_to eq(nil)
+        expect(access_token).not_to be(nil)
         verify_access_token access_token
       end
     end
@@ -183,7 +183,7 @@ RSpec.describe "oauth api" do
 
     query = Rack::Utils.parse_query(URI.parse(current_url).query)
     access_token = query["access_token"]
-    expect(access_token).not_to eq(nil)
+    expect(access_token).not_to be(nil)
     verify_access_token access_token
   end
 
@@ -195,7 +195,7 @@ RSpec.describe "oauth api" do
     # We just do a sanity check of the /me route here. There is a more
     # complete test in api_controller_spec.
     expect(json['me']['id']).to eq(user.id)
-    expect(json['me']['dob']).to eq(nil)
+    expect(json['me']['dob']).to be(nil)
     expect(json['me']['email']).to eq(user.email)
   end
 end

--- a/spec/requests/oauth/oauth_spec.rb
+++ b/spec/requests/oauth/oauth_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "oauth api" do
     json = JSON.parse(response.body)
     expect(json['error']).to eq(nil)
     access_token = json['access_token']
-    expect(access_token).to_not eq(nil)
+    expect(access_token).not_to eq(nil)
     verify_access_token access_token
   end
 
@@ -63,7 +63,7 @@ RSpec.describe "oauth api" do
       json = JSON.parse(response.body)
       expect(json['error']).to eq(nil)
       access_token = json['access_token']
-      expect(access_token).to_not eq(nil)
+      expect(access_token).not_to eq(nil)
       verify_access_token access_token
     end
 
@@ -110,10 +110,10 @@ RSpec.describe "oauth api" do
       json = JSON.parse(response.body)
       expect(json['error']).to eq(nil)
       access_token = json['access_token']
-      expect(access_token).to_not eq(nil)
+      expect(access_token).not_to eq(nil)
       verify_access_token access_token
       refresh_token = json['refresh_token']
-      expect(refresh_token).to_not eq(nil)
+      expect(refresh_token).not_to eq(nil)
 
       # Since we now have a refresh token, we should be able to get a new access
       # token.
@@ -122,7 +122,7 @@ RSpec.describe "oauth api" do
       json = JSON.parse(response.body)
       expect(json['error']).to eq(nil)
       access_token = json['access_token']
-      expect(access_token).to_not eq(nil)
+      expect(access_token).not_to eq(nil)
       verify_access_token access_token
     end
 
@@ -158,7 +158,7 @@ RSpec.describe "oauth api" do
         json = JSON.parse(response.body)
         expect(json['error']).to eq(nil)
         access_token = json['access_token']
-        expect(access_token).to_not eq(nil)
+        expect(access_token).not_to eq(nil)
         verify_access_token access_token
       end
     end
@@ -183,7 +183,7 @@ RSpec.describe "oauth api" do
 
     query = Rack::Utils.parse_query(URI.parse(current_url).query)
     access_token = query["access_token"]
-    expect(access_token).to_not eq(nil)
+    expect(access_token).not_to eq(nil)
     verify_access_token access_token
   end
 

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -531,6 +531,7 @@ RSpec.describe "registrations" do
       let(:competition) { FactoryBot.create(:competition, :stripe_connected, :visible, :registration_open, events: Event.where(id: %w(222 333))) }
       let!(:user) { FactoryBot.create(:user, :wca_id) }
       let!(:registration) { FactoryBot.create(:registration, competition: competition, user: user) }
+
       sign_out
 
       it "redirects to the sign in page" do

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "registrations" do
         ]
         expect {
           post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-        }.to_not change { competition.registrations.count }
+        }.not_to change { competition.registrations.count }
         follow_redirect!
         expect(response.body).to include "The given file includes 2 accepted registrations, which is more than the competitor limit of 1."
       end
@@ -67,7 +67,7 @@ RSpec.describe "registrations" do
         ]
         expect {
           post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-        }.to_not change { competition.registrations.count }
+        }.not_to change { competition.registrations.count }
         follow_redirect!
         expect(response.body).to include "Error importing #{two_timer_dave.name}: Validation failed: Competition You can only be accepted for one Series competition at a time."
       end
@@ -80,7 +80,7 @@ RSpec.describe "registrations" do
         ]
         expect {
           post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-        }.to_not change { competition.registrations.count }
+        }.not_to change { competition.registrations.count }
         follow_redirect!
         expect(response.body).to include "Email must be unique, found the following duplicates: sherlock@example.com."
       end
@@ -93,7 +93,7 @@ RSpec.describe "registrations" do
         ]
         expect {
           post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-        }.to_not change { competition.registrations.count }
+        }.not_to change { competition.registrations.count }
         follow_redirect!
         expect(response.body).to include "WCA ID must be unique, found the following duplicates: 2019HOLM01."
       end
@@ -107,7 +107,7 @@ RSpec.describe "registrations" do
         ]
         expect {
           post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-        }.to_not change { competition.registrations.count }
+        }.not_to change { competition.registrations.count }
         follow_redirect!
         expect(response.body).to include "Birthdate must follow the YYYY-mm-dd format (year-month-day, for example 1944-07-13), found the following dates which cannot be parsed: 01.01.2000, Jan 01 2000."
       end
@@ -115,14 +115,14 @@ RSpec.describe "registrations" do
       describe "registrations import" do
         context "registrant has WCA ID" do
           it "renders an error if the WCA ID doesn't exist" do
-            expect(RegistrationsMailer).to_not receive(:notify_registrant_of_locked_account_creation)
+            expect(RegistrationsMailer).not_to receive(:notify_registrant_of_locked_account_creation)
             file = csv_file [
               ["Status", "Name", "Country", "WCA ID", "Birth date", "Gender", "Email", "333", "444"],
               ["a", "Sherlock Holmes", "United Kingdom", "1000DARN99", "2000-01-01", "m", "sherlock@example.com", "1", "0"],
             ]
             expect {
               post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-            }.to_not change { competition.registrations.count }
+            }.not_to change { competition.registrations.count }
             follow_redirect!
             expect(response.body).to match(/The WCA ID 1000DARN99 doesn.*t exist/)
           end
@@ -141,7 +141,7 @@ RSpec.describe "registrations" do
                     ]
                     expect {
                       post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                    }.to_not change { competition.registrations.count }
+                    }.not_to change { competition.registrations.count }
                     follow_redirect!
                     expect(response.body).to include "There is already a user with email #{user.email}, but it has WCA ID of #{user.wca_id} instead of #{dummy_user.wca_id}."
                   end
@@ -175,9 +175,9 @@ RSpec.describe "registrations" do
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                  }.to_not change { User.count }
+                  }.not_to change { User.count }
                   user = dummy_user.reload
-                  expect(user).to_not be_dummy_account
+                  expect(user).not_to be_dummy_account
                   expect(user).to be_locked_account
                   expect(user.email).to eq "sherlock@example.com"
                   expect(user.registrations.first.events.map(&:id)).to eq %w(333)
@@ -195,7 +195,7 @@ RSpec.describe "registrations" do
                 ]
                 expect {
                   post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                }.to_not change { User.count }
+                }.not_to change { User.count }
                 expect(user.registrations.first.events.map(&:id)).to eq %w(333)
                 expect(competition.registrations.count).to eq 1
               end
@@ -221,7 +221,7 @@ RSpec.describe "registrations" do
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                  }.to_not change { competition.registrations.count }
+                  }.not_to change { competition.registrations.count }
                   follow_redirect!
                   expect(response.body).to include "There is already a user with email #{user.email}, but it has unconfirmed WCA ID of #{unconfirmed_person.wca_id} instead of #{person.wca_id}."
                 end
@@ -243,7 +243,7 @@ RSpec.describe "registrations" do
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                  }.to_not change { User.count }
+                  }.not_to change { User.count }
                   expect(user.reload.wca_id).to eq person.wca_id
                   expect(user.reload.unconfirmed_wca_id).to be_nil
                   expect(user.reload.delegate_to_handle_wca_id_claim).to be_nil
@@ -262,7 +262,7 @@ RSpec.describe "registrations" do
                   ]
                   expect {
                     post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-                  }.to_not change { User.count }
+                  }.not_to change { User.count }
                   expect(user.reload.wca_id).to eq person.wca_id
                   expect(user.registrations.first.events.map(&:id)).to eq %w(333)
                   expect(competition.registrations.count).to eq 1
@@ -299,7 +299,7 @@ RSpec.describe "registrations" do
               ]
               expect {
                 post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-              }.to_not change { User.count }
+              }.not_to change { User.count }
               expect(user.registrations.first.events.map(&:id)).to eq %w(333)
               expect(competition.registrations.count).to eq 1
             end
@@ -312,7 +312,7 @@ RSpec.describe "registrations" do
               ]
               expect {
                 post competition_registrations_do_import_path(competition), params: { registrations_import: { registrations_file: file } }
-              }.to_not change { User.count }
+              }.not_to change { User.count }
               expect(user.reload.name).to eq "Sherlock Holmes"
               expect(user.dob).to eq Date.new(2000, 1, 1)
               expect(user.country_iso2).to eq "GB"
@@ -481,7 +481,7 @@ RSpec.describe "registrations" do
                 gender: two_timer_dave.gender, email: two_timer_dave.email, event_ids: ["444"]
               },
             }
-          }.to_not change { competition.registrations.count }
+          }.not_to change { competition.registrations.count }
           expect(response.body).to include "You can only be accepted for one Series competition at a time"
         end
       end
@@ -518,7 +518,7 @@ RSpec.describe "registrations" do
                 gender: "m", email: "sherlock@example.com", event_ids: ["444"]
               },
             }
-          }.to_not change { competition.registrations.count }
+          }.not_to change { competition.registrations.count }
           follow_redirect!
           expect(response.body).to include "The competitor limit has been reached"
         end
@@ -675,7 +675,7 @@ RSpec.describe "registrations" do
           }
 
           payment_intent = registration.reload.payment_intents.first
-          expect(payment_intent).to_not be_nil
+          expect(payment_intent).not_to be_nil
 
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
@@ -695,8 +695,8 @@ RSpec.describe "registrations" do
 
           stripe_record = payment_intent.reload.payment_record
           # Now we should have a confirmation after calling the return_url hook :)
-          expect(payment_intent.confirmed_at).to_not be_nil
-          expect(stripe_record).to_not be_nil
+          expect(payment_intent.confirmed_at).not_to be_nil
+          expect(stripe_record).not_to be_nil
           expect(stripe_record.stripe_status).to eq "succeeded"
           metadata = stripe_record.parameters["metadata"]
           expect(metadata["competition"]).to eq competition.id
@@ -727,7 +727,7 @@ RSpec.describe "registrations" do
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
-          }.to_not change { registration.reload.outstanding_entry_fees }
+          }.not_to change { registration.reload.outstanding_entry_fees }
 
           expect(registration.paid_entry_fees).to eq 0
           expect(payment_intent.payment_record.reload.stripe_status).to eq('requires_action')
@@ -744,7 +744,7 @@ RSpec.describe "registrations" do
           }
 
           payment_intent = registration.reload.payment_intents.first
-          expect(payment_intent).to_not be_nil
+          expect(payment_intent).not_to be_nil
 
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
@@ -766,7 +766,7 @@ RSpec.describe "registrations" do
 
           # Now we should still wait for the confirmation because SCA hasn't been completed yet
           expect(payment_intent.confirmed_at).to be_nil
-          expect(stripe_record).to_not be_nil
+          expect(stripe_record).not_to be_nil
           expect(stripe_record.stripe_status).to eq 'requires_action'
           metadata = stripe_record.parameters["metadata"]
           expect(metadata["competition"]).to eq competition.id
@@ -798,7 +798,7 @@ RSpec.describe "registrations" do
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
-          }.to_not change { registration.reload.outstanding_entry_fees }
+          }.not_to change { registration.reload.outstanding_entry_fees }
 
           expect(registration.paid_entry_fees).to eq 0
           expect(payment_intent.confirmed_at).to be_nil
@@ -828,7 +828,7 @@ RSpec.describe "registrations" do
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
-          }.to_not change { registration.reload.outstanding_entry_fees }
+          }.not_to change { registration.reload.outstanding_entry_fees }
 
           expect(registration.paid_entry_fees).to eq 0
           expect(payment_intent.confirmed_at).to be_nil
@@ -858,7 +858,7 @@ RSpec.describe "registrations" do
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
-          }.to_not change { registration.reload.outstanding_entry_fees }
+          }.not_to change { registration.reload.outstanding_entry_fees }
 
           expect(registration.paid_entry_fees).to eq 0
           expect(payment_intent.confirmed_at).to be_nil
@@ -888,7 +888,7 @@ RSpec.describe "registrations" do
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
-          }.to_not change { registration.reload.outstanding_entry_fees }
+          }.not_to change { registration.reload.outstanding_entry_fees }
 
           expect(registration.paid_entry_fees).to eq 0
           expect(payment_intent.confirmed_at).to be_nil
@@ -915,7 +915,7 @@ RSpec.describe "registrations" do
               payment_intent: payment_intent.payment_record.stripe_id,
               payment_intent_client_secret: payment_intent.client_secret,
             }
-          }.to_not change { registration.reload.outstanding_entry_fees }
+          }.not_to change { registration.reload.outstanding_entry_fees }
 
           expect(registration.paid_entry_fees).to eq 0
           expect(payment_intent.confirmed_at).to be_nil
@@ -932,7 +932,7 @@ RSpec.describe "registrations" do
           }
 
           payment_intent = registration.reload.payment_intents.first
-          expect(payment_intent).to_not be_nil
+          expect(payment_intent).not_to be_nil
 
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
@@ -955,9 +955,9 @@ RSpec.describe "registrations" do
           stripe_record = payment_intent.reload.payment_record
           # Now we should still wait for the confirmation because the card has been declined
           expect(payment_intent.confirmed_at).to be_nil
-          expect(stripe_record).to_not be_nil
+          expect(stripe_record).not_to be_nil
           expect(stripe_record.stripe_status).to eq "requires_payment_method"
-          expect(stripe_record.error).to_not be_nil
+          expect(stripe_record.error).not_to be_nil
           metadata = stripe_record.parameters["metadata"]
           expect(metadata["competition"]).to eq competition.id
         end
@@ -971,7 +971,7 @@ RSpec.describe "registrations" do
           }
 
           payment_intent = registration.reload.payment_intents.first
-          expect(payment_intent).to_not be_nil
+          expect(payment_intent).not_to be_nil
 
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
@@ -1018,7 +1018,7 @@ RSpec.describe "registrations" do
           }
 
           payment_intent = registration.reload.payment_intents.first
-          expect(payment_intent).to_not be_nil
+          expect(payment_intent).not_to be_nil
 
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
@@ -1067,7 +1067,7 @@ RSpec.describe "registrations" do
           }
 
           payment_intent = registration.reload.payment_intents.first
-          expect(payment_intent).to_not be_nil
+          expect(payment_intent).not_to be_nil
           # Intent should not be confirmed at this stage, because we have never received a receipt charge from Stripe yet
           expect(payment_intent.confirmed_at).to be_nil
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "users" do
       it 'does not generate backup codes for user without 2FA' do
         expect {
           post profile_generate_2fa_backup_path
-        }.to_not change { user.otp_backup_codes }
+        }.not_to change { user.otp_backup_codes }
         json = JSON.parse(response.body)
         expect(json["error"]["message"]).to include "not enabled"
       end
@@ -122,7 +122,7 @@ RSpec.describe "users" do
         expect {
           post profile_generate_2fa_backup_path
           follow_redirect!
-        }.to_not change { user.otp_backup_codes }
+        }.not_to change { user.otp_backup_codes }
         expect(response.body).to include I18n.t('users.edit.sensitive.identity_error')
       end
     end
@@ -138,7 +138,7 @@ RSpec.describe "users" do
         post profile_enable_2fa_path
         secret_after = user.reload.otp_secret
         expect(response.body).to include "Successfully regenerated"
-        expect(secret_before).to_not eq secret_after
+        expect(secret_before).not_to eq secret_after
       end
 
       it 'can disable 2FA' do
@@ -150,7 +150,7 @@ RSpec.describe "users" do
       it 'can (re)generate backup codes for user with 2FA' do
         expect(user.otp_backup_codes).to eq nil
         post profile_generate_2fa_backup_path
-        expect(user.reload.otp_backup_codes).to_not eq nil
+        expect(user.reload.otp_backup_codes).not_to eq nil
         json = JSON.parse(response.body)
         expect(json["codes"]&.size).to eq User::NUMBER_OF_BACKUP_CODES
       end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -148,9 +148,9 @@ RSpec.describe "users" do
       end
 
       it 'can (re)generate backup codes for user with 2FA' do
-        expect(user.otp_backup_codes).to eq nil
+        expect(user.otp_backup_codes).to be nil
         post profile_generate_2fa_backup_path
-        expect(user.reload.otp_backup_codes).not_to eq nil
+        expect(user.reload.otp_backup_codes).not_to be nil
         json = JSON.parse(response.body)
         expect(json["codes"]&.size).to eq User::NUMBER_OF_BACKUP_CODES
       end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -91,10 +91,12 @@ RSpec.describe "users" do
 
   context "user without 2FA" do
     let!(:user) { FactoryBot.create(:user) }
+
     before { sign_in user }
 
     context "recently authenticated" do
       before { post users_authenticate_sensitive_path, params: { 'user[password]': user.password } }
+
       it 'can enable 2FA' do
         post profile_enable_2fa_path
         expect(response.body).to include "Successfully enabled two-factor"
@@ -130,9 +132,12 @@ RSpec.describe "users" do
 
   context "user with 2FA" do
     let!(:user) { FactoryBot.create(:user, :with_2fa) }
+
     before { sign_in user }
+
     context "recently authenticated" do
       before { post users_authenticate_sensitive_path, params: { 'user[otp_attempt]': user.current_otp } }
+
       it 'can reset 2FA' do
         secret_before = user.otp_secret
         post profile_enable_2fa_path

--- a/spec/requests/wfc_spec.rb
+++ b/spec/requests/wfc_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "WFC controller" do
       end
     end
   end
+
   describe "GET /competitions_export" do
     context "when signed in as a regular user" do
       sign_in { FactoryBot.create :user }

--- a/spec/views/wfc/competition_export.csv.erb_spec.rb
+++ b/spec/views/wfc/competition_export.csv.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "wfc/competition_export.csv.erb" do
     render
 
     delegates_without_trainees = competition.delegates.reject(&:trainee_delegate?)
-    expect(delegates_without_trainees.length).to_not eq competition.delegates.length
+    expect(delegates_without_trainees.length).not_to eq competition.delegates.length
 
     table = rendered.csv_header
     expect(table[0]["Delegates"]).to eq delegates_without_trainees.map(&:name).sort.join(",")


### PR DESCRIPTION
This changeset looks daunting, but it only affects specs by:
- changing all `eq` to `be`
- changing all `to_not` to `not_to`
- adds some whitespace