### PR TITLE
Clean up routes from old "attendee ID" concept

### DIFF
--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -3,15 +3,12 @@
 class PaymentController < ApplicationController
   def available_refunds
     if current_user
-      attendee_id = params.require(:attendee_id)
-      competition_id, user_id = attendee_id.split("-")
-      competition = Competition.find(competition_id)
-
-      registration = Registration.includes(:registration_payments).find_by(competition: competition, user_id: user_id)
+      registration_id = params.require(:registration_id)
+      registration = Registration.includes(:registration_payments).find(registration_id)
 
       return render status: :bad_request, json: { error: "Registration not found" } if registration.blank?
 
-      return render status: :unauthorized, json: { error: 'unauthorized' } unless current_user.can_manage_competition?(competition)
+      return render status: :unauthorized, json: { error: 'unauthorized' } unless current_user.can_manage_competition?(registration.competition)
 
       # Use `filter` here on purpose because the whole `registration_payments` list has been included above.
       #   Using `where` would create an SQL query, but it would also break (i.e. make redundant) the `includes` call above.

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -63,8 +63,10 @@ class RegistrationsController < ApplicationController
   end
 
   def edit
-    @competition = Competition.find(params[:competition_id])
-    @user = User.find(params[:user_id])
+    @registration = registration_from_params
+
+    @competition = @registration.competition
+    @user = @registration.user
   end
 
   def import
@@ -489,7 +491,7 @@ class RegistrationsController < ApplicationController
 
     registration = payment_record.root_record.payment_intent.holder
 
-    redirect_path = edit_registration_v2_path(competition_id, registration.user_id)
+    redirect_path = edit_registration_path(registration)
 
     refund_amount_param = params.require(:payment).require(:refund_amount)
     refund_amount = refund_amount_param.to_i

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -69,6 +69,13 @@ class RegistrationsController < ApplicationController
     @user = @registration.user
   end
 
