### PR TITLE
Hide unannounced comps in series list for non admins

### DIFF
--- a/app/views/competitions/_registration_requirements.html.erb
+++ b/app/views/competitions/_registration_requirements.html.erb
@@ -29,7 +29,9 @@
   <%= t('competitions.competition_info.part_of_a_series_list', name: @competition.competition_series.name) %>
   <ul>
     <% @competition.series_sibling_competitions.each do |comp| %>
-      <li><%= link_to comp.name, competition_path(comp.id) %></li>
+      <% if comp.showAtAll? || @current_user&.can_admin_competitions? %>
+        <li><%= link_to comp.name, competition_path(comp.id) %></li>
+      <% end %>
     <% end %>
   </ul>
   <%= t('competitions.competition_info.series_registration_warning_html') %>

--- a/app/views/competitions/_registration_requirements.html.erb
+++ b/app/views/competitions/_registration_requirements.html.erb
@@ -29,7 +29,7 @@
   <%= t('competitions.competition_info.part_of_a_series_list', name: @competition.competition_series.name) %>
   <ul>
     <% @competition.series_sibling_competitions.each do |comp| %>
-      <% if comp.showAtAll? || @current_user&.can_admin_competitions? %>
+      <% if comp.showAtAll? || @current_user&.can_manage_competition?(comp) %>
         <li><%= link_to comp.name, competition_path(comp.id) %></li>
       <% end %>
     <% end %>


### PR DESCRIPTION
Fixes: https://github.com/thewca/worldcubeassociation.org/issues/8129

3 comps in series A, B, C. 
A and B are announced and C isn't

Public page: 
![image](https://github.com/user-attachments/assets/fe55f7c6-567e-4539-843e-3bb2935465ae)

logged in as a speedcuber:
![image](https://github.com/user-attachments/assets/b879a5c5-a7a7-4951-9603-8a5197b0b3ae)

logged in as admin:
![image](https://github.com/user-attachments/assets/3769c192-f26c-414f-b641-f1b2548b78c4)

logged in as comp delegate:
![image](https://github.com/user-attachments/assets/b7c226e2-b72a-4cfb-96da-f83748bed415)
