### PR TITLE
Activate Migration Cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -287,24 +287,6 @@ Rails/PluralizationGrammar:
 Rails/I18nLocaleAssignment:
   Enabled: false
 
-Rails/ReversibleMigration:
-  Enabled: false
-
-Rails/BulkChangeTable:
-  Enabled: false
-
-Rails/ThreeStateBooleanColumn:
-  Enabled: false
-
-Rails/CreateTableWithTimestamps:
-  Enabled: false
-
-Rails/NotNullColumn:
-  Enabled: false
-
-Rails/DangerousColumnNames:
-  Enabled: false
-
 Rails/RedundantForeignKey:
   Enabled: false
 

--- a/db/migrate/20150501004846_rename_drupal_indices_to_be_unique.rb
+++ b/db/migrate/20150501004846_rename_drupal_indices_to_be_unique.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameDrupalIndicesToBeUnique < ActiveRecord::Migration

--- a/db/migrate/20150504022234_devise_create_devise_users.rb
+++ b/db/migrate/20150504022234_devise_create_devise_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DeviseCreateDeviseUsers < ActiveRecord::Migration

--- a/db/migrate/20150504163657_create_doorkeeper_tables.rb
+++ b/db/migrate/20150504163657_create_doorkeeper_tables.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateDoorkeeperTables < ActiveRecord::Migration

--- a/db/migrate/20150520080634_rolify_create_roles.rb
+++ b/db/migrate/20150520080634_rolify_create_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RolifyCreateRoles < ActiveRecord::Migration

--- a/db/migrate/20150521000833_remove_rolify.rb
+++ b/db/migrate/20150521000833_remove_rolify.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveRolify < ActiveRecord::Migration

--- a/db/migrate/20150521001340_add_roles_to_devise_user.rb
+++ b/db/migrate/20150521001340_add_roles_to_devise_user.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRolesToDeviseUser < ActiveRecord::Migration

--- a/db/migrate/20150521005227_no_more_drupal.rb
+++ b/db/migrate/20150521005227_no_more_drupal.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class NoMoreDrupal < ActiveRecord::Migration

--- a/db/migrate/20150521225109_rename_devise_users_to_users.rb
+++ b/db/migrate/20150521225109_rename_devise_users_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameDeviseUsersToUsers < ActiveRecord::Migration

--- a/db/migrate/20150526035517_drop_queue_table.rb
+++ b/db/migrate/20150526035517_drop_queue_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DropQueueTable < ActiveRecord::Migration

--- a/db/migrate/20150601061358_add_delegate_status_to_users.rb
+++ b/db/migrate/20150601061358_add_delegate_status_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDelegateStatusToUsers < ActiveRecord::Migration

--- a/db/migrate/20150601224750_add_region_to_user.rb
+++ b/db/migrate/20150601224750_add_region_to_user.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegionToUser < ActiveRecord::Migration

--- a/db/migrate/20150602044759_add_wca_id_to_users.rb
+++ b/db/migrate/20150602044759_add_wca_id_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWcaIdToUsers < ActiveRecord::Migration

--- a/db/migrate/20150602062127_add_index_to_users_wca_id.rb
+++ b/db/migrate/20150602062127_add_index_to_users_wca_id.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIndexToUsersWcaId < ActiveRecord::Migration

--- a/db/migrate/20150602233220_remove_empty_string_wca_ids_from_users.rb
+++ b/db/migrate/20150602233220_remove_empty_string_wca_ids_from_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveEmptyStringWcaIdsFromUsers < ActiveRecord::Migration

--- a/db/migrate/20150603015039_rename_results_php_indices_to_be_unique.rb
+++ b/db/migrate/20150603015039_rename_results_php_indices_to_be_unique.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameResultsPhpIndicesToBeUnique < ActiveRecord::Migration

--- a/db/migrate/20150718020058_create_competition_organizers.rb
+++ b/db/migrate/20150718020058_create_competition_organizers.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionOrganizers < ActiveRecord::Migration

--- a/db/migrate/20150718020123_create_competition_delegates.rb
+++ b/db/migrate/20150718020123_create_competition_delegates.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionDelegates < ActiveRecord::Migration

--- a/db/migrate/20150806172310_remove_organiser_password_and_admin_password_from_competitions.rb
+++ b/db/migrate/20150806172310_remove_organiser_password_and_admin_password_from_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveOrganiserPasswordAndAdminPasswordFromCompetitions < ActiveRecord::Migration

--- a/db/migrate/20150812014543_change_wca_delegate_and_organiser_to_text_in_competitions.rb
+++ b/db/migrate/20150812014543_change_wca_delegate_and_organiser_to_text_in_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeWcaDelegateAndOrganiserToTextInCompetitions < ActiveRecord::Migration

--- a/db/migrate/20150819064257_add_contact_to_competitions.rb
+++ b/db/migrate/20150819064257_add_contact_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddContactToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20150821164902_remove_organiser_and_wca_delegate_from_competitions.rb
+++ b/db/migrate/20150821164902_remove_organiser_and_wca_delegate_from_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveOrganiserAndWcaDelegateFromCompetitions < ActiveRecord::Migration

--- a/db/migrate/20150826003626_add_avatar_to_users.rb
+++ b/db/migrate/20150826003626_add_avatar_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAvatarToUsers < ActiveRecord::Migration

--- a/db/migrate/20150831195312_add_pending_avatar_to_users.rb
+++ b/db/migrate/20150831195312_add_pending_avatar_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddPendingAvatarToUsers < ActiveRecord::Migration

--- a/db/migrate/20150903083847_no_null_sticky_posts_allowed.rb
+++ b/db/migrate/20150903083847_no_null_sticky_posts_allowed.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class NoNullStickyPostsAllowed < ActiveRecord::Migration

--- a/db/migrate/20150904062512_add_crop_coordinates_to_users.rb
+++ b/db/migrate/20150904062512_add_crop_coordinates_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCropCoordinatesToUsers < ActiveRecord::Migration

--- a/db/migrate/20150908183742_rename_crop_coordinates_in_users.rb
+++ b/db/migrate/20150908183742_rename_crop_coordinates_in_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameCropCoordinatesInUsers < ActiveRecord::Migration

--- a/db/migrate/20150924011143_make_sticky_default_in_posts.rb
+++ b/db/migrate/20150924011143_make_sticky_default_in_posts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MakeStickyDefaultInPosts < ActiveRecord::Migration

--- a/db/migrate/20150924011919_add_world_readable_to_posts.rb
+++ b/db/migrate/20150924011919_add_world_readable_to_posts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWorldReadableToPosts < ActiveRecord::Migration

--- a/db/migrate/20150924155057_post_boolean_fields_not_null.rb
+++ b/db/migrate/20150924155057_post_boolean_fields_not_null.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class PostBooleanFieldsNotNull < ActiveRecord::Migration

--- a/db/migrate/20151001191340_add_teams_to_users.rb
+++ b/db/migrate/20151001191340_add_teams_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTeamsToUsers < ActiveRecord::Migration

--- a/db/migrate/20151008211834_convert_competition_website_to_url.rb
+++ b/db/migrate/20151008211834_convert_competition_website_to_url.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ConvertCompetitionWebsiteToUrl < ActiveRecord::Migration

--- a/db/migrate/20151014220307_copy_names_from_persons_to_users.rb
+++ b/db/migrate/20151014220307_copy_names_from_persons_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CopyNamesFromPersonsToUsers < ActiveRecord::Migration

--- a/db/migrate/20151116195414_add_opt_out_registration_emails_to_users.rb
+++ b/db/migrate/20151116195414_add_opt_out_registration_emails_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddOptOutRegistrationEmailsToUsers < ActiveRecord::Migration

--- a/db/migrate/20151117183214_move_opt_out_registration_emails_from_users_to_delegates_and_organizers.rb
+++ b/db/migrate/20151117183214_move_opt_out_registration_emails_from_users_to_delegates_and_organizers.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MoveOptOutRegistrationEmailsFromUsersToDelegatesAndOrganizers < ActiveRecord::Migration

--- a/db/migrate/20151119063335_add_remarks_to_competitions.rb
+++ b/db/migrate/20151119063335_add_remarks_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRemarksToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20151119072940_drop_inbox_persons_old_and_inbox_results_old_tables.rb
+++ b/db/migrate/20151119072940_drop_inbox_persons_old_and_inbox_results_old_tables.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DropInboxPersonsOldAndInboxResultsOldTables < ActiveRecord::Migration

--- a/db/migrate/20151207230222_create_polls_tables.rb
+++ b/db/migrate/20151207230222_create_polls_tables.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreatePollsTables < ActiveRecord::Migration

--- a/db/migrate/20151209003851_add_unconfirmed_wca_id_to_users.rb
+++ b/db/migrate/20151209003851_add_unconfirmed_wca_id_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUnconfirmedWcaIdToUsers < ActiveRecord::Migration

--- a/db/migrate/20151213232440_remove_wca_website_team.rb
+++ b/db/migrate/20151213232440_remove_wca_website_team.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveWcaWebsiteTeam < ActiveRecord::Migration

--- a/db/migrate/20151214000352_create_vote_options.rb
+++ b/db/migrate/20151214000352_create_vote_options.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateVoteOptions < ActiveRecord::Migration

