### PR TITLE
Move waiting list position validations to Rails model

### DIFF
--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -41,19 +41,13 @@ module Waitlistable
       should_move = self.waitlistable? && self.waiting_list_position?
       should_remove = !self.waitlistable? && self.waiting_list_position?
 
-      self.waiting_list.add(self.waitlistable_id) if should_add
-      self.waiting_list.move_to_position(self.waitlistable_id, @waiting_list_position) if should_move
-      self.waiting_list.remove(self.waitlistable_id) if should_remove
+      self.waiting_list.add(self) if should_add
+      self.waiting_list.move_to_position(self, @waiting_list_position) if should_move
+      self.waiting_list.remove(self) if should_remove
     end
 
     def clear_waitlist_position
       self.waiting_list_position = nil
-    end
-
-    # Tells the waitlist entity what ID to waitlist by.
-    #   For most objects, this should be `id` by default.
-    def waitlistable_id
-      self.id
     end
 
     # Tells the hooks whether the current entity
@@ -63,7 +57,7 @@ module Waitlistable
     end
 
     def waiting_list_position
-      @waiting_list_position ||= self.waiting_list&.position(self.waitlistable_id)
+      @waiting_list_position ||= self.waiting_list&.position(self)
     end
   end
 end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -28,6 +28,8 @@ module Waitlistable
       unless: :waiting_list_empty?,
     }
 
+    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+
     def waiting_list_position?
       @waiting_list_position.present?
     end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -34,7 +34,8 @@ module Waitlistable
       @waiting_list_position.present?
     end
 
-    after_save :commit_waitlist_position
+    # TODO: V3-REG cleanup: Enable this hook so that we can actually have the updating function for free
+    # after_save :commit_waitlist_position
 
     def commit_waitlist_position
       should_add = self.waitlistable? && !self.waiting_list_position?

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -8,6 +8,8 @@ module Waitlistable
   included do
     attr_writer :waiting_list_position
 
+    validates :waiting_list_position, numericality: { only_integer: true, allow_nil: true, frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION }
+
     def waiting_list_position?
       @waiting_list_position.present?
     end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module Waitlistable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :new_waitlist_position
+
+    def new_waitlist_position?
+      self.new_waitlist_position.present?
+    end
+
+    after_commit :clear_waitlist_position, on: :save
+
+    def clear_waitlist_position
+      self.new_waitlist_position = nil
+    end
+
+    # Tells the waitlist entity what ID to waitlist by.
+    #   For most objects, this should be `id` by default.
+    def waitlistable_id
+      self.id
+    end
+
+    # Tells the hooks whether the current entity
+    #   can be put on the waitlist in the first place.
+    def waitlistable?
+      true
+    end
+
+    def waiting_list_position
+      self.waiting_list.position(self.waitlistable_id)
+    end
+  end
+end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -13,16 +13,19 @@ module Waitlistable
     validates :waiting_list_position, numericality: {
       only_integer: true,
       greater_than_or_equal_to: 1,
+      allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
       if: :waitlistable?,
     }
     validates :waiting_list_position, numericality: {
       equal_to: 1,
+      allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
       if: [:waitlistable?, :waiting_list_empty?],
     }
     validates :waiting_list_position, numericality: {
       less_than_or_equal_to: :waiting_list_length,
+      allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
       if: :waitlistable?,
       unless: :waiting_list_empty?,

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -46,7 +46,7 @@ module Waitlistable
       should_remove = !self.waitlistable? && self.waiting_list_position?
 
       self.waiting_list.add(self) if should_add
-      self.waiting_list.move_to_position(self, @waiting_list_position) if should_move
+      self.waiting_list.move_to_position(self, self.waiting_list_position) if should_move
       self.waiting_list.remove(self) if should_remove
     end
 

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -51,7 +51,7 @@ module Waitlistable
     end
 
     def clear_waitlist_position
-      self.waiting_list_position = nil
+      @waiting_list_position = nil
     end
 
     # Tells the hooks whether the current entity

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -29,6 +29,7 @@ class Registration < ApplicationRecord
   has_many :assignments, as: :registration, dependent: :delete_all
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
   has_many :payment_intents, as: :holder, dependent: :delete_all
+  has_one :waiting_list, through: :competition
 
   enum :competing_status, {
     pending: Registrations::Helper::STATUS_PENDING,

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -29,7 +29,6 @@ class Registration < ApplicationRecord
   has_many :assignments, as: :registration, dependent: :delete_all
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
   has_many :payment_intents, as: :holder, dependent: :delete_all
-  has_one :waiting_list, through: :competition
 
   enum :competing_status, {
     pending: Registrations::Helper::STATUS_PENDING,
@@ -98,6 +97,12 @@ class Registration < ApplicationRecord
   def waitlisted?
     competing_status_waiting_list?
   end
+
+  # Can NOT use a `has_one :waiting_list, through: :competition` association here, because
+  #   that would screw us over with caching. Unfortunately, even `through` associations cache themselves
+  #   so every registration of a competition then effectively has "its own" waiting list.
+  #   (We might want to revisit this decision when we switch to hook-based committing in waitlistable.rb)
+  delegate :waiting_list, to: :competition, allow_nil: true
 
   def waitlistable?
     waitlisted?

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Registration < ApplicationRecord
+  include Waitlistable
+
   COMMENT_CHARACTER_LIMIT = 240
   DEFAULT_GUEST_LIMIT = 99
 
@@ -94,6 +96,10 @@ class Registration < ApplicationRecord
 
   def waitlisted?
     competing_status_waiting_list?
+  end
+
+  def waitlistable?
+    waitlisted?
   end
 
   def accepted?
@@ -208,10 +214,6 @@ class Registration < ApplicationRecord
     end
   end
 
-  def waiting_list_position
-    competition.waiting_list.position(self)
-  end
-
   def wcif_status
     # Non-competing staff are treated as accepted.
     # TODO: WCIF spec needs to be updated - and possibly versioned - to include new statuses
@@ -274,7 +276,7 @@ class Registration < ApplicationRecord
                                 admin_comment: administrative_notes|| "",
                               },
                             })
