### PR TITLE
Run Feature Specs off Playwright

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -34,3 +34,4 @@ STAGING_OAUTH_SECRET=example-secret
 AVATARS_PUBLIC_STORAGE=local
 AVATARS_PRIVATE_STORAGE=local_private
 DUMP_HOST=https://assets.worldcubeassociation.org
+PLAYWRIGHT_SERVER_SOCKET_URL=ws://playwright:8089

--- a/.env.test
+++ b/.env.test
@@ -35,3 +35,4 @@ AVATARS_PUBLIC_STORAGE=local
 AVATARS_PRIVATE_STORAGE=local_private
 DUMP_HOST=https://assets.worldcubeassociation.org
 PLAYWRIGHT_SERVER_SOCKET_URL=ws://playwright:8089
+CAPYBARA_APP_HOST=http://wca_on_rails:3000

--- a/.github/workflows/ruby-test.yml
+++ b/.github/workflows/ruby-test.yml
@@ -13,6 +13,7 @@ jobs:
       RACK_ENV: test
       RAILS_ENV: test
       NODE_ENV: test
+      PLAYWRIGHT_BROWSERS_PATH: ${{ env.GITHUB_WORKSPACE }}/pw-browsers
     steps:
       - uses: actions/checkout@v4
       - uses: fregante/setup-git-user@v2 # set up dummy user.name and user.email in git so that Overcommit doesn't explode
@@ -48,6 +49,11 @@ jobs:
         run: |
           bin/bundle exec i18n export
           bin/rake assets:precompile
+      - name: Cache Playwright runnables
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/node_modules/playwright*') }}
       - name: Install Playwright Browsers # as per https://playwright.dev/docs/ci#github-actions
         run: bin/yarn playwright install --with-deps --no-shell chromium
       - name: Run tests

--- a/.github/workflows/ruby-test.yml
+++ b/.github/workflows/ruby-test.yml
@@ -49,7 +49,7 @@ jobs:
           bin/bundle exec i18n export
           bin/rake assets:precompile
       - name: Install Playwright Browsers # as per https://playwright.dev/docs/ci#github-actions
-        run: bin/yarn playwright install --with-deps chromium
+        run: bin/yarn playwright install --with-deps --no-shell chromium
       - name: Run tests
         id: rspec
         run: bin/rspec

--- a/.github/workflows/ruby-test.yml
+++ b/.github/workflows/ruby-test.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           bin/bundle exec i18n export
           bin/rake assets:precompile
+      - name: Install Playwright Browsers # as per https://playwright.dev/docs/ci#github-actions
+        run: bin/yarn playwright install --with-deps chromium
       - name: Run tests
         id: rspec
         run: bin/rspec

--- a/.github/workflows/ruby-test.yml
+++ b/.github/workflows/ruby-test.yml
@@ -13,7 +13,7 @@ jobs:
       RACK_ENV: test
       RAILS_ENV: test
       NODE_ENV: test
-      PLAYWRIGHT_BROWSERS_PATH: ${{ env.GITHUB_WORKSPACE }}/pw-browsers
+      PLAYWRIGHT_BROWSERS_PATH: ./pw-browsers
     steps:
       - uses: actions/checkout@v4
       - uses: fregante/setup-git-user@v2 # set up dummy user.name and user.email in git so that Overcommit doesn't explode

--- a/.github/workflows/ruby-test.yml
+++ b/.github/workflows/ruby-test.yml
@@ -14,6 +14,7 @@ jobs:
       RAILS_ENV: test
       NODE_ENV: test
       PLAYWRIGHT_BROWSERS_PATH: ./pw-browsers
+      CAPYBARA_APP_HOST: "" # Explicitly set a blank value to override our default Docker container setup
     steps:
       - uses: actions/checkout@v4
       - uses: fregante/setup-git-user@v2 # set up dummy user.name and user.email in git so that Overcommit doesn't explode

