### PR TITLE
Activate Style/GuardClause

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,9 +82,6 @@ Style/TrailingCommaInHashLiteral:
   # non-empty array and hash literals.
   EnforcedStyleForMultiline: comma
 
-Style/GuardClause:
-  Enabled: false
-
 Metrics/AbcSize:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -220,9 +220,6 @@ Style/YodaCondition:
 Style/FormatStringToken:
   Enabled: false
 
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
 Lint/EmptyFile:
   Exclude:
     - 'db/seeds.rb'

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -312,10 +312,9 @@ class AdminController < ApplicationController
     @competition_ids = competition_list_from_string(@competition_ids_string)
     @persons_to_finish = FinishUnfinishedPersons.search_persons(@competition_ids)
 
-    if @persons_to_finish.empty?
-      flash[:warning] = "There are no persons to complete for the selected competition"
-      redirect_to panel_page_path(id: User.panel_pages[:createNewComers], competition_ids: @competition_ids)
-    end
+    return unless @persons_to_finish.empty?
+    flash[:warning] = "There are no persons to complete for the selected competition"
+    redirect_to panel_page_path(id: User.panel_pages[:createNewComers], competition_ids: @competition_ids)
   end
 
   def do_complete_persons

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -313,6 +313,7 @@ class AdminController < ApplicationController
     @persons_to_finish = FinishUnfinishedPersons.search_persons(@competition_ids)
 
     return unless @persons_to_finish.empty?
+
     flash[:warning] = "There are no persons to complete for the selected competition"
     redirect_to panel_page_path(id: User.panel_pages[:createNewComers], competition_ids: @competition_ids)
   end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -240,6 +240,7 @@ class Api::V0::ApiController < ApplicationController
 
   private def require_user!
     raise WcaExceptions::MustLogIn.new if current_api_user.nil? && current_user.nil?
+
     current_api_user || current_user
   end
 
@@ -250,6 +251,7 @@ class Api::V0::ApiController < ApplicationController
   def competition_series
     competition_series = CompetitionSeries.find_by(wcif_id: params[:id])
     raise WcaExceptions::NotFound.new("Competition series with ID #{params[:id]} not found") if competition_series.blank? || competition_series.public_competitions.empty?
+
     render json: competition_series.to_wcif
   end
 end

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -154,11 +154,10 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     cache_key = "wcif/#{id}"
     competition = competition_from_params
     expires_in 5.minutes, public: true
-    if stale?(competition, public: true)
-      render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
-        competition.to_wcif
-      }
-    end
+    return unless stale?(competition, public: true)
+    render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
+      competition.to_wcif
+    }
   end
 
   def update_wcif

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -155,6 +155,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     competition = competition_from_params
     expires_in 5.minutes, public: true
     return unless stale?(competition, public: true)
+
     render json: Rails.cache.fetch(cache_key, expires_in: 5.minutes) {
       competition.to_wcif
     }
@@ -190,6 +191,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     competition = nil if competition && !competition.showAtAll && !can_manage?(competition)
 
     raise WcaExceptions::NotFound.new("Competition with id #{id} not found") unless competition
+
     competition
   end
 

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -228,44 +228,40 @@ class Api::V0::UserRolesController < Api::V0::ApiController
         new_role.save!
       end
     elsif group_type == UserGroup.group_types[:delegate_probation]
-      if params.key?(:endDate)
-        end_date = params.require(:endDate)
-        changes << UserRole::UserRoleChange.new(
-          changed_parameter: 'End Date',
-          previous_value: role.end_date || 'Empty',
-          new_value: end_date,
-        )
+      return render status: :unprocessable_entity, json: { error: "Invalid parameter to be changed" } unless params.key?(:endDate)
+      end_date = params.require(:endDate)
+      changes << UserRole::UserRoleChange.new(
+        changed_parameter: 'End Date',
+        previous_value: role.end_date || 'Empty',
+        new_value: end_date,
+      )
 
-        role.update!(end_date: Date.safe_parse(end_date))
-      else
-        return render status: :unprocessable_entity, json: { error: "Invalid parameter to be changed" }
-      end
+      role.update!(end_date: Date.safe_parse(end_date))
+
     elsif [UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]].include?(group_type)
-      if params.key?(:status)
-        status = params.require(:status)
-        changes << UserRole::UserRoleChange.new(
-          changed_parameter: 'Status',
-          previous_value: I18n.t("enums.user_roles.status.#{group_type}.#{role.metadata.status}", locale: 'en'),
-          new_value: I18n.t("enums.user_roles.status.#{group_type}.#{status}", locale: 'en'),
-        )
+      return render status: :unprocessable_entity, json: { error: "Invalid parameter to be changed" } unless params.key?(:status)
+      status = params.require(:status)
+      changes << UserRole::UserRoleChange.new(
+        changed_parameter: 'Status',
+        previous_value: I18n.t("enums.user_roles.status.#{group_type}.#{role.metadata.status}", locale: 'en'),
+        new_value: I18n.t("enums.user_roles.status.#{group_type}.#{status}", locale: 'en'),
+      )
 
-        ActiveRecord::Base.transaction do
-          role.update!(end_date: Date.today)
-          if group_type == UserGroup.group_types[:teams_committees]
-            metadata = RolesMetadataTeamsCommittees.create!(status: status)
-          elsif group_type == UserGroup.group_types[:councils]
-            metadata = RolesMetadataCouncils.create!(status: status)
-          end
-          role = UserRole.create!(
-            user_id: role.user.id,
-            group_id: role.group.id,
-            start_date: Date.today,
-            metadata: metadata,
-          )
+      ActiveRecord::Base.transaction do
+        role.update!(end_date: Date.today)
+        if group_type == UserGroup.group_types[:teams_committees]
+          metadata = RolesMetadataTeamsCommittees.create!(status: status)
+        elsif group_type == UserGroup.group_types[:councils]
+          metadata = RolesMetadataCouncils.create!(status: status)
         end
-      else
-        return render status: :unprocessable_entity, json: { error: "Invalid parameter to be changed" }
+        role = UserRole.create!(
+          user_id: role.user.id,
+          group_id: role.group.id,
+          start_date: Date.today,
+          metadata: metadata,
+        )
       end
+
     elsif group_type == UserGroup.group_types[:banned_competitors]
       role.end_date = params[:endDate] if params.key?(:endDate)
 

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -47,6 +47,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     id = params.require(:id)
     role = UserRole.find(id)
     return render status: :unauthorized, json: { error: "Cannot access role" } unless role.can_user_read?(current_user)
+
     render json: role
   end
 
@@ -229,6 +230,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
       end
     elsif group_type == UserGroup.group_types[:delegate_probation]
       return render status: :unprocessable_entity, json: { error: "Invalid parameter to be changed" } unless params.key?(:endDate)
