### PR TITLE
some registration editor fix

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -207,11 +207,15 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
         )}
         <Header>
           {`${competitor.name} `}
-          (
-          <a href={personUrl(competitor.wca_id)} target="_blank" rel="noreferrer" className="hide-new-window-icon">{competitor.wca_id}</a>
-          )
+          {competitor.wca_id && (
+              <>
+                (
+                <a href={personUrl(competitor.wca_id)} target="_blank" rel="noreferrer" className="hide-new-window-icon">{competitor.wca_id}</a>
+                )
+              </>
+            )}
           {' ' /* Necessary to space the icon away from the wca_id */ }
-          <a href={personUrl(competitor.wca_id)} target="_blank" rel="noreferrer" className="hide-new-window-icon"><Icon name="edit" /></a>
+          <a href={editPersonUrl(competitor.id)} target="_blank" rel="noreferrer" className="hide-new-window-icon"><Icon name="edit" /></a>
         </Header>
         <Form.Field required error={selectedEventIds.size === 0}>
           <EventSelector


### PR DESCRIPTION
- rendering this parenthesis only if wca_id is present

![image](https://github.com/user-attachments/assets/b21dbe30-06f3-4cec-b1b6-854242165d63)

- The pencil icon was redirecting to the person's page, fixed it to redirect to the edit person page
