### PR TITLE
Move registration_checker competing status validations to model

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -139,7 +139,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   end
 
   def validate_update_request
-    Registrations::RegistrationChecker.update_registration_allowed!(params, @registration, @current_user)
+    Registrations::RegistrationChecker.update_registration_allowed!(params, @registration)
   end
 
   def user_can_bulk_modify_registrations
@@ -163,7 +163,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
       @request = update_request
       user_can_modify_registration
 
-      Registrations::RegistrationChecker.update_registration_allowed!(update_request, @registration, @current_user)
+      Registrations::RegistrationChecker.update_registration_allowed!(update_request, @registration)
     rescue WcaExceptions::RegistrationError => e
       errors[update_request['user_id']] = e.error
     end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -692,6 +692,7 @@ class Competition < ApplicationRecord
              'bookmarked_users',
              'competition_series',
              'series_competitions',
+             'series_registrations',
              'posting_user',
              'inbox_results',
              'inbox_persons',

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -32,6 +32,7 @@ class Competition < ApplicationRecord
   has_many :bookmarked_users, through: :bookmarked_competitions, source: :user
   belongs_to :competition_series, optional: true
   has_many :series_competitions, -> { readonly }, through: :competition_series, source: :competitions
+  has_many :series_registrations, -> { readonly }, through: :series_competitions, source: :registrations
   belongs_to :posting_user, optional: true, foreign_key: 'posting_by', class_name: "User"
   has_many :inbox_results, foreign_key: "competitionId", dependent: :delete_all
   has_many :inbox_persons, foreign_key: "competitionId", dependent: :delete_all
@@ -1854,7 +1855,7 @@ class Competition < ApplicationRecord
   end
 
   def other_series_ids
-    series_sibling_competitions.pluck(:id)
+    series_sibling_competitions.ids
   end
 
   def qualification_wcif
@@ -2236,6 +2237,13 @@ class Competition < ApplicationRecord
 
     series_competitions
       .where.not(id: self.id)
+  end
+
+  def series_sibling_registrations
+    return [] unless part_of_competition_series?
+
+    series_registrations
+      .where.not(competition: self)
   end
 
   def find_round_for(event_id, round_type_id, format_id = nil)

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -471,12 +471,16 @@ class Registration < ApplicationRecord
     competing_status_changed? && (competing_status_cancelled? || competing_status_rejected?)
   end
 
-  validate :not_changing_events_when_cancelling, if: [:trying_to_cancel?, :competition_events_changed?], unless: :new_record?
+  validate :not_changing_events_when_cancelling, if: [:trying_to_cancel?, :tracked_event_ids?, :competition_events_changed?]
   private def not_changing_events_when_cancelling
-    errors.add(:competition_events, :cannot_change_when_cancelling, message: I18n.t('registrations.errors.cannot_change_events_when_cancelling'), frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA)
+    errors.add(:competition_events, :cannot_change_events_when_cancelling, message: I18n.t('registrations.errors.cannot_change_events_when_cancelling'), frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA)
   end
 
   attr_writer :tracked_event_ids
+
+  def tracked_event_ids?
+    @tracked_event_ids.present?
+  end
 
   def tracked_event_ids
     @tracked_event_ids ||= self.event_ids

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -414,10 +414,8 @@ class Registration < ApplicationRecord
     competing_status_changed? && competing_status_accepted?
   end
 
-  validate :only_one_accepted_per_series
+  validate :only_one_accepted_per_series, if: [:part_of_competition_series?, :trying_to_accept?, :has_accepted_sibling_registrations?]
   private def only_one_accepted_per_series
