### PR TITLE
Be less strict on Edit Events Deadline in competition form soft edits

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1199,8 +1199,8 @@ class Competition < ApplicationRecord
     self.on_the_spot_registration_changed? && self.on_the_spot_registration?
   end
 
-  validate :on_the_spot_registration_must_be_valid
-  private def on_the_spot_registration_must_be_valid
+  validate :enforce_edit_deadline_ots_consistency
+  private def enforce_edit_deadline_ots_consistency
     errors.add(:on_the_spot_registration, I18n.t('competitions.errors.on_the_spot_with_past_event_change_deadline')) if enabling_on_the_spot_registration? && event_change_deadline_date&.past?
   end
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1195,6 +1195,15 @@ class Competition < ApplicationRecord
     errors.add(:event_change_deadline_date, I18n.t('competitions.errors.event_change_deadline_after_end_date')) if event_change_deadline_date > end_date.to_datetime.end_of_day
   end
 
+  def enabling_on_the_spot_registration?
+    self.on_the_spot_registration_changed? && self.on_the_spot_registration?
+  end
+
+  validate :on_the_spot_registration_must_be_valid
+  private def on_the_spot_registration_must_be_valid
+    errors.add(:on_the_spot_registration, I18n.t('competitions.errors.on_the_spot_with_past_event_change_deadline')) if enabling_on_the_spot_registration? && event_change_deadline_date&.past?
+  end
+
   # Since Competition.events only includes saved events
   # this method is required to ensure that in any forms which
   # select events, unsaved events are still presented if

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2496,7 +2496,7 @@ class Competition < ApplicationRecord
         # These keys all represent timestamps. They may only be edited by non-admins if...
         #   - the original value (pre-edit) has not yet passed
         #   - the new value is in the future (extending deadlines is allowed, shortening them is not)
-        if %w[registration.closingDateTime registration.waitingListDeadlineDate registration.eventChangeDeadlineDate].include?(joined_key)
+        if %w[registration.closingDateTime registration.eventChangeDeadlineDate].include?(joined_key)
           existing_value = current_state_form.dig(*prefixes, key)
 
           if existing_value.present?

--- a/app/webpacker/components/CompetitionForm/FormSections/RegistrationDetails.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/RegistrationDetails.js
@@ -40,7 +40,6 @@ export default function RegistrationDetails() {
   const {
     registration: {
       waitingListDeadlineDate: originalWaitingListDeadlineDate,
-      eventChangeDeadlineDate: originalEventChangeDeadlineDate,
     },
   } = useFormInitialObject();
 
@@ -52,15 +51,10 @@ export default function RegistrationDetails() {
     [originalWaitingListDeadlineDate],
   );
 
-  const eventChangeNotYetPast = useMemo(
-    () => hasNotPassedOrNull(originalEventChangeDeadlineDate, 'UTC'),
-    [originalEventChangeDeadlineDate],
-  );
-
   return (
     <SubSection section="registration">
       <InputDate id="waitingListDeadlineDate" dateTime required ignoreDisabled={waitingListNotYetPast} />
-      <InputDate id="eventChangeDeadlineDate" dateTime required ignoreDisabled={eventChangeNotYetPast} />
+      <InputDate id="eventChangeDeadlineDate" dateTime required ignoreDisabled />
       <InputBooleanSelect id="allowOnTheSpot" required ignoreDisabled />
       <InputSelect id="competitorCanCancel" options={canCancelOptions} required ignoreDisabled />
       <InputBooleanSelect id="allowSelfEdits" required ignoreDisabled />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1994,6 +1994,7 @@ en:
       event_change_deadline_before_registration_close: "Deadline for updating events cannot be before registration close date."
       event_change_deadline_after_end_date: "Deadline for updating events cannot be after the competition."
       event_change_deadline_with_ots: "Deadline for updating events must be during the competition if on the spot registrations are accepted."
+      on_the_spot_with_past_event_change_deadline: "Cannot enable on the spot registrations if the deadline for updating events is in the past."
       series_distance_km: "The competition is located too far away from %{competition}."
       series_distance_days: "The competition is scheduled too many days away from %{competition}."
       must_ask_about_guests_if_specifying_limit: "Must ask about guests if a guest limit is specified."


### PR DESCRIPTION
Fixes #11416

Essentially does two things:
1. Lift the restriction that `eventChangeDeadlineDate` can only be touched if it hasn't passed yet. All other date-related restrictions (for example, cannot set a deadline to an earlier date than the original deadline, even if the old and new deadline dates haven't passed yet) stay in place
2. Adds a validation that OTS cannot be enabled if Edit Events has already passed. This avoids scenarios where Delegates soft-edit to enable OTS, then go to the OTS page, then try to add someone, get a hard error from the Reg model validation, and have to go back to make another soft edit to `eventChangeDeadlineDate`.