### PR TITLE
Set fail-on-error to false in coveralls action

### DIFF
--- a/.github/workflows/ruby-test.yml
+++ b/.github/workflows/ruby-test.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: 'coverage/lcov/worldcubeassociation.org.lcov'
+          fail-on-error: false
       - uses: actions/upload-artifact@v4
         if: always() && steps.rspec.outcome == 'failure'
         with:


### PR DESCRIPTION
Will stop all these CI failures just because Coveralls is down.

See https://github.com/coverallsapp/github-action?tab=readme-ov-file#inputs