### PR TITLE
Make admin_comment column sortable in Registration Admin

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableHeader.jsx
@@ -113,7 +113,10 @@ export default function TableHeader({
             >
               {I18n.t('activerecord.attributes.registration.comments')}
             </Table.HeaderCell>
-            <Table.HeaderCell disabled>
+            <Table.HeaderCell
+              sorted={sortColumn === 'administrative_notes' ? sortDirection : undefined}
+              onClick={() => onColumnClick('administrative_notes')}
+            >
               {I18n.t('activerecord.attributes.registration.administrative_notes')}
             </Table.HeaderCell>
           </>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationsAdministrationTable.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationsAdministrationTable.jsx
@@ -24,6 +24,7 @@ export const sortReducer = createSortReducer([
   'paid_on',
   'comment',
   'dob',
+  'administrative_notes',
   ...WCA_EVENT_IDS,
 ]);
 

--- a/app/webpacker/lib/utils/registrationAdmin.js
+++ b/app/webpacker/lib/utils/registrationAdmin.js
@@ -134,6 +134,9 @@ export function sortRegistrations(registrations, sortColumn, sortDirection) {
       case 'comment':
         return a.competing.comment.localeCompare(b.competing.comment);
 
+      case 'administrative_notes':
+        return a.competing.admin_comment.localeCompare(b.competing.admin_comment);
+
       case 'registered_on':
         return DateTime.fromISO(a.competing.registered_on).toMillis()
           - DateTime.fromISO(b.competing.registered_on).toMillis();


### PR DESCRIPTION
Currently, it is not possible for organizers to sort by admin_comment. However, this is very useful for if an organizer quickly wants to see all admin comments applied to users - as such, I have enabled it. 

Requested in Discord by @lnzainn :
![image](https://github.com/user-attachments/assets/68e572e3-a1f4-45cf-bc7e-f655184d7cd9)
