### PR TITLE
Removed default `0` value from refundPolicyPercent

### DIFF
--- a/app/webpacker/components/CompetitionForm/FormSections/RegistrationFees.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/RegistrationFees.js
@@ -53,7 +53,7 @@ export default function RegistrationFees() {
       </ConditionalSection>
       <InputCurrencyAmount id="guestEntryFee" currency={currency} />
       <InputBoolean id="donationsEnabled" />
-      <InputNumber id="refundPolicyPercent" min={0} max={100} step={1} defaultValue={0} required />
+      <InputNumber id="refundPolicyPercent" min={0} max={100} step={1} required />
       <InputDate id="refundPolicyLimitDate" dateTime required />
     </SubSection>
   );


### PR DESCRIPTION
Per discussion in Slack with Gregor, this will make the lives of delegates slightly-but-meaningfully less frustrating