### PR TITLE
Fetch registration history from separate endpoint

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
   def show
     registration = Registration.find_by!(user_id: @user_id, competition_id: @competition_id)
-    render json: registration.to_v2_json(admin: true, history: true)
+    render json: registration.to_v2_json(admin: true)
   end
 
   def create
@@ -81,7 +81,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   def update
     if params[:competing]
       updated_registration = Registrations::Lanes::Competing.update_raw!(params, @competition, @current_user.id)
-      return render json: { status: 'ok', registration: updated_registration.to_v2_json(admin: true, history: true) }, status: :ok
+      return render json: { status: 'ok', registration: updated_registration.to_v2_json(admin: true) }, status: :ok
     end
     render json: { status: 'bad request', message: 'You need to supply at least one lane' }, status: :bad_request
   end
@@ -214,7 +214,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
       user: :delegate_role_metadata,
       registration_payments: :receipt,
       registration_history_entries: :registration_history_changes,
-    ).map { |r| r.to_v2_json(admin: true, history: true, pii: true) }
+    ).map { |r| r.to_v2_json(admin: true, pii: true) }
   end
 
   def validate_payment_ticket_request

--- a/app/controllers/registration_history_controller.rb
+++ b/app/controllers/registration_history_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RegistrationHistoryController < ApplicationController
+  def show
+    registration_id = params.require(:registration_id)
+    registration = Registration.find(registration_id)
+
+    return head :unauthorized unless current_user.id == registration.user_id || current_user.can_manage_competition?(registration.competition)
+
+    render json: registration.registration_history
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -76,6 +76,15 @@ class RegistrationsController < ApplicationController
     redirect_to edit_registration_path(registration)
   end
 
+  def registration_history
+    registration_id = params.require(:registration_id)
+    registration = Registration.find(registration_id)
+
+    return head :unauthorized unless current_user.id == registration.user_id || current_user.can_manage_competition?(registration.competition)
+
+    render json: registration.registration_history
+  end
+
   def import
     @competition = competition_from_params
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -76,14 +76,6 @@ class RegistrationsController < ApplicationController
     redirect_to edit_registration_path(registration)
   end
 
-  def registration_history
-    registration = registration_from_params
-
-    return head :unauthorized unless current_user.id == registration.user_id || current_user.can_manage_competition?(registration.competition)
-
-    render json: registration.registration_history
-  end
-
   def import
     @competition = competition_from_params
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -77,8 +77,7 @@ class RegistrationsController < ApplicationController
   end
 
   def registration_history
-    registration_id = params.require(:registration_id)
-    registration = Registration.find(registration_id)
+    registration = registration_from_params
 
     return head :unauthorized unless current_user.id == registration.user_id || current_user.can_manage_competition?(registration.competition)
 

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -249,7 +249,7 @@ class Registration < ApplicationRecord
     end
   end
 
-  def to_v2_json(admin: false, history: false, pii: false)
+  def to_v2_json(admin: false, pii: false)
     private_attributes = pii ? %w[dob email] : nil
 
     base_json = {
@@ -282,11 +282,6 @@ class Registration < ApplicationRecord
                               },
                             })
       base_json[:competing][:waiting_list_position] = waiting_list_position if competing_status_waiting_list?
-    end
-    if history
-      base_json.deep_merge!({
-                              history: registration_history,
-                            })
     end
     base_json
   end

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -15,7 +15,10 @@ import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 
 export default function Payments({
-  registrationId, competitionId, competitorsInfo,
+  registrationId,
+  competitionId,
+  competitorsInfo,
+  refetchHistory,
 }) {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
@@ -50,6 +53,8 @@ export default function Payments({
           ],
         }),
       );
+
+      refetchHistory();
     },
     onError: (data) => {
       const { error } = data.json;

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -15,7 +15,7 @@ import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 
 export default function Payments({
-  onSuccess, registrationId, competitionId, competitorsInfo,
+  registrationId, competitionId, competitorsInfo,
 }) {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
@@ -50,8 +50,6 @@ export default function Payments({
           ],
         }),
       );
-
-      onSuccess();
     },
     onError: (data) => {
       const { error } = data.json;

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -79,6 +79,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
           payment: serverRegistration.payment,
         },
       );
+
       // Going from cancelled -> pending
       if (registration.competing.registration_status === 'cancelled') {
         dispatch(showMessage('registrations.flash.registered', 'positive'));
@@ -86,6 +87,8 @@ export default function RegistrationEditor({ registrationId, competitor, competi
       } else {
         dispatch(showMessage('registrations.flash.updated', 'positive'));
       }
+
+      refetchHistory();
     },
   });
 
@@ -314,6 +317,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
               competitionId={competitionInfo.id}
               registrationId={registrationId}
               competitorsInfo={competitorsInfo}