--- a/db/migrate/20151215193124_change_deadline_to_timestamp.rb
+++ b/db/migrate/20151215193124_change_deadline_to_timestamp.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeDeadlineToTimestamp < ActiveRecord::Migration

--- a/db/migrate/20151217001125_fix_deadline_to_datetime.rb
+++ b/db/migrate/20151217001125_fix_deadline_to_datetime.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixDeadlineToDatetime < ActiveRecord::Migration

--- a/db/migrate/20151217054555_add_user_id_to_preregs.rb
+++ b/db/migrate/20151217054555_add_user_id_to_preregs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUserIdToPreregs < ActiveRecord::Migration

--- a/db/migrate/20151217062612_add_dob_gender_country_to_users.rb
+++ b/db/migrate/20151217062612_add_dob_gender_country_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDobGenderCountryToUsers < ActiveRecord::Migration

--- a/db/migrate/20151222013017_add_timestamps_to_preregs.rb
+++ b/db/migrate/20151222013017_add_timestamps_to_preregs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTimestampsToPreregs < ActiveRecord::Migration

--- a/db/migrate/20151230174411_add_registration_open_and_close_dates_to_competition.rb
+++ b/db/migrate/20151230174411_add_registration_open_and_close_dates_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegistrationOpenAndCloseDatesToCompetition < ActiveRecord::Migration

--- a/db/migrate/20160109070723_convert_process_links_format_to_markdown.rb
+++ b/db/migrate/20160109070723_convert_process_links_format_to_markdown.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ConvertProcessLinksFormatToMarkdown < ActiveRecord::Migration

--- a/db/migrate/20160120071503_add_owner_to_application.rb
+++ b/db/migrate/20160120071503_add_owner_to_application.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddOwnerToApplication < ActiveRecord::Migration

--- a/db/migrate/20160128023834_rename_software_admin_team_to_software_team.rb
+++ b/db/migrate/20160128023834_rename_software_admin_team_to_software_team.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameSoftwareAdminTeamToSoftwareTeam < ActiveRecord::Migration

--- a/db/migrate/20160218135313_create_teams.rb
+++ b/db/migrate/20160218135313_create_teams.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTeams < ActiveRecord::Migration

--- a/db/migrate/20160218234447_create_team_members.rb
+++ b/db/migrate/20160218234447_create_team_members.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTeamMembers < ActiveRecord::Migration

--- a/db/migrate/20160223204831_toggle_guests.rb
+++ b/db/migrate/20160223204831_toggle_guests.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ToggleGuests < ActiveRecord::Migration

--- a/db/migrate/20160224013453_guests_enabled_by_default.rb
+++ b/db/migrate/20160224013453_guests_enabled_by_default.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class GuestsEnabledByDefault < ActiveRecord::Migration

--- a/db/migrate/20160303144700_fill_teams_tables.rb
+++ b/db/migrate/20160303144700_fill_teams_tables.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FillTeamsTables < ActiveRecord::Migration

--- a/db/migrate/20160305170821_remove_teams_columns.rb
+++ b/db/migrate/20160305170821_remove_teams_columns.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveTeamsColumns < ActiveRecord::Migration

--- a/db/migrate/20160406192349_change_preregs_created_at_to_not_null.rb
+++ b/db/migrate/20160406192349_change_preregs_created_at_to_not_null.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangePreregsCreatedAtToNotNull < ActiveRecord::Migration

--- a/db/migrate/20160407005537_change_preregs_updated_at_to_not_null.rb
+++ b/db/migrate/20160407005537_change_preregs_updated_at_to_not_null.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangePreregsUpdatedAtToNotNull < ActiveRecord::Migration

--- a/db/migrate/20160407210623_add_updated_at_to_results.rb
+++ b/db/migrate/20160407210623_add_updated_at_to_results.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUpdatedAtToResults < ActiveRecord::Migration

--- a/db/migrate/20160504170758_create_user_preferred_events.rb
+++ b/db/migrate/20160504170758_create_user_preferred_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateUserPreferredEvents < ActiveRecord::Migration

--- a/db/migrate/20160504230105_add_results_posted_to_competitions.rb
+++ b/db/migrate/20160504230105_add_results_posted_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddResultsPostedToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20160505231300_create_registration_events.rb
+++ b/db/migrate/20160505231300_create_registration_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRegistrationEvents < ActiveRecord::Migration

--- a/db/migrate/20160513162613_add_results_notifications_enabled_to_users.rb
+++ b/db/migrate/20160513162613_add_results_notifications_enabled_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddResultsNotificationsEnabledToUsers < ActiveRecord::Migration

--- a/db/migrate/20160514124545_add_approved_at_to_registrations.rb
+++ b/db/migrate/20160514124545_add_approved_at_to_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddApprovedAtToRegistrations < ActiveRecord::Migration

--- a/db/migrate/20160514141051_fill_accepted_at_registrations_column.rb
+++ b/db/migrate/20160514141051_fill_accepted_at_registrations_column.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FillAcceptedAtRegistrationsColumn < ActiveRecord::Migration

--- a/db/migrate/20160517140653_add_rails_persons_view.rb
+++ b/db/migrate/20160517140653_add_rails_persons_view.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRailsPersonsView < ActiveRecord::Migration

--- a/db/migrate/20160518020433_create_delayed_jobs.rb
+++ b/db/migrate/20160518020433_create_delayed_jobs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateDelayedJobs < ActiveRecord::Migration

--- a/db/migrate/20160518045741_create_completed_jobs.rb
+++ b/db/migrate/20160518045741_create_completed_jobs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompletedJobs < ActiveRecord::Migration

--- a/db/migrate/20160520230353_remove_results_status.rb
+++ b/db/migrate/20160520230353_remove_results_status.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveResultsStatus < ActiveRecord::Migration

--- a/db/migrate/20160528071910_add_results_nag_sent_at_to_competitions.rb
+++ b/db/migrate/20160528071910_add_results_nag_sent_at_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddResultsNagSentAtToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20160531124049_update_competition_names.rb
+++ b/db/migrate/20160531124049_update_competition_names.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateCompetitionNames < ActiveRecord::Migration

--- a/db/migrate/20160602105428_create_delegate_reports.rb
+++ b/db/migrate/20160602105428_create_delegate_reports.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateDelegateReports < ActiveRecord::Migration

--- a/db/migrate/20160610191605_create_competition_tabs.rb
+++ b/db/migrate/20160610191605_create_competition_tabs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionTabs < ActiveRecord::Migration

--- a/db/migrate/20160616183719_add_display_order_to_competition_tabs.rb
+++ b/db/migrate/20160616183719_add_display_order_to_competition_tabs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDisplayOrderToCompetitionTabs < ActiveRecord::Migration

--- a/db/migrate/20160627215744_create_competition_events.rb
+++ b/db/migrate/20160627215744_create_competition_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionEvents < ActiveRecord::Migration

--- a/db/migrate/20160701034833_reference_table_updates.rb
+++ b/db/migrate/20160701034833_reference_table_updates.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ReferenceTableUpdates < ActiveRecord::Migration

--- a/db/migrate/20160705120632_add_generate_website_to_competition.rb
+++ b/db/migrate/20160705120632_add_generate_website_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddGenerateWebsiteToCompetition < ActiveRecord::Migration

--- a/db/migrate/20160705121551_rename_website_to_external_website.rb
+++ b/db/migrate/20160705121551_rename_website_to_external_website.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameWebsiteToExternalWebsite < ActiveRecord::Migration

--- a/db/migrate/20160727000015_add_liechtenstein_to_countries.rb
+++ b/db/migrate/20160727000015_add_liechtenstein_to_countries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddLiechtensteinToCountries < ActiveRecord::Migration

--- a/db/migrate/20160731181145_remove_unnecessary_columns_from_countries.rb
+++ b/db/migrate/20160731181145_remove_unnecessary_columns_from_countries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveUnnecessaryColumnsFromCountries < ActiveRecord::Migration

--- a/db/migrate/20160811013347_add_announced_at_to_competitions.rb
+++ b/db/migrate/20160811013347_add_announced_at_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAnnouncedAtToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
+++ b/db/migrate/20160825124202_notify_users_of_delegates_demotion.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class NotifyUsersOfDelegatesDemotion < ActiveRecord::Migration

--- a/db/migrate/20160831212003_create_delegate_reports_for_all_comps.rb
+++ b/db/migrate/20160831212003_create_delegate_reports_for_all_comps.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateDelegateReportsForAllComps < ActiveRecord::Migration

--- a/db/migrate/20160901120254_remove_delegate_reports_without_comps.rb
+++ b/db/migrate/20160901120254_remove_delegate_reports_without_comps.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveDelegateReportsWithoutComps < ActiveRecord::Migration

--- a/db/migrate/20160902230822_fix_results_posted_at.rb
+++ b/db/migrate/20160902230822_fix_results_posted_at.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixResultsPostedAt < ActiveRecord::Migration

--- a/db/migrate/20160914122252_remove_event_specs_from_competitions.rb
+++ b/db/migrate/20160914122252_remove_event_specs_from_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveEventSpecsFromCompetitions < ActiveRecord::Migration

--- a/db/migrate/20160930213354_convert_event_id_to_competition_event_id.rb
+++ b/db/migrate/20160930213354_convert_event_id_to_competition_event_id.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ConvertEventIdToCompetitionEventId < ActiveRecord::Migration