--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,6 @@ group :test do
   gem 'oga' # XML parsing library introduced for testing RSS feed
   gem 'database_cleaner'
   gem 'rails-controller-testing'
-  gem 'apparition', github: 'twalpole/apparition'
   gem 'capybara-playwright-driver'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,7 @@ group :test do
   gem 'database_cleaner'
   gem 'rails-controller-testing'
   gem 'apparition', github: 'twalpole/apparition'
+  gem 'capybara-playwright-driver'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,14 +41,6 @@ GIT
       railties (>= 3.2)
 
 GIT
-  remote: https://github.com/twalpole/apparition.git
-  revision: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
-  specs:
-    apparition (0.6.0)
-      capybara (~> 3.13, < 4)
-      websocket-driver (>= 0.6.5)
-
-GIT
   remote: https://github.com/zpaulovics/datetimepicker-rails.git
   revision: 7a4640cb932e55866500a86c4f78808a4fca46e6
   submodules: true
@@ -982,7 +974,6 @@ DEPENDENCIES
   activestorage-validator
   after_commit_everywhere
   api-pagination
-  apparition!
   aws-sdk-cloudfront
   aws-sdk-rds
   aws-sdk-s3
@@ -1126,7 +1117,6 @@ CHECKSUMS
   after_commit_everywhere (1.6.0) sha256=c8b3409a1172e43070d2e57f4b9d7b89dce5a7f057576b748cb9fe0a0dd4d917
   ansi (1.5.0) sha256=5408253274e33d9d27d4a98c46d2998266fd51cba58a7eb9d08f50e57ed23592
   api-pagination (6.0.0) sha256=4e8918fc36b7c1cb101f37ef291cae2f69dcb3f288c3c9243b3f403cc514be85
-  apparition (0.6.0)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   autoprefixer-rails (9.4.7) sha256=7104f54efa89e6390391bd894498a9db92bffaf74474942c4152e6dc0775ab3b
   aws-eventstream (1.3.2) sha256=7e2c3a55ca70d7861d5d3c98e47daa463ed539c349caba22b48305b8919572d7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-playwright-driver (0.5.4)
+      addressable
+      capybara
+      playwright-ruby-client (>= 1.16.0)
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
@@ -991,6 +995,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
+  capybara-playwright-driver
   capybara-screenshot
   cocoon
   cookies_eu
@@ -1150,6 +1155,7 @@ CHECKSUMS
   byebug (12.0.0) sha256=d4a150d291cca40b66ec9ca31f754e93fed8aa266a17335f71bb0afa7fca1a1e
   camertron-eprun (1.1.1) sha256=9a8e337916445e62648f6a4f35d229302fc44c50549cc881bff1e296ccf9ce4b
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
+  capybara-playwright-driver (0.5.4) sha256=a28183d8c2c8e9f19587130d5c1d9567515dbd6e4485eb7c3146443cb9069b6c
   capybara-screenshot (1.0.26) sha256=816b9370a07752097c82a05f568aaf5d3b7f45c3db5d3aab2014071e1b3c0c77
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe

--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -64,6 +64,9 @@ test:
   # Compile test packs to a separate directory
   public_output_path: packs-test
 
+  # Make sure that asset paths are stable across browser runs
+  cache_manifest: true
+
 production:
   <<: *default
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,7 @@ services:
     environment:
       - DEBIAN_FRONTEND=noninteractive
       - DEBUG=pw:api
+      - DISPLAY=$DISPLAY
     ports:
       - "8089:8089"
     working_dir: /app
@@ -181,6 +182,7 @@ services:
       - .:/app
       - node_modules_volume:/app/node_modules
       - pdf_fonts_volume:/usr/share/fonts
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
     networks:
       - wca-main
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,10 +165,16 @@ services:
   wca_playwright:
     image: mcr.microsoft.com/playwright:v1.51.1
     container_name: "playwright"
