### PR TITLE
Registration Edit: profile & edit user links

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -27,7 +27,6 @@ import RegistrationHistory from './RegistrationHistory';
 import { hasPassed } from '../../../lib/utils/dates';
 import getUsersInfo from '../api/user/post/getUserInfo';
 import { useRegistration } from '../lib/RegistrationProvider';
-import I18nHTMLTranslate from '../../I18nHTMLTranslate';
 import useSet from '../../../lib/hooks/useSet';
 
 export default function RegistrationEditor({ competitor, competitionInfo }) {
@@ -189,17 +188,6 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
   return (
     <Segment padded attached loading={isUpdating}>
       <Form onSubmit={handleRegisterClick}>
-        {!competitor.wca_id && (
-          <Message>
-            <I18nHTMLTranslate
-              // i18n-tasks-use t('registrations.registered_with_account_html')
-              i18nKey="registrations.registered_with_account_html"
-              options={{
-                here: `<a href=${editPersonUrl(competitor.id)}>here</a>`,
-              }}
-            />
-          </Message>
-        )}
         {registrationEditDeadlinePassed && (
           <Message>
             {I18n.t('registrations.errors.edit_deadline_passed')}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -206,12 +206,15 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
           </Message>
         )}
         <Header>
-          {`${competitor.name} `}
-          (
-          <a href={personUrl(competitor.wca_id)} target="_blank" rel="noreferrer" className="hide-new-window-icon">{competitor.wca_id}</a>
-          )
-          {' ' /* Necessary to space the icon away from the wca_id */ }
-          <a href={personUrl(competitor.wca_id)} target="_blank" rel="noreferrer" className="hide-new-window-icon"><Icon name="edit" /></a>
+          {competitor.name}
+          {' ('}
+          {competitor.wca_id ? (
+            <a href={personUrl(competitor.wca_id)} target="_blank" rel="noreferrer" className="hide-new-window-icon">{competitor.wca_id}</a>
+          ) : (
+            I18n.t('registrations.registration_info_people.newcomer.one')
+          )}
+          {') '}
+          <a href={editPersonUrl(competitor.id)} target="_blank" rel="noreferrer" className="hide-new-window-icon"><Icon name="edit" /></a>
         </Header>
         <Form.Field required error={selectedEventIds.size === 0}>
           <EventSelector


### PR DESCRIPTION
For competitors with IDs, we had "Name (ID) Icon" with both ID and Icon linking to the profile.
For newcomers, we had "Name () Icon" with nothing in the parens and Icon linking to `persons/null`.

Now, the ID links to the profile, or just says 'first-timer' if there's no id. And Icon links to the edit user page in both cases.
I also removed the message about registering with an account because that applies to everyone (not helpful), and the link is already built into the icon.

### Old

Same link twice:
![image](https://github.com/user-attachments/assets/2571ac02-c370-403f-8c06-9f825abae415)

Empty () and broken link:
![image](https://github.com/user-attachments/assets/438cda4f-4ab7-4126-9a3f-68674884d50f)

### New

![image](https://github.com/user-attachments/assets/28ccaac7-0d61-42c8-a137-c502a2cd8eab)

![image](https://github.com/user-attachments/assets/42a5ee3d-0436-4052-a3f9-d3058fc0175e)
