### PR TITLE
Configure separate cache directory for test webpacker assemblies

### DIFF
--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -67,6 +67,9 @@ test:
   # Make sure that asset paths are stable across browser runs
   cache_manifest: true
 
+  # Make sure that test assets don't interfere with the webpack-dev-server running in Docker
+  cache_path: tmp/cache/webpacker-test
+
 production:
   <<: *default
 


### PR DESCRIPTION
Small fix for test assets. This is relevant when running feature specs on your local machine in the `test` environment, while also the Docker orchestra is running with a dev server on the `development` environment at the same time.