+    # The following options `ipc`, `cap_add` and `init` are per Playwright's documentation: https://playwright.dev/docs/ci#docker
+    ipc: "host"
+    cap_add:
+      - SYS_ADMIN
+    init: true
     environment:
       - DEBIAN_FRONTEND=noninteractive
       - DEBUG=pw:api
       - DISPLAY=$DISPLAY
+      - GSK_RENDERER=cairo # For WebKit to work in headed debug mode
     ports:
       - "8089:8089"
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,8 @@ services:
   wca_playwright:
     image: mcr.microsoft.com/playwright:v1.51.1
     container_name: "playwright"
+    extra_hosts:
+      - "hostmachine:host-gateway"
     # The following options `ipc`, `cap_add` and `init` are per Playwright's documentation: https://playwright.dev/docs/ci#docker
     ipc: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,7 +176,6 @@ services:
       - DEBIAN_FRONTEND=noninteractive
       - DEBUG=pw:api
       - DISPLAY=$DISPLAY
-      - GSK_RENDERER=cairo # For WebKit to work in headed debug mode
     ports:
       - "8089:8089"
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,12 @@ services:
       - .:/app
       - node_modules_volume:/app/node_modules
       - pdf_fonts_volume:/usr/share/fonts
-      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      # If you want to run tests in debug mode with a visible browser, you have to expose an X11 socket to Playwright
+      #   under `/tmp/.X11-unix` within the container. Chances are high that the original X11 socket on the host machine
+      #   lives in that exact same folder, but it's hard to be sure with all the different OSes that we want to support.
+      # Please enable the following mount at your own risk.
+      # You also have to make sure the owner's user ID matches the container's user ID to avoid X11 rendering glitches.
+      #  - /tmp/.X11-unix:/tmp/.X11-unix:rw
     networks:
       - wca-main
 

--- a/env_config.rb
+++ b/env_config.rb
@@ -112,6 +112,9 @@ EnvConfig = SuperConfig.new(raise_exception: !is_compiling_assets) do
   optional :PLAYWRIGHT_BROWSERS_PATH, :string, ''
   optional :PLAYWRIGHT_RUN_LOCALLY, :bool, false
 
+  # For developer setups who have a local Ruby runtime
+  optional :RUN_CAPYBARA_ON_HOST, :bool, false
+
   # For API Only Server
   optional :API_ONLY, :bool, false
 

--- a/env_config.rb
+++ b/env_config.rb
@@ -113,7 +113,8 @@ EnvConfig = SuperConfig.new(raise_exception: !is_compiling_assets) do
   optional :PLAYWRIGHT_RUN_LOCALLY, :bool, false
 
   # For developer setups who have a local Ruby runtime
-  optional :RUN_CAPYBARA_ON_HOST, :bool, false
+  optional :CAPYBARA_RUN_ON_HOST, :bool, false
+  optional :CAPYBARA_APP_HOST, :string, ''
 
   # For API Only Server
   optional :API_ONLY, :bool, false

--- a/spec/features/competition_management_spec.rb
+++ b/spec/features/competition_management_spec.rb
@@ -21,14 +21,6 @@ def region_input
   all(:css, 'div#venue-countryId>input.search').last
 end
 
-def fill_date(selector, with:)
-  fill_in selector, with: with
-  # After migrating to react-datepicker v7, you somehow need to tab out of the field (de-focus, aka. blur)
-  #   in order to make the automated tests register that the value has changed. An alternative would be
-  #   to `sleep` for a second, i.e. pause the test. This is not noticeable in production use and likely a glitch in the test drivers.
-  find_field(selector).native.send_keys :tab
-end
-
 # HTML 'checkbox' elements in SemUI are not actual <checkbox> fields.
 # They are a label with a rectangle and a tick mark injected via CSS, so we have to write our custom find method.
 def wca_registration_checkbox
@@ -52,8 +44,8 @@ RSpec.feature "Competition management", :js, retry: 10 do
         visit new_competition_path
         fill_in "Name", with: "My Competition 2015"
         region_input.fill_in with: "United States"