--- a/db/migrate/20161011005956_rename_preregs_to_registrations.rb
+++ b/db/migrate/20161011005956_rename_preregs_to_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenamePreregsToRegistrations < ActiveRecord::Migration

--- a/db/migrate/20161018220122_clean_duplicated_registration_competition_events.rb
+++ b/db/migrate/20161018220122_clean_duplicated_registration_competition_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CleanDuplicatedRegistrationCompetitionEvents < ActiveRecord::Migration

--- a/db/migrate/20161026201019_simplify_registrations.rb
+++ b/db/migrate/20161026201019_simplify_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class SimplifyRegistrations < ActiveRecord::Migration

--- a/db/migrate/20161031215932_add_entry_fees_to_competitions.rb
+++ b/db/migrate/20161031215932_add_entry_fees_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEntryFeesToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20161108081416_add_connected_stripe_account_id_to_competitions.rb
+++ b/db/migrate/20161108081416_add_connected_stripe_account_id_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddConnectedStripeAccountIdToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20161108210423_create_registration_payments.rb
+++ b/db/migrate/20161108210423_create_registration_payments.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRegistrationPayments < ActiveRecord::Migration

--- a/db/migrate/20161117085757_cleanup_events_issue96.rb
+++ b/db/migrate/20161117085757_cleanup_events_issue96.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CleanupEventsIssue96 < ActiveRecord::Migration

--- a/db/migrate/20161118141833_change_latitude_and_longitude_default.rb
+++ b/db/migrate/20161118141833_change_latitude_and_longitude_default.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeLatitudeAndLongitudeDefault < ActiveRecord::Migration

--- a/db/migrate/20161122014040_add_tracking_to_registrations.rb
+++ b/db/migrate/20161122014040_add_tracking_to_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTrackingToRegistrations < ActiveRecord::Migration

--- a/db/migrate/20161122162029_add_end_year_to_competitions.rb
+++ b/db/migrate/20161122162029_add_end_year_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEndYearToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20161201211133_add_additional_fields_for_delegates.rb
+++ b/db/migrate/20161201211133_add_additional_fields_for_delegates.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAdditionalFieldsForDelegates < ActiveRecord::Migration

--- a/db/migrate/20161206204738_add_confirmed_at_to_polls.rb
+++ b/db/migrate/20161206204738_add_confirmed_at_to_polls.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddConfirmedAtToPolls < ActiveRecord::Migration

--- a/db/migrate/20161212200704_add_maldives_to_countries.rb
+++ b/db/migrate/20161212200704_add_maldives_to_countries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddMaldivesToCountries < ActiveRecord::Migration

--- a/db/migrate/20161221205552_add_country_id_index_to_competitions.rb
+++ b/db/migrate/20161221205552_add_country_id_index_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCountryIdIndexToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20161226223701_change_event_order_and_names.rb
+++ b/db/migrate/20161226223701_change_event_order_and_names.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeEventOrderAndNames < ActiveRecord::Migration

--- a/db/migrate/20161227202950_add_preferred_locale_to_users.rb
+++ b/db/migrate/20161227202950_add_preferred_locale_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddPreferredLocaleToUsers < ActiveRecord::Migration

--- a/db/migrate/20170121202850_organisation_to_organization.rb
+++ b/db/migrate/20170121202850_organisation_to_organization.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class OrganisationToOrganization < ActiveRecord::Migration

--- a/db/migrate/20170212005142_modify_registration_payments_for_partial_refunds.rb
+++ b/db/migrate/20170212005142_modify_registration_payments_for_partial_refunds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ModifyRegistrationPaymentsForPartialRefunds < ActiveRecord::Migration

--- a/db/migrate/20170215221832_add_proper_date_fields_to_competition.rb
+++ b/db/migrate/20170215221832_add_proper_date_fields_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddProperDateFieldsToCompetition < ActiveRecord::Migration

--- a/db/migrate/20170223153915_add_enable_donations_to_competitions.rb
+++ b/db/migrate/20170223153915_add_enable_donations_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEnableDonationsToCompetitions < ActiveRecord::Migration

--- a/db/migrate/20170228140556_set_default_currency_to_competitions.rb
+++ b/db/migrate/20170228140556_set_default_currency_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class SetDefaultCurrencyToCompetitions < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170320222511_change_default_entry_fee_for_competitions.rb
+++ b/db/migrate/20170320222511_change_default_entry_fee_for_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeDefaultEntryFeeForCompetitions < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170402223714_change_rounds_to_round_types.rb
+++ b/db/migrate/20170402223714_change_rounds_to_round_types.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeRoundsToRoundTypes < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170404184332_convert_utf8_to_utf8mb4.rb
+++ b/db/migrate/20170404184332_convert_utf8_to_utf8mb4.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # See https://gist.github.com/tjh/1711329#gistcomment-2046518.

--- a/db/migrate/20170406170418_create_rounds.rb
+++ b/db/migrate/20170406170418_create_rounds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRounds < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170417072301_remove_description_from_teams.rb
+++ b/db/migrate/20170417072301_remove_description_from_teams.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveDescriptionFromTeams < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170418171035_allow_null_gender.rb
+++ b/db/migrate/20170418171035_allow_null_gender.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AllowNullGender < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170421204700_add_time_limit_and_cutoffs_to_rounds.rb
+++ b/db/migrate/20170421204700_add_time_limit_and_cutoffs_to_rounds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTimeLimitAndCutoffsToRounds < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170426145811_create_linkings.rb
+++ b/db/migrate/20170426145811_create_linkings.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateLinkings < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170502232234_create_timestamps.rb
+++ b/db/migrate/20170502232234_create_timestamps.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTimestamps < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170503205810_add_index_on_results_country_id.rb
+++ b/db/migrate/20170503205810_add_index_on_results_country_id.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIndexOnResultsCountryId < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170510071858_change_rounds_index_to_unique.rb
+++ b/db/migrate/20170510071858_change_rounds_index_to_unique.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeRoundsIndexToUnique < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170516002944_rename_advance_to_next_round_requirement_to_advancement_condition.rb
+++ b/db/migrate/20170516002944_rename_advance_to_next_round_requirement_to_advancement_condition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameAdvanceToNextRoundRequirementToAdvancementCondition < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170517192919_add_nag_sent_at_to_delegate_reports.rb
+++ b/db/migrate/20170517192919_add_nag_sent_at_to_delegate_reports.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddNagSentAtToDelegateReports < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170517194354_add_competitor_limit_to_competitions.rb
+++ b/db/migrate/20170517194354_add_competitor_limit_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCompetitorLimitToCompetitions < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170517213035_update_list_of_countries.rb
+++ b/db/migrate/20170517213035_update_list_of_countries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateListOfCountries < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170518011526_add_event_fees_to_competition_events.rb
+++ b/db/migrate/20170518011526_add_event_fees_to_competition_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEventFeesToCompetitionEvents < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170523034604_create_post_tags.rb
+++ b/db/migrate/20170523034604_create_post_tags.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreatePostTags < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170523185221_add_show_on_homepage_to_posts.rb
+++ b/db/migrate/20170523185221_add_show_on_homepage_to_posts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddShowOnHomepageToPosts < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170524221221_drop_cubing_phpbb_database.rb
+++ b/db/migrate/20170524221221_drop_cubing_phpbb_database.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DropCubingPhpbbDatabase < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170524224533_rename_old_registrations_to_archive_registrations.rb
+++ b/db/migrate/20170524224533_rename_old_registrations_to_archive_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameOldRegistrationsToArchiveRegistrations < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170624115851_add_wca_financial_committee.rb
+++ b/db/migrate/20170624115851_add_wca_financial_committee.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWcaFinancialCommittee < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170629134754_change_competitor_limit_reason_type_to_text.rb
+++ b/db/migrate/20170629134754_change_competitor_limit_reason_type_to_text.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeCompetitorLimitReasonTypeToText < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170726133627_update_preferred_formats.rb
+++ b/db/migrate/20170726133627_update_preferred_formats.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdatePreferredFormats < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170801010739_create_championships.rb
+++ b/db/migrate/20170801010739_create_championships.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateChampionships < ActiveRecord::Migration[5.0]

--- a/db/migrate/20170812120421_convert_latin1_to_utf8mb4.rb
+++ b/db/migrate/20170812120421_convert_latin1_to_utf8mb4.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ConvertLatin1ToUtf8mb4 < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170816115449_create_eligible_country_iso2s_for_championship.rb
+++ b/db/migrate/20170816115449_create_eligible_country_iso2s_for_championship.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateEligibleCountryIso2sForChampionship < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170816143703_add_greater_china_championship_type.rb
+++ b/db/migrate/20170816143703_add_greater_china_championship_type.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddGreaterChinaChampionshipType < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170818141716_fix_tables_and_database_collation.rb
+++ b/db/migrate/20170818141716_fix_tables_and_database_collation.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixTablesAndDatabaseCollation < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170818164058_fix_columns_collation.rb
+++ b/db/migrate/20170818164058_fix_columns_collation.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixColumnsCollation < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170820023104_add_multiple_continents.rb
+++ b/db/migrate/20170820023104_add_multiple_continents.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddMultipleContinents < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170823170616_add_multiple_countries.rb
+++ b/db/migrate/20170823170616_add_multiple_countries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddMultipleCountries < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170823203113_create_incidents.rb
+++ b/db/migrate/20170823203113_create_incidents.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateIncidents < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170824082448_create_incident_tags.rb
+++ b/db/migrate/20170824082448_create_incident_tags.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateIncidentTags < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170824133352_create_incident_competitions.rb
+++ b/db/migrate/20170824133352_create_incident_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateIncidentCompetitions < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170830140540_fix_nullable_linkings_wca_ids.rb
+++ b/db/migrate/20170830140540_fix_nullable_linkings_wca_ids.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixNullableLinkingsWcaIds < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170831170616_fix_multiple_countries.rb
+++ b/db/migrate/20170831170616_fix_multiple_countries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixMultipleCountries < ActiveRecord::Migration[5.1]

