### PR TITLE
Add Dependabot (and Yarn 4.7) to /next-frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+- package-ecosystem: npm
+  directory: "/next-frontend"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/next-frontend/package.json
+++ b/next-frontend/package.json
@@ -43,5 +43,5 @@
     "prettier": "^3.5.3",
     "typescript": "^5"
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.7.0"
 }


### PR DESCRIPTION
See title. Activates Dependabot for the NextJS project