-        fill_date "Start date", with: '08/11/2015'
-        fill_date "End date", with: '08/11/2015'
+        fill_in "Start date", with: '08/11/2015'
+        fill_in "End date", with: '08/11/2015'
         wca_registration_checkbox.click
         fill_in "Maximum number of competitors", with: '123'
         fill_in "The reason for the competitor limit", with: 'Because it is required'
@@ -78,8 +70,8 @@ RSpec.feature "Competition management", :js, retry: 10 do
         visit edit_competition_path(competition)
         click_link "Clone"
         fill_in "Name", with: "Pedro 2016"
-        fill_date "Start date", with: "2016-11-30"
-        fill_date "End date", with: "2016-11-30"
+        fill_in "Start date", with: "2016-11-30"
+        fill_in "End date", with: "2016-11-30"
         click_button "Create Competition"
 
         # Force Capybara to wait until the page finishes updating
@@ -91,8 +83,8 @@ RSpec.feature "Competition management", :js, retry: 10 do
         visit edit_competition_path(competition)
         click_link "Clone"
         # See https://github.com/thewca/worldcubeassociation.org/issues/1016#issuecomment-262573451
-        fill_date "Start date", with: "2016-11-30"
-        fill_date "End date", with: "2016-11-30"
+        fill_in "Start date", with: "2016-11-30"
+        fill_in "End date", with: "2016-11-30"
         click_button "Create Competition"
 
         expect(page).to have_text("must end with a year", wait: SLUGGISH_WAIT_TIME)
@@ -241,8 +233,8 @@ RSpec.feature "Competition management", :js, retry: 10 do
 
       fill_in "Name", with: "New Comp 2015"
       region_input.fill_in with: "United States"
-      fill_date "Start date", with: '08/11/2015'
-      fill_date "End date", with: '08/11/2015'
+      fill_in "Start date", with: '08/11/2015'
+      fill_in "End date", with: '08/11/2015'
       wca_registration_checkbox.click
       fill_in "Maximum number of competitors", with: '123'
       fill_in "The reason for the competitor limit", with: 'Because it is required'

--- a/spec/features/competition_management_spec.rb
+++ b/spec/features/competition_management_spec.rb
@@ -28,10 +28,7 @@ def wca_registration_checkbox
   all(:css, "label[for='website-usesWcaRegistration']").last
 end
 
-# The retry count for this specific set of tests is ludicrously high because our slow and deprecated
-# Apparition browser engine does not render React state changes properly.
-# We can remove this `retry` count when we migrated to a "proper" browser engine in tests.
-RSpec.feature "Competition management", :js, retry: 10 do
+RSpec.feature "Competition management", :js do
   context "when signed in as admin" do
     let!(:admin) { FactoryBot.create :admin }
 

--- a/spec/features/competitions_list_spec.rb
+++ b/spec/features/competitions_list_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Competitions list", :js do
 
     it 'renders finished competition without results' do
       FactoryBot.create(:competition, :visible, starts: 2.days.ago, name: "Test Comp 2017")
-      visit '/competitions?state=recent&display=admin'
+      visit '/competitions?state=recent&show_admin_details=yes'
       expect(page).to have_http_status(:ok)
       expect(page).to have_text "Test Comp 2017"
       tr = page.find("tr", text: "Test Comp 2017")

--- a/spec/features/cookie_law_spec.rb
+++ b/spec/features/cookie_law_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "cookie law" do
 
       # Clear cookies and visit the homepage again. The cookie banner should
       # show back up.
-      page.driver.clear_cookies
+      page.driver.with_playwright_page { it.context.clear_cookies }
       visit_homepage_and_wait_for_load
       expect(page).to have_selector(CookieBannerHelper::ACKNOWLEDGE_SELECTOR)
     end
@@ -35,7 +35,7 @@ RSpec.feature "cookie law" do
 
       # Clear cookies. This logs us out and clears the acknowledgement cookie.
       # The banner should come back.