+  def redirect_v2_attendee
+    search_params = params.permit(:competition_id, :user_id)
+    registration = Registration.find_by!(**search_params)
+
+    redirect_to edit_registration_path(registration)
+  end
+
   def import
     @competition = competition_from_params
   end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -253,6 +253,7 @@ class Registration < ApplicationRecord
     private_attributes = pii ? %w[dob email] : nil
 
     base_json = {
+      id: id,
       user: user.as_json(only: %w[id wca_id name gender country_iso2], methods: %w[country], include: [], private_attributes: private_attributes),
       user_id: user_id,
       competing: {

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -1,5 +1,6 @@
 <% provide(:title, t('registrations.edit_registration.title', person: @user.name, comp: @competition.name)) %>
 <%= render layout: 'nav' do %>
-  <%= react_component('RegistrationsV2/RegistrationEdit', { competitionInfo: @competition.to_competition_info ,
+  <%= react_component('RegistrationsV2/RegistrationEdit', { registrationId: @registration.id,
+                                                            competitionInfo: @competition.to_competition_info ,
                                                             user: @user }) %>
 <% end %>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, t('registrations.edit_registration.title', person: @user.person&.name || @user.name, comp: @competition.name)) %>
+<% provide(:title, t('registrations.edit_registration.title', person: @user.name, comp: @competition.name)) %>
 <%= render layout: 'nav' do %>
   <%= react_component('RegistrationsV2/RegistrationEdit', { competitionInfo: @competition.to_competition_info ,
                                                             user: @user }) %>

--- a/app/views/registrations_mailer/notify_organizers_of_new_registration.html.erb
+++ b/app/views/registrations_mailer/notify_organizers_of_new_registration.html.erb
@@ -16,7 +16,7 @@
 
 <p>
   You can approve or delete this registration
-  <%= link_to "here", edit_registration_v2_url(competition_id: @registration.competition.id, user_id: @registration.user.id) %>.
+  <%= link_to "here", edit_registration_url(@registration) %>.
 </p>
 
 <p>

--- a/app/webpacker/components/Live/components/ResultsTable.jsx
+++ b/app/webpacker/components/Live/components/ResultsTable.jsx
@@ -125,7 +125,7 @@ export default function ResultsTable({
               </Table.Cell>
               )}
               <Table.Cell>
-                <a href={isAdmin ? editRegistrationUrl(competitor.user_id, competitionId)
+                <a href={isAdmin ? editRegistrationUrl(competitor.id)
                   : liveUrls.personResults(competitionId, competitor.id)}
                 >
                   {competitor.user.name}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -80,7 +80,7 @@ export default function TableRow({
     timestamp: timestampIsShown,
   } = columnsExpanded;
   const {
-    id, wca_id: wcaId, name, country, dob: dateOfBirth, email: emailAddress,
+    id: userId, wca_id: wcaId, name, country, dob: dateOfBirth, email: emailAddress,
   } = registration.user;
   const {
     registered_on: registeredOn,
@@ -116,7 +116,7 @@ export default function TableRow({
       {(provided) => (
         <Ref innerRef={provided.innerRef}>
           <Table.Row
-            key={id}
+            key={userId}
             active={isSelected}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
@@ -135,7 +135,7 @@ export default function TableRow({
             )}
 
             <Table.Cell>
-              <a href={editRegistrationUrl(id, competitionInfo.id)}>
+              <a href={editRegistrationUrl(registration.id)}>
                 {I18n.t('registrations.list.edit')}
               </a>
             </Table.Cell>
@@ -144,7 +144,7 @@ export default function TableRow({
               {wcaId ? (
                 <a href={personUrl(wcaId)}>{wcaId}</a>
               ) : (
-                <a href={editPersonUrl(id)}>
+                <a href={editPersonUrl(userId)}>
                   <Icon name="edit" />
                   {I18n.t('users.edit.profile')}
                 </a>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -415,7 +415,6 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
 
       <RegistrationAdministrationSearch
         partitionedRegistrations={partitionedRegistrations}
-        competitionId={competitionInfo.id}
         usingPayments={competitionInfo['using_payment_integrations?']}
         currencyCode={competitionInfo.currency_code}
       />

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationSearch.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationSearch.jsx
@@ -12,7 +12,6 @@ const MIN_SEARCH_TEXT_LEN = 2;
 
 export default function RegistrationAdministrationSearch({
   partitionedRegistrations,
-  competitionId,
   usingPayments,
   currencyCode,
 }) {
@@ -25,7 +24,9 @@ export default function RegistrationAdministrationSearch({
         status,
         {
           name: status,
-          results: registrations.map(({ user, competing, payment }) => ({
+          results: registrations.map(({
+            id, user, competing, payment,
+          }) => ({
             title: `${user.name}${user.wca_id ? ` (${user.wca_id})` : ''}`,
             description: `${
               user.email
@@ -41,7 +42,7 @@ export default function RegistrationAdministrationSearch({
             price: usingPayments
               ? isoMoneyToHumanReadable(payment.payment_amount_iso, currencyCode)
               : undefined,
-            userId: user.id,
+            id,
             searchable: {
               name: user.name,
               wcaId: user.wca_id,
@@ -77,8 +78,8 @@ export default function RegistrationAdministrationSearch({
     [debouncedSearchText, options],
   );
 
-  const navigateToRegistrationEdit = ({ userId }) => {
-    window.location.href = editRegistrationUrl(userId, competitionId);
+  const navigateToRegistrationEdit = ({ id }) => {
+    window.location.href = editRegistrationUrl(id);
   };
 
   const renderStatusIcon = ({ name: status }) => (

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Refunds.jsx
@@ -12,15 +12,15 @@ import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import I18n from '../../../lib/i18n';
 
 export default function Refunds({
-  onSuccess, userId, competitionId,
+  onSuccess, registrationId, competitionId,
 }) {
   const {
     data: refunds,
     isLoading: refundsLoading,
     refetch,
   } = useQuery({
-    queryKey: ['refunds', competitionId, userId],
-    queryFn: () => getAvailableRefunds(competitionId, userId),
+    queryKey: ['refunds', registrationId],
+    queryFn: () => getAvailableRefunds(registrationId),
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     staleTime: Infinity,
@@ -62,7 +62,6 @@ export default function Refunds({
               refund={refund}
               refundMutation={refundMutation}
               isMutating={isMutating}
-              userId={userId}
               competitionId={competitionId}
               key={refund.payment_id}
             />
@@ -74,7 +73,7 @@ export default function Refunds({
 }
 
 function RefundRow({
-  refund, refundMutation, isMutating, userId, competitionId,
+  refund, refundMutation, isMutating, competitionId,
 }) {
   const [amountToRefund, setAmountToRefund] = useInputState(refund.ruby_amount_refundable);
 
@@ -92,7 +91,6 @@ function RefundRow({
   }).then(() => {
     refundMutation({
       competitionId,
-      userId,
       paymentId: refund.payment_id,
       paymentProvider: refund.payment_provider,
       amount: amountToRefund,

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -29,7 +29,7 @@ import getUsersInfo from '../api/user/post/getUserInfo';
 import { useRegistration } from '../lib/RegistrationProvider';
 import useSet from '../../../lib/hooks/useSet';
 
-export default function RegistrationEditor({ competitor, competitionInfo }) {
+export default function RegistrationEditor({ registrationId, competitor, competitionInfo }) {
   const dispatch = useDispatch();
   const [comment, setComment] = useState('');
   const [adminComment, setAdminComment] = useState('');
@@ -312,7 +312,7 @@ export default function RegistrationEditor({ competitor, competitionInfo }) {
           {(registration.payment.payment_statuses.includes('succeeded') || registration.payment.payment_statuses.includes('refund')) && (
             <Refunds
               competitionId={competitionInfo.id}
-              userId={competitor.id}
+              registrationId={registrationId}
               onSuccess={refetch}
             />
           )}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/index.jsx
@@ -8,7 +8,7 @@ import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvide
 import ConfirmProvider from '../../../lib/providers/ConfirmProvider';
 import RegistrationProvider from '../lib/RegistrationProvider';
 
-export default function RegistrationEdit({ competitionInfo, user }) {
+export default function RegistrationEdit({ registrationId, competitionInfo, user }) {
   const ref = useRef();
   return (
     <div ref={ref}>
@@ -19,7 +19,11 @@ export default function RegistrationEdit({ competitionInfo, user }) {
               <Sticky context={ref}>
                 <RegistrationMessage />
               </Sticky>
-              <RegistrationEditor competitionInfo={competitionInfo} competitor={user} />
+              <RegistrationEditor
+                registrationId={registrationId}
+                competitionInfo={competitionInfo}
+                competitor={user}
+              />
             </RegistrationProvider>
           </ConfirmProvider>
         </StoreProvider>

--- a/app/webpacker/components/RegistrationsV2/api/payment/get/getAvailableRefunds.js
+++ b/app/webpacker/components/RegistrationsV2/api/payment/get/getAvailableRefunds.js
@@ -2,9 +2,8 @@ import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthentic
 import { availableRefundsUrl } from '../../../../../lib/requests/routes.js.erb';
 
 export default async function getAvailableRefunds(
-  competitionId,
-  userId,
+  registrationId,
 ) {
-  const { data } = await fetchJsonOrError(availableRefundsUrl(competitionId, userId));
+  const { data } = await fetchJsonOrError(availableRefundsUrl(registrationId));
   return data;
 }

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -97,7 +97,7 @@ export const adminFixResultsUrl = (personId, competition_id = undefined, event_i
 
 export const paymentFinishUrl = (competitionId, paymentIntegration) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_payment_completion_url("${competitionId}", "${paymentIntegration}", host: EnvConfig.ROOT_URL)) %>`
 
-export const availableRefundsUrl = (competitionId, userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.refunds_path) %>?attendee_id=${competitionId}-${userId}`
+export const availableRefundsUrl = (registrationId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.available_refunds_path("${registrationId}")) %>`
 
 export const refundPaymentUrl = (competitionId, paymentIntegration, paymentId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_payment_refund_path("${competitionId}", "${paymentIntegration}", "${paymentId}")) %>`
 

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -316,7 +316,7 @@ export const wcaRegistrationUrl = `<%= CGI.unescape(EnvConfig.WCA_REGISTRATIONS_
 
 export const getPsychSheetForEventUrl = (competitionId, eventId, sortBy) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_competition_event_psych_sheet_path(competition_id: '${competitionId}', event_id: '${eventId}')) %>?sort_by=${sortBy}`
 
-export const editRegistrationUrl = (userId, competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_registration_v2_path(competition_id: "${competitionId}", user_id: "${userId}"))%>`
+export const editRegistrationUrl = (registrationId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_registration_path(id: "${registrationId}"))%>`
 
 export const eligibleVotersUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.eligible_voters_path) %>`;
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
   get 'competitions/for_senior(/:user_id)' => 'competitions#for_senior', as: :competitions_for_senior
   post 'competitions/bookmark' => 'competitions#bookmark', as: :bookmark
   post 'competitions/unbookmark' => 'competitions#unbookmark', as: :unbookmark
+  get 'competitions/registrations_v2/:competition_id/:user_id/edit' => 'registrations#redirect_v2_attendee'
 
   resources :competitions do
     get 'edit/admin' => 'competitions#admin_edit', as: :admin_edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,6 @@ Rails.application.routes.draw do
   get 'competitions/for_senior(/:user_id)' => 'competitions#for_senior', as: :competitions_for_senior
   post 'competitions/bookmark' => 'competitions#bookmark', as: :bookmark
   post 'competitions/unbookmark' => 'competitions#unbookmark', as: :unbookmark
-  get 'competitions/registrations_v2/:competition_id/:user_id/edit' => 'registrations#edit', as: :edit_registration_v2
 
   resources :competitions do
     get 'edit/admin' => 'competitions#admin_edit', as: :admin_edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,6 @@ Rails.application.routes.draw do
 
   get 'competitions/mine' => 'competitions#my_competitions', as: :my_comps
   get 'competitions/for_senior(/:user_id)' => 'competitions#for_senior', as: :competitions_for_senior
-  get 'competitions/:id/enable_v2' => "competitions#enable_v2", as: :enable_v2
   post 'competitions/bookmark' => 'competitions#bookmark', as: :bookmark
   post 'competitions/unbookmark' => 'competitions#unbookmark', as: :unbookmark
   get 'competitions/registrations_v2/:competition_id/:user_id/edit' => 'registrations#edit', as: :edit_registration_v2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,7 @@ Rails.application.routes.draw do
     post '/payment_integration/:payment_integration/disconnect' => 'competitions#disconnect_payment_integration', as: :disconnect_payment_integration
   end
   scope :payment do
-    get '/refunds' => 'payment#available_refunds'
+    get '/refunds/:registration_id' => 'payment#available_refunds', as: :available_refunds
   end
 
   get 'competitions/:competition_id/report/edit' => 'delegate_reports#edit', as: :delegate_report_edit

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
 
         it 'issues a full refund' do
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: competition.base_entry_fee.cents } }
-          expect(response).to redirect_to edit_registration_v2_path(competition, registration.user)
+          expect(response).to redirect_to edit_registration_path(registration)
           refund = registration.reload.registration_payments.last.receipt.retrieve_stripe
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee
@@ -107,7 +107,7 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
         it 'issues a 50% refund' do
           refund_amount = competition.base_entry_fee.cents / 2
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
-          expect(response).to redirect_to edit_registration_v2_path(competition, registration.user)
+          expect(response).to redirect_to edit_registration_path(registration)
           refund = registration.reload.registration_payments.last.receipt.retrieve_stripe
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee / 2
@@ -119,7 +119,7 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
         it 'disallows negative refund' do
           refund_amount = -1
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
-          expect(response).to redirect_to edit_registration_v2_path(competition, registration.user)
+          expect(response).to redirect_to edit_registration_path(registration)
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq 0
           expect(flash[:danger]).to eq "The refund amount must be greater than zero."
@@ -129,7 +129,7 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
         it 'disallows a refund more than the payment' do
           refund_amount = competition.base_entry_fee.cents * 2
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
-          expect(response).to redirect_to edit_registration_v2_path(competition, registration.user)
+          expect(response).to redirect_to edit_registration_path(registration)
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq 0
           expect(flash[:danger]).to eq "You are not allowed to refund more than the competitor has paid."

--- a/spec/features/register_for_competition_spec.rb
+++ b/spec/features/register_for_competition_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Registering for a competition", :js do
     end
 
     scenario "updating registration" do
-      visit edit_registration_v2_path(competition_id: competition.id, user_id: user.id)
+      visit edit_registration_path(registration)
 
       fill_in "guest-dropdown", with: 1
       click_button "Update Registration"
@@ -171,7 +171,7 @@ RSpec.feature "Registering for a competition", :js do
     end
 
     scenario "deleting registration" do
-      visit edit_registration_v2_path(competition_id: competition.id, user_id: user.id)
+      visit edit_registration_path(registration)
 
       # SemUI render the actual radio inputs as `hidden` in CSS, so we have to take a detour via the label
       find('label[for="radio-status-cancelled"]').click

--- a/spec/mailers/registrations_mailer_spec.rb
+++ b/spec/mailers/registrations_mailer_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe RegistrationsMailer, type: :mailer do
       competition_delegate2.receive_registration_emails = true
       competition_delegate2.save!
 
-      expect(mail.body.encoded).to match(edit_registration_v2_url(competition_id: registration.competition_id, user_id: registration.user_id))
+      expect(mail.body.encoded).to match(edit_registration_url(registration))
     end
 
     it "handles no organizers receiving email" do


### PR DESCRIPTION
Replaces all registration routes that were still using (competitionId, userId) tuples to work with our internal registration IDs instead.

A redirect for the old format has been added if Delegates click on things in emails, which we unfortunately cannot retroactively manipulate.