### PR TITLE
Add attempt based scramble match

### DIFF
--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -1,8 +1,11 @@
 import React, { useMemo, useState } from 'react';
 import { Button, Header } from 'semantic-ui-react';
-import { activityCodeToName } from '@wca/helpers';
+import { activityCodeToName, parseActivityCode } from '@wca/helpers';
 import ScrambleMatch from './ScrambleMatch';
 import I18n from '../../lib/i18n';
+import ScrambleAttemptMatch from './ScrambleAttemptMatch';
+
+const ATTEMPT_BASED_EVENTS = ['333mbf', '333fm'];
 
 export default function Rounds({ wcifRounds, matchState, moveRoundScrambleSet }) {
   const [selectedRoundId, setSelectedRoundId] = useState();
@@ -11,6 +14,9 @@ export default function Rounds({ wcifRounds, matchState, moveRoundScrambleSet })
     () => wcifRounds.find((r) => r.id === selectedRoundId),
     [wcifRounds, selectedRoundId],
   );
+
+  const isAttemptBased = selectedRound
+    && ATTEMPT_BASED_EVENTS.includes(parseActivityCode(selectedRound.id).eventId);
 
   return (
     <>
@@ -38,13 +44,22 @@ export default function Rounds({ wcifRounds, matchState, moveRoundScrambleSet })
           </Button>
         ))}
       </Button.Group>
-      {selectedRound && (
+      {selectedRound && !isAttemptBased && (
         <ScrambleMatch
           activeRound={selectedRound}
           matchState={matchState}
           moveRoundScrambleSet={moveRoundScrambleSet}
         />
       )}
+      {
+        selectedRound && isAttemptBased && (
+          <ScrambleAttemptMatch
+            activeRound={selectedRound}
+            matchState={matchState}
+            moveRoundScrambleSet={moveRoundScrambleSet}
+          />
+        )
+      }
     </>
   );
 }