+
       end_date = params.require(:endDate)
       changes << UserRole::UserRoleChange.new(
         changed_parameter: 'End Date',
@@ -240,6 +242,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
 
     elsif [UserGroup.group_types[:teams_committees], UserGroup.group_types[:councils]].include?(group_type)
       return render status: :unprocessable_entity, json: { error: "Invalid parameter to be changed" } unless params.key?(:status)
+
       status = params.require(:status)
       changes << UserRole::UserRoleChange.new(
         changed_parameter: 'Status',
@@ -288,6 +291,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     role = UserRole.find(id)
 
     return head :unauthorized unless current_user.has_permission?(:can_edit_groups, role.group.id)
+
     role.update!(end_date: Date.today)
     RoleChangeMailer.notify_role_end(role, current_user).deliver_later
     remove_pending_wca_id_claims(role) if role.group.delegate_regions? && !role.user.any_kind_of_delegate?

--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -3,10 +3,9 @@
 class Api::V0::UsersController < Api::V0::ApiController
   def show_me
     require_user!
-    if stale?(current_user)
-      # Also include the users current prs so we can handle qualifications on the Frontend
-      show_user(current_user, show_rankings: true, private_attributes: ['email'])
-    end
+    return unless stale?(current_user)
+    # Also include the users current prs so we can handle qualifications on the Frontend
+    show_user(current_user, show_rankings: true, private_attributes: ['email'])
   end
 
   def show_user_by_id

--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -4,6 +4,7 @@ class Api::V0::UsersController < Api::V0::ApiController
   def show_me
     require_user!
     return unless stale?(current_user)
+
     # Also include the users current prs so we can handle qualifications on the Frontend
     show_user(current_user, show_rankings: true, private_attributes: ['email'])
   end
@@ -36,6 +37,7 @@ class Api::V0::UsersController < Api::V0::ApiController
   def personal_records
     require_user!
     return render json: { single: [], average: [] } if current_user.wca_id.blank?
+
     person = Person.includes(:ranksSingle, :ranksAverage).find_by!(wca_id: current_user.wca_id)
     render json: { single: person.ranksSingle.map(&:to_wcif), average: person.ranksAverage.map(&:to_wcif) }
   end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -9,6 +9,7 @@ class Api::V1::ApiController < ActionController::API
   def validate_jwt_token
     auth_header = request.headers['Authorization']
     return render json: { error: Registrations::ErrorCodes::MISSING_AUTHENTICATION }, status: :unauthorized if auth_header.blank?
+
     token = auth_header.split[1]
     begin
       decode_result = JWT.decode token, AppSecrets.JWT_KEY, true, { algorithm: 'HS256' }

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -151,6 +151,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
       if status == 'cancelled'
         return self_updating ? 'Competitor delete' : 'Admin delete'
       end
+
       self_updating ? 'Competitor update' : 'Admin update'
     end
 

--- a/app/controllers/delegate_reports_controller.rb
+++ b/app/controllers/delegate_reports_controller.rb
@@ -13,25 +13,24 @@ class DelegateReportsController < ApplicationController
 
   def show
     @competition = competition_from_params
-    redirect_to_root_unless_user(:can_view_delegate_report?, @competition.delegate_report) && return
+    return if redirect_to_root_unless_user(:can_view_delegate_report?, @competition.delegate_report)
 
     @delegate_report = @competition.delegate_report
   end
 
   def edit
     @competition = competition_from_params
-    redirect_to_root_unless_user(:can_edit_delegate_report?, @competition.delegate_report) && return
+    return if redirect_to_root_unless_user(:can_edit_delegate_report?, @competition.delegate_report)
 
     @delegate_report = @competition.delegate_report
   end
 
   def update
     @competition = competition_from_params
-    if (params[:delegate_report]) && (params[:delegate_report][:posted])
-      redirect_to_root_unless_user(:can_post_delegate_report?, @competition.delegate_report) && return
-    else
-      redirect_to_root_unless_user(:can_edit_delegate_report?, @competition.delegate_report) && return
-    end
+    return if params[:delegate_report]&.dig(:posted) &&
+              redirect_to_root_unless_user(:can_post_delegate_report?, @competition.delegate_report)
+
+    return if redirect_to_root_unless_user(:can_edit_delegate_report?, @competition.delegate_report)
 
     @delegate_report = @competition.delegate_report
     @delegate_report.current_user = current_user

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -114,6 +114,7 @@ class PostsController < ApplicationController
     #  1 row in set, 1 warning (0.00 sec)
     post = Post.find_by(slug: params[:id]) || Post.find_by(id: params[:id])
     raise ActiveRecord::RecordNotFound.new("Couldn't find post") if !post
+
     post
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -22,10 +22,9 @@ class RegistrationsController < ApplicationController
 
   before_action :competition_must_be_using_wca_registration!, except: [:import, :do_import, :add, :do_add, :index, :psych_sheet, :psych_sheet_event, :stripe_webhook, :payment_denomination]
   private def competition_must_be_using_wca_registration!
-    if !competition_from_params.use_wca_registration?
-      flash[:danger] = I18n.t('registrations.flash.not_using_wca')
-      redirect_to competition_path(competition_from_params)
-    end
+    return if competition_from_params.use_wca_registration?
+    flash[:danger] = I18n.t('registrations.flash.not_using_wca')
+    redirect_to competition_path(competition_from_params)
   end
 
   before_action :competition_must_not_be_using_wca_registration!, only: [:import, :do_import]

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -14,6 +14,7 @@ class RegistrationsController < ApplicationController
                     Registration.find(params[:id]).competition
                   end
     raise ActionController::RoutingError.new('Not Found') unless competition.user_can_view?(current_user)
+
     competition
   end
 
@@ -23,6 +24,7 @@ class RegistrationsController < ApplicationController
   before_action :competition_must_be_using_wca_registration!, except: [:import, :do_import, :add, :do_add, :index, :psych_sheet, :psych_sheet_event, :stripe_webhook, :payment_denomination]
   private def competition_must_be_using_wca_registration!
     return if competition_from_params.use_wca_registration?
+
     flash[:danger] = I18n.t('registrations.flash.not_using_wca')
     redirect_to competition_path(competition_from_params)
   end
@@ -77,6 +79,7 @@ class RegistrationsController < ApplicationController
     headers = CSV.read(file.path).first.compact.map(&:downcase)
     missing_headers = required_columns - headers
     raise I18n.t("registrations.import.errors.missing_columns", columns: missing_headers.join(", ")) if missing_headers.any?
+
     registration_rows = CSV.read(file.path, headers: true, header_converters: :symbol, skip_blanks: true, converters: ->(string) { string&.strip })
                            .map(&:to_hash)
                            .select { |registration_row| registration_row[:status] == "a" }
@@ -88,12 +91,15 @@ class RegistrationsController < ApplicationController
     emails = registration_rows.pluck(:email)
     email_duplicates = emails.select { |email| emails.count(email) > 1 }.uniq
     raise I18n.t("registrations.import.errors.email_duplicates", emails: email_duplicates.join(", ")) if email_duplicates.any?
+
     wca_ids = registration_rows.pluck(:wca_id)
     wca_id_duplicates = wca_ids.select { |wca_id| wca_ids.count(wca_id) > 1 }.uniq
     raise I18n.t("registrations.import.errors.wca_id_duplicates", wca_ids: wca_id_duplicates.join(", ")) if wca_id_duplicates.any?
+
     raw_dobs = registration_rows.pluck(:birth_date)
     wrong_format_dobs = raw_dobs.select { |raw_dob| Date.safe_parse(raw_dob)&.to_fs != raw_dob }
     raise I18n.t("registrations.import.errors.wrong_dob_format", raw_dobs: wrong_format_dobs.join(", ")) if wrong_format_dobs.any?
+
     new_locked_users = []
     # registered_at stores millisecond precision, but we want all registrations
     #   from CSV import to be considered as one "batch". So we mark a timestamp
@@ -152,6 +158,7 @@ class RegistrationsController < ApplicationController
         reg.registered_at = Time.now.utc
       end
       raise I18n.t("registrations.add.errors.already_registered") unless registration.new_record?
+
       registration_comment = params.dig(:registration_data, :comments)
       registration.assign_attributes(comments: registration_comment) if registration_comment.present?
       registration.assign_attributes(competing_status: Registrations::Helper::STATUS_ACCEPTED)
@@ -181,6 +188,7 @@ class RegistrationsController < ApplicationController
     }
     if registration_row[:wca_id].present?
       raise I18n.t("registrations.import.errors.non_existent_wca_id", wca_id: registration_row[:wca_id]) unless Person.exists?(wca_id: registration_row[:wca_id])
+
       user = User.find_by(wca_id: registration_row[:wca_id])
       if user
         if user.dummy_account?

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -389,6 +389,7 @@ class ResultsController < ApplicationController
 
   private def compute_rankings_by_region(rows, continent, country)
     return [[], 0, 0] if rows.empty?
+
     best_value_of_world = rows.first["value"]
     best_values_of_continents = {}
     best_values_of_countries = {}

--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -15,6 +15,7 @@ class ResultsSubmissionController < ApplicationController
   def upload_json
     @competition = competition_from_params
     return redirect_to competition_submit_results_edit_path if @competition.results_submitted?
+
     # Do json analysis + insert record in db, then redirect to check inbox
     # (and delete existing record if any)
     upload_json_params = params.require(:upload_json).permit(:results_file)

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -10,7 +10,7 @@ class SearchResultsController < ApplicationController
     # strict sanitization to prevent injecting any HTML tags at all
     @omni_query = sanitize(@omni_query, tags: [], attributes: [])
 
-    return unless @omni_query.present?
+    return if @omni_query.blank?
 
     @competitions = Competition.search(@omni_query).page(params[:competitions_page]).per(SEARCH_RESULT_LIMIT)
     @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -10,12 +10,11 @@ class SearchResultsController < ApplicationController
     # strict sanitization to prevent injecting any HTML tags at all
     @omni_query = sanitize(@omni_query, tags: [], attributes: [])
 
-    if @omni_query.present?
-      @competitions = Competition.search(@omni_query).page(params[:competitions_page]).per(SEARCH_RESULT_LIMIT)
-      @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)
-      @posts = Post.search(@omni_query).page(params[:posts_page]).per(SEARCH_RESULT_LIMIT)
-      @regulations = Kaminari.paginate_array(Regulation.search(@omni_query)).page(params[:regulations_page]).per(SEARCH_RESULT_LIMIT)
-      @incidents = Incident.search(@omni_query).page(params[:incidents_page]).per(SEARCH_RESULT_LIMIT)
-    end
+    return unless @omni_query.present?
+    @competitions = Competition.search(@omni_query).page(params[:competitions_page]).per(SEARCH_RESULT_LIMIT)
+    @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)
+    @posts = Post.search(@omni_query).page(params[:posts_page]).per(SEARCH_RESULT_LIMIT)
+    @regulations = Kaminari.paginate_array(Regulation.search(@omni_query)).page(params[:regulations_page]).per(SEARCH_RESULT_LIMIT)
+    @incidents = Incident.search(@omni_query).page(params[:incidents_page]).per(SEARCH_RESULT_LIMIT)
   end
 end

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -11,6 +11,7 @@ class SearchResultsController < ApplicationController
     @omni_query = sanitize(@omni_query, tags: [], attributes: [])
 
     return unless @omni_query.present?
+
     @competitions = Competition.search(@omni_query).page(params[:competitions_page]).per(SEARCH_RESULT_LIMIT)
     @persons = User.search(@omni_query, params: { persons_table: true }).page(params[:people_page]).per(SEARCH_RESULT_LIMIT)
     @posts = Post.search(@omni_query).page(params[:posts_page]).per(SEARCH_RESULT_LIMIT)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -54,6 +54,7 @@ class SessionsController < Devise::SessionsController
 
   def generate_email_otp
     return render json: { error: { message: I18n.t("devise.sessions.new.2fa.errors.cant_send_email") } } unless session[:otp_user_id] || current_user
+
     user = User.find(session[:otp_user_id] || current_user.id)
     TwoFactorMailer.send_otp_to_user(user).deliver_now
     render json: { status: "ok" }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -87,6 +87,7 @@ class UsersController < ApplicationController
 
   def regenerate_2fa_backup_codes
     return render json: { error: { message: I18n.t("devise.sessions.new.2fa.errors.not_enabled") } } unless current_user.otp_required_for_login
+
     codes = current_user.generate_otp_backup_codes!
     current_user.save!
     render json: { codes: codes }
@@ -123,6 +124,7 @@ class UsersController < ApplicationController
 
     @user = user_to_edit
     return if redirect_if_cannot_edit_user(@user)
+
     @current_user = current_user
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -178,10 +178,9 @@ module ApplicationHelper
   end
 
   def wca_id_link(wca_id, **options)
-    if wca_id.present?
-      content_tag :span, class: "wca-id" do
-        link_to wca_id, person_url(wca_id), options
-      end
+    return unless wca_id.present?
+    content_tag :span, class: "wca-id" do
+      link_to wca_id, person_url(wca_id), options
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -179,6 +179,7 @@ module ApplicationHelper
 
   def wca_id_link(wca_id, **options)
     return unless wca_id.present?
+
     content_tag :span, class: "wca-id" do
       link_to wca_id, person_url(wca_id), options
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -178,7 +178,7 @@ module ApplicationHelper
   end
 
   def wca_id_link(wca_id, **options)
-    return unless wca_id.present?
+    return if wca_id.blank?
 
     content_tag :span, class: "wca-id" do
       link_to wca_id, person_url(wca_id), options

