### PR TITLE
Display mismatch warning for number of scramble sets in MBLD

### DIFF
--- a/lib/results_validators/scrambles_validator.rb
+++ b/lib/results_validators/scrambles_validator.rb
@@ -97,9 +97,8 @@ module ResultsValidators
                                              :scrambles, competition.id,
                                              round_id: round_id)
             end
-          else
-            @errors.concat(errors_for_round)
           end
+          @errors.concat(errors_for_round)
         end
       end
     end

--- a/lib/results_validators/scrambles_validator.rb
+++ b/lib/results_validators/scrambles_validator.rb
@@ -91,12 +91,10 @@ module ResultsValidators
                                                :scrambles, competition.id,
                                                round_id: round_id)
           end
-          if round_id.start_with?("333mbf")
-            unless errors_for_round.size < scrambles_by_group_id.keys.size
-              @errors << ValidationError.new(MISSING_SCRAMBLES_FOR_MULTI_ERROR,
-                                             :scrambles, competition.id,
-                                             round_id: round_id)
-            end
+          if round_id.start_with?("333mbf") && (errors_for_round.size >= scrambles_by_group_id.size)
+            @errors << ValidationError.new(MISSING_SCRAMBLES_FOR_MULTI_ERROR,
+                                           :scrambles, competition.id,
+                                           round_id: round_id)
           end
           @errors.concat(errors_for_round)
         end


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/6788. I followed the suggestion quoted in that issue thread to the letter.

Essentially this PR is just a "move one statement out of the `else` block". But by doing so, the `else` block became empty and redundant, and all that was left was the `else`'s original `if` branch, which RuboCop then insisted to merge with the parent `if`.

(And to facilitate the merge, I changed `unless a < b` for `if a >= b`)