-    return unless part_of_competition_series? && trying_to_accept? && !series_sibling_registrations.accepted.empty?
-
     errors.add(
       :competition_id,
       :already_registered_in_series,
@@ -433,6 +431,10 @@ class Registration < ApplicationRecord
 
     competition.series_sibling_registrations
                .where(user_id: self.user_id)
+  end
+
+  def has_accepted_sibling_registrations?
+    series_sibling_registrations.accepted.any?
   end
 
   def ensure_waitlist_eligibility!

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -411,33 +411,14 @@ class Registration < ApplicationRecord
 
   validate :only_one_accepted_per_series
   private def only_one_accepted_per_series
-    errors.add(:competition_id, I18n.t('registrations.errors.series_more_than_one_accepted')) if competition&.part_of_competition_series? && competing_status_accepted? && !series_sibling_registrations(:accepted).empty?
+    errors.add(:competition_id, I18n.t('registrations.errors.series_more_than_one_accepted')) if competition&.part_of_competition_series? && competing_status_accepted? && !series_sibling_registrations.accepted.empty?
   end
 
-  def series_sibling_registrations(registration_status = nil)
+  def series_sibling_registrations
     return [] unless competition.part_of_competition_series?
 
-    sibling_ids = competition.series_sibling_competitions.map(&:id)
-
-    sibling_registrations = user.registrations
-                                .where(competition_id: sibling_ids)
-
-    if registration_status.nil?
-      return sibling_registrations
-             .joins(:competition)
-             .order(:start_date)
-    end
-
-    # this relies on the scopes being named the same as `checked_status` but it is a significant performance improvement
-    sibling_registrations.send(registration_status)
-  end
-
-  SERIES_SIBLING_DISPLAY_STATUSES = [:accepted, :pending].freeze
-
-  def series_registration_info
-    SERIES_SIBLING_DISPLAY_STATUSES.map { |st| series_sibling_registrations(st) }
-                                   .map(&:count)
-                                   .join(" + ")
+    competition.series_sibling_registrations
+               .where(user_id: self.user_id)
   end
 
   def ensure_waitlist_eligibility!

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -33,7 +33,7 @@ class Registration < ApplicationRecord
     cancelled: Registrations::Helper::STATUS_CANCELLED,
     rejected: Registrations::Helper::STATUS_REJECTED,
     waiting_list: Registrations::Helper::STATUS_WAITING_LIST,
-  }, prefix: true
+  }, prefix: true, validate: true
 
   serialize :roles, coder: YAML
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -413,8 +413,7 @@ class Registration < ApplicationRecord
     :trying_to_accept?,
     :competitor_limit_enabled?,
     :enforce_newcomer_month_reservations?,
-    :newcomer_month_eligible?,
-  ]
+  ], unless: :newcomer_month_eligible?
 
   private def cannot_exceed_newcomer_limit
     available_spots = competition.competitor_limit - competition.registrations.accepted_and_competing_count

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -453,7 +453,7 @@ class Registration < ApplicationRecord
     )
   end
 
-  delegate :part_of_competition_series?, to: :competition
+  delegate :part_of_competition_series?, to: :competition, allow_nil: true
 
   def series_sibling_registrations
     return [] unless part_of_competition_series?
@@ -471,9 +471,9 @@ class Registration < ApplicationRecord
     competing_status_changed? && (competing_status_cancelled? || competing_status_rejected?)
   end
 
-  validate :not_changing_when_cancelling, if: [:trying_to_cancel?, :competition_events_changed?]
-  private def not_changing_when_cancelling
-    errors.add(:competition_events, :cannot_change_when_cancelling, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA)
+  validate :not_changing_events_when_cancelling, if: [:trying_to_cancel?, :competition_events_changed?], unless: :new_record?
+  private def not_changing_events_when_cancelling
+    errors.add(:competition_events, :cannot_change_when_cancelling, message: I18n.t('registrations.errors.cannot_change_events_when_cancelling'), frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA)
   end
 
   attr_writer :tracked_event_ids

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -34,7 +34,7 @@ class Registration < ApplicationRecord
     cancelled: Registrations::Helper::STATUS_CANCELLED,
     rejected: Registrations::Helper::STATUS_REJECTED,
     waiting_list: Registrations::Helper::STATUS_WAITING_LIST,
-  }, prefix: true, validate: true
+  }, prefix: true, validate: { frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
   serialize :roles, coder: YAML
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1136,6 +1136,7 @@ en:
       undelete_banned: "is a banned competitor and cannot be undeleted"
       series_more_than_one_accepted: "You can only be accepted for one Series competition at a time."
       can_only_register_for_qualified_events: "You cannot register for events you are not qualified for."
+      cannot_change_events_when_cancelling: "You cannot change your events while cancelling your registration."
       cannot_register_without_comment: "You must make a comment. Please read the Registration Requirements above to see what must be included (e.g. in an FMC simultaneous competition, which location you will compete at)."
     registration_info_people:
       #context: pluralization of "x first-timer(s)"

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -143,14 +143,8 @@ module Registrations
         competition = registration.competition
         target_user = registration.user
 
-        new_status = registration.competing_status
-
         process_validation_error!(registration, :competing_status)
         process_validation_error!(registration, :competition_id)
-
-        return unless new_status == Registrations::Helper::STATUS_ACCEPTED && competition.competitor_limit_enabled?
-        raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED) if
-          competition.registrations.accepted_and_competing_count >= competition.competitor_limit
 
         return unless competition.enforce_newcomer_month_reservations? && !target_user.newcomer_month_eligible?
 

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -140,22 +140,8 @@ module Registrations
       end
 
       def validate_status_value!(registration)
