### PR TITLE
Fix the staff crash course link

### DIFF
--- a/app/views/panel/staff.html.erb
+++ b/app/views/panel/staff.html.erb
@@ -6,7 +6,7 @@
   <ul>
     <%= documents_list("policies/internal") %>
     <li>
-      <%= link_to "Staff crash course", "https://documents.worldcubeassociation.org/edudoc/staff-crash-course/staff_crash_course.pdf" %>
+      <%= link_to "Staff crash course", "https://documents.worldcubeassociation.org/edudoc/staff-crash-course/volunteer_crash_course.pdf" %>
     </li>
     <li>
       <%= link_to "Merch Order Form (with staff discount)", "https://forms.gle/RAor4LyzNCxs6Mvb8" %>


### PR DESCRIPTION
Blocked by this: https://github.com/thewca/wca-documents/pull/478