### PR TITLE
Changed homepage link to point directly to international store

### DIFF
--- a/app/views/posts/homepage.html.erb
+++ b/app/views/posts/homepage.html.erb
@@ -16,7 +16,7 @@
           <%= t('homepage.competitions.text_html',
                 wca_live_link: raw(link_to("WCA Live", "https://live.worldcubeassociation.org"))) %>
         <% end %>
-        <%= render "box", title: t('homepage.merchandise.title'), path: 'https://shop.worldcubeassociation.org', link_title: t('homepage.merchandise.link_title') do %>
+        <%= render "box", title: t('homepage.merchandise.title'), path: '/merch', link_title: t('homepage.merchandise.link_title') do %>
           <%= t('homepage.merchandise.text_html') %>
         <% end %>
         <%= render "box", title: t('homepage.records.title'), path: records_path do %>

--- a/app/views/posts/homepage.html.erb
+++ b/app/views/posts/homepage.html.erb
@@ -16,7 +16,7 @@
           <%= t('homepage.competitions.text_html',
                 wca_live_link: raw(link_to("WCA Live", "https://live.worldcubeassociation.org"))) %>
         <% end %>
-        <%= render "box", title: t('homepage.merchandise.title'), path: '/merch', link_title: t('homepage.merchandise.link_title') do %>
+        <%= render "box", title: t('homepage.merchandise.title'), path: 'https://shop.worldcubeassociation.org', link_title: t('homepage.merchandise.link_title') do %>
           <%= t('homepage.merchandise.text_html') %>
         <% end %>
         <%= render "box", title: t('homepage.records.title'), path: records_path do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,7 +252,7 @@ Rails.application.routes.draw do
   get 'faq' => 'static_pages#faq'
   get 'logo' => 'static_pages#logo'
   get 'media-instagram' => 'static_pages#media_instagram'
-  get 'merch' => 'static_pages#merch'
+  get 'merch', to: redirect('https://shop.worldcubeassociation.org/')
   get 'organizer-guidelines' => 'static_pages#organizer_guidelines'
   get 'privacy' => 'static_pages#privacy'
   get 'score-tools' => 'static_pages#score_tools'


### PR DESCRIPTION
Per Hariprasad's request in "Removal of Indian store link", this PR restores the original functionality of the "Link to shop" button on the homepage - linking directly to the international shop. Also, `/merch` now redirects to the international shop as well, in case anyone accesses it directly.

The only reason /merch was introduced was to let users choose between the International and Indian stores. 

`merch.html.erb` not removed from static pages so that it is easy to re-enable when the Indian store comes back online.