### PR TITLE
Fix record history by region

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -334,10 +334,10 @@ class ResultsController < ApplicationController
     @continent = Continent.c_find(params[:region])
     @country = Country.c_find(params[:region])
     if @continent.present?
-      @region_condition = "AND results.country_id IN (#{@continent.country_ids.map { |id| "'#{id}'" }.join(',')})"
+      @region_condition = "AND result.country_id IN (#{@continent.country_ids.map { |id| "'#{id}'" }.join(',')})"
       @region_condition += " AND record_name IN ('WR', '#{@continent.record_name}')" if @is_histories
     elsif @country.present?
-      @region_condition = "AND results.country_id = '#{@country.id}'"
+      @region_condition = "AND result.country_id = '#{@country.id}'"
       @region_condition += " AND record_name <> ''" if @is_histories
     else
       @region_condition = ""

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,7 +4,7 @@ class ResultsController < ApplicationController
   REGION_WORLD = "world"
   YEARS_ALL = "all years"
   SHOW_100_PERSONS = "100 persons"
-  SHOWS = ["mixedslimseparatehistorymixed history"].freeze
+  SHOWS = ['mixed', 'slim', 'separate', 'history', 'mixed history'].freeze
   GENDERS = %w[Male Female].freeze
   SHOW_MIXED = "mixed"
   GENDER_ALL = "All"

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,6 +4,8 @@ class ResultsController < ApplicationController
   REGION_WORLD = "world"
   YEARS_ALL = "all years"
   SHOW_100_PERSONS = "100 persons"
+  SHOWS = %w[mixed slim separate history mixed_history]
+  GENDERS = %w[Male Female]
   SHOW_MIXED = "mixed"
   GENDER_ALL = "All"
   EVENTS_ALL = "all events"
@@ -176,12 +178,11 @@ class ResultsController < ApplicationController
     params[:show] ||= SHOW_MIXED
     params[:gender] ||= GENDER_ALL
 
-    @shows = [SHOW_MIXED, "slim", "separate", "history", "mixed history"]
-    @is_mixed = params[:show] == @shows[0]
-    @is_slim = params[:show] == @shows[1]
-    @is_separate = params[:show] == @shows[2]
-    @is_history = params[:show] == @shows[3]
-    @is_mixed_history = params[:show] == @shows[4]
+    @is_mixed = params[:show] == SHOWS[0]
+    @is_slim = params[:show] == SHOWS[1]
+    @is_separate = params[:show] == SHOWS[2]
+    @is_history = params[:show] == SHOWS[3]
+    @is_mixed_history = params[:show] == SHOWS[4]
     @is_histories = @is_history || @is_mixed_history
 
     shared_constants_and_conditions
@@ -203,24 +204,24 @@ class ResultsController < ApplicationController
           DAY(competitions.start_date)   day,
           events.id              event_id,
           events.name            event_name,
-          result.id              id,
-          result.type            type,
-          result.value           value,
-          result.format_id       format_id,
-          result.round_type_id   round_type_id,
+          results.id              id,
+          results.type            type,
+          results.value           value,
+          results.format_id       format_id,
+          results.round_type_id   round_type_id,
           events.format          value_format,
                                  record_name,
-          result.person_id       person_id,
-          result.person_name     person_name,
-          result.country_id      country_id,
+          results.person_id       person_id,
+          results.person_name     person_name,
+          results.country_id      country_id,
           countries.name         country_name,
           competitions.id        competition_id,
           competitions.cell_name competition_name,
           value1, value2, value3, value4, value5
         FROM
           (SELECT results.*, 'single' type, best value, regional_single_record record_name FROM results WHERE regional_single_record<>'' UNION
-            SELECT results.*, 'average' type, average value, regional_average_record record_name FROM results WHERE regional_average_record<>'') result
-          #{@gender_condition.present? ? 'JOIN persons ON result.person_id = persons.wca_id and persons.sub_id = 1,' : ','}
+            SELECT results.*, 'average' type, average value, regional_average_record record_name FROM results WHERE regional_average_record<>'') results
+          #{@gender_condition.present? ? 'JOIN persons ON results.person_id = persons.wca_id and persons.sub_id = 1,' : ','}
           events,
           round_types,
           competitions,
@@ -229,7 +230,7 @@ class ResultsController < ApplicationController
           AND events.`rank` < 1000
           AND round_types.id = round_type_id
           AND competitions.id = competition_id
-          AND countries.id = result.country_id
+          AND countries.id = results.country_id
           #{@region_condition}
           #{@event_condition}
           #{@years_condition_competition}
