### PR TITLE
Admin Search (search with email) in anonymization page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1182,12 +1182,16 @@ class User < ApplicationRecord
   end
 
   def self.search(query, params: {})
-    users = Person.includes(:user).current
-    # We can't search by email on the 'Person' table
-    search_by_email = false
-    unless ActiveRecord::Type::Boolean.new.cast(params[:persons_table])
+    search_by_email = ActiveRecord::Type::Boolean.new.cast(params[:email])
+    admin_search = ActiveRecord::Type::Boolean.new.cast(params[:adminSearch])
+
+    return User.where(email: query) if admin_search && search_by_email
+
+    if ActiveRecord::Type::Boolean.new.cast(params[:persons_table])
+      users = Person.includes(:user).current
+      search_by_email = false # We can't search by email on the 'Person' table
+    else
       users = User.confirmed_email.not_dummy_account
-      search_by_email = ActiveRecord::Type::Boolean.new.cast(params[:email])
 
       users = users.where(id: self.staff_delegate_ids) if ActiveRecord::Type::Boolean.new.cast(params[:only_staff_delegates])
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1184,10 +1184,11 @@ class User < ApplicationRecord
   def self.search(query, params: {})
     search_by_email = ActiveRecord::Type::Boolean.new.cast(params[:email])
     admin_search = ActiveRecord::Type::Boolean.new.cast(params[:adminSearch])
+    searching_persons_table = ActiveRecord::Type::Boolean.new.cast(params[:persons_table])
 
     return User.where(email: query) if admin_search && search_by_email
 
-    if ActiveRecord::Type::Boolean.new.cast(params[:persons_table])
+    if searching_persons_table
       users = Person.includes(:user).current
       search_by_email = false # We can't search by email on the 'Person' table
     else

--- a/app/webpacker/components/Panel/pages/AnonymizationScriptPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/AnonymizationScriptPage/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormField, FormGroup, Radio } from 'semantic-ui-react';
-import { IdWcaSearch } from '../../../SearchWidget/WcaSearch';
+import AdminWcaSearch from '../../../SearchWidget/AdminWcaSearch';
 import SEARCH_MODELS from '../../../SearchWidget/SearchModel';
 import useInputState from '../../../../lib/hooks/useInputState';
 import AnonymizationTicketWorkbenchForWrt from '../../../Tickets/TicketWorkbenches/AnonymizationTicketWorkbenchForWrt';
@@ -41,7 +41,7 @@ export default function AnonymizationScriptPage() {
           </FormField>
         ))}
       </FormGroup>
-      <IdWcaSearch
+      <AdminWcaSearch
         label={`Search ${activeModel.name}`}
         model={activeModel.id}
         multiple={false}

--- a/app/webpacker/components/SearchWidget/AdminWcaSearch.jsx
+++ b/app/webpacker/components/SearchWidget/AdminWcaSearch.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Checkbox } from 'semantic-ui-react';
+import { IdWcaSearch } from './WcaSearch';
+import SEARCH_MODELS from './SearchModel';
+import useCheckboxState from '../../lib/hooks/useCheckboxState';
+
+function AdminWcaSearch({
+  value, onChange, model, label, multiple,
+}) {
+  const [emailSearchEnabled, setEmailSearchEnabled] = useCheckboxState(false);
+
+  return (
+    <>
+      <IdWcaSearch
+        value={value}
+        onChange={onChange}
+        model={model}
+        label={label}
+        multiple={multiple}
+        params={{
+          adminSearch: true,
+          email: emailSearchEnabled,
+        }}
+      />
+      {model === SEARCH_MODELS.user && (
+        <>
+          <Checkbox
+            label="Enable email search"
+            value={emailSearchEnabled}
+            onChange={setEmailSearchEnabled}
+          />
+          <p>
+            Note: When email search is enabled, you can search only with email, and you are
+            expected to enter the full email address.
+          </p>
+        </>
+      )}
+    </>
+  );
+}
+
+export default AdminWcaSearch;

--- a/app/webpacker/components/SearchWidget/WcaSearch.jsx
+++ b/app/webpacker/components/SearchWidget/WcaSearch.jsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react';
 import { QueryClient, useQueries } from '@tanstack/react-query';
 import {
   userSearchApiUrl,
+  userAdminSearchApiUrl,
   personSearchApiUrl,
   competitionSearchApiUrl,
   apiV0Urls,
@@ -116,7 +117,9 @@ export default function WcaSearch({
   const urlFn = useCallback((query) => {
     switch (model) {
       case SEARCH_MODELS.user:
-        return `${userSearchApiUrl(query)}&${new URLSearchParams(params).toString()}`;
+        return (params.adminSearch
+          ? `${userAdminSearchApiUrl(query)}&${new URLSearchParams(params).toString()}`
+          : `${userSearchApiUrl(query)}&${new URLSearchParams(params).toString()}`);
       case SEARCH_MODELS.person:
         return `${personSearchApiUrl(query)}&${new URLSearchParams(params).toString()}`;
       case SEARCH_MODELS.competition:

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -119,6 +119,8 @@ export const personSearchApiUrl = (query) => `<%= Rails.application.routes.url_h
 
 export const userSearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_users_path %>?q=${query}`;
 
+export const userAdminSearchApiUrl = (query) => `<%= CGI.unescape(Rails.application.routes.url_helpers.users_admin_search_path) %>?q=${query}`;
+
 export const geocodingApiUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_geocoding_search_path) %>`;
 export const geocodingTimeZoneUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_geocoding_time_zone_path) %>`;
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
   post 'users/:id/avatar' => 'users#upload_avatar'
   patch 'users/:id/avatar' => 'users#update_avatar'
   delete 'users/:id/avatar' => 'users#delete_avatar'
+  get '/users/admin_search' => 'users#admin_search'
   get 'admin/avatars/pending' => 'admin/avatars#pending_avatar_users', as: :pending_avatars
   post 'admin/avatars' => 'admin/avatars#update_avatar', as: :admin_update_avatar
 


### PR DESCRIPTION
This is an attempt to use a new search endpoint through which we can search for emails and there is no cache. This new search endpoint will be used if `emailSearchEnabled` is enabled.