### PR TITLE
Bye Bye HEIC in Delegate Reports

### DIFF
--- a/app/views/delegate_reports/edit.html.erb
+++ b/app/views/delegate_reports/edit.html.erb
@@ -23,7 +23,7 @@
           <%= f.hidden_field :setup_images, multiple: true, value: image.signed_id %>
         <% end %>
 
-        <%= f.input :setup_images, multiple: true, hint: t('simple_form.hints.delegate_report.setup_images', image_count: @delegate_report.required_setup_images_count), input_html: { multiple: true, accept: 'image/*' } %>
+        <%= f.input :setup_images, multiple: true, hint: t('simple_form.hints.delegate_report.setup_images', image_count: @delegate_report.required_setup_images_count), input_html: { multiple: true, accept: ActiveStorage.web_image_content_types.join(", ") } %>
 
         <% if @delegate_report.setup_images.attached? %>
           <div class="row">


### PR DESCRIPTION
Seems that `image/*` is still too generous for that one company that doesn't release its file format specifications in the year 2025