--- a/app/helpers/persons_helper.rb
+++ b/app/helpers/persons_helper.rb
@@ -21,15 +21,14 @@ module PersonsHelper
   end
 
   def return_podium_class(result)
-    if (['f', 'c'].include?(result.roundTypeId)) && !result.best_solve.dnf?
-      case result.pos
-      when 1
-        "gold-place"
-      when 2
-        "silver-place"
-      when 3
-        "bronze-place"
-      end
+    return unless (['f', 'c'].include?(result.roundTypeId)) && !result.best_solve.dnf?
+    case result.pos
+    when 1
+      "gold-place"
+    when 2
+      "silver-place"
+    when 3
+      "bronze-place"
     end
   end
 end

--- a/app/helpers/persons_helper.rb
+++ b/app/helpers/persons_helper.rb
@@ -22,6 +22,7 @@ module PersonsHelper
 
   def return_podium_class(result)
     return unless (['f', 'c'].include?(result.roundTypeId)) && !result.best_solve.dnf?
+
     case result.pos
     when 1
       "gold-place"

--- a/app/inputs/date_picker_input.rb
+++ b/app/inputs/date_picker_input.rb
@@ -59,6 +59,7 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
 
     def set_value_html_option
       return if value.blank?
+
       input_html_options[:value] ||= value.is_a?(String) ? value : I18n.l(value, format: self.class.display_pattern)
     end
 

--- a/app/mailers/registrations_mailer.rb
+++ b/app/mailers/registrations_mailer.rb
@@ -84,12 +84,11 @@ class RegistrationsMailer < ApplicationMailer
   def notify_delegates_of_formerly_banned_user_registration(registration)
     @registration = registration
     to = registration.competition.competition_delegates.map { |x| x.user.email }
-    unless to.empty?
-      mail(
-        to: to,
-        reply_to: UserGroup.teams_committees_group_wic.metadata.email,
-        subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
-      )
-    end
+    return if to.empty?
+    mail(
+      to: to,
+      reply_to: UserGroup.teams_committees_group_wic.metadata.email,
+      subject: "A formerly-banned competitor just registered for #{registration.competition.name}",
+    )
   end
 end

--- a/app/mailers/registrations_mailer.rb
+++ b/app/mailers/registrations_mailer.rb
@@ -85,6 +85,7 @@ class RegistrationsMailer < ApplicationMailer
     @registration = registration
     to = registration.competition.competition_delegates.map { |x| x.user.email }
     return if to.empty?
+
     mail(
       to: to,
       reply_to: UserGroup.teams_committees_group_wic.metadata.email,

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -350,6 +350,7 @@ class Competition < ApplicationRecord
   private def auto_close_threshold_validations
     errors.add(:auto_close_threshold, I18n.t('competitions.errors.auto_close_positive_nonzero')) unless auto_close_threshold > 0
     return unless auto_close_threshold != 0
+
     errors.add(:auto_close_threshold, I18n.t('competitions.errors.use_wca_registration')) unless use_wca_registration
     errors.add(:auto_close_threshold, I18n.t('competitions.errors.must_exceed_competitor_limit')) if
       competitor_limit.present? && auto_close_threshold <= competitor_limit
@@ -378,6 +379,7 @@ class Competition < ApplicationRecord
   validate :registation_must_not_be_past, if: :should_validate_registration_closing?
   private def registation_must_not_be_past
     return unless editing_user_id
+
     editing_user = User.find(editing_user_id)
     errors.add(:registration_close, I18n.t('competitions.errors.registration_already_closed')) if !editing_user.can_admin_competitions? && registration_range_specified? && registration_past?
   end
@@ -399,6 +401,7 @@ class Competition < ApplicationRecord
     # TODO: This logic belongs in a controller more appropriately than in the validation.
     # IF we build a controller endpoint specifically for auto_accept, this logic should be move there.
     return unless auto_accept_registrations_changed? && auto_accept_registrations?
+
     errors.add(:auto_accept_registrations, I18n.t('competitions.errors.auto_accept_accept_paid_pending')) if registrations.pending.with_payments.count > 0
     errors.add(:auto_accept_registrations, I18n.t('competitions.errors.auto_accept_accept_waitlisted')) if
       registrations.waitlisted.count > 0 && !registration_full_and_accepted?
@@ -530,6 +533,7 @@ class Competition < ApplicationRecord
   validate :delegates_must_be_delegates, unless: :is_probably_over?
   def delegates_must_be_delegates
     return if self.delegates.all?(&:any_kind_of_delegate?)
+
     errors.add(:staff_delegate_ids, I18n.t('competitions.errors.not_all_delegates'))
     errors.add(:trainee_delegate_ids, I18n.t('competitions.errors.not_all_delegates'))
   end
@@ -721,6 +725,7 @@ class Competition < ApplicationRecord
   private def clone_associations
     # Clone competition tabs.
     return unless clone_tabs
+
     being_cloned_from&.tabs&.each do |tab|
       tabs.create!(tab.attributes.slice(*CompetitionTab::CLONEABLE_ATTRIBUTES))
     end
@@ -737,6 +742,7 @@ class Competition < ApplicationRecord
   def create_id_and_cell_name(force_override: false)
     m = VALID_NAME_RE.match(name)
     return unless m
+
     name_without_year = m[1]
     year = m[2]
     if id.blank? || force_override
@@ -747,6 +753,7 @@ class Competition < ApplicationRecord
       self.id = safe_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
     end
     return unless cellName.blank? || force_override
+
     year = " #{year}"
     self.cellName = name_without_year.truncate(MAX_CELL_NAME_LENGTH - year.length) + year
   end
@@ -899,8 +906,10 @@ class Competition < ApplicationRecord
   validate :user_cannot_demote_themself
   def user_cannot_demote_themself
     return unless editing_user_id
+
     editing_user = User.find(editing_user_id)
     return if editing_user.can_manage_competition?(self)
+
     errors.add(:staff_delegate_ids, "You cannot demote yourself")
     errors.add(:trainee_delegate_ids, "You cannot demote yourself")
     errors.add(:organizer_ids, "You cannot demote yourself")
@@ -944,6 +953,7 @@ class Competition < ApplicationRecord
   def receiving_registration_emails?(user_id)
     competition_delegate = competition_delegates.find_by(delegate_id: user_id)
     return true if competition_delegate&.receive_registration_emails
+
     competition_organizer = competition_organizers.find_by(organizer_id: user_id)
     return true if competition_organizer&.receive_registration_emails
 
@@ -953,6 +963,7 @@ class Competition < ApplicationRecord
   def can_receive_registration_emails?(user_id)
     competition_delegate = competition_delegates.find_by(delegate_id: user_id)
     return true if competition_delegate
+
     competition_organizer = competition_organizers.find_by(organizer_id: user_id)
     return true if competition_organizer
 
@@ -961,6 +972,7 @@ class Competition < ApplicationRecord
 
   def update_receive_registration_emails
     return unless editing_user_id && !@receive_registration_emails.nil?
+
     competition_delegate = competition_delegates.find_by(delegate_id: editing_user_id)
     competition_delegate&.update_attribute(:receive_registration_emails, @receive_registration_emails)
     competition_organizer = competition_organizers.find_by(organizer_id: editing_user_id)
@@ -1192,6 +1204,7 @@ class Competition < ApplicationRecord
   validate :waiting_list_dates_must_be_valid
   private def waiting_list_dates_must_be_valid
     return unless waiting_list_deadline_date?
+
     errors.add(:waiting_list_deadline_date, I18n.t('competitions.errors.waiting_list_deadline_before_registration_close')) if waiting_list_deadline_date < registration_close
     errors.add(:waiting_list_deadline_date, I18n.t('competitions.errors.waiting_list_deadline_before_refund_date')) if refund_policy_limit_date? && waiting_list_deadline_date < refund_policy_limit_date
     errors.add(:waiting_list_deadline_date, I18n.t('competitions.errors.waiting_list_deadline_after_end')) if waiting_list_deadline_date > end_date
@@ -1200,6 +1213,7 @@ class Competition < ApplicationRecord
   validate :event_change_dates_must_be_valid
   private def event_change_dates_must_be_valid
     return unless event_change_deadline_date?
+
     errors.add(:event_change_deadline_date, I18n.t('competitions.errors.event_change_deadline_before_registration_close')) if event_change_deadline_date < registration_close
     errors.add(:event_change_deadline_date, I18n.t('competitions.errors.event_change_deadline_with_ots')) if on_the_spot_registration? && event_change_deadline_date < start_date
     errors.add(:event_change_deadline_date, I18n.t('competitions.errors.event_change_deadline_after_end_date')) if event_change_deadline_date > end_date.to_datetime.end_of_day
@@ -1290,6 +1304,7 @@ class Competition < ApplicationRecord
   validate :start_date_must_be_28_days_in_advance, if: :should_validate_start_date?
   def start_date_must_be_28_days_in_advance
     return unless editing_user_id
+
     editing_user = User.find(editing_user_id)
     errors.add(:start_date, I18n.t('competitions.errors.start_date_must_be_28_days_in_advance')) if !editing_user.can_admin_competitions? && start_date && days_until < MUST_BE_ANNOUNCED_GTE_THIS_MANY_DAYS
   end
@@ -1300,6 +1315,7 @@ class Competition < ApplicationRecord
 
   def days_until_competition?(c)
     return false if !c.has_date? || !self.has_date?
+
     days_until = (c.start_date - self.end_date).to_i
     days_until = (self.start_date - c.end_date).to_i * -1 if days_until < 0
     days_until
@@ -1315,6 +1331,7 @@ class Competition < ApplicationRecord
 
   def start_date_adjacent_to?(c, distance_days)
     return false if !c.has_date? || !self.has_date?
+
     self.days_until_competition?(c).abs < distance_days
   end
 
@@ -1324,11 +1341,13 @@ class Competition < ApplicationRecord
 
   def registration_open_adjacent_to?(c, distance_minutes)
     return false if !c.has_registration_start_date? || !self.has_registration_start_date?
+
     self.minutes_until_other_registration_starts(c).abs < distance_minutes
   end
 
   def minutes_until_other_registration_starts(c)
     return false if !c.has_registration_start_date? || !self.has_registration_start_date?
+
     seconds_until = (c.registration_open - self.registration_open).to_i
     seconds_until = (self.registration_open - c.registration_open).to_i * -1 if seconds_until < 0
     seconds_until / 60
@@ -1683,6 +1702,7 @@ class Competition < ApplicationRecord
     if params[:continent].present?
       continent = Continent.find(params[:continent])
       raise WcaExceptions::BadApiParameter.new("Invalid continent: '#{params[:continent]}'") if !continent
+
       competitions = competitions.joins(:country)
                                  .where(country: { continent: continent })
     end
@@ -1690,12 +1710,14 @@ class Competition < ApplicationRecord
     if params[:country_iso2].present?
       country = Country.find_by(iso2: params[:country_iso2])
       raise WcaExceptions::BadApiParameter.new("Invalid country_iso2: '#{params[:country_iso2]}'") if !country
+
       competitions = competitions.where(countryId: country.id)
     end
 
     if params[:delegate].present?
       delegate_user = User.find_by(wca_id: params[:delegate]) || User.find(params[:delegate])
       raise WcaExceptions::BadApiParameter.new("Invalid delegate: '#{params[:delegate]}'") if !delegate_user || !delegate_user.delegate_status
+
       competitions = competitions.left_outer_joins(:delegates)
                                  .where(competition_delegates: { delegate_id: delegate_user.id })
     end
@@ -1703,6 +1725,7 @@ class Competition < ApplicationRecord
     if params[:event_ids].present?
       event_ids = params[:event_ids].presence
       raise WcaExceptions::BadApiParameter.new("Invalid event IDs: '#{params[:event_ids]}'") unless event_ids.is_a?(Array)
+
       event_ids.each do |event_id|
         # This looks completely crazy (why not just pass the array as a whole, to build a `WHERE event_id IN (...)`??)
         #   but is actually necessary to make sure that the competition holds ALL of the required events
@@ -1714,24 +1737,28 @@ class Competition < ApplicationRecord
     if params[:start].present?
       start_date = Date.safe_parse(params[:start])
       raise WcaExceptions::BadApiParameter.new("Invalid start: '#{params[:start]}'") if !start_date
+
       competitions = competitions.where(start_date: start_date..)
     end
 
     if params[:end].present?
       end_date = Date.safe_parse(params[:end])
       raise WcaExceptions::BadApiParameter.new("Invalid end: '#{params[:end]}'") if !end_date
+
       competitions = competitions.where(end_date: ..end_date)
     end
 
     if params[:ongoing_and_future].present?
       target_date = Date.safe_parse(params[:ongoing_and_future])
       raise WcaExceptions::BadApiParameter.new("Invalid ongoing_and_future: '#{params[:ongoing_and_future]}'") if !target_date
+
       competitions = competitions.where(end_date: target_date..)
     end
 
     if params[:announced_after].present?
       announced_date = Date.safe_parse(params[:announced_after])
       raise WcaExceptions::BadApiParameter.new("Invalid announced date: '#{params[:announced_after]}'") if !announced_date
+
       competitions = competitions.where("announced_at > ?", announced_date)
     end
 
@@ -1840,6 +1867,7 @@ class Competition < ApplicationRecord
 
   def qualification_wcif
     return {} unless uses_qualification?
+
     competition_events
       .where.not(qualification: nil)
       .index_by(&:event_id)
@@ -1964,6 +1992,7 @@ class Competition < ApplicationRecord
       event_to_be_removed = !wcif_event || !wcif_event["rounds"]
       if event_to_be_removed
         raise WcaExceptions::BadApiParameter.new("Cannot remove events") unless current_user.can_add_and_remove_events?(self)
+
         competition_event.destroy!
       end
     end
@@ -1974,6 +2003,7 @@ class Competition < ApplicationRecord
       event_to_be_added = wcif_event["rounds"]
       if !event_found && event_to_be_added
         raise WcaExceptions::BadApiParameter.new("Cannot add events") unless current_user.can_add_and_remove_events?(self)
+
         competition_events.create!(event_id: wcif_event["id"])
       end
     end
@@ -1983,6 +2013,7 @@ class Competition < ApplicationRecord
       event_to_be_updated = wcif_event["rounds"]
       if event_to_be_updated
         raise WcaExceptions::BadApiParameter.new("Cannot update events") unless current_user.can_update_events?(self)
+
         competition_events.find { |ce| ce.event_id == wcif_event["id"] }.load_wcif!(wcif_event)
       end
     end
@@ -2015,6 +2046,7 @@ class Competition < ApplicationRecord
         )
       end
       next if registration.blank?
