### PR TITLE
Edit Schedule: automatic calendar bounds

### DIFF
--- a/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -79,15 +79,15 @@ function EditActivities({
 
     if (activities?.length) {
       setCalendarStart(
-        Math.min(
-          getHour(earliestTimeOfDayWithBuffer(activities, timezone)),
-          8,
+        Math.max(
+          getHour(earliestTimeOfDayWithBuffer(activities, timezone)) - 1,
+          0,
         ),
       );
       setCalendarEnd(
-        Math.max(
-          getHour(latestTimeOfDayWithBuffer(activities, timezone), { roundForward: true }),
-          20,
+        Math.min(
+          getHour(latestTimeOfDayWithBuffer(activities, timezone), { roundForward: true }) + 1,
+          24,
         ),
       );
     }

--- a/app/webpacker/lib/utils/activities.js
+++ b/app/webpacker/lib/utils/activities.js
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon';
+import { DateTime, Duration } from 'luxon';
 import {
   addEndBufferWithinDay,
   areOnSameDate,
@@ -120,11 +120,11 @@ export const latestTimeOfDayWithBuffer = (
 /** e.g. '15:00:00' -> 15 */
 export const getHour = (timeString, options = {}) => {
   if (timeString) {
-    const [h, m] = timeString.split(':');
-    if (options.roundForward && m !== '00') {
-      return Number(h) + 1;
+    const { hours, minutes } = Duration.fromISOTime(timeString).toObject();
+    if (options.roundForward && minutes !== 0) {
+      return hours + 1;
     }
-    return Number(h);
+    return hours;
   }
   return undefined;
 };

--- a/app/webpacker/lib/utils/activities.js
+++ b/app/webpacker/lib/utils/activities.js
@@ -117,6 +117,18 @@ export const latestTimeOfDayWithBuffer = (
   return result;
 };
 
+/** e.g. '15:00:00' -> 15 */
+export const getHour = (timeString, options = {}) => {
+  if (timeString) {
+    const [h, m] = timeString.split(':');
+    if (options.roundForward && m !== '00') {
+      return Number(h) + 1;
+    }
+    return Number(h);
+  }
+  return undefined;
+};
+
 export const localizeActivityName = (activity, wcifEvents) => {
   const activityEvent = findActivityEvent(activity, wcifEvents);
   const activityRound = findActivityRound(activity, activityEvent.rounds);


### PR DESCRIPTION
I was going to do the right-click-to-delete feature I mentioned in a previous PR, but ended up doing this instead, because it's annoyed me in the past and others have complained about it too.

Originally, bounds were 8am-8pm and only changed when the user manually changed them.

Now, initial bounds are 8am-8pm. When you select a room, it fits the activities from that room, with an up to two-hour buffer (but cutting off at midnight). If you select a room with no activities, the bounds don't change.

[Screencast from 2025-05-05 06:34:11 PM.webm](https://github.com/user-attachments/assets/88ca4722-c8e6-4fdc-be38-0e0bee0dc581)

Alternatively, the bounds could keep the 8am-8pm window always visible (unless the user manually adjusts them of course), but extend further if there are activities outside this window (when a room is selected). This was the behaviour after the first commit, so revert the 2nd commit to achieve this.

I don't have a strong preference between the above two behaviours. Both are an improvement over the current behaviour.

In a future PR, I would like to add a warning if there are any activities outside the competition dates, and a button to remove them. Even though the calendar is restricted to the competition dates, you can still drag an activity so that a portion of it is beyond midnight. Also I think there have been cases of the competition date being changed but the old activities being left behind and not accessible through the UI.

Another possible improvement, for a future PR, is to automatically extend (but never shrink) the bounds when activities are added/moved, to maintain a two-hour buffer.