### PR TITLE
Add a Manual External Payment Integration

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -9,8 +9,8 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   before_action :validate_create_request, only: [:create]
   before_action :validate_show_registration, only: [:show]
   before_action :validate_list_admin, only: [:list_admin]
-  before_action :ensure_registration_exists, only: [:update]
-  before_action :user_can_modify_registration, only: [:update]
+  before_action :ensure_registration_exists, only: [:update, :add_payment_reference]
+  before_action :user_can_modify_registration, only: [:update, :add_payment_reference]
   before_action :validate_update_request, only: [:update]
   before_action :user_can_bulk_modify_registrations, only: [:bulk_update]
   before_action :validate_bulk_update_request, only: [:bulk_update]
@@ -84,6 +84,12 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
       return render json: { status: 'ok', registration: updated_registration.to_v2_json(admin: true, history: true) }, status: :ok
     end
     render json: { status: 'bad request', message: 'You need to supply at least one lane' }, status: :bad_request
+  end
+
+  def add_payment_reference
+    ManualPaymentRecord.create(registration: @registration, payment_reference: params.require[:payment_reference])
+
+    render json: { status: 'ok' }, status: :ok
   end
 
   def ensure_registration_exists

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -259,6 +259,21 @@ class CompetitionsController < ApplicationController
     render :edit
   end
 
+  def payment_integration_manual_setup
+    @competition = competition_from_params
+  end
+
+  def add_manual_payment_setup
+    @competition = competition_from_params
+    payment_info = params[:payment_info]
+    payment_reference = params[:payment_reference]
+
+    ManualPaymentIntegration.create(payment_info: payment_info, payment_reference: payment_reference)
+
+    render json: { status: "ok" }
+  end
+
+
   def payment_integration_setup
     @competition = competition_from_params
 

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -273,7 +273,6 @@ class CompetitionsController < ApplicationController
     render json: { status: "ok" }
   end
 
-
   def payment_integration_setup
     @competition = competition_from_params
 

