### PR TITLE
Fixed history button to show 'history'

### DIFF
--- a/app/webpacker/components/Delegates/DelegatesTable.jsx
+++ b/app/webpacker/components/Delegates/DelegatesTable.jsx
@@ -89,6 +89,7 @@ export default function DelegatesTable({
                     display: 'admin',
                     years: 'all',
                     delegate: delegate.user.id,
+                    state: 'past',
                   })}
                   >
                     {I18n.t('delegates_page.table.history')}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -167,7 +167,7 @@ export const wfcDuesRedirectsUrl = `<%= CGI.unescape(Rails.application.routes.ur
 
 export const pendingClaimsUrl = (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.pending_claims_path) %>/${userId}`;
 
-export const competitionsUrl = ({display, years, delegate}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competitions_path) %>?${jsonToQueryString({ display, years, delegate })}`;
+export const competitionsUrl = ({display, years, delegate, state}) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competitions_path) %>?${jsonToQueryString({ display, years, delegate, state })}`;
 
 export const competitionsForSeniorUrl = (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competitions_for_senior_path) %>/${userId}`;
 


### PR DESCRIPTION
The history button on all delegates page redirects to this URL: 
https://www.worldcubeassociation.org/competitions?years=all&delegate=51390&show_admin_details=yes

Fixed so it will redirect to past comps: 
https://www.worldcubeassociation.org/competitions?years=all&delegate=51390&show_admin_details=yes&state=past