-      page.driver.clear_cookies
+      page.driver.with_playwright_page { it.context.clear_cookies }
       visit_homepage_and_wait_for_load
       expect(page).to have_selector(CookieBannerHelper::ACKNOWLEDGE_SELECTOR)
 

--- a/spec/features/set_locale_spec.rb
+++ b/spec/features/set_locale_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Set the locale" do
   scenario "visiting the home page while not signed in and changing the locale", :js do
     # Our navigation hide the language name on small resolutions, make sure we
     # use one wide enough.
-    page.driver.resize(1280, 1024)
+    page.driver.resize_window_to(page.driver.current_window_handle, 1280, 1024)
     visit "/#foo"
     expect(page).to have_content "English"
     expect(page).not_to have_content "Français"
@@ -22,7 +22,7 @@ RSpec.feature "Set the locale" do
   end
 
   scenario "signing in updates to the preferred_locale", :js do
-    page.driver.resize(1280, 1024)
+    page.driver.resize_window_to(page.driver.current_window_handle, 1280, 1024)
     visit "/"
     expect(page).to have_content "English"
     expect(page).not_to have_content "Français"

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -65,10 +65,7 @@ RSpec.feature "Sign up" do
 
       # First, intentionally fill in the incorrect birthdate,
       # to test out our validations.
-      fill_in "Birthdate", with: "1900-01-01"
-      # Close the date selector popup: Depending on how long the month is, and how the days are distributed over the weeks,
-      #   the date popup may become too big (especially if 31-day months are spread out over 5 weeks), obstructing the submit button.
-      page.driver.with_playwright_page { it.press("body", "Escape") }
+      fill_in("Birthdate", with: "1900-01-01").send_keys(:escape)
       click_button "Sign up"
 
       # Make sure we inform the user of the incorrect birthdate they just

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -40,8 +40,6 @@ RSpec.feature "Sign up" do
     end
 
     it 'finds people by name' do
-      pending('Date popup suddenly started obstruting sign-in button. Signed DH 30/Aug/2024')
-
       visit "/users/sign_up"
 
       fill_in "Email", with: "jack@example.com"
@@ -68,6 +66,9 @@ RSpec.feature "Sign up" do
       # First, intentionally fill in the incorrect birthdate,
       # to test out our validations.
       fill_in "Birthdate", with: "1900-01-01"
+      # Close the date selector popup: Depending on how long the month is, and how the days are distributed over the weeks,
+      #   the date popup may become too big (especially if 31-day months are spread out over 5 weeks), obstructing the submit button.
+      page.driver.with_playwright_page { it.press("body", "Escape") }
       click_button "Sign up"
 
       # Make sure we inform the user of the incorrect birthdate they just

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature "Sign up" do
     # The cookie banner just gets in the way of these tests, and is already
     # tested elsewhere. Set a cookie that prevents the cookie banner from
     # appearing.
-    page.driver.set_cookie('cookie_eu_consented', 'true')
+    cookie_eu_consented = { name: 'cookie_eu_consented', value: 'true', domain: Capybara.app_host, path: '/' }
+    page.driver.with_playwright_page { it.context.add_cookies([cookie_eu_consented]) }
   end
 
   context 'when signing up as a returning competitor', :js do
@@ -300,7 +301,7 @@ RSpec.feature "Sign up" do
 
   context "when signing up as a non-english speaker", :js do
     it "stores the user's preferred locale" do
-      page.driver.headers = { 'Accept-Language' => 'es' }
+      page.driver.with_playwright_page { it.context.set_extra_http_headers({ 'Accept-Language' => 'es' }) }
       visit "/users/sign_up"
 
       fill_in "user[email]", with: "jack@example.com"

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature "Sign up" do
     # The cookie banner just gets in the way of these tests, and is already
     # tested elsewhere. Set a cookie that prevents the cookie banner from
     # appearing.