--- a/app/models/competition_payment_integration.rb
+++ b/app/models/competition_payment_integration.rb
@@ -9,6 +9,7 @@ class CompetitionPaymentIntegration < ApplicationRecord
   AVAILABLE_INTEGRATIONS = {
     paypal: 'ConnectedPaypalAccount',
     stripe: 'ConnectedStripeAccount',
+    manual: 'ManualPaymentIntegration',
   }.freeze
 
   INTEGRATION_DASHBOARD_URLS = {
@@ -24,10 +25,12 @@ class CompetitionPaymentIntegration < ApplicationRecord
   INTEGRATION_RECORD_TYPES = {
     paypal: 'PaypalRecord',
     stripe: 'StripeRecord',
+    manual: 'ManualPaymentRecord',
   }.freeze
 
   scope :paypal, -> { where(connected_account_type: AVAILABLE_INTEGRATIONS[:paypal]) }
   scope :stripe, -> { where(connected_account_type: AVAILABLE_INTEGRATIONS[:stripe]) }
+  scope :manual, -> { where(connected_account_type: AVAILABLE_INTEGRATIONS[:manual]) }
 
   def self.validate_integration_name!(integration_name)
     raise ArgumentError.new("Invalid integration name. Allowed values are: #{AVAILABLE_INTEGRATIONS.keys.join(', ')}") unless

--- a/app/models/manual_payment_integration.rb
+++ b/app/models/manual_payment_integration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ManualPaymentIntegration < ApplicationRecord
+  def find_payment(record_id)
+    ManualPaymentRecord.find(record_id)
+  end
+
+  def self.generate_onboarding_link(competition_id)
+    Rails.application.routes.url_helpers.competition_manual_payment_setup_url(competition_id)
+  end
+end

--- a/app/models/manual_payment_record.rb
+++ b/app/models/manual_payment_record.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ManualPaymentRecord < ApplicationRecord
+  has_one :registration
+
+  validates :registration_id, presence: true
+  validates :payment_reference, presence: true
+end

--- a/app/views/competitions/payment_integration_manual_setup.erb
+++ b/app/views/competitions/payment_integration_manual_setup.erb
@@ -1,0 +1,7 @@
+<% provide(:title, @competition.name) %>
+
+<%= render layout: 'nav' do %>
+  <%= react_component("ManualPaymentSetup", {
+    competitionId: @competition.id,
+  }) %>
+<% end %>

--- a/app/webpacker/components/ManualPaymentSetup/index.jsx
+++ b/app/webpacker/components/ManualPaymentSetup/index.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import {
+  Form, FormField, Header, Message,
+} from 'semantic-ui-react';
+import { useMutation } from '@tanstack/react-query';
+import I18n from '../../lib/i18n';
+import MarkdownEditor from '../wca/FormBuilder/input/MarkdownEditor';
+import useInputState from '../../lib/hooks/useInputState';
+import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
+import { addManualPaymentIntegration } from '../../lib/requests/routes.js.erb';
+
+export default function ManualPaymentSetup({ competitionId }) {
+  const [paymentInfo, setPaymentInfo] = useInputState('');
+  const [paymentReference, setPaymentReference] = useInputState('');
+  const [success, setSuccess] = useState(false);
+
+  const { mutate } = useMutation({
+    mutationFn: ({ info, reference }) => fetchJsonOrError(
+      addManualPaymentIntegration(competitionId),
+      {
+        method: 'POST',
+        body: JSON.stringify({ paymentInfo: info, paymentReference: reference }),
+      },
+    ),
+    onSuccess: () => setSuccess(true),
+  });
+
+  return (
+    <>
+      <Header>
+        {I18n.t('payments.payment_setup.manual_payments_header')}
+      </Header>
+      { success && (
+        <Message possitve>
+          Successfully created the manual payment integration.
+        </Message>
+      )}
+      <Form onSubmit={() => mutate({ info: paymentInfo, reference: paymentReference })}>
+        <FormField>
+          <label htmlFor="paymentInfo">{I18n.t('payments.payment_setup.account_details.manual.payment_info')}</label>
+          <MarkdownEditor id="paymentInfo" value={paymentInfo} onChange={setPaymentInfo} imageUploadEnabled />
+        </FormField>
+        <FormField>
+          <label htmlFor="paymentReference">{I18n.t('payments.payment_setup.account_details.manual.payment_reference')}</label>
+          <Form.Input id="paymentReference" value={paymentReference} onChange={setPaymentReference} />
+        </FormField>
+      </Form>
+    </>
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/Register/ManualPaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/ManualPaymentStep.jsx
@@ -1,0 +1,55 @@
+import React, { useCallback } from 'react';
+import {
+  Form,
+  Message,
+  Segment,
+} from 'semantic-ui-react';
+import { useMutation } from '@tanstack/react-query';
+import I18n from '../../../lib/i18n';
+import { hasPassed } from '../../../lib/utils/dates';
+import useInputState from '../../../lib/hooks/useInputState';
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+import { addPaymentReferenceUrl } from '../../../lib/requests/routes.js.erb';
+
+export default function ManualPaymentStep({
+  userInfo,
+  competitionInfo,
+  paymentInfo,
+  nextStep,
+}) {
+  const [paymentReference, setPaymentReference] = useInputState('');
+
+  const { mutate } = useMutation({
+    mutationFn: ({ reference }) => fetchJsonOrError(
+      addPaymentReferenceUrl(competitionInfo.id, userInfo.id),
+      {
+        method: 'POST',
+        body: JSON.stringify({ paymentReference: reference }),
+      },
+    ),
+    onSuccess: () => nextStep(),
+  });
+
+  const handleSubmit = useCallback(async (e) => {
+    e.preventDefault();
+    mutate({ reference: paymentReference });
+  }, [mutate, paymentReference]);
+
+  if (hasPassed(competitionInfo.registration_close)) {
+    return (
+      <Message color="red">{I18n.t('registrations.payment_form.errors.registration_closed')}</Message>
+    );
+  }
+
+  return (
+    <Segment>
+      {paymentInfo.payment_info}
+      <Form id="manual-payment-form" onSubmit={handleSubmit}>
+        <Form.Field>
+          <label htmlFor="paymentReference">{paymentInfo.payment_reference}</label>
+          <Form.Input id="paymentReference" value={paymentReference} onChange={setPaymentReference} />
+        </Form.Field>
+      </Form>
+    </Segment>
+  );
+}

--- a/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/StepPanel.jsx
@@ -6,6 +6,7 @@ import StripeWrapper from './StripeWrapper';
 import I18n from '../../../lib/i18n';
 import RegistrationOverview from './RegistrationOverview';
 import { useRegistration } from '../lib/RegistrationProvider';
+import ManualPaymentStep from './ManualPaymentStep';
 
 const requirementsStepConfig = {
   key: 'requirements',
@@ -23,6 +24,12 @@ const paymentStepConfig = {
   key: 'payment',
   i18nKey: 'competitions.registration_v2.register.panel.payment',
   component: StripeWrapper,
+};
+
+const manualPaymentStepConfig = {
+  key: 'manual',
+  i18nKey: 'competitions.registration_v2.register.panel.payment',
+  component: ManualPaymentStep,
 };
 
 const registrationOverviewConfig = {
@@ -88,8 +95,12 @@ export default function StepPanel({
 
   const steps = useMemo(() => {
     const stepList = [requirementsStepConfig, competingStepConfig];
-    if (competitionInfo['using_payment_integrations?']) {
+    if (competitionInfo['using_payment_integrations?'] && competitionInfo.payment_integration === 'stripe') {
       stepList.push(paymentStepConfig);
+    }
+
+    if (competitionInfo['using_payment_integrations?'] && competitionInfo.payment_integration === 'manual') {
+      stepList.push(manualPaymentStepConfig);
     }
 
     if (isRegistered) {

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -121,6 +121,7 @@ export const competitionUserPreferencesUrl = (competitionId) => `<%= CGI.unescap
 export const competitionConfirmationDataUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_confirmation_data_path("${competitionId}")) %>`
 export const updateCompetitionConfirmationDataUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_update_confirmation_data_path("${competitionId}")) %>`
 
+export const addManualPaymentIntegration = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_manual_payment_setup_path("${competitionId}")) %>`
 export const announceCompetitionUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_announce_path("${competitionId}")) %>`
 export const cancelCompetitionUrl = (competitionId, undo = false) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_cancel_path("${competitionId}")) %>?undo=${undo}`
 export const closeRegistrationWhenFullUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_close_full_registration_path("${competitionId}")) %>`
@@ -327,6 +328,8 @@ export const confirmedRegistrationsUrl = (competitionId) => `<%= CGI.unescape(Ra
 export const allRegistrationsUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v1_registrations_list_admin_path(competition_id: "${competitionId}")) %>`;
 
 export const singleRegistrationUrl = (competitionId, userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v1_registrations_register_path(competition_id: "${competitionId}", user_id: "${userId}")) %>`;
+
+export const addPaymentReferenceUrl = (competitionId, userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v1_registrations_add_payment_reference_path(competition_id: "${competitionId}", user_id: "${userId}")) %>`;
 
 export const submitRegistrationUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v1_registrations_register_path) %>`;
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2233,6 +2233,7 @@ en:
     payment_providers:
       paypal: 'PayPal'
       stripe: 'Stripe'
+      manual: 'External Payment (Manual)'
     #context: Setting up and making payments
     payment_setup:
       external_dashboard: '%{provider} Dashboard'
@@ -2246,13 +2247,16 @@ en:
       supported_currencies: "%{provider} Supported Currencies"
       provider_heading: "%{provider} Payments"
       accept_payments_header: "Accept Registration Payments"
+      manual_payments_header: "Configure Manual Payments"
       connect_button: "Connect with %{provider}"
       connect_account_info:
         stripe: "In order to accept payments for this competition, you need to connect your own Stripe account with the WCA Stripe account by clicking the button below. If you don't already have your own Stripe account you can still click on the button below and it will guide you through the process."
         paypal: "A PayPal Business account is required to accept PayPal payments via the competition page. If you don't already have a PayPal business account, you can still click on the button below and it will guide you through the process."
+        manual: "Manual External Payments will enable you to track payments by the user submitting a payment reference as part of the registration process."
       connect_account_warning:
         stripe: "Connecting your Stripe account gives the WCA website the ability to create charges, and issue refunds directly on your Stripe account."
         paypal: "Connecting your PayPal account gives the WCA website the ability to route payments to you, and issue refunds directly on your PayPal account."
+        manual: ""
       currently_connected_info: "This competition is set up to accept payments through %{provider}. The Delegate(s) of the competition should contact WCAT to make any changes to connected accounts."
       before_disconnect_warning: "Disconnecting on this page will make our website forget the connection to your %{provider} account. But your %{provider} dashboard (see link below) may still list the WCA website based on the authorization that you previously granted. Note that revoking authorization in the %{provider} dashboard will also affect any other competition linked to accept payments through this account!"
       before_disconnect_info: "Keep in mind that disconnecting an account should only be done in exceptional situations, such as the current account being unable to receive payments."
@@ -2264,6 +2268,9 @@ en:
         paypal:
           display_name: "Name"
           primary_email: "Email"
+        manual:
+          payment_info: "Instructions for the competitor how they will pay"
+          payment_reference: "Reference that the competitor should enter after paying (could be Name, Mobile Phone Number, Payment ID, etc.)"
         fallback_not_applicable: "N/A"
     statuses:
       succeeded: "Succeeded"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,8 @@ Rails.application.routes.draw do
     get '/admin/scrambles/:round_id/new' => 'admin/scrambles#new', as: :new_scramble
 
     get '/payment_integration/setup' => 'competitions#payment_integration_setup', as: :payment_integration_setup
+    get '/payment_integration/setup/manual' => 'competitions#payment_integration_manual_setup', as: :manual_payment_setup
+    post '/payment_integration/setup/manual' => 'competitions#payment_integration_manual_add', as: :add_manual_payment_setup
     get '/payment_integration/:payment_integration/connect' => 'competitions#connect_payment_integration', as: :connect_payment_integration
     post '/payment_integration/:payment_integration/disconnect' => 'competitions#disconnect_payment_integration', as: :disconnect_payment_integration
   end
@@ -355,6 +357,7 @@ Rails.application.routes.draw do
         get '/:competition_id', to: 'registrations#list'
         get '/:competition_id/admin', to: 'registrations#list_admin', as: :list_admin
         get '/:competition_id/payment', to: 'registrations#payment_ticket', as: :payment_ticket
+        get '/:competition_id/:user_id/payment_reference', to: 'registrations#add_payment_reference', as: :add_payment_reference
       end
     end
 


### PR DESCRIPTION
Replacement for #9737 

This is still WIP because I didn't add any DB changes yet. I would like to have some feedback on this before.

I could not use the already existing `connect_payment_integration` method because that requires a redirect, which doesn't work in react world. I also think it doesn't really make sense, because there are no accounts to save.

I added a new page to input the payment information text and needed payment reference instead. 