+
       WcifExtension.update_wcif_extensions!(registration, wcif_person["extensions"]) if wcif_person["extensions"]
       # NOTE: person doesn't necessarily have corresponding registration (e.g. registratinless organizer/delegate).
       if wcif_person["roles"]
@@ -2028,6 +2060,7 @@ class Competition < ApplicationRecord
           competition_activity.wcif_id == assignment_wcif["activityId"]
         end
         raise WcaExceptions::BadApiParameter.new("Cannot create assignment for non-existent activity with id #{assignment_wcif["activityId"]}") unless schedule_activity
+
         assignment = registration.assignments.find do |a|
           a.wcif_equal?(assignment_wcif)
         end
@@ -2042,6 +2075,7 @@ class Competition < ApplicationRecord
           assignment_code: assignment_wcif["assignmentCode"],
         )
         raise WcaExceptions::BadApiParameter.new("Invalid assignment: #{a.errors.map(&:full_message)} for #{assignment_wcif}") unless assignment.valid?
+
         local_assignments << assignment
       end
       new_assignments.concat(local_assignments.map(&:attributes))
@@ -2057,6 +2091,7 @@ class Competition < ApplicationRecord
     elsif wcif_schedule["numberOfDays"] != number_of_days
       raise WcaExceptions::BadApiParameter.new("Wrong number of days for competition")
     end
