### PR TITLE
Reg Admin: non-competing section

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -265,7 +265,7 @@ class Registration < ApplicationRecord
       base_json.deep_merge!({
                               guests: guests,
                               competing: {
-                                registration_status: competing_status,
+                                registration_status: is_competing ? competing_status : 'non_competing',
                                 registered_on: registered_at,
                                 comment: comments,
                                 admin_comment: administrative_notes,

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -74,7 +74,7 @@ export default function RegistrationActions({
   const anySelected = selectedCount > 0;
 
   const {
-    pending, accepted, cancelled, waiting, rejected,
+    pending, accepted, cancelled, waiting, rejected, nonCompeting,
   } = partitionedSelectedIds;
   const anyPending = pending.length < selectedCount;
   const anyApprovable = accepted.length < selectedCount;
@@ -92,7 +92,9 @@ export default function RegistrationActions({
     [registrations],
   );
 
-  const selectedEmails = [...pending, ...waiting, ...accepted, ...cancelled, ...rejected]
+  const selectedEmails = [
+    ...pending, ...waiting, ...accepted, ...cancelled, ...rejected, ...nonCompeting,
+  ]
     .map((userId) => userEmailMap[userId])
     .join(',');
 

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -193,7 +193,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
               onSelect={selectedIds.add}
               onUnselect={selectedIds.remove}
               onToggle={selectedIds.toggle}
-              competition_id={competitionInfo.id}
               competitionInfo={competitionInfo}
               color={PENDING_COLOR}
               distinguishPaidUnpaid
@@ -229,7 +228,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
               onSelect={selectedIds.add}
               onUnselect={selectedIds.remove}
               onToggle={selectedIds.toggle}
-              competition_id={competitionInfo.id}
               initialSortColumn="waiting_list_position"
               competitionInfo={competitionInfo}
               registrations={waiting.toSorted(
@@ -274,7 +272,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
             onSelect={selectedIds.add}
             onUnselect={selectedIds.remove}
             onToggle={selectedIds.toggle}
-            competition_id={competitionInfo.id}
             competitionInfo={competitionInfo}
             color={APPROVED_COLOR}
           />
@@ -306,7 +303,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
               onSelect={selectedIds.add}
               onUnselect={selectedIds.remove}
               onToggle={selectedIds.toggle}
-              competition_id={competitionInfo.id}
               competitionInfo={competitionInfo}
               color={CANCELLED_COLOR}
             />
@@ -339,7 +335,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
               onSelect={selectedIds.add}
               onUnselect={selectedIds.remove}
               onToggle={selectedIds.toggle}
-              competition_id={competitionInfo.id}
               competitionInfo={competitionInfo}
               color={REJECTED_COLOR}
             />
@@ -372,7 +367,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
               onSelect={selectedIds.add}
               onUnselect={selectedIds.remove}
               onToggle={selectedIds.toggle}
-              competition_id={competitionInfo.id}
               competitionInfo={competitionInfo}
               color={NON_COMPETING_COLOR}
             />

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -18,6 +18,8 @@ import useOrderedSet from '../../../lib/hooks/useOrderedSet';
 import {
   APPROVED_COLOR, APPROVED_ICON,
   CANCELLED_COLOR, CANCELLED_ICON,
+  NON_COMPETING_COLOR,
+  NON_COMPETING_ICON,
   partitionRegistrations,
   PENDING_COLOR, PENDING_ICON,
   REJECTED_COLOR, REJECTED_ICON,
@@ -109,7 +111,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
   });
 
   const {
-    waiting, accepted, cancelled, pending, rejected,
+    waiting, accepted, cancelled, pending, rejected, nonCompeting,
   } = useMemo(
     () => partitionRegistrations(registrations ?? []),
     [registrations],
@@ -123,8 +125,11 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
       accepted: selectedIds.asArray.filter((id) => accepted.some((reg) => id === reg.user.id)),
       cancelled: selectedIds.asArray.filter((id) => cancelled.some((reg) => id === reg.user.id)),
       rejected: selectedIds.asArray.filter((id) => rejected.some((reg) => id === reg.user.id)),
+      nonCompeting: selectedIds.asArray.filter(
+        (id) => nonCompeting.some((reg) => id === reg.user.id),
+      ),
     }),
-    [selectedIds.asArray, pending, waiting, accepted, cancelled, rejected],
+    [selectedIds.asArray, pending, waiting, accepted, cancelled, rejected, nonCompeting],
   );
 
   // some sticky/floating bar somewhere with totals/info would be better
@@ -342,8 +347,40 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
         ),
       },
     },
-    // TODO: Either add non competing registrations here on in a separate staff tab
-  ];
+    nonCompeting.length > 0 && {
+      key: 'nonCompeting',
+      title: {
+        content: (
+          <SectionToggle
+            icon={NON_COMPETING_ICON}
+            title={I18n.t('competitions.registration_v2.list.non_competing.title')}
+            inParens={nonCompeting.length}
+            color={NON_COMPETING_COLOR}
+          />
+        ),
+      },
+      content: {
+        content: (
+          <>
+            <Header.Subheader>
+              {I18n.t('competitions.registration_v2.list.non_competing.information')}
+            </Header.Subheader>
+            <RegistrationAdministrationTable
+              columnsExpanded={expandedColumns}
+              registrations={nonCompeting}
+              selected={partitionedSelectedIds.nonCompeting}
+              onSelect={selectedIds.add}
+              onUnselect={selectedIds.remove}
+              onToggle={selectedIds.toggle}
+              competition_id={competitionInfo.id}
+              competitionInfo={competitionInfo}
+              color={NON_COMPETING_COLOR}
+            />
+          </>
+        ),
+      },
+    },
+  ].filter(Boolean);
 
   const nonEmptyTableIndices = [
     ['pending', pending],
@@ -351,6 +388,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
     ['accepted', accepted],
     ['cancelled', cancelled],
     ['rejected', rejected],
+    ['nonCompeting', nonCompeting],
   ].filter(
     ([, list]) => list.length > 0,
   ).map(

--- a/app/webpacker/lib/utils/registrationAdmin.js
+++ b/app/webpacker/lib/utils/registrationAdmin.js
@@ -6,12 +6,14 @@ export const WAITLIST_COLOR = 'yellow';
 export const APPROVED_COLOR = 'green';
 export const CANCELLED_COLOR = 'orange';
 export const REJECTED_COLOR = 'red';
+export const NON_COMPETING_COLOR = 'purple';
 
 export const PENDING_ICON = 'circle notched';
 export const WAITLIST_ICON = 'hourglass';
 export const APPROVED_ICON = 'check';
 export const CANCELLED_ICON = 'trash';
 export const REJECTED_ICON = 'x';
+export const NON_COMPETING_ICON = 'clipboard outline';
 
 export const partitionRegistrations = (registrations) => registrations.reduce(
   (result, registration) => {

--- a/app/webpacker/lib/utils/registrationAdmin.js
+++ b/app/webpacker/lib/utils/registrationAdmin.js
@@ -33,13 +33,16 @@ export const partitionRegistrations = (registrations) => registrations.reduce(
       case 'rejected':
         result.rejected.push(registration);
         break;
+      case 'non_competing':
+        result.nonCompeting.push(registration);
+        break;
       default:
         break;
     }
     return result;
   },
   {
-    pending: [], waiting: [], accepted: [], cancelled: [], rejected: [],
+    pending: [], waiting: [], accepted: [], cancelled: [], rejected: [], nonCompeting: [],
   },
 );
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1835,6 +1835,9 @@ en:
         rejected:
           title: "Rejected Registrations"
           information: "Rejected competitors cannot re-register."
+        non_competing:
+          title: "Non-Competing Registrations"
+          information: "For non-competitors that you can assign staff duties to in the WCIF."
         payment:
          refunded_status: "Refunded"
          initialized: "Payment process was started on %{date}, but not finished."


### PR DESCRIPTION
Back-end change based on slack thread. Feel free to modify this PR if there's a better way.

Competition without any non-competing registrations:
![image](https://github.com/user-attachments/assets/6a7dcdf5-ed72-4654-9253-f00deeeea614)

And with:
![image](https://github.com/user-attachments/assets/fc433def-05ba-429a-b3da-9d26cba1458b)

Cannot move people to it:
![image](https://github.com/user-attachments/assets/61cee7ab-1ee7-4e60-a223-854fc6908b32)

It _looks_ like you can move them, but they aren't passed on to the back-end when you click (similar to how the "move x to" count is wrong if you have anyone selected from the destination section). I might be able to improve that in one of my other draft PRs, but it seems unimportant for now.
![image](https://github.com/user-attachments/assets/72260359-2a57-4852-978b-1e4b63eaf462)
