### PR TITLE
Edit Schedule: right-click to delete

### DIFF
--- a/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -520,6 +520,14 @@ function EditActivities({
                     select={addActivityFromCalendarDrag}
                     // allow clicking on existing events to edit them
                     eventClick={editCustomEvent}
+                    // allow right-clicking on existing events to delete them;
+                    //  no direct `eventContextMenu` prop or anything like that unfortunately
+                    eventDidMount={(arg) => {
+                      arg.el.addEventListener('contextmenu', (e) => {
+                        e.preventDefault();
+                        removeEvent(arg.event);
+                      });
+                    }}
                   />
                 </Grid.Column>
               </Grid.Row>

--- a/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -518,9 +518,9 @@ function EditActivities({
                     selectable
                     dateClick={addActivityFromCalendarClick}
                     select={addActivityFromCalendarDrag}
-                    // allow clicking on existing events to edit them
+                    // allow clicking on existing (custom) events to edit them
                     eventClick={editCustomEvent}
-                    // allow right-clicking on existing events to delete them;
+                    // allow right-clicking on (any) existing events to delete them;
                     //  no direct `eventContextMenu` prop or anything like that unfortunately
                     eventDidMount={(arg) => {
                       arg.el.addEventListener('contextmenu', (e) => {


### PR DESCRIPTION
Taken from what I mentioned on #11308. I could not find a simple way to have a context menu appear, because we aren't rendering the event on the calendar (FullCalendar is, we just provide the content) and therefore cannot wrap it in a `Popup` or anything. I'm open to suggestions though.

It's not clear to users that this functionality now exists. It's a bit jarring maybe, if you weren't expecting it, but it's easy to click no to cancel. Before this, right-click would do nothing.

[Screencast from 2025-05-09 10:20:42 PM.webm](https://github.com/user-attachments/assets/6923e22a-bd09-43d3-b7e3-829d034afa67)
