### PR TITLE
Fix a variable name typo in development seeds

### DIFF
--- a/db/seeds/development/competitions.seeds.rb
+++ b/db/seeds/development/competitions.seeds.rb
@@ -63,7 +63,7 @@ after "development:users", "development:user_roles" do
       event = competition_event.event
       round_types = %w(1 2 f).freeze
 
-      round_types.each_with_index do |_round_type_id, j|
+      round_types.each_with_index do |round_type_id, j|
         round_format = event.preferred_formats.first.format
         is_final = j == round_types.length - 1
 


### PR DESCRIPTION
This makes `docker exec -it rails bash -c "bin/rake db:reset"` work again.