### PR TITLE
Remove usages of `holder` in ScheduleActivity Rails code

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2144,12 +2144,11 @@ class Competition < ApplicationRecord
 
   def to_ics
     cal = Icalendar::Calendar.new
-    wcif_ids = rounds.to_h { |r| [r.wcif_id, r.to_string_map] }
     all_activities.each do |activity|
       event = Icalendar::Event.new
       event.dtstart = Icalendar::Values::DateTime.new(activity.start_time, "TZID" => "Etc/UTC")
       event.dtend = Icalendar::Values::DateTime.new(activity.end_time, "TZID" => "Etc/UTC")
-      event.summary = activity.localized_name(wcif_ids)
+      event.summary = activity.localized_name
       cal.add_event(event)
     end
     cal.publish

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -34,6 +34,8 @@ class Round < ApplicationRecord
   serialize :round_results, coder: RoundResults
   validates_associated :round_results
 
+  has_many :schedule_activities, -> { root_activities }, dependent: :destroy
+
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
 
   has_many :live_results

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class ScheduleActivity < ApplicationRecord
+  ACTIVITY_CODE_OTHER = 'other'
   # See https://docs.google.com/document/d/1hnzAZizTH0XyGkSYe-PxFL5xpKVWl_cvSdTzlT_kAs8/edit#heading=h.14uuu58hnua
-  VALID_ACTIVITY_CODE_BASE = (Event::OFFICIAL_IDS + %w[other]).freeze
+  VALID_ACTIVITY_CODE_BASE = (Event::OFFICIAL_IDS + [ACTIVITY_CODE_OTHER]).freeze
   VALID_OTHER_ACTIVITY_CODE = %w[registration checkin multi breakfast lunch dinner awards unofficial misc tutorial setup teardown].freeze
   belongs_to :venue_room
   belongs_to :round, optional: true
@@ -18,8 +19,13 @@ class ScheduleActivity < ApplicationRecord
   validates :start_time, presence: { allow_blank: false }
   validates :end_time, presence: { allow_blank: false }
   validates :activity_code, presence: { allow_blank: false }
+  validates :round, presence: { if: :event_activity? }
   # TODO: we don't yet care for scramble_set_id
   delegate :color, to: :venue_room
+
+  private def event_activity?
+    self.parsed_activity_code[:event_id] != ACTIVITY_CODE_OTHER
+  end
 
   validate :included_in_competition_dates
   def included_in_competition_dates

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -61,6 +61,14 @@ class ScheduleActivity < ApplicationRecord
     errors.add(:activity_code, "should share its base activity id with parent") unless activity_id == parent_activity_id
   end
 
+  validate :consistent_round_information, if: :round_id?
+  def consistent_round_information
+    parts = self.parsed_activity_code
+
+    errors.add(:activity_code, "group should not be larger than the number of scramble sets") if parts[:group_number].present? && (parts[:group_number] > round.scramble_set_count)
+    errors.add(:activity_code, "attempt number should not be larger than the number of expected attempts") if parts[:group_number].present? && (parts[:group_number] > round.format.expected_solve_count)
+  end
+
   # Name can be specified externally, but we may want to infer the activity name
   # from its activity code (eg: if it's for an event or round).
   def localized_name(rounds_by_wcif_id = {})

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -11,6 +11,8 @@ class ScheduleActivity < ApplicationRecord
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
   has_many :assignments, dependent: :delete_all
 
+  scope :root_activities, -> { where(parent_activity_id: nil) }
+
   validates :name, presence: true
   validates :wcif_id, numericality: { only_integer: true }
   validates :start_time, presence: { allow_blank: false }

--- a/app/models/venue_room.rb
+++ b/app/models/venue_room.rb
@@ -6,7 +6,7 @@ class VenueRoom < ApplicationRecord
   belongs_to :competition_venue
   has_one :competition, through: :competition_venue
   delegate :start_time, :end_time, to: :competition
-  has_many :schedule_activities, dependent: :destroy
+  has_many :schedule_activities, -> { root_activities }, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
 
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: "Please input a valid hexadecimal color code" }

--- a/app/models/venue_room.rb
+++ b/app/models/venue_room.rb
@@ -5,9 +5,8 @@ class VenueRoom < ApplicationRecord
   DEFAULT_ROOM_COLOR = "#304a96"
   belongs_to :competition_venue
   has_one :competition, through: :competition_venue
-  delegate :start_time, to: :competition
-  delegate :end_time, to: :competition
-  has_many :schedule_activities, as: :holder, dependent: :destroy
+  delegate :start_time, :end_time, to: :competition
+  has_many :schedule_activities, dependent: :destroy
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
 
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: "Please input a valid hexadecimal color code" }

--- a/app/views/competitions/_schedule_table.pdf.erb
+++ b/app/views/competitions/_schedule_table.pdf.erb
@@ -1,6 +1,6 @@
 <% rounds_by_wcif_id = Hash[@competition.rounds.map { |r| [r.wcif_id, r.to_string_map(short: true)] }] %>
 <% activities = @competition.competition_venues.flat_map(&:top_level_activities).sort_by(&:start_time) %>
-<% activities.map!{ |a| a.to_event(rounds_by_wcif_id) } %>
+<% activities.map!{ it.to_event } %>
 <% activities_by_day = activities.group_by { |a| a[:start].strftime("%Y-%m-%d") } %>
 <% output_venue_name = @competition.competition_venues.size > 1 %>
 <% output_room_name = @competition.competition_venues.flat_map(&:venue_rooms).size > 1 %>
@@ -22,7 +22,7 @@
         </tr>
       </thead>
       <tbody>
-        <% grouped_activities.each do |title, activities| %>
+        <% grouped_activities.each do |_, activities| %>
           <% a = activities.first %>
           <% activity_code_without_attempt = "#{a[:activityDetails][:event_id]}-r#{a[:activityDetails][:round_number]}" %>
           <% round_data = rounds_by_wcif_id[activity_code_without_attempt] || {} %>

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -5,9 +5,6 @@ module DatabaseDumper
   JOIN_WHERE_VISIBLE_COMP = "JOIN competitions ON competitions.id = competition_id #{WHERE_VISIBLE_COMP}".freeze
   DEV_TIMESTAMP_NAME = "developer_dump_exported_at"
   RESULTS_TIMESTAMP_NAME = "public_results_exported_at"
-  VISIBLE_ACTIVITY_IDS = "SELECT A.id FROM schedule_activities AS A " \
-                         "JOIN venue_rooms ON (venue_rooms.id = holder_id AND holder_type = 'VenueRoom') " \
-                         "JOIN competition_venues ON competition_venues.id = competition_venue_id #{JOIN_WHERE_VISIBLE_COMP}".freeze
   PUBLIC_COMPETITION_JOIN = "LEFT JOIN competition_events ON competitions.id = competition_events.competition_id " \
                             "LEFT JOIN competition_delegates ON competitions.id = competition_delegates.competition_id " \
                             "LEFT JOIN users AS users_delegates ON users_delegates.id = competition_delegates.delegate_id " \
@@ -457,7 +454,7 @@ module DatabaseDumper
     "live_attempts" => :skip_all_rows,
     "live_attempt_history_entries" => :skip_all_rows,
     "schedule_activities" => {
-      where_clause: "WHERE (holder_type=\"ScheduleActivity\" AND holder_id IN (#{VISIBLE_ACTIVITY_IDS}) or id in (#{VISIBLE_ACTIVITY_IDS}))",
+      where_clause: "JOIN venue_rooms ON venue_rooms.id = venue_room_id JOIN competition_venues ON competition_venues.id = venue_rooms.competition_venue_id #{JOIN_WHERE_VISIBLE_COMP}",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w[
           id


### PR DESCRIPTION
Forst follow-up to #11642

This now relies on the additional linking information we have available, as well as making the existing `holder` linking less cryptic. Instead of having to rely on type checks à la `holder.is_a?(VenueRoom)`, we can now directly query the data we need.

The direct round linking also gives us advantages when computing names and related information on-the-fly, which is mostly done in React these days but still kinda relevant in the competition PDF code (which uses a static Rails template)