### PR TITLE
allows dynamic tab links

### DIFF
--- a/app/models/competition_tab.rb
+++ b/app/models/competition_tab.rb
@@ -39,6 +39,7 @@ class CompetitionTab < ApplicationRecord
     content.scan(/\[(.*?)\]\((.*?)\)/).any? do |match|
       url = match[1]
       next if url.blank?
+
       errors.add(:content, I18n.t('competitions.errors.not_full_url', url: url)) unless url.starts_with?('http://', 'https://', 'mailto:')
     end
   end

--- a/app/models/competition_tab.rb
+++ b/app/models/competition_tab.rb
@@ -38,6 +38,7 @@ class CompetitionTab < ApplicationRecord
   private def verify_if_full_urls
     content.scan(/\[(.*?)\]\((.*?)\)/).any? do |match|
       url = match[1]
+      next if url.blank?
       errors.add(:content, I18n.t('competitions.errors.not_full_url', url: url)) unless url.starts_with?('http://', 'https://', 'mailto:')
     end
   end


### PR DESCRIPTION
fixes: https://github.com/thewca/worldcubeassociation.org/issues/11243

```ruby
errors.add(:content, I18n.t('competitions.errors.not_full_url', url: url)) unless url.starts_with?('http://', 'https://', 'mailto:') || url.blank ?
```

this will also work i guess