### PR TITLE
Don't return null to the frontend for empty registration comment

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -276,8 +276,8 @@ class Registration < ApplicationRecord
                               competing: {
                                 registration_status: is_competing ? competing_status : 'non_competing',
                                 registered_on: registered_at,
-                                comment: comments,
-                                admin_comment: administrative_notes,
+                                comment: comments || "",
+                                admin_comment: administrative_notes|| "",
                               },
                             })
       base_json[:competing][:waiting_list_position] = waiting_list_position if competing_status == "waiting_list"


### PR DESCRIPTION
This causes issue when trying to sort the competitors in the admin page