### PR TITLE
Change `admin_comment` to `organizer_comment`

### DIFF
--- a/app/controllers/api/v1/registrations/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations/registrations_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
   def create
     # Currently we only have one lane
     if params[:competing]
-      competing_params = params.permit(:guests, competing: [:status, :comment, { event_ids: [] }, :admin_comment])
+      competing_params = params.permit(:guests, competing: [:status, :comment, { event_ids: [] }, :organizer_comment])
 
       user_id = registration_params['user_id']
       competition_id = registration_params['competition_id']
@@ -263,7 +263,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
 
     def update_params
       params.require([:user_id, :competition_id])
-      params.permit(:guests, competing: [:status, :comment, { event_ids: [] }, :admin_comment])
+      params.permit(:guests, competing: [:status, :comment, { event_ids: [] }, :organizer_comment])
       params
     end
 
@@ -311,7 +311,7 @@ class Api::V1::Registrations::RegistrationsController < Api::V1::ApiController
     end
 
     def contains_admin_fields?(request)
-      organizer_fields = ['admin_comment', 'waiting_list_position']
+      organizer_fields = ['organizer_comment', 'waiting_list_position']
 
       request['competing']&.keys&.any? { |key| organizer_fields.include?(key) }
     end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -278,7 +278,7 @@ class Registration < ApplicationRecord
                                 registration_status: is_competing ? competing_status : 'non_competing',
                                 registered_on: registered_at,
                                 comment: comments || "",
