### PR TITLE
Give RegistrationPayments an independent refresh button

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import {
-  Button, Message, Table,
+  Button, Header, Message, Table,
 } from 'semantic-ui-react';
 import _ from 'lodash';
 import getRegistrationPayments from '../api/payment/get/getRegistrationPayments';
@@ -27,6 +27,7 @@ export default function Payments({
   const {
     data: payments,
     isLoading: paymentsLoading,
+    refetch: refetchPayments,
   } = useQuery({
     queryKey: ['payments', registrationId],
     queryFn: () => getRegistrationPayments(registrationId),
@@ -79,6 +80,30 @@ export default function Payments({
     return <Loading />;
   }
 
+  return (
+    <>
+      <Header>
+        Payments
+        <Button floated="right" onClick={refetchPayments}>Refresh</Button>
+      </Header>
+      <PaymentsMainBody
+        payments={payments}
+        refundMutation={refundMutation}
+        isMutating={isMutating}
+        competitionId={competitionId}
+        userInfo={userInfo}
+      />
+    </>
+  );
+}
+
+function PaymentsMainBody({
+  payments,
+  refundMutation,
+  isMutating,
+  competitionId,
+  userInfo,
+}) {
   if (payments.length === 0) {
     return <Message warning>{I18n.t('payments.messages.charges_refunded')}</Message>;
   }

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/Payments.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   Button, Message, Table,
 } from 'semantic-ui-react';
+import _ from 'lodash';
 import getRegistrationPayments from '../api/payment/get/getRegistrationPayments';
 import refundPayment from '../api/payment/get/refundPayment';
 import Loading from '../../Requests/Loading';
@@ -13,11 +14,11 @@ import I18n from '../../../lib/i18n';
 import { showMessage } from '../Register/RegistrationMessage';
 import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
+import getUsersInfo from '../api/user/post/getUserInfo';
 
 export default function Payments({
   registrationId,
   competitionId,
-  competitorsInfo,
   refetchHistory,
 }) {
   const dispatch = useDispatch();
@@ -30,6 +31,12 @@ export default function Payments({
     queryKey: ['payments', registrationId],
     queryFn: () => getRegistrationPayments(registrationId),
     select: (data) => data.charges.filter((r) => r.iso_amount_refundable !== 0),
+  });
+
+  const { data: userInfo, isLoading: userInfoLoading } = useQuery({
+    queryKey: ['payments-user', payments],
+    queryFn: () => getUsersInfo(_.uniq(payments.map((p) => p.user_id))),
+    enabled: Boolean(payments),
   });
 
   const { mutate: refundMutation, isPending: isMutating } = useMutation({
@@ -68,7 +75,7 @@ export default function Payments({
     },
   });
 
-  if (paymentsLoading) {
+  if (paymentsLoading || userInfoLoading) {
     return <Loading />;
   }
 
@@ -94,7 +101,7 @@ export default function Payments({
             isMutating={isMutating}
             competitionId={competitionId}
             key={refund.payment_id}
-            competitorsInfo={competitorsInfo}
+            userinfo={userInfo}
           />
         ))}
       </Table.Body>
@@ -103,7 +110,7 @@ export default function Payments({
 }
 
 function PaymentRow({
-  payment, refundMutation, isMutating, competitionId, competitorsInfo,
+  payment, refundMutation, isMutating, competitionId, userInfo,
 }) {
   const [amountToRefund, setAmountToRefund] = useInputState(payment.iso_amount_refundable);
 
@@ -164,7 +171,7 @@ function PaymentRow({
           <Table.Cell>
             Refunded by
             {' '}
-            {competitorsInfo.find(
+            {userInfo.find(
               (c) => c.id === Number(p.user_id),
             )?.name}
           </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -24,7 +24,6 @@ import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import I18n from '../../../lib/i18n';
 import RegistrationHistory from './RegistrationHistory';
 import { hasPassed } from '../../../lib/utils/dates';
-import getUsersInfo from '../api/user/post/getUserInfo';
 import { useRegistration } from '../lib/RegistrationProvider';
 import useSet from '../../../lib/hooks/useSet';
 import { getRegistrationHistory } from '../api/registration/get/get_registrations';
@@ -53,13 +52,6 @@ export default function RegistrationEditor({ registrationId, competitor, competi
   } = useQuery({
     queryKey: ['registration-history', registrationId],
     queryFn: () => getRegistrationHistory(registrationId),
-  });
-
-  const { isLoading: competitorsInfoLoading, data: competitorsInfo } = useQuery({
-    queryKey: ['history-user', registrationHistory],
-    queryFn: () => getUsersInfo(_.uniq(registrationHistory.flatMap((e) => (
-      (e.actor_type === 'user' || e.actor_type === 'worker') ? Number(e.actor_id) : [])))),
-    enabled: Boolean(registrationHistory),
   });
 
   const { mutate: updateRegistrationMutation, isPending: isUpdating } = useMutation({
@@ -193,7 +185,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
   const registrationEditDeadlinePassed = Boolean(competitionInfo.event_change_deadline_date)
     && hasPassed(competitionInfo.event_change_deadline_date);
 
-  if (isRegistrationLoading || historyLoading || competitorsInfoLoading) {
+  if (isRegistrationLoading || historyLoading) {
     return <Loading />;
   }
 
@@ -315,14 +307,12 @@ export default function RegistrationEditor({ registrationId, competitor, competi
           <Payments
             competitionId={competitionInfo.id}
             registrationId={registrationId}
-            competitorsInfo={competitorsInfo}
             refetchHistory={refetchHistory}
           />
         </>
       )}
       <RegistrationHistory
         history={registrationHistory.toReversed()}
-        competitorsInfo={competitorsInfo}
         refetchHistory={refetchHistory}
       />
     </Segment>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -70,7 +70,8 @@ export default function RegistrationEditor({ registrationId, competitor, competi
         dispatch(showMessage('registrations.flash.updated', 'positive'));
       }
 
-      queryClient.invalidateQueries({ queryKey: ['registration-history', registrationId] });
+      queryClient.refetchQueries({ queryKey: ['registration-history', registrationId], exact: true });
+      queryClient.refetchQueries({ queryKey: ['registration-payments', registrationId], exact: true });
     },
   });
 

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -18,7 +18,7 @@ import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { showMessage } from '../Register/RegistrationMessage';
 import Loading from '../../Requests/Loading';
 import EventSelector from '../../wca/EventSelector';
-import Payments from './Payments';
+import RegistrationPayments from './RegistrationPayments';
 import { personUrl, editPersonUrl } from '../../../lib/requests/routes.js.erb';
 import { useConfirm } from '../../../lib/providers/ConfirmProvider';
 import I18n from '../../../lib/i18n';
@@ -302,7 +302,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
       {/* i18n-tasks-use t('registrations.list.series_registrations') */}
 
       {competitionInfo['using_payment_integrations?'] && (
-        <Payments
+        <RegistrationPayments
           competitionId={competitionInfo.id}
           registrationId={registrationId}
           refetchHistory={refetchHistory}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -302,14 +302,11 @@ export default function RegistrationEditor({ registrationId, competitor, competi
       {/* i18n-tasks-use t('registrations.list.series_registrations') */}
 
       {competitionInfo['using_payment_integrations?'] && (
-        <>
-          <Header>Payments</Header>
-          <Payments
-            competitionId={competitionInfo.id}
-            registrationId={registrationId}
-            refetchHistory={refetchHistory}
-          />
-        </>
+        <Payments
+          competitionId={competitionInfo.id}
+          registrationId={registrationId}
+          refetchHistory={refetchHistory}
+        />
       )}
       <RegistrationHistory
         history={registrationHistory.toReversed()}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -2,10 +2,14 @@ import React from 'react';
 import {
   Button, Header, Popup, Table,
 } from 'semantic-ui-react';
+import { useQuery } from '@tanstack/react-query';
+import _ from 'lodash';
 import { getIsoDateString, getShortTimeString, getTimeWithSecondsString } from '../../../lib/utils/dates';
 import { events } from '../../../lib/wca-data.js.erb';
 import EventIcon from '../../wca/EventIcon';
 import I18n from '../../../lib/i18n';
+import getUsersInfo from '../api/user/post/getUserInfo';
+import Loading from '../../Requests/Loading';
 
 const formatHistoryColumn = (key, value) => {
   if (key === 'event_ids') {
@@ -14,7 +18,18 @@ const formatHistoryColumn = (key, value) => {
   return value;
 };
 
-export default function RegistrationHistory({ history, competitorsInfo, refetchHistory }) {
+export default function RegistrationHistory({ history, refetchHistory }) {
+  const { data: competitorsInfo, isLoading: competitorsInfoLoading } = useQuery({
+    queryKey: ['history-user', history],
+    queryFn: () => getUsersInfo(_.uniq(history.flatMap((e) => (
+      (e.actor_type === 'user' || e.actor_type === 'worker') ? Number(e.actor_id) : [])))),
+    enabled: Boolean(history),
+  });
+
+  if (competitorsInfoLoading) {
+    return <Loading />;
+  }
+
   return (
     <>
       <Header>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -10,6 +10,7 @@ import EventIcon from '../../wca/EventIcon';
 import I18n from '../../../lib/i18n';
 import getUsersInfo from '../api/user/post/getUserInfo';
 import Loading from '../../Requests/Loading';
+import { getRegistrationHistory } from '../api/registration/get/get_registrations';
 
 const formatHistoryColumn = (key, value) => {
   if (key === 'event_ids') {
@@ -18,7 +19,16 @@ const formatHistoryColumn = (key, value) => {
   return value;
 };
 
-export default function RegistrationHistory({ history, refetchHistory }) {
+export default function RegistrationHistory({ registrationId }) {
+  const {
+    isLoading: historyLoading,
+    data: history,
+    refetch: refetchHistory,
+  } = useQuery({
+    queryKey: ['registration-history', registrationId],
+    queryFn: () => getRegistrationHistory(registrationId),
+  });
+
   const { data: competitorsInfo, isLoading: competitorsInfoLoading } = useQuery({
     queryKey: ['history-user', history],
     queryFn: () => getUsersInfo(_.uniq(history.flatMap((e) => (
@@ -26,7 +36,7 @@ export default function RegistrationHistory({ history, refetchHistory }) {
     enabled: Boolean(history),
   });
 
-  if (competitorsInfoLoading) {
+  if (historyLoading || competitorsInfoLoading) {
     return <Loading />;
   }
 

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
@@ -19,7 +19,6 @@ import getUsersInfo from '../api/user/post/getUserInfo';
 export default function RegistrationPayments({
   registrationId,
   competitionId,
-  refetchHistory,
 }) {
   const {
     data: payments,
@@ -52,7 +51,6 @@ export default function RegistrationPayments({
         payments={payments}
         competitionId={competitionId}
         userInfo={userInfo}
-        refetchHistory={refetchHistory}
       />
     </>
   );
@@ -63,7 +61,6 @@ function PaymentsMainBody({
   payments,
   competitionId,
   userInfo,
-  refetchHistory,
 }) {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
@@ -90,7 +87,7 @@ function PaymentsMainBody({
         }),
       );
 
-      refetchHistory();
+      queryClient.invalidateQueries({ queryKey: ['registration-history', registrationId] });
     },
     onError: (data) => {
       const { error } = data.json;

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
@@ -25,7 +25,7 @@ export default function RegistrationPayments({
     isLoading: paymentsLoading,
     refetch: refetchPayments,
   } = useQuery({
-    queryKey: ['payments', registrationId],
+    queryKey: ['registration-payments', registrationId],
     queryFn: () => getRegistrationPayments(registrationId),
     select: (data) => data.charges.filter((r) => r.iso_amount_refundable !== 0),
   });

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
@@ -21,9 +21,6 @@ export default function RegistrationPayments({
   competitionId,
   refetchHistory,
 }) {
-  const dispatch = useDispatch();
-  const queryClient = useQueryClient();
-
   const {
     data: payments,
     isLoading: paymentsLoading,
@@ -39,6 +36,37 @@ export default function RegistrationPayments({
     queryFn: () => getUsersInfo(_.uniq(payments.map((p) => p.user_id))),
     enabled: Boolean(payments),
   });
+
+  if (paymentsLoading || userInfoLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <>
+      <Header>
+        Payments
+        <Button floated="right" onClick={refetchPayments}>Refresh</Button>
+      </Header>
+      <PaymentsMainBody
+        registrationId={registrationId}
+        payments={payments}
+        competitionId={competitionId}
+        userInfo={userInfo}
+        refetchHistory={refetchHistory}
+      />
+    </>
+  );
+}
+
+function PaymentsMainBody({
+  registrationId,
+  payments,
+  competitionId,
+  userInfo,
+  refetchHistory,
+}) {
+  const dispatch = useDispatch();
+  const queryClient = useQueryClient();
 
   const { mutate: refundMutation, isPending: isMutating } = useMutation({
     mutationFn: refundPayment,
@@ -76,34 +104,6 @@ export default function RegistrationPayments({
     },
   });
 
-  if (paymentsLoading || userInfoLoading) {
-    return <Loading />;
-  }
-
-  return (
-    <>
-      <Header>
-        Payments
-        <Button floated="right" onClick={refetchPayments}>Refresh</Button>
-      </Header>
-      <PaymentsMainBody
-        payments={payments}
-        refundMutation={refundMutation}
-        isMutating={isMutating}
-        competitionId={competitionId}
-        userInfo={userInfo}
-      />
-    </>
-  );
-}
-
-function PaymentsMainBody({
-  payments,
-  refundMutation,
-  isMutating,
-  competitionId,
-  userInfo,
-}) {
   if (payments.length === 0) {
     return <Message warning>{I18n.t('payments.messages.charges_refunded')}</Message>;
   }

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationPayments.jsx
@@ -16,7 +16,7 @@ import { useDispatch } from '../../../lib/providers/StoreProvider';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
 import getUsersInfo from '../api/user/post/getUserInfo';
 
-export default function Payments({
+export default function RegistrationPayments({
   registrationId,
   competitionId,
   refetchHistory,


### PR DESCRIPTION
Spin-off from https://github.com/thewca/worldcubeassociation.org/pull/11453. Lets `RegistrationPayments` load its own data, which also gives us a refresh button.

As a small bonus, this makes `RegistrationPayments` and `RegistrationHistory` look very similar so I went ahead and changed them into smaller, self-contained units. We don't have to pass refetchers around anymore because we now can just invalidate queries on the client directly.