### PR TITLE
Fix unintended null pointer error in Stripe Webhook

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -313,18 +313,18 @@ class RegistrationsController < ApplicationController
     stripe_intent = event.data.object # contains a polymorphic type that depends on the event
     stored_record = StripeRecord.find_by(stripe_id: stripe_intent.id)
 
-    if StripeWebhookEvent::HANDLED_EVENTS.include?(event.type)
-      if stored_record.nil?
-        logger.error "Stripe webhook reported event on entity #{stripe_intent.id} but we have no matching transaction."
-        return head :not_found
-      else
-        audit_event.update!(stripe_record: stored_record, handled: true)
-      end
+    handling_event = StripeWebhookEvent::HANDLED_EVENTS.include?(event.type)
+
+    if stored_record.nil?
+      logger.error "Stripe webhook reported event on entity #{stripe_intent.id} but we have no matching transaction."
+      return head :not_found
+    else
+      audit_event.update!(stripe_record: stored_record, handled: handling_event)
     end
 
     connected_account = ConnectedStripeAccount.find_by(account_id: stored_record.account_id)
 
-    if connected_account.blank?
+    if connected_account.nil?
       logger.error "Stripe webhook reported event for account '#{stored_record.account_id}' but we are not connected to that account."
       return head :not_found
     end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -317,6 +317,12 @@ class RegistrationsController < ApplicationController
 
     if stored_record.nil?
       logger.error "Stripe webhook reported event on entity #{stripe_intent.id} but we have no matching transaction."
+
+      # If this is an event that we actually want to handle, but we did not find the Stripe transaction in our records,
+      #   additionally notify the alarms channel on Slack.
+      # If this happens too much, we can think about other ways for monitoring the Webhook. Signed GB 2025-04-28
+      SlackBot.send_alarm_message("Stripe webhook reported event on entity #{stripe_intent.id} but we have no matching transaction.") if handling_event
+
       return head :not_found
     else
       audit_event.update!(stripe_record: stored_record, handled: handling_event)

--- a/lib/slack_bot.rb
+++ b/lib/slack_bot.rb
@@ -16,4 +16,11 @@ module SlackBot
       initial_comment: message,
     )
   end
+
+  def self.send_alarm_message(message)
+    self.client.chat_postMessage(
+      channel: ALARMS_CHANNEL_ID,
+      message: message,
+    )
+  end
 end


### PR DESCRIPTION
With the recent Stripe API upgrade (see https://github.com/thewca/worldcubeassociation.org/pull/11298) the Webhook now sends some new events that we don't want/need to handle but that are hard to filter.

Our existing filter mechanism only returned 404 if the `StripeRecord` was missing on an event that was handled by us. However, for events that are *not* handled by us, it's actually much, much more likely (and also not harmful at all) that we don't have the `StripeRecord` on file. Ironically, in that case we were trying to load the connected account on a Stripe record that we did not find, leading to errors.

TL;DR: The point in time when we abort with a `404` changes to a tiny bit earlier. The overall webhook structure is completely unaffected.