### PR TITLE
Get rid of light_results_from_relation

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1463,65 +1463,46 @@ class Competition < ApplicationRecord
   end
 
   def events_with_podium_results
-    light_results_from_relation(
-      results.podium.order(:pos),
-    ).group_by(&:event)
-      .sort_by { |event, _results| event.rank }
+    results.podium.order(:pos).group_by(&:event)
+    .sort_by { |event, _results| event.rank }
   end
 
   def winning_results
-    light_results_from_relation(
-      results.winners,
-    )
+    results.winners
   end
 
   def person_ids_with_results
-    light_results_from_relation(results)
-      .group_by(&:personId)
-      .sort_by { |_personId, results| results.first.personName }
-      .map do |personId, results|
-        results.sort_by! { |r| [r.event.rank, -r.round_type.rank] }
+    results.group_by(&:personId)
+           .sort_by { |_personId, results| results.first.personName }
+           .map do |personId, results|
+             results.sort_by! { |r| [r.event.rank, -r.round_type.rank] }
 
-        # Mute (soften) each result that wasn't the competitor's last for the event.
-        last_event = nil
-        results.each do |result|
-          result.muted = (result.event == last_event)
-          last_event = result.event
-        end
+             # Mute (soften) each result that wasn't the competitor's last for the event.
+             last_event = nil
+             results.each do |result|
+               result.muted = (result.event == last_event)
+               last_event = result.event
+             end
 
-        [personId, results.sort_by { |r| [r.event.rank, -r.round_type.rank] }]
-      end
+             [personId, results.sort_by { |r| [r.event.rank, -r.round_type.rank] }]
+            end
   end
 
   def events_with_round_types_with_results
-    light_results_from_relation(results)
-      .group_by(&:event)
-      .sort_by { |event, _results| event.rank }
-      .map do |event, results_for_event|
-        round_types_with_results = results_for_event
-                                   .group_by(&:round_type)
-                                   .sort_by { |format, _results| format.rank }.reverse
-                                   .map { |round_type, results| [round_type, results.sort_by { |r| [r.pos, r.personName] }] }
+    results.group_by(&:event)
+           .sort_by { |event, _results| event.rank }
+           .map do |event, results_for_event|
+             round_types_with_results = results_for_event
+                                        .group_by(&:round_type)
+                                        .sort_by { |format, _results| format.rank }.reverse
+                                        .map { |round_type, results| [round_type, results.sort_by { |r| [r.pos, r.personName] }] }
 
-        [event, round_types_with_results]
-      end
+             [event, round_types_with_results]
+           end
   end
 
   def ineligible_events(user)
     competition_events.reject { |ce| ce.can_register?(user) }.map(&:event)
-  end
-
-  # Profiling the rendering of _results_table.html.erb showed quite some
-  # time was spent in `ActiveRecord#read_attribute`. So, I load the results
-  # using raw SQL and instantiate a PORO. The code definitely got uglier,
-  # but the performance gains are worth it IMO. Not using ActiveRecord led
-  # to a 40% performance improvement.
-  private def light_results_from_relation(relation)
-    ActiveRecord::Base.connection
-                      .execute(relation.to_sql)
-                      .each(as: :hash).map do |r|
-                        LightResult.new(r)
-                      end
   end
 
   def started?

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1464,7 +1464,7 @@ class Competition < ApplicationRecord
 
   def events_with_podium_results
     results.podium.order(:pos).group_by(&:event)
-    .sort_by { |event, _results| event.rank }
+           .sort_by { |event, _results| event.rank }
   end
 
   def winning_results
@@ -1475,9 +1475,9 @@ class Competition < ApplicationRecord
     results.group_by(&:personId)
            .sort_by { |_personId, results| results.first.personName }
            .map do |personId, results|
-             results.sort_by! { |r| [r.event.rank, -r.round_type.rank] }
-             [personId, results.sort_by { |r| [r.event.rank, -r.round_type.rank] }]
-            end
+      results.sort_by! { |r| [r.event.rank, -r.round_type.rank] }
+      [personId, results.sort_by { |r| [r.event.rank, -r.round_type.rank] }]
+    end
   end
 
   def events_with_round_types_with_results

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1476,14 +1476,6 @@ class Competition < ApplicationRecord
            .sort_by { |_personId, results| results.first.personName }
            .map do |personId, results|
              results.sort_by! { |r| [r.event.rank, -r.round_type.rank] }
-
-             # Mute (soften) each result that wasn't the competitor's last for the event.
-             last_event = nil
-             results.each do |result|
-               result.muted = (result.event == last_event)
-               last_event = result.event
-             end
-
              [personId, results.sort_by { |r| [r.event.rank, -r.round_type.rank] }]
             end
   end

--- a/app/views/competitions/_results_table.html.erb
+++ b/app/views/competitions/_results_table.html.erb
@@ -37,11 +37,13 @@
   </thead>
 
   <tbody>
+  <% last_event = nil %>
     <% results.each_with_index do |result, i| %>
-      <tr class="sort-by-<%= result.format.sort_by.to_s %> <%= result.muted ? "text-muted" : "" %>">
+      <% muted =  (result.event == last_event) %>
+      <tr class="sort-by-<%= result.format.sort_by.to_s %> <%= muted ? "text-muted" : "" %>">
         <% if !hide_event %>
           <td class="event">
-            <% if !result.muted && (i == 0 || result.eventId != results[i - 1].eventId) %>
+            <% if !muted && (i == 0 || result.eventId != results[i - 1].eventId) %>
               <%= link_to competition_results_all_path(@competition, event: result.eventId) do %>
                 <%= cubing_icon result.event.id %>
                 <%= result.event.name %>
@@ -49,7 +51,7 @@
             <% end %>
           </td>
         <% end %>
-
+        <% last_event = result.event %>
         <% if !hide_round %>
           <td class="round"><%= result.round_type.cellName %></td>
         <% end %>

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -963,12 +963,6 @@ RSpec.describe Competition do
       expect(result.size).to eq 4
       expect(result.map(&:first)).to eq [person_four, person_one, person_three, person_two].map(&:wca_id)
       expect(result.second.last.map(&:roundTypeId)).to eq %w(f 1 c)
-
-      expect(result[1][1][1].muted).to be true
-      expect(result[1][1][2].muted).to be false
-
-      expect(result[2][1][1].muted).to be true
-      expect(result[3][1][1].muted).to be true
     end
 
     it "events_with_round_types_with_results" do


### PR DESCRIPTION
We got rid of `_results_table.html.erb` in the `/results/all` quite a while ago. And I did not see a noticeable slowdown in `results/by_person`. 

`compute_rankings_by_region` still uses LightResults, but I don't think we use any of it's functionality as the React Port does all the computations in the frontend