### PR TITLE
Allow bulk auto accept in production

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -576,13 +576,7 @@ class Registration < ApplicationRecord
 
   delegate :auto_accept_registrations, to: :competition
 
-  def auto_accept_in_current_env?
-    !(Rails.env.production? && EnvConfig.WCA_LIVE_SITE?)
-  end
-
   def attempt_auto_accept
-    return false unless auto_accept_in_current_env?
-
     failure_reason = auto_accept_failure_reason
     if failure_reason.present?
       log_auto_accept_failure(failure_reason)

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -574,7 +574,7 @@ class Registration < ApplicationRecord
       .first
   end
 
-  delegate :auto_accept_registrations, to: :competition
+  delegate :auto_accept_registrations?, to: :competition
 
   def attempt_auto_accept
     failure_reason = auto_accept_failure_reason
@@ -600,7 +600,7 @@ class Registration < ApplicationRecord
 
   private def auto_accept_failure_reason
     return Registrations::ErrorCodes::OUTSTANDING_FEES if outstanding_entry_fees.positive?
-    return Registrations::ErrorCodes::AUTO_ACCEPT_NOT_ENABLED unless competition.auto_accept_registrations?
+    return Registrations::ErrorCodes::AUTO_ACCEPT_NOT_ENABLED unless auto_accept_registrations?
     return Registrations::ErrorCodes::INELIGIBLE_FOR_AUTO_ACCEPT unless competing_status_pending? || waiting_list_leader?
     return Registrations::ErrorCodes::AUTO_ACCEPT_DISABLE_THRESHOLD if competition.auto_accept_threshold_reached?
 

--- a/app/models/registration_payment.rb
+++ b/app/models/registration_payment.rb
@@ -9,7 +9,7 @@ class RegistrationPayment < ApplicationRecord
   belongs_to :refunded_registration_payment, class_name: 'RegistrationPayment', optional: true
   has_many :refunding_registration_payments, class_name: 'RegistrationPayment', inverse_of: :refunded_registration_payment, foreign_key: :refunded_registration_payment_id, dependent: :destroy
 
-  delegate :auto_accept_in_current_env?, :auto_accept_registrations, to: :registration
+  delegate :auto_accept_registrations, to: :registration
   after_create :auto_accept_hook, if: :should_auto_accept?
   after_create :auto_close_hook, unless: :refunded_registration_payment_id?
 
@@ -23,7 +23,7 @@ class RegistrationPayment < ApplicationRecord
   end
 
   private def should_auto_accept?
-    auto_accept_in_current_env? && auto_accept_registrations && Registration::LIVE_AUTO_ACCEPT_ENABLED
+    auto_accept_registrations && Registration::LIVE_AUTO_ACCEPT_ENABLED
   end
 
   private def auto_accept_hook

--- a/app/models/registration_payment.rb
+++ b/app/models/registration_payment.rb
@@ -23,7 +23,7 @@ class RegistrationPayment < ApplicationRecord
   end
 
   private def should_auto_accept?
-    auto_accept_in_current_env? && auto_accept_registrations? && Registration::LIVE_AUTO_ACCEPT_ENABLED
+    auto_accept_registrations? && Registration::LIVE_AUTO_ACCEPT_ENABLED
   end
 
   private def auto_accept_hook

--- a/app/models/registration_payment.rb
+++ b/app/models/registration_payment.rb
@@ -9,7 +9,7 @@ class RegistrationPayment < ApplicationRecord
   belongs_to :refunded_registration_payment, class_name: 'RegistrationPayment', optional: true
   has_many :refunding_registration_payments, class_name: 'RegistrationPayment', inverse_of: :refunded_registration_payment, foreign_key: :refunded_registration_payment_id, dependent: :destroy
 
-  delegate :auto_accept_registrations, to: :registration
+  delegate :auto_accept_registrations?, to: :registration
   after_create :auto_accept_hook, if: :should_auto_accept?
   after_create :auto_close_hook, unless: :refunded_registration_payment_id?
 
@@ -23,7 +23,7 @@ class RegistrationPayment < ApplicationRecord
   end
 
   private def should_auto_accept?
-    auto_accept_registrations && Registration::LIVE_AUTO_ACCEPT_ENABLED
+    auto_accept_in_current_env? && auto_accept_registrations? && Registration::LIVE_AUTO_ACCEPT_ENABLED
   end
 
   private def auto_accept_hook

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -605,7 +605,15 @@ RSpec.describe Registration do
     let(:auto_accept_comp) { create(:competition, :auto_accept, :registration_open) }
     let!(:reg) { create(:registration, competition: auto_accept_comp) }
 
-    it 'auto accepts a competitor who pays for their pending registration' do
+    it 'live auto accept is not triggered upon payment' do
+      expect(reg.competing_status).to eq('pending')
+
+      create(:registration_payment, registration: reg, competition: auto_accept_comp)
+
+      expect(reg.reload.competing_status).to eq('pending')
+    end
+
+    it 'works for a paid pending registration' do
       expect(reg.competing_status).to eq('pending')
 
       create(:registration_payment, :skip_create_hook, registration: reg, competition: auto_accept_comp)
@@ -616,7 +624,7 @@ RSpec.describe Registration do
       expect(reg.registration_history_entries.last.actor_id).to eq('auto-accept')
     end
 
-    it 'auto accepts a competitor who included a donation in their payment' do
+    it 'works for a competitor who included a donation in their payment' do
       expect(reg.competing_status).to eq('pending')
 
       create(:registration_payment, :skip_create_hook, :with_donation, registration: reg, competition: auto_accept_comp)


### PR DESCRIPTION
Previously, we had a flag which prevented the `attempt_auto_accept` from running in production _at all_ - this PR:
- allows `attempt_auto_accept` to run in production
- adds a test that ensures that live auto accept doesn't work at all (even in test) 

This will allow bulk auto accept to work in prod without concerns of accidentally enabling live auto accept.