### PR TITLE
Fix event selector popup

### DIFF
--- a/app/webpacker/components/wca/EventSelector.jsx
+++ b/app/webpacker/components/wca/EventSelector.jsx
@@ -79,7 +79,6 @@ export default function EventSelector({
               return (
                 <Popup
                   key={eventId}
-                  disabled={selectedEvents.length === 0}
                   trigger={(
                     // hover events don't work on disabled buttons, so wrap in a div
                     <div style={{ display: 'inline-block' }}>

--- a/app/webpacker/components/wca/EventSelector.jsx
+++ b/app/webpacker/components/wca/EventSelector.jsx
@@ -81,8 +81,8 @@ export default function EventSelector({
                   key={eventId}
                   disabled={selectedEvents.length === 0}
                   trigger={(
-                    <span>
-                      {/* Wrap in span so hover works on disabled buttons */}
+                    // hover events don't work on disabled buttons, so wrap in a div
+                    <div style={{ display: 'inline-block' }}>
                       <Button
                         key={eventId}
                         disabled={isDisabled}
@@ -104,7 +104,7 @@ export default function EventSelector({
                           style={eventsDisabled.includes(eventId) ? { color: '#FFBBBB' } : {}}
                         />
                       </Button>
-                    </span>
+                    </div>
                   )}
                 >
                   {eventsDisabled.includes(eventId) ? disabledText(eventId) : I18n.t(`events.${eventId}`)}


### PR DESCRIPTION
I'm no expert on spans and divs, but this seems to fix it, and I'm not sure how else to do it.

I'm not sure why the popups were disabled when nothing was selected. I can't think of any use case for that, and it doesn't make sense in many contexts, such as the psych sheet event selector.

Before:

![image](https://github.com/user-attachments/assets/3c60361b-c1fe-4cc2-9f99-ef7bf864942f)

[Screencast from 2025-03-15 08:40:34 PM.webm](https://github.com/user-attachments/assets/03f3d56c-1afa-4fb1-b7b2-9ac32be6ebab)

[Screencast from 2025-03-15 08:41:19 PM.webm](https://github.com/user-attachments/assets/dcffc667-0ed8-45fe-a923-5c150d20e662)


After:

![image](https://github.com/user-attachments/assets/bc3780a2-4eb9-4445-b697-11809fa67e6d)

[Screencast from 2025-03-15 08:38:57 PM.webm](https://github.com/user-attachments/assets/fe516e17-40d2-49fc-9a27-dd7911a7c53d)

[Screencast from 2025-03-15 08:42:10 PM.webm](https://github.com/user-attachments/assets/8727e111-9f3e-4fc9-b59d-cbc11dacb5e4)

Still works on mobile:
![image](https://github.com/user-attachments/assets/60e5f2db-c758-43f3-bcc1-ea6d379ffa91)

