### PR TITLE
Enable last FactoryBot Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -387,8 +387,3 @@ RSpecRails/NegationBeValid:
 
 RSpecRails/InferredSpecType:
   Enabled: false
-
-# Factory Bot
-
-FactoryBot/ExcessiveCreateList:
-  Enabled: false

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -1127,7 +1127,7 @@ RSpec.describe Registrations::RegistrationChecker do
         competitor_limit = create(:competition, :with_competitor_limit, :with_organizer, competitor_limit: 3)
         limited_reg = create(:registration, competition: competitor_limit)
         create_list(:registration, 2, :accepted, competition: competitor_limit)
-        create_list(:registration, 17, :accepted)
+        create_list(:registration, 10, :accepted)
 
         update_request = build(
           :update_request,

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UserGroup, type: :model do
   let(:asia_west_region) { GroupsMetadataDelegateRegions.find_by!(friendly_id: 'asia-west').user_group }
   let(:india_region) { GroupsMetadataDelegateRegions.find_by!(friendly_id: 'india').user_group }
   let(:australia_region) { GroupsMetadataDelegateRegions.find_by!(friendly_id: 'australia').user_group }
-  let(:delegate_roles) { create_list(:delegate_role, 44) }
+  let(:delegate_roles) { create_list(:delegate_role, 44) } # rubocop:disable FactoryBot/ExcessiveCreateList
   let(:delegate_users) { delegate_roles.map(&:user) }
   let(:users) { create_list(:user_with_wca_id, 10) }
 


### PR DESCRIPTION
In case of registrations, I don't know where the number 17 came from. The Cop prefers <=10, so that's what I arbitrarily went with.

In the case of Delegate Roles, I opted to ignore the cop because we really do have that many different regions/roles to test.