### PR TITLE
Change `refunded` i18n key to `refund`

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -313,7 +313,7 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
             {registration.payment.payment_statuses.map((paymentStatus) => (
               <List.Item key={paymentStatus}>
                 {/* i18n-tasks-use t('payments.statuses.succeeded') */}
-                {/* i18n-tasks-use t('payments.statuses.refunded') */}
+                {/* i18n-tasks-use t('payments.statuses.refund') */}
                 {I18n.t(`payments.statuses.${paymentStatus}`)}
               </List.Item>
             ))}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2267,7 +2267,7 @@ en:
         fallback_not_applicable: "N/A"
     statuses:
       succeeded: "Succeeded"
-      refunded: "Refunded"
+      refund: "Refunded"
   persons:
     #context: Person search page
     index:


### PR DESCRIPTION
Our payment statuses are `succeeded` and `refund` - we call the i18n key by passing the payment status directly. When making the PR, I used `refunded` as the i18n key - so calling `refund` caused a key miss. 

We may want to consider refactoring `refund` to `refunded` - but that will balloon the scope of this otherwise trivial PR, so I'd say it should be handled separately.