-        competition = registration.competition
-        target_user = registration.user
-
         process_validation_error!(registration, :competing_status)
         process_validation_error!(registration, :competition_id)
-
-        return unless competition.enforce_newcomer_month_reservations? && !target_user.newcomer_month_eligible?
-
-        available_spots = competition.competitor_limit - competition.registrations.competing_status_accepted.count
-
-        # There are a limited number of "reserved" spots for newcomer_month_eligible competitions
-        # We know that there are _some_ available_spots in the comp available, because we passed the competitor_limit check above
-        # However, we still don't know how many of the reserved spots have been taken up by newcomers, versus how many "general" spots are left
-        # For a non-newcomer to be accepted, there need to be more spots available than spots still reserved for newcomers
-        raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::NO_UNRESERVED_SPOTS_REMAINING) unless
-          available_spots > competition.newcomer_month_reserved_spots_remaining
       end
 
       def validate_user_permissions!(persisted_registration, updated_registration)

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -142,9 +142,7 @@ module Registrations
         target_user = registration.user
 
         process_validation_error!(registration, :competing_status)
-
-        raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
-          new_status == Registrations::Helper::STATUS_ACCEPTED && existing_registration_in_series?(registration)
+        process_validation_error!(registration, :competition_id)
 
         return unless new_status == Registrations::Helper::STATUS_ACCEPTED && competition.competitor_limit_enabled?
         raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED) if
@@ -166,10 +164,6 @@ module Registrations
         # Users aren't allowed to change events when cancelling
         raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_REQUEST_DATA) if
           updated_registration.volatile_event_ids != persisted_registration.event_ids
-      end
-
-      def existing_registration_in_series?(registration)
-        registration.part_of_competition_series? && registration.series_sibling_registrations.might_attend.any?
       end
     end
   end

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -132,15 +132,17 @@ module Registrations
 
       def validate_update_status!(new_status, current_user, persisted_registration, updated_registration)
         competition = persisted_registration.competition
-        target_user = persisted_registration.user
 
-        validate_status_value!(new_status, competition, target_user)
+        validate_status_value!(new_status, updated_registration)
         validate_user_permissions!(persisted_registration, updated_registration) unless current_user.can_manage_competition?(competition)
       end
 
-      def validate_status_value!(new_status, competition, target_user)
-        raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_REQUEST_DATA) unless
-          Registration.competing_statuses.include?(new_status)
+      def validate_status_value!(new_status, registration)
+        competition = registration.competition
+        target_user = registration.user
+
+        process_validation_error!(registration, :competing_status)
+
         raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
           new_status == Registrations::Helper::STATUS_ACCEPTED && existing_registration_in_series?(competition, target_user)
 

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -21,6 +21,7 @@ module Registrations
         # Since even deep cloning does not take care of associations, we must fall back to the original registration.
         #   Otherwise, every payload that does not specify `event_ids` would trigger "must register for >= 1 event"
         desired_events = competing_payload&.dig('event_ids') || registration.event_ids
+        new_registration.tracked_event_ids = registration.event_ids
 
         competition_events_lookup = registration.competition.competition_events.where(event_id: desired_events).index_by(&:event_id)
         competition_events = desired_events.map { competition_events_lookup[it]&.deep_dup }
@@ -64,6 +65,7 @@ module Registrations
       def validate_registration_events!(registration)
         process_nested_validation_error!(registration, :registration_competition_events, :competition_event) { it.event_id }
         process_validation_error!(registration, :registration_competition_events)
+        process_validation_error!(registration, :competition_events)
       end
 
       def process_validation_error!(registration, field)

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1181,7 +1181,7 @@ RSpec.describe Registrations::RegistrationChecker do
           Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg, User.find(update_request['submitted_by']))
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED)
-          expect(error.status).to eq(:forbidden)
+          expect(error.status).to eq(:unprocessable_entity)
         end
       end
 