-                                admin_comment: administrative_notes || "",
+                                organizer_comment: administrative_notes || "",
                               },
                             })
       base_json[:competing][:waiting_list_position] = waiting_list_position if competing_status_waiting_list?

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -86,7 +86,7 @@ export default function TableRow({
     registered_on: registeredOn,
     event_ids: eventIds,
     comment,
-    admin_comment: adminComment,
+    organizer_comment: organizerComment,
     waiting_list_position: position,
   } = registration.competing;
   const {
@@ -220,8 +220,8 @@ export default function TableRow({
 
                 <Table.Cell>
                   <Popup
-                    content={adminComment}
-                    trigger={<span>{truncateComment(adminComment)}</span>}
+                    content={organizerComment}
+                    trigger={<span>{truncateComment(organizerComment)}</span>}
                   />
                 </Table.Cell>
               </>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationSearch.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationSearch.jsx
@@ -35,8 +35,8 @@ export default function RegistrationAdministrationSearch({
                 ? ` ${I18n.t('activerecord.attributes.registration.comments')}: ${competing.comment}`
                 : ''
             }${
-              competing.admin_comment
-                ? ` ${I18n.t('activerecord.attributes.registration.administrative_notes')}: ${competing.admin_comment}`
+              competing.organizer_comment
+                ? ` ${I18n.t('activerecord.attributes.registration.administrative_notes')}: ${competing.organizer_comment}`
                 : ''
             }`,
             price: usingPayments
@@ -48,7 +48,7 @@ export default function RegistrationAdministrationSearch({
               wcaId: user.wca_id,
               email: user.email,
               comment: competing.comment,
-              note: competing.admin_comment,
+              note: competing.organizer_comment,
             },
           })),
         },

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -31,7 +31,7 @@ import useSet from '../../../lib/hooks/useSet';
 export default function RegistrationEditor({ registrationId, competitor, competitionInfo }) {
   const dispatch = useDispatch();
   const [comment, setComment] = useState('');
-  const [adminComment, setAdminComment] = useState('');
+  const [organizerComment, setOrganizerComment] = useState('');
   const [status, setStatus] = useState('');
   const [guests, setGuests] = useState(0);
   const selectedEventIds = useSet();
@@ -87,7 +87,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
       setComment(serverRegistration.competing.comment ?? '');
       setStatus(serverRegistration.competing.registration_status);
       setSelectedEventIds(serverRegistration.competing.event_ids);
-      setAdminComment(serverRegistration.competing.admin_comment ?? '');
+      setOrganizerComment(serverRegistration.competing.organizer_comment ?? '');
       setGuests(serverRegistration.guests ?? 0);
     }
   }, [serverRegistration, setSelectedEventIds]);
@@ -96,15 +96,15 @@ export default function RegistrationEditor({ registrationId, competitor, competi
     && _.xor(serverRegistration.competing.event_ids, selectedEventIds.asArray).length > 0;
   const hasCommentChanged = serverRegistration
     && comment !== (serverRegistration.competing.comment ?? '');
-  const hasAdminCommentChanged = serverRegistration
-    && adminComment !== (serverRegistration.competing.admin_comment ?? '');
+  const hasOrganizerCommentChanged = serverRegistration
+    && organizerComment !== (serverRegistration.competing.organizer_comment ?? '');
   const hasStatusChanged = serverRegistration
     && status !== serverRegistration.competing.registration_status;
   const hasGuestsChanged = serverRegistration && guests !== serverRegistration.guests;
 
   const hasChanges = hasEventsChanged
     || hasCommentChanged
-    || hasAdminCommentChanged
+    || hasOrganizerCommentChanged
     || hasStatusChanged
     || hasGuestsChanged;
 
@@ -139,8 +139,8 @@ export default function RegistrationEditor({ registrationId, competitor, competi
       if (hasCommentChanged) {
         body.competing.comment = comment;
       }
-      if (hasAdminCommentChanged) {
-        body.competing.admin_comment = adminComment;
+      if (hasOrganizerCommentChanged) {
+        body.competing.organizer_comment = organizerComment;
       }
       if (hasStatusChanged) {
         body.competing.status = status;
@@ -166,13 +166,13 @@ export default function RegistrationEditor({ registrationId, competitor, competi
     competitionInfo.id,
     hasEventsChanged,
     hasCommentChanged,
-    hasAdminCommentChanged,
+    hasOrganizerCommentChanged,
     hasStatusChanged,
     hasGuestsChanged,
     updateRegistrationMutation,
     selectedEventIds.asArray,
     comment,
-    adminComment,
+    organizerComment,
     status,
     guests,
   ]);
@@ -228,8 +228,8 @@ export default function RegistrationEditor({ registrationId, competitor, competi
           label={I18n.t('activerecord.attributes.registration.administrative_notes')}
           id="admin-comment"
           maxLength={240}
-          value={adminComment}
-          onChange={(event, data) => setAdminComment(data.value)}
+          value={organizerComment}
+          onChange={(event, data) => setOrganizerComment(data.value)}
         />
 
         <Header as="h6">{I18n.t('activerecord.attributes.registration.status')}</Header>

--- a/app/webpacker/lib/utils/registrationAdmin.js
+++ b/app/webpacker/lib/utils/registrationAdmin.js
@@ -135,7 +135,7 @@ export function sortRegistrations(registrations, sortColumn, sortDirection) {
         return a.competing.comment.localeCompare(b.competing.comment);
 
       case 'administrative_notes':
-        return a.competing.admin_comment.localeCompare(b.competing.admin_comment);
+        return a.competing.organizer_comment.localeCompare(b.competing.organizer_comment);
 
       case 'registered_on':
         return DateTime.fromISO(a.competing.registered_on).toMillis()

--- a/db/migrate/20250501060442_rename_administrative_note_to_organizer_comment.rb
+++ b/db/migrate/20250501060442_rename_administrative_note_to_organizer_comment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameAdministrativeNoteToOrganizerComment < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :registrations, :administrative_notes, :organizer_comment
+  end
+end

--- a/lib/registrations/registration_checker.rb
+++ b/lib/registrations/registration_checker.rb
@@ -33,12 +33,12 @@ module Registrations
 
         competing_payload = raw_payload['competing']
         comment = competing_payload&.dig('comment')
-        admin_comment = competing_payload&.dig('admin_comment')
+        organizer_comment = competing_payload&.dig('organizer_comment')
         competing_status = competing_payload&.dig('status')
         waiting_list_position = competing_payload&.dig('waiting_list_position')
 
         new_registration.comments = comment if competing_payload&.key?('comment')
-        new_registration.administrative_notes = admin_comment if competing_payload&.key?('admin_comment')
+        new_registration.administrative_notes = organizer_comment if competing_payload&.key?('organizer_comment')
         new_registration.competing_status = competing_status if competing_payload&.key?('status')
         new_registration.waiting_list_position = waiting_list_position if competing_payload&.key?('waiting_list_position')
 
@@ -73,7 +73,7 @@ module Registrations
       # Migrated to ActiveRecord-style validations
       validate_guests!(updated_registration)
       validate_comment!(updated_registration)
-      validate_admin_comment!(updated_registration)
+      validate_organizer_comment!(updated_registration)
       validate_registration_events!(updated_registration)
       validate_status_value!(updated_registration)
       validate_waiting_list_position!(updated_registration)
@@ -131,7 +131,7 @@ module Registrations
         process_validation_error!(registration, :comments)
       end
 
-      def validate_admin_comment!(registration)
+      def validate_organizer_comment!(registration)
         process_validation_error!(registration, :administrative_notes)
       end
 

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -772,22 +772,22 @@ RSpec.describe Registrations::RegistrationChecker do
     end
 
     describe '#update_registration_allowed!.validate_organizer_fields!' do
-      it 'organizer can add admin_comment' do
+      it 'organizer can add organizer_comment' do
         update_request = build(
           :update_request,
           user_id: default_registration.user_id,
           competition_id: default_registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'admin_comment' => 'this is an admin comment' },
+          competing: { 'organizer_comment' => 'this is an organizer comment' },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
           .not_to raise_error
       end
 
-      it 'organizer can change admin_comment' do
+      it 'organizer can change organizer_comment' do
         registration = create(
-          :registration, user_id: default_user.id, competition_id: default_competition.id, administrative_notes: 'admin comment'
+          :registration, user_id: default_user.id, competition_id: default_competition.id, administrative_notes: 'organizer comment'
         )
 
         update_request = build(
@@ -795,7 +795,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: registration.user_id,
           competition_id: registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'admin_comment' => 'this is an admin comment' },
+          competing: { 'organizer_comment' => 'this is an organizer comment' },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, registration) }
@@ -803,8 +803,8 @@ RSpec.describe Registrations::RegistrationChecker do
       end
     end
 
-    describe '#update_registration_allowed!.validate_admin_comment!' do
-      it 'admin comment cant exceed 240 characters' do
+    describe '#update_registration_allowed!.validate_organizer_comment!' do
+      it 'organizer comment cant exceed 240 characters' do
         long_comment = 'comment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer
         than 240 characterscomment longer than 240 characters'
 
@@ -813,7 +813,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: default_registration.user_id,
           competition_id: default_registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'admin_comment' => long_comment },
+          competing: { 'organizer_comment' => long_comment },
         )
 
         expect {
@@ -824,7 +824,7 @@ RSpec.describe Registrations::RegistrationChecker do
         end
       end
 
-      it 'admin comment can match 240 characters' do
+      it 'organizer comment can match 240 characters' do
         at_character_limit = 'comment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than 240 characterscomment longer than' \
                              '240 characterscomment longer longer than 240 12345'
 
@@ -833,7 +833,7 @@ RSpec.describe Registrations::RegistrationChecker do
           user_id: default_registration.user_id,
           competition_id: default_registration.competition_id,
           submitted_by: default_competition.organizers.first.id,
-          competing: { 'admin_comment' => at_character_limit },
+          competing: { 'organizer_comment' => at_character_limit },
         )
 
         expect { Registrations::RegistrationChecker.update_registration_allowed!(update_request, default_registration) }
@@ -2015,13 +2015,13 @@ RSpec.describe Registrations::RegistrationChecker do
         end
       end
 
-      it 'organizer can update admin comment in attendees non-accepted series comp registration' do
+      it 'organizer can update organizer comment in attendees non-accepted series comp registration' do
         update_request = build(
           :update_request,
           user_id: registrationB.user_id,
           competition_id: registrationB.competition_id,
           submitted_by: competitionB.organizers.first.id,
-          competing: { 'admin_comment' => 'why they were cancelled' },
+          competing: { 'organizer_comment' => 'why they were cancelled' },
         )
 
         expect {

--- a/spec/lib/registrations/registration_checker_spec.rb
+++ b/spec/lib/registrations/registration_checker_spec.rb
@@ -787,7 +787,7 @@ RSpec.describe Registrations::RegistrationChecker do
 
       it 'organizer can change organizer_comment' do
         registration = create(
-          :registration, user_id: default_user.id, competition_id: default_competition.id, administrative_notes: 'organizer comment'
+          :registration, user_id: default_user.id, competition_id: default_competition.id, organizer_comment: 'organizer comment'
         )
 
         update_request = build(

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe Registration do
 
       registration.reload
       expect(registration.comments).to eq('user comment')
-      expect(registration.administrative_notes).to eq('updated organizer comment')
+      expect(registration.organizer_comment).to eq('updated organizer comment')
       expect(registration.guests).to eq(3)
       expect(registration.competing_status).to eq('accepted')
       expect(registration.event_ids).to eq(['333', '555'])
@@ -491,7 +491,7 @@ RSpec.describe Registration do
     it 'updates organizer comment' do
       registration.update_lanes!({ user_id: registration.user.id, competing: { organizer_comment: 'test organizer comment' } }.with_indifferent_access, registration.user)
       registration.reload
-      expect(registration.administrative_notes).to eq('test organizer comment')
+      expect(registration.organizer_comment).to eq('test organizer comment')
     end
 
     it 'removes events' do

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe Registration do
       registration.update_lanes!(
         {
           user_id: registration.user.id, guests: 3, competing: {
-            admin_comment: 'updated admin comment', comment: 'user comment', status: 'accepted', event_ids: ['333', '555']
+            organizer_comment: 'updated organizer comment', comment: 'user comment', status: 'accepted', event_ids: '333', '555']
           }
         }.with_indifferent_access,
         registration.user,
@@ -413,7 +413,7 @@ RSpec.describe Registration do
 
       registration.reload
       expect(registration.comments).to eq('user comment')
-      expect(registration.administrative_notes).to eq('updated admin comment')
+      expect(registration.administrative_notes).to eq('updated organizer comment')
       expect(registration.guests).to eq(3)
       expect(registration.competing_status).to eq('accepted')
       expect(registration.event_ids).to eq(['333', '555'])
@@ -488,10 +488,10 @@ RSpec.describe Registration do
       expect(registration.comments).to eq('test comment')
     end
 
-    it 'updates admin comment' do
-      registration.update_lanes!({ user_id: registration.user.id, competing: { admin_comment: 'test admin comment' } }.with_indifferent_access, registration.user)
+    it 'updates organizer comment' do
+      registration.update_lanes!({ user_id: registration.user.id, competing: { organizer_comment: 'test organizer comment' } }.with_indifferent_access, registration.user)
       registration.reload
-      expect(registration.administrative_notes).to eq('test admin comment')
+      expect(registration.administrative_notes).to eq('test organizer comment')
     end
 
     it 'removes events' do

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -595,12 +595,12 @@ RSpec.describe 'API Registrations' do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it 'user cant submit an admin comment' do
+    it 'user cant submit an organizer comment' do
       update_request = build(
         :update_request,
         user_id: registration.user_id,
         competition_id: registration.competition_id,
-        competing: { 'admin_comment' => 'this is an admin comment' },
+        competing: { 'organizer_comment' => 'this is an organizer comment' },
       )
 
       headers = { 'Authorization' => update_request['jwt_token'] }


### PR DESCRIPTION
Follow-up PR to #11408, Gregor and I discussed in slack that 11408 should establish consistency in the naming of this field. My suggestion is that we be more consistent in our usage of `admin`, to differentiate between comment made by a _website_ admin and an _administrative comment_

I think that in the context of calling it the "Reg Admin" page, the contraction of "administration" -> "admin" is more obvious. Just hearing "admin comment", it's easier to think of it as a contraction of "administrator", which can cause confusion. 