### PR TITLE
Move validate status permission checks

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -23,7 +23,6 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   rescue_from WcaExceptions::RegistrationError do |e|
     # TODO: Figure out what the best way to log errors in development is
     Rails.logger.debug { "Create was rejected with error #{e.error} at #{e.backtrace[0]}" }
-    puts("Create was rejected with error #{e.error} at #{e.backtrace[0]}")
     render_error(e.status, e.error, e.data)
   end
 
@@ -111,6 +110,8 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
       existing_registration_in_series?(@competition, target_user) && !current_user.can_manage_competition?(@competition)
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_organizer_fields?(@request) && !@current_user.can_manage_competition?(@competition)
+
+    return if @current_user.can_manage_competition?(@competition)
 
     # A competitor (ie, these restrictions don't apply to organizers) is only allowed to:
     # 1. Reactivate their registration if they previously cancelled it (ie, change status from 'cancelled' to 'pending')

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -23,6 +23,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   rescue_from WcaExceptions::RegistrationError do |e|
     # TODO: Figure out what the best way to log errors in development is
     Rails.logger.debug { "Create was rejected with error #{e.error} at #{e.backtrace[0]}" }
+    puts("Create was rejected with error #{e.error} at #{e.backtrace[0]}")
     render_error(e.status, e.error, e.data)
   end
 
@@ -99,23 +100,28 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless
       can_administer_or_current_user?(@competition, @current_user, target_user)
+
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::USER_EDITS_NOT_ALLOWED) unless
       @competition.registration_edits_currently_permitted? || @current_user.can_manage_competition?(@competition) || user_uncancelling_registration?(@registration, new_status)
+
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::REGISTRATION_IS_REJECTED) if
       user_is_rejected?(@current_user, target_user, @registration) && !organizer_modifying_own_registration?(@competition, @current_user, target_user)
+
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
       existing_registration_in_series?(@competition, target_user) && !current_user.can_manage_competition?(@competition)
+
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_organizer_fields?(@request) && !@current_user.can_manage_competition?(@competition)
 
-    # A competitor (ie, these restrictions dont apply to organizers) is only allowed to:
+    # A competitor (ie, these restrictions don't apply to organizers) is only allowed to:
     # 1. Reactivate their registration if they previously cancelled it (ie, change status from 'cancelled' to 'pending')
     # 2. Cancel their registration, assuming they are allowed to cancel
 
     # User reactivating registration
     if new_status == Registrations::Helper::STATUS_PENDING
       raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @registration.cancelled?
+
       raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) if
-        @registration.cancelled? && !competition.registration_currently_open?
+        @registration.cancelled? && !@competition.registration_currently_open?
 
       return # No further checks needed if status is pending
     end

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -106,6 +106,27 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
       existing_registration_in_series?(@competition, target_user) && !current_user.can_manage_competition?(@competition)
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_organizer_fields?(@request) && !@current_user.can_manage_competition?(@competition)
+
+    # A competitor (ie, these restrictions dont apply to organizers) is only allowed to:
+    # 1. Reactivate their registration if they previously cancelled it (ie, change status from 'cancelled' to 'pending')
+    # 2. Cancel their registration, assuming they are allowed to cancel
+
+    # User reactivating registration
+    if new_status == Registrations::Helper::STATUS_PENDING
+      raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @registration.cancelled?
+      raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) if
+        @registration.cancelled? && !competition.registration_currently_open?
+
+      return # No further checks needed if status is pending
+    end
+
+    # Now that we've checked the 'pending' case, raise an error if the status is not cancelled (cancelling is the only valid action remaining)
+    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless
+      [Registrations::Helper::STATUS_DELETED, Registrations::Helper::STATUS_CANCELLED].include?(new_status)
+
+    # Raise an error if competition prevents users from cancelling a registration once it is accepted
+    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::ORGANIZER_MUST_CANCEL_REGISTRATION) unless
+      @registration.permit_user_cancellation?
   end
 
   def validate_update_request

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -111,7 +111,9 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_organizer_fields?(@request) && !@current_user.can_manage_competition?(@competition)
 
+    # The rest of these are status + normal user related
     return if @current_user.can_manage_competition?(@competition)
+    return if new_status.nil?
 
     # A competitor (ie, these restrictions don't apply to organizers) is only allowed to:
     # 1. Reactivate their registration if they previously cancelled it (ie, change status from 'cancelled' to 'pending')

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -135,7 +135,7 @@ module Registrations
         target_user = persisted_registration.user
 
         validate_status_value!(new_status, competition, target_user)