-    cookie_eu_consented = { name: 'cookie_eu_consented', value: 'true', domain: Capybara.app_host, path: '/' }
+    default_domain = Capybara.app_host || Capybara.server_host
+    cookie_eu_consented = { name: 'cookie_eu_consented', value: 'true', domain: default_domain, path: '/' }
     page.driver.with_playwright_page { it.context.add_cookies([cookie_eu_consented]) }
   end
 

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -273,8 +273,10 @@ RSpec.feature "Sign up" do
       fill_in_selectize "WCA ID", with: person.wca_id
 
       click_button "Sign up"
-      click_on "I have never competed in a WCA competition."
       expect(page.find("#user_dob", visible: :hidden).value).to eq ""
+
+      click_on "I have never competed in a WCA competition."
+      expect(page.find("#user_dob", visible: :visible).value).to eq ""
     end
 
     it "does not allow both panels to be open after failed submission" do

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature "Sign up" do
       click_button "Sign up"
 
       # Verify that the custom delegate is still selected.
-      selectize_items = selectize.all("div.selectize-control .items")
+      selectize_items = selectize.all(".items")
       expect(selectize_items.length).to eq 1
       expect(selectize_items[0].find('.name').text).to eq custom_delegate.name
 

--- a/spec/features/stripe_integration_spec.rb
+++ b/spec/features/stripe_integration_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Stripe PaymentElement integration", :js do
       donation_money = competition.base_entry_fee / 2
 
       give_donation_checkbox.click
-      fill_in with: donation_money.amount.to_s, id: 'donationInputField'
+      fill_in_autonumeric '#donationInputField', with: donation_money.amount.to_s
 
       format_money = format_money(registration.outstanding_entry_fees + donation_money)
       expect(subtotal_label).to have_text(format_money)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,7 +48,11 @@ Capybara.register_driver :playwright_debug do |app|
 end
 
 Capybara.register_driver :playwright do |app|
-  Capybara::Playwright::Driver.new(app, playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL)
+  if ENV["CI"].present?
+    Capybara::Playwright::Driver.new(app, playwright_cli_executable_path: 'yarn playwright')
+  else
+    Capybara::Playwright::Driver.new(app, playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL)
+  end
 end
 
 Capybara.javascript_driver = :playwright

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,9 +49,9 @@ end
 
 Capybara.register_driver :playwright do |app|
   if ENV["CI"].present?
-    Capybara::Playwright::Driver.new(app, playwright_cli_executable_path: 'yarn playwright')
+    Capybara::Playwright::Driver.new(app, playwright_cli_executable_path: 'yarn playwright', channel: :chromium)
   else
-    Capybara::Playwright::Driver.new(app, playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL)
+    Capybara::Playwright::Driver.new(app, playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL, channel: :chromium)
   end
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,7 +39,9 @@ Capybara.register_driver :playwright_debug do |app|
   Capybara::Playwright::Driver.new(
     app,
     playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL,
-    browser_type: :firefox, # Chrome can have issues rendering its GUI out of a Docker container
+    browser_type: :firefox,
+    # Under Linux with the mounted X11 socket, you will most likely need the following line to make Chromium work:
+    # args: ["--no-zygote"],
     headless: false,
     slowMo: 500,
   )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,7 +57,7 @@ Capybara.register_driver :playwright_debug do |app|
 end
 
 Capybara.register_driver :playwright do |app|
-  Capybara::Playwright::Driver.new(app, playwright_server_endpoint_url: 'ws://localhost:8089')
+  Capybara::Playwright::Driver.new(app, playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL)
 end
 
 Capybara.javascript_driver = :playwright

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,9 +39,7 @@ Capybara.register_driver :playwright_debug do |app|
   Capybara::Playwright::Driver.new(
     app,
     playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL,
-    browser_type: :firefox,
-    # Under Linux with the mounted X11 socket, you will most likely need the following line to make Chromium work:
-    # args: ["--no-zygote"],
+    browser_type: :chromium,
     headless: false,
     slowMo: 500,
   )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,12 @@ Capybara.javascript_driver = :playwright
 # Recommended per https://playwright-ruby-client.vercel.app/docs/article/guides/rails_integration#update-timeout
 Capybara.default_max_wait_time = 15
 
