### PR TITLE
Add tests for stability of Results Dump schema

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -27,6 +27,7 @@ production:
     database: results_dump
     database_tasks: false
     migrations_paths: db/results_migrate
+    use_metadata_table: false
 
 development:
   primary:
@@ -45,6 +46,7 @@ development:
     database: wca_dump_results
     database_tasks: false
     migrations_paths: db/results_migrate
+    use_metadata_table: false
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -68,3 +70,4 @@ test:
     database: wca_dump_results
     database_tasks: false
     migrations_paths: db/results_migrate
+    use_metadata_table: false

--- a/db/results_dump_schema.rb
+++ b/db/results_dump_schema.rb
@@ -140,8 +140,7 @@ ActiveRecord::Schema[7.1].define(version: 0) do
     t.string "championship_type", null: false
   end
 
-  create_table "eligible_country_iso2s_for_championship", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "id", default: 0, null: false
+  create_table "eligible_country_iso2s_for_championship", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "championship_type", null: false
     t.string "eligible_country_iso2", null: false
   end

--- a/db/results_dump_schema.rb
+++ b/db/results_dump_schema.rb
@@ -123,10 +123,6 @@ ActiveRecord::Schema[7.1].define(version: 0) do
     t.boolean "final", null: false
   end
 
-  create_table "Rounds", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "sorry_message", limit: 172, default: "", null: false, collation: "utf8mb3_general_ci"
-  end
-
   create_table "Scrambles", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "scrambleId", default: 0, null: false, unsigned: true
     t.string "competitionId", limit: 32, null: false

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -1141,6 +1141,9 @@ module DatabaseDumper
           championship_type
           eligible_country_iso2
         ),
+        db_default: %w(
+          id
+        ),
       ),
     }.freeze,
   }.freeze

--- a/spec/lib/database_dumper_spec.rb
+++ b/spec/lib/database_dumper_spec.rb
@@ -86,5 +86,19 @@ RSpec.describe "DatabaseDumper" do
         expect(DatabaseDumper::RESULTS_SANITIZERS.keys).to match_array actual_table_names
       end
     end
+
+    DatabaseDumper::RESULTS_SANITIZERS.each do |table_name, table_sanitizer|
+      it "defines a sanitizer of table '#{table_name}'" do
+        unless table_sanitizer == :skip_all_rows
+          where_clause = table_sanitizer[:where_clause]
+          expect(where_clause).to be_nil.or(match(/WHERE/)).or(match(/JOIN/))
+          where_clause = table_sanitizer[:order_by_clause]
+          expect(where_clause).to be_nil.or(match(/ORDER BY/))
+          column_sanitizers = table_sanitizer[:column_sanitizers]
+          column_names = with_database(:results_dump) { ActiveRecord::Base.connection.columns(table_name).map(&:name) }
+          expect(column_sanitizers.keys).to match_array(column_names)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/database_dumper_spec.rb
+++ b/spec/lib/database_dumper_spec.rb
@@ -78,7 +78,12 @@ RSpec.describe "DatabaseDumper" do
   context "Results Export" do
     it "defines sanitizers that match the expected output schema (backwards compatibility)" do
       with_database :results_dump do
-        expect(DatabaseDumper::RESULTS_SANITIZERS.keys).to match_array ActiveRecord::Base.connection.data_sources
+        # Rails *always* includes a `schema_migrations` table when loading any pre-defined schema file.
+        #   You can _change_ the name in the database configuration file, but you cannot turn it off / disable the table entirely.
+        #   But since we don't care about Rails-ian specifics in our Results Export, we manually skip the table here.
+        actual_table_names = ActiveRecord::Base.connection.data_sources - ["schema_migrations"]
+
+        expect(DatabaseDumper::RESULTS_SANITIZERS.keys).to match_array actual_table_names
       end
     end
   end

--- a/spec/lib/database_dumper_spec.rb
+++ b/spec/lib/database_dumper_spec.rb
@@ -74,4 +74,12 @@ RSpec.describe "DatabaseDumper" do
       expect(banned_group.roles).to be_empty
     end
   end
+
+  context "Results Export" do
+    it "defines sanitizers that match the expected output schema (backwards compatibility)" do
+      with_database :results_dump do
+        expect(DatabaseDumper::RESULTS_SANITIZERS.keys).to match_array ActiveRecord::Base.connection.data_sources
+      end
+    end
+  end
 end


### PR DESCRIPTION
Mostly copy-paste from the Dev Dump schema tests, with one minor exception that is directly contained in the code comments.

Surprisingly, our Results Dump has an ID column for the `eligible_country_iso2s_for_championship` table. I confirmed this by downloading and inspecting the latest SQL export from our website (as of writing this comment). Funnily enough, the original source table does not have IDs anymore (I think we changed this when we started loading data statically from files) and so currently they all get filled with `0`. I am hesitant to fully remove the column from the Results Export (although if anybody relied on this, they would probably already have complained to us that it's all zeroes...) so I just changed it to assign "meaningful" (read: auto-increment) IDs at least.