### PR TITLE
Scrambles Matcher: Fix base computation of additional uploads

### DIFF
--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -54,14 +54,27 @@ class ScrambleFilesController < ApplicationController
       tnoodle_wcif[:events].each do |wcif_event|
         competition_event = competition.competition_events.find_by(event_id: wcif_event[:id])
 
-        wcif_event[:rounds].each do |wcif_round|
-          competition_round = competition_event.rounds.find { it.wcif_id == wcif_round[:id] }
+        wcif_event[:rounds].each_with_index do |wcif_round, rd_idx|
+          competition_round = competition_event&.rounds&.find { it.wcif_id == wcif_round[:id] }
+
+          round_number = rd_idx + 1
+          guessed_round_type_id = round_number == wcif_event[:rounds].count ? "f" : round_number.to_s
+
+          round_scope = {
+            competition_id: competition_round&.competition_id || competition.id,
+            event_id: competition_round&.event_id || wcif_event[:id],
+            round_type_id: competition_round&.round_type_id || guessed_round_type_id,
+          }
+
+          existing_sets_count = InboxScrambleSet.where(**round_scope).count
+          highest_ordered_index = InboxScrambleSet.where(**round_scope).maximum(:ordered_index) || 0
 
           wcif_round[:scrambleSets].each_with_index do |wcif_scramble_set, idx|
             scramble_set = scr_file_upload.inbox_scramble_sets.create!(
-              scramble_set_number: idx + 1,
-              ordered_index: idx,
+              scramble_set_number: idx + existing_sets_count + 1,
+              ordered_index: idx + highest_ordered_index,
               matched_round: competition_round,
+              **round_scope,
             )
 
             %i[scrambles extraScrambles].each do |scramble_kind|

--- a/app/webpacker/components/ScrambleMatcher/reducer.jsx
+++ b/app/webpacker/components/ScrambleMatcher/reducer.jsx
@@ -19,7 +19,14 @@ export function mergeScrambleSets(state, newScrambleFile) {
   return _.mergeWith(
     orderedScrambleSets,
     state,
-    (a, b) => _.uniqBy([...b, ...a], 'id'),
+    (a, b) => {
+      const aOrEmpty = a ?? [];
+      const bOrEmpty = b ?? [];
+
+      const merged = [...bOrEmpty, ...aOrEmpty];
+
+      return _.uniqBy(merged, 'id');
+    },
   );
 }
 


### PR DESCRIPTION
Each upload was individually starting to count at 1 (or 0, respectively) again, causing the Rails uniqueness validation to clash.

This PR calculates the correct offset and applies it to new, subsequent uploads. It also fixes a small follow-up frontend bug where a newly uploaded file contains only partial information, for example only scrambles for one event of the competition.