+if EnvConfig.RUN_CAPYBARA_ON_HOST?
+  Capybara.server_host = '0.0.0.0'
+  Capybara.always_include_port = true
+  Capybara.app_host = "http://hostmachine"
+end
+
 Capybara::Screenshot.register_driver :playwright do |driver, path|
   driver.save_screenshot(path)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,6 @@ require 'rspec/rails'
 # From http://everydayrails.com/2012/04/24/testing-series-rspec-requests.html
 require "capybara/rspec"
 require 'capybara-screenshot/rspec'
-require 'capybara/apparition'
 
 require 'active_record/testing/query_assertions'
 
@@ -32,16 +31,6 @@ Rails.root.glob('spec/support/**/*.rb').each { |f| require f }
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
-
-# To debug feature specs using apparition, set `Capybara.javascript_driver = :apparition_debug`
-# and then call `page.driver.debug` in your feature spec.
-Capybara.register_driver :apparition_debug do |app|
-  Capybara::Apparition::Driver.new(app, inspector: true, debug: true, headless: false)
-end
-
-Capybara.register_driver :apparition do |app|
-  Capybara::Apparition::Driver.new(app, js_errors: true, headless: true)
-end
 
 # To debug feature specs using apparition, set `Capybara.javascript_driver = :playwright_debug`
 # and then call `page.driver.with_playwright_page { it.context.enable_debug_console!;it.pause }` in your feature spec.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,9 @@ Capybara.register_driver :playwright_debug do |app|
     app,
     playwright_server_endpoint_url: EnvConfig.PLAYWRIGHT_SERVER_SOCKET_URL,
     browser_type: :chromium,
+    # For running Playwright browsers in headed mode, there has to be a writable X11 socket under `/tmp/.X11-unix`
+    #   available in the container, and its user ID (file ownership) has to match the host system exactly.
+    # See also the comment in `docker-compose.yml` for a sample implementation.
     headless: false,
     slowMo: 500,
   )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,10 +61,14 @@ Capybara.javascript_driver = :playwright
 # Recommended per https://playwright-ruby-client.vercel.app/docs/article/guides/rails_integration#update-timeout
 Capybara.default_max_wait_time = 15
 
-if EnvConfig.RUN_CAPYBARA_ON_HOST?
+Capybara.app_host = EnvConfig.CAPYBARA_APP_HOST.presence
+
+if EnvConfig.CAPYBARA_RUN_ON_HOST?
   Capybara.server_host = '0.0.0.0'
   Capybara.always_include_port = true
   Capybara.app_host = "http://hostmachine"
+else
+  Capybara.run_server = EnvConfig.CAPYBARA_APP_HOST.blank?
 end
 
 Capybara::Screenshot.register_driver :playwright do |driver, path|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -113,6 +113,7 @@ RSpec.configure do |config|
   # Make helpers available in feature specs
   config.include SessionHelper, type: :feature
   config.include SelectizeHelper, type: :feature
+  config.include AutonumericHelper, type: :feature
   config.include CookieBannerHelper, type: :feature
 
   # Make sign_in helper available in controller and request specs

--- a/spec/support/autonumeric_helper.rb
+++ b/spec/support/autonumeric_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AutonumericHelper
+  def fill_in_autonumeric(selector, with:)
+    autonumeric_input = find(selector)
+
+    # Playwright usually fills elements by just "magically setting" the text directly.
+    # But AutoNumeric specifically requires you to type out the text one-by-one,
+    #   so that the corresponding update events fire.
+    autonumeric_input.with_playwright_element_handle do |pw_node|
+      pw_node.select_text
+      pw_node.type(with.to_s)
+    end
+  end
+end