+
     competition_venues = self.competition_venues.includes [
       {
         venue_rooms: [
@@ -2185,6 +2220,7 @@ class Competition < ApplicationRecord
   validate :series_siblings_must_be_valid
   private def series_siblings_must_be_valid
     return unless part_of_competition_series?
+
     series_sibling_competitions.each do |comp|
       errors.add(:competition_series, I18n.t('competitions.errors.series_distance_km', competition: comp.name)) unless self.distance_adjacent_to?(comp, CompetitionSeries::MAX_SERIES_DISTANCE_KM)
       errors.add(:competition_series, I18n.t('competitions.errors.series_distance_days', competition: comp.name)) unless self.start_date_adjacent_to?(comp, CompetitionSeries::MAX_SERIES_DISTANCE_DAYS)
@@ -2806,6 +2842,7 @@ class Competition < ApplicationRecord
 
   def attempt_auto_close!
     return false if auto_close_threshold.nil?
+
     threshold_reached = fully_paid_registrations_count >= auto_close_threshold && auto_close_threshold > 0
     threshold_reached && update(closing_full_registration: true, registration_close: Time.now)
   end

--- a/app/models/competition_series.rb
+++ b/app/models/competition_series.rb
@@ -31,21 +31,19 @@ class CompetitionSeries < ApplicationRecord
   before_validation :create_id_and_cell_name
   def create_id_and_cell_name
     m = VALID_NAME_RE.match(name)
-    if m
-      name_without_year = m[1]
-      year = m[2]
-      if wcif_id.blank?
-        # Generate competition id from name
-        # By replacing accented chars with their ascii equivalents, and then
-        # removing everything that isn't a digit or a character.
-        safe_name_without_year = ActiveSupport::Inflector.transliterate(name_without_year).gsub(/[^a-z0-9]+/i, '')
-        self.wcif_id = safe_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
-      end
-      if short_name.blank?
-        year = " #{year}"
-        self.short_name = name_without_year.truncate(MAX_SHORT_NAME_LENGTH - year.length) + year
-      end
+    return unless m
+    name_without_year = m[1]
+    year = m[2]
+    if wcif_id.blank?
+      # Generate competition id from name
+      # By replacing accented chars with their ascii equivalents, and then
+      # removing everything that isn't a digit or a character.
+      safe_name_without_year = ActiveSupport::Inflector.transliterate(name_without_year).gsub(/[^a-z0-9]+/i, '')
+      self.wcif_id = safe_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
     end
+    return if short_name.present?
+    year = " #{year}"
+    self.short_name = name_without_year.truncate(MAX_SHORT_NAME_LENGTH - year.length) + year
   end
 
   # The notion of circumventing model associations is stolen from competition.rb#delegate_ids et al.
@@ -56,9 +54,8 @@ class CompetitionSeries < ApplicationRecord
   end
 
   def destroy_if_orphaned
-    if persisted? && competitions.count <= 1
-      self.destroy # NULL is handled by has_many#dependent set to :nullify above
-    end
+    return unless persisted? && competitions.count <= 1
+    self.destroy # NULL is handled by has_many#dependent set to :nullify above
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
@@ -172,10 +169,9 @@ class CompetitionSeries < ApplicationRecord
 
   before_save :unpack_competition_ids
   private def unpack_competition_ids
-    if @competition_ids
-      unpacked_competitions = @competition_ids.split(',').map { |id| Competition.find(id) }
-      self.competitions = unpacked_competitions
-    end
+    return unless @competition_ids
+    unpacked_competitions = @competition_ids.split(',').map { |id| Competition.find(id) }
+    self.competitions = unpacked_competitions
   end
 
   after_save :clear_competition_ids

--- a/app/models/competition_series.rb
+++ b/app/models/competition_series.rb
@@ -32,6 +32,7 @@ class CompetitionSeries < ApplicationRecord
   def create_id_and_cell_name
     m = VALID_NAME_RE.match(name)
     return unless m
+
     name_without_year = m[1]
     year = m[2]
     if wcif_id.blank?
@@ -42,6 +43,7 @@ class CompetitionSeries < ApplicationRecord
       self.wcif_id = safe_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
     end
     return if short_name.present?
+
     year = " #{year}"
     self.short_name = name_without_year.truncate(MAX_SHORT_NAME_LENGTH - year.length) + year
   end
@@ -55,6 +57,7 @@ class CompetitionSeries < ApplicationRecord
 
   def destroy_if_orphaned
     return unless persisted? && competitions.count <= 1
+
     self.destroy # NULL is handled by has_many#dependent set to :nullify above
   end
 
@@ -170,6 +173,7 @@ class CompetitionSeries < ApplicationRecord
   before_save :unpack_competition_ids
   private def unpack_competition_ids
     return unless @competition_ids
+
     unpacked_competitions = @competition_ids.split(',').map { |id| Competition.find(id) }
     self.competitions = unpacked_competitions
   end

--- a/app/models/competition_tab.rb
+++ b/app/models/competition_tab.rb
@@ -46,12 +46,11 @@ class CompetitionTab < ApplicationRecord
     current_display_order = display_order
     other_display_order = display_order + (direction.to_s == "up" ? -1 : 1)
     other_tab = competition.tabs.find_by(display_order: other_display_order)
-    if other_tab
-      ActiveRecord::Base.transaction do
-        update_column :display_order, nil
-        other_tab.update_column :display_order, current_display_order
-        update_column :display_order, other_display_order
-      end
+    return unless other_tab
+    ActiveRecord::Base.transaction do
+      update_column :display_order, nil
+      other_tab.update_column :display_order, current_display_order
+      update_column :display_order, other_display_order
     end
   end
 end

--- a/app/models/competition_tab.rb
+++ b/app/models/competition_tab.rb
@@ -47,6 +47,7 @@ class CompetitionTab < ApplicationRecord
     other_display_order = display_order + (direction.to_s == "up" ? -1 : 1)
     other_tab = competition.tabs.find_by(display_order: other_display_order)
     return unless other_tab
+
     ActiveRecord::Base.transaction do
       update_column :display_order, nil
       other_tab.update_column :display_order, current_display_order

--- a/app/models/concerns/resultable.rb
+++ b/app/models/concerns/resultable.rb
@@ -53,6 +53,7 @@ module Resultable
     validate :belongs_to_a_round
     def belongs_to_a_round
       return if round.present?
+
       errors.add(:round_type,
                  "Result must belong to a valid round. Please check that the tuple (competitionId, eventId, roundTypeId, formatId) matches an existing round.")
     end

--- a/app/models/concerns/resultable.rb
+++ b/app/models/concerns/resultable.rb
@@ -52,10 +52,9 @@ module Resultable
 
     validate :belongs_to_a_round
     def belongs_to_a_round
-      if round.blank?
-        errors.add(:round_type,
-                   "Result must belong to a valid round. Please check that the tuple (competitionId, eventId, roundTypeId, formatId) matches an existing round.")
-      end
+      return if round.present?
+      errors.add(:round_type,
+                 "Result must belong to a valid round. Please check that the tuple (competitionId, eventId, roundTypeId, formatId) matches an existing round.")
     end
 
     validate :validate_each_solve, if: :event

--- a/app/models/merge_people.rb
+++ b/app/models/merge_people.rb
@@ -40,6 +40,7 @@ class MergePeople
   validate :must_look_like_the_same_person
   def must_look_like_the_same_person
     return unless person1 && person2
+
     errors.add(:person2_wca_id, "Names don't match") if person1.name != person2.name
     errors.add(:person2_wca_id, "Countries don't match") if person1.countryId != person2.countryId
     errors.add(:person2_wca_id, "Genders don't match") if person1.gender != person2.gender

--- a/app/models/merge_people.rb
+++ b/app/models/merge_people.rb
@@ -39,12 +39,11 @@ class MergePeople
 
   validate :must_look_like_the_same_person
   def must_look_like_the_same_person
-    if person1 && person2
-      errors.add(:person2_wca_id, "Names don't match") if person1.name != person2.name
-      errors.add(:person2_wca_id, "Countries don't match") if person1.countryId != person2.countryId
-      errors.add(:person2_wca_id, "Genders don't match") if person1.gender != person2.gender
-      errors.add(:person2_wca_id, "Birthdays don't match") if person1.dob != person2.dob
-    end
+    return unless person1 && person2
+    errors.add(:person2_wca_id, "Names don't match") if person1.name != person2.name
+    errors.add(:person2_wca_id, "Countries don't match") if person1.countryId != person2.countryId
+    errors.add(:person2_wca_id, "Genders don't match") if person1.gender != person2.gender
+    errors.add(:person2_wca_id, "Birthdays don't match") if person1.dob != person2.dob
   end
 
   validate :person2_must_not_have_associated_user

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -51,10 +51,9 @@ class Person < ApplicationRecord
   # to A, then we cannot go back, as all their results are now for country A.
   validate :cannot_change_country_to_country_represented_before
   private def cannot_change_country_to_country_represented_before
-    if countryId_changed? && !new_record? && !@updating_using_sub_id
-      has_represented_this_country_already = Person.exists?(wca_id: wca_id, countryId: countryId)
-      errors.add(:countryId, I18n.t('users.errors.already_represented_country')) if has_represented_this_country_already
-    end
+    return unless countryId_changed? && !new_record? && !@updating_using_sub_id
+    has_represented_this_country_already = Person.exists?(wca_id: wca_id, countryId: countryId)
+    errors.add(:countryId, I18n.t('users.errors.already_represented_country')) if has_represented_this_country_already
   end
 
   # This is necessary because we use a view instead of a real table.

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -52,6 +52,7 @@ class Person < ApplicationRecord
   validate :cannot_change_country_to_country_represented_before
   private def cannot_change_country_to_country_represented_before
     return unless countryId_changed? && !new_record? && !@updating_using_sub_id
+
     has_represented_this_country_already = Person.exists?(wca_id: wca_id, countryId: countryId)
     errors.add(:countryId, I18n.t('users.errors.already_represented_country')) if has_represented_this_country_already
   end
@@ -191,6 +192,7 @@ class Person < ApplicationRecord
                 previous_old_pos = old_pos
                 previous_new_pos = result.pos
                 break if result.pos > 3
+
                 championship_podium_results.push result if result.personId == self.wca_id
               end
             end

--- a/app/models/reassign_wca_id.rb
+++ b/app/models/reassign_wca_id.rb
@@ -40,6 +40,7 @@ class ReassignWcaId
   validate :must_look_like_the_same_person
   def must_look_like_the_same_person
     return unless account1_user && account2_user
+
     errors.add(:account2, "Names don't match") unless account1_user.name == account2_user.name
     errors.add(:account2, "Countries don't match") unless account1_user.country_iso2 == account2_user.country_iso2
     errors.add(:account2, "Genders don't match") unless account1_user.gender == account2_user.gender

--- a/app/models/reassign_wca_id.rb
+++ b/app/models/reassign_wca_id.rb
@@ -39,12 +39,11 @@ class ReassignWcaId
 
   validate :must_look_like_the_same_person
   def must_look_like_the_same_person
-    if account1_user && account2_user
-      errors.add(:account2, "Names don't match") unless account1_user.name == account2_user.name
-      errors.add(:account2, "Countries don't match") unless account1_user.country_iso2 == account2_user.country_iso2
-      errors.add(:account2, "Genders don't match") unless account1_user.gender == account2_user.gender
-      errors.add(:account2, "Birthdays don't match") unless account1_user.dob == account2_user.dob
-    end
+    return unless account1_user && account2_user
+    errors.add(:account2, "Names don't match") unless account1_user.name == account2_user.name
+    errors.add(:account2, "Countries don't match") unless account1_user.country_iso2 == account2_user.country_iso2
+    errors.add(:account2, "Genders don't match") unless account1_user.gender == account2_user.gender
+    errors.add(:account2, "Birthdays don't match") unless account1_user.dob == account2_user.dob
   end
 
   def do_reassign_wca_id

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -347,6 +347,7 @@ class Registration < ApplicationRecord
   private def must_not_register_for_more_events_than_event_limit
     return if competition.blank? || !competition.events_per_registration_limit_enabled?
     return unless registration_competition_events.count { |element| !element.marked_for_destruction? } > competition.events_per_registration_limit
+
     errors.add(:registration_competition_events, I18n.t('registrations.errors.exceeds_event_limit', count: competition.events_per_registration_limit))
   end
 
@@ -354,6 +355,7 @@ class Registration < ApplicationRecord
   private def cannot_register_for_unqualified_events
     return if competition && competition.allow_registration_without_qualification
     return unless registration_competition_events.reject(&:marked_for_destruction?).any? { |event| !event.competition_event&.can_register?(user) }
+
     errors.add(:registration_competition_events, I18n.t('registrations.errors.can_only_register_for_qualified_events'))
   end
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -346,17 +346,15 @@ class Registration < ApplicationRecord
   validate :must_not_register_for_more_events_than_event_limit
   private def must_not_register_for_more_events_than_event_limit
     return if competition.blank? || !competition.events_per_registration_limit_enabled?
-    if registration_competition_events.count { |element| !element.marked_for_destruction? } > competition.events_per_registration_limit
-      errors.add(:registration_competition_events, I18n.t('registrations.errors.exceeds_event_limit', count: competition.events_per_registration_limit))
-    end
+    return unless registration_competition_events.count { |element| !element.marked_for_destruction? } > competition.events_per_registration_limit
+    errors.add(:registration_competition_events, I18n.t('registrations.errors.exceeds_event_limit', count: competition.events_per_registration_limit))
   end
 
   validate :cannot_register_for_unqualified_events
   private def cannot_register_for_unqualified_events
     return if competition && competition.allow_registration_without_qualification
-    if registration_competition_events.reject(&:marked_for_destruction?).any? { |event| !event.competition_event&.can_register?(user) }
-      errors.add(:registration_competition_events, I18n.t('registrations.errors.can_only_register_for_qualified_events'))
-    end
+    return unless registration_competition_events.reject(&:marked_for_destruction?).any? { |event| !event.competition_event&.can_register?(user) }
+    errors.add(:registration_competition_events, I18n.t('registrations.errors.can_only_register_for_qualified_events'))
   end
 
   strip_attributes only: [:comments, :administrative_notes]

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -141,6 +141,7 @@ class Round < ApplicationRecord
 
   def previous_round
     return nil if number == 1
+
     Round.joins(:competition_event).find_by(competition_event: competition_event, number: number - 1)
   end
 

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -36,10 +36,9 @@ class ScheduleActivity < ApplicationRecord
       errors.add(:activity_code, "is an invalid 'other' activity code") unless VALID_OTHER_ACTIVITY_CODE.include?(other_id)
     end
 
-    if holder.has_attribute?(:activity_code)
-      holder_activity_id = holder.activity_code.split('-').first
-      errors.add(:activity_code, "should share its base activity id with parent") unless activity_id == holder_activity_id
-    end
+    return unless holder.has_attribute?(:activity_code)
+    holder_activity_id = holder.activity_code.split('-').first
+    errors.add(:activity_code, "should share its base activity id with parent") unless activity_id == holder_activity_id
   end
 
   # Name can be specified externally, but we may want to infer the activity name

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -21,6 +21,7 @@ class ScheduleActivity < ApplicationRecord
 
   def included_in_parent_schedule
     return if errors.present?
+
     errors.add(:start_time, "should be after parent's start_time") unless start_time >= holder.start_time
     errors.add(:end_time, "should be before parent's end_time") unless end_time <= holder.end_time
     errors.add(:end_time, "should be after start_time") unless start_time <= end_time
@@ -37,6 +38,7 @@ class ScheduleActivity < ApplicationRecord
     end
 
     return unless holder.has_attribute?(:activity_code)
+
     holder_activity_id = holder.activity_code.split('-').first
     errors.add(:activity_code, "should share its base activity id with parent") unless activity_id == holder_activity_id
   end
@@ -84,6 +86,7 @@ class ScheduleActivity < ApplicationRecord
   # TODO: not a fan of how it works (= passing round information)
   def to_event(rounds_by_wcif_id = {})
     raise "#to_event called for nested activity" unless holder.is_a?(VenueRoom)
+
     {
       title: localized_name(rounds_by_wcif_id),
       roomId: holder.id,

--- a/app/models/semi_id.rb
+++ b/app/models/semi_id.rb
@@ -42,6 +42,7 @@ class SemiId
       # The given name has no usable parts, we can only generate an invalid SemiId
       return SemiId.new
     end
+
     # Take the first 4 chars of the last name
     semi_id_name = name_parts.pop.first(4)
     # If needed, take the first few chars of the first name.

--- a/app/models/stripe_record.rb
+++ b/app/models/stripe_record.rb
@@ -92,6 +92,7 @@ class StripeRecord < ApplicationRecord
 
   def update_amount_remote(amount_iso, currency_iso)
     return unless self.payment_intent?
+
     stripe_amount = StripeRecord.amount_to_stripe(amount_iso, currency_iso)
 
     update_intent_args = {

--- a/app/models/stripe_record.rb
+++ b/app/models/stripe_record.rb
@@ -91,29 +91,28 @@ class StripeRecord < ApplicationRecord
   alias_method :retrieve_remote, :retrieve_stripe
 
   def update_amount_remote(amount_iso, currency_iso)
-    if self.payment_intent?
-      stripe_amount = StripeRecord.amount_to_stripe(amount_iso, currency_iso)
+    return unless self.payment_intent?
+    stripe_amount = StripeRecord.amount_to_stripe(amount_iso, currency_iso)
 
-      update_intent_args = {
-        amount: stripe_amount,
-        currency: currency_iso,
-      }
+    update_intent_args = {
+      amount: stripe_amount,
+      currency: currency_iso,
+    }
 
-      Stripe::PaymentIntent.update(
-        self.stripe_id,
-        update_intent_args,
-        stripe_account: self.account_id,
-      )
+    Stripe::PaymentIntent.update(
+      self.stripe_id,
+      update_intent_args,
+      stripe_account: self.account_id,
+    )
 
-      updated_parameters = self.parameters.deep_merge(update_intent_args)
+    updated_parameters = self.parameters.deep_merge(update_intent_args)
 
-      # Update our own journals so that we know we changed something
-      self.update!(
-        parameters: updated_parameters,
-        amount_stripe_denomination: stripe_amount,
-        currency_code: currency_iso,
-      )
-    end
+    # Update our own journals so that we know we changed something
+    self.update!(
+      parameters: updated_parameters,
+      amount_stripe_denomination: stripe_amount,
+      currency_code: currency_iso,
+    )
   end
 
   def money_amount

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -19,11 +19,13 @@ class Ticket < ApplicationRecord
   # the user can be any of the two stakeholders.
   def user_stakeholders(user)
     return [] if user.nil?
+
     ticket_stakeholders.belongs_to_user(user).or(ticket_stakeholders.belongs_to_groups(user.active_groups))
   end
 
   def can_user_access?(user)
     return false if user.nil?
+
     (
       ticket_stakeholders.belongs_to_user(user).any? ||
       ticket_stakeholders.belongs_to_groups(user.active_groups).any?

--- a/app/models/tickets_edit_person_field.rb
+++ b/app/models/tickets_edit_person_field.rb
@@ -16,10 +16,9 @@ class TicketsEditPersonField < ApplicationRecord
       errors.add(:new_value, gender_error_message) unless User::ALLOWABLE_GENDERS.include?(new_value.to_sym)
     end
 
-    if field_name_country_iso2?
-      country_error_message = "must be one of the allowed countries"
-      errors.add(:old_value, country_error_message) unless Country::WCA_COUNTRY_ISO_CODES.include?(old_value)
-      errors.add(:new_value, country_error_message) unless Country::WCA_COUNTRY_ISO_CODES.include?(new_value)
-    end
+    return unless field_name_country_iso2?
+    country_error_message = "must be one of the allowed countries"
+    errors.add(:old_value, country_error_message) unless Country::WCA_COUNTRY_ISO_CODES.include?(old_value)
+    errors.add(:new_value, country_error_message) unless Country::WCA_COUNTRY_ISO_CODES.include?(new_value)
   end
 end

--- a/app/models/tickets_edit_person_field.rb
+++ b/app/models/tickets_edit_person_field.rb
@@ -17,6 +17,7 @@ class TicketsEditPersonField < ApplicationRecord
     end
 
     return unless field_name_country_iso2?
+
     country_error_message = "must be one of the allowed countries"
     errors.add(:old_value, country_error_message) unless Country::WCA_COUNTRY_ISO_CODES.include?(old_value)
     errors.add(:new_value, country_error_message) unless Country::WCA_COUNTRY_ISO_CODES.include?(new_value)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,19 +157,17 @@ class User < ApplicationRecord
 
   validate :wca_id_is_unique_or_for_dummy_account
   def wca_id_is_unique_or_for_dummy_account
-    if wca_id_change && wca_id
-      user = User.find_by(wca_id: wca_id)
-      # If there is a non dummy user with this WCA ID, fail validation.
-      if user && !user.dummy_account?
-        errors.add(
-          :wca_id,
-          I18n.t('users.errors.unique_html',
-                 used_name: user.name,
-                 used_email: user.email,
-                 used_edit_path: Rails.application.routes.url_helpers.edit_user_path(user)).html_safe,
-        )
-      end
-    end
+    return unless wca_id_change && wca_id
+    user = User.find_by(wca_id: wca_id)
+    # If there is a non dummy user with this WCA ID, fail validation.
+    return unless user && !user.dummy_account?
+    errors.add(
+      :wca_id,
+      I18n.t('users.errors.unique_html',
+             used_name: user.name,
+             used_email: user.email,
+             used_edit_path: Rails.application.routes.url_helpers.edit_user_path(user)).html_safe,
+    )
   end
 
   validate :name_must_match_person_name
@@ -179,10 +177,9 @@ class User < ApplicationRecord
 
   validate :check_if_email_used_by_locked_account, on: :create
   private def check_if_email_used_by_locked_account
-    if User.find_by(email: email)&.locked_account?
-      errors.delete(:email)
-      errors.add(:email, I18n.t('users.errors.email_used_by_locked_account_html').html_safe)
-    end
+    return unless User.find_by(email: email)&.locked_account?
+    errors.delete(:email)
+    errors.add(:email, I18n.t('users.errors.email_used_by_locked_account_html').html_safe)
   end
 
   validate do
@@ -201,10 +198,9 @@ class User < ApplicationRecord
 
   before_validation :maybe_clear_claimed_wca_id
   def maybe_clear_claimed_wca_id
-    if !claiming_wca_id && ((unconfirmed_wca_id_was.present? && wca_id == unconfirmed_wca_id_was) || unconfirmed_wca_id.blank?)
-      self.unconfirmed_wca_id = nil
-      self.delegate_to_handle_wca_id_claim = nil
-    end
+    return unless !claiming_wca_id && ((unconfirmed_wca_id_was.present? && wca_id == unconfirmed_wca_id_was) || unconfirmed_wca_id.blank?)
+    self.unconfirmed_wca_id = nil
+    self.delegate_to_handle_wca_id_claim = nil
   end
 
   # Virtual attribute for people claiming a WCA ID.
@@ -225,31 +221,30 @@ class User < ApplicationRecord
       end
     end
 
-    if claiming_wca_id || (unconfirmed_wca_id.present? && unconfirmed_wca_id_change)
-      errors.add(:delegate_id_to_handle_wca_id_claim, I18n.t('simple_form.required.text')) if delegate_id_to_handle_wca_id_claim.blank?
+    return unless claiming_wca_id || (unconfirmed_wca_id.present? && unconfirmed_wca_id_change)
+    errors.add(:delegate_id_to_handle_wca_id_claim, I18n.t('simple_form.required.text')) if delegate_id_to_handle_wca_id_claim.blank?
 
-      errors.add(:unconfirmed_wca_id, I18n.t('simple_form.required.text')) if unconfirmed_wca_id.blank?
+    errors.add(:unconfirmed_wca_id, I18n.t('simple_form.required.text')) if unconfirmed_wca_id.blank?
 
-      dob_verification_date = Date.safe_parse(dob_verification, nil)
-      if unconfirmed_person && (!current_user || !current_user.can_view_all_users?)
-        dob_form_path = Rails.application.routes.url_helpers.contact_dob_path
-        wrt_contact_path = Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt')
-        remaining_wca_id_claims = [0, MAX_INCORRECT_WCA_ID_CLAIM_COUNT - unconfirmed_person.incorrect_wca_id_claim_count].max
-        if remaining_wca_id_claims == 0 || !unconfirmed_person.dob
-          errors.add(:dob_verification, I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path).html_safe)
-        elsif unconfirmed_person.gender.blank?
-          errors.add(:gender, I18n.t('users.errors.wca_id_no_gender_html', wrt_contact_path: wrt_contact_path).html_safe)
-        elsif !already_assigned_to_user && unconfirmed_person.dob != dob_verification_date
-          # Note that we don't verify DOB for WCA IDs that have already been
-          # claimed. This protects people from DOB guessing attacks.
-          self.was_incorrect_wca_id_claim = true
-          errors.add(:dob_verification, I18n.t('users.errors.dob_incorrect_html', dob_form_path: dob_form_path).html_safe)
-        end
+    dob_verification_date = Date.safe_parse(dob_verification, nil)
+    if unconfirmed_person && (!current_user || !current_user.can_view_all_users?)
+      dob_form_path = Rails.application.routes.url_helpers.contact_dob_path
+      wrt_contact_path = Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt')
+      remaining_wca_id_claims = [0, MAX_INCORRECT_WCA_ID_CLAIM_COUNT - unconfirmed_person.incorrect_wca_id_claim_count].max
+      if remaining_wca_id_claims == 0 || !unconfirmed_person.dob
+        errors.add(:dob_verification, I18n.t('users.errors.wca_id_no_birthdate_html', dob_form_path: dob_form_path).html_safe)
+      elsif unconfirmed_person.gender.blank?
+        errors.add(:gender, I18n.t('users.errors.wca_id_no_gender_html', wrt_contact_path: wrt_contact_path).html_safe)
+      elsif !already_assigned_to_user && unconfirmed_person.dob != dob_verification_date
+        # Note that we don't verify DOB for WCA IDs that have already been
+        # claimed. This protects people from DOB guessing attacks.
+        self.was_incorrect_wca_id_claim = true
+        errors.add(:dob_verification, I18n.t('users.errors.dob_incorrect_html', dob_form_path: dob_form_path).html_safe)
       end
-      errors.add(:unconfirmed_wca_id, I18n.t('users.errors.already_have_id', wca_id: wca_id)) if claiming_wca_id && person
-
-      errors.add(:delegate_id_to_handle_wca_id_claim, I18n.t('users.errors.not_found')) if delegate_id_to_handle_wca_id_claim.present? && !delegate_to_handle_wca_id_claim&.any_kind_of_delegate?
     end
+    errors.add(:unconfirmed_wca_id, I18n.t('users.errors.already_have_id', wca_id: wca_id)) if claiming_wca_id && person
+
+    errors.add(:delegate_id_to_handle_wca_id_claim, I18n.t('users.errors.not_found')) if delegate_id_to_handle_wca_id_claim.present? && !delegate_to_handle_wca_id_claim&.any_kind_of_delegate?
   end
 
   # workaround / very nasty hotfix for Rails 6 issue with rollback triggers.
@@ -281,22 +276,20 @@ class User < ApplicationRecord
     # Otherwise (when setting WCA ID directly) we want to validate
     # that the user details matches the person details instead.
     p = (wca_id_was.present? && person) || unconfirmed_person
-    if p
-      self.name = p.name
-      self.dob = p.dob
-      self.gender = p.gender
-      self.country_iso2 = p.country_iso2
-    end
+    return unless p
+    self.name = p.name
+    self.dob = p.dob
+    self.gender = p.gender
+    self.country_iso2 = p.country_iso2
   end
 
   validate :must_look_like_the_corresponding_person
   private def must_look_like_the_corresponding_person
-    if person
-      errors.add(:name, I18n.t("users.errors.must_match_person")) if self.name != person.name
-      errors.add(:country_iso2, I18n.t("users.errors.must_match_person")) if self.country_iso2 != person.country_iso2
-      errors.add(:gender, I18n.t("users.errors.must_match_person")) if self.gender != person.gender
-      errors.add(:dob, I18n.t("users.errors.must_match_person")) if self.dob != person.dob
-    end
+    return unless person
+    errors.add(:name, I18n.t("users.errors.must_match_person")) if self.name != person.name
+    errors.add(:country_iso2, I18n.t("users.errors.must_match_person")) if self.country_iso2 != person.country_iso2
+    errors.add(:gender, I18n.t("users.errors.must_match_person")) if self.gender != person.gender
+    errors.add(:dob, I18n.t("users.errors.must_match_person")) if self.dob != person.dob
   end
 
   before_validation :strip_name
@@ -307,10 +300,9 @@ class User < ApplicationRecord
   validate :wca_id_prereqs
   def wca_id_prereqs
     p = person || unconfirmed_person
-    if p
-      cannot_be_assigned_reasons = p.cannot_be_assigned_to_user_reasons
-      errors.add(:wca_id, cannot_be_assigned_reasons.xss_aware_to_sentence) unless cannot_be_assigned_reasons.empty?
-    end
+    return unless p
+    cannot_be_assigned_reasons = p.cannot_be_assigned_to_user_reasons
+    errors.add(:wca_id, cannot_be_assigned_reasons.xss_aware_to_sentence) unless cannot_be_assigned_reasons.empty?
   end
 
   # To handle profile pictures that predate our user account system, we created
@@ -319,21 +311,19 @@ class User < ApplicationRecord
   # avatar.
   before_save :remove_dummy_account_and_copy_name_when_wca_id_changed
   def remove_dummy_account_and_copy_name_when_wca_id_changed
-    if wca_id_change && wca_id.present?
-      dummy_user = User.find_by(wca_id: wca_id, dummy_account: true)
-      if dummy_user
-        # Transfer current and pending avatar associations
-        self.current_avatar = dummy_user.current_avatar
-        self.pending_avatar = dummy_user.pending_avatar
+    return unless wca_id_change && wca_id.present?
+    dummy_user = User.find_by(wca_id: wca_id, dummy_account: true)
+    return unless dummy_user
+    # Transfer current and pending avatar associations
+    self.current_avatar = dummy_user.current_avatar
+    self.pending_avatar = dummy_user.pending_avatar
 
-        # Transfer historic avatars
-        self.user_avatars = dummy_user.user_avatars
+    # Transfer historic avatars
+    self.user_avatars = dummy_user.user_avatars
 
-        # The `reload` is necessary because otherwise, the old pre-reload `user_avatars`
-        # association on `dummy_user` would pull the avatars to the grave.
-        dummy_user.reload.destroy!
-      end
-    end
+    # The `reload` is necessary because otherwise, the old pre-reload `user_avatars`
+    # association on `dummy_user` would pull the avatars to the grave.
+    dummy_user.reload.destroy!
   end
 
   def avatar
@@ -1029,12 +1019,11 @@ class User < ApplicationRecord
                          elsif user_to_edit == self && !(admin? || any_kind_of_delegate?) && user_to_edit.registrations.accepted.count > 0
                            I18n.t('users.edit.cannot_edit.reason.registered')
                          end
-    if cannot_edit_reason
-      I18n.t('users.edit.cannot_edit.msg',
-             reason: cannot_edit_reason,
-             wrt_contact_path: Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt'),
-             delegate_url: Rails.application.routes.url_helpers.delegates_path).html_safe
-    end
+    return unless cannot_edit_reason
+    I18n.t('users.edit.cannot_edit.msg',
+           reason: cannot_edit_reason,
+           wrt_contact_path: Rails.application.routes.url_helpers.contact_path(contactRecipient: 'wrt'),
+           delegate_url: Rails.application.routes.url_helpers.delegates_path).html_safe
   end
 
   CLAIM_WCA_ID_PARAMS = [
@@ -1124,14 +1113,13 @@ class User < ApplicationRecord
   end
 
   def maybe_assign_wca_id_by_results(competition, notify: true)
-    if !wca_id && !unconfirmed_wca_id
-      matches = []
-      matches = competition.competitors.where(name: name, dob: dob, gender: gender, countryId: country.id).to_a unless country.nil? || dob.nil?
-      if matches.size == 1 && matches.first.user.nil?
-        update(wca_id: matches.first.wca_id)
-      elsif notify
-        notify_of_id_claim_possibility(competition)
-      end
+    return unless !wca_id && !unconfirmed_wca_id
+    matches = []
+    matches = competition.competitors.where(name: name, dob: dob, gender: gender, countryId: country.id).to_a unless country.nil? || dob.nil?
+    if matches.size == 1 && matches.first.user.nil?
+      update(wca_id: matches.first.wca_id)
+    elsif notify
+      notify_of_id_claim_possibility(competition)
     end
   end
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -156,6 +156,7 @@ class UserRole < ApplicationRecord
   def can_user_read?(user)
     return true unless group.is_hidden # Roles of non-hidden groups are public
     return false if user.nil? # Roles of hidden groups are visible only to a set of users based on permisssions.
+
     role_permission = is_active? ? :can_read_groups_current : :can_read_groups_past
     user.has_permission?(role_permission, group.id)
   end

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -30,6 +30,7 @@ class WaitingList < ApplicationRecord
   # This is the position from the user/organizers perspective - ie, we start counting at 1
   def position(entry)
     return nil unless entries.include?(entry.id)
+
     entries.index(entry.id) + 1
   end
 end

--- a/config/initializers/i18n_ignore_missing_interpolation_argument.rb
+++ b/config/initializers/i18n_ignore_missing_interpolation_argument.rb
@@ -2,6 +2,7 @@
 
 I18n.config.missing_interpolation_argument_handler = lambda do |missing_key, provided_hash, string|
   raise MissingInterpolationArgument.new(missing_key, provided_hash, string) if I18n.locale == :en
+
   # We only want to raise exceptions for English. This allows development to continue
   # in English, without being held up by slow translations.
   #  https://github.com/thewca/worldcubeassociation.org/issues/1259

--- a/config/initializers/i18n_ignore_missing_interpolation_argument.rb
+++ b/config/initializers/i18n_ignore_missing_interpolation_argument.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 I18n.config.missing_interpolation_argument_handler = lambda do |missing_key, provided_hash, string|
-  if I18n.locale == :en
-    # We only want to raise exceptions for English. This allows development to continue
-    # in English, without being held up by slow translations.
-    #  https://github.com/thewca/worldcubeassociation.org/issues/1259
-    raise MissingInterpolationArgument.new(missing_key, provided_hash, string)
-  else
-    "UNKNOWN_INTERPOLATION_KEY_FOUND_IN_TRANSLATION (#{missing_key})"
-  end
+  raise MissingInterpolationArgument.new(missing_key, provided_hash, string) if I18n.locale == :en
+  # We only want to raise exceptions for English. This allows development to continue
+  # in English, without being held up by slow translations.
+  #  https://github.com/thewca/worldcubeassociation.org/issues/1259
+
+  "UNKNOWN_INTERPOLATION_KEY_FOUND_IN_TRANSLATION (#{missing_key})"
 end

--- a/db/seeds/development/competitions.seeds.rb
+++ b/db/seeds/development/competitions.seeds.rb
@@ -192,6 +192,7 @@ after "development:users", "development:user_roles" do
 
     # Create registrations for some competitions taking place far in the future
     next if i < 480
+
     users.each_with_index do |user, j|
       competing_status = j % 4 == 0 ? Registrations::Helper::STATUS_ACCEPTED : Registrations::Helper::STATUS_PENDING
       registration_competition_events = competition.competition_events.sample(rand(1..competition.competition_events.count))

--- a/lib/advancement_conditions/attempt_result_condition.rb
+++ b/lib/advancement_conditions/attempt_result_condition.rb
@@ -21,6 +21,7 @@ module AdvancementConditions
 
     def max_advancing(results)
       return 0 if results.empty?
+
       field = results.first.format.sort_by == "single" ? :best : :average
       results.count do |r|
         r.to_solve_time(field).complete? && r.send(field) < attempt_result

--- a/lib/auxiliary_data_computation.rb
+++ b/lib/auxiliary_data_computation.rb
@@ -69,6 +69,7 @@ module AuxiliaryDataComputation
             # e.g. 2008SEAR01 twice in North America and World because of his two countries).
             ["World", continent_id, country_id].each do |region|
               next if ranked[region][person_id]
+
               counter[region] += 1
               # As we ordered by value it can either be greater or tie the previous one.
               current_rank[region] = counter[region] if previous_value[region].nil? || value > previous_value[region]
@@ -80,6 +81,7 @@ module AuxiliaryDataComputation
             # in other words, the personId from the Concise*Results table is not found in the Persons table.
             # In the past, this has occurred when temporary results have been inserted for newcomers.
             next if cached_country.nil?
+
             # Set the person's data (first time the current location is matched).
             personal_rank[person_id][:best] ||= value
             personal_rank[person_id][:world_rank] ||= current_rank["World"]

--- a/lib/city_validator.rb
+++ b/lib/city_validator.rb
@@ -11,10 +11,9 @@ class CityValidator < ActiveModel::EachValidator
     end
 
     city_validator = self.class.get_validator_for_country(record.country.iso2)
-    if city_validator
-      reason_why_invalid = city_validator.reason_why_invalid(value)
-      record.errors.add(attribute, reason_why_invalid) if reason_why_invalid
-    end
+    return unless city_validator
+    reason_why_invalid = city_validator.reason_why_invalid(value)
+    record.errors.add(attribute, reason_why_invalid) if reason_why_invalid
   end
 
   def self.get_validator_for_country(country_iso2)

--- a/lib/city_validator.rb
+++ b/lib/city_validator.rb
@@ -12,6 +12,7 @@ class CityValidator < ActiveModel::EachValidator
 
     city_validator = self.class.get_validator_for_country(record.country.iso2)
     return unless city_validator
+
     reason_why_invalid = city_validator.reason_why_invalid(value)
     record.errors.add(attribute, reason_why_invalid) if reason_why_invalid
   end

--- a/lib/file_size_validator.rb
+++ b/lib/file_size_validator.rb
@@ -14,6 +14,7 @@ class FileSizeValidator < ActiveModel::EachValidator
     range = (options.delete(:in) || options.delete(:within))
     if range
       raise ArgumentError.new(":in and :within must be a Range") unless range.is_a?(Range)
+
       options[:minimum] = range.begin
       options[:maximum] = range.end
       options[:maximum] -= 1 if range.exclude_end?

--- a/lib/qualification.rb
+++ b/lib/qualification.rb
@@ -42,6 +42,7 @@ class Qualification
 
   def can_register?(user, event_id)
     return false if user.person.nil?
+
     before_deadline_results = user.person.results.in_event(event_id).on_or_before(self.when_date)
     # Allow any competitor with a result to register when type == "ranking" or type == "anyResult".
     # When type == "ranking", the results need to be manually cleared out later.

--- a/lib/registrations/helper.rb
+++ b/lib/registrations/helper.rb
@@ -21,6 +21,7 @@ module Registrations
         return self_updating ? 'Competitor delete' : 'Admin delete'
       end
       return 'Admin reject' if status == STATUS_REJECTED
+
       self_updating ? 'Competitor update' : 'Admin update'
     end
 
@@ -44,6 +45,7 @@ module Registrations
 
     def self.qualification_data(event, type, time, date)
       raise ArgumentError.new("'type' may only contain the symbols `:single` or `:average`") unless [:single, :average].include?(type)
+
       {
         eventId: event,
         type: type,

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -128,6 +128,7 @@ module Registrations
 
       def validate_qualifications!(request, competition, target_user)
         return unless competition.enforces_qualifications?
+
         event_ids = request.dig('competing', 'event_ids')
 
         unqualified_events = event_ids.filter do |event|
@@ -140,6 +141,7 @@ module Registrations
 
       def process_validation_error!(registration, field)
         return if registration.valid?
+
         error_details = registration.errors.details[field].first
 
         return if error_details.blank?

--- a/lib/results_validators/individual_results_validator.rb
+++ b/lib/results_validators/individual_results_validator.rb
@@ -159,6 +159,7 @@ module ResultsValidators
         first_index = all_solve_times.find_index(&:dns?)
         # Just use '5' here to get all of them
         return unless first_index && all_solve_times[first_index, 5].any?(&:complete?)
+
         competition_id, result, round_id, = context
         @warnings << ValidationWarning.new(RESULT_AFTER_DNS_WARNING,
                                            :results, competition_id,
@@ -172,6 +173,7 @@ module ResultsValidators
         # "check consistency of roundTypeIds and formatIds" across a given round
         # Check that the result's format matches the round format
         return if round_info.format.id == result.formatId
+
         @errors << ValidationError.new(MISMATCHED_RESULT_FORMAT_ERROR,
                                        :results, competition_id,
                                        round_id: round_id,
@@ -275,6 +277,7 @@ module ResultsValidators
         avg_per_solve = sum_of_times_for_rounds.to_f / completed_solves_for_rounds.size
         # We want to issue a warning if the estimated time for all solves + DNFs goes roughly over the cumulative time limit by at least 20% (estimation tolerance to reduce false positive).
         return unless (number_of_dnf_solves + completed_solves_for_rounds.size) * avg_per_solve >= 1.2 * time_limit_for_round.centiseconds
+
         @warnings << ValidationWarning.new(SUSPICIOUS_DNF_WARNING,
                                            :results, competition_id,
                                            round_ids: cumulative_round_ids.join(","),
@@ -293,6 +296,7 @@ module ResultsValidators
         # return (A, B), which is why we require A.id < B.id.
         results.each_with_index do |r, index|
           next if index >= reference_index
+
           # We attribute 1 point for each identical solve_time, we then just have to count the points.
           score = r.solve_times.zip(reference.solve_times).count do |solve_time, reference_solve_time|
             solve_time.complete? && solve_time == reference_solve_time

--- a/lib/solve_time.rb
+++ b/lib/solve_time.rb
@@ -81,6 +81,7 @@ class SolveTime
 
   def time_centiseconds=(time_centiseconds)
     raise "time out of range" unless time_centiseconds.between?(0, 99_999 * 100)
+
     @time_centiseconds = time_centiseconds
     recompute_wca_value
   end
@@ -97,12 +98,14 @@ class SolveTime
 
   def solved=(solved)
     raise "solved out of range" unless (0...100).cover?(solved)
+
     @solved = solved
     recompute_wca_value
   end
 
   def attempted=(attempted)
     raise "attempted out of range" unless (0...100).cover?(attempted)
+
     @attempted = attempted
     recompute_wca_value
   end
@@ -254,6 +257,7 @@ class SolveTime
   validate :time_centiseconds_must_not_be_nil
   def time_centiseconds_must_not_be_nil
     return if incomplete? || (!@event.timed_event? && !@event.multiple_blindfolded?)
+
     # For 333mbo only, time_centiseconds may be nil to indicate an unknown time.
     errors.add(:base, "time_centiseconds must not be nil") unless time_centiseconds || @event.id == "333mbo"
   end
@@ -262,6 +266,7 @@ class SolveTime
   def times_over_10_minutes_must_be_rounded
     # See validation for nil time_centiseconds above
     return if incomplete? || time_centiseconds.nil?
+
     errors.add(:base, "times over 10 minutes should be rounded") if (@event.timed_event? || @event.multiple_blindfolded?) && time_minutes > 10 && time_centiseconds % 100 > 0
   end
 

--- a/lib/time_limit.rb
+++ b/lib/time_limit.rb
@@ -58,6 +58,7 @@ class TimeLimit
   # this file.
   def self.load(json)
     return UNDEF_TL.dup if json.nil?
+
     TimeLimit.new.tap do |time_limit|
       json_obj = json.is_a?(Hash) ? json : JSON.parse(json)
       time_limit.cumulative_round_ids = json_obj['cumulativeRoundIds']
@@ -81,6 +82,7 @@ class TimeLimit
 
   def to_s(round)
     return "" if round.has_undef_tl?
+
     time_str = SolveTime.new(round.event.id, :best, self.centiseconds).clock_format
     case self.cumulative_round_ids.length
     when 0

--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -492,6 +492,7 @@ FactoryBot.define do
 
         events_wcif.each do |event|
           next unless qualification_data.key?(event['id'])
+
           event['qualification'] = qualification_data[event['id']]
         end
 


### PR DESCRIPTION
this is also something we usually point out in a review. But it is a pretty big changeset.

Rubocop documentation says:
```
Autocorrect works in most cases except with if-else statements that contain logical operators such as `foo || raise('exception')`
```
which I don't think we do?