### PR TITLE
Mailcatcher fix: Manually require dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,9 @@ services:
     ports:
       - "1080:1080"
     command: >
-      bash -c 'gem install mailcatcher &&
+      bash -c 'gem install eventmachine -v "~> 1.0" &&
+      gem install thin -v "~> 1.8" &&
+      gem install mailcatcher &&
       mailcatcher --foreground --ip=0.0.0.0'
 
   wca_sidekiq:


### PR DESCRIPTION
Mailcatcher was yielding errors indicating that its dependencies weren't being included. I wasn't able to figure out from a cursory glance why this wasn't the case - perhaps some issue with Ruby 3.4.2[1]? 

I took the "obvious" approach of just manually installing the dependencies in the bash commands until it worked - and now it's working locally again. Open to more refined approaches if anyone can see what the underlying issue might be! 

[1] Finn pointed out in Slack that my Rails seemed to think it was still v3.4.0 - this is the output in the Docker terminal, which makes me think my Docker is on the right Ruby version: 
```bash
duncan@duncan-elitebook:~$ docker exec -it rails bash
root@1e12c9feb5cc:/app# ruby -v
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [x86_64-linux]
```