### PR TITLE
Only run validations on waiting list position if there is a waiting list

### DIFF
--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -7,6 +7,7 @@ module Waitlistable
 
   included do
     delegate :empty?, :length, to: :waiting_list, prefix: true
+    delegate :present?, to: :waiting_list, prefix: true, allow_nil: true
 
     attr_writer :waiting_list_position
 
@@ -21,13 +22,13 @@ module Waitlistable
       equal_to: 1,
       allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
-      if: [:waitlistable?, :waiting_list_empty?],
+      if: [:waitlistable?, :waiting_list_present?, :waiting_list_empty?],
     }
     validates :waiting_list_position, numericality: {
       less_than_or_equal_to: :waiting_list_length,
       allow_nil: true,
       frontend_code: Registrations::ErrorCodes::INVALID_WAITING_LIST_POSITION,
-      if: :waitlistable?,
+      if: [:waitlistable?, :waiting_list_present?],
       unless: :waiting_list_empty?,
     }
 

--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -33,6 +33,7 @@ module Waitlistable
     }
 
     validates :waitlistable?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
+    validates :waiting_list_present?, presence: { if: :waiting_list_position?, frontend_code: Registrations::ErrorCodes::INVALID_REQUEST_DATA }
 
     def waiting_list_position?
       @waiting_list_position.present?

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -114,6 +114,7 @@ module Registrations
       def validate_waiting_list_position!(registration)
         process_validation_error!(registration, :waiting_list_position)
         process_validation_error!(registration, :waitlistable?)
+        process_validation_error!(registration, :waiting_list_present?)
       end
 
       def validate_status_value!(registration)


### PR DESCRIPTION
Unexpected error in bulk updates because we currently only create a waiting list at the very very last moment, i.e. as soon as we detected that a registration wants to be put on the waiting list and we're just about to put it on there.

However, this conflicts with the bulk endpoint because the bulk reqeusts are first *all* checked for validity, and *then* once again looped and actioned. The waiting list is only created during the later "and actioned" part, but during the first loop the validations already try to make sure that its positional value is correct.