### PR TITLE
Skip CSRF protection for OAuth internal methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,9 +8,9 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  prepend_before_action :set_locale, unless: :is_api_request?
+  prepend_before_action :set_locale, unless: :ignore_client_language?
   # The API should only ever respond in English
-  prepend_before_action :set_default_locale, if: :is_api_request?
+  prepend_before_action :set_default_locale, if: :ignore_client_language?
 
   before_action :store_user_location!, if: :storable_location?
   before_action :add_new_relic_headers
@@ -116,8 +116,16 @@ class ApplicationController < ActionController::Base
       request.get? && is_navigational_format? && !devise_controller? && !request.xhr? && !is_api_request?
     end
 
+    def ignore_client_language?
+      is_api_request? || is_oauth_request?
+    end
+
+    def is_oauth_request?
+      request.fullpath.include?('/oauth/')
+    end
+
     def is_api_request?
-      request.fullpath.include?('/api/') || request.fullpath.include?('/oauth/')
+      request.fullpath.include?('/api/')
     end
 
     def store_user_location!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   include TimeWillTell::Helpers::DateRangeHelper
   include Devise::Controllers::StoreLocation
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, unless: :is_oauth_request?
 
   prepend_before_action :set_locale, unless: :ignore_client_language?
   # The API should only ever respond in English

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -121,7 +121,7 @@ class ApplicationController < ActionController::Base
     end
 
     def is_oauth_request?
-      request.fullpath.include?('/oauth/')
+      request.fullpath.include?('/oauth/') && self.class.ancestors.include?(Doorkeeper::ApplicationMetalController)
     end
 
     def is_api_request?


### PR DESCRIPTION
Because of https://github.com/thewca/worldcubeassociation.org/pull/11176 the OAuth routes now also "inherited" forgery protection. But of course they shouldn't. So I've added `unless` to the `protect_from_forgery` method to fix that.

I also took the chance to make the method names slightly less arbitrary.