@@ -334,10 +335,10 @@ class ResultsController < ApplicationController
     @continent = Continent.c_find(params[:region])
     @country = Country.c_find(params[:region])
     if @continent.present?
-      @region_condition = "AND result.country_id IN (#{@continent.country_ids.map { |id| "'#{id}'" }.join(',')})"
+      @region_condition = "AND results.country_id IN (#{@continent.country_ids.map { |id| "'#{id}'" }.join(',')})"
       @region_condition += " AND record_name IN ('WR', '#{@continent.record_name}')" if @is_histories
     elsif @country.present?
-      @region_condition = "AND result.country_id = '#{@country.id}'"
+      @region_condition = "AND results.country_id = '#{@country.id}'"
       @region_condition += " AND record_name <> ''" if @is_histories
     else
       @region_condition = ""

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,7 +4,7 @@ class ResultsController < ApplicationController
   REGION_WORLD = "world"
   YEARS_ALL = "all years"
   SHOW_100_PERSONS = "100 persons"
-  SHOWS = %w[mixed slim separate history mixed_history]
+  SHOWS = ['mixed' 'slim' 'separate' 'history' 'mixed history']
   GENDERS = %w[Male Female]
   SHOW_MIXED = "mixed"
   GENDER_ALL = "All"

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,8 +4,8 @@ class ResultsController < ApplicationController
   REGION_WORLD = "world"
   YEARS_ALL = "all years"
   SHOW_100_PERSONS = "100 persons"
-  SHOWS = ['mixed' 'slim' 'separate' 'history' 'mixed history']
-  GENDERS = %w[Male Female]
+  SHOWS = ["mixedslimseparatehistorymixed history"].freeze
+  GENDERS = %w[Male Female].freeze
   SHOW_MIXED = "mixed"
   GENDER_ALL = "All"
   EVENTS_ALL = "all events"

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe "results" do
+  TEST_EVENTS = %w[333 333mbf 333fm]
+  TEST_REGIONS = ['_Africa', 'South Africa']
+
   describe "GET #rankings" do
     context "with valid params" do
       it "shows rankings" do
@@ -39,21 +42,42 @@ RSpec.describe "results" do
 
     context 'json' do
       let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
+      let(:genders) { ['Male', 'Female'] }
 
-      it 'shows history for Africa' do
-        get records_path, headers: headers, params: { region: '_Africa', show: 'history' }
-        expect(response).to be_successful
+      RSpec.shared_examples 'single parameter' do |param_name, param_value|
+        it "returns success for param #{param_name} with value: #{param_value}" do
+          get records_path, headers: headers, params: { **{ param_name => param_value } }
+          expect(response).to be_successful
+        end
       end
 
-      it 'shows history for South Africa' do
-        get records_path, headers: headers, params: { region: 'South Africa', show: 'history' }
-        expect(response).to be_successful
+      ResultsController::SHOWS.each do |show|
+        it_behaves_like 'single parameter', 'show', show
       end
 
-      it 'shows female records for Africa' do
+      ResultsController::GENDERS.each do |gender|
+        it_behaves_like 'single parameter', 'gender', gender
       end
 
-      it 'shows female records for South Africa' do
+      TEST_EVENTS.each do |event|
+        it_behaves_like 'single parameter', 'event_id', event
+      end
+
+      TEST_REGIONS.each do |region|
+        it_behaves_like 'single parameter', 'region', region
+      end
+
+      RSpec.shared_examples 'two parameters' do |param_1, param_2, value_1, value_2|
+        it "returns success for params #{param_1}/#{param_2} with values: #{value_1}/#{value_2}" do
+          get records_path, headers: headers, params: { ** { param_1 => value_1, param_2 => value_2 } }
+          expect(response).to be_successful
+        end
+      end
+
+      ResultsController::SHOWS.each do |show|
+        TEST_REGIONS.each do |region|
+          it_behaves_like 'two parameters', 'show', 'region', show, region
+        end
       end
     end
   end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -30,9 +30,23 @@ RSpec.describe "results" do
   end
 
   describe "GET #records" do
-    context "with default params" do
-      it "shows records" do
+    context 'html request format' do
+      it "show records given default params" do
         get records_path
+        expect(response).to be_successful
+      end
+    end
+
+    context 'json' do
+      let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
+
+      it 'shows history for Africa' do
+        get records_path, headers: headers, params: { region: '_Africa' , show: 'history'}
+        expect(response).to be_successful
+      end
+
+      it 'shows history for South Africa', :tag do
+        get records_path, headers: headers, params: { region: 'South Africa' , show: 'history'}
         expect(response).to be_successful
       end
     end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe "results" do
