### PR TITLE
Activate naming cops in RuboCop config

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,29 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-###
-### We can't get rid of all the camelCase until we've done database migrations.
-###
-# Offense count: 4
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: snake_case, camelCase
-Naming/MethodName:
-  Exclude:
-    - 'app/controllers/users_controller.rb'
-    - 'app/models/light_result.rb'
-    - 'app/models/event.rb'
-    - 'app/models/round_type.rb'
-    - 'db/migrate/20160109070723_convert_process_links_format_to_markdown.rb'
-
-# Offense count: 16
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: snake_case, camelCase
-Naming/VariableName:
-  Enabled: false
-###
-### End camelCase stuff
-###
-
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/controllers/competitions_controller.rb'

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -65,11 +65,11 @@ class ContactsController < ApplicationController
   end
 
   def contact
-    formValues = JSON.parse(params.require(:formValues), symbolize_names: true)
-    contact_recipient = formValues[:contactRecipient]
+    form_values = JSON.parse(params.require(:formValues), symbolize_names: true)
+    contact_recipient = form_values[:contactRecipient]
     attachment = params[:attachment]
-    contact_params = formValues[contact_recipient.to_sym]
-    requestor_details = current_user || formValues[:userData]
+    contact_params = form_values[contact_recipient.to_sym]
+    requestor_details = current_user || form_values[:userData]
 
     return render status: :bad_request, json: { error: "Invalid arguments" } if contact_recipient.nil? || contact_params.nil? || requestor_details.nil?
 
@@ -120,11 +120,11 @@ class ContactsController < ApplicationController
   end
 
   def edit_profile_action
-    formValues = JSON.parse(params.require(:formValues), symbolize_names: true)
-    edited_profile_details = formValues[:editedProfileDetails]
-    edit_profile_reason = formValues[:editProfileReason]
+    form_values = JSON.parse(params.require(:formValues), symbolize_names: true)
+    edited_profile_details = form_values[:editedProfileDetails]
+    edit_profile_reason = form_values[:editProfileReason]
     attachment = params[:attachment]
-    wca_id = formValues[:wcaId]
+    wca_id = form_values[:wcaId]
     person = Person.find_by(wca_id: wca_id)
     edit_others_profile_mode = current_user&.wca_id != wca_id
 


### PR DESCRIPTION
Never `camelCase` again! (at least in the backend...)