### PR TITLE
Rate limit explorations

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -3,6 +3,7 @@
 class Api::V0::ApiController < ApplicationController
   include Rails::Pagination
   include NewRelic::Agent::Instrumentation::ControllerInstrumentation if Rails.env.production?
+  rate_limit to: 60, within: 1.minutes
   protect_from_forgery with: :null_session
   before_action :doorkeeper_authorize!, only: [:me]
   rescue_from WcaExceptions::ApiException do |e|

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -3,7 +3,7 @@
 class Api::V0::ApiController < ApplicationController
   include Rails::Pagination
   include NewRelic::Agent::Instrumentation::ControllerInstrumentation if Rails.env.production?
-  rate_limit to: 60, within: 1.minutes
+  rate_limit to: 60, within: 1.minute
   protect_from_forgery with: :null_session
   before_action :doorkeeper_authorize!, only: [:me]
   rescue_from WcaExceptions::ApiException do |e|

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -3,7 +3,7 @@
 class Api::V0::ApiController < ApplicationController
   include Rails::Pagination
   include NewRelic::Agent::Instrumentation::ControllerInstrumentation if Rails.env.production?
-  rate_limit to: 60, within: 1.minute
+  rate_limit to: 60, within: 1.minute if Rails.env.production?
   protect_from_forgery with: :null_session
   before_action :doorkeeper_authorize!, only: [:me]
   rescue_from WcaExceptions::ApiException do |e|

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < Devise::SessionsController
-  rate_limit to: 10, within: 1.minutes, only: [:new, :create]
+  rate_limit to: 10, within: 1.minute, only: [:new, :create]
 
   prepend_before_action :authenticate_with_two_factor,
                         if: -> { action_name == 'create' && two_factor_enabled? }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < Devise::SessionsController
-  rate_limit to: 10, within: 1.minute, only: [:new, :create]
+  rate_limit to: 10, within: 1.minute, only: [:new, :create] if Rails.env.production?
 
   prepend_before_action :authenticate_with_two_factor,
                         if: -> { action_name == 'create' && two_factor_enabled? }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SessionsController < Devise::SessionsController
+  rate_limit to: 10, within: 1.minutes, only: [:new, :create]
+
   prepend_before_action :authenticate_with_two_factor,
                         if: -> { action_name == 'create' && two_factor_enabled? }
   skip_before_action :require_no_authentication, only: [:new, :create]


### PR DESCRIPTION
We had a report months ago that we should rate limit the sign in/up route which I am right limiting here to 10 a minute.

I think rate limiting the API to 1 request a second over a 60 second period is probably also reasonable?