-  TEST_EVENTS = %w[333 333mbf 333fm]
-  TEST_REGIONS = ['_Africa', 'South Africa']
+  TEST_EVENTS = %w[333 333mbf 333fm].freeze
+  TEST_REGIONS = ['_Africa', 'South Africa'].freeze
 
   describe "GET #rankings" do
     context "with valid params" do
@@ -42,7 +42,7 @@ RSpec.describe "results" do
 
     context 'json' do
       let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
-      let(:genders) { ['Male', 'Female'] }
+      let(:genders) { %w[Male Female] }
 
       RSpec.shared_examples 'single parameter' do |param_name, param_value|
         it "returns success for param #{param_name} with value: #{param_value}" do

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -3,9 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe "results" do
-  TEST_EVENTS = %w[333 333mbf 333fm].freeze
-  TEST_REGIONS = ['_Africa', 'South Africa'].freeze
-
   describe "GET #rankings" do
     context "with valid params" do
       it "shows rankings" do
@@ -59,11 +56,11 @@ RSpec.describe "results" do
         it_behaves_like 'single parameter', 'gender', gender
       end
 
-      TEST_EVENTS.each do |event|
+      TestConstants::RESULT_TEST_EVENTS.each do |event|
         it_behaves_like 'single parameter', 'event_id', event
       end
 
-      TEST_REGIONS.each do |region|
+      TestConstants::RESULT_TEST_REGIONS.each do |region|
         it_behaves_like 'single parameter', 'region', region
       end
 
@@ -75,7 +72,7 @@ RSpec.describe "results" do
       end
 
       ResultsController::SHOWS.each do |show|
-        TEST_REGIONS.each do |region|
+        TestConstants::RESULT_TEST_REGIONS.each do |region|
           it_behaves_like 'two parameters', 'show', 'region', show, region
         end
       end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe "results" do
         get records_path, headers: headers, params: { region: 'South Africa', show: 'history' }
         expect(response).to be_successful
       end
+
+      it 'shows female records for Africa' do
+      end
+
+      it 'shows female records for South Africa' do
+      end
     end
   end
 end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "results" do
         expect(response).to be_successful
       end
 
-      it 'shows history for South Africa', :tag do
+      it 'shows history for South Africa' do
         get records_path, headers: headers, params: { region: 'South Africa' , show: 'history'}
         expect(response).to be_successful
       end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe "results" do
       let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
 
       it 'shows history for Africa' do
-        get records_path, headers: headers, params: { region: '_Africa' , show: 'history'}
+        get records_path, headers: headers, params: { region: '_Africa', show: 'history' }
         expect(response).to be_successful
       end
 
       it 'shows history for South Africa' do
-        get records_path, headers: headers, params: { region: 'South Africa' , show: 'history'}
+        get records_path, headers: headers, params: { region: 'South Africa', show: 'history' }
         expect(response).to be_successful
       end
     end

--- a/spec/support/test_constants.rb
+++ b/spec/support/test_constants.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module TestConstants
+  RESULT_TEST_EVENTS = %w[333 333mbf 333fm].freeze
+  RESULT_TEST_REGIONS = ['_Africa', 'South Africa'].freeze
+end


### PR DESCRIPTION
Fixes #11462 

Currently, [record history by region](https://www.worldcubeassociation.org/results/records?region=_Africa&show=history) is broken in prod. I replicated this issue locally through tests, and fixed it by correcting what appears to be inconsistent table aliases in the SQL queries.

I have added parametrized tests to cover the basic cases that were failing - there is more that can be done here though.

Follow-up PR: This section of the code is severely under-tested. Add more tests against the results API endpoints we use in production. Specifically:
- [ ] Add 3 and 4-parameter tests
- [ ] Add all cases of 2-parameter tests (currently we're only testing combinations of `show` and `region` - but we should ideally test all combinations of 
- [ ] We _possibly_ don't always return errors when an incorrect value is supplied (this may just be an error in my tests at the time of writing them, not an error with the code) - investigate this and raises tests/fix if necessary
- [ ] We don't raise errors if unexpected parameters are supplied (eg, 'event' instead of 'event_id') - perhaps not the end of the world, but leads to false-positives when testing

It is particularly important to make sure the test fails first, to ensure that you are actually triggering the behaviour you expect. (For example, in this PR, my test database was incompletely populated, and so wasn't triggering the region-specific code. I would not have picked this up if not for the fact that this use case was failing in production but not under my testing.)