### PR TITLE
Add semicolon to venue notes row

### DIFF
--- a/app/views/delegate_reports/working_group_2024/_venue_default.md
+++ b/app/views/delegate_reports/working_group_2024/_venue_default.md
@@ -7,6 +7,6 @@ Gen 5 Timers:
 Speed Stacks Displays:
 QiYi Displays:
 
-* **Venue notes** [Type of venue used, were any complaints made about aspects of the venue such as lighting or temperature, was there anything noteworthy or unique about the venue?]
+* **Venue notes:** [Type of venue used, were any complaints made about aspects of the venue such as lighting or temperature, was there anything noteworthy or unique about the venue?]
 
 * **Setup:** [Please write a brief description of the competition set up. Photo(s) of the scrambling area and competition setup are to be uploaded using the upload button below.]


### PR DESCRIPTION
Just a missing semicolon in the delegate report template.