### PR TITLE
Expose refunds asynchronously instead of hard-redirecting

### DIFF
--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -13,7 +13,7 @@ class PaymentController < ApplicationController
       # Use `filter` here on purpose because the whole `registration_payments` list has been included above.
       #   Using `where` would create an SQL query, but it would also break (i.e. make redundant) the `includes` call above.
       root_payments = registration.registration_payments.filter { |rp| rp.refunded_registration_payment_id.nil? }
-      serialized_payments = root_payments.map(&:to_v2_json)
+      serialized_payments = root_payments.map { it.to_v2_json(helpers) }
 
       render json: { charges: serialized_payments }, status: :ok
     else

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -13,7 +13,7 @@ class PaymentController < ApplicationController
       # Use `filter` here on purpose because the whole `registration_payments` list has been included above.
       #   Using `where` would create an SQL query, but it would also break (i.e. make redundant) the `includes` call above.
       root_payments = registration.registration_payments.filter { |rp| rp.refunded_registration_payment_id.nil? }
-      serialized_payments = root_payments.map { it.to_v2_json(helpers, refunds: true) }
+      serialized_payments = root_payments.map { it.to_v2_json(refunds: true) }
 
       render json: { charges: serialized_payments }, status: :ok
     else

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -13,28 +13,9 @@ class PaymentController < ApplicationController
       # Use `filter` here on purpose because the whole `registration_payments` list has been included above.
       #   Using `where` would create an SQL query, but it would also break (i.e. make redundant) the `includes` call above.
       root_payments = registration.registration_payments.filter { |rp| rp.refunded_registration_payment_id.nil? }
+      serialized_payments = root_payments.map(&:to_v2_json)
 
-      charges = root_payments.map { |reg_payment|
-        payment_provider = CompetitionPaymentIntegration::INTEGRATION_RECORD_TYPES.invert[reg_payment.receipt_type]
-
-        available_amount = reg_payment.amount_available_for_refund
-        full_amount_ruby = reg_payment.amount_lowest_denomination
-
-        human_amount_refundable = helpers.ruby_money_to_human_readable(available_amount, reg_payment.currency_code)
-        human_amount_payment = helpers.ruby_money_to_human_readable(full_amount_ruby, reg_payment.currency_code)
-
-        {
-          payment_id: reg_payment.receipt_id,
-          payment_provider: payment_provider,
-          ruby_amount_refundable: available_amount,
-          human_amount_refundable: human_amount_refundable,
-          human_amount_payment: human_amount_payment,
-          currency_code: reg_payment.currency_code,
-          refunding_payments: reg_payment.refunding_registration_payments,
-        }
-      }
-
-      render json: { charges: charges }, status: :ok
+      render json: { charges: serialized_payments }, status: :ok
     else
       render status: :unauthorized, json: { error: I18n.t('api.login_message') }
     end

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -13,7 +13,7 @@ class PaymentController < ApplicationController
       # Use `filter` here on purpose because the whole `registration_payments` list has been included above.
       #   Using `where` would create an SQL query, but it would also break (i.e. make redundant) the `includes` call above.
       root_payments = registration.registration_payments.filter { |rp| rp.refunded_registration_payment_id.nil? }
-      serialized_payments = root_payments.map { it.to_v2_json(helpers) }
+      serialized_payments = root_payments.map { it.to_v2_json(helpers, refunds: true) }
 
       render json: { charges: serialized_payments }, status: :ok
     else

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -519,8 +519,9 @@ class RegistrationsController < ApplicationController
     # The `reload` is necessary here, because we just inserted a refund payment
     #   through the original `registration`. So the parent payment doesn't know about it yet.
     refunded_payment = payment_record.registration_payment.reload
+    refund_json = refunded_payment.to_v2_json(helpers, refunds: true)
 
-    render json: { status: :ok, message: :charge_refunded, refunded_charge: refunded_payment.to_v2_json(helpers) }
+    render json: { status: :ok, message: :charge_refunded, refunded_charge: refund_json }
   end
 
   private def registration_from_params

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -489,30 +489,18 @@ class RegistrationsController < ApplicationController
     payment_integration = params[:payment_integration].to_sym
     payment_account = competition.payment_account_for(payment_integration)
 
-    if payment_account.blank?
-      flash[:danger] = "You cannot issue a refund for this competition anymore. Please use your payment provider's dashboard to do so."
-      return redirect_to competition_registrations_path(competition)
-    end
+    return render status: :not_found, json: { error: :provider_disconnected } if payment_account.blank?
 
     payment_record = payment_account.find_payment(params[:payment_id])
 
     registration = payment_record.root_record.payment_intent.holder
 
-    redirect_path = edit_registration_path(registration)
-
     refund_amount_param = params.require(:payment).require(:refund_amount)
     refund_amount = refund_amount_param.to_i
     amount_left = payment_record.ruby_amount_available_for_refund - refund_amount
 
-    if amount_left.negative?
-      flash[:danger] = "You are not allowed to refund more than the competitor has paid."
-      return redirect_to redirect_path
-    end
-
-    if refund_amount.negative?
-      flash[:danger] = "The refund amount must be greater than zero."
-      return redirect_to redirect_path
-    end
+    return render status: :bad_request, json: { error: :refund_amount_too_high } if amount_left.negative?
+    return render status: :bad_request, json: { error: :refund_amount_too_low } if refund_amount.negative?
 
     refund_receipt = payment_account.issue_refund(payment_record, refund_amount)
 
@@ -528,8 +516,7 @@ class RegistrationsController < ApplicationController
       current_user.id,
     )
 
-    flash[:success] = 'Payment was refunded'
-    redirect_to redirect_path
+    render json: { status: :ok, message: :charge_refunded }
   end
 
   private def registration_from_params

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -516,7 +516,11 @@ class RegistrationsController < ApplicationController
       current_user.id,
     )
 
-    render json: { status: :ok, message: :charge_refunded }
+    # The `reload` is necessary here, because we just inserted a refund payment
+    #   through the original `registration`. So the parent payment doesn't know about it yet.
+    refunded_payment = payment_record.registration_payment.reload
+
+    render json: { status: :ok, message: :charge_refunded, refunded_charge: refunded_payment.to_v2_json(helpers) }
   end
 
   private def registration_from_params

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -519,7 +519,7 @@ class RegistrationsController < ApplicationController
     # The `reload` is necessary here, because we just inserted a refund payment
     #   through the original `registration`. So the parent payment doesn't know about it yet.
     refunded_payment = payment_record.registration_payment.reload
-    refund_json = refunded_payment.to_v2_json(helpers, refunds: true)
+    refund_json = refunded_payment.to_v2_json(refunds: true)
 
     render json: { status: :ok, message: :charge_refunded, refunded_charge: refund_json }
   end

--- a/app/models/registration_payment.rb
+++ b/app/models/registration_payment.rb
@@ -29,6 +29,26 @@ class RegistrationPayment < ApplicationRecord
     end
   end
 
+  def to_v2_json
+    payment_provider = CompetitionPaymentIntegration::INTEGRATION_RECORD_TYPES.invert[self.receipt_type]
+
+    available_amount = self.amount_available_for_refund
+    full_amount_ruby = self.amount_lowest_denomination
+
+    human_amount_refundable = helpers.ruby_money_to_human_readable(available_amount, self.currency_code)
+    human_amount_payment = helpers.ruby_money_to_human_readable(full_amount_ruby, self.currency_code)
+
+    {
+      payment_id: self.receipt_id,
+      payment_provider: payment_provider,
+      ruby_amount_refundable: available_amount,
+      human_amount_refundable: human_amount_refundable,
+      human_amount_payment: human_amount_payment,
+      currency_code: self.currency_code,
+      refunding_payments: self.refunding_registration_payments,
+    }
+  end
+
   private def auto_close_hook
     registration.consider_auto_close
   end

--- a/app/models/registration_payment.rb
+++ b/app/models/registration_payment.rb
@@ -30,7 +30,7 @@ class RegistrationPayment < ApplicationRecord
   end
 
   def to_v2_json(refunds: false)
-    payment_provider = CompetitionPaymentIntegration::INTEGRATION_RECORD_TYPES.invert[self.receipt_type]
+    payment_provider = CompetitionPaymentIntegration::INTEGRATION_RECORD_TYPES.key(self.receipt_type)
 
     v2_json = {
       user_id: self.user_id,

--- a/app/models/registration_payment.rb
+++ b/app/models/registration_payment.rb
@@ -29,7 +29,7 @@ class RegistrationPayment < ApplicationRecord
     end
   end
 
-  def to_v2_json
+  def to_v2_json(helpers)
     payment_provider = CompetitionPaymentIntegration::INTEGRATION_RECORD_TYPES.invert[self.receipt_type]
 
     available_amount = self.amount_available_for_refund

--- a/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/PaymentStep.jsx
@@ -90,6 +90,7 @@ export default function PaymentStep({
 
     setIsLoading(false);
   };
+
   if (hasPassed(competitionInfo.registration_close)) {
     return (
       <Message color="red">{I18n.t('registrations.payment_form.errors.registration_closed')}</Message>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -12,7 +12,7 @@ import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import I18n from '../../../lib/i18n';
 import { showMessage } from '../Register/RegistrationMessage';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
-import {isoMoneyToHumanReadable} from "../../../lib/helpers/money";
+import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 
 export default function Payments({
   onSuccess, registrationId, competitionId, competitorsInfo,

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -12,6 +12,7 @@ import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import I18n from '../../../lib/i18n';
 import { showMessage } from '../Register/RegistrationMessage';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
+import {isoMoneyToHumanReadable} from "../../../lib/helpers/money";
 
 export default function Payments({
   onSuccess, registrationId, competitionId, competitorsInfo,
@@ -25,7 +26,7 @@ export default function Payments({
   } = useQuery({
     queryKey: ['payments', registrationId],
     queryFn: () => getRegistrationPayments(registrationId),
-    select: (data) => data.charges.filter((r) => r.ruby_amount_refundable !== 0),
+    select: (data) => data.charges.filter((r) => r.iso_amount_refundable !== 0),
   });
 
   const { mutate: refundMutation, isPending: isMutating } = useMutation({
@@ -97,7 +98,7 @@ export default function Payments({
 function PaymentRow({
   payment, refundMutation, isMutating, competitionId, competitorsInfo,
 }) {
-  const [amountToRefund, setAmountToRefund] = useInputState(payment.ruby_amount_refundable);
+  const [amountToRefund, setAmountToRefund] = useInputState(payment.iso_amount_refundable);
 
   const confirm = useConfirm();
 
@@ -114,7 +115,7 @@ function PaymentRow({
         const { refunded_charge: refundedCharge } = data;
 
         setAmountToRefund(
-          (prevAmount) => Math.min(prevAmount, refundedCharge.ruby_amount_refundable),
+          (prevAmount) => Math.min(prevAmount, refundedCharge.iso_amount_refundable),
         );
       },
     });
@@ -124,17 +125,17 @@ function PaymentRow({
     <>
       <Table.Row>
         <Table.Cell>
-          {payment.human_amount_refundable}
+          {isoMoneyToHumanReadable(payment.iso_amount_refundable, payment.currency_code)}
         </Table.Cell>
         <Table.Cell>
-          {payment.human_amount_payment}
+          {isoMoneyToHumanReadable(payment.iso_amount_payment, payment.currency_code)}
         </Table.Cell>
         <Table.Cell>
           <AutonumericField
             currency={payment.currency_code.toUpperCase()}
             value={amountToRefund}
             onChange={setAmountToRefund}
-            max={payment.ruby_amount_refundable}
+            max={payment.iso_amount_refundable}
           />
         </Table.Cell>
         <Table.Cell>
@@ -151,7 +152,7 @@ function PaymentRow({
           <Table.Cell />
           <Table.Cell />
           <Table.Cell>
-            {p.human_amount_payment}
+            {isoMoneyToHumanReadable(p.iso_amount_payment, p.currency_code)}
           </Table.Cell>
           <Table.Cell>
             Refunded by

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -35,6 +35,7 @@ export default function Payments({
     onSuccess: (data) => {
       const { message, refunded_charge: refundedCharge } = data;
 
+      // i18n-tasks-use t('payments.messages.charge_refunded')
       dispatch(showMessage(
         `payments.messages.${message}`,
         'positive',

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -10,7 +10,6 @@ import AutonumericField from '../../wca/FormBuilder/input/AutonumericField';
 import useInputState from '../../../lib/hooks/useInputState';
 import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import I18n from '../../../lib/i18n';
-import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 import { showMessage } from '../Register/RegistrationMessage';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 
@@ -37,7 +36,7 @@ export default function Payments({
 
       dispatch(showMessage(
         `payments.messages.${message}`,
-        'negative',
+        'positive',
       ));
 
       queryClient.setQueryData(
@@ -148,11 +147,11 @@ function PaymentRow({
         </Table.Cell>
       </Table.Row>
       {payment.refunding_payments.map((p) => (
-        <Table.Row>
+        <Table.Row key={p.payment_id}>
           <Table.Cell />
           <Table.Cell />
           <Table.Cell>
-            {isoMoneyToHumanReadable(Math.abs(p.amount_lowest_denomination), p.currency_code)}
+            {p.human_amount_payment}
           </Table.Cell>
           <Table.Cell>
             Refunded by

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -32,7 +32,7 @@ export default function Payments({
     mutationFn: refundPayment,
     // The Backend will set a flash error on success or error
     onSuccess: (data) => {
-      const { message, refunded_charge: refundedCharge } = data.json;
+      const { message, refunded_charge: refundedCharge } = data;
 
       dispatch(showMessage(
         `payments.messages.${message}`,
@@ -111,7 +111,7 @@ function PaymentRow({
       amount: amountToRefund,
     }, {
       onSuccess: (data) => {
-        const { refunded_charge: refundedCharge } = data.json;
+        const { refunded_charge: refundedCharge } = data;
 
         setAmountToRefund(
           (prevAmount) => Math.min(prevAmount, refundedCharge.ruby_amount_refundable),

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -54,6 +54,9 @@ export default function Payments({
     },
     onError: (data) => {
       const { error } = data.json;
+      // i18n-tasks-use t('payments.errors.refund.provider_disconnected')
+      // i18n-tasks-use t('payments.errors.refund.refund_amount_too_high')
+      // i18n-tasks-use t('payments.errors.refund.refund_amount_too_low')
       dispatch(showMessage(
         `payments.errors.refund.${error}`,
         'negative',

--- a/app/webpacker/components/RegistrationsV2/api/payment/get/refundPayment.js
+++ b/app/webpacker/components/RegistrationsV2/api/payment/get/refundPayment.js
@@ -1,4 +1,4 @@
-import { fetchWithAuthenticityToken } from '../../../../../lib/requests/fetchWithAuthenticityToken';
+import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
 import { refundPaymentUrl } from '../../../../../lib/requests/routes.js.erb';
 
 export default async function refundPayment({
@@ -7,7 +7,7 @@ export default async function refundPayment({
   paymentProvider,
   amount,
 }) {
-  return fetchWithAuthenticityToken(
+  const { data } = await fetchJsonOrError(
     refundPaymentUrl(competitionId, paymentProvider, paymentId),
     {
       body:
@@ -22,4 +22,6 @@ export default async function refundPayment({
       method: 'POST',
     },
   );
+
+  return data;
 }

--- a/app/webpacker/lib/helpers/money.js
+++ b/app/webpacker/lib/helpers/money.js
@@ -3,6 +3,5 @@ import { currenciesData } from '../wca-data.js.erb';
 // eslint-disable-next-line import/prefer-default-export
 export function isoMoneyToHumanReadable(amount, isoCode, name = false) {
   const currency = currenciesData.byIso[isoCode];
-  return `${currency.symbol}${amount
-  / currency.subunitToUnit} (${name ? currency.name : isoCode})`;
+  return `${currency.symbol}${amount / currency.subunitToUnit} (${name ? currency.name : isoCode})`;
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2231,7 +2231,13 @@ en:
     connect_wca_id: "Connect your WCA ID to your account!"
   payments:
     messages:
+      charge_refunded: "Payment was refunded"
       charges_refunded: "All charges have been refunded"
+    errors:
+      refund:
+        provider_disconnected: "You cannot issue a refund for this competition anymore. Please use your payment provider's dashboard to do so."
+        refund_amount_too_high: "You are not allowed to refund more than the competitor has paid."
+        refund_amount_too_low: "The refund amount must be greater than zero."
     labels:
       net_payment: "Net Payment"
       original_payment: "Original Payment"

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -93,12 +93,10 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
 
         it 'issues a full refund' do
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: competition.base_entry_fee.cents } }
-          expect(response).to redirect_to edit_registration_path(registration)
           refund = registration.reload.registration_payments.last.receipt.retrieve_stripe
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee
           expect(refund.amount).to eq competition.base_entry_fee.cents
-          expect(flash[:success]).to eq "Payment was refunded"
           expect(@payment.reload.amount_available_for_refund).to eq 0
           # Check that the website actually records who made the refund
           expect(registration.registration_payments.last.user).to eq organizer
@@ -107,40 +105,38 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
         it 'issues a 50% refund' do
           refund_amount = competition.base_entry_fee.cents / 2
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
-          expect(response).to redirect_to edit_registration_path(registration)
           refund = registration.reload.registration_payments.last.receipt.retrieve_stripe
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq competition.base_entry_fee / 2
           expect(refund.amount).to eq competition.base_entry_fee.cents / 2
-          expect(flash[:success]).to eq "Payment was refunded"
           expect(@payment.reload.amount_available_for_refund).to eq competition.base_entry_fee.cents / 2
         end
 
         it 'disallows negative refund' do
           refund_amount = -1
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
-          expect(response).to redirect_to edit_registration_path(registration)
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to eq { "error" => "refund_amount_too_low" }
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq 0
-          expect(flash[:danger]).to eq "The refund amount must be greater than zero."
           expect(@payment.reload.amount_available_for_refund).to eq competition.base_entry_fee.cents
         end
 
         it 'disallows a refund more than the payment' do
           refund_amount = competition.base_entry_fee.cents * 2
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
-          expect(response).to redirect_to edit_registration_path(registration)
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body).to eq { "error" => "refund_amount_too_high" }
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq 0
-          expect(flash[:danger]).to eq "You are not allowed to refund more than the competitor has paid."
           expect(@payment.reload.amount_available_for_refund).to eq competition.base_entry_fee.cents
         end
 
         it "disallows a refund after clearing the Stripe account id" do
           ClearConnectedPaymentIntegrations.perform_now
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: competition.base_entry_fee.cents } }
-          expect(response).to redirect_to competition_registrations_path(competition)
-          expect(flash[:danger]).to eq "You cannot issue a refund for this competition anymore. Please use your payment provider's dashboard to do so."
+          expect(response).to have_http_status(:not_found)
+          expect(response.parsed_body).to eq { "error" => "provider_disconnected" }
           expect(@payment.reload.amount_available_for_refund).to eq competition.base_entry_fee.cents
         end
       end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
           refund_amount = -1
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
           expect(response).to have_http_status(:bad_request)
-          expect(response.parsed_body).to eq { "error" => "refund_amount_too_low" }
+          expect(response.parsed_body).to(eq { "error" => "refund_amount_too_low" })
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq 0
           expect(@payment.reload.amount_available_for_refund).to eq competition.base_entry_fee.cents
@@ -126,7 +126,7 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
           refund_amount = competition.base_entry_fee.cents * 2
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: refund_amount } }
           expect(response).to have_http_status(:bad_request)
-          expect(response.parsed_body).to eq { "error" => "refund_amount_too_high" }
+          expect(response.parsed_body).to(eq { "error" => "refund_amount_too_high" })
           expect(competition.base_entry_fee).to be > 0
           expect(registration.outstanding_entry_fees).to eq 0
           expect(@payment.reload.amount_available_for_refund).to eq competition.base_entry_fee.cents
@@ -136,7 +136,7 @@ RSpec.describe RegistrationsController, :clean_db_with_truncation do
           ClearConnectedPaymentIntegrations.perform_now
           post :refund_payment, params: { competition_id: competition.id, payment_integration: :stripe, payment_id: @payment.receipt.id, payment: { refund_amount: competition.base_entry_fee.cents } }
           expect(response).to have_http_status(:not_found)
-          expect(response.parsed_body).to eq { "error" => "provider_disconnected" }
+          expect(response.parsed_body).to(eq { "error" => "provider_disconnected" })
           expect(@payment.reload.amount_available_for_refund).to eq competition.base_entry_fee.cents
         end
       end


### PR DESCRIPTION
The React refunds panel was still using the old Rails-esque endpoint that redirected the user and communicated using flash messages. The aim of this PR is to communicate the result directly via JSON asynchronously and let the frontend handle displaying the messages and updating the values.

This has two practical consequences:
1. The refunds endpoint upon success now exposes the payment it just refunded. This allows React to replace the affected rows in-place, instead of triggering a hard reload
2. `RegistrationPayment` entities now get their own custom "V2 JSON" format. Consider it an early, preliminary API spec. Since this only used internally, it will be easy to change in the future whenever required.