### PR TITLE
Add error column to competition dues export & moved row generation to model instead of view file

### DIFF
--- a/app/controllers/wfc_controller.rb
+++ b/app/controllers/wfc_controller.rb
@@ -11,8 +11,7 @@ class WfcController < ApplicationController
     select_attributes = [
       :id, :name, :start_date, :end_date,
       :country_id, :announced_at, :results_posted_at,
-      :currency_code, :base_entry_fee_lowest_denomination,
-      "count(distinct persons.id) as num_competitors"
+      :currency_code, :base_entry_fee_lowest_denomination
     ]
     from = params.require(:from_date)
     to = params.require(:to_date)

--- a/app/controllers/wfc_controller.rb
+++ b/app/controllers/wfc_controller.rb
@@ -18,6 +18,7 @@ class WfcController < ApplicationController
     response.headers["Content-Disposition"] = "attachment; filename=\"wfc-competitions-export-#{from}-#{to}.tsv\""
     @competitions = Competition
                     .select(select_attributes)
+                    .select('COUNT(DISTINCT persons.id) AS num_competitors')
                     .includes(:delegates, :championships, :organizers, :events, organizers: [:wfc_dues_redirect])
                     .left_joins(:competitors)
                     .group(:id)

--- a/app/controllers/wfc_controller.rb
+++ b/app/controllers/wfc_controller.rb
@@ -8,10 +8,10 @@ class WfcController < ApplicationController
   end
 
   def competition_export
-    select_attributes = [
-      :id, :name, :start_date, :end_date,
-      :country_id, :announced_at, :results_posted_at,
-      :currency_code, :base_entry_fee_lowest_denomination
+    select_attributes = %i[
+      id name start_date end_date
+      country_id announced_at results_posted_at
+      currency_code base_entry_fee_lowest_denomination
     ]
     from = params.require(:from_date)
     to = params.require(:to_date)

--- a/app/controllers/wfc_controller.rb
+++ b/app/controllers/wfc_controller.rb
@@ -8,17 +8,17 @@ class WfcController < ApplicationController
   end
 
   def competition_export
-    select_attributes = %i[
-      id name start_date end_date
-      country_id announced_at results_posted_at
-      currency_code base_entry_fee_lowest_denomination
+    select_attributes = [
+      :id, :name, :start_date, :end_date,
+      :country_id, :announced_at, :results_posted_at,
+      :currency_code, :base_entry_fee_lowest_denomination,
+      "count(distinct persons.id) as num_competitors"
     ]
     from = params.require(:from_date)
     to = params.require(:to_date)
     response.headers["Content-Disposition"] = "attachment; filename=\"wfc-competitions-export-#{from}-#{to}.tsv\""
     @competitions = Competition
                     .select(select_attributes)
-                    .select('COUNT(DISTINCT persons.id) AS num_competitors')
                     .includes(:delegates, :championships, :organizers, :events, organizers: [:wfc_dues_redirect])
                     .left_joins(:competitors)
                     .group(:id)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2219,16 +2219,8 @@ class Competition < ApplicationRecord
   end
 
   def export_for_dues_generation
-    begin
-      dues_per_competitor_in_usd = DuesCalculator.dues_per_competitor_in_usd(self.country_iso2, self.base_entry_fee_lowest_denomination.to_i, self.currency_code)
-      error = 'None'
-    rescue Money::Currency::UnknownCurrency, CurrencyUnavailable, Money::Bank::UnknownRate
-      dues_per_competitor_in_usd = 0
-      error = 'Unknown/unavailable currency/rate'
-    rescue ArgumentError
-      dues_per_competitor_in_usd = 0
-      error = 'Invalid arguments'
-    end
+    error = DuesCalculator.error_in_dues_calculation(self.country_iso2, self.currency_code)
+    dues_per_competitor_in_usd = error.nil? ? DuesCalculator.dues_per_competitor_in_usd(self.country_iso2, self.base_entry_fee_lowest_denomination.to_i, self.currency_code) : 0
 
     [
       id, name, country.iso2, continent.id,

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2223,16 +2223,13 @@ class Competition < ApplicationRecord
 
     begin
       dues_per_competitor_in_usd = DuesCalculator.dues_per_competitor_in_usd(self.country_iso2, self.base_entry_fee_lowest_denomination.to_i, self.currency_code)
-      error_in_dues_calculation = false
-      error_invalid_arguments = false
+      error = 'None'
     rescue Money::Currency::UnknownCurrency, CurrencyUnavailable, Money::Bank::UnknownRate
       dues_per_competitor_in_usd = 0
-      error_in_dues_calculation = true
-      error_invalid_arguments = false
+      error = 'Unknown/unavailable currency/rate'
     rescue ArgumentError
       dues_per_competitor_in_usd = 0
-      error_in_dues_calculation = false
-      error_invalid_arguments = true
+      error = 'Invalid arguments'
     end
 
     [
@@ -2242,7 +2239,7 @@ class Competition < ApplicationRecord
       currency_code, base_entry_fee_lowest_denomination, Money::Currency.new(currency_code).subunit_to_unit,
       championships.map(&:championship_type).sort.join(","), exempt_from_wca_dues?, organizers.map(&:name).sort.join(","),
       dues_per_competitor_in_usd * num_competitors, dues_payer_name, dues_payer_email, dues_payer_is_combined_invoice?, country.try(:band).try(:number) || 0,
-      error_in_dues_calculation, error_invalid_arguments
+      error
     ]
   end
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2228,7 +2228,7 @@ class Competition < ApplicationRecord
       Rails.application.routes.url_helpers.competition_url(id), num_competitors, delegates.reject(&:trainee_delegate?).map(&:name).sort.join(","),
       currency_code, base_entry_fee_lowest_denomination, Money::Currency.new(currency_code).subunit_to_unit,
       championships.map(&:championship_type).sort.join(","), exempt_from_wca_dues?, organizers.map(&:name).sort.join(","),
-      dues_per_competitor_in_usd * num_competitors, dues_payer_name, dues_payer_email, dues_payer_is_combined_invoice?, country.try(:band).try(:number) || 0,
+      dues_per_competitor_in_usd * num_competitors, dues_payer_name, dues_payer_email, dues_payer_is_combined_invoice?, country.band&.number || 0,
       error
     ]
   end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2219,8 +2219,6 @@ class Competition < ApplicationRecord
   end
 
   def export_for_dues_generation
-    num_competitors = competitors.count
-
     begin
       dues_per_competitor_in_usd = DuesCalculator.dues_per_competitor_in_usd(self.country_iso2, self.base_entry_fee_lowest_denomination.to_i, self.currency_code)
       error = 'None'

--- a/app/views/wfc/competition_export.csv.erb
+++ b/app/views/wfc/competition_export.csv.erb
@@ -6,7 +6,7 @@
   "Currency Code", "Base Registration Fee", "Currency Subunit",
   "Championship Type", "Exempt from WCA Dues", "Organizers", "Calculated Dues",
   "Dues Payer Name", "Dues Payer Email", "Is Combined Invoice", "Dues Band",
-  "Error in Dues Calculation", "Error (Invalid Arguments)",
+  "Error (if any)",
 ] %>
 <%= CSV.generate_line(headers, col_sep: "\t").html_safe -%>
 <% @competitions.each do |c| %>

--- a/app/views/wfc/competition_export.csv.erb
+++ b/app/views/wfc/competition_export.csv.erb
@@ -6,15 +6,9 @@
   "Currency Code", "Base Registration Fee", "Currency Subunit",
   "Championship Type", "Exempt from WCA Dues", "Organizers", "Calculated Dues",
   "Dues Payer Name", "Dues Payer Email", "Is Combined Invoice", "Dues Band",
+  "Error in Dues Calculation", "Error (Invalid Arguments)",
 ] %>
 <%= CSV.generate_line(headers, col_sep: "\t").html_safe -%>
 <% @competitions.each do |c| %>
