### PR TITLE
Add test asserting that accepted registrations in a full comp can edit registration details

### DIFF
--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1105,6 +1105,24 @@ RSpec.describe Registrations::RegistrationChecker do
           .not_to raise_error
       end
 
+      it 'organizer can edit accepted registration when competition is full' do
+        competitor_limit = FactoryBot.create(:competition, :with_competitor_limit, :with_organizer, competitor_limit: 3)
+        FactoryBot.create_list(:registration, 2, :accepted, competition: competitor_limit)
+        registration = FactoryBot.create(:registration, :accepted, competition: competitor_limit)
+
+        update_request = FactoryBot.build(
+          :update_request,
+          user_id: registration.user_id,
+          competition_id: registration.competition_id,
+          submitted_by: competitor_limit.organizers.first.id,
+          competing: { 'comment' => 'test comment' },
+        )
+
+        expect {
+          Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration)
+        }.not_to raise_error
+      end
+
       it 'only considers regstrations from current comp when calculating accepted registrations' do
         competitor_limit = FactoryBot.create(:competition, :with_competitor_limit, :with_organizer, competitor_limit: 3)
         limited_reg = FactoryBot.create(:registration, competition: competitor_limit)


### PR DESCRIPTION
#11184 introduced a fix for an issue in production where organizers could not update the events of an `accepted` registration in a full competition. 

This was happening because `deep_dup` (used in validating registration payloads) creates a "blank" registration object, and _then_ applies the changes - so it appeared that the registration's status was being changed to accepted, triggering our `competitor_limit` validations.

This PR is simply a test which reproduces that issue, and ensures that data on an accepted registration in a full comp (guests, comments, event id's) can still be edited. To verify that the test worked, I commented out `registration_checker:15`, ensured the test failed, and then uncommented that line, ensuring the test would then pass.