### PR TITLE
Reuse registration payload writing logic in create/update steps

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -80,7 +80,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
   def update
     if params[:competing]
-      updated_registration = Registrations::Lanes::Competing.update!(params, @competition, @current_user.id)
+      updated_registration = Registrations::Lanes::Competing.update_raw!(params, @competition, @current_user.id)
       return render json: { status: 'ok', registration: updated_registration.to_v2_json(admin: true, history: true) }, status: :ok
     end
     render json: { status: 'bad request', message: 'You need to supply at least one lane' }, status: :bad_request
@@ -175,7 +175,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     updated_registrations = {}
 
     @update_requests.each do |update|
-      updated_registrations[update['user_id']] = Registrations::Lanes::Competing.update!(update, @competition, @current_user.id)
+      updated_registrations[update['user_id']] = Registrations::Lanes::Competing.update_raw!(update, @competition, @current_user.id)
     end
 
     render json: { status: 'ok', updated_registrations: updated_registrations }

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -78,11 +78,11 @@ module Waitlistable
       should_move = self.waitlistable? && target_position.present?
       should_remove = !self.waitlistable? && target_position.present?
 
-      self.waiting_list.add(self) if should_add
-      self.waiting_list.move_to_position(self, target_position) if should_move
-      self.waiting_list.remove(self) if should_remove
+      was_added = self.waiting_list.add(self) if should_add
+      was_moved = self.waiting_list.move_to_position(self, target_position) if should_move
+      was_removed = self.waiting_list.remove(self) if should_remove
 
-      nothing_happened = !should_add && !should_move && !should_remove
+      nothing_happened = !was_added && !was_moved && !was_removed
 
       # If there was no (reasonable) change to act on, then we don't want to track
       #   that the waiting list position actually changed.

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -67,7 +67,7 @@ module Waitlistable
     end
 
     def waiting_list_position=(target_position)
-      if waiting_list_persisted?
+      if self.persisted? && waiting_list_persisted?
         should_add = self.waitlistable? && target_position.nil?
         should_move = self.waitlistable? && target_position.present?
         should_remove = !self.waitlistable? && target_position.present?

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -32,8 +32,8 @@ module Waitlistable
       unless: :waiting_list_empty?,
     }
 