--- a/db/migrate/20170916165728_change_incident_status.rb
+++ b/db/migrate/20170916165728_change_incident_status.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeIncidentStatus < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171006182851_delete_registrations_for_non_existing_competitions.rb
+++ b/db/migrate/20171006182851_delete_registrations_for_non_existing_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DeleteRegistrationsForNonExistingCompetitions < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171113154922_increase_scramble_column_width.rb
+++ b/db/migrate/20171113154922_increase_scramble_column_width.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class IncreaseScrambleColumnWidth < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171119143749_add_registration_requirements_to_competitions.rb
+++ b/db/migrate/20171119143749_add_registration_requirements_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegistrationRequirementsToCompetitions < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171122010954_remove_rubiks.rb
+++ b/db/migrate/20171122010954_remove_rubiks.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveRubiks < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171122220857_add_fulltext_index_on_persons_name.rb
+++ b/db/migrate/20171122220857_add_fulltext_index_on_persons_name.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddFulltextIndexOnPersonsName < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171124184454_convert_old_333mbf_groups_into_attempts.rb
+++ b/db/migrate/20171124184454_convert_old_333mbf_groups_into_attempts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ConvertOld333mbfGroupsIntoAttempts < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171219000023_add_ethics_and_quality_committees.rb
+++ b/db/migrate/20171219000023_add_ethics_and_quality_committees.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEthicsAndQualityCommittees < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171219200237_add_scramble_group_count_to_rounds.rb
+++ b/db/migrate/20171219200237_add_scramble_group_count_to_rounds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddScrambleGroupCountToRounds < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171219204656_update_committes_emails.rb
+++ b/db/migrate/20171219204656_update_committes_emails.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateCommittesEmails < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171221184910_add_dangerously_allow_any_redirect_uri_to_oauth_applications.rb
+++ b/db/migrate/20171221184910_add_dangerously_allow_any_redirect_uri_to_oauth_applications.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDangerouslyAllowAnyRedirectUriToOauthApplications < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171222100000_cleanup_orphaned_rounds.rb
+++ b/db/migrate/20171222100000_cleanup_orphaned_rounds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CleanupOrphanedRounds < ActiveRecord::Migration[5.1]

--- a/db/migrate/20171222182940_update_round_ids.rb
+++ b/db/migrate/20171222182940_update_round_ids.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateRoundIds < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180104132335_update_preferred_formats_for_feet.rb
+++ b/db/migrate/20180104132335_update_preferred_formats_for_feet.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdatePreferredFormatsForFeet < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180107142301_update_feet_format_in_rounds.rb
+++ b/db/migrate/20180107142301_update_feet_format_in_rounds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateFeetFormatInRounds < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180120132926_add_board_team.rb
+++ b/db/migrate/20180120132926_add_board_team.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddBoardTeam < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180201005000_add_round_results_to_rounds.rb
+++ b/db/migrate/20180201005000_add_round_results_to_rounds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRoundResultsToRounds < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180205000001_create_competition_venues.rb
+++ b/db/migrate/20180205000001_create_competition_venues.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionVenues < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180205000002_create_venue_rooms.rb
+++ b/db/migrate/20180205000002_create_venue_rooms.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateVenueRooms < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180205000003_create_schedule_activities.rb
+++ b/db/migrate/20180205000003_create_schedule_activities.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateScheduleActivities < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180206211650_add_locations_table.rb
+++ b/db/migrate/20180206211650_add_locations_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddLocationsTable < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180403194359_add_roles_to_registration.rb
+++ b/db/migrate/20180403194359_add_roles_to_registration.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRolesToRegistration < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180526084857_set_registration_requirements_for_visible_competitions.rb
+++ b/db/migrate/20180526084857_set_registration_requirements_for_visible_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class SetRegistrationRequirementsForVisibleCompetitions < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180528130810_update_trinidad_and_tobago.rb
+++ b/db/migrate/20180528130810_update_trinidad_and_tobago.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateTrinidadAndTobago < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180621093155_add_nordic_championship_type.rb
+++ b/db/migrate/20180621093155_add_nordic_championship_type.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddNordicChampionshipType < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180623171213_add_registration_requirements_columns_to_competitions.rb
+++ b/db/migrate/20180623171213_add_registration_requirements_columns_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegistrationRequirementsColumnsToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180629112054_add_color_to_venue_room.rb
+++ b/db/migrate/20180629112054_add_color_to_venue_room.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddColorToVenueRoom < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180701160042_add_total_number_of_rounds_to_round.rb
+++ b/db/migrate/20180701160042_add_total_number_of_rounds_to_round.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTotalNumberOfRoundsToRound < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180703172949_add_hidden_to_teams.rb
+++ b/db/migrate/20180703172949_add_hidden_to_teams.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddHiddenToTeams < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180705231137_rename_scramble_group_to_scramble_set.rb
+++ b/db/migrate/20180705231137_rename_scramble_group_to_scramble_set.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameScrambleGroupToScrambleSet < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180708214503_add_results_submitted_at_to_competition.rb
+++ b/db/migrate/20180708214503_add_results_submitted_at_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddResultsSubmittedAtToCompetition < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180709220826_add_timestamps_columns_to_competitions.rb
+++ b/db/migrate/20180709220826_add_timestamps_columns_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTimestampsColumnsToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180710165401_allow_null_base_entry_fee.rb
+++ b/db/migrate/20180710165401_allow_null_base_entry_fee.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AllowNullBaseEntryFee < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180711124055_add_index_on_competition_id_and_person_id_to_inbox_person.rb
+++ b/db/migrate/20180711124055_add_index_on_competition_id_and_person_id_to_inbox_person.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIndexOnCompetitionIdAndPersonIdToInboxPerson < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180729000001_add_hidden_team_for_banned_competitors.rb
+++ b/db/migrate/20180729000001_add_hidden_team_for_banned_competitors.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddHiddenTeamForBannedCompetitors < ActiveRecord::Migration[5.1]

--- a/db/migrate/20180730182509_add_confidential_to_doorkeeper_application.rb
+++ b/db/migrate/20180730182509_add_confidential_to_doorkeeper_application.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddConfidentialToDoorkeeperApplication < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180731204733_remove_nordic_championship_type.rb
+++ b/db/migrate/20180731204733_remove_nordic_championship_type.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveNordicChampionshipType < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180822165331_add_wca_marketing_team.rb
+++ b/db/migrate/20180822165331_add_wca_marketing_team.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWcaMarketingTeam < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180825114051_clear_null_registration_requirements.rb
+++ b/db/migrate/20180825114051_clear_null_registration_requirements.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ClearNullRegistrationRequirements < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180825115701_change_registration_requirements_column_name.rb
+++ b/db/migrate/20180825115701_change_registration_requirements_column_name.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeRegistrationRequirementsColumnName < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180831075355_nullify_competitor_limit.rb
+++ b/db/migrate/20180831075355_nullify_competitor_limit.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class NullifyCompetitorLimit < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180831164420_add_z1_and_z3_columns_to_competitions.rb
+++ b/db/migrate/20180831164420_add_z1_and_z3_columns_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddZ1AndZ3ColumnsToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180908195553_add_name_reason_to_competitions.rb
+++ b/db/migrate/20180908195553_add_name_reason_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddNameReasonToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180911140010_create_uploaded_json.rb
+++ b/db/migrate/20180911140010_create_uploaded_json.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateUploadedJson < ActiveRecord::Migration[5.2]

--- a/db/migrate/20180912042457_add_confirmed_at_to_competitions.rb
+++ b/db/migrate/20180912042457_add_confirmed_at_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddConfirmedAtToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181020004209_add_wcat.rb
+++ b/db/migrate/20181020004209_add_wcat.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWcat < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181021185003_create_stripe_charges.rb
+++ b/db/migrate/20181021185003_create_stripe_charges.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateStripeCharges < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181022031135_remove_rank_from_teams_table.rb
+++ b/db/migrate/20181022031135_remove_rank_from_teams_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveRankFromTeamsTable < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181109172930_add_external_registration_page_link_to_competitions.rb
+++ b/db/migrate/20181109172930_add_external_registration_page_link_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddExternalRegistrationPageLinkToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181122233823_create_wcif_extensions.rb
+++ b/db/migrate/20181122233823_create_wcif_extensions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateWcifExtensions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181208145408_add_receive_delegate_reports_column_to_users_table.rb
+++ b/db/migrate/20181208145408_add_receive_delegate_reports_column_to_users_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddReceiveDelegateReportsColumnToUsersTable < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181209171137_add_incorrect_wca_id_claim_count_to_persons.rb
+++ b/db/migrate/20181209171137_add_incorrect_wca_id_claim_count_to_persons.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIncorrectWcaIdClaimCountToPersons < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181222224850_add_dummy_account_marker_to_users.rb
+++ b/db/migrate/20181222224850_add_dummy_account_marker_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDummyAccountMarkerToUsers < ActiveRecord::Migration[5.2]

