### PR TITLE
Added tests against Competitions API

### DIFF
--- a/spec/requests/api_competitions_spec.rb
+++ b/spec/requests/api_competitions_spec.rb
@@ -571,6 +571,28 @@ RSpec.describe "API Competitions" do
       end
     end
   end
+
+  describe "GET #competition_index" do
+    it 'returns a paginated list of competitions' do
+      FactoryBot.create_list(:competition, 5, :visible)
+      get api_v0_competition_index_path
+      expect(response).to be_successful
+
+      response_json = response.parsed_body
+      expect(response_json.length).to eq(5)
+    end
+
+    it 'takes parameter to filter by continent' do
+      FactoryBot.create_list(:competition, 6, :visible)
+      FactoryBot.create_list(:competition, 4, :visible, countryId: 'Afghanistan')
+
+      get api_v0_competition_index_path, params: { continent: '_North America' }
+      expect(response).to be_successful
+
+      response_json = response.parsed_body
+      expect(response_json.length).to eq(6)
+    end
+  end
 end
 
 def create_wcif_with_events(event_ids)


### PR DESCRIPTION
Adds 2 basic tests: 
- general "does the API work" smoketest
- a test with a parameter filtering for continent

In general, our test coverage against this API is practically non-existent. I think there are 3 main areas of test coverage we can/should add: 
- model tests against the `search` function - here's where we can check that each search parameter we _could_ pass actually works
- a couple more non-admin API tests - this doesn't need to be exhaustive, just check some multi-filter combinations and that "admin" information isn't returned
- API tests with admin mode enabled - confirming that the admin information is returned as expected