### PR TITLE
Activate SymbolProc Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -170,7 +170,15 @@ Style/WordArray:
   Enabled: false
 
 Style/SymbolProc:
-  Enabled: false
+  AllowedMethods:
+    # Capybara DSL plugins
+    - with_playwright_element_handle
+    - with_playwright_page
+  Exclude:
+    # 3rd-party libraries often use configuration DSLs
+    #   that look like we might pass a proc, but actually we want to
+    #   stick as close to their README as possible
+    - 'config/initializers/**/*.rb'
 
 Naming/MethodParameterName:
   AllowedNames:

--- a/app/controllers/api/v0/user_roles_controller.rb
+++ b/app/controllers/api/v0/user_roles_controller.rb
@@ -289,7 +289,7 @@ class Api::V0::UserRolesController < Api::V0::ApiController
     query = params.require(:query)
     group_type = params.require(:groupType)
     roles = UserGroup.roles_of_group_type(group_type)
-    active_roles = roles.select { |role| role.active? }
+    active_roles = roles.select(&:active?)
 
     query.split.each do |part|
       active_roles = active_roles.select do |role|

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -191,7 +191,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
                                   competition.event_ids,
                                   registrations.joins(:user).order(:id).pluck(:id, :updated_at, user: [:updated_at]),
                                 ]) do
-      registrations.includes(:user).map { |r| r.to_v2_json }
+      registrations.includes(:user).map(&:to_v2_json)
     end
     render json: payload
   end

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -377,9 +377,7 @@ class CompetitionsController < ApplicationController
       },
       limit: other_comp.competitor_limit_enabled ? other_comp.competitor_limit : "",
       competitors: other_comp.probably_over? ? other_comp.results.select('DISTINCT person_id').count : "",
-      events: other_comp.events.map { |event|
-        event.id
-      },
+      events: other_comp.events.map(&:id),
       coordinates: {
         lat: other_comp.latitude_degrees,
         long: other_comp.longitude_degrees,
@@ -424,9 +422,7 @@ class CompetitionsController < ApplicationController
       minutesUntil: competition.minutes_until_other_registration_starts(other_comp),
       cityName: other_comp.city_name,
       countryId: other_comp.country_id,
-      events: other_comp.events.map { |event|
-        event.id
-      },
+      events: other_comp.events.map(&:id),
     }
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -251,7 +251,7 @@ class RegistrationsController < ApplicationController
       country_iso2: Country.c_find(registration_row[:country]).iso2,
       gender: registration_row[:gender],
       dob: registration_row[:birth_date],
-    ).tap { |user| user.save! }
+    ).tap(&:save!)
   end
 
   def register

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -182,9 +182,7 @@ class TicketsController < ApplicationController
     ActiveRecord::Base.transaction do
       person&.anonymize
 
-      users_to_anonymize.each do |user_to_anonymize|
-        user_to_anonymize.anonymize
-      end
+      users_to_anonymize.each(&:anonymize)
     end
 
     render json: {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -275,7 +275,7 @@ class UsersController < ApplicationController
     all_groups = User.all_discourse_groups
 
     # Get the teams/councils/Delegate status for user
-    user_groups = current_user.active_roles.map { |role| role.discourse_user_group }.uniq.compact.sort
+    user_groups = current_user.active_roles.map(&:discourse_user_group).uniq.compact.sort
 
     sso.external_id = current_user.id
     sso.name = current_user.name

--- a/app/jobs/clear_connected_payment_integrations.rb
+++ b/app/jobs/clear_connected_payment_integrations.rb
@@ -5,8 +5,6 @@ class ClearConnectedPaymentIntegrations < WcaCronjob
 
   def perform
     comps_to_disconnect = Competition.where(end_date: ...DELAY_IN_DAYS.days.ago).joins(:competition_payment_integrations).distinct
-    comps_to_disconnect.find_each do |comp|
-      comp.disconnect_all_payment_integrations
-    end
+    comps_to_disconnect.find_each(&:disconnect_all_payment_integrations)
   end
 end

--- a/app/jobs/job_utils.rb
+++ b/app/jobs/job_utils.rb
@@ -21,7 +21,7 @@ module JobUtils
     DelegatesMetadataSyncJob,
   ].freeze
 
-  WCA_CRONJOBS_MAP = WCA_CRONJOBS.index_by { |job| job.name }
+  WCA_CRONJOBS_MAP = WCA_CRONJOBS.index_by(&:name)
 
   def self.cronjob_statistics_from_cronjob_name(cronjob_name)
     WCA_CRONJOBS_MAP[cronjob_name]&.cronjob_statistics

--- a/app/models/competition_medium.rb
+++ b/app/models/competition_medium.rb
@@ -13,7 +13,7 @@ class CompetitionMedium < ApplicationRecord
   # https://github.com/thewca/worldcubeassociation.org/issues/2070
   # tracks adding this gem to our codebase.
   def self.media_types_i18n
-    self.media_types.keys.index_with { |k| k.titleize }
+    self.media_types.keys.index_with(&:titleize)
   end
 
   scope :belongs_to_region, lambda { |region_id|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,8 +81,8 @@ class User < ApplicationRecord
       UserGroup.board,
       UserGroup.officers,
     ].flatten.flat_map(&:active_roles)
-      .select { |role| role.eligible_voter? }
-      .map { |role| role.user }
+      .select(&:eligible_voter?)
+      .map(&:user)
       .uniq
   end
 
@@ -447,7 +447,7 @@ class User < ApplicationRecord
   end
 
   def staff?
-    active_roles.any? { |role| role.staff? }
+    active_roles.any?(&:staff?)
   end
 
   def admin?
@@ -1155,8 +1155,8 @@ class User < ApplicationRecord
     UserGroup
       .delegate_regions
       .flat_map(&:active_roles)
-      .select { |role| role.staff? }
-      .map { |role| role.user_id }
+      .select(&:staff?)
+      .map(&:user_id)
   end
 
   def self.trainee_delegate_ids
@@ -1164,7 +1164,7 @@ class User < ApplicationRecord
       .delegate_regions
       .flat_map(&:active_roles)
       .select { |role| role.metadata.status == RolesMetadataDelegateRegions.statuses[:trainee_delegate] }
-      .map { |role| role.user_id }
+      .map(&:user_id)
   end
 
   def self.search(query, params: {})
@@ -1208,7 +1208,7 @@ class User < ApplicationRecord
         ].include?(role.group_type)
       }
       .reject { |role| role.group.is_hidden }
-      .map { |role| role.deprecated_team_role }
+      .map(&:deprecated_team_role)
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
@@ -1399,7 +1399,7 @@ class User < ApplicationRecord
 
   def subordinate_delegates
     delegate_roles
-      .filter { |role| role.lead? }
+      .filter(&:lead?)
       .flat_map { |role| role.group.active_users + role.group.active_all_child_users }
       .uniq
   end
@@ -1409,7 +1409,7 @@ class User < ApplicationRecord
   end
 
   private def highest_delegate_role
-    delegate_roles.max_by { |role| role.status_rank }
+    delegate_roles.max_by(&:status_rank)
   end
 
   def delegate_status

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -59,11 +59,11 @@ class UserGroup < ApplicationRecord
   end
 
   def all_child_users
-    self.all_child_roles.map { |role| role.user }
+    self.all_child_roles.map(&:user)
   end
 
   def active_all_child_users
-    self.active_all_child_roles.map { |role| role.user }
+    self.active_all_child_roles.map(&:user)
   end
 
   def self.group_types_containing_status_metadata
@@ -170,7 +170,7 @@ class UserGroup < ApplicationRecord
   end
 
   def lead_role
-    active_roles.includes(:group, :metadata).find { |role| role.lead? }
+    active_roles.includes(:group, :metadata).find(&:lead?)
   end
 
   # TODO: Once the roles migration is done, add a validation to make sure there is only one lead_user per group.

--- a/lib/advancement_conditions/advancement_condition.rb
+++ b/lib/advancement_conditions/advancement_condition.rb
@@ -27,7 +27,7 @@ module AdvancementConditions
     end
 
     def self.wcif_type_to_class
-      @@wcif_type_to_class ||= @@advancement_conditions.index_by { |cls| cls.wcif_type }
+      @@wcif_type_to_class ||= @@advancement_conditions.index_by(&:wcif_type)
     end
 
     def self.load(json)

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -11,7 +11,7 @@ module Registrations
         #   cloning _then_ sets it to the `accepted` status of the original registration.
         # In practice, this change is necessary so that verifying a registration update
         #   of a full competition does not trigger registration limit checks.
-        entity&.deep_dup&.tap { it.clear_changes_information }
+        entity&.deep_dup&.tap(&:clear_changes_information)
       else
         entity
       end
@@ -81,7 +81,7 @@ module Registrations
 
     class << self
       def validate_registration_events!(registration)
-        process_nested_validation_error!(registration, :registration_competition_events, :competition_event) { it.event_id }
+        process_nested_validation_error!(registration, :registration_competition_events, :competition_event, &:event_id)
         process_validation_error!(registration, :registration_competition_events)
         process_validation_error!(registration, :competition_events)
       end
@@ -101,7 +101,7 @@ module Registrations
         return if registration.valid?
 
         grouped_error_details = registration.public_send(association)
-                                            .reject { it.valid? }
+                                            .reject(&:valid?)
                                             .index_with { it.errors.details[field]&.presence }
                                             .compact
 

--- a/lib/results_validators/competitions_results_validator.rb
+++ b/lib/results_validators/competitions_results_validator.rb
@@ -40,7 +40,7 @@ module ResultsValidators
     end
 
     def persons_by_id
-      @persons_by_id ||= @persons.index_by { |person| person.ref_id }
+      @persons_by_id ||= @persons.index_by(&:ref_id)
     end
 
     def competition_associations


### PR DESCRIPTION
Everything in the diff comes from the auto-correct routine. Added a few exceptions, notably:
- The Capybara DSL
- The configuration initializers

:warning: This was using the **unsafe** auto-correct, read more about the safety here: https://docs.rubocop.org/rubocop/1.75/cops_style.html#safety-stylesymbolproc (I don't think this affects us, but I might be overlooking something)