--- a/db/migrate/20181226115357_add_senior_members_column_to_teams.rb
+++ b/db/migrate/20181226115357_add_senior_members_column_to_teams.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddSeniorMembersColumnToTeams < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190105215446_create_assignments.rb
+++ b/db/migrate/20190105215446_create_assignments.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateAssignments < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190112130723_add_officers_teams.rb
+++ b/db/migrate/20190112130723_add_officers_teams.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddOfficersTeams < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190113180945_add_wca_data_protection_committee.rb
+++ b/db/migrate/20190113180945_add_wca_data_protection_committee.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWcaDataProtectionCommittee < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190117112257_change_wcif_extensions_extendable_id_to_string.rb
+++ b/db/migrate/20190117112257_change_wcif_extensions_extendable_id_to_string.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # One of the extendable models is Competition, with id type of string.

--- a/db/migrate/20190124180224_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20190124180224_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This migration comes from active_storage (originally 20170806125915)

--- a/db/migrate/20190208175255_add_wac.rb
+++ b/db/migrate/20190208175255_add_wac.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWac < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190216102110_create_regional_organizations.rb
+++ b/db/migrate/20190216102110_create_regional_organizations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRegionalOrganizations < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190221194112_add_missing_multiple_countries.rb
+++ b/db/migrate/20190221194112_add_missing_multiple_countries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddMissingMultipleCountries < ActiveRecord::Migration[5.1]

--- a/db/migrate/20190514234342_add_hidden_team_for_delegates_on_probation.rb
+++ b/db/migrate/20190514234342_add_hidden_team_for_delegates_on_probation.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddHiddenTeamForDelegatesOnProbation < ActiveRecord::Migration[5.1]

--- a/db/migrate/20190601105825_add_fields_to_regional_organizations.rb
+++ b/db/migrate/20190601105825_add_fields_to_regional_organizations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddFieldsToRegionalOrganizations < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190601231550_add_unstick_at_to_posts.rb
+++ b/db/migrate/20190601231550_add_unstick_at_to_posts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUnstickAtToPosts < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190622173635_allow_null_start_date_for_regional_organizations.rb
+++ b/db/migrate/20190622173635_allow_null_start_date_for_regional_organizations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AllowNullStartDateForRegionalOrganizations < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190716065618_add_id_to_inbox_results.rb
+++ b/db/migrate/20190716065618_add_id_to_inbox_results.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIdToInboxResults < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190728084145_add_wrc_and_wdc_fields_to_delegate_reports.rb
+++ b/db/migrate/20190728084145_add_wrc_and_wdc_fields_to_delegate_reports.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWrcAndWdcFieldsToDelegateReports < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190803202212_update_wca_states.rb
+++ b/db/migrate/20190803202212_update_wca_states.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateWcaStates < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190806173355_create_weat.rb
+++ b/db/migrate/20190806173355_create_weat.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateWeat < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190814232833_add_results_index_on_value_x.rb
+++ b/db/migrate/20190814232833_add_results_index_on_value_x.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddResultsIndexOnValueX < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190816001639_change_z_regulations_column_name.rb
+++ b/db/migrate/20190816001639_change_z_regulations_column_name.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeZRegulationsColumnName < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190816004605_add_event_restriction_columns_to_competitions.rb
+++ b/db/migrate/20190816004605_add_event_restriction_columns_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEventRestrictionColumnsToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190817170648_add_country_iso2_to_venue.rb
+++ b/db/migrate/20190817170648_add_country_iso2_to_venue.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCountryIso2ToVenue < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190817193315_fix_country_iso2_on_venue.rb
+++ b/db/migrate/20190817193315_fix_country_iso2_on_venue.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixCountryIso2OnVenue < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190818102517_create_bookmarked_competitions.rb
+++ b/db/migrate/20190818102517_create_bookmarked_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateBookmarkedCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190825095512_add_fields_to_competitions_table.rb
+++ b/db/migrate/20190825095512_add_fields_to_competitions_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddFieldsToCompetitionsTable < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190826005902_add_wrc_users_to_delegate_report.rb
+++ b/db/migrate/20190826005902_add_wrc_users_to_delegate_report.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWrcUsersToDelegateReport < ActiveRecord::Migration[5.2]

--- a/db/migrate/20190916133253_change_stripe_charge_id_type.rb
+++ b/db/migrate/20190916133253_change_stripe_charge_id_type.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeStripeChargeIdType < ActiveRecord::Migration[5.2]

--- a/db/migrate/20191005203556_add_user_to_registration_payments.rb
+++ b/db/migrate/20191005203556_add_user_to_registration_payments.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUserToRegistrationPayments < ActiveRecord::Migration[5.2]

--- a/db/migrate/20191013211511_create_country_bands.rb
+++ b/db/migrate/20191013211511_create_country_bands.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCountryBands < ActiveRecord::Migration[5.2]

--- a/db/migrate/20191107212356_add_devise_two_factor_to_users.rb
+++ b/db/migrate/20191107212356_add_devise_two_factor_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDeviseTwoFactorToUsers < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200125180554_update_feet_rank.rb
+++ b/db/migrate/20200125180554_update_feet_rank.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateFeetRank < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200206012756_change_empty_main_event_to_nil.rb
+++ b/db/migrate/20200206012756_change_empty_main_event_to_nil.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeEmptyMainEventToNil < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200304044931_create_competition_trainee_delegates.rb
+++ b/db/migrate/20200304044931_create_competition_trainee_delegates.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionTraineeDelegates < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200319193625_rename_combined_rounds_to_cutoff_rounds.rb
+++ b/db/migrate/20200319193625_rename_combined_rounds_to_cutoff_rounds.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameCombinedRoundsToCutoffRounds < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200331082313_rename_some_wca_states.rb
+++ b/db/migrate/20200331082313_rename_some_wca_states.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameSomeWcaStates < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200415151734_add_index_to_results_on_records.rb
+++ b/db/migrate/20200415151734_add_index_to_results_on_records.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIndexToResultsOnRecords < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200419133415_remove_additional_fields_for_delegates.rb
+++ b/db/migrate/20200419133415_remove_additional_fields_for_delegates.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveAdditionalFieldsForDelegates < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200502095048_add_old_type_to_round.rb
+++ b/db/migrate/20200502095048_add_old_type_to_round.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddOldTypeToRound < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200522095030_change_default_tl_value.rb
+++ b/db/migrate/20200522095030_change_default_tl_value.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeDefaultTlValue < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200522125145_remove_world_readable_from_posts.rb
+++ b/db/migrate/20200522125145_remove_world_readable_from_posts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveWorldReadableFromPosts < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200607140007_add_cancelled_at_to_competition.rb
+++ b/db/migrate/20200607140007_add_cancelled_at_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCancelledAtToCompetition < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200627195628_add_session_validity_token_to_users.rb
+++ b/db/migrate/20200627195628_add_session_validity_token_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddSessionValidityTokenToUsers < ActiveRecord::Migration[5.2]

--- a/db/migrate/20200725152218_change_media_timestamp_decided_to_nullable.rb
+++ b/db/migrate/20200725152218_change_media_timestamp_decided_to_nullable.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeMediaTimestampDecidedToNullable < ActiveRecord::Migration[5.2]

--- a/db/migrate/20201020193829_create_wrt_sanity_check_tables.rb
+++ b/db/migrate/20201020193829_create_wrt_sanity_check_tables.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateWrtSanityCheckTables < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210129181657_add_sanity_check_tables_constraints.rb
+++ b/db/migrate/20210129181657_add_sanity_check_tables_constraints.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddSanityCheckTablesConstraints < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210221190945_add_hidden_team_for_wct_china.rb
+++ b/db/migrate/20210221190945_add_hidden_team_for_wct_china.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddHiddenTeamForWctChina < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210301002636_hide_wdpc_team.rb
+++ b/db/migrate/20210301002636_hide_wdpc_team.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class HideWdpcTeam < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210325202019_add_waiting_list_and_events_deadlines_to_competitions.rb
+++ b/db/migrate/20210325202019_add_waiting_list_and_events_deadlines_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWaitingListAndEventsDeadlinesToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210501213332_add_hidden_team_for_wst_admin.rb
+++ b/db/migrate/20210501213332_add_hidden_team_for_wst_admin.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddHiddenTeamForWstAdmin < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210506205912_add_qualification_to_event.rb
+++ b/db/migrate/20210506205912_add_qualification_to_event.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddQualificationToEvent < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210521195423_add_allow_registration_edits_to_competition.rb
+++ b/db/migrate/20210521195423_add_allow_registration_edits_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAllowRegistrationEditsToCompetition < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210727081850_add_cookies_acknowleded_to_users.rb
+++ b/db/migrate/20210727081850_add_cookies_acknowleded_to_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCookiesAcknowlededToUsers < ActiveRecord::Migration[5.2]

--- a/db/migrate/20210802065056_add_free_guest_entry_status_to_competitions.rb
+++ b/db/migrate/20210802065056_add_free_guest_entry_status_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddFreeGuestEntryStatusToCompetitions < ActiveRecord::Migration[5.2]

