### PR TITLE
Set API calls to default I18N locale (en)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   prepend_before_action :set_locale, unless: :is_api_request?
+  # The API should only ever respond in English
+  prepend_before_action :set_default_locale, if: :is_api_request?
+
   before_action :store_user_location!, if: :storable_location?
   before_action :add_new_relic_headers
   protected def add_new_relic_headers
@@ -31,6 +34,10 @@ class ApplicationController < ActionController::Base
 
     @@locale_counts ||= Hash.new(0)
     @@locale_counts[I18n.locale] += 1
+  end
+
+  def set_default_locale
+    I18n.locale = I18n.default_locale
   end
 
   def update_locale


### PR DESCRIPTION
See title. This is an attempt at fixing https://github.com/thewca/worldcubeassociation.org/issues/11171.

Context: We already had `set_locale`, which sets `I18n.locale`. This value is then stored to the current Thread, so the same request will have the same locale throughout its lifecycle. When the request is finished, Puma might reuse *the same thread* (because it uses a pre-provisioned Thread pool) to then immediately serve the next request. So if you make an innocent API call, and the last request that was served on this thread before you happened to be a user from China, your API response would be in Chinese.