### PR TITLE
Use ISO2 cache for country reads

### DIFF
--- a/app/controllers/api/v0/wfc/dues_redirects_controller.rb
+++ b/app/controllers/api/v0/wfc/dues_redirects_controller.rb
@@ -15,7 +15,7 @@ class Api::V0::Wfc::DuesRedirectsController < Api::V0::ApiController
     redirect_to_id = params.require(:redirectToId)
     if redirect_type == WfcDuesRedirect.redirect_source_types[:Country]
       redirect_from_country_iso2 = params.require(:redirectFromCountryIso2)
-      redirect_source = Country.find_by(iso2: redirect_from_country_iso2)
+      redirect_source = Country.c_find_by_iso2(redirect_from_country_iso2)
     elsif redirect_type == WfcDuesRedirect.redirect_source_types[:User]
       redirect_from_organizer_id = params.require(:redirectFromOrganizerId)
       redirect_source = User.find(redirect_from_organizer_id)

--- a/app/controllers/api/v0/wrt/persons_controller.rb
+++ b/app/controllers/api/v0/wrt/persons_controller.rb
@@ -11,7 +11,7 @@ class Api::V0::Wrt::PersonsController < Api::V0::ApiController
     representing = person_params.require(:representing)
     gender = person_params.require(:gender)
     dob = person_params.require(:dob)
-    country_id = Country.find_by(iso2: representing).id
+    country_id = Country.c_find_by_iso2(representing).id
 
     {
       name: name,

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -90,7 +90,7 @@ class ContactsController < ApplicationController
   private def value_humanized(value, field)
     case field
     when :country_iso2
-      Country.find_by(iso2: value).name_in(:en)
+      Country.c_find_by_iso2(value).name_in(:en)
     when :gender
       User::GENDER_LABEL_METHOD.call(value.to_sym)
     else

--- a/app/models/championship.rb
+++ b/app/models/championship.rb
@@ -31,7 +31,7 @@ class Championship < ApplicationRecord
   end
 
   def country
-    Country.find_by(iso2: championship_type)
+    Country.c_find_by_iso2(championship_type)
   end
 
   def greater_china?

--- a/app/models/competition_venue.rb
+++ b/app/models/competition_venue.rb
@@ -19,7 +19,7 @@ class CompetitionVenue < ApplicationRecord
   validates :timezone_id, inclusion: { in: VALID_TIMEZONES }
 
   def country
-    Country.find_by(iso2: self.country_iso2)
+    Country.c_find_by_iso2(self.country_iso2)
   end
 
   def load_wcif!(wcif)

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -73,7 +73,7 @@ class Country < ApplicationRecord
     Continent.c_find(self.continent_id)
   end
 
-  def self.find_by_iso2(iso2)
+  def self.c_find_by_iso2(iso2)
     c_values.find { |c| c.iso2 == iso2 }
   end
 

--- a/app/models/country_band.rb
+++ b/app/models/country_band.rb
@@ -11,7 +11,7 @@ class CountryBand < ApplicationRecord
   }
 
   def country
-    Country.find_by(iso2: self.iso2)
+    Country.c_find_by_iso2(self.iso2)
   end
 
   def active_country_band_detail

--- a/app/models/inbox_person.rb
+++ b/app/models/inbox_person.rb
@@ -24,9 +24,7 @@ class InboxPerson < ApplicationRecord
   end
 
   def country
-    # We disable RuboCop because `find_by_iso2` is actually a manually created method
-    #   by us that just "happens to" sound like a dynamic finder.
-    Country.find_by_iso2(self.country_iso2) # rubocop:disable Rails/DynamicFindBy
+    Country.c_find_by_iso2(self.country_iso2)
   end
 
   # NOTE: silly method overriding: we don't have an id on that table.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -367,7 +367,7 @@ class User < ApplicationRecord
   end
 
   def country
-    Country.find_by(iso2: country_iso2)
+    Country.c_find_by_iso2(country_iso2)
   end
 
   def newcomer_month_eligible?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -216,7 +216,7 @@ FactoryBot.define do
 
     trait :wca_id do
       transient do
-        person { FactoryBot.create(:person, name: name, country_id: Country.find_by(iso2: country_iso2).id, gender: gender, dob: dob.strftime("%F")) }
+        person { FactoryBot.create(:person, name: name, country_id: Country.c_find_by_iso2(country_iso2).id, gender: gender, dob: dob.strftime("%F")) }
       end
     end
 
@@ -224,7 +224,7 @@ FactoryBot.define do
       transient do
         person {
           FactoryBot.create(
-            :person, name: name, country_id: Country.find_by(iso2: country_iso2).id, gender: gender, dob: dob.strftime("%F"), wca_id_year: Time.current.year.to_s
+            :person, name: name, country_id: Country.c_find_by_iso2(country_iso2).id, gender: gender, dob: dob.strftime("%F"), wca_id_year: Time.current.year.to_s
           )
         }
       end


### PR DESCRIPTION
See title. The `Country` is already a `Cacheable` implementation since ages, but that module relies on the `id` column. Some of our models reference `iso2` instead, which was going through the database instead of the useful cache layer.

The name `c_find_by_iso2` doesn't exactly roll off the tongue, but it has two purposes:
1. Be consistent with the `Cacheable` concern, which already uses the `c_` prefix
2. Avoid detection by `Rails/DynamicFindBy` cop, because this is not actually a dynamic `findBy`.