-    validates :waitlistable?, presence: { if: :waitlist_position_changed?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
-    validates :waiting_list_present?, presence: { if: :waitlist_position_changed?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
     after_save :commit_waitlist_position, if: :waiting_list_persisted?
 

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -81,6 +81,12 @@ module Waitlistable
       self.waiting_list.add(self) if should_add
       self.waiting_list.move_to_position(self, target_position) if should_move
       self.waiting_list.remove(self) if should_remove
+
+      nothing_happened = !should_add && !should_move && !should_remove
+
+      # If there was no (reasonable) change to act on, then we don't want to track
+      #   that the waiting list position actually changed.
+      self.clear_tracked_waitlist_position! if nothing_happened
     end
   end
 end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -11,20 +11,20 @@ module Waitlistable
 
     attr_accessor :tracked_waitlist_position
 
-    validates :waiting_list_position, numericality: {
+    validates :tracked_waiting_list_position, numericality: {
       only_integer: true,
       greater_than_or_equal_to: 1,
       allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
       if: :waitlistable?,
     }
-    validates :waiting_list_position, numericality: {
+    validates :tracked_waiting_list_position, numericality: {
       equal_to: 1,
       allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
       if: [:waitlistable?, :waiting_list_present?, :waiting_list_empty?],
     }
-    validates :waiting_list_position, numericality: {
+    validates :tracked_waiting_list_position, numericality: {
       less_than_or_equal_to: :waiting_list_length,
       allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
@@ -45,7 +45,7 @@ module Waitlistable
     after_commit :track_waitlist_position!
 
     private def track_waitlist_position!
-      @tracked_waiting_list_position = self.persisted_waiting_list_position
+      @tracked_waiting_list_position = self.waiting_list_position
     end
 
     # Tells the hooks whether the current entity
@@ -54,20 +54,20 @@ module Waitlistable
       false
     end
 
-    def persisted_waiting_list_position
+    def waiting_list_position
       self.waiting_list&.position(self)
     end
 
-    def waiting_list_position
-      @tracked_waiting_list_position || self.persisted_waiting_list_position
+    def tracked_waiting_list_position
+      @tracked_waiting_list_position || self.waiting_list_position
     end
 
     def waiting_list_position?
-      self.waiting_list_position.present?
+      self.tracked_waiting_list_position.present?
     end
 
     def waiting_list_position_changed?
-      @tracked_waiting_list_position != self.persisted_waiting_list_position
+      @tracked_waiting_list_position != self.waiting_list_position
     end
 
     def waiting_list_position=(target_position)

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -66,11 +66,9 @@ module Waitlistable
     end
 
     def waiting_list_position=(target_position)
-      if self.persisted? && waiting_list_persisted?
-        self.apply_to_waiting_list(target_position)
-      else
-        self.tracked_waitlist_position = target_position
-      end
+      self.tracked_waitlist_position = target_position
+
+      self.apply_to_waiting_list(target_position) if self.persisted? && waiting_list_persisted?
     end
 
     private def apply_to_waiting_list(target_position)

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -32,7 +32,7 @@ module Waitlistable
       unless: :waiting_list_empty?,
     }
 
-    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }, on: :create
+    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
     validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
     after_save :commit_waitlist_position, if: :waiting_list_persisted?

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -36,11 +36,12 @@ module Waitlistable
     validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
     after_save :commit_waitlist_position, if: :waiting_list_persisted?
-    after_commit :clear_tracked_waitlist_position!, on: :update
 
-    def commit_waitlist_position
+    private def commit_waitlist_position
       self.waiting_list_position = self.tracked_waitlist_position
     end
+
+    after_commit :clear_tracked_waitlist_position!
 
     private def clear_tracked_waitlist_position!
       self.tracked_waitlist_position = nil

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -32,8 +32,8 @@ module Waitlistable
       unless: :waiting_list_empty?,
     }
 
-    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
-    validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waitlistable?, presence: { if: :waitlist_position_changed?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waiting_list_present?, presence: { if: :waitlist_position_changed?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
     after_save :commit_waitlist_position, if: :waiting_list_persisted?
 

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -32,7 +32,7 @@ module Waitlistable
       unless: :waiting_list_empty?,
     }
 
-    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }, on: :create
     validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
     def waiting_list_position?

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -75,6 +75,9 @@ module Waitlistable
         self.waiting_list.add(self) if should_add
         self.waiting_list.move_to_position(self, target_position) if should_move
         self.waiting_list.remove(self) if should_remove
+
+        # Keep track of the now-updated position
+        self.track_waitlist_position!
       else
         @tracked_waiting_list_position = target_position
       end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -79,6 +79,9 @@ module Waitlistable
       self.waiting_list.add(self) if should_add
       self.waiting_list.move_to_position(self, target_position) if should_move
       self.waiting_list.remove(self) if should_remove
+
+      # Now that we definitely updated the "real" WL, we can forget about our tracking safely.
+      self.clear_tracked_waitlist_position!
     end
   end
 end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -63,6 +63,10 @@ module Waitlistable
       false
     end
 
+    # Tiny hack: Calling `waiting_list_position` internally caches the result (like a Rails association would)
+    #   so if we ever want to explicitly trigger a cache, all we have to do is call the base method.
+    after_find :waiting_list_position, if: :waitlistable?
+
     def waiting_list_position
       @waiting_list_position ||= self.waiting_list&.position(self)
     end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -35,14 +35,6 @@ module Waitlistable
     validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }, on: :create
     validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
-    def waiting_list_position?
-      waiting_list_position.present?
-    end
-
-    def waiting_list_position_changed?
-      @tracked_waiting_list_position != waiting_list_position
-    end
-
     after_save :commit_waitlist_position, if: :waiting_list_persisted?
 
     def commit_waitlist_position
@@ -53,7 +45,7 @@ module Waitlistable
     after_commit :track_waitlist_position!
 
     private def track_waitlist_position!
-      @tracked_waiting_list_position = self.waiting_list_position
+      @tracked_waiting_list_position = self.persisted_waiting_list_position
     end
 
     # Tells the hooks whether the current entity
@@ -62,8 +54,20 @@ module Waitlistable
       false
     end
 
-    def waiting_list_position
+    def persisted_waiting_list_position
       self.waiting_list&.position(self)
+    end
+
+    def waiting_list_position
+      @tracked_waiting_list_position || self.persisted_waiting_list_position
+    end
+
+    def waiting_list_position?
+      self.waiting_list_position.present?
+    end
+
+    def waiting_list_position_changed?
+      @tracked_waiting_list_position != self.persisted_waiting_list_position
     end
 
     def waiting_list_position=(target_position)

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -68,11 +68,9 @@ module Waitlistable
     alias_method :waitlist_position_changed?, :tracked_waitlist_position?
 
     def waiting_list_position=(target_position)
-      self.apply_to_waiting_list(target_position) if self.persisted? && waiting_list_persisted?
-
-      # Keep track here so that even if we successfully persisted the position,
-      #   we can still track the change via `waitlist_position_changed?`
       self.tracked_waitlist_position = target_position
+
+      self.apply_to_waiting_list(target_position) if self.persisted? && waiting_list_persisted?
     end
 
     private def apply_to_waiting_list(target_position)
@@ -83,9 +81,6 @@ module Waitlistable
       self.waiting_list.add(self) if should_add
       self.waiting_list.move_to_position(self, target_position) if should_move
       self.waiting_list.remove(self) if should_remove
-
-      # Now that we definitely updated the "real" WL, we can forget about our tracking safely.
-      self.clear_tracked_waitlist_position!
     end
   end
 end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -38,7 +38,7 @@ module Waitlistable
     after_save :commit_waitlist_position, if: :waiting_list_persisted?
 
     private def commit_waitlist_position
-      self.waiting_list_position = self.tracked_waitlist_position
+      self.apply_to_waiting_list(self.waiting_list_position)
     end
 
     after_commit :clear_tracked_waitlist_position!
@@ -67,16 +67,20 @@ module Waitlistable
 
     def waiting_list_position=(target_position)
       if self.persisted? && waiting_list_persisted?
-        should_add = self.waitlistable? && target_position.nil?
-        should_move = self.waitlistable? && target_position.present?
-        should_remove = !self.waitlistable? && target_position.present?
-
-        self.waiting_list.add(self) if should_add
-        self.waiting_list.move_to_position(self, target_position) if should_move
-        self.waiting_list.remove(self) if should_remove
+        self.apply_to_waiting_list(target_position)
       else
         self.tracked_waitlist_position = target_position
       end
+    end
+
+    private def apply_to_waiting_list(target_position)
+      should_add = self.waitlistable? && target_position.nil?
+      should_move = self.waitlistable? && target_position.present?
+      should_remove = !self.waitlistable? && target_position.present?
+
+      self.waiting_list.add(self) if should_add
+      self.waiting_list.move_to_position(self, target_position) if should_move
+      self.waiting_list.remove(self) if should_remove
     end
   end
 end

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -32,8 +32,8 @@ module Waitlistable
       unless: :waiting_list_empty?,
     }
 
-    validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
-    validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waitlistable?, presence: { if: :tracked_waitlist_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waiting_list_present?, presence: { if: :tracked_waitlist_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
     after_save :commit_waitlist_position, if: :waiting_list_persisted?
 
@@ -61,9 +61,11 @@ module Waitlistable
       self.waiting_list_position.present?
     end
 
-    def waitlist_position_changed?
+    def tracked_waitlist_position?
       self.tracked_waitlist_position.present?
     end
+
+    alias_method :waitlist_position_changed?, :tracked_waitlist_position?
 
     def waiting_list_position=(target_position)
       self.apply_to_waiting_list(target_position) if self.persisted? && waiting_list_persisted?

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -39,8 +39,7 @@ module Waitlistable
       @waiting_list_position.present?
     end
 
-    # TODO: V3-REG cleanup: Enable this hook so that we can actually have the updating function for free
-    # after_save :commit_waitlist_position
+    after_save :commit_waitlist_position
 
     def commit_waitlist_position
       should_add = self.waitlistable? && !self.waiting_list_position?
@@ -52,7 +51,9 @@ module Waitlistable
       self.waiting_list.remove(self) if should_remove
     end
 
-    def clear_waitlist_position
+    after_commit :clear_waitlist_position
+
+    private def clear_waitlist_position
       @waiting_list_position = nil
     end
 

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -66,9 +66,11 @@ module Waitlistable
     end
 
     def waiting_list_position=(target_position)
-      self.tracked_waitlist_position = target_position
-
       self.apply_to_waiting_list(target_position) if self.persisted? && waiting_list_persisted?
+
+      # Keep track here so that even if we successfully persisted the position,
+      #   we can still track the change via `waitlist_position_changed?`
+      self.tracked_waitlist_position = target_position
     end
 
     private def apply_to_waiting_list(target_position)

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -102,9 +102,7 @@ class Registration < ApplicationRecord
   #   that would screw us over with caching. Unfortunately, even `through` associations cache themselves
   #   so every registration of a competition then effectively has "its own" waiting list.
   #   (We might want to revisit this decision when we switch to hook-based committing in waitlistable.rb)
-  def waiting_list
-    competition&.waiting_list || competition&.create_waiting_list(entries: [])
-  end
+  delegate :waiting_list, to: :competition, allow_nil: true
 
   def waitlistable?
     waitlisted?

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -102,7 +102,9 @@ class Registration < ApplicationRecord
   #   that would screw us over with caching. Unfortunately, even `through` associations cache themselves
   #   so every registration of a competition then effectively has "its own" waiting list.
   #   (We might want to revisit this decision when we switch to hook-based committing in waitlistable.rb)
-  delegate :waiting_list, to: :competition, allow_nil: true
+  def waiting_list
+    competition&.waiting_list || competition&.create_waiting_list(entries: [])
+  end
 
   def waitlistable?
     waitlisted?
@@ -485,6 +487,12 @@ class Registration < ApplicationRecord
 
   def tracked_event_ids?
     @tracked_event_ids.present?
+  end
+
+  after_commit :reset_tracked_event_ids
+
+  private def reset_tracked_event_ids
+    @tracked_event_ids = nil
   end
 
   def tracked_event_ids

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -67,7 +67,7 @@ class Registration < ApplicationRecord
   end
 
   def update_lanes!(params, acting_user)
-    Registrations::Lanes::Competing.update!(params, self.competition, acting_user.id)
+    Registrations::Lanes::Competing.update!(params, self, acting_user.id)
   end
 
   def guest_limit

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -498,6 +498,10 @@ class Registration < ApplicationRecord
     registration_competition_events.map(&:event_id)
   end
 
+  def changed_event_ids
+    self.volatile_event_ids - self.tracked_event_ids
+  end
+
   def competition_events_changed?
     self.tracked_event_ids.sort != self.volatile_event_ids.sort ||
       self.competition_events.any?(&:changed?)

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -6,6 +6,8 @@ class WaitingList < ApplicationRecord
   delegate :empty?, :length, to: :entries
 
   def remove(entry)
+    return unless entries.include?(entry.id)
+
     update_column :entries, entries - [entry.id]
   end
 

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -6,14 +6,14 @@ class WaitingList < ApplicationRecord
   delegate :empty?, :length, to: :entries
 
   def remove(entry)
-    return false unless entries.include?(entry.id)
+    return unless entries.include?(entry.id)
 
     update_column :entries, entries - [entry.id]
   end
 
   def add(entry)
     entry.try(:ensure_waitlist_eligibility!) # raises an error if not waitlistable
-    return false if entries.include?(entry.id)
+    return if entries.include?(entry.id)
 
     if entries.nil?
       update_column :entries, [entry.id]
@@ -26,7 +26,7 @@ class WaitingList < ApplicationRecord
     raise ArgumentError.new('Target position out of waiting list range') if new_position > entries.length || new_position < 1
 
     old_index = entries.find_index(entry.id)
-    return false if old_index == new_position - 1
+    return if old_index == new_position - 1
 
     update_column :entries, entries.insert(new_position - 1, entries.delete_at(old_index))
   end

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -6,14 +6,14 @@ class WaitingList < ApplicationRecord
   delegate :empty?, :length, to: :entries
 
   def remove(entry)
-    return unless entries.include?(entry.id)
+    return false unless entries.include?(entry.id)
 
     update_column :entries, entries - [entry.id]
   end
 
   def add(entry)
     entry.try(:ensure_waitlist_eligibility!) # raises an error if not waitlistable
-    return if entries.include?(entry.id)
+    return false if entries.include?(entry.id)
 
     if entries.nil?
       update_column :entries, [entry.id]
@@ -26,7 +26,7 @@ class WaitingList < ApplicationRecord
     raise ArgumentError.new('Target position out of waiting list range') if new_position > entries.length || new_position < 1
 
     old_index = entries.find_index(entry.id)
-    return if old_index == new_position - 1
+    return false if old_index == new_position - 1
 
     update_column :entries, entries.insert(new_position - 1, entries.delete_at(old_index))
   end

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -45,7 +45,7 @@ module Registrations
       end
 
       def self.send_status_change_email(registration, current_user_id)
-        case registration.status
+        case registration.competing_status
         when Registrations::Helper::STATUS_WAITING_LIST
           RegistrationsMailer.notify_registrant_of_waitlisted_registration(registration).deliver_later
         when Registrations::Helper::STATUS_PENDING

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -26,7 +26,7 @@ module Registrations
         user_id = update_params[:user_id]
 
         registration = Registration.find_by(competition: competition, user_id: user_id)
-        registration = Registrations::RegistrationChecker.apply_payload(registration, update_params)
+        registration = Registrations::RegistrationChecker.apply_payload(registration, update_params, clone: false)
 
         ActiveRecord::Base.transaction do
           changes = registration.changes.transform_values { |change| change[1] }

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -32,6 +32,9 @@ module Registrations
       def self.update!(update_params, registration, current_user_id)
         registration = Registrations::RegistrationChecker.apply_payload(registration, update_params, clone: false)
 
+        # Make sure that a waiting list always exists if you need one during the update
+        registration.competition.create_waiting_list(entries: []) if registration.waitlistable? && !registration.waiting_list_persisted?
+
         ActiveRecord::Base.transaction do
           changes = registration.changes.transform_values { |change| change[1] }
 

--- a/lib/registrations/lanes/competing.rb
+++ b/lib/registrations/lanes/competing.rb
@@ -35,7 +35,7 @@ module Registrations
         ActiveRecord::Base.transaction do
           changes = registration.changes.transform_values { |change| change[1] }
 
-          changes[:waiting_list_position] = registration.waiting_list_position if registration.waiting_list_position_changed?
+          changes[:waiting_list_position] = registration.waiting_list_position if registration.waitlist_position_changed?
           changes[:event_ids] = registration.changed_event_ids if registration.changed_event_ids.present?
 
           registration.save!

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -48,7 +48,9 @@ module Registrations
         new_registration.tracked_event_ids = registration.event_ids
 
         competition_events_lookup = registration.competition.competition_events.where(event_id: desired_events).index_by(&:event_id)
-        competition_events = desired_events.map { build_copy(competition_events_lookup[it], clone: clone) }
+        # Cloning behavior is hard-coded to `false` here, because this line is working on the intermediary competition_events.
+        #   The entities actually related to the registration (the registration_competition_events) inherit the cloning behavior below.
+        competition_events = desired_events.map { build_copy(competition_events_lookup[it], clone: false) }
 
         upserted_competition_events = competition_events.map { build_association_copy(registration.registration_competition_events, clone: clone, competition_event: it) }
         new_registration.registration_competition_events = upserted_competition_events

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -26,12 +26,12 @@ module Registrations
 
         competing_payload = raw_payload['competing']
         comment = competing_payload&.dig('comment')
-        organizer_comment = competing_payload&.dig('organizer_comment')
+        organizer_comment = competing_payload&.dig('organizer_comment') || competing_payload&.dig('admin_comment')
         competing_status = competing_payload&.dig('status')
         waiting_list_position = competing_payload&.dig('waiting_list_position')
 
         new_registration.comments = comment if competing_payload&.key?('comment')
-        new_registration.administrative_notes = organizer_comment if competing_payload&.key?('organizer_comment')
+        new_registration.administrative_notes = organizer_comment if competing_payload&.key?('organizer_comment') || competing_payload&.key?('admin_comment')
         new_registration.competing_status = competing_status if competing_payload&.key?('status')
         new_registration.waiting_list_position = waiting_list_position if competing_payload&.key?('waiting_list_position')
 

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -136,7 +136,7 @@ module Registrations
       end
 
       def validate_waiting_list_position!(registration)
-        process_validation_error!(registration, :tracked_waiting_list_position)
+        process_validation_error!(registration, :waiting_list_position)
         process_validation_error!(registration, :waitlistable?)
         process_validation_error!(registration, :waiting_list_present?)
       end

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -136,7 +136,7 @@ module Registrations
       end
 
       def validate_waiting_list_position!(registration)
-        process_validation_error!(registration, :waiting_list_position)
+        process_validation_error!(registration, :tracked_waiting_list_position)
         process_validation_error!(registration, :waitlistable?)
         process_validation_error!(registration, :waiting_list_present?)
       end

--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -124,7 +124,7 @@ FactoryBot.define do
     end
 
     after(:create) do |registration|
-      registration.competition.waiting_list.add(registration) if registration.competing_status == Registrations::Helper::STATUS_WAITING_LIST
+      registration.waiting_list.add(registration) if registration.competing_status == Registrations::Helper::STATUS_WAITING_LIST
     end
   end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe Registration do
     end
 
     it 'updates guests' do
-      registration.update_lanes!({ user_id: registration.user.id, guests: 5 }, registration.user)
+      registration.update_lanes!({ user_id: registration.user.id, guests: 5 }.with_indifferent_access, registration.user)
       registration.reload
       expect(registration.guests).to eq(5)
     end


### PR DESCRIPTION
For the previous `registration_checker` migrations, we created logic that allows "applying" a payload to a registration.
Incidentally, that's just the same thing that the queue job handler / updater is doing, except that it was doing it separately.

This PR aims for some basic code reuse and cleanup of now-duplicated features. It does not yet touch on transaction/rollback-based validation.

(Didn't run CI locally, let's see how many tests will fail first try!)