-      base_json[:competing][:waiting_list_position] = waiting_list_position if competing_status == "waiting_list"
+      base_json[:competing][:waiting_list_position] = waiting_list_position if competing_status_waiting_list?
     end
     if history
       base_json.deep_merge!({

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -3,34 +3,33 @@
 class WaitingList < ApplicationRecord
   belongs_to :holder, polymorphic: true
 
-  def remove(entry)
-    update_column :entries, entries - [entry.id]
+  def remove(entry_id)
+    update_column :entries, entries - [entry_id]
   end
 
-  def add(entry)
-    entry.try(:ensure_waitlist_eligibility!) # raises an error if not waitlistable
-    return if entries.include?(entry.id)
+  def add(entry_id)
+    return if entries.include?(entry_id)
 
     if entries.nil?
-      update_column :entries, [entry.id]
+      update_column :entries, [entry_id]
     else
-      update_column :entries, entries + [entry.id]
+      update_column :entries, entries + [entry_id]
     end
   end
 
-  def move_to_position(entry, new_position)
+  def move_to_position(entry_id, new_position)
     raise ArgumentError.new('Target position out of waiting list range') if new_position > entries.length || new_position < 1
 
-    old_index = entries.find_index(entry.id)
-    return if old_index == new_position-1
+    old_index = entries.find_index(entry_id)
+    return if old_index == new_position - 1
 
-    update_column :entries, entries.insert(new_position-1, entries.delete_at(old_index))
+    update_column :entries, entries.insert(new_position - 1, entries.delete_at(old_index))
   end
 
   # This is the position from the user/organizers perspective - ie, we start counting at 1
-  def position(entry)
-    return nil unless entries.include?(entry.id)
+  def position(entry_id)
+    return nil unless entries.include?(entry_id)
 
-    entries.index(entry.id) + 1
+    entries.index(entry_id) + 1
   end
 end

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -3,6 +3,8 @@
 class WaitingList < ApplicationRecord
   belongs_to :holder, polymorphic: true
 
+  delegate :empty?, :length, to: :entries
+
   def remove(entry_id)
     update_column :entries, entries - [entry_id]
   end

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -5,33 +5,34 @@ class WaitingList < ApplicationRecord
 
   delegate :empty?, :length, to: :entries
 
-  def remove(entry_id)
-    update_column :entries, entries - [entry_id]
+  def remove(entry)
+    update_column :entries, entries - [entry.id]
   end
 
-  def add(entry_id)
-    return if entries.include?(entry_id)
+  def add(entry)
+    entry.try(:ensure_waitlist_eligibility!) # raises an error if not waitlistable
+    return if entries.include?(entry.id)
 
     if entries.nil?
-      update_column :entries, [entry_id]
+      update_column :entries, [entry.id]
     else
-      update_column :entries, entries + [entry_id]
+      update_column :entries, entries + [entry.id]
     end
   end
 
-  def move_to_position(entry_id, new_position)
+  def move_to_position(entry, new_position)
     raise ArgumentError.new('Target position out of waiting list range') if new_position > entries.length || new_position < 1
 
-    old_index = entries.find_index(entry_id)
+    old_index = entries.find_index(entry.id)
     return if old_index == new_position - 1
 
     update_column :entries, entries.insert(new_position - 1, entries.delete_at(old_index))
   end
 
   # This is the position from the user/organizers perspective - ie, we start counting at 1
-  def position(entry_id)
-    return nil unless entries.include?(entry_id)
+  def position(entry)
+    return nil unless entries.include?(entry.id)
 
-    entries.index(entry_id) + 1
+    entries.index(entry.id) + 1
   end
 end

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -113,6 +113,7 @@ module Registrations
 
       def validate_waiting_list_position!(registration)
         process_validation_error!(registration, :waiting_list_position)
+        process_validation_error!(registration, :waitlistable?)
       end
 
       def validate_status_value!(registration)

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -13,10 +13,12 @@ module Registrations
         comment = competing_payload&.dig('comment')
         organizer_comment = competing_payload&.dig('organizer_comment')
         competing_status = competing_payload&.dig('status')
+        waiting_list_position = competing_payload&.dig('waiting_list_position')
 
         new_registration.comments = comment if competing_payload&.key?('comment')
         new_registration.administrative_notes = organizer_comment if competing_payload&.key?('organizer_comment')
         new_registration.competing_status = competing_status if competing_payload&.key?('status')
+        new_registration.waiting_list_position = waiting_list_position if competing_payload&.key?('waiting_list_position')
 
         # Since even deep cloning does not take care of associations, we must fall back to the original registration.
         #   Otherwise, every payload that does not specify `event_ids` would trigger "must register for >= 1 event"
@@ -42,8 +44,6 @@ module Registrations
     end
 
     def self.update_registration_allowed!(update_request, registration)
-      waiting_list_position = update_request.dig('competing', 'waiting_list_position')
-
       updated_registration = self.apply_payload(registration, update_request)
 
       # Migrated to ActiveRecord-style validations
@@ -52,9 +52,7 @@ module Registrations
       validate_organizer_comment!(updated_registration)
       validate_registration_events!(updated_registration)
       validate_status_value!(updated_registration)
-
-      # Old-style validations within this class
-      validate_waiting_list_position!(updated_registration) unless waiting_list_position.nil?
+      validate_waiting_list_position!(updated_registration)
     end
 
     class << self
@@ -114,9 +112,7 @@ module Registrations
       end
 
       def validate_waiting_list_position!(registration)
-        # User must be on the wating list
-        raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_REQUEST_DATA) unless
-         registration.competing_status == Registrations::Helper::STATUS_WAITING_LIST
+        process_validation_error!(registration, :waiting_list_position)
       end
 
       def validate_status_value!(registration)

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -120,12 +120,8 @@ module Registrations
         raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_REQUEST_DATA) unless
          updated_registration.competing_status == Registrations::Helper::STATUS_WAITING_LIST
 
