### PR TITLE
Ensure locale is set when entering 2FA codes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -87,6 +87,15 @@ class SessionsController < Devise::SessionsController
     end
 
     def authenticate_with_two_factor
+      # The method we're currently in gets called as a `prepend_before_action`
+      #   with the purpose to "intercept" users who need to enter 2FA codes.
+      # Unfortunately, rendering out the 2FA form halts any Rails action filter chain,
+      #   so the `set_locale` that is normally (correctly!) set up in the top-level `ApplicationController`
+      #   is not called in this instance. The "cheapest" fix is just to call it manually here.
+      # (The basic notiong of "halting" is described at https://guides.rubyonrails.org/action_controller_overview.html#before-action
+      #   although not in very great detail. The server also logs a message about "was halted because ... rendered something" during runtime.)
+      set_locale
+
       user = self.resource = find_user
       if user_params[:otp_attempt].present? && session[:otp_user_id]
         authenticate_via_otp(user)


### PR DESCRIPTION
Finally found out why the 2FA form appears in so many random languages. I tried to explain it in the code comment, but here's another high-level overview of the steps
1. Normally, we set the locale for (non-API) requests in the base `ApplicationController` through a `prepend_before_action`. (Basically a `before_before_action`, i.e. something that runs before even `before_action` can run)
    1. Our first suspicion was that Devise controllers do not inherit from `ApplicationController` properly, but that turned out to be incorrect. They do inherit, you can experience this first-hand by seeing that the login form follows your locale setting. And you can see in `config/initializers/devise.rb` that we are clearly setting `ApplicationController` as `parent_controller`.
2. For Devise sessions specifically, we override Devise's `SessionController` with our own `SessionController`. It does properly inherit from Devise's controller though, and by transitive property it does also inherit from our base controller. So it _should_ set the locale.
3. Unfortunately, the way we render the 2FA form is a bit "flaky": It's not a fully-fledged, independent authorization step in Warden just like Username/Password is. Instead, it is an "extra hack" on top of the username/password flow. That is, we *intercept* a user after entering their basic credentials, and *inject* the 2FA code form before letting them proceed normally
    1. This injection is what is causing the Rails filter chain (the thing that triggers all `before_action` and `prepend_before_action` one by one) to completely halt. This is actually intended Rails behavior: If any `prepend_before_action` redirects or renders output, the filter chain is halted
    2. You can see this in the server log: Somewhere in there it says `Filter chain halted as :authenticate_with_two_factor rendered or redirected`

So the "cheapest" solution that I came up with is to just call `set_locale` directly in the method that acts as the 2FA interceptor. That is, the very method which is causing the filter chain to halt because it injects rendered content now sets its own locale "manually" just before rendering.