-        validate_user_permissions!(new_status, persisted_registration, updated_registration, competition) unless current_user.can_manage_competition?(competition)
+        validate_user_permissions!(persisted_registration, updated_registration) unless current_user.can_manage_competition?(competition)
       end
 
       def validate_status_value!(new_status, competition, target_user)

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -329,6 +329,16 @@ RSpec.describe 'API Registrations' do
     let(:user) { FactoryBot.create :user }
     let(:competition) { FactoryBot.create :competition, :registration_open, :editable_registrations, :with_organizer }
     let(:registration) { FactoryBot.create(:registration, competition: competition, user: user) }
+    let(:paid_cant_cancel) {
+      FactoryBot.create(
+        :competition, :registration_closed, :editable_registrations, :with_organizer, competitor_can_cancel: :unpaid
+      )
+    }
+    let(:accepted_cant_cancel) {
+      FactoryBot.create(
+        :competition, :registration_closed, :editable_registrations, :with_organizer, competitor_can_cancel: :not_accepted
+      )
+    }
 
     it 'updates a registration' do
       update_request = FactoryBot.build(
@@ -682,6 +692,131 @@ RSpec.describe 'API Registrations' do
 
       expect(response.body).to eq(error_json)
       expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'cancelled user cant re-register if registration is closed' do
+      closed_comp = FactoryBot.create(:competition, :registration_closed, :editable_registrations)
+      cancelled_reg = FactoryBot.create(:registration, :cancelled, competition: closed_comp)
+
+      update_request = FactoryBot.build(
+        :update_request,
+        user_id: cancelled_reg.user_id,
+        competition_id: cancelled_reg.competition_id,
+        competing: { 'status' => 'pending' },
+        )
+
+      headers = { 'Authorization' => update_request['jwt_token'] }
+
+      patch api_v1_registrations_register_path, params: update_request, headers: headers
+      error_json = {
+        error: Registrations::ErrorCodes::REGISTRATION_CLOSED,
+      }.to_json
+
+      expect(response.body).to eq(error_json)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'stops user cancelling fully paid registration' do
+      paid_reg = FactoryBot.create(:registration, :paid, competition: paid_cant_cancel)
+
+      update_request = FactoryBot.build(
+        :update_request,
+        user_id: paid_reg.user_id,
+        competition_id: paid_reg.competition_id,
+        competing: { 'status' => 'cancelled' },
+        )
+
+      headers = { 'Authorization' => update_request['jwt_token'] }
+
+      patch api_v1_registrations_register_path, params: update_request, headers: headers
+      error_json = {
+        error: Registrations::ErrorCodes::ORGANIZER_MUST_CANCEL_REGISTRATION,
+      }.to_json
+
+      expect(response.body).to eq(error_json)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'stops user cancelling partially paid registration' do
+      paid_reg = FactoryBot.create(:registration, :partially_paid, competition: paid_cant_cancel)
+
+      update_request = FactoryBot.build(
+        :update_request,
+        user_id: paid_reg.user_id,
+        competition_id: paid_reg.competition_id,
+        competing: { 'status' => 'cancelled' },
+        )
+      headers = { 'Authorization' => update_request['jwt_token'] }
+
+      patch api_v1_registrations_register_path, params: update_request, headers: headers
+      error_json = {
+        error: Registrations::ErrorCodes::ORGANIZER_MUST_CANCEL_REGISTRATION,
+      }.to_json
+
+      expect(response.body).to eq(error_json)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'stops accepted user from cancelling' do
+      accepted_reg = FactoryBot.create(:registration, :accepted, competition: accepted_cant_cancel)
+
+      update_request = FactoryBot.build(
+        :update_request,
+        user_id: accepted_reg.user_id,
+        competition_id: accepted_reg.competition_id,
+        competing: { 'status' => 'cancelled' },
+        )
+      headers = { 'Authorization' => update_request['jwt_token'] }
+
+      patch api_v1_registrations_register_path, params: update_request, headers: headers
+      error_json = {
+        error: Registrations::ErrorCodes::ORGANIZER_MUST_CANCEL_REGISTRATION,
+      }.to_json
+
+      expect(response.body).to eq(error_json)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    RSpec.shared_examples 'invalid user status updates' do |initial_status, new_status|
+      it "user cant change 'status' => #{initial_status} to: #{new_status}" do
+        registration = FactoryBot.create(:registration, initial_status, competition: competition)
+
+        update_request = FactoryBot.build(
+          :update_request,
+          user_id: registration.user_id,
+          competition_id: registration.competition_id,
+          competing: { 'status' => new_status },
+          )
+        headers = { 'Authorization' => update_request['jwt_token'] }
+
+        patch api_v1_registrations_register_path, params: update_request, headers: headers
+        error_json = {
+          error: Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS,
+        }.to_json
+
+        expect(response.body).to eq(error_json)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    [
+      { initial_status: :pending, new_status: 'accepted' },
+      { initial_status: :pending, new_status: 'waiting_list' },
+      { initial_status: :pending, new_status: 'pending' },
+      { initial_status: :pending, new_status: 'rejected' },
+      { initial_status: :waiting_list, new_status: 'pending' },
+      { initial_status: :waiting_list, new_status: 'waiting_list' },
+      { initial_status: :waiting_list, new_status: 'accepted' },
+      { initial_status: :waiting_list, new_status: 'rejected' },
+      { initial_status: :accepted, new_status: 'pending' },
+      { initial_status: :accepted, new_status: 'waiting_list' },
+      { initial_status: :accepted, new_status: 'accepted' },
+      { initial_status: :accepted, new_status: 'rejected' },
+      { initial_status: :cancelled, new_status: 'accepted' },
+      { initial_status: :cancelled, new_status: 'waiting_list' },
+      { initial_status: :cancelled, new_status: 'rejected' },
+    ].each do |params|
+      it_behaves_like 'invalid user status updates', params[:initial_status], params[:new_status]
     end
 
     RSpec.shared_examples 'user cant update rejected registration' do |initial_status, new_status|

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -703,7 +703,7 @@ RSpec.describe 'API Registrations' do
         user_id: cancelled_reg.user_id,
         competition_id: cancelled_reg.competition_id,
         competing: { 'status' => 'pending' },
-        )
+      )
 
       headers = { 'Authorization' => update_request['jwt_token'] }
 
