### PR TITLE
add edit text as icon fallback

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -9,7 +9,7 @@
       <% if current_user&.can_create_posts? %>
         <span class="pull-right">
           <%= link_to edit_post_path(post.slug) do %>
-            <span class="icon pencil alternate"></span>
+            <span class="icon pencil alternate">Edit</span>
           <% end %>
           <% if post.persisted? %>
             <%= link_to post_path(post.slug), method: "delete", data: { confirm: I18n.t('posts.confirm_delete_post') } do %>


### PR DESCRIPTION
Hotfix for #11399 - I gave myself 30 minutes to try and look into/resolve this, and found the following: 
- We are still rendering posts with Ruby, not React - despite other parts of the Post stack using React
- It appears that the icon `icon pencil alternate` is not being found; I'm not sure why, although I suspect we may have removed FontAwesome, which is where the icon seems to be from? 
  - The reason we still have pencil icons in `/posts` (ie, the list view) is because that uses the `PostsWidget` React component. 

**My fix:** Adding "Edit" in the icon's span ensures that something is rendered so that WCT can continue to edit posts from within the posts page, as requested by Zain. 

**Better Fixes:**
- Figure out why the icon isn't being rendered and resolve that, or
- Ideally, rewrite this page in React
  - Not particularly difficult, but it includes permissions check that make such a rewrite just-untrivial-enough that I don't want to delve into it now