### PR TITLE
Refine InboxScrambles backend for matching submission

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -12,69 +12,6 @@ class ResultsSubmissionController < ApplicationController
     @results_validator.validate(@competition.id)
   end
 
-  def upload_scramble_json
-    competition = competition_from_params
-
-    raw_file_contents = params.require(:tnoodle).require(:json).read
-    tnoodle_json = JSON.parse(raw_file_contents, symbolize_names: true)
-
-    # The original Java `LocalDateTime` format is defined as `"MMM dd, yyyy h:m:s a"`.
-    generation_date = DateTime.strptime(tnoodle_json[:generationDate], "%b %d, %Y %l:%M:%S %p")
-
-    tnoodle_wcif = tnoodle_json[:wcif]
-
-    existing_upload = ScrambleFileUpload.find_by(
-      competition: competition,
-      scramble_program: tnoodle_json[:version],
-      generated_at: generation_date,
-    )
-
-    return render json: { success: :ok, scramble_file: existing_upload } if existing_upload.present?
-
-    scr_file_upload = ScrambleFileUpload.create!(
-      uploaded_by_user: current_user,
-      uploaded_at: DateTime.now,
-      competition: competition,
-      scramble_program: tnoodle_json[:version],
-      generated_at: generation_date,
-      raw_wcif: tnoodle_json[:wcif],
-    )
-
-    scr_file_upload.transaction do
-      tnoodle_wcif[:events].each do |wcif_event|
-        competition_event = competition.competition_events.find_by(event_id: wcif_event[:id])
-
-        wcif_event[:rounds].each do |wcif_round|
-          competition_round = competition_event.rounds.find { it.wcif_id == wcif_round[:id] }
-
-          wcif_round[:scrambleSets].each_with_index do |wcif_scramble_set, idx|
-            scramble_set = scr_file_upload.inbox_scramble_sets.create!(
-              ordered_index: idx,
-              matched_round: competition_round,
-            )
-
-            wcif_scramble_set[:scrambles].each_with_index do |wcif_scramble, n|
-              scramble_set.inbox_scrambles.create!(
-                scramble_string: wcif_scramble,
-                scramble_number: n + 1,
-              )
-            end
-
-            wcif_scramble_set[:extraScrambles].each_with_index do |wcif_extra_scramble, n|
-              scramble_set.inbox_scrambles.create!(
-                scramble_string: wcif_extra_scramble,
-                scramble_number: n + 1,
-                is_extra: true,
-              )
-            end
-          end
-        end
-      end
-    end
-
-    render json: { success: :ok, scramble_file: scr_file_upload }
-  end
-
   def upload_json
     @competition = competition_from_params
     return redirect_to competition_submit_results_edit_path if @competition.results_submitted?

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+class ScrambleFilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { redirect_to_root_unless_user(:can_upload_competition_results?, competition_from_params) }, except: :destroy
+
+  def index
+    competition = competition_from_params
+
+    existing_files = ScrambleFileUpload
+                     .includes(inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] })
+                     .where(competition: competition)
+
+    render json: existing_files
+  end
+
+  def create
+    competition = competition_from_params
+
+    uploaded_file = params.require(:tnoodle).require(:json)
+
+    raw_file_contents = uploaded_file.read
+    tnoodle_json = JSON.parse(raw_file_contents, symbolize_names: true)
+
+    # The original Java `LocalDateTime` format is defined as `"MMM dd, yyyy h:m:s a"`.
+    generation_date = DateTime.strptime(tnoodle_json[:generationDate], "%b %d, %Y %l:%M:%S %p")
+    tnoodle_version = tnoodle_json[:version]
+
+    existing_upload = ScrambleFileUpload
+                      .includes(inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] })
+                      .find_by(
+                        competition: competition,
+                        scramble_program: tnoodle_version,
+                        generated_at: generation_date,
+                      )
+
+    return render json: existing_upload if existing_upload.present?
+
+    tnoodle_wcif = tnoodle_json[:wcif]
+
+    scr_file_upload = ScrambleFileUpload.create!(
+      uploaded_by_user: current_user,
+      uploaded_at: DateTime.now,
+      competition: competition,
+      original_filename: uploaded_file.original_filename,
+      scramble_program: tnoodle_version,
+      generated_at: generation_date,
+      raw_wcif: tnoodle_wcif,
+    )
+
+    scr_file_upload.transaction do
+      tnoodle_wcif[:events].each do |wcif_event|
+        competition_event = competition.competition_events.find_by(event_id: wcif_event[:id])
+
+        wcif_event[:rounds].each do |wcif_round|
+          competition_round = competition_event.rounds.find { it.wcif_id == wcif_round[:id] }
+
+          wcif_round[:scrambleSets].each_with_index do |wcif_scramble_set, idx|
+            scramble_set = scr_file_upload.inbox_scramble_sets.create!(
+              scramble_set_number: idx + 1,
+              matched_round: competition_round,
+            )
+
+            %i[scrambles extraScrambles].each do |scramble_kind|
+              wcif_scramble_set[scramble_kind].each_with_index do |wcif_scramble, n|
+                scramble_set.inbox_scrambles.create!(
+                  scramble_string: wcif_scramble,
+                  scramble_number: n + 1,
+                  is_extra: scramble_kind == :extraScrambles,
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    render json: scr_file_upload, status: :created
+  end
+
+  def destroy
+    scramble_file_id = params.require(:id)
+    scramble_upload = ScrambleFileUpload.find(scramble_file_id)
+
+    return head :not_found if scramble_upload.blank?
+
+    destroyed_file = scramble_upload.destroy
+
+    render json: destroyed_file
+  end
+
+  def update_round_matching
+    competition = competition_from_params
+
+    competition.rounds.each do |round|
+      updated_set_ids = params[round.wcif_id]
+
+      next if updated_set_ids.blank?
+
+      round.inbox_scramble_sets.update_all(matched_round_id: nil)
+
+      InboxScrambleSet.find(updated_set_ids)
+                      .each_with_index do |scramble_set, idx|
+        scramble_set.update!(matched_round: round, matched_round_ordered_index: idx)
+      end
+    end
+
+    render json: { success: :ok }
+  end
+
+  private def competition_from_params
+    Competition.find(params[:competition_id])
+  end
+end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -37,6 +37,7 @@ class Competition < ApplicationRecord
   belongs_to :announced_by_user, optional: true, foreign_key: "announced_by", class_name: "User"
   belongs_to :cancelled_by_user, optional: true, foreign_key: "cancelled_by", class_name: "User"
   has_many :competition_payment_integrations
+  has_many :scramble_file_uploads
 
   accepts_nested_attributes_for :competition_events, allow_destroy: true
   accepts_nested_attributes_for :championships, allow_destroy: true
@@ -698,7 +699,8 @@ class Competition < ApplicationRecord
              'competition_payment_integrations',
              'venue_countries',
              'venue_continents',
-             'waiting_list'
+             'waiting_list',
+             'scramble_file_uploads'
           # Do nothing as they shouldn't be cloned.
         when 'organizers'
           clone.organizers = organizers

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -8,11 +8,13 @@ class InboxScrambleSet < ApplicationRecord
   belongs_to :scramble_file_upload, optional: true, foreign_key: "external_upload_id", inverse_of: :inbox_scramble_sets
   belongs_to :matched_round, class_name: "Round", optional: true
 
-  has_many :inbox_scrambles
+  has_many :inbox_scrambles, dependent: :destroy
 
-  validates :ordered_index, uniqueness: { scope: %i[competition_id event_id round_type_id] }
+  validates :scramble_set_number, uniqueness: { scope: %i[competition_id event_id round_type_id] }
 
   before_validation :backfill_round_information!, if: :matched_round_id?
+
+  delegate :wcif_id, to: :matched_round, prefix: true, allow_nil: true
 
   def backfill_round_information!
     return if matched_round.blank?
@@ -23,6 +25,8 @@ class InboxScrambleSet < ApplicationRecord
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
+    except: %w[matched_round_id],
+    methods: %w[matched_round_wcif_id],
     include: %w[inbox_scrambles],
   }.freeze
 

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -11,6 +11,8 @@ class Round < ApplicationRecord
 
   has_many :registrations, through: :competition_event
 