@@ -724,7 +724,7 @@ RSpec.describe 'API Registrations' do
         user_id: paid_reg.user_id,
         competition_id: paid_reg.competition_id,
         competing: { 'status' => 'cancelled' },
-        )
+      )
 
       headers = { 'Authorization' => update_request['jwt_token'] }
 
@@ -745,7 +745,7 @@ RSpec.describe 'API Registrations' do
         user_id: paid_reg.user_id,
         competition_id: paid_reg.competition_id,
         competing: { 'status' => 'cancelled' },
-        )
+      )
       headers = { 'Authorization' => update_request['jwt_token'] }
 
       patch api_v1_registrations_register_path, params: update_request, headers: headers
@@ -765,7 +765,7 @@ RSpec.describe 'API Registrations' do
         user_id: accepted_reg.user_id,
         competition_id: accepted_reg.competition_id,
         competing: { 'status' => 'cancelled' },
-        )
+      )
       headers = { 'Authorization' => update_request['jwt_token'] }
 
       patch api_v1_registrations_register_path, params: update_request, headers: headers
@@ -786,7 +786,7 @@ RSpec.describe 'API Registrations' do
           user_id: registration.user_id,
           competition_id: registration.competition_id,
           competing: { 'status' => new_status },
-          )
+        )
         headers = { 'Authorization' => update_request['jwt_token'] }
 
         patch api_v1_registrations_register_path, params: update_request, headers: headers


### PR DESCRIPTION
There is still an issue because of 
```
# Now that we've checked the 'pending' case, raise an error if the status is not cancelled (cancelling is the only valid action remaining)
        raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless
          [Registrations::Helper::STATUS_DELETED, Registrations::Helper::STATUS_CANCELLED].include?(new_status)
```
I assume this is because this is now checked so early in the chain. Maybe @dunkOnIT knows what to do about that. Leaving in draft until tomorrows meeting
The 
```
        # Users aren't allowed to change events when cancelling
        raise WcaExceptions::RegistrationError.new(:unprocessable_entity, Registrations::ErrorCodes::INVALID_REQUEST_DATA) if
          updated_registration.volatile_event_ids != persisted_registration.event_ids

```
check also needs to go to model validations.