@@ -2036,7 +2036,7 @@ RSpec.describe Registrations::RegistrationChecker do
             Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg, User.find(update_request['submitted_by']))
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::NO_UNRESERVED_SPOTS_REMAINING)
-            expect(error.status).to eq(:forbidden)
+            expect(error.status).to eq(:unprocessable_entity)
           end
         end
 
@@ -2152,7 +2152,7 @@ RSpec.describe Registrations::RegistrationChecker do
           Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg, User.find(update_request['submitted_by']))
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::NO_UNRESERVED_SPOTS_REMAINING)
-          expect(error.status).to eq(:forbidden)
+          expect(error.status).to eq(:unprocessable_entity)
         end
       end
     end

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1167,7 +1167,7 @@ RSpec.describe Registrations::RegistrationChecker do
       it 'organizer cant accept a user when registration list is over full' do
         competitor_limit = FactoryBot.create(:competition, :with_competitor_limit, :with_organizer, competitor_limit: 3)
         limited_reg = FactoryBot.create(:registration, competition: competitor_limit)
-        FactoryBot.create_list(:registration, 4, :accepted, competition: competitor_limit)
+        FactoryBot.create_list(:registration, 4, :accepted, :skip_validations, competition: competitor_limit)
 
         update_request = FactoryBot.build(
           :update_request,

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1160,7 +1160,7 @@ RSpec.describe Registrations::RegistrationChecker do
           Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg, User.find(update_request['submitted_by']))
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED)
-          expect(error.status).to eq(:forbidden)
+          expect(error.status).to eq(:unprocessable_entity)
         end
       end
 
@@ -1993,7 +1993,7 @@ RSpec.describe Registrations::RegistrationChecker do
           Registrations::RegistrationChecker.update_registration_allowed!(update_request, registrationB, User.find(update_request['submitted_by']))
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES)
-          expect(error.status).to eq(:forbidden)
+          expect(error.status).to eq(:unprocessable_entity)
         end
       end
 
@@ -2132,7 +2132,7 @@ RSpec.describe Registrations::RegistrationChecker do
           Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_reg, User.find(update_request['submitted_by']))
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED)
-          expect(error.status).to eq(:forbidden)
+          expect(error.status).to eq(:unprocessable_entity)
         end
       end
 

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -617,7 +617,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.not_to raise_error
 
         # We never actually fired the update, we just checked whether it _would_ be permissible to do so
@@ -634,7 +634,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'comment' => 'new comment' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -650,7 +650,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::USER_COMMENT_TOO_LONG)
@@ -668,7 +668,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'comment' => at_character_limit },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -680,7 +680,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'comment' => '' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -696,7 +696,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::REQUIRED_COMMENT_MISSING)
@@ -713,7 +713,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: registration.user_id,
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
 
@@ -731,7 +731,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'status' => 'accepted' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
 
@@ -746,7 +746,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'comment' => 'heres a random different comment' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
 
@@ -763,7 +763,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::USER_COMMENT_TOO_LONG)
@@ -781,7 +781,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'organizer_comment' => 'this is an admin comment' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -798,7 +798,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'organizer_comment' => 'this is an admin comment' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
     end
@@ -817,7 +817,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::USER_COMMENT_TOO_LONG)
@@ -836,7 +836,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'organizer_comment' => at_character_limit },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
     end
@@ -850,7 +850,7 @@ RSpec.describe Registrations::RegistrationChecker do
           guests: 4,
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -866,7 +866,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::GUEST_LIMIT_EXCEEDED)
           expect(error.status).to eq(:unprocessable_entity)
@@ -885,7 +885,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration)
         }.not_to raise_error
       end
 
@@ -900,7 +900,7 @@ RSpec.describe Registrations::RegistrationChecker do
           guests: 0,
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
 
@@ -916,7 +916,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_REQUEST_DATA)
@@ -931,7 +931,7 @@ RSpec.describe Registrations::RegistrationChecker do
           guests: 99,
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -944,7 +944,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::UNREASONABLE_GUEST_COUNT)
@@ -960,7 +960,7 @@ RSpec.describe Registrations::RegistrationChecker do
           guests: 5,
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -976,7 +976,7 @@ RSpec.describe Registrations::RegistrationChecker do
           guests: 5,
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
     end
@@ -999,7 +999,7 @@ RSpec.describe Registrations::RegistrationChecker do
             competing: { 'status' => 'cancelled' },
           )
 
