### PR TITLE
Add index on (competition ID, competing status) in registrations table

### DIFF
--- a/db/migrate/20250428123246_add_competing_status_index.rb
+++ b/db/migrate/20250428123246_add_competing_status_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCompetingStatusIndex < ActiveRecord::Migration[7.2]
+  def change
+    add_index :registrations, [:competition_id, :competing_status]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_20_065218) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_28_123246) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1016,6 +1016,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_20_065218) do
     t.text "administrative_notes"
     t.string "competing_status", default: "pending", null: false
     t.datetime "registered_at", null: false
+    t.index ["competition_id", "competing_status"], name: "index_registrations_on_competition_id_and_competing_status"
     t.index ["competition_id", "user_id"], name: "index_registrations_on_competition_id_and_user_id", unique: true
     t.index ["competition_id"], name: "index_registrations_on_competition_id"
     t.index ["user_id"], name: "index_registrations_on_user_id"


### PR DESCRIPTION
See title. This is intended to speed up the computation of "registration status" (is the competition full, are there still spots available, etc.) which does a lot of
```sql
SELECT COUNT(*)
FROM `registrations`
WHERE `registrations`.`competition_id` = 'ErfurtOpen2015'
  AND `registrations`.`competing_status` = 'accepted';

SELECT COUNT(DISTINCT `registrations`.`id`)
FROM `registrations`
         LEFT OUTER JOIN `registration_payments`
             ON `registration_payments`.`registration_id` = `registrations`.`id`
WHERE `registrations`.`competition_id` = 'ErfurtOpen2015'
  AND `registrations`.`competing_status` = 'pending'
``` 

Note in particular the `WHERE registrations.competition_id = 'FooComp2025' AND registrations.competing_status = 'hooray';` part. That's what I think can benefit from an index.