### PR TITLE
Allow force-resetting cronjobs in the admin panel

### DIFF
--- a/app/webpacker/components/Panel/views/CronJobStatus/CronjobActions.jsx
+++ b/app/webpacker/components/Panel/views/CronJobStatus/CronjobActions.jsx
@@ -1,19 +1,27 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import React, { useState } from 'react';
+import React from 'react';
 import { Button } from 'semantic-ui-react';
 import runCronjob from './api/runCronjob';
 import Loading from '../../../Requests/Loading';
 import Errored from '../../../Requests/Errored';
 import resetCronjob from './api/resetCronjob';
 import { useConfirm } from '../../../../lib/providers/ConfirmProvider';
+import useToggleButtonState from '../../../../lib/hooks/useToggleButtonState';
 
 export default function CronjobActions({ cronjobName, cronjobDetails }) {
-  const isResetDisabled = !(cronjobDetails?.in_progress && cronjobDetails?.recently_errored);
+  const [showDebugInfo, setShowDebugInfo] = useToggleButtonState(false);
+
+  // Usually, we want to reset if we can clearly establish that
+  //   the cronjob halted because of an error (i.e. it halted AND an error state was recorded)
+  const terminatedAndErrored = !cronjobDetails?.in_progress && cronjobDetails?.recently_errored;
+  // However, due to deployment chokes, we manually override the button to be enabled
+  //   when the debug information is shown (there is still an extra confirmation warning)
+  const isResetDisabled = !(terminatedAndErrored || showDebugInfo);
+
   const isDoItDisabled = (
     cronjobDetails?.reason_not_to_run || cronjobDetails?.scheduled || cronjobDetails?.in_progress
   );
 
-  const [showDebugInfo, setShowDebugInfo] = useState();
   const confirm = useConfirm();
 
   const queryClient = useQueryClient();
@@ -39,8 +47,15 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
   });
 
   const resetCronjobConfirmation = () => {
+    // Did you reach here just by opening the debug panel, withOUT the cronjob actually erroring?
+    const isWstOverride = showDebugInfo && !terminatedAndErrored;
+
+    const confirmationMessage = isWstOverride
+      ? 'BEEP BOOP! Danger territory ahead! You are about to reset a cronjob without an actual error state. This should only ever be done in extraordinary circumstances (deployment chokes) and IS VERY DANGEROUS unless you absolutely know what you\'re doing!'
+      : 'Are you sure that you want to proceed with reset? Usually this needs to be done if you know that the source of the error has been fixed. If you push this button without consulting WST, you risk incurring their wrath!';
+
     confirm({
-      content: 'Are you sure that you want to proceed with reset? Usually this needs to be done if you know that source of the error has been fixed. If you push this button without consulting WST, you risk incurring their wrath!',
+      content: confirmationMessage,
     }).then(() => resetCronjobMutation({ cronjobName }));
   };
 
@@ -64,7 +79,7 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
       <Button
         toggle
         active={showDebugInfo}
-        onClick={() => setShowDebugInfo((debugInfoWas) => !debugInfoWas)}
+        onClick={setShowDebugInfo}
       >
         Show Debug info for WST
       </Button>


### PR DESCRIPTION
The Results Dump is failing every now and then for mysterious, unknown reasons. Could be deployment-related, but then I would expect the Developer Dump to be affected as well, but it isn't.

This is a "fix" that allows us to reset CJ state without digging into the database, by force-enabling the `Reset` button when the debug section is expanded. A little bit overkill, but should get the job done while we don't have the time (or motivation) to dig super deep into the Redis logs or memory model of Sidekiq...