-  <%= CSV.generate_line([
-    c.id, c.name, c.country.iso2, c.continent.id,
-    c.start_date, c.end_date, c.announced_at, c.results_posted_at,
-    competition_url(c.id), c.num_competitors, c.delegates.reject(&:trainee_delegate?).map(&:name).sort.join(","),
-    c.currency_code, c.base_entry_fee_lowest_denomination, Money::Currency.new(c.currency_code).subunit_to_unit,
-    c.championships.map(&:championship_type).sort.join(","), c.exempt_from_wca_dues?, c.organizers.map(&:name).sort.join(","),
-    c.dues_per_competitor_in_usd * c.num_competitors, c.dues_payer_name, c.dues_payer_email, c.dues_payer_is_combined_invoice?, c.country.try(:band).try(:number) || 0,
-  ], col_sep: "\t").html_safe -%>
+  <%= CSV.generate_line(c.export_for_dues_generation, col_sep: "\t").html_safe -%>
 <% end %>

--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -4,15 +4,13 @@ module DuesCalculator
   def self.dues_per_competitor(country_iso2, base_entry_fee_lowest_denomination, currency_code)
     dues_per_competitor_in_usd_money = dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)
     dues_per_competitor_in_usd_money&.exchange_to(currency_code)
-  rescue Money::Currency::UnknownCurrency, CurrencyUnavailable, Money::Bank::UnknownRate, ArgumentError
-    nil
   end
 
   def self.dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)
+    return nil if DuesCalculator.error_in_dues_calculation(country_iso2, currency_code)
+
     country_band = CountryBand.find_by(iso2: country_iso2)
     country_band_detail = country_band&.active_country_band_detail
-
-    raise ArgumentError.new("Country band not found for #{country_iso2}") if country_band.nil?
 
     # Calculation of 'registration fee dues'
     registration_fees_in_usd = Money.new(base_entry_fee_lowest_denomination, currency_code).exchange_to("USD")
@@ -23,5 +21,18 @@ module DuesCalculator
 
     # The maximum of the two is the total dues per competitor
     [registration_fee_dues, country_band_dues].max
+  end
+
+  def self.error_in_dues_calculation(country_iso2, currency_code)
+    country_band = CountryBand.find_by(iso2: country_iso2)
+    if country_band.nil?
+      "Country band not found."
+    elsif country_band.active_country_band_detail.nil?
+      "Country band detail not found for #{country_band.iso2}."
+    elsif !Money::Currency.table.key?(currency_code.downcase.to_sym)
+      "Currency #{currency_code} is not supported."
+    elsif Money.default_bank.get_rate(currency_code, 'USD').nil?
+      "Currency #{currency_code} cannot be converted to USD."
+    end
   end
 end

--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -4,7 +4,7 @@ module DuesCalculator
   def self.dues_per_competitor(country_iso2, base_entry_fee_lowest_denomination, currency_code)
     dues_per_competitor_in_usd_money = dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)
     dues_per_competitor_in_usd_money&.exchange_to(currency_code)
-  rescue CurrencyUnavailable
+  rescue Money::Currency::UnknownCurrency, CurrencyUnavailable, Money::Bank::UnknownRate, ArgumentError
     nil
   end
 
@@ -12,7 +12,7 @@ module DuesCalculator
     country_band = CountryBand.find_by(iso2: country_iso2)
     country_band_detail = country_band&.active_country_band_detail
 
-    return nil if country_band_detail.nil?
+    raise ArgumentError.new("Country band not found for #{country_iso2}") if country_band.nil?
 
     # Calculation of 'registration fee dues'
     registration_fees_in_usd = Money.new(base_entry_fee_lowest_denomination, currency_code).exchange_to("USD")
@@ -23,7 +23,5 @@ module DuesCalculator
 
     # The maximum of the two is the total dues per competitor
     [registration_fee_dues, country_band_dues].max
-  rescue Money::Currency::UnknownCurrency, CurrencyUnavailable, Money::Bank::UnknownRate
-    nil
   end
 end

--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -7,7 +7,7 @@ module DuesCalculator
   end
 
   def self.dues_per_competitor_in_usd(country_iso2, base_entry_fee_lowest_denomination, currency_code)
-    return nil if DuesCalculator.error_in_dues_calculation(country_iso2, currency_code)
+    return nil if DuesCalculator.error_in_dues_calculation(country_iso2, currency_code).present?
 
     country_band = CountryBand.find_by(iso2: country_iso2)
     country_band_detail = country_band&.active_country_band_detail

--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -34,5 +34,11 @@ module DuesCalculator
     elsif Money.default_bank.get_rate(currency_code, 'USD').nil?
       "Currency #{currency_code} cannot be converted to USD."
     end
+    # Money.default_bank.get_rate will return CurrencyUnavailable if the currency cannot be
+    # converted. There is currently no way to check if the currency exists because of poor
+    # code design of EuCentralBank. Till we have a method, we will use rescue to catch the
+    # error.
+  rescue CurrencyUnavailable
+    "Currency #{currency_code} cannot be converted to USD."
   end
 end

--- a/spec/views/wfc/competition_export.csv.erb_spec.rb
+++ b/spec/views/wfc/competition_export.csv.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "wfc/competition_export.csv.erb" do
       "Currency Code", "Base Registration Fee", "Currency Subunit",
       "Championship Type", "Exempt from WCA Dues", "Organizers",
       "Calculated Dues", "Dues Payer Name", "Dues Payer Email",
-      "Is Combined Invoice", "Dues Band", "Error in Dues Calculation", "Error (Invalid Arguments)"
+      "Is Combined Invoice", "Dues Band", "Error (if any)"
     ]
 
     assign(:competitions, [])

--- a/spec/views/wfc/competition_export.csv.erb_spec.rb
+++ b/spec/views/wfc/competition_export.csv.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "wfc/competition_export.csv.erb" do
       "Currency Code", "Base Registration Fee", "Currency Subunit",
       "Championship Type", "Exempt from WCA Dues", "Organizers",
       "Calculated Dues", "Dues Payer Name", "Dues Payer Email",
-      "Is Combined Invoice", "Dues Band"
+      "Is Combined Invoice", "Dues Band", "Error in Dues Calculation", "Error (Invalid Arguments)"
     ]
 
     assign(:competitions, [])


### PR DESCRIPTION
WFC is facing issue while downloading export if the export includes Venezuela competitions. The reason is that Venezuela competitions are using VEF currency which is deprecated currency since 2018. (WFC is enquiring with Delegate why they used the deprecated currency).

Along with this change, I've added couple of error columns in the export, because WFC is going to trust the dues calculation by our system, and if the errors are silently converted to zeroes, it might lead to mistakes in WFC's side. The error columns will help WFC to understand that something is wrong.

With this change, `DuesCalculator.dues_per_competitor_in_usd` is no longer going to be error-free always, instead it will throw error if something goes wrong. The error will be catched before generating the columns for a competition.