--- a/db/migrate/20211031152615_create_announcement_tables.starburst.rb
+++ b/db/migrate/20211031152615_create_announcement_tables.starburst.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This migration comes from starburst (originally 20141004214002)

--- a/db/migrate/20211031152616_add_category_to_starburst_announcements.starburst.rb
+++ b/db/migrate/20211031152616_add_category_to_starburst_announcements.starburst.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This migration comes from starburst (originally 20141112140703)

--- a/db/migrate/20211031152617_add_index_and_uniqueness_to_announcement_views.starburst.rb
+++ b/db/migrate/20211031152617_add_index_and_uniqueness_to_announcement_views.starburst.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This migration comes from starburst (originally 20141209221904)

--- a/db/migrate/20211031154101_add_marketing_shop_announcement.rb
+++ b/db/migrate/20211031154101_add_marketing_shop_announcement.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddMarketingShopAnnouncement < ActiveRecord::Migration[6.0]

--- a/db/migrate/20211210100657_repopulate_preferred_formats.rb
+++ b/db/migrate/20211210100657_repopulate_preferred_formats.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This is done to clean up this table and make it comply with the 2020 regulations

--- a/db/migrate/20220223163446_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20220223163446_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This migration comes from active_storage (originally 20190112182829)

--- a/db/migrate/20220223163447_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20220223163447_create_active_storage_variant_records.active_storage.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This migration comes from active_storage (originally 20191206030411)

--- a/db/migrate/20220511025003_add_hidden_team_for_wsot.rb
+++ b/db/migrate/20220511025003_add_hidden_team_for_wsot.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddHiddenTeamForWsot < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220516124717_add_team_for_wat.rb
+++ b/db/migrate/20220516124717_add_team_for_wat.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTeamForWat < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220619200832_add_allow_registration_self_delete_to_competition.rb
+++ b/db/migrate/20220619200832_add_allow_registration_self_delete_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAllowRegistrationSelfDeleteToCompetition < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220623121810_registration_email_default_change.rb
+++ b/db/migrate/20220623121810_registration_email_default_change.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RegistrationEmailDefaultChange < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220627195217_add_allow_registration_without_qualification_to_competitions.rb
+++ b/db/migrate/20220627195217_add_allow_registration_without_qualification_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAllowRegistrationWithoutQualificationToCompetitions < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220630233246_add_use_wca_live_for_scoretaking.rb
+++ b/db/migrate/20220630233246_add_use_wca_live_for_scoretaking.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUseWcaLiveForScoretaking < ActiveRecord::Migration[6.0]

--- a/db/migrate/20220706232200_create_cached_results.rb
+++ b/db/migrate/20220706232200_create_cached_results.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCachedResults < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220725045202_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
+++ b/db/migrate/20220725045202_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 # This migration comes from active_storage (originally 20211119233751)

--- a/db/migrate/20220725045819_add_otp_secret_to_user.rb
+++ b/db/migrate/20220725045819_add_otp_secret_to_user.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddOtpSecretToUser < ActiveRecord::Migration[7.0]

--- a/db/migrate/20220804193822_add_registration_notifications_default_to_user.rb
+++ b/db/migrate/20220804193822_add_registration_notifications_default_to_user.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegistrationNotificationsDefaultToUser < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220822232936_create_competition_series_table.rb
+++ b/db/migrate/20220822232936_create_competition_series_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionSeriesTable < ActiveRecord::Migration[6.1]

--- a/db/migrate/20220916132536_add_reminder_sent_at_to_delegate_reports.rb
+++ b/db/migrate/20220916132536_add_reminder_sent_at_to_delegate_reports.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddReminderSentAtToDelegateReports < ActiveRecord::Migration[7.0]

--- a/db/migrate/20221121111430_add_guest_limit_to_competitions.rb
+++ b/db/migrate/20221121111430_add_guest_limit_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddGuestLimitToCompetitions < ActiveRecord::Migration[6.1]

--- a/db/migrate/20221123090104_add_community_survey_announcement.rb
+++ b/db/migrate/20221123090104_add_community_survey_announcement.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCommunitySurveyAnnouncement < ActiveRecord::Migration[7.0]

--- a/db/migrate/20221123121220_remove_trainee_delegate_associations.rb
+++ b/db/migrate/20221123121220_remove_trainee_delegate_associations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveTraineeDelegateAssociations < ActiveRecord::Migration[7.0]

--- a/db/migrate/20221224215048_add_is_competing_to_registration.rb
+++ b/db/migrate/20221224215048_add_is_competing_to_registration.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIsCompetingToRegistration < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230119115432_add_events_per_registration_limit_to_competitions.rb
+++ b/db/migrate/20230119115432_add_events_per_registration_limit_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEventsPerRegistrationLimitToCompetitions < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230204111111_add_force_comment_to_registration_to_competitions.rb
+++ b/db/migrate/20230204111111_add_force_comment_to_registration_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddForceCommentToRegistrationToCompetitions < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230303093411_add_worlds_merch_announcement.rb
+++ b/db/migrate/20230303093411_add_worlds_merch_announcement.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddWorldsMerchAnnouncement < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230311165116_add_receipt_to_registration_payments.rb
+++ b/db/migrate/20230311165116_add_receipt_to_registration_payments.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddReceiptToRegistrationPayments < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230311183558_restructure_stripe_charges_table.rb
+++ b/db/migrate/20230311183558_restructure_stripe_charges_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RestructureStripeChargesTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230312182740_create_stripe_payment_intents_table.rb
+++ b/db/migrate/20230312182740_create_stripe_payment_intents_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateStripePaymentIntentsTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230315170143_create_stripe_webhook_events.rb
+++ b/db/migrate/20230315170143_create_stripe_webhook_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateStripeWebhookEvents < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230515103948_add_administrative_notes_to_registrations.rb
+++ b/db/migrate/20230515103948_add_administrative_notes_to_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAdministrativeNotesToRegistrations < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230517135741_remove_legacy_devise_two_factor_secrets_from_users.rb
+++ b/db/migrate/20230517135741_remove_legacy_devise_two_factor_secrets_from_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveLegacyDeviseTwoFactorSecretsFromUsers < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230520171858_remove_persons_view.rb
+++ b/db/migrate/20230520171858_remove_persons_view.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemovePersonsView < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230520173123_change_day_month_year_to_date.rb
+++ b/db/migrate/20230520173123_change_day_month_year_to_date.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeDayMonthYearToDate < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230701100417_change_country_names_in_table.rb
+++ b/db/migrate/20230701100417_change_country_names_in_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeCountryNamesInTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230707182015_create_cronjob_statistics_table.rb
+++ b/db/migrate/20230707182015_create_cronjob_statistics_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCronjobStatisticsTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230729032534_fix_column_name.rb
+++ b/db/migrate/20230729032534_fix_column_name.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixColumnName < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230822155348_change_media_submitter_email_column_length.rb
+++ b/db/migrate/20230822155348_change_media_submitter_email_column_length.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeMediaSubmitterEmailColumnLength < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230822160657_recompute_persons_table_indices.rb
+++ b/db/migrate/20230822160657_recompute_persons_table_indices.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RecomputePersonsTableIndices < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230828211643_add_created_at_remote_to_stripe_events.rb
+++ b/db/migrate/20230828211643_add_created_at_remote_to_stripe_events.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCreatedAtRemoteToStripeEvents < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230906135843_remove_relations.rb
+++ b/db/migrate/20230906135843_remove_relations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveRelations < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230906155619_remove_delayed_jobs_table.rb
+++ b/db/migrate/20230906155619_remove_delayed_jobs_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveDelayedJobsTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230910095715_create_user_groups.rb
+++ b/db/migrate/20230910095715_create_user_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateUserGroups < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230910105700_create_roles.rb
+++ b/db/migrate/20230910105700_create_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRoles < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230910113122_add_delegate_probation_to_groups.rb
+++ b/db/migrate/20230910113122_add_delegate_probation_to_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDelegateProbationToGroups < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230910114732_add_probations_to_roles.rb
+++ b/db/migrate/20230910114732_add_probations_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddProbationsToRoles < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230918144054_remove_timestamps_table.rb
+++ b/db/migrate/20230918144054_remove_timestamps_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveTimestampsTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230918144154_create_server_settings_table.rb
+++ b/db/migrate/20230918144154_create_server_settings_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateServerSettingsTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230921143204_add_posting_by_to_competition.rb
+++ b/db/migrate/20230921143204_add_posting_by_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddPostingByToCompetition < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230922133827_create_user_avatars_table.rb
+++ b/db/migrate/20230922133827_create_user_avatars_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateUserAvatarsTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230922141741_migrate_existing_avatars.rb
+++ b/db/migrate/20230922141741_migrate_existing_avatars.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateExistingAvatars < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230922151140_remove_avatar_columns_from_users.rb
+++ b/db/migrate/20230922151140_remove_avatar_columns_from_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveAvatarColumnsFromUsers < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231010152057_create_attendee_payment_requests.rb
+++ b/db/migrate/20231010152057_create_attendee_payment_requests.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateAttendeePaymentRequests < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231010152058_create_jwt_denylist.rb
+++ b/db/migrate/20231010152058_create_jwt_denylist.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateJwtDenylist < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231103102744_add_region_to_user_table.rb
+++ b/db/migrate/20231103102744_add_region_to_user_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegionToUserTable < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231103103433_add_user_groups.rb
+++ b/db/migrate/20231103103433_add_user_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUserGroups < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231115153211_add_email_to_sanity_check.rb
+++ b/db/migrate/20231115153211_add_email_to_sanity_check.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddEmailToSanityCheck < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231120172504_add_uses_v2_registrations.rb
+++ b/db/migrate/20231120172504_add_uses_v2_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddUsesV2Registrations < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231122153605_create_wfc_xero_users.rb
+++ b/db/migrate/20231122153605_create_wfc_xero_users.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateWfcXeroUsers < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231122153755_create_wfc_dues_redirects.rb
+++ b/db/migrate/20231122153755_create_wfc_dues_redirects.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateWfcDuesRedirects < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231124161841_drop_senior_delegate_id.rb
+++ b/db/migrate/20231124161841_drop_senior_delegate_id.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DropSeniorDelegateId < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231125045609_create_groups_metadata_delegate_regions.rb
+++ b/db/migrate/20231125045609_create_groups_metadata_delegate_regions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateGroupsMetadataDelegateRegions < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231125061943_add_groups_metadata_delegate_regions.rb
+++ b/db/migrate/20231125061943_add_groups_metadata_delegate_regions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddGroupsMetadataDelegateRegions < ActiveRecord::Migration[7.0]

