### PR TITLE
Scramble matcher UX Improvements

### DIFF
--- a/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
+++ b/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
@@ -56,12 +56,19 @@ export default function FileUpload({
     onError: (responseError) => setError(responseError.message),
   });
 
+  const resetFileUpload = useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.value = null;
+    }
+  }, [inputRef]);
+
   const uploadNewScramble = useCallback((ev) => {
     const filesArr = Array.from(ev.target.files);
     const uploadPromises = filesArr.map((f) => mutateAsync(f));
 
-    return Promise.all(uploadPromises);
-  }, [mutateAsync]);
+    return Promise.all(uploadPromises)
+      .finally(resetFileUpload);
+  }, [mutateAsync, resetFileUpload]);
 
   const clickOnInput = () => {
     inputRef.current?.click();

--- a/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
+++ b/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
@@ -23,7 +23,7 @@ async function uploadScrambleFile(competitionId, file) {
   return data;
 }
 
-export default function ScrambleFiles({
+export default function FileUpload({
   competitionId,
   initialScrambleFiles,
   addScrambleFile,
@@ -74,12 +74,7 @@ export default function ScrambleFiles({
         {' '}
         {uploadedJsonFiles?.length}
         {' '}
-        <Header.Subheader>
-          Scrambles are assigned automatically when you upload a TNoodle JSON file.
-          If there is a discrepancy between the number of scramble sets in the JSON file
-          and the number of groups in the round you can manually assign them below.
-        </Header.Subheader>
-        <Button.Group>
+        <Button.Group floated="right">
           <Button
             positive
             icon="plus"
@@ -97,6 +92,11 @@ export default function ScrambleFiles({
             disabled={isFetching}
           />
         </Button.Group>
+        <Header.Subheader>
+          Scrambles are assigned automatically when you upload a TNoodle JSON file.
+          If there is a discrepancy between the number of scramble sets in the JSON file
+          and the number of groups in the round you can manually assign them below.
+        </Header.Subheader>
       </Header>
       {error && <Message negative onDismiss={() => setError(null)}>{error}</Message>}
       <input

--- a/app/webpacker/components/ScrambleMatcher/Groups.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Groups.jsx
@@ -11,26 +11,30 @@ export default function Groups({
   scrambleSets,
   dispatchMatchState,
 }) {
+  if (scrambleSetCount === 1) {
+    return (
+      <SelectedGroupPanel
+        selectedGroupNumber={0}
+        scrambleSets={scrambleSets}
+        dispatchMatchState={dispatchMatchState}
+      />
+    );
+  }
+  return (
+    <GroupsPicker
+      scrambleSetCount={scrambleSetCount}
+      scrambleSets={scrambleSets}
+      dispatchMatchState={dispatchMatchState}
+    />
+  );
+}
+
+function GroupsPicker({ dispatchMatchState, scrambleSetCount, scrambleSets }) {
   const [selectedGroupNumber, setSelectedGroupNumber] = useState(null);
 
-  const availableEventIds = useMemo(
+  const availableGroups = useMemo(
     () => _.times(scrambleSetCount),
     [scrambleSetCount],
-  );
-
-  const onGroupDragCompleted = useCallback(
-    (fromIndex, toIndex) => dispatchMatchState({
-      type: 'moveScrambleInSet',
-      setNumber: selectedGroupNumber,
-      fromIndex,
-      toIndex,
-    }),
-    [dispatchMatchState, selectedGroupNumber],
-  );
-
-  const groupScrambleToName = useCallback(
-    (idx) => `Attempt ${idx + 1}`,
-    [],
   );
 
   return (
@@ -47,7 +51,7 @@ export default function Groups({
         </Button>
       </Header>
       <Button.Group>
-        {availableEventIds.map((num) => (
+        {availableGroups.map((num) => (
           <Button
             key={num}
             toggle
@@ -62,13 +66,38 @@ export default function Groups({
         ))}
       </Button.Group>
       {selectedGroupNumber !== null && (
-        <ScrambleMatch
-          matchableRows={scrambleSets[selectedGroupNumber].inbox_scrambles}
-          onRowDragCompleted={onGroupDragCompleted}
-          computeDefinitionName={groupScrambleToName}
-          computeRowName={scrambleToName}
+        <SelectedGroupPanel
+          dispatchMatchState={dispatchMatchState}
+          selectedGroupNumber={selectedGroupNumber}
+          scrambleSets={scrambleSets}
         />
       )}
     </>
+  );
+}
+
+function SelectedGroupPanel({ dispatchMatchState, selectedGroupNumber, scrambleSets }) {
+  const onGroupDragCompleted = useCallback(
+    (fromIndex, toIndex) => dispatchMatchState({
+      type: 'moveScrambleInSet',
+      setNumber: selectedGroupNumber,
+      fromIndex,
+      toIndex,
+    }),
+    [dispatchMatchState, selectedGroupNumber],
+  );
+
+  const groupScrambleToName = useCallback(
+    (idx) => `Attempt ${idx + 1}`,
+    [],
+  );
+
+  return (
+    <ScrambleMatch
+      matchableRows={scrambleSets[selectedGroupNumber].inbox_scrambles}
+      onRowDragCompleted={onGroupDragCompleted}
+      computeDefinitionName={groupScrambleToName}
+      computeRowName={scrambleToName}
+    />
   );
 }

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -7,7 +7,17 @@ import Groups from './Groups';
 import { events, roundTypes } from '../../lib/wca-data.js.erb';
 import { useDispatchWrapper } from './reducer';
 
-const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} ${roundTypes.byId[scrambleSet.round_type_id].name} - ${String.fromCharCode(64 + scrambleSet.scramble_set_number)}`;
+const prefixForIndex = (index) => {
+  if (index < 26) {
+    return String.fromCharCode(65 + index);
+  }
+  return (
+    prefixForIndex(Math.floor(index / 26) - 1)
+    + String.fromCharCode(65 + (index % 26))
+  );
+};
+
+const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} ${roundTypes.byId[scrambleSet.round_type_id].name} - ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
 
 export default function Rounds({
   wcifRounds,

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -8,13 +8,9 @@ import { events, roundTypes } from '../../lib/wca-data.js.erb';
 import { useDispatchWrapper } from './reducer';
 
 const prefixForIndex = (index) => {
-  if (index < 26) {
-    return String.fromCharCode(65 + index);
-  }
-  return (
-    prefixForIndex(Math.floor(index / 26) - 1)
-    + String.fromCharCode(65 + (index % 26))
-  );
+  const char = String.fromCharCode(65 + (index % 26));
+  if (index < 26) return char;
+  return prefixForIndex(Math.floor(index / 26) - 1) + char;
 };
 
 const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} ${roundTypes.byId[scrambleSet.round_type_id].name} - ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -8,6 +8,7 @@ import { events, roundTypes } from '../../lib/wca-data.js.erb';
 import { useDispatchWrapper } from './reducer';
 
 const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} ${roundTypes.byId[scrambleSet.round_type_id].name} - ${String.fromCharCode(64 + scrambleSet.scramble_set_number)}`;
+
 export default function Rounds({
   wcifRounds,
   matchState,
@@ -24,6 +25,7 @@ export default function Rounds({
       />
     );
   }
+
   return (
     <RoundsPicker
       wcifRounds={wcifRounds}
@@ -33,6 +35,7 @@ export default function Rounds({
     />
   );
 }
+
 function SelectedRoundPanel({
   selectedRound,
   matchState,
@@ -56,6 +59,7 @@ function SelectedRoundPanel({
     (idx) => `${activityCodeToName(selectedRound.id)}, Group ${idx + 1}`,
     [selectedRound.id],
   );
+
   return (
     <>
       <ScrambleMatch
@@ -75,6 +79,7 @@ function SelectedRoundPanel({
     </>
   );
 }
+
 function RoundsPicker({
   wcifRounds,
   matchState,
@@ -86,6 +91,7 @@ function RoundsPicker({
     () => wcifRounds.find((r) => r.id === selectedRoundId),
     [wcifRounds, selectedRoundId],
   );
+
   return (
     <>
       <Header as="h4">

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -8,40 +8,84 @@ import { events, roundTypes } from '../../lib/wca-data.js.erb';
 import { useDispatchWrapper } from './reducer';
 
 const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} ${roundTypes.byId[scrambleSet.round_type_id].name} - ${String.fromCharCode(64 + scrambleSet.scramble_set_number)}`;
-
 export default function Rounds({
   wcifRounds,
   matchState,
   dispatchMatchState,
   showGroupsPicker = false,
 }) {
+  if (wcifRounds.length === 1) {
+    return (
+      <SelectedRoundPanel
+        selectedRound={wcifRounds[0]}
+        matchState={matchState}
+        dispatchMatchState={dispatchMatchState}
+        showGroupsPicker={showGroupsPicker}
+      />
+    );
+  }
+  return (
+    <RoundsPicker
+      wcifRounds={wcifRounds}
+      matchState={matchState}
+      dispatchMatchState={dispatchMatchState}
+      showGroupsPicker={showGroupsPicker}
+    />
+  );
+}
+function SelectedRoundPanel({
+  selectedRound,
+  matchState,
+  dispatchMatchState,
+  showGroupsPicker = false,
+}) {
+  const onRoundDragCompleted = useCallback(
+    (fromIndex, toIndex) => dispatchMatchState({
+      type: 'moveRoundScrambleSet',
+      roundId: selectedRound.id,
+      fromIndex,
+      toIndex,
+    }),
+    [dispatchMatchState, selectedRound.id],
+  );
+  const wrappedDispatch = useDispatchWrapper(
+    dispatchMatchState,
+    { roundId: selectedRound.id },
+  );
+  const roundToGroupName = useCallback(
+    (idx) => `${activityCodeToName(selectedRound.id)}, Group ${idx + 1}`,
+    [selectedRound.id],
+  );
+  return (
+    <>
+      <ScrambleMatch
+        matchableRows={matchState[selectedRound.id]}
+        expectedNumOfRows={selectedRound.scrambleSetCount}
+        onRowDragCompleted={onRoundDragCompleted}
+        computeDefinitionName={roundToGroupName}
+        computeRowName={scrambleSetToName}
+      />
+      {showGroupsPicker && (
+        <Groups
+          scrambleSetCount={selectedRound.scrambleSetCount}
+          scrambleSets={matchState[selectedRound.id]}
+          dispatchMatchState={wrappedDispatch}
+        />
+      )}
+    </>
+  );
+}
+function RoundsPicker({
+  wcifRounds,
+  matchState,
+  dispatchMatchState,
+  showGroupsPicker = false,
+}) {
   const [selectedRoundId, setSelectedRoundId] = useState();
-
   const selectedRound = useMemo(
     () => wcifRounds.find((r) => r.id === selectedRoundId),
     [wcifRounds, selectedRoundId],
   );
-
-  const onRoundDragCompleted = useCallback(
-    (fromIndex, toIndex) => dispatchMatchState({
-      type: 'moveRoundScrambleSet',
-      roundId: selectedRoundId,
-      fromIndex,
-      toIndex,
-    }),
-    [dispatchMatchState, selectedRoundId],
-  );
-
-  const wrappedDispatch = useDispatchWrapper(
-    dispatchMatchState,
-    { roundId: selectedRoundId },
-  );
-
-  const roundToGroupName = useCallback(
-    (idx) => `${activityCodeToName(selectedRoundId)}, Group ${idx + 1}`,
-    [selectedRoundId],
-  );
-
   return (
     <>
       <Header as="h4">
@@ -69,22 +113,12 @@ export default function Rounds({
         ))}
       </Button.Group>
       {selectedRound && (
-        <>
-          <ScrambleMatch
-            matchableRows={matchState[selectedRoundId]}
-            expectedNumOfRows={selectedRound.scrambleSetCount}
-            onRowDragCompleted={onRoundDragCompleted}
-            computeDefinitionName={roundToGroupName}
-            computeRowName={scrambleSetToName}
-          />
-          {showGroupsPicker && (
-            <Groups
-              scrambleSetCount={selectedRound.scrambleSetCount}
-              scrambleSets={matchState[selectedRoundId]}
-              dispatchMatchState={wrappedDispatch}
-            />
-          )}
-        </>
+        <SelectedRoundPanel
+          selectedRound={selectedRound}
+          matchState={matchState}
+          dispatchMatchState={dispatchMatchState}
+          showGroupsPicker={showGroupsPicker}
+        />
       )}
     </>
   );

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFiles.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFiles.jsx
@@ -74,6 +74,11 @@ export default function ScrambleFiles({
         {' '}
         {uploadedJsonFiles?.length}
         {' '}
+        <Header.Subheader>
+          Scrambles are assigned automatically when you upload a TNoodle JSON file.
+          If there is a discrepancy between the number of scramble sets in the JSON file
+          and the number of groups in the round you can manually assign them below.
+        </Header.Subheader>
         <Button.Group>
           <Button
             positive

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -79,10 +79,10 @@ export default function ScrambleMatch({
 
                   return (
                     <Draggable
-                      key={rowData.id}
-                      draggableId={rowData.id.toString()}
+                      key={rowData?.id ?? `extra-scramble-set-${index + 1}`}
+                      draggableId={rowData?.id?.toString() ?? `extra-scramble-set-${index + 1}`}
                       index={index}
-                      isDragDisabled={rowCount === 1}
+                      isDragDisabled={rowCount === 1 || hasError}
                     >
                       {(providedDraggable, snapshot) => {
                         const definitionIndex = computeOnDragIndex(index, snapshot.isDragging);
@@ -90,7 +90,7 @@ export default function ScrambleMatch({
                         return (
                           <Ref innerRef={providedDraggable.innerRef}>
                             <Table.Row
-                              key={rowData.id}
+                              key={rowData?.id ?? `extra-scramble-set-${index + 1}`}
                               {...providedDraggable.draggableProps}
                               negative={hasError || isExtra}
                             >
@@ -98,17 +98,16 @@ export default function ScrambleMatch({
                                 {isExpected
                                   ? computeDefinitionName(definitionIndex)
                                   : 'Extra Scramble set (unassigned)'}
-                                {(hasError || isExtra) && (
+                                {isExtra && (
                                   <>
-                                    {' '}
                                     <Icon name="exclamation triangle" />
-                                    {hasError ? 'Missing scramble' : 'Unexpected Scramble Set'}
+                                    Unexpected Scramble Set
                                   </>
                                 )}
                               </Table.Cell>
                               <Table.Cell {...providedDraggable.dragHandleProps}>
-                                <Icon name="bars" />
-                                {computeRowName(rowData)}
+                                <Icon name={hasError ? 'exclamation triangle' : 'bars'} />
+                                {hasError ? 'Missing scramble set' : computeRowName(rowData)}
                               </Table.Cell>
                             </Table.Row>
                           </Ref>

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -77,11 +77,12 @@ export default function ScrambleMatch({
 
                   const hasError = isExpected && !rowData;
                   const fallbackIndex = `extra-scramble-set-${index + 1}`;
+                  const key = rowData?.id?.toString() ?? fallbackIndex;
 
                   return (
                     <Draggable
-                      key={rowData?.id ?? fallbackIndex}
-                      draggableId={rowData?.id?.toString() ?? fallbackIndex}
+                      key={key}
+                      draggableId={key}
                       index={index}
                       isDragDisabled={rowCount === 1 || hasError}
                     >
@@ -91,7 +92,7 @@ export default function ScrambleMatch({
                         return (
                           <Ref innerRef={providedDraggable.innerRef}>
                             <Table.Row
-                              key={rowData?.id ?? fallbackIndex}
+                              key={key}
                               {...providedDraggable.draggableProps}
                               negative={hasError || isExtra}
                             >

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -68,7 +68,8 @@ export default function ScrambleMatch({
           {(providedDroppable) => (
             <Ref innerRef={providedDroppable.innerRef}>
               <Table.Body {...providedDroppable.droppableProps}>
-                {matchableRows.map((rowData, index) => {
+                {_.times(Math.max(matchableRows.length, expectedNumOfRows)).map((index) => {
+                  const rowData = matchableRows[index];
                   const isExpected = index < expectedNumOfRows;
                   const isExtra = !isExpected;
 

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -76,11 +76,12 @@ export default function ScrambleMatch({
                   const isExtra = !isExpected;
 
                   const hasError = isExpected && !rowData;
+                  const fallbackIndex = `extra-scramble-set-${index + 1}`;
 
                   return (
                     <Draggable
-                      key={rowData?.id ?? `extra-scramble-set-${index + 1}`}
-                      draggableId={rowData?.id?.toString() ?? `extra-scramble-set-${index + 1}`}
+                      key={rowData?.id ?? fallbackIndex}
+                      draggableId={rowData?.id?.toString() ?? fallbackIndex}
                       index={index}
                       isDragDisabled={rowCount === 1 || hasError}
                     >
@@ -90,7 +91,7 @@ export default function ScrambleMatch({
                         return (
                           <Ref innerRef={providedDraggable.innerRef}>
                             <Table.Row
-                              key={rowData?.id ?? `extra-scramble-set-${index + 1}`}
+                              key={rowData?.id ?? fallbackIndex}
                               {...providedDraggable.draggableProps}
                               negative={hasError || isExtra}
                             >

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -12,6 +12,8 @@ export default function ScrambleMatch({
   const [currentDragStart, setCurrentDragStart] = useState(null);
   const [currentDragIndex, setCurrentDragIndex] = useState(null);
 
+  const rowCount = Math.max(matchableRows.length, expectedNumOfRows);
+
   const handleOnBeforeDragStart = (init) => {
     setCurrentDragStart(init.source?.index);
     setCurrentDragIndex(init.source?.index);
@@ -68,7 +70,7 @@ export default function ScrambleMatch({
           {(providedDroppable) => (
             <Ref innerRef={providedDroppable.innerRef}>
               <Table.Body {...providedDroppable.droppableProps}>
-                {_.times(Math.max(matchableRows.length, expectedNumOfRows)).map((index) => {
+                {_.times(rowCount).map((index) => {
                   const rowData = matchableRows[index];
                   const isExpected = index < expectedNumOfRows;
                   const isExtra = !isExpected;
@@ -80,6 +82,7 @@ export default function ScrambleMatch({
                       key={rowData.id}
                       draggableId={rowData.id.toString()}
                       index={index}
+                      isDragDisabled={rowCount === 1}
                     >
                       {(providedDraggable, snapshot) => {
                         const definitionIndex = computeOnDragIndex(index, snapshot.isDragging);

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { useMutation } from '@tanstack/react-query';
 import { activityCodeToName } from '@wca/helpers';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
-import ScrambleFiles from './ScrambleFiles';
+import FileUpload from './FileUpload';
 import Events from './Events';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 import { scramblesUpdateRoundMatchingUrl } from '../../lib/requests/routes.js.erb';
@@ -117,7 +117,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
           </Message.List>
         </Message>
       )}
-      <ScrambleFiles
+      <FileUpload
         competitionId={competitionId}
         initialScrambleFiles={initialScrambleFiles}
         addScrambleFile={addScrambleFile}

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -65,13 +65,10 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
   const roundIds = useMemo(() => wcifEvents.flatMap((event) => event.rounds)
     .map((r) => r.id), [wcifEvents]);
 
-  const missingIds = useMemo(() => {
-    if (!matchState) return [];
-    return _.difference(roundIds, Object.keys(matchState));
-  }, [matchState, roundIds]);
+  const roundIdsWithoutScrambles = useMemo(() => _.difference(roundIds, Object.keys(matchState)), [matchState, roundIds]);
 
   const missingScrambleIds = useMemo(() => {
-    if (!matchState) return [];
+    if (_.isEmpty(matchState)) return [];
     return roundIds.filter((roundId) => {
       const matchedRound = matchState[roundId];
       const wcifRound = wcifEvents.flatMap((event) => event.rounds).find((r) => r.id === roundId);
@@ -81,19 +78,11 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
 
   return (
     <>
-      <Message info>
-        <Message.Header>Matching scrambles to rounds</Message.Header>
-        <Message.Content>
-          Scrambles are assigned automatically when you upload a TNoodle JSON file.
-          If there is a discrepancy between the number of scramble sets in the JSON file
-          and the number of groups in the round you can manually assign them below.
-        </Message.Content>
-      </Message>
-      { missingIds.length > 0 && (
+      { roundIdsWithoutScrambles.length > 0 && (
         <Message error>
           <Message.Header>Missing Scramble Sets</Message.Header>
           <Message.List>
-            { missingIds.map((id) => (
+            { roundIdsWithoutScrambles.map((id) => (
               <Message.Item key={id}>
                 Missing scramble sets for round
                 {' '}
@@ -109,7 +98,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
           <Message.List>
             { missingScrambleIds.map((id) => (
               <Message.Item key={id}>
-                Missing scrambles round
+                Missing scrambles in round
                 {' '}
                 {activityCodeToName(id)}
               </Message.Item>
@@ -132,7 +121,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
         primary
         onClick={submitMatchState}
         loading={isSubmitting}
-        disabled={isSubmitting || missingScrambleIds.length > 0 || missingIds.length > 0}
+        disabled={isSubmitting || missingScrambleIds.length > 0 || roundIdsWithoutScrambles.length > 0}
       >
         Save Changes
       </Button>

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -81,25 +81,33 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
 
   return (
     <>
-      { roundIdsWithoutScrambles.length > 0 && (
-        <Message error>
-          <Message.Header>Missing Scramble Sets</Message.Header>
-          <Message.List>
-            { roundIdsWithoutScrambles.map((id) => (
-              <Message.Item key={id}>
-                Missing scramble sets for round
-                {' '}
-                {activityCodeToName(id)}
-              </Message.Item>
-            ))}
-          </Message.List>
-        </Message>
+      {roundIdsWithoutScrambles.length > 0 && (
+        Object.keys(matchState).length === 0 ? (
+          <Message
+            warning
+            header="No scramble sets available"
+            content="Upload some JSON files to get started!"
+          />
+        ) : (
+          <Message error>
+            <Message.Header>Missing Scramble Sets</Message.Header>
+            <Message.List>
+              {roundIdsWithoutScrambles.map((id) => (
+                <Message.Item key={id}>
+                  Missing scramble sets for round
+                  {' '}
+                  {activityCodeToName(id)}
+                </Message.Item>
+              ))}
+            </Message.List>
+          </Message>
+        )
       )}
-      { missingScrambleIds.length > 0 && (
+      {missingScrambleIds.length > 0 && (
         <Message error>
           <Message.Header>Missing Scrambles</Message.Header>
           <Message.List>
-            { missingScrambleIds.map((id) => (
+            {missingScrambleIds.map((id) => (
               <Message.Item key={id}>
                 Missing scrambles in round
                 {' '}

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -124,7 +124,9 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
         primary
         onClick={submitMatchState}
         loading={isSubmitting}
-        disabled={isSubmitting || missingScrambleIds.length > 0 || roundIdsWithoutScrambles.length > 0}
+        disabled={isSubmitting
+          || missingScrambleIds.length > 0
+          || roundIdsWithoutScrambles.length > 0}
       >
         Save Changes
       </Button>

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -61,18 +61,18 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
     mutationFn: () => submitMatchedScrambles(competitionId, matchState),
   });
 
-  const roundIds = useMemo(() => _.flatMap(wcifEvents, 'rounds').map((r) => r.id), [wcifEvents]);
+  const roundIds = useMemo(() => wcifEvents.flatMap((event) => event.rounds).map((r) => r.id), [wcifEvents]);
 
   const missingIds = useMemo(() => {
     if (!matchState) return [];
-    return _.difference(roundIds, _.keys(matchState));
+    return _.difference(roundIds, Object.keys(matchState));
   }, [matchState, roundIds]);
 
   const missingScrambleIds = useMemo(() => {
     if (!matchState) return [];
-    return _.filter(roundIds, (roundId) => {
+    return roundIds.filter((roundId) => {
       const matchedRound = matchState[roundId];
-      const wcifRound = _.flatMap(wcifEvents, 'rounds').find((r) => r.id === roundId);
+      const wcifRound = wcifEvents.flatMap((event) => event.rounds).find((r) => r.id === roundId);
       return matchedRound.length < wcifRound.scrambleSetCount;
     });
   }, [matchState, roundIds, wcifEvents]);

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useReducer } from 'react';
 import { Button, Divider, Message } from 'semantic-ui-react';
 import _ from 'lodash';
 import { useMutation } from '@tanstack/react-query';
+import { activityCodeToName } from '@wca/helpers';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
 import ScrambleFiles from './ScrambleFiles';
 import Events from './Events';
@@ -61,7 +62,8 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
     mutationFn: () => submitMatchedScrambles(competitionId, matchState),
   });
 
-  const roundIds = useMemo(() => wcifEvents.flatMap((event) => event.rounds).map((r) => r.id), [wcifEvents]);
+  const roundIds = useMemo(() => wcifEvents.flatMap((event) => event.rounds)
+    .map((r) => r.id), [wcifEvents]);
 
   const missingIds = useMemo(() => {
     if (!matchState) return [];
@@ -95,7 +97,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
               <Message.Item key={id}>
                 Missing scramble sets for round
                 {' '}
-                {id}
+                {activityCodeToName(id)}
               </Message.Item>
             ))}
           </Message.List>
@@ -109,7 +111,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
               <Message.Item key={id}>
                 Missing scrambles round
                 {' '}
-                {id}
+                {activityCodeToName(id)}
               </Message.Item>
             ))}
           </Message.List>
@@ -127,12 +129,12 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
       />
       <Divider />
       <Button
-        positive
+        primary
         onClick={submitMatchState}
         loading={isSubmitting}
         disabled={isSubmitting || missingScrambleIds.length > 0 || missingIds.length > 0}
       >
-        Submit
+        Save Changes
       </Button>
     </>
   );

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -130,7 +130,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
         positive
         onClick={submitMatchState}
         loading={isSubmitting}
-        disabled={isSubmitting || error}
+        disabled={isSubmitting || missingScrambleIds.length > 0 || missingIds.length > 0}
       >
         Submit
       </Button>

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -65,7 +65,10 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
   const roundIds = useMemo(() => wcifEvents.flatMap((event) => event.rounds)
     .map((r) => r.id), [wcifEvents]);
 
-  const roundIdsWithoutScrambles = useMemo(() => _.difference(roundIds, Object.keys(matchState)), [matchState, roundIds]);
+  const roundIdsWithoutScrambles = useMemo(() => _.difference(
+    roundIds,
+    Object.keys(matchState),
+  ), [matchState, roundIds]);
 
   const missingScrambleIds = useMemo(() => {
     if (_.isEmpty(matchState)) return [];

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -109,7 +109,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
         positive
         onClick={submitMatchState}
         loading={isSubmitting}
-        disabled={isSubmitting}
+        disabled={isSubmitting || error}
       >
         Submit
       </Button>


### PR DESCRIPTION
Adds:
- Can't drag if there is only 1 row
- Can't drag if a scramble is missing
- Shows missing scramble in table
- Don't show Rounds Panel when there is only one round

I still want to add an error indicator for missing scrambles and greying out the submit button when there are no changes or there are errors