### PR TITLE
Remove Stripe initializer defaults

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-Stripe.api_key = AppSecrets.STRIPE_API_KEY
-Stripe.api_version = "2023-10-16"


### PR DESCRIPTION
The two values that we were (historically) pinning in the `stripe.rb` both have reasonable defaults now:
- `Stripe.api_key` is not necessary anymore thanks to https://github.com/thewca/worldcubeassociation.org/pull/10954. The `StripeClient` instances there have the API key baked in when calling their constructor.
- `Stripe.api_version` is pinned by the Stripe Ruby SDK since version 9, released August 2023: https://github.com/stripe/stripe-ruby/releases/tag/v9.0.0

The (interesting) consequence of this is that whenever the Stripe Ruby SDK now has a SemVer major version bump, our underlying Stripe API version also changes. But I think that's a good thing since we have decent CI coverage for Stripe and our previous API version was pinned at a waaay too old value (end of 2023).