--- a/db/migrate/20231202155158_add_senior_delegate_region_index.rb
+++ b/db/migrate/20231202155158_add_senior_delegate_region_index.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddSeniorDelegateRegionIndex < ActiveRecord::Migration[7.1]

--- a/db/migrate/20231220090853_rename_roles_to_user_roles.rb
+++ b/db/migrate/20231220090853_rename_roles_to_user_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameRolesToUserRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20231227094930_add_friendly_id_to_groups_metadata_delegate_regions.rb
+++ b/db/migrate/20231227094930_add_friendly_id_to_groups_metadata_delegate_regions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddFriendlyIdToGroupsMetadataDelegateRegions < ActiveRecord::Migration[7.1]

--- a/db/migrate/20231227095728_update_friendly_id_fields.rb
+++ b/db/migrate/20231227095728_update_friendly_id_fields.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class UpdateFriendlyIdFields < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240112161530_create_groups_metadata_translators.rb
+++ b/db/migrate/20240112161530_create_groups_metadata_translators.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateGroupsMetadataTranslators < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240112161627_create_translators_group.rb
+++ b/db/migrate/20240112161627_create_translators_group.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTranslatorsGroup < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240112161627_create_translators_group.rb
+++ b/db/migrate/20240112161627_create_translators_group.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 class CreateTranslatorsGroup < ActiveRecord::Migration[7.1]
-  # rubocop:disable Style/NumericLiterals
   VERIFIED_TRANSLATORS_BY_LOCALE = {
     "ca" => [94007, 15295],
     "cs" => [8583],

--- a/db/migrate/20240117084208_create_roles_metadata_delegate_regions.rb
+++ b/db/migrate/20240117084208_create_roles_metadata_delegate_regions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRolesMetadataDelegateRegions < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240117132919_create_doorkeeper_openid_connect_tables.rb
+++ b/db/migrate/20240117132919_create_doorkeeper_openid_connect_tables.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240127053701_create_metadata_for_delegate_groups.rb
+++ b/db/migrate/20240127053701_create_metadata_for_delegate_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateMetadataForDelegateGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240130054925_create_competition_payment_integrations.rb
+++ b/db/migrate/20240130054925_create_competition_payment_integrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCompetitionPaymentIntegrations < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240130055245_create_connected_paypal_accounts.rb
+++ b/db/migrate/20240130055245_create_connected_paypal_accounts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateConnectedPaypalAccounts < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240202060026_create_connected_stripe_accounts.rb
+++ b/db/migrate/20240202060026_create_connected_stripe_accounts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateConnectedStripeAccounts < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240203180115_fix_translators_groups.rb
+++ b/db/migrate/20240203180115_fix_translators_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class FixTranslatorsGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240206154319_migrate_seniors_to_roles.rb
+++ b/db/migrate/20240206154319_migrate_seniors_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateSeniorsToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240219104624_populate_existing_stripe_connections.rb
+++ b/db/migrate/20240219104624_populate_existing_stripe_connections.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class PopulateExistingStripeConnections < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240221033850_migrate_locales_to_user_groups.rb
+++ b/db/migrate/20240221033850_migrate_locales_to_user_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateLocalesToUserGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240222134242_create_paypal_records_table.rb
+++ b/db/migrate/20240222134242_create_paypal_records_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreatePaypalRecordsTable < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240306133747_add_registration_microservice_shadow_table.rb
+++ b/db/migrate/20240306133747_add_registration_microservice_shadow_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegistrationMicroserviceShadowTable < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240306134217_make_assignments_table_registration_polymorphic.rb
+++ b/db/migrate/20240306134217_make_assignments_table_registration_polymorphic.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MakeAssignmentsTableRegistrationPolymorphic < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240307181801_add_staff_dummy_fields_to_microservice_registrations.rb
+++ b/db/migrate/20240307181801_add_staff_dummy_fields_to_microservice_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddStaffDummyFieldsToMicroserviceRegistrations < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240309071510_create_roles_metadata_officers.rb
+++ b/db/migrate/20240309071510_create_roles_metadata_officers.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRolesMetadataOfficers < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240309071801_migrate_officers_to_roles.rb
+++ b/db/migrate/20240309071801_migrate_officers_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateOfficersToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240309141549_add_treasurer_to_roles.rb
+++ b/db/migrate/20240309141549_add_treasurer_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddTreasurerToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240310030132_create_groups_metadata_board.rb
+++ b/db/migrate/20240310030132_create_groups_metadata_board.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateGroupsMetadataBoard < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240310030319_create_board_user_group.rb
+++ b/db/migrate/20240310030319_create_board_user_group.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateBoardUserGroup < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240311053739_rename_stripe_transaction_to_stripe_record.rb
+++ b/db/migrate/20240311053739_rename_stripe_transaction_to_stripe_record.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameStripeTransactionToStripeRecord < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240312122903_make_stripe_payment_intent_generic.rb
+++ b/db/migrate/20240312122903_make_stripe_payment_intent_generic.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MakeStripePaymentIntentGeneric < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240318171127_create_groups_metadata_councils.rb
+++ b/db/migrate/20240318171127_create_groups_metadata_councils.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateGroupsMetadataCouncils < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240318171344_migrate_councils_to_user_groups.rb
+++ b/db/migrate/20240318171344_migrate_councils_to_user_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateCouncilsToUserGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240326023855_create_board_roles.rb
+++ b/db/migrate/20240326023855_create_board_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateBoardRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240326163055_create_groups_metadata_teams_committees.rb
+++ b/db/migrate/20240326163055_create_groups_metadata_teams_committees.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateGroupsMetadataTeamsCommittees < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240326163100_migrate_teams_to_groups.rb
+++ b/db/migrate/20240326163100_migrate_teams_to_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateTeamsToGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240326194726_create_roles_metadata_councils.rb
+++ b/db/migrate/20240326194726_create_roles_metadata_councils.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRolesMetadataCouncils < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240326194731_migrate_wac_roles.rb
+++ b/db/migrate/20240326194731_migrate_wac_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateWacRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240402051116_add_delegate_roles.rb
+++ b/db/migrate/20240402051116_add_delegate_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddDelegateRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240404165513_drop_attendee_payment_request.rb
+++ b/db/migrate/20240404165513_drop_attendee_payment_request.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DropAttendeePaymentRequest < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240408032204_remove_columns_from_user_table.rb
+++ b/db/migrate/20240408032204_remove_columns_from_user_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveColumnsFromUserTable < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240408114807_create_roles_metadata_teams_committees.rb
+++ b/db/migrate/20240408114807_create_roles_metadata_teams_committees.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRolesMetadataTeamsCommittees < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240408115512_migrate_wst_admin_to_roles.rb
+++ b/db/migrate/20240408115512_migrate_wst_admin_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateWstAdminToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240409195329_rename_paypal_record_columns.rb
+++ b/db/migrate/20240409195329_rename_paypal_record_columns.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenamePaypalRecordColumns < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240411113530_rename_candidate_to_trainee.rb
+++ b/db/migrate/20240411113530_rename_candidate_to_trainee.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RenameCandidateToTrainee < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240418014842_migrate_wct_china_to_roles.rb
+++ b/db/migrate/20240418014842_migrate_wct_china_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateWctChinaToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240424033200_migrate_wrt_to_roles.rb
+++ b/db/migrate/20240424033200_migrate_wrt_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateWrtToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240426045248_add_newcomer_allowed_to_competition.rb
+++ b/db/migrate/20240426045248_add_newcomer_allowed_to_competition.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddNewcomerAllowedToCompetition < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240430101638_add_preferred_contact_mode_to_groups_metadata_teams_committees.rb
+++ b/db/migrate/20240430101638_add_preferred_contact_mode_to_groups_metadata_teams_committees.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddPreferredContactModeToGroupsMetadataTeamsCommittees < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240502013953_migrate_some_teams_to_groups.rb
+++ b/db/migrate/20240502013953_migrate_some_teams_to_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateSomeTeamsToGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240503103418_migrate_some_more_teams_to_groups.rb
+++ b/db/migrate/20240503103418_migrate_some_more_teams_to_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateSomeMoreTeamsToGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240503144557_migrate_wdpc_to_groups.rb
+++ b/db/migrate/20240503144557_migrate_wdpc_to_groups.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateWdpcToGroups < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240503154148_migrate_wst_to_roles.rb
+++ b/db/migrate/20240503154148_migrate_wst_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateWstToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240505004834_migrate_wrc_to_roles.rb
+++ b/db/migrate/20240505004834_migrate_wrc_to_roles.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateWrcToRoles < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240518022919_create_roles_metadata_banned_competitors.rb
+++ b/db/migrate/20240518022919_create_roles_metadata_banned_competitors.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRolesMetadataBannedCompetitors < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240518023151_migrate_banned_competitors.rb
+++ b/db/migrate/20240518023151_migrate_banned_competitors.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MigrateBannedCompetitors < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240520170239_set_microservice_reg_table_not_null.rb
+++ b/db/migrate/20240520170239_set_microservice_reg_table_not_null.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class SetMicroserviceRegTableNotNull < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240523104316_change_competition_string_lengths.rb
+++ b/db/migrate/20240523104316_change_competition_string_lengths.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeCompetitionStringLengths < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240604023815_remove_teams.rb
+++ b/db/migrate/20240604023815_remove_teams.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveTeams < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240604023859_remove_team_members.rb
+++ b/db/migrate/20240604023859_remove_team_members.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class RemoveTeamMembers < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240605145605_add_indexes_to_registrations.rb
+++ b/db/migrate/20240605145605_add_indexes_to_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIndexesToRegistrations < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240624081321_add_summary_to_delegate_reports.rb
+++ b/db/migrate/20240624081321_add_summary_to_delegate_reports.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddSummaryToDelegateReports < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240716145605_add_more_indexes_to_registrations.rb
+++ b/db/migrate/20240716145605_add_more_indexes_to_registrations.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddMoreIndexesToRegistrations < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240716200248_drop_championship_iso2_primary_key.rb
+++ b/db/migrate/20240716200248_drop_championship_iso2_primary_key.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DropChampionshipIso2PrimaryKey < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240717095605_add_needed_indexes.rb
+++ b/db/migrate/20240717095605_add_needed_indexes.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddNeededIndexes < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240717123410_drop_cell_name_from_event.rb
+++ b/db/migrate/20240717123410_drop_cell_name_from_event.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class DropCellNameFromEvent < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240717142240_alter_external_registration_page_max_length.rb
+++ b/db/migrate/20240717142240_alter_external_registration_page_max_length.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AlterExternalRegistrationPageMaxLength < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240720203821_add_version_column_to_delegate_reports.rb
+++ b/db/migrate/20240720203821_add_version_column_to_delegate_reports.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddVersionColumnToDelegateReports < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240721143446_opt_in_current_junior_and_trainee_to_reports.rb
+++ b/db/migrate/20240721143446_opt_in_current_junior_and_trainee_to_reports.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class OptInCurrentJuniorAndTraineeToReports < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240721145135_add_reports_region_to_users_table.rb
+++ b/db/migrate/20240721145135_add_reports_region_to_users_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddReportsRegionToUsersTable < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240811091103_august24_motion_changes_wdc.rb
+++ b/db/migrate/20240811091103_august24_motion_changes_wdc.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class August24MotionChangesWdc < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240811094358_august24_motion_changes_wec.rb
+++ b/db/migrate/20240811094358_august24_motion_changes_wec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class August24MotionChangesWec < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240811095430_august24_motion_changes_wapc.rb
+++ b/db/migrate/20240811095430_august24_motion_changes_wapc.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class August24MotionChangesWapc < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240811100821_august24_motion_changes_wac.rb
+++ b/db/migrate/20240811100821_august24_motion_changes_wac.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class August24MotionChangesWac < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240913052148_add_last_successful_run_to_cronjobs.rb
+++ b/db/migrate/20240913052148_add_last_successful_run_to_cronjobs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddLastSuccessfulRunToCronjobs < ActiveRecord::Migration[7.1]

--- a/db/migrate/20240924132217_create_waiting_list.rb
+++ b/db/migrate/20240924132217_create_waiting_list.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateWaitingList < ActiveRecord::Migration[7.2]

--- a/db/migrate/20240924132724_create_registration_history_entry.rb
+++ b/db/migrate/20240924132724_create_registration_history_entry.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRegistrationHistoryEntry < ActiveRecord::Migration[7.2]

--- a/db/migrate/20240924132809_create_registration_history_changes.rb
+++ b/db/migrate/20240924132809_create_registration_history_changes.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRegistrationHistoryChanges < ActiveRecord::Migration[7.2]

--- a/db/migrate/20240930132809_add_new_v2_columns.rb
+++ b/db/migrate/20240930132809_add_new_v2_columns.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddNewV2Columns < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241009111904_add_cascade_to_microservice_competition_id.rb
+++ b/db/migrate/20241009111904_add_cascade_to_microservice_competition_id.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCascadeToMicroserviceCompetitionId < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241015131314_change_waiting_list_holder_id_to_string.rb
+++ b/db/migrate/20241015131314_change_waiting_list_holder_id_to_string.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeWaitingListHolderIdToString < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241022093010_create_regional_records_lookup_table.rb
+++ b/db/migrate/20241022093010_create_regional_records_lookup_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateRegionalRecordsLookupTable < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241025161404_make_registration_version_an_enum.rb
+++ b/db/migrate/20241025161404_make_registration_version_an_enum.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MakeRegistrationVersionAnEnum < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241029104311_create_tickets.rb
+++ b/db/migrate/20241029104311_create_tickets.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTickets < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241029105150_create_ticket_stakeholders.rb
+++ b/db/migrate/20241029105150_create_ticket_stakeholders.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTicketStakeholders < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241029105222_create_ticket_logs.rb
+++ b/db/migrate/20241029105222_create_ticket_logs.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTicketLogs < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241029105239_create_tickets_edit_person.rb
+++ b/db/migrate/20241029105239_create_tickets_edit_person.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTicketsEditPerson < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241031120315_crr_foreign_key_cascade.rb
+++ b/db/migrate/20241031120315_crr_foreign_key_cascade.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CrrForeignKeyCascade < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241104161404_add_competing_status_enum.rb
+++ b/db/migrate/20241104161404_add_competing_status_enum.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddCompetingStatusEnum < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241118145843_change_rche_value_to_text.rb
+++ b/db/migrate/20241118145843_change_rche_value_to_text.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ChangeRcheValueToText < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241124050607_create_tickets_edit_person_fields.rb
+++ b/db/migrate/20241124050607_create_tickets_edit_person_fields.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTicketsEditPersonFields < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241126084446_add_newcomer_reserved_spots_to_competitions.rb
+++ b/db/migrate/20241126084446_add_newcomer_reserved_spots_to_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddNewcomerReservedSpotsToCompetitions < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241225030959_create_country_band_details.rb
+++ b/db/migrate/20241225030959_create_country_band_details.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateCountryBandDetails < ActiveRecord::Migration[7.2]

--- a/db/migrate/20241225031242_populate_country_band_details.rb
+++ b/db/migrate/20241225031242_populate_country_band_details.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class PopulateCountryBandDetails < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250124154917_create_live_result_tables.rb
+++ b/db/migrate/20250124154917_create_live_result_tables.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateLiveResultTables < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250204104514_add_auto_close_to_competitions_table.rb
+++ b/db/migrate/20250204104514_add_auto_close_to_competitions_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAutoCloseToCompetitionsTable < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250210071551_expand_cancellation_restrictions_for_competitions.rb
+++ b/db/migrate/20250210071551_expand_cancellation_restrictions_for_competitions.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class ExpandCancellationRestrictionsForCompetitions < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250210154917_make_live_result_nullable_in_live_attempts.rb
+++ b/db/migrate/20250210154917_make_live_result_nullable_in_live_attempts.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class MakeLiveResultNullableInLiveAttempts < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250212082508_add_indices_to_rce.rb
+++ b/db/migrate/20250212082508_add_indices_to_rce.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddIndicesToRce < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250212142508_create_live_attempt_history_entries.rb
+++ b/db/migrate/20250212142508_create_live_attempt_history_entries.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateLiveAttemptHistoryEntries < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250214015507_create_ticket_comments.rb
+++ b/db/migrate/20250214015507_create_ticket_comments.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class CreateTicketComments < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250218070141_add_registered_at_timestamp.rb
+++ b/db/migrate/20250218070141_add_registered_at_timestamp.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddRegisteredAtTimestamp < ActiveRecord::Migration[7.2]

--- a/db/migrate/20250306165113_add_auto_accept_to_competitions_table.rb
+++ b/db/migrate/20250306165113_add_auto_accept_to_competitions_table.rb
@@ -1,3 +1,4 @@
+# rubocop:disable all
 # frozen_string_literal: true
 
 class AddAutoAcceptToCompetitionsTable < ActiveRecord::Migration[7.2]


### PR DESCRIPTION
This touches every migration file, but this was how gitlab did this 8 years ago https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/4559

And I do agree that we don't need to run any formatting cops on old migrations 