--- a/spec/support/autonumeric_helper.rb
+++ b/spec/support/autonumeric_helper.rb
@@ -7,9 +7,7 @@ module AutonumericHelper
     # Playwright usually fills elements by just "magically setting" the text directly.
     # But AutoNumeric specifically requires you to type out the text one-by-one,
     #   so that the corresponding update events fire.
-    autonumeric_input.with_playwright_element_handle do |pw_node|
-      pw_node.select_text
-      pw_node.type(with.to_s)
-    end
+    autonumeric_input.with_playwright_element_handle { it.select_text }
+    autonumeric_input.send_keys(with)
   end
 end

--- a/spec/support/selectize_helper.rb
+++ b/spec/support/selectize_helper.rb
@@ -11,7 +11,7 @@ module SelectizeHelper
       selectize_input = page.find("div.#{for_id} .selectize-control input")
     end
 
-    selectize_input.with_playwright_element_handle { it.type(with) }
+    selectize_input.send_keys(with)
     # Wait for selectize popup to appear.
     expect(page).to have_selector("div.selectize-dropdown", visible: true)
     # Select item with selectize.

--- a/spec/support/selectize_helper.rb
+++ b/spec/support/selectize_helper.rb
@@ -15,6 +15,6 @@ module SelectizeHelper
     # Wait for selectize popup to appear.
     expect(page).to have_selector("div.selectize-dropdown", visible: true)
     # Select item with selectize.
-    selectize_input.with_playwright_element_handle { it.press('Enter') }
+    selectize_input.send_keys(:enter)
   end
 end

--- a/spec/support/selectize_helper.rb
+++ b/spec/support/selectize_helper.rb
@@ -3,7 +3,7 @@
 module SelectizeHelper
   def fill_in_selectize(label_or_node, with:)
     if label_or_node.instance_of? Capybara::Node::Element
-      selectize_input = label_or_node
+      selectize_input = label_or_node.find("input")
     else
       label = label_or_node
       label_node = find(:label, text: label, exact_text: true)

--- a/spec/support/selectize_helper.rb
+++ b/spec/support/selectize_helper.rb
@@ -11,10 +11,10 @@ module SelectizeHelper
       selectize_input = page.find("div.#{for_id} .selectize-control input")
     end
 
-    selectize_input.native.send_key(with)
+    selectize_input.with_playwright_element_handle { it.type(with) }
     # Wait for selectize popup to appear.
     expect(page).to have_selector("div.selectize-dropdown", visible: true)
     # Select item with selectize.
-    selectize_input.native.send_key(:enter)
+    selectize_input.with_playwright_element_handle { it.press('Enter') }
   end
 end


### PR DESCRIPTION
Now that we have a working Playwright setup via https://github.com/thewca/worldcubeassociation.org/pull/11223, we can use that same instance to run our feature tests.

No more struggling with old Apparition driver issues (in fact, this PR already removes one "hack" that we had to do for datetime fields) and also no more struggles having to set up Chromedriver on your local machine. The browsers "live" in our Docker setup behind a nice, clean, maintained API now.

The changes to the Docker-Compose file were mostly for improved Playwright memory management, as per Playwright's own documentation.

The only thing that is harder, now that the browsers are living inside Docker, is opening a visible browser window for debugging. You would have to "pipe through" your Xorg display socket into the container, pay attention that it is mounted under the exact same user ID as your host machine user (otherwise Xorg glitches out due to access restrictions) and then run in debug mode. I have confirmed that this works under Linux with native Xorg, Linux with native Wayland and bridged XWayland, and Windows with WLS2 and WSLg display socket.

Lastly, some users may still want to run tests locally (for example, if the IDE running on your host machine is highly integrated with RSpec and allows you to launch individual tests on the fly), so I added an extra flag for that. Curiously, the Docker Playwright browser then needs to reach the Docker host machine (which is running the test server) but fortunately there's a Docker feature for that.