-          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_accepted_reg, User.find(update_request['submitted_by'])) }
+          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_accepted_reg) }
             .not_to raise_error
         end
 
@@ -1014,7 +1014,7 @@ RSpec.describe Registrations::RegistrationChecker do
             submitted_by: not_accepted_reg.competition.organizers.first.id,
           )
 
-          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_accepted_reg, User.find(update_request['submitted_by'])) }
+          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_accepted_reg) }
             .not_to raise_error
         end
       end
@@ -1036,7 +1036,7 @@ RSpec.describe Registrations::RegistrationChecker do
             competing: { 'status' => 'cancelled' },
           )
 
-          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_paid_reg, User.find(update_request['submitted_by'])) }
+          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_paid_reg) }
             .not_to raise_error
         end
 
@@ -1051,7 +1051,7 @@ RSpec.describe Registrations::RegistrationChecker do
             submitted_by: not_paid_reg.competition.organizers.first.id,
           )
 
-          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_paid_reg, User.find(update_request['submitted_by'])) }
+          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, not_paid_reg) }
             .not_to raise_error
         end
       end
@@ -1065,7 +1065,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_REQUEST_DATA)
@@ -1082,7 +1082,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_REQUEST_DATA)
@@ -1101,7 +1101,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'status' => 'accepted' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
 
@@ -1120,7 +1120,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg)
         }.not_to raise_error
       end
 
@@ -1139,7 +1139,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg)
         }.not_to raise_error
       end
 
@@ -1157,7 +1157,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED)
           expect(error.status).to eq(:unprocessable_entity)
@@ -1178,7 +1178,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED)
           expect(error.status).to eq(:unprocessable_entity)
@@ -1198,7 +1198,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'status' => 'accepted' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_reg) }
           .not_to raise_error
       end
 
@@ -1210,7 +1210,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'status' => 'cancelled' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -1223,7 +1223,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_REQUEST_DATA)
@@ -1241,7 +1241,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'status' => 'pending' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, cancelled_reg, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, cancelled_reg) }
           .not_to raise_error
       end
 
@@ -1259,7 +1259,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'status' => 'cancelled' },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
           .not_to raise_error
       end
 
@@ -1275,7 +1275,7 @@ RSpec.describe Registrations::RegistrationChecker do
             submitted_by: default_competition.organizers.first.id,
           )
 
-          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
             .not_to raise_error
         end
 
@@ -1291,7 +1291,7 @@ RSpec.describe Registrations::RegistrationChecker do
             submitted_by: admin.id,
           )
 
-          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
             .not_to raise_error
         end
 
@@ -1307,7 +1307,7 @@ RSpec.describe Registrations::RegistrationChecker do
             submitted_by: competition.organizers.first.id,
           )
 
-          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration, User.find(update_request['submitted_by'])) }
+          expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
             .not_to raise_error
         end
       end
@@ -1354,7 +1354,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'event_ids' => ['333', '444', '555', 'minx'] },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -1366,7 +1366,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'event_ids' => ['333'] },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -1378,7 +1378,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'event_ids' => ['pyram', 'minx'] },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -1391,7 +1391,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_EVENT_SELECTION)
@@ -1407,7 +1407,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_EVENT_SELECTION)
@@ -1423,7 +1423,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_EVENT_SELECTION)
@@ -1439,7 +1439,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'event_ids' => ['333', '555'] },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
@@ -1453,7 +1453,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_EVENT_SELECTION)
@@ -1468,7 +1468,7 @@ RSpec.describe Registrations::RegistrationChecker do
           competing: { 'event_ids' => ['333', '333oh', '555', 'pyram', 'minx'] },
         )
 
-        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_registration, User.find(update_request['submitted_by'])) }
+        expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_registration) }
           .not_to raise_error
       end
 
@@ -1481,7 +1481,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, limited_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_EVENT_SELECTION)
@@ -1499,7 +1499,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, organizer_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, organizer_reg)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_EVENT_SELECTION)
@@ -1525,7 +1525,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.not_to raise_error
       end
 
@@ -1539,7 +1539,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION)
@@ -1556,7 +1556,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.not_to raise_error
       end
 
@@ -1570,7 +1570,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION)
@@ -1587,7 +1587,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:forbidden)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION)
@@ -1604,7 +1604,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:forbidden)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION)
@@ -1621,7 +1621,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_REQUEST_DATA)
@@ -1675,7 +1675,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, easy_registration_with_results_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, easy_registration_with_results_reg)
         }.not_to raise_error
       end
 
