### PR TITLE
Bump Shakapacker to version 8.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'i18n-country-translations', github: 'thewca/i18n-country-translations'
 gem 'http_accept_language'
 gem 'twitter_cldr'
 # version explicitly specified because Shakapacker wants to keep Gemfile and package.json in sync
-gem 'shakapacker', '8.2.0'
+gem 'shakapacker', '8.3.0'
 gem 'json-schema'
 gem 'translighterate'
 gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -822,7 +822,7 @@ GEM
     seedbank (0.5.0)
       rake (>= 10.0)
     semantic_range (3.1.0)
-    shakapacker (8.2.0)
+    shakapacker (8.3.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -1078,7 +1078,7 @@ DEPENDENCIES
   sdoc
   seedbank
   selectize-rails!
-  shakapacker (= 8.2.0)
+  shakapacker (= 8.3.0)
   shoryuken
   sidekiq
   sidekiq-cron
@@ -1421,7 +1421,7 @@ CHECKSUMS
   seedbank (0.5.0) sha256=9840c0bf3427ac9ac0815feceeceeeac76dc89039503d393a7e220184855f437
   selectize-rails (0.12.1)
   semantic_range (3.1.0) sha256=9fc01ee40f2e5f81042e95d421837f688177dd603753b5eab41ff9bba50a34a1
-  shakapacker (8.2.0) sha256=52725d578889e959268ec59a99b1db204835b066a2d72bd032440aa299ee2462
+  shakapacker (8.3.0) sha256=bdf41f950792f049235bc15e6936811c11cfde920cf3436bc0438eaf0aba01c0
   shellany (0.0.1) sha256=0e127a9132698766d7e752e82cdac8250b6adbd09e6c0a7fbbb6f61964fedee7
   shoryuken (6.2.1) sha256=95ddc0a717624a54e799d25a0a05100cb5a0c3728a96211935c214faaf16b3b6
   sidekiq (8.0.3) sha256=0e618886ba2072b76e4de10a3ce4a04d09ab52da1c65b03c7eedbda5bbc76d2e

--- a/app/webpacker/lib/polyfills.js
+++ b/app/webpacker/lib/polyfills.js
@@ -1,12 +1,3 @@
 import 'whatwg-fetch';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-
-// There's a bug in Shakapacker <= 8.2.0 that pins a terribly old CoreJS version inside Babel.
-// We have installed a newer CoreJS version correctly, but its nice features "go to waste".
-// Until their fix is released, we force some polyfills manually.
-//   (cf. https://github.com/shakacode/shakapacker/pull/556/files)
-import 'core-js/es/typed-array/to-sorted';
-import 'core-js/es/array/to-sorted';
-import 'core-js/es/typed-array/to-reversed';
-import 'core-js/es/array/to-reversed';

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "sass": "^1.87.0",
     "sass-loader": "^16.0.5",
     "semantic-ui-react": "^2.1.5",
-    "shakapacker": "8.2.0",
+    "shakapacker": "8.3.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.3.14",
     "webpack": "^5.99.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10278,7 +10278,7 @@ __metadata:
     sass: "npm:^1.87.0"
     sass-loader: "npm:^16.0.5"
     semantic-ui-react: "npm:^2.1.5"
-    shakapacker: "npm:8.2.0"
+    shakapacker: "npm:8.3.0"
     style-loader: "npm:^4.0.0"
     stylelint: "npm:^16.19.1"
     stylelint-config-recommended-scss: "npm:^14.1.0"
@@ -10611,9 +10611,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shakapacker@npm:8.2.0":
-  version: 8.2.0
-  resolution: "shakapacker@npm:8.2.0"
+"shakapacker@npm:8.3.0":
+  version: 8.3.0
+  resolution: "shakapacker@npm:8.3.0"
   dependencies:
     js-yaml: "npm:^4.1.0"
     path-complete-extname: "npm:^1.0.0"
@@ -10627,8 +10627,8 @@ __metadata:
     babel-loader: ^8.2.4 || ^9.0.0 || ^10.0.0
     compression-webpack-plugin: ^9.0.0 || ^10.0.0|| ^11.0.0
     terser-webpack-plugin: ^5.3.1
-    webpack: ^5.72.0
-    webpack-assets-manifest: ^5.0.6
+    webpack: ^5.76.0
+    webpack-assets-manifest: ^5.0.6 || ^6.0.0
     webpack-cli: ^4.9.2 || ^5.0.0 || ^6.0.0
     webpack-dev-server: ^4.9.0 || ^5.0.0
     webpack-merge: ^5.8.0 || ^6.0.0
@@ -10637,7 +10637,7 @@ __metadata:
       optional: true
     "@types/webpack":
       optional: true
-  checksum: 10c0/934ec9e903447cf16e2e1ba568331f3a2ba8377d8a98094477a090e68d3ceed8bb2ad3a889ff639b127dcd96c2561214cddad1ab208ac35c3d588ac329197e80
+  checksum: 10c0/ddcac57f13458eabdb2ca1a021013acc28b6d3dc74e82dece3a485e64f0e3b6ab789d4ba725c8f748c78bcbfe8427ef82782f7cd8024c954ffd4c12a0cd25a22
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
They released a new version, and I don't want to leave this one to Dependabot because it probably still tries to update them separately and explodes...

Bonus: This fixes the workaround we introduced in https://github.com/thewca/worldcubeassociation.org/pull/11179