### PR TITLE
Fix incorrect report posted date calculation in the competitions admin view

### DIFF
--- a/app/webpacker/lib/utils/competition-table.js
+++ b/app/webpacker/lib/utils/competition-table.js
@@ -92,9 +92,7 @@ export function numberOfDaysAfter(competition, refDate) {
   const parsedEndDate = parseDateString(competition.end_date).startOf('day');
   const parsedRefDate = DateTime.fromISO(refDate, { zone: 'utc' }).startOf('day');
 
-  const numberOfDays = parsedRefDate.diff(parsedEndDate, 'days').days;
-
-  return Math.abs(numberOfDays);
+  return parsedRefDate.diff(parsedEndDate, 'days').days;
 }
 
 export function timeDifferenceAfter(competition, refDate) {

--- a/app/webpacker/lib/utils/competition-table.js
+++ b/app/webpacker/lib/utils/competition-table.js
@@ -94,7 +94,7 @@ export function numberOfDaysAfter(competition, refDate) {
 
   const numberOfDays = parsedRefDate.diff(parsedEndDate, 'days').days;
 
-  return Math.max(0, numberOfDays);
+  return Math.abs(numberOfDays);
 }
 
 export function timeDifferenceAfter(competition, refDate) {

--- a/app/webpacker/lib/utils/competition-table.js
+++ b/app/webpacker/lib/utils/competition-table.js
@@ -89,13 +89,12 @@ export function timeDifferenceBefore(competition, refDate) {
 }
 
 export function numberOfDaysAfter(competition, refDate) {
-  const parsedStartDate = parseDateString(competition.end_date).endOf('day');
-  const parsedRefDate = DateTime.fromISO(refDate);
+  const parsedEndDate = parseDateString(competition.end_date).startOf('day');
+  const parsedRefDate = DateTime.fromISO(refDate, { zone: 'utc' }).startOf('day');
 
-  const numberOfDays = parsedStartDate.diff(parsedRefDate, 'days').days;
+  const numberOfDays = parsedRefDate.diff(parsedEndDate, 'days').days;
 
-  // Floor is used here because we want to show 0 days after the competition if it's the same day
-  return Math.floor(Math.abs(numberOfDays));
+  return Math.max(0, numberOfDays);
 }
 
 export function timeDifferenceAfter(competition, refDate) {


### PR DESCRIPTION
Despite the fixes in #10783 and #10962, the report posted date is still sometimes calculated incorrectly. This PR aims to finally resolve the issue