-        # Floats are not allowed
-        raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION) if waiting_list_position.is_a? Float
-
         # We convert strings to integers and then check if they are an integer
-        converted_position = Integer(waiting_list_position, exception: false)
-        raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION) unless converted_position.is_a? Integer
+        converted_position = waiting_list_position.to_i
 
         waiting_list = competition.waiting_list.entries
         raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION) if waiting_list.empty? && converted_position != 1

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1589,7 +1589,7 @@ RSpec.describe Registrations::RegistrationChecker do
         expect {
           Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
-          expect(error.status).to eq(:forbidden)
+          expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION)
         end
       end
@@ -1606,7 +1606,7 @@ RSpec.describe Registrations::RegistrationChecker do
         expect {
           Registrations::RegistrationChecker.update_registration_allowed!(update_request, waitlisted_registration)
         }.to raise_error(WcaExceptions::RegistrationError) do |error|
-          expect(error.status).to eq(:forbidden)
+          expect(error.status).to eq(:unprocessable_entity)
           expect(error.error).to eq(Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION)
         end
       end


### PR DESCRIPTION
Introduces a new `Waitlistable` trait that manages the validations. Should play nicely with our generic approach to waiting lists.

The hook should be able to do the waiting list management in an easy `after_save` hook as well, but I disabled that one for now so that we don't introduce too many changes in one PR.

But in theory, this could even replace the `try(:ensure_waitlist_eligibility)` approach from #10241 by using some form of `def waitlistable_id` and passing that directly to the waiting list interface.