### PR TITLE
Remove `allow_registration_self_delete_after_acceptance` from `competition` table

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -126,7 +126,6 @@ class Competition < ApplicationRecord
     on_the_spot_registration
     on_the_spot_entry_fee_lowest_denomination
     allow_registration_edits
-    allow_registration_self_delete_after_acceptance
     allow_registration_without_qualification
     refund_policy_percent
     guests_entry_fee_lowest_denomination
@@ -223,7 +222,6 @@ class Competition < ApplicationRecord
   validates :on_the_spot_registration, inclusion: { in: [true, false], if: :on_the_spot_registration_required? }
   validates :on_the_spot_entry_fee_lowest_denomination, numericality: { greater_than_or_equal_to: 0, if: :on_the_spot_entry_fee_required? }
   validates :allow_registration_edits, inclusion: { in: [true, false] }
-  validates :allow_registration_self_delete_after_acceptance, inclusion: { in: [true, false] }
   monetize :on_the_spot_entry_fee_lowest_denomination,
            as: "on_the_spot_base_entry_fee",
            allow_nil: true,

--- a/db/migrate/20250420065218_remove_self_delete_after_acceptance.rb
+++ b/db/migrate/20250420065218_remove_self_delete_after_acceptance.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveSelfDeleteAfterAcceptance < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :competitions, :allow_registration_self_delete_after_acceptance, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_18_024459) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_20_065218) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -447,7 +447,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_18_024459) do
     t.datetime "event_change_deadline_date", precision: nil
     t.integer "guest_entry_status", default: 0, null: false
     t.boolean "allow_registration_edits", default: false, null: false
-    t.boolean "allow_registration_self_delete_after_acceptance", default: false, null: false
     t.integer "competition_series_id"
     t.boolean "use_wca_live_for_scoretaking", default: false, null: false
     t.boolean "allow_registration_without_qualification", default: false

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -103,7 +103,6 @@ module DatabaseDumper
           event_change_deadline_date
           force_comment_in_registration
           allow_registration_edits
-          allow_registration_self_delete_after_acceptance
           competition_series_id
           use_wca_live_for_scoretaking
           allow_registration_without_qualification


### PR DESCRIPTION
This field was deprecated by the introduction of `competitor_can_cancel` (#10807). I've grepped for calls to this property in the codebase and found none besides
- a validation against the field's value
- usage in migrations

so looks safe to remove outright.

There are also still keys with this field's name in i18n files - not sure how these get resolved/removed. The relevant keys seem to be removed from en.yml, but that doesn't appear to automatically propagate to other i18n files?