### PR TITLE
Disable image upload in tickets comment

### DIFF
--- a/app/webpacker/components/Tickets/TicketCommentCreate.jsx
+++ b/app/webpacker/components/Tickets/TicketCommentCreate.jsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, Modal } from 'semantic-ui-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import MarkdownEditor from '../wca/FormBuilder/input/MarkdownEditor';
-import useInputState from '../../lib/hooks/useInputState';
+import SimpleMdeReact from 'react-simplemde-editor';
 import createComment from './api/createComment';
 import Loading from '../Requests/Loading';
 import Errored from '../Requests/Errored';
@@ -10,7 +9,7 @@ import Errored from '../Requests/Errored';
 export default function TicketCommentCreate({
   open, onClose, ticketId, currentStakeholder,
 }) {
-  const [comment, setComment] = useInputState();
+  const [comment, setComment] = useState();
 
   const queryClient = useQueryClient();
   const {
@@ -39,8 +38,11 @@ export default function TicketCommentCreate({
     >
       <Modal.Header>Add new comment</Modal.Header>
       <Modal.Content>
-        <MarkdownEditor
-          id="new-comment"
+        <SimpleMdeReact
+          options={{
+            autofocus: true,
+            spellChecker: false,
+          }}
           value={comment}
           onChange={setComment}
         />

--- a/app/webpacker/components/Tickets/TicketCommentCreate.jsx
+++ b/app/webpacker/components/Tickets/TicketCommentCreate.jsx
@@ -1,15 +1,20 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Button, Modal } from 'semantic-ui-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import SimpleMdeReact from 'react-simplemde-editor';
+import MarkdownEditor from '../wca/FormBuilder/input/MarkdownEditor';
+import useInputState from '../../lib/hooks/useInputState';
 import createComment from './api/createComment';
 import Loading from '../Requests/Loading';
 import Errored from '../Requests/Errored';
 
+const TICKET_COMMENTS_MD_EDITOR_OPTIONS = {
+  enableImageUpload: false,
+};
+
 export default function TicketCommentCreate({
   open, onClose, ticketId, currentStakeholder,
 }) {
-  const [comment, setComment] = useState();
+  const [comment, setComment] = useInputState();
 
   const queryClient = useQueryClient();
   const {
@@ -38,13 +43,11 @@ export default function TicketCommentCreate({
     >
       <Modal.Header>Add new comment</Modal.Header>
       <Modal.Content>
-        <SimpleMdeReact
-          options={{
-            autofocus: true,
-            spellChecker: false,
-          }}
+        <MarkdownEditor
+          id="new-comment"
           value={comment}
           onChange={setComment}
+          editorOptions={TICKET_COMMENTS_MD_EDITOR_OPTIONS}
         />
       </Modal.Content>
       <Modal.Actions>

--- a/app/webpacker/components/Tickets/TicketCommentCreate.jsx
+++ b/app/webpacker/components/Tickets/TicketCommentCreate.jsx
@@ -7,10 +7,6 @@ import createComment from './api/createComment';
 import Loading from '../Requests/Loading';
 import Errored from '../Requests/Errored';
 
-const TICKET_COMMENTS_MD_EDITOR_OPTIONS = {
-  enableImageUpload: false,
-};
-
 export default function TicketCommentCreate({
   open, onClose, ticketId, currentStakeholder,
 }) {
@@ -47,7 +43,7 @@ export default function TicketCommentCreate({
           id="new-comment"
           value={comment}
           onChange={setComment}
-          editorOptions={TICKET_COMMENTS_MD_EDITOR_OPTIONS}
+          imageUploadEnabled={false}
         />
       </Modal.Content>
       <Modal.Actions>

--- a/app/webpacker/components/wca/FormBuilder/input/MarkdownEditor.js
+++ b/app/webpacker/components/wca/FormBuilder/input/MarkdownEditor.js
@@ -3,6 +3,8 @@ import SimpleMDE from 'react-simplemde-editor';
 import { fetchWithAuthenticityToken } from '../../../../lib/requests/fetchWithAuthenticityToken';
 import 'easymde/dist/easymde.min.css';
 
+const DEFAULT_EDITOR_OPTIONS = { enableImageUpload: true };
+
 function insertText(editor, markup, promptText) {
   const cm = editor.codemirror;
 
@@ -28,7 +30,7 @@ function insertText(editor, markup, promptText) {
   cm.focus();
 }
 
-function getOptions(disabled) {
+function getOptions(editorOptions) {
   const table = {
     name: 'table-custom',
     action: '\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Text     | Text      | Text     |\n\n',
@@ -69,16 +71,22 @@ function getOptions(disabled) {
 
   const textFormattings = ['bold', 'italic', 'heading'];
   const textStructures = ['quote', 'unordered-list', 'ordered-list', table];
-  const uploadsAndInserts = ['link', 'upload-image', map, youtube];
+  const inserts = ['link', map, youtube];
+  const uploadImageTool = editorOptions?.enableImageUpload ? ['upload-image'] : [];
   const previews = ['preview', 'side-by-side', 'fullscreen'];
   const helps = ['guide'];
   const toolbar = [
     ...textFormattings,
     '|', ...textStructures,
-    '|', ...uploadsAndInserts,
+    '|', ...inserts, ...uploadImageTool,
     '|', ...previews,
     '|', ...helps,
   ];
+
+  const imageOptions = editorOptions.enableImageUpload ? {
+    status: ['upload-image'],
+    uploadImage: true,
+  } : {};
 
   function previewRender(plainText, preview) {
     const previewTarget = preview;
@@ -100,8 +108,8 @@ function getOptions(disabled) {
     spellChecker: false,
     promptURLs: true,
     previewRender,
-    status: ['upload-image'],
-    uploadImage: true,
+    status: [],
+    uploadImage: false,
     async imageUploadFunction(file, onSuccess, onError) {
       const formData = new FormData();
       formData.append('image', file);
@@ -113,7 +121,7 @@ function getOptions(disabled) {
         onError(e);
       }
     },
-    disabled,
+    ...imageOptions,
   };
 }
 
@@ -121,8 +129,9 @@ export default function MarkdownEditor({
   id,
   value,
   onChange,
+  editorOptions = DEFAULT_EDITOR_OPTIONS,
 }) {
-  const options = useMemo(() => getOptions(false), []);
+  const options = useMemo(() => getOptions(editorOptions), [editorOptions]);
   const mdChange = useCallback((text) => onChange(null, { value: text }), [onChange]);
 
   return (

--- a/app/webpacker/components/wca/FormBuilder/input/MarkdownEditor.js
+++ b/app/webpacker/components/wca/FormBuilder/input/MarkdownEditor.js
@@ -3,7 +3,7 @@ import SimpleMDE from 'react-simplemde-editor';
 import { fetchWithAuthenticityToken } from '../../../../lib/requests/fetchWithAuthenticityToken';
 import 'easymde/dist/easymde.min.css';
 
-const DEFAULT_EDITOR_OPTIONS = { enableImageUpload: true };
+const UPLOAD_IMAGE_KEY = 'upload-image';
 
 function insertText(editor, markup, promptText) {
   const cm = editor.codemirror;
@@ -30,7 +30,7 @@ function insertText(editor, markup, promptText) {
   cm.focus();
 }
 
-function getOptions(editorOptions) {
+function getOptions(imageUploadEnabled) {
   const table = {
     name: 'table-custom',
     action: '\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Text     | Text      | Text     |\n\n',
@@ -71,22 +71,17 @@ function getOptions(editorOptions) {
 
   const textFormattings = ['bold', 'italic', 'heading'];
   const textStructures = ['quote', 'unordered-list', 'ordered-list', table];
-  const inserts = ['link', map, youtube];
-  const uploadImageTool = editorOptions?.enableImageUpload ? ['upload-image'] : [];
+  const uploadImageTool = [imageUploadEnabled && UPLOAD_IMAGE_KEY].filter(Boolean);
+  const inserts = ['link', map, youtube, ...uploadImageTool];
   const previews = ['preview', 'side-by-side', 'fullscreen'];
   const helps = ['guide'];
   const toolbar = [
     ...textFormattings,
     '|', ...textStructures,
-    '|', ...inserts, ...uploadImageTool,
+    '|', ...inserts,
     '|', ...previews,
     '|', ...helps,
   ];
-
-  const imageOptions = editorOptions.enableImageUpload ? {
-    status: ['upload-image'],
-    uploadImage: true,
-  } : {};
 
   function previewRender(plainText, preview) {
     const previewTarget = preview;
@@ -108,8 +103,8 @@ function getOptions(editorOptions) {
     spellChecker: false,
     promptURLs: true,
     previewRender,
-    status: [],
-    uploadImage: false,
+    status: [imageUploadEnabled && UPLOAD_IMAGE_KEY].filter(Boolean),
+    uploadImage: imageUploadEnabled,
     async imageUploadFunction(file, onSuccess, onError) {
       const formData = new FormData();
       formData.append('image', file);
@@ -121,7 +116,6 @@ function getOptions(editorOptions) {
         onError(e);
       }
     },
-    ...imageOptions,
   };
 }
 
@@ -129,9 +123,9 @@ export default function MarkdownEditor({
   id,
   value,
   onChange,
-  editorOptions = DEFAULT_EDITOR_OPTIONS,
+  imageUploadEnabled = true,
 }) {
-  const options = useMemo(() => getOptions(editorOptions), [editorOptions]);
+  const options = useMemo(() => getOptions(imageUploadEnabled), [imageUploadEnabled]);
   const mdChange = useCallback((text) => onChange(null, { value: text }), [onChange]);
 
   return (


### PR DESCRIPTION
Currently in tickets, while adding a new comment we can upload image. But this is not a necessary feature, and allows user to upload documents.

Recently there was an incident where WRT asked the requestor via email to submit their ID proof, and what WRT meant is to submit it as a reply to the email. But they thought of doing it via tickets, and added a comment there. (The comment looks like the user has uploaded an image, but we were not able to see the image in the comment anyway. Mostly it's because we are just printing the comment body, I didn't spend time to investigate this, maybe I'll try it later).

One approach to tackle this was to add an option in existing `MarkdownEditor`, but I feel most of the features in `MarkdownEditor` is not meant for general use-case. So I thought instead of using `MarkdownEditor`, I'll directly use `SimpleMdeReact` ([official documentation link](https://www.npmjs.com/package/react-simplemde-editor#controlled-usage)).