### PR TITLE
Implement forum age restriction

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -264,6 +264,9 @@ class UsersController < ApplicationController
     if current_user.forum_banned?
       flash[:alert] = I18n.t('registrations.errors.banned_html').html_safe
       return redirect_to new_user_session_path
+    elsif current_user.below_forum_age_requirement?
+      flash[:alert] = I18n.t('registrations.errors.forum_age_requirement').html_safe # TODO: Consider alternative i18n key path
+      return redirect_to new_user_session_path
     end
 
     # Use the 'SingleSignOn' lib provided by Discourse. Our secret and URL is

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -265,7 +265,7 @@ class UsersController < ApplicationController
       flash[:alert] = I18n.t('registrations.errors.banned_html').html_safe
       return redirect_to new_user_session_path
     elsif current_user.below_forum_age_requirement?
-      flash[:alert] = I18n.t('registrations.errors.forum_age_requirement').html_safe # TODO: Consider alternative i18n key path
+      flash[:alert] = I18n.t('misc.forum_age_requirement').html_safe
       return redirect_to new_user_session_path
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,8 @@ class User < ApplicationRecord
   ANONYMOUS_GENDER = 'o'
   ANONYMOUS_COUNTRY_ISO2 = 'US'
 
+  FORUM_AGE_REQUIREMENT = 13
+
   def self.eligible_voters
     [
       UserGroup.delegate_regions,
@@ -490,12 +492,22 @@ class User < ApplicationRecord
     user.senior_delegates.include?(self)
   end
 
-  def banned?
-    group_member?(UserGroup.banned_competitors.first)
+  def age_in_years
+    age = Date.today.year - dob.year
+    age -= 1 if Date.today < dob.advance(years: age)
+    age
+  end
+
+  def below_forum_age_requirement?
+    age_in_years < FORUM_AGE_REQUIREMENT
   end
 
   def forum_banned?
     current_ban&.metadata&.scope == 'competing_and_attending_and_forums'
+  end
+
+  def banned?
+    group_member?(UserGroup.banned_competitors.first)
   end
 
   def banned_in_past?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2323,7 +2323,9 @@ en:
     messages:
       success: "Thank you for your message. We will contact you soon!"
       delivery_error: "Error sending message."
-
+  #context: for keys which don't fit into another category, and don't justify a category of their own
+  misc:
+    forum_age_requirement: "You must be 13 years old to access the WCA Forum."
   #context: FAQ page
   faq:
     title: "Frequently Asked Questions"

--- a/db/migrate/20250421053202_add_invoice_items_table.rb
+++ b/db/migrate/20250421053202_add_invoice_items_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddInvoiceItemsTable < ActiveRecord::Migration[7.2]
+  def change
+    create_table :invoice_items do |t|
+      t.belongs_to :registration
+      t.integer :amount_lowest_denomination
+      t.string :currency_code
+      t.integer :status
+      t.string :display_name
+      t.timestamps
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -765,4 +765,46 @@ RSpec.describe User, type: :model do
       expect(user.teams_committees_at_least_senior_roles).not_to include(wrt_role)
     end
   end
+
+  describe '#age_in_years' do
+    let(:user) { FactoryBot.create(:user) }
+
+    it 'returns an integer' do
+      expect(user.age_in_years.class).to be(Integer)
+    end
+
+    it 'counts the year if after user birthday' do
+      user.dob = Date.today.advance(days: -1, years: -10)
+      expect(user.age_in_years).to be(10)
+    end
+
+    it 'counts the year if on user birthday' do
+      user.dob = Date.today.advance(years: -10)
+      expect(user.age_in_years).to be(10)
+    end
+
+    it 'doesnt count the year if before user birthday' do
+      user.dob = Date.today.advance(years: -10, days: 1)
+      expect(user.age_in_years).to be(9)
+    end
+  end
+
+  describe '#below_forum_age_requirement?' do
+    let(:user) { FactoryBot.create(:user) }
+
+    it 'true when user under 13' do
+      user.dob = Date.today.advance(days: 1, years: -13)
+      expect(user.below_forum_age_requirement?).to be(true)
+    end
+
+    it 'false when user is 13' do
+      user.dob = Date.today.advance(years: -13)
+      expect(user.below_forum_age_requirement?).to be(false)
+    end
+
+    it 'false when user older than 13' do
+      user.dob = Date.today.advance(years: -27)
+      expect(user.below_forum_age_requirement?).to be(false)
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -224,6 +224,14 @@ RSpec.describe "users" do
       get "#{sso_discourse_path}?#{sso.payload}"
       expect(response).to redirect_to new_user_session_path
     end
+
+    it 'doesnt authenticate user under 13' do
+      user = FactoryBot.create(:user, dob: Date.today.advance(years: -13, days: 1))
+      sign_in user
+      sso.nonce = 1234
+      get "#{sso_discourse_path}?#{sso.payload}"
+      expect(response).to redirect_to new_user_session_path
+    end
   end
 
   def query_string_from_location(location)


### PR DESCRIPTION
In the email thread "Adding Age Requirement to WCA Forum", WCT has requested that we implement an age requirement of 13 years old for signing up to the forum - this will align us with COPPA. From a data protection perspective, WRT confirmed that we can use age data to enforce this type of restriction.

This PR blocks SSO if the user's age is below 13, following a similar pattern to how we prevent banned users from registering. Importantly, this PR also adds a `misc` category for i18n keys - I couldn't see a better category to put a one-off forum key in.