### PR TITLE
Set consistent language in OAuth token responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,7 @@ class ApplicationController < ActionController::Base
     end
 
     def is_api_request?
-      request.fullpath.include?('/api/')
+      request.fullpath.include?('/api/') || request.fullpath.include?('/oauth/')
     end
 
     def store_user_location!

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -10,6 +10,7 @@ Doorkeeper.configure do
   optional_scopes :dob, :email, :manage_competitions, :openid, :profile
 
   base_controller 'ApplicationController'
+  base_metal_controller 'ApplicationController'
 
   # Change the ORM that doorkeeper will use.
   # Currently supported options are :active_record, :mongoid2, :mongoid3,


### PR DESCRIPTION
Partially addresses #7735 

Doorkeeper was always wired to use our locale-aware `ApplicationController` for "pretty" pages, i.e. for pages that render actual HTML to the user. Pages that "only" show JSON or handle some other form of bare API response use a different base controller in Doorkeeper.
But since we (in our own API v0 and API v1) also use `ApplicationController` as a base in APIs, I thought it wouldn't hurt to propagate that and use it in Doorkeeper as well.

In order to enforce English consistently, #11174 needs to be merged first. Then, the change in this PR will detect OAuth token negotiations as "API calls" (in the broader sense) and enforce English for them.