+  has_many :inbox_scramble_sets, foreign_key: "matched_round_id", inverse_of: :matched_round, dependent: :nullify
+
   # For the following association, we want to keep it to be able to do some joins,
   # but we definitely want to use cached values when directly using the method.
   belongs_to :format

--- a/app/models/scramble_file_upload.rb
+++ b/app/models/scramble_file_upload.rb
@@ -4,7 +4,7 @@ class ScrambleFileUpload < ApplicationRecord
   belongs_to :uploaded_by_user, foreign_key: "uploaded_by", class_name: "User"
   belongs_to :competition
 
-  has_many :inbox_scramble_sets, inverse_of: :scramble_file_upload
+  has_many :inbox_scramble_sets, inverse_of: :scramble_file_upload, dependent: :destroy
 
   serialize :raw_wcif, coder: JSON
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,9 @@ Rails.application.routes.draw do
     # Delegate views and action
     get 'submit-results' => 'results_submission#new', as: :submit_results_edit
     post 'submit-results' => 'results_submission#create', as: :submit_results
-    post 'upload-scramble-json' => 'results_submission#upload_scramble_json', as: :upload_scramble_json
+    resources :scramble_files, only: %i[index create destroy], shallow: true do
+      patch 'update-round-matching' => 'scramble_files#update_round_matching', on: :collection
+    end
     post 'upload-json' => 'results_submission#upload_json', as: :upload_results_json
     # WRT views and action
     get '/admin/upload-results' => "admin#new_results", as: :admin_upload_results_edit