@@ -1707,7 +1707,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_for_unenforced_hard_quali, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_for_unenforced_hard_quali)
           }.not_to raise_error
         end
 
@@ -1720,7 +1720,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_no_results_for_unenforced_hard_quali, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_no_results_for_unenforced_hard_quali)
           }.not_to raise_error
         end
 
@@ -1733,7 +1733,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_for_unenforced_easy_quali, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_for_unenforced_easy_quali)
           }.not_to raise_error
         end
       end
@@ -1769,7 +1769,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_easy_quali, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_easy_quali)
           }.not_to raise_error
         end
 
@@ -1782,7 +1782,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_future_easy_quali, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, reg_with_results_future_easy_quali)
           }.not_to raise_error
         end
       end
@@ -1824,7 +1824,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, user_with_results_registering_for_past, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, user_with_results_registering_for_past)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::QUALIFICATION_NOT_MET)
             expect(error.status).to eq(:unprocessable_entity)
@@ -1841,7 +1841,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, user_without_results_easy_quali, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, user_without_results_easy_quali)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::QUALIFICATION_NOT_MET)
             expect(error.status).to eq(:unprocessable_entity)
@@ -1858,7 +1858,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, user_with_dnfs_easy_quali, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, user_with_dnfs_easy_quali)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::QUALIFICATION_NOT_MET)
             expect(error.status).to eq(:unprocessable_entity)
@@ -1890,7 +1890,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_single_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_single_reg)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::QUALIFICATION_NOT_MET)
             expect(error.status).to eq(:unprocessable_entity)
@@ -1911,7 +1911,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_single_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_single_reg)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::QUALIFICATION_NOT_MET)
             expect(error.status).to eq(:unprocessable_entity)
@@ -1932,7 +1932,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_average_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_average_reg)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::QUALIFICATION_NOT_MET)
             expect(error.status).to eq(:unprocessable_entity)
@@ -1953,7 +1953,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_average_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, slow_average_reg)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::QUALIFICATION_NOT_MET)
             expect(error.status).to eq(:unprocessable_entity)
@@ -1990,7 +1990,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registrationB, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registrationB)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES)
           expect(error.status).to eq(:unprocessable_entity)
@@ -2007,7 +2007,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registrationB, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registrationB)
         }.not_to raise_error
       end
     end
@@ -2033,7 +2033,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg)
           }.to raise_error(WcaExceptions::RegistrationError) do |error|
             expect(error.error).to eq(Registrations::ErrorCodes::NO_UNRESERVED_SPOTS_REMAINING)
             expect(error.status).to eq(:unprocessable_entity)
@@ -2050,7 +2050,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_reg)
           }.not_to raise_error
         end
 
@@ -2064,7 +2064,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_month_eligible_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_month_eligible_reg)
           }.not_to raise_error
         end
       end
@@ -2084,7 +2084,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_reg)
           }.not_to raise_error
         end
 
@@ -2098,7 +2098,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_month_eligible_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_month_eligible_reg)
           }.not_to raise_error
         end
 
@@ -2112,7 +2112,7 @@ RSpec.describe Registrations::RegistrationChecker do
           )
 
           expect {
-            Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg, User.find(update_request['submitted_by']))
+            Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg)
           }.not_to raise_error
         end
       end
@@ -2129,7 +2129,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, newcomer_reg)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::COMPETITOR_LIMIT_REACHED)
           expect(error.status).to eq(:unprocessable_entity)
@@ -2149,7 +2149,7 @@ RSpec.describe Registrations::RegistrationChecker do
         )
 
         expect {
-          Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg, User.find(update_request['submitted_by']))
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, non_newcomer_reg)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
           expect(error.error).to eq(Registrations::ErrorCodes::NO_UNRESERVED_SPOTS_REMAINING)
           expect(error.status).to eq(:unprocessable_entity)


### PR DESCRIPTION
Part of our fast-paced effort to get rid of (the essence of) `registration_checker`.
Adds validations for competitor limit, newcomer spots, series registrations. But only triggers those if you're setting the status to `accepted`.

The series registration check was historically appended under `competition_id`, but I think we should change it to `competing_status`. You are allowed to _register_ for multiple competitions in a Series after all. You're just not allowed to be _accepted_ for more than one at a time. So the competing status is what breaks the camels neck, while the competition that you're trying to be accepted for is legit in itself.