### PR TITLE
fix check logo on polls page

### DIFF
--- a/app/views/polls/_polls_list.html.erb
+++ b/app/views/polls/_polls_list.html.erb
@@ -4,7 +4,7 @@
       <td><%=md poll.question %></td>
       <td>
         <% if poll.user_already_voted?(current_user) %>
-          <span class="icon check circle" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-container="body" title="You have already voted in this poll"></span>
+          <i class="icon check circle" aria-hidden="true" data-toggle="tooltip" data-placement="top" data-container="body" title="You have already voted in this poll"></i>
         <% end %>
       </td>
       <td>


### PR DESCRIPTION
After looking at this PR: https://github.com/thewca/worldcubeassociation.org/pull/11409. I searched for other instances of similar cases (`span class="icon`) and found this

![image](https://github.com/user-attachments/assets/08cb49ef-e46f-42ab-92a5-d4b664f531fb)