--- a/db/migrate/20250514233739_add_filename_to_scramble_file_uploads.rb
+++ b/db/migrate/20250514233739_add_filename_to_scramble_file_uploads.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFilenameToScrambleFileUploads < ActiveRecord::Migration[7.2]
+  def change
+    add_column :scramble_file_uploads, :original_filename, :string, after: :competition_id
+  end
+end

--- a/db/migrate/20250516155856_change_indices_on_scramble_sets.rb
+++ b/db/migrate/20250516155856_change_indices_on_scramble_sets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ChangeIndicesOnScrambleSets < ActiveRecord::Migration[7.2]
+  def change
+    change_table :inbox_scramble_sets, bulk: true do |t|
+      t.rename :ordered_index, :scramble_set_number
+      t.integer :matched_round_ordered_index, after: :matched_round_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_13_130014) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_16_155856) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -673,12 +673,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_13_130014) do
     t.string "competition_id", null: false
     t.string "event_id", null: false
     t.string "round_type_id", null: false
-    t.integer "ordered_index", null: false
+    t.integer "scramble_set_number", null: false
     t.integer "matched_round_id"
+    t.integer "matched_round_ordered_index"
     t.bigint "external_upload_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["competition_id", "event_id", "round_type_id", "ordered_index"], name: "idx_on_competition_id_event_id_round_type_id_ordere_68a2d4495c", unique: true
+    t.index ["competition_id", "event_id", "round_type_id", "scramble_set_number"], name: "idx_on_competition_id_event_id_round_type_id_ordere_68a2d4495c", unique: true
     t.index ["competition_id", "event_id", "round_type_id"], name: "idx_on_competition_id_event_id_round_type_id_8b43d7b7e6"
     t.index ["competition_id"], name: "index_inbox_scramble_sets_on_competition_id"
     t.index ["event_id"], name: "fk_rails_7a55abc2f3"
@@ -1199,6 +1200,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_13_130014) do
     t.integer "uploaded_by", null: false
     t.timestamp "uploaded_at", null: false
     t.string "competition_id", null: false
+    t.string "original_filename"
     t.string "scramble_program"
     t.timestamp "generated_at"
     t.text "raw_wcif", size: :long, null: false


### PR DESCRIPTION
Pulled the backend changes out of #11573. Notable changes:
- Makes individual scramble files listable/addressable, instead of just having one big bulk endpoint
- In that same spirit, adds a delete button for scramble files
- Adds a (crude) submit endpoint to rearrange the matched order of scramble sets