### PR TITLE
Edit Schedule: Only render open accordions

### DIFF
--- a/app/webpacker/components/EditSchedule/index.js
+++ b/app/webpacker/components/EditSchedule/index.js
@@ -131,10 +131,12 @@ function EditSchedule({
           <Accordion.Content
             active={openAccordion === 0}
           >
-            <EditVenues
-              countryZones={countryZones}
-              referenceTime={referenceTime}
-            />
+            {openAccordion === 0 && (
+              <EditVenues
+                countryZones={countryZones}
+                referenceTime={referenceTime}
+              />
+            )}
           </Accordion.Content>
           <Accordion.Title
             index={1}
@@ -146,11 +148,13 @@ function EditSchedule({
           <Accordion.Content
             active={openAccordion === 1}
           >
-            <EditActivities
-              wcifEvents={wcifEvents}
-              referenceTime={referenceTime}
-              calendarLocale={calendarLocale}
-            />
+            {openAccordion === 1 && (
+              <EditActivities
+                wcifEvents={wcifEvents}
+                referenceTime={referenceTime}
+                calendarLocale={calendarLocale}
+              />
+            )}
           </Accordion.Content>
         </Accordion>
         {unsavedChanges && renderUnsavedChangesAlert()}


### PR DESCRIPTION
Fixes #11519. I didn't see a built-in way to only render active accordion content, but this is still quite simple.

There are no problems with making edits (to venues, rooms, or schedules), closing the accordion, and reopening it - changes persist.