### PR TITLE
Block competition form soft-edits when results have been submitted

### DIFF
--- a/app/views/competitions/edit.html.erb
+++ b/app/views/competitions/edit.html.erb
@@ -7,6 +7,7 @@
     storedEvents: @competition.events,
     isAdminView: @competition_admin_view,
     isSeriesPersisted: @competition.competition_series&.persisted? || false,
+    areResultsSubmitted: @competition.results_submitted?,
     editingUserId: current_user.id,
   }) %>
 <% end %>

--- a/app/webpacker/components/CompetitionForm/Edit.js
+++ b/app/webpacker/components/CompetitionForm/Edit.js
@@ -22,6 +22,7 @@ function EditCompetition({
   storedEvents,
   isAdminView,
   isSeriesPersisted,
+  areResultsSubmitted,
 }) {
   const originalCompId = competition.competitionId;
   const backendUrl = `${competitionUrl(originalCompId)}?adminView=${isAdminView}`;
@@ -90,8 +91,13 @@ function EditCompetition({
     const { staff: { staffDelegateIds, traineeDelegateIds } } = competition;
     const allDelegates = [...staffDelegateIds, ...traineeDelegateIds];
 
-    return isAdminView || allDelegates.includes(editingUserId);
-  }, [competition, editingUserId, isAdminView]);
+    const isDelegateEdit = allDelegates.includes(editingUserId);
+
+    // Admins can edit whenever the heck they want.
+    // Delegates should only be allowed to edit as long as results are not submitted,
+    //   see https://github.com/thewca/worldcubeassociation.org/issues/11415 for details.
+    return isAdminView || (isDelegateEdit && !areResultsSubmitted);
+  }, [competition, editingUserId, isAdminView, areResultsSubmitted]);
 
   return (
     <StoreProvider
@@ -123,6 +129,7 @@ export default function Wrapper({
   storedEvents = [],
   isAdminView = false,
   isSeriesPersisted = false,
+  areResultsSubmitted = false,
 }) {
   return (
     <WCAQueryClientProvider>
@@ -132,6 +139,7 @@ export default function Wrapper({
         storedEvents={storedEvents}
         isAdminView={isAdminView}
         isSeriesPersisted={isSeriesPersisted}
+        areResultsSubmitted={areResultsSubmitted}
       />
     </WCAQueryClientProvider>
   );


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/11415