### PR TITLE
Registration admin page fix for anonymized registration

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -154,9 +154,13 @@ export default function TableRow({
             {dobIsShown && <Table.Cell>{dateOfBirth}</Table.Cell>}
 
             <Table.Cell>
-              <RegionFlag iso2={country.iso2} withoutTooltip={regionIsExpanded} />
-              {' '}
-              {regionIsExpanded && countries.byIso2[country.iso2].name}
+              {country?.iso2 && (
+                <>
+                  <RegionFlag iso2={country.iso2} withoutTooltip={regionIsExpanded} />
+                  {' '}
+                  {regionIsExpanded && countries.byIso2?.[country.iso2]?.name}
+                </>
+              )}
             </Table.Cell>
 
             <Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationActions.jsx
@@ -23,7 +23,7 @@ function V3csvExport(selected, registrations, competition) {
     .forEach((registration) => {
       csvContent += `${registration.competing.registration_status === 'accepted' ? 'a' : 'p'},"${
         registration.user.name
-      }","${countries.byIso2[registration.user.country.iso2].name}",${
+      }","${countries.byIso2[registration.user.country?.iso2]?.name}",${
         registration.user.wca_id
       },${registration.user.dob},${
         registration.user.gender

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -27,7 +27,7 @@ export default function RegistrationAdministrationTableFooter({
   const countryCount = new Set(
     registrations
       .map((reg) => reg.user.country?.iso2)
-      .filter((iso2) => iso2),
+      .filter(Boolean),
   ).size;
 
   const guestCount = _.sum(registrations.map((r) => r.guests));

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -25,7 +25,9 @@ export default function RegistrationAdministrationTableFooter({
   ).length;
 
   const countryCount = new Set(
-    registrations.map((reg) => reg.user.country.iso2),
+    registrations
+    .map((reg) => reg.user.country?.iso2)
+    .filter((iso2) => iso2)
   ).size;
 
   const guestCount = _.sum(registrations.map((r) => r.guests));

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -26,8 +26,8 @@ export default function RegistrationAdministrationTableFooter({
 
   const countryCount = new Set(
     registrations
-    .map((reg) => reg.user.country?.iso2)
-    .filter((iso2) => iso2)
+      .map((reg) => reg.user.country?.iso2)
+      .filter((iso2) => iso2),
   ).size;
 
   const guestCount = _.sum(registrations.map((r) => r.guests));


### PR DESCRIPTION
The registration admin page breaks if any registration is anonymized. 

![image](https://github.com/user-attachments/assets/998d844d-b63f-4e13-b40a-d56b9dccab14)

This happens because of the null value of the country! 