### PR TITLE
Fix UnknownRate error while exporting competition export

### DIFF
--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -23,7 +23,7 @@ module DuesCalculator
 
     # The maximum of the two is the total dues per competitor
     [registration_fee_dues, country_band_dues].max
-  rescue Money::Currency::UnknownCurrency, CurrencyUnavailable
+  rescue Money::Currency::UnknownCurrency, CurrencyUnavailable, Money::Bank::UnknownRate
     nil
   end
 end


### PR DESCRIPTION
This is blocking WFC currently because on one particular date, there is a currency whose exchange rate is not available, and because of that export is failing.