### PR TITLE
Add backend linking columns to ScheduleActivity

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2046,7 +2046,10 @@ class Competition < ApplicationRecord
       {
         venue_rooms: [
           :wcif_extensions,
-          { schedule_activities: [{ child_activities: %i[child_activities wcif_extensions] }, :wcif_extensions] },
+          {
+            schedule_activities: [{ child_activities: %i[child_activities wcif_extensions] }, :wcif_extensions],
+            competition: { competition_events: :rounds },
+          },
         ],
       },
       :wcif_extensions,

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -5,6 +5,7 @@ class ScheduleActivity < ApplicationRecord
   VALID_ACTIVITY_CODE_BASE = (Event::OFFICIAL_IDS + %w[other]).freeze
   VALID_OTHER_ACTIVITY_CODE = %w[registration checkin multi breakfast lunch dinner awards unofficial misc tutorial setup teardown].freeze
   belongs_to :holder, polymorphic: true
+  belongs_to :venue_room, optional: true # TODO: remove the `optional` part after the old holder column is gone
   belongs_to :parent_activity, class_name: "ScheduleActivity", optional: true
   has_many :child_activities, class_name: "ScheduleActivity", as: :holder, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -5,6 +5,7 @@ class ScheduleActivity < ApplicationRecord
   VALID_ACTIVITY_CODE_BASE = (Event::OFFICIAL_IDS + %w[other]).freeze
   VALID_OTHER_ACTIVITY_CODE = %w[registration checkin multi breakfast lunch dinner awards unofficial misc tutorial setup teardown].freeze
   belongs_to :holder, polymorphic: true
+  belongs_to :parent_activity, class_name: "ScheduleActivity", optional: true
   has_many :child_activities, class_name: "ScheduleActivity", as: :holder, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
   has_many :assignments, dependent: :delete_all
@@ -69,6 +70,10 @@ class ScheduleActivity < ApplicationRecord
 
   def all_activities
     [self, child_activities.map(&:all_activities)].flatten
+  end
+
+  def root_activity
+    parent_activity&.root_activity || self
   end
 
   def to_wcif

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -6,6 +6,7 @@ class ScheduleActivity < ApplicationRecord
   VALID_OTHER_ACTIVITY_CODE = %w[registration checkin multi breakfast lunch dinner awards unofficial misc tutorial setup teardown].freeze
   belongs_to :holder, polymorphic: true
   belongs_to :venue_room, optional: true # TODO: remove the `optional` part after the old holder column is gone
+  belongs_to :round, optional: true
   belongs_to :parent_activity, class_name: "ScheduleActivity", optional: true
   has_many :child_activities, class_name: "ScheduleActivity", as: :holder, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
@@ -48,7 +49,7 @@ class ScheduleActivity < ApplicationRecord
   # Name can be specified externally, but we may want to infer the activity name
   # from its activity code (eg: if it's for an event or round).
   def localized_name(rounds_by_wcif_id = {})
-    parts = ScheduleActivity.parse_activity_code(activity_code)
+    parts = self.parsed_activity_code
     if parts[:event_id] == "other"
       # TODO/NOTE: should we fix the name for event with predefined activity codes? (ie: those below but 'misc' and 'unofficial')
       # VALID_OTHER_ACTIVITY_CODE = %w(registration checkin multi breakfast lunch dinner awards unofficial misc).freeze
@@ -77,6 +78,10 @@ class ScheduleActivity < ApplicationRecord
     parent_activity&.root_activity || self
   end
 
+  def parsed_activity_code
+    ScheduleActivity.parse_activity_code(self.activity_code)
+  end
+
   def to_wcif
     {
       "id" => wcif_id,
@@ -99,7 +104,7 @@ class ScheduleActivity < ApplicationRecord
       roomName: holder.name,
       venueName: holder.competition_venue.name,
       color: color,
-      activityDetails: ScheduleActivity.parse_activity_code(activity_code),
+      activityDetails: parsed_activity_code,
       start: start_time.in_time_zone(holder.competition_venue.timezone_id),
       end: end_time.in_time_zone(holder.competition_venue.timezone_id),
     }
@@ -111,6 +116,10 @@ class ScheduleActivity < ApplicationRecord
       parent_activity: parent_activity,
       **ScheduleActivity.wcif_to_attributes(wcif),
     )
+    if self.activity_code_previously_changed?
+      round = parent_activity&.round || self.find_matched_round
+      self.update_attribute!(:round, round) if round.present?
+    end
     new_child_activities = wcif["childActivities"].map do |activity_wcif|
       activity = child_activities.find { |a| a.wcif_id == activity_wcif["id"] } || child_activities.build
       activity.load_wcif!(activity_wcif, venue_room, parent_activity: self)
@@ -118,6 +127,14 @@ class ScheduleActivity < ApplicationRecord
     self.child_activities = new_child_activities
     WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
     self
+  end
+
+  private def find_matched_round
+    # Using `find` instead of `find_by` throughout to leverage preloaded associations
+    competition_event = venue_room.competition.competition_events.find { it.event_id == self.parsed_activity_code[:event_id] }
+    return nil if competition_event.blank?
+
+    competition_event.rounds.find { it.number == self.parsed_activity_code[:round_number] }
   end
 
   def move_by(diff)

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -105,11 +105,15 @@ class ScheduleActivity < ApplicationRecord
     }
   end
 
-  def load_wcif!(wcif)
-    update!(ScheduleActivity.wcif_to_attributes(wcif))
+  def load_wcif!(wcif, venue_room, parent_activity: nil)
+    update!(
+      venue_room: venue_room,
+      parent_activity: parent_activity,
+      **ScheduleActivity.wcif_to_attributes(wcif),
+    )
     new_child_activities = wcif["childActivities"].map do |activity_wcif|
       activity = child_activities.find { |a| a.wcif_id == activity_wcif["id"] } || child_activities.build
-      activity.load_wcif!(activity_wcif)
+      activity.load_wcif!(activity_wcif, venue_room, parent_activity: self)
     end
     self.child_activities = new_child_activities
     WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]

--- a/app/models/venue_room.rb
+++ b/app/models/venue_room.rb
@@ -57,7 +57,7 @@ class VenueRoom < ApplicationRecord
     update!(VenueRoom.wcif_to_attributes(wcif))
     new_activities = wcif["activities"].map do |activity_wcif|
       activity = schedule_activities.find { |a| a.wcif_id == activity_wcif["id"] } || schedule_activities.build
-      activity.load_wcif!(activity_wcif)
+      activity.load_wcif!(activity_wcif, self)
     end
     self.schedule_activities = new_activities
     WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]

--- a/db/migrate/20250526015242_add_columns_to_schedule_activities.rb
+++ b/db/migrate/20250526015242_add_columns_to_schedule_activities.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AddColumnsToScheduleActivities < ActiveRecord::Migration[7.2]
+  def change
+    change_table :schedule_activities, bulk: true do |t|
+      t.references :venue_room, after: :holder_id, foreign_key: true
+      t.references :parent_activity, after: :venue_room_id, foreign_key: { to_table: :schedule_activities }
+      t.references :round, after: :activity_code, type: :integer, foreign_key: true
+    end
+
+    reversible do |direction|
+      direction.up do
+        execute <<-SQL.squish
+          UPDATE schedule_activities
+          SET venue_room_id = holder_id
+          WHERE holder_type = 'VenueRoom'
+        SQL
+
+        execute <<-SQL.squish
+          UPDATE schedule_activities
+          SET parent_activity_id = holder_id
+          WHERE holder_type = 'ScheduleActivity'
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_20_093305) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_26_015242) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1185,9 +1185,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_20_093305) do
   create_table "schedule_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "holder_type", null: false
     t.bigint "holder_id", null: false
+    t.bigint "venue_room_id"
+    t.bigint "parent_activity_id"
     t.integer "wcif_id", null: false
     t.string "name", null: false
     t.string "activity_code", null: false
+    t.integer "round_id"
     t.datetime "start_time", precision: nil, null: false
     t.datetime "end_time", precision: nil, null: false
     t.integer "scramble_set_id"
@@ -1195,6 +1198,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_20_093305) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["holder_type", "holder_id", "wcif_id"], name: "index_activities_on_their_id_within_holder", unique: true
     t.index ["holder_type", "holder_id"], name: "index_schedule_activities_on_holder_type_and_holder_id"
+    t.index ["parent_activity_id"], name: "index_schedule_activities_on_parent_activity_id"
+    t.index ["round_id"], name: "index_schedule_activities_on_round_id"
+    t.index ["venue_room_id"], name: "index_schedule_activities_on_venue_room_id"
   end
 
   create_table "scramble_file_uploads", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1517,6 +1523,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_20_093305) do
   add_foreign_key "registration_history_changes", "registration_history_entries"
   add_foreign_key "sanity_check_exclusions", "sanity_checks"
   add_foreign_key "sanity_checks", "sanity_check_categories"
+  add_foreign_key "schedule_activities", "rounds"
+  add_foreign_key "schedule_activities", "schedule_activities", column: "parent_activity_id"
+  add_foreign_key "schedule_activities", "venue_rooms"
   add_foreign_key "scramble_file_uploads", "users", column: "uploaded_by"
   add_foreign_key "stripe_records", "stripe_records", column: "parent_record_id"
   add_foreign_key "stripe_webhook_events", "stripe_records"

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -463,9 +463,12 @@ module DatabaseDumper
           id
           holder_type
           holder_id
+          venue_room_id
+          parent_activity_id
           wcif_id
           name
           activity_code
+          round_id
           start_time
           end_time
           scramble_set_id

--- a/lib/tasks/schedule_activities.rake
+++ b/lib/tasks/schedule_activities.rake
@@ -13,4 +13,35 @@ namespace :schedule_activities do
       )
     end
   end
+
+  desc "Fill round_id for activities based on their activity code"
+  task backfill_rounds: :environment do
+    ScheduleActivity.where(round_id: nil)
+                    .where.not("activity_code LIKE ?", "other%")
+                    .find_each do |activity|
+      puts "Updating activity #{activity.id} with code #{activity.activity_code}"
+
+      parsed_ac = ScheduleActivity.parse_activity_code(activity.activity_code)
+
+      competition = activity.venue_room.competition
+      competition_event = competition.competition_events.find_by(event_id: parsed_ac[:event_id])
+
+      if competition_event.blank?
+        puts "Could not find event #{parsed_ac[:event_id]} in competition #{competition.id}!"
+        next
+      end
+
+      matched_round = competition_event.rounds.find_by(number: parsed_ac[:round_number])
+
+      if matched_round.blank?
+        puts "Could not find round #{parsed_ac[:round_number]} for event #{parsed_ac[:event_id]} in competition #{competition.id}!"
+        next
+      end
+
+      activity.update_column(
+        :round_id,
+        matched_round.id,
+      )
+    end
+  end
 end

--- a/lib/tasks/schedule_activities.rake
+++ b/lib/tasks/schedule_activities.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :schedule_activities do
+  desc "Fill venue_room_id for child activities based on their parent activity"
+  task backfill_venue_rooms: :environment do
+    ScheduleActivity.where(venue_room_id: nil)
+                    .find_each do |activity|
+      puts "Updating activity #{activity.id}"
+
+      activity.update_column(
+        :venue_room_id,
+        activity.root_activity.venue_room_id,
+      )
+    end
+  end
+end


### PR DESCRIPTION
The basic idea is to break up the generic `holder` structure. It's very intransparent to navigate if you want to know the link between an activity and its competition. It also makes it hard to link activities and rounds together (which we will need to properly compute records in the future).

This PR changes the following columns:
- adds `parent_activity_id` and `venue_room_id` (instead of polymorphically including `ScheduleActivity` and `VenueRoom` as `holder_type`)
- adds a `round_id` to link to the `competition_event`'s `round` entity that this activity is representing. Can be `nil` because some activities (especially those starting with `other` codes) don't have a corresponding round.
- Starts linking the columns to the degree that is necessary for the existing WCIF endpoint to continue working.

There are also two Rake tasks for backfilling the new information into existing activities. They will need to be run on prod after this PR has been deployed and migrated.

The two follow-up PRs will be:
1. Unlink the old `holder` structure and use the new fields in all places where `holder` was previously used
2. Remove the `holder` columns from the DB (separate PR to avoid weird production crashes of pending requests during deployment)