--- a/app/webpacker/components/ScrambleMatcher/ScrambleAttemptMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleAttemptMatch.jsx
@@ -15,7 +15,7 @@ export default function ScrambleAttemptMatch({ activeRound, matchState, moveRoun
     onDragUpdate,
     onDragEnd,
     computeOnDragIndex,
-  } = useScrambleDrag((from, to) => moveRoundScrambleSet(activeRound.id, from, to));
+  } = useScrambleDrag((from, to) => moveRoundScrambleSet(activeRound.id, from, to, 'moveAttemptScrambles'));
 
   return (
     <ScrambleDragTable

--- a/app/webpacker/components/ScrambleMatcher/ScrambleAttemptMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleAttemptMatch.jsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from 'react';
+import { activityCodeToName } from '@wca/helpers';
+import useScrambleDrag from './useScrambleDrag';
+import ScrambleDragTable from './ScrambleDragTable';
+import { formats } from '../../lib/wca-data.js.erb';
+
+export default function ScrambleAttemptMatch({ activeRound, matchState, moveRoundScrambleSet }) {
+  const scrambles = useMemo(() => matchState[activeRound.id]?.[0]?.inbox_scrambles
+    ?? [], [matchState, activeRound.id]);
+
+  const expectedAttempts = formats.byId[activeRound.format].expectedSolveCount;
+
+  const {
+    onBeforeDragStart,
+    onDragUpdate,
+    onDragEnd,
+    computeOnDragIndex,
+  } = useScrambleDrag((from, to) => moveRoundScrambleSet(activeRound.id, from, to));
+
+  return (
+    <ScrambleDragTable
+      scrambles={scrambles}
+      expectedCount={expectedAttempts}
+      computeOnDragIndex={computeOnDragIndex}
+      onBeforeDragStart={onBeforeDragStart}
+      onDragUpdate={onDragUpdate}
+      onDragEnd={onDragEnd}
+      renderLabel={({ definitionIndex, isExpected }) => (isExpected
+        ? `${activityCodeToName(activeRound.id)}, Attempt ${definitionIndex + 1}`
+        : 'Extra Scramble (unassigned)')}
+      renderDetails={({ scramble }) => `Attempt ${scramble.scramble_number}`}
+    />
+  );
+}

--- a/app/webpacker/components/ScrambleMatcher/ScrambleDragTable.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleDragTable.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Table, Icon, Ref } from 'semantic-ui-react';
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+
+export default function ScrambleDragTable({
+  scrambles,
+  expectedCount,
+  computeOnDragIndex,
+  onBeforeDragStart,
+  onDragUpdate,
+  onDragEnd,
+  renderLabel,
+  renderDetails,
+}) {
+  return (
+    <Table definition>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell />
+          <Table.HeaderCell>Assigned Scrambles</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <DragDropContext
+        onBeforeDragStart={onBeforeDragStart}
+        onDragUpdate={onDragUpdate}
+        onDragEnd={onDragEnd}
+      >
+        <Droppable droppableId="scrambles">
+          {(providedDroppable) => (
+            <Ref innerRef={providedDroppable.innerRef}>
+              <Table.Body {...providedDroppable.droppableProps}>
+                {scrambles.map((scramble, index) => {
+                  const isExpected = index < expectedCount;
+                  const hasError = isExpected && !scramble;
+                  const isExtra = index >= expectedCount;
+
+                  return (
+                    <Draggable
+                      key={scramble.id}
+                      draggableId={scramble.id.toString()}
+                      index={index}
+                    >
+                      {(providedDraggable, snapshot) => {
+                        const definitionIndex = computeOnDragIndex(index, snapshot.isDragging);
+
+                        return (
+                          <Ref innerRef={providedDraggable.innerRef}>
+                            <Table.Row
+                              key={scramble.id}
+                              {...providedDraggable.draggableProps}
+                              negative={hasError || isExtra}
+                            >
+                              <Table.Cell textAlign="right" collapsing>
+                                {renderLabel({
+                                  scramble, index, definitionIndex, isExpected, isExtra, hasError,
+                                })}
+                                {(hasError || isExtra) && (
+                                  <>
+                                    {' '}
+                                    <Icon name="exclamation triangle" />
+                                    {hasError ? 'Missing scramble' : 'Unexpected Scramble'}
+                                  </>
+                                )}
+                              </Table.Cell>
+                              <Table.Cell {...providedDraggable.dragHandleProps}>
+                                <Icon name="bars" />
+                                {renderDetails({ scramble })}
+                              </Table.Cell>
+                            </Table.Row>
+                          </Ref>
+                        );
+                      }}
+                    </Draggable>
+                  );
+                })}
+                {providedDroppable.placeholder}
+              </Table.Body>
+            </Ref>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </Table>
+  );
+}

--- a/app/webpacker/components/ScrambleMatcher/ScrambleDragTable.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleDragTable.jsx
@@ -12,6 +12,7 @@ export default function ScrambleDragTable({
   renderLabel,
   renderDetails,
 }) {
+  /* eslint-disable react/jsx-props-no-spreading */
   return (
     <Table definition>
       <Table.Header>

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -1,129 +1,32 @@
-import React, { useState } from 'react';
-import { Icon, Ref, Table } from 'semantic-ui-react';
+import React from 'react';
 import { activityCodeToName } from '@wca/helpers';
-import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
+import useScrambleDrag from './useScrambleDrag';
+import ScrambleDragTable from './ScrambleDragTable';
 import { events, roundTypes } from '../../lib/wca-data.js.erb';
 
-export default function ScrambleMatch({
-  activeRound,
-  matchState,
-  moveRoundScrambleSet,
-}) {
+export default function ScrambleMatch({ activeRound, matchState, moveRoundScrambleSet }) {
   const { scrambleSetCount } = activeRound;
-  const scrambleSets = matchState[activeRound.id] ?? [];
+  const scrambles = matchState[activeRound.id] ?? [];
 
-  const [currentDragStart, setCurrentDragStart] = useState(null);
-  const [currentDragIndex, setCurrentDragIndex] = useState(null);
+  const {
+    onBeforeDragStart,
+    onDragUpdate,
+    onDragEnd,
+    computeOnDragIndex,
+  } = useScrambleDrag((from, to) => moveRoundScrambleSet(activeRound.id, from, to));
 
-  const handleOnBeforeDragStart = (init) => {
-    setCurrentDragStart(init.source?.index);
-    setCurrentDragIndex(init.source?.index);
-  };
-
-  const handleOnDragEnd = (result) => {
-    setCurrentDragStart(null);
-    setCurrentDragIndex(null);
-
-    const { destination, source } = result;
-
-    if (destination) {
-      moveRoundScrambleSet(activeRound.id, source.index, destination.index);
-    }
-  };
-
-  const handleOnDragUpdate = (update) => {
-    setCurrentDragIndex(update.destination?.index);
-  };
-
-  const dragDistance = currentDragIndex === null ? 0 : currentDragIndex - currentDragStart;
-  const dragDirection = Math.sign(dragDistance);
-
-  const computeOnDragIndex = (elIndex, isDragging = false) => {
-    if (isDragging) {
-      return currentDragIndex;
-    }
-
-    const dragRangeStart = Math.min(currentDragStart, currentDragIndex);
-    const dragRangeEnd = Math.max(currentDragStart, currentDragIndex);
-
-    if (elIndex >= dragRangeStart && elIndex <= dragRangeEnd) {
-      return elIndex - dragDirection;
-    }
-    return elIndex;
-  };
-
-  /* eslint-disable react/jsx-props-no-spreading */
   return (
-    <Table definition>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell />
-          <Table.HeaderCell>Assigned Scrambles</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <DragDropContext
-        onBeforeDragStart={handleOnBeforeDragStart}
-        onDragUpdate={handleOnDragUpdate}
-        onDragEnd={handleOnDragEnd}
-      >
-        <Droppable droppableId="scrambles">
-          {(providedDroppable) => (
-            <Ref innerRef={providedDroppable.innerRef}>
-              <Table.Body {...providedDroppable.droppableProps}>
-                {scrambleSets.map((scramble, index) => {
-                  const isExpected = index < scrambleSetCount;
-                  const hasError = isExpected && !scramble;
-                  const isExtra = index >= scrambleSetCount;
-
-                  return (
-                    <Draggable
-                      key={scramble.id}
-                      draggableId={scramble.id.toString()}
-                      index={index}
-                    >
-                      {(providedDraggable, snapshot) => {
-                        const definitionIndex = computeOnDragIndex(index, snapshot.isDragging);
-
-                        return (
-                          <Ref innerRef={providedDraggable.innerRef}>
-                            <Table.Row
-                              key={scramble.id}
-                              {...providedDraggable.draggableProps}
-                              negative={hasError || isExtra}
-                            >
-                              <Table.Cell textAlign="right" collapsing>
-                                {isExpected
-                                  ? `${activityCodeToName(activeRound.id)}, Group ${definitionIndex + 1}`
-                                  : 'Extra Scramble set (unassigned)'}
-                                {(hasError || isExtra) && (
-                                  <>
-                                    {' '}
-                                    <Icon name="exclamation triangle" />
-                                    {hasError ? 'Missing scramble' : 'Unexpected Scramble Set'}
-                                  </>
-                                )}
-                              </Table.Cell>
-                              <Table.Cell {...providedDraggable.dragHandleProps}>
-                                <Icon name="bars" />
-                                {events.byId[scramble.event_id].name}
-                                {' '}
-                                {roundTypes.byId[scramble.round_type_id].name}
-                                {' - '}
-                                {String.fromCharCode(64 + scramble.scramble_set_number)}
-                              </Table.Cell>
-                            </Table.Row>
-                          </Ref>
-                        );
-                      }}
-                    </Draggable>
-                  );
-                })}
-                {providedDroppable.placeholder}
-              </Table.Body>
-            </Ref>
-          )}
-        </Droppable>
-      </DragDropContext>
-    </Table>
+    <ScrambleDragTable
+      scrambles={scrambles}
+      expectedCount={scrambleSetCount}
+      computeOnDragIndex={computeOnDragIndex}
+      onBeforeDragStart={onBeforeDragStart}
+      onDragUpdate={onDragUpdate}
+      onDragEnd={onDragEnd}
+      renderLabel={({ definitionIndex, isExpected }) => (isExpected
+        ? `${activityCodeToName(activeRound.id)}, Group ${definitionIndex + 1}`
+        : 'Extra Scramble set (unassigned)')}
+      renderDetails={({ scramble }) => `${events.byId[scramble.event_id].name} ${roundTypes.byId[scramble.round_type_id].name} - ${String.fromCharCode(64 + scramble.scramble_set_number)}`}
+    />
   );
 }

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -56,6 +56,20 @@ function scrambleMatchReducer(state, action) {
           action.toIndex,
         ),
       };
+    case 'moveAttemptScrambles': {
+      const scrambleSet = state[action.roundId][0];
+      return {
+        ...state,
+        [action.roundId]: [{
+          ...scrambleSet,
+          inbox_scrambles: moveArrayItem(
+            scrambleSet.inbox_scrambles,
+            action.fromIndex,
+            action.toIndex,
+          ),
+        }],
+      };
+    }
     default:
       throw new Error(`Unhandled action type: ${action.type}`);
   }

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -121,8 +121,8 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
   );
 
   const moveRoundScrambleSet = useCallback(
-    (roundId, fromIndex, toIndex) => dispatchMatchState({
-      type: 'moveRoundScrambleSet',
+    (roundId, fromIndex, toIndex, type = 'moveRoundScrambleSet') => dispatchMatchState({
+      type,
       roundId,
       fromIndex,
       toIndex,

--- a/app/webpacker/components/ScrambleMatcher/useScrambleDrag.js
+++ b/app/webpacker/components/ScrambleMatcher/useScrambleDrag.js
@@ -1,0 +1,45 @@
+import { useState, useCallback } from 'react';
+
+export default function useScrambleDrag(onMove) {
+  const [currentDragStart, setCurrentDragStart] = useState(null);
+  const [currentDragIndex, setCurrentDragIndex] = useState(null);
+
+  const onBeforeDragStart = useCallback(({ source }) => {
+    setCurrentDragStart(source?.index);
+    setCurrentDragIndex(source?.index);
+  }, []);
+
+  const onDragEnd = useCallback(({ source, destination }) => {
+    setCurrentDragStart(null);
+    setCurrentDragIndex(null);
+    if (destination) {
+      onMove(source.index, destination.index);
+    }
+  }, [onMove]);
+
+  const onDragUpdate = useCallback(({ destination }) => {
+    setCurrentDragIndex(destination?.index);
+  }, []);
+
+  const dragDistance = currentDragIndex === null ? 0 : currentDragIndex - currentDragStart;
+  const dragDirection = Math.sign(dragDistance);
+
+  const computeOnDragIndex = useCallback((elIndex, isDragging = false) => {
+    if (isDragging) return currentDragIndex;
+
+    const start = Math.min(currentDragStart, currentDragIndex);
+    const end = Math.max(currentDragStart, currentDragIndex);
+
+    if (elIndex >= start && elIndex <= end) {
+      return elIndex - dragDirection;
+    }
+    return elIndex;
+  }, [currentDragStart, currentDragIndex, dragDirection]);
+
+  return {
+    onBeforeDragStart,
+    onDragUpdate,
+    onDragEnd,
+    computeOnDragIndex,
+  };
+}


### PR DESCRIPTION
I wrote a second version that can do attempts and then let chatgpt refactor it into shared components.
I did notice though that we actually do not handle the case where there are less scrambles than groups/attempts as we iterate over the scrambles currently. Do we need to do that?