+              refetchHistory={refetchHistory}
             />
           )}
         </>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -43,7 +43,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
 
   const {
     isFetching: isRegistrationLoading,
-    registration: serverRegistration, refetchRegistration: refetch,
+    registration: serverRegistration,
   } = useRegistration();
 
   const { isLoading: historyLoading, data: registrationHistory } = useQuery({
@@ -309,7 +309,6 @@ export default function RegistrationEditor({ registrationId, competitor, competi
             <Payments
               competitionId={competitionInfo.id}
               registrationId={registrationId}
-              onSuccess={refetch}
               competitorsInfo={competitorsInfo}
             />
           )}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -46,7 +46,11 @@ export default function RegistrationEditor({ registrationId, competitor, competi
     registration: serverRegistration,
   } = useRegistration();
 
-  const { isLoading: historyLoading, data: registrationHistory } = useQuery({
+  const {
+    isLoading: historyLoading,
+    data: registrationHistory,
+    refetch: refetchHistory,
+  } = useQuery({
     queryKey: ['registration-history', registrationId],
     queryFn: () => getRegistrationHistory(registrationId),
   });
@@ -317,6 +321,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
       <RegistrationHistory
         history={registrationHistory.toReversed()}
         competitorsInfo={competitorsInfo}
+        refetchHistory={refetchHistory}
       />
     </Segment>
   );

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Header, Popup, Table } from 'semantic-ui-react';
+import {
+  Button, Header, Popup, Table,
+} from 'semantic-ui-react';
 import { getIsoDateString, getShortTimeString, getTimeWithSecondsString } from '../../../lib/utils/dates';
 import { events } from '../../../lib/wca-data.js.erb';
 import EventIcon from '../../wca/EventIcon';
@@ -12,10 +14,13 @@ const formatHistoryColumn = (key, value) => {
   return value;
 };
 
-export default function RegistrationHistory({ history, competitorsInfo }) {
+export default function RegistrationHistory({ history, competitorsInfo, refetchHistory }) {
   return (
     <>
-      <Header>{I18n.t('registrations.registration_history.title')}</Header>
+      <Header>
+        {I18n.t('registrations.registration_history.title')}
+        <Button floated="right" onClick={refetchHistory}>Refresh</Button>
+      </Header>
       <Table>
         <Table.Header>
           <Table.Row>

--- a/app/webpacker/components/RegistrationsV2/api/registration/get/get_registrations.js
+++ b/app/webpacker/components/RegistrationsV2/api/registration/get/get_registrations.js
@@ -1,6 +1,6 @@
 import {
   allRegistrationsUrl, confirmedRegistrationsUrl,
-  getPsychSheetForEventUrl, singleRegistrationUrl,
+  getPsychSheetForEventUrl, registrationHistoryUrl, singleRegistrationUrl,
 } from '../../../../../lib/requests/routes.js.erb';
 import fetchWithJWTToken from '../../../../../lib/requests/fetchWithJWTToken';
 import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
@@ -42,4 +42,11 @@ export async function getSingleRegistration(
     }
     throw e;
   }
+}
+
+export async function getRegistrationHistory(
+  registrationId,
+) {
+  const { data } = await fetchJsonOrError(registrationHistoryUrl(registrationId));
+  return data;
 }

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -99,6 +99,8 @@ export const paymentFinishUrl = (competitionId, paymentIntegration) => `<%= CGI.
 
 export const registrationPaymentsUrl = (registrationId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_payments_path("${registrationId}")) %>`
 
+export const registrationHistoryUrl = (registrationId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_history_path("${registrationId}")) %>`;
+
 export const refundPaymentUrl = (competitionId, paymentIntegration, paymentId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_payment_refund_path("${competitionId}", "${paymentIntegration}", "${paymentId}")) %>`
 
 export const paymentDenominationUrl = (competitionId, userId, isoDonationAmount) => `<%= CGI.unescape(Rails.application.routes.url_helpers.registration_payment_denomination_path("${competitionId}" , "${userId}")) %>?iso_donation_amount=${isoDonationAmount}`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,7 @@ Rails.application.routes.draw do
     get 'registrations/psych-sheet/:event_id' => 'registrations#psych_sheet_event', as: :psych_sheet_event
     resources :registrations, only: %i[index update create edit destroy], shallow: true do
       get 'payments' => 'payment#registration_payments', as: :payments
-      get 'history' => 'registrations#registration_history', on: :member, as: :history
+      resource :history, only: [:show], controller: :registration_history
     end
     get 'edit/registrations' => 'registrations#edit_registrations'
     get 'register' => 'registrations#register'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,7 @@ Rails.application.routes.draw do
     get 'registrations/psych-sheet/:event_id' => 'registrations#psych_sheet_event', as: :psych_sheet_event
     resources :registrations, only: %i[index update create edit destroy], shallow: true do
       get 'payments' => 'payment#registration_payments', as: :payments
-      get 'history' => 'registrations#registration_history', as: :history
+      get 'history' => 'registrations#registration_history', on: :member, as: :history
     end
     get 'edit/registrations' => 'registrations#edit_registrations'
     get 'register' => 'registrations#register'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
     get 'registrations/psych-sheet/:event_id' => 'registrations#psych_sheet_event', as: :psych_sheet_event
     resources :registrations, only: %i[index update create edit destroy], shallow: true do
       get 'payments' => 'payment#registration_payments', as: :payments
+      get 'history' => 'registrations#registration_history', as: :history
     end
     get 'edit/registrations' => 'registrations#edit_registrations'
     get 'register' => 'registrations#register'


### PR DESCRIPTION
In the spirit of https://github.com/thewca/worldcubeassociation.org/pull/11442, let's also create a separate endpoint for the history!

(This also saves one silly refetch from the refund endpoint where refunding would effectively reload the whole page just so the registration history could be correct)