### PR TITLE
Only include `is_competing: true` registrations in competitor limit check

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -272,7 +272,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
     def will_exceed_competitor_limit?(update_requests, competition)
       registrations_to_be_accepted = update_requests.count { |r| r.dig('competing', 'status') == Registrations::Helper::STATUS_ACCEPTED }
-      total_accepted_registrations_after_update = competition.registrations.accepted_count + registrations_to_be_accepted
+      total_accepted_registrations_after_update = competition.registrations.accepted_and_competing_count + registrations_to_be_accepted
 
       competition.competitor_limit_enabled &&
         registrations_to_be_accepted > 0 &&

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -314,6 +314,10 @@ class Registration < ApplicationRecord
     accepted.count
   end
 
+  def self.accepted_and_competing_count
+    accepted.competing.count
+  end
+
   def self.accepted_and_paid_pending_count
     accepted_count + pending.with_payments.count
   end

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -116,7 +116,7 @@ module Registrations
 
         if new_status == Registrations::Helper::STATUS_ACCEPTED && competition.competitor_limit_enabled?
           raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED) if
-            competition.registrations.competing_status_accepted.count >= competition.competitor_limit
+            competition.registrations.competing_status_accepted.competing.count >= competition.competitor_limit
 
           if competition.enforce_newcomer_month_reservations? && !target_user.newcomer_month_eligible?
             available_spots = competition.competitor_limit - competition.registrations.competing_status_accepted.count

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -116,7 +116,7 @@ module Registrations
 
         if new_status == Registrations::Helper::STATUS_ACCEPTED && competition.competitor_limit_enabled?
           raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED) if
-            competition.registrations.competing_status_accepted.competing.count >= competition.competitor_limit
+            competition.registrations.accepted_and_competing_count >= competition.competitor_limit
 
           if competition.enforce_newcomer_month_reservations? && !target_user.newcomer_month_eligible?
             available_spots = competition.competitor_limit - competition.registrations.competing_status_accepted.count

--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -24,6 +24,11 @@ FactoryBot.define do
       to_create { |instance| instance.save(validate: false) }
     end
 
+    trait :non_competing do
+      accepted # Must be accepted so that it shows up in WCIF
+      is_competing { false }
+    end
+
     trait :accepted do
       competing_status { Registrations::Helper::STATUS_ACCEPTED }
     end

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -1074,6 +1074,19 @@ RSpec.describe 'API Registrations' do
         expect(Registration.find_by(user_id: update_request3['user_id']).competing_status).to eq('accepted')
       end
 
+      it 'doesnt include non-competing registrations in competitor limit' do
+        FactoryBot.create(:registration, :non_competing, competition: competition)
+        competition.update(competitor_limit: 3)
+
+        patch api_v1_registrations_bulk_update_path, params: bulk_update_request, headers: headers
+
+        expect(response).to have_http_status(:ok)
+
+        expect(Registration.find_by(user_id: update_request1['user_id']).competing_status).to eq('accepted')
+        expect(Registration.find_by(user_id: update_request2['user_id']).competing_status).to eq('accepted')
+        expect(Registration.find_by(user_id: update_request3['user_id']).competing_status).to eq('accepted')
+      end
+
       it 'wont accept competitors over the competitor limit' do
         competition.update(competitor_limit: 2)
 


### PR DESCRIPTION
This fixes an issue Cailyn is having where the she cannot accept the 300th competitor, because the non-competing registration in `WarmUpSeattle2025` is still counted in the competitor_limit check

Note: This should also be added in: 
- [x] Bulk update validation - although this seems to have disappeared from the registration_checker file??? 
- [ ] Competitor limit validation in #10977