### PR TITLE
Consistently use admin_comment in registration payloads

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -109,7 +109,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
       existing_registration_in_series?(@competition, target_user) && !current_user.can_manage_competition?(@competition)
 
-    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_organizer_fields?(@request) && !@current_user.can_manage_competition?(@competition)
+    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_admin_fields?(@request) && !@current_user.can_manage_competition?(@competition)
 
     # The rest of these are status + normal user related
     return if @current_user.can_manage_competition?(@competition)
@@ -310,7 +310,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
         total_accepted_registrations_after_update > competition.competitor_limit
     end
 
-    def contains_organizer_fields?(request)
+    def contains_admin_fields?(request)
       organizer_fields = ['admin_comment', 'waiting_list_position']
 
       request['competing']&.keys&.any? { |key| organizer_fields.include?(key) }

--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -311,7 +311,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     end
 
     def contains_organizer_fields?(request)
-      organizer_fields = ['organizer_comment', 'waiting_list_position']
+      organizer_fields = ['admin_comment', 'waiting_list_position']
 
       request['competing']&.keys&.any? { |key| organizer_fields.include?(key) }
     end

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -33,12 +33,12 @@ module Registrations
 
         competing_payload = raw_payload['competing']
         comment = competing_payload&.dig('comment')
-        organizer_comment = competing_payload&.dig('organizer_comment') || competing_payload&.dig('admin_comment')
+        admin_comment = competing_payload&.dig('admin_comment')
         competing_status = competing_payload&.dig('status')
         waiting_list_position = competing_payload&.dig('waiting_list_position')
 
         new_registration.comments = comment if competing_payload&.key?('comment')
-        new_registration.administrative_notes = organizer_comment if competing_payload&.key?('organizer_comment') || competing_payload&.key?('admin_comment')
+        new_registration.administrative_notes = admin_comment if competing_payload&.key?('admin_comment')
         new_registration.competing_status = competing_status if competing_payload&.key?('status')
         new_registration.waiting_list_position = waiting_list_position if competing_payload&.key?('waiting_list_position')
 
@@ -73,7 +73,7 @@ module Registrations
       # Migrated to ActiveRecord-style validations
       validate_guests!(updated_registration)
       validate_comment!(updated_registration)
-      validate_organizer_comment!(updated_registration)
+      validate_admin_comment!(updated_registration)
       validate_registration_events!(updated_registration)
       validate_status_value!(updated_registration)
       validate_waiting_list_position!(updated_registration)
@@ -131,7 +131,7 @@ module Registrations
         process_validation_error!(registration, :comments)
       end
 
-      def validate_organizer_comment!(registration)
+      def validate_admin_comment!(registration)
         process_validation_error!(registration, :administrative_notes)
       end
 

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -772,20 +772,20 @@ RSpec.describe Registrations::RegistrationChecker do
     end
 
     describe '#update_registration_allowed!.validate_organizer_fields!' do
-      it 'organizer can add organizer_comment' do
+      it 'organizer can add admin_comment' do
         update_request = build(
           :update_request,
           user_id: default_registration.user_id,
           competition_id: default_registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'organizer_comment' => 'this is an admin comment' },
+          competing: { 'admin_comment' => 'this is an admin comment' },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
-      it 'organizer can change organizer_comment' do
+      it 'organizer can change admin_comment' do
         registration = create(
           :registration, user_id: default_user.id, competition_id: default_competition.id, administrative_notes: 'organizer comment'
         )
@@ -795,7 +795,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: registration.user_id,
           competition_id: registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'organizer_comment' => 'this is an admin comment' },
+          competing: { 'admin_comment' => 'this is an admin comment' },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
@@ -803,7 +803,7 @@ RSpec.describe Registrations::RegistrationChecker do
       end
     end
 
-    describe '#update_registration_allowed!.validate_organizer_comment!' do
+    describe '#update_registration_allowed!.validate_admin_comment!' do
       it 'organizer comment cant exceed 240 characters' do
         long_comment = 'comment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer
         than 240 characterscomment longer than 240 characters'
@@ -813,7 +813,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: default_registration.user_id,
           competition_id: default_registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'organizer_comment' => long_comment },
+          competing: { 'admin_comment' => long_comment },
         )
 
         expect {
@@ -833,7 +833,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: default_registration.user_id,
           competition_id: default_registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'organizer_comment' => at_character_limit },
+          competing: { 'admin_comment' => at_character_limit },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -787,7 +787,7 @@ RSpec.describe Registrations::RegistrationChecker do
 
       it 'organizer can change admin_comment' do
         registration = create(
-          :registration, user_id: default_user.id, competition_id: default_competition.id, administrative_notes: 'organizer comment'
+          :registration, user_id: default_user.id, competition_id: default_competition.id, administrative_notes: 'admin comment'
         )
 
         update_request = build(
@@ -804,7 +804,7 @@ RSpec.describe Registrations::RegistrationChecker do
     end
 
     describe '#update_registration_allowed!.validate_admin_comment!' do
-      it 'organizer comment cant exceed 240 characters' do
+      it 'admin comment cant exceed 240 characters' do
         long_comment = 'comment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer
         than 240 characterscomment longer than 240 characters'
 
@@ -824,7 +824,7 @@ RSpec.describe Registrations::RegistrationChecker do
         end
       end
 
-      it 'organizer comment can match 240 characters' do
+      it 'admin comment can match 240 characters' do
         at_character_limit = 'comment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than' \
                              '240 characterscomment longer longer than 240 12345'
 

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -595,7 +595,7 @@ RSpec.describe 'API Registrations' do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it 'user cant submit an organizer comment' do
+    it 'user cant submit an admin comment' do
       update_request = build(
         :update_request,
         user_id: registration.user_id,

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -600,7 +600,7 @@ RSpec.describe 'API Registrations' do
         :update_request,
         user_id: registration.user_id,
         competition_id: registration.competition_id,
-        competing: { 'organizer_comment' => 'this is an admin comment' },
+        competing: { 'admin_comment' => 'this is an admin comment' },
       )
 
       headers = { 'Authorization' => update_request['jwt_token'] }


### PR DESCRIPTION
Replaced all occurences that were spotted by my IDE using global search. From the looks of it, the frontend was already consistently using `admin_comment`, only some tests were stuck with `organizer_comment` :joy: 

I decided to go with `admin_comment` consistently, because that's being used in more places (and in the frontend payloads), and the backend field is also called `administrative_notes`.