### PR TITLE
allow pending or waitlist registrations to be edited by competitiors

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -199,11 +199,8 @@ export default function CompetingStep({
     guests,
   ]);
 
-  const canEditRegistration = (competitionInfo, registration) => {
-    return (
-      competitionInfo.allow_registration_edits || ['pending', 'waiting_list'].includes(registration.competing.registration_status)
-    );
-  };
+  const canEditRegistration = (competitionInfo, registration) =>
+    competitionInfo.allow_registration_edits || ['pending', 'waiting_list'].includes(registration.competing.registration_status);
 
 
   const actionUpdateRegistration = useCallback(() => {

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -60,7 +60,8 @@ export default function CompetingStep({
 }) {
   const maxEvents = competitionInfo.events_per_registration_limit ?? Infinity;
   const {
-    registration, isRegistered, hasPaid, isPolling, isProcessing, startPolling, refetchRegistration, isPending, isWaitingList,
+    registration, isRegistered, hasPaid, isPolling, isProcessing, startPolling, refetchRegistration,
+    isPending, isWaitingList,
   } = useRegistration();
   const dispatch = useDispatch();
 
@@ -199,15 +200,11 @@ export default function CompetingStep({
     guests,
   ]);
 
-  const canEditRegistration = (compInfo) => (
-    compInfo.allow_registration_edits || isPending || isWaitingList
-  );
-
   const actionUpdateRegistration = useCallback(() => {
     confirm({
-      content: I18n.t(canEditRegistration(competitionInfo) ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
+      content: I18n.t(competitionInfo.allow_registration_edits || isPending || isWaitingList ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
     }).then(() => {
-      if (canEditRegistration(competitionInfo)) {
+      if (competitionInfo.allow_registration_edits || isPending || isWaitingList) {
         dispatch(showMessage('competitions.registration_v2.update.being_updated', 'basic'));
         updateRegistrationMutation({
           user_id: registration.user_id,

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -200,11 +200,15 @@ export default function CompetingStep({
     guests,
   ]);
 
+  const canEditRegistration = useMemo(() => (
+    competitionInfo.allow_registration_edits || isPending || isWaitingList
+  ), [competitionInfo.allow_registration_edits, isPending, isWaitingList]);
+
   const actionUpdateRegistration = useCallback(() => {
     confirm({
-      content: I18n.t(competitionInfo.allow_registration_edits || isPending || isWaitingList ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
+      content: I18n.t(canEditRegistration ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
     }).then(() => {
-      if (competitionInfo.allow_registration_edits || isPending || isWaitingList) {
+      if (canEditRegistration) {
         dispatch(showMessage('competitions.registration_v2.update.being_updated', 'basic'));
         updateRegistrationMutation({
           user_id: registration.user_id,
@@ -235,6 +239,7 @@ export default function CompetingStep({
     selectedEventIds.asArray,
     hasGuestsChanged,
     guests,
+    canEditRegistration,
   ]);
 
   const actionReRegister = useCallback(() => {

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -60,7 +60,7 @@ export default function CompetingStep({
 }) {
   const maxEvents = competitionInfo.events_per_registration_limit ?? Infinity;
   const {
-    registration, isRegistered, hasPaid, isPolling, isProcessing, startPolling, refetchRegistration,
+    registration, isRegistered, hasPaid, isPolling, isProcessing, startPolling, refetchRegistration, isPending, isWaitingList,
   } = useRegistration();
   const dispatch = useDispatch();
 
@@ -199,15 +199,15 @@ export default function CompetingStep({
     guests,
   ]);
 
-  const canEditRegistration = (compInfo, regInfo) => (
-    compInfo.allow_registration_edits || ['pending', 'waiting_list'].includes(regInfo.competing.registration_status)
+  const canEditRegistration = (compInfo) => (
+    compInfo.allow_registration_edits || isPending || isWaitingList
   );
 
   const actionUpdateRegistration = useCallback(() => {
     confirm({
-      content: I18n.t(canEditRegistration(competitionInfo, registration) ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
+      content: I18n.t(canEditRegistration(competitionInfo) ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
     }).then(() => {
-      if (canEditRegistration(competitionInfo, registration)) {
+      if (canEditRegistration(competitionInfo)) {
         dispatch(showMessage('competitions.registration_v2.update.being_updated', 'basic'));
         updateRegistrationMutation({
           user_id: registration.user_id,

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -199,9 +199,9 @@ export default function CompetingStep({
     guests,
   ]);
 
-  const canEditRegistration = (competitionInfo, registration) =>
-    competitionInfo.allow_registration_edits || ['pending', 'waiting_list'].includes(registration.competing.registration_status);
-
+  const canEditRegistration = (compInfo, regInfo) => (
+    compInfo.allow_registration_edits || ['pending', 'waiting_list'].includes(regInfo.competing.registration_status)
+  );
 
   const actionUpdateRegistration = useCallback(() => {
     confirm({

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -199,6 +199,13 @@ export default function CompetingStep({
     guests,
   ]);
 
+  const canEditRegistration = (competitionInfo, registration) => {
+    return (
+      competitionInfo.allow_registration_edits || ['pending', 'waiting_list'].includes(registration.competing.registration_status)
+    );
+  };
+
+
   const actionUpdateRegistration = useCallback(() => {
     confirm({
       content: I18n.t(canEditRegistration(competitionInfo, registration) ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
@@ -235,13 +242,6 @@ export default function CompetingStep({
     hasGuestsChanged,
     guests,
   ]);
-
-  const canEditRegistration = (competitionInfo, registration) => {
-    return (
-      competitionInfo.allow_registration_edits ||
-      ['pending', 'waiting_list'].includes(registration.competing.registration_status)
-    );
-  };
 
   const actionReRegister = useCallback(() => {
     updateRegistrationMutation({

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -201,9 +201,9 @@ export default function CompetingStep({
 
   const actionUpdateRegistration = useCallback(() => {
     confirm({
-      content: I18n.t(competitionInfo.allow_registration_edits ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
+      content: I18n.t(canEditRegistration(competitionInfo, registration) ? 'competitions.registration_v2.update.update_confirm' : 'competitions.registration_v2.update.update_confirm_contact'),
     }).then(() => {
-      if (competitionInfo.allow_registration_edits) {
+      if (canEditRegistration(competitionInfo, registration)) {
         dispatch(showMessage('competitions.registration_v2.update.being_updated', 'basic'));
         updateRegistrationMutation({
           user_id: registration.user_id,
@@ -235,6 +235,13 @@ export default function CompetingStep({
     hasGuestsChanged,
     guests,
   ]);
+
+  const canEditRegistration = (competitionInfo, registration) => {
+    return (
+      competitionInfo.allow_registration_edits ||
+      ['pending', 'waiting_list'].includes(registration.competing.registration_status)
+    );
+  };
 
   const actionReRegister = useCallback(() => {
     updateRegistrationMutation({

--- a/app/webpacker/components/RegistrationsV2/lib/RegistrationProvider.js
+++ b/app/webpacker/components/RegistrationsV2/lib/RegistrationProvider.js
@@ -66,12 +66,16 @@ export default function RegistrationProvider({
   const isAccepted = isRegistered && registration.competing.registration_status === 'accepted';
   const isRejected = isRegistered && registration.competing.registration_status === 'rejected';
   const hasPaid = registration?.payment?.has_paid;
+  const isPending = isRegistered && registration.competing.registration_status === 'pending';
+  const isWaitingList = isRegistered && registration.competing.registration_status === 'waiting_list';
 
   const value = useMemo(() => ({
     isRegistered,
     isAccepted,
     isRejected,
     hasPaid,
+    isPending,
+    isWaitingList,
     registration,
     refetchRegistration,
     isFetching,
@@ -87,6 +91,8 @@ export default function RegistrationProvider({
     isFetching,
     isRegistered,
     isRejected,
+    isPending,
+    isWaitingList,
     isPolling,
     refetchRegistration,
     registration,


### PR DESCRIPTION
fixes: https://github.com/thewca/worldcubeassociation.org/issues/11388

When the option is:
![image](https://github.com/user-attachments/assets/8f7a1f82-fd74-47ff-bf74-79198c63df73)
