### PR TITLE
Scrambles Matcher: Add round_number for inbox_scramble_sets

### DIFF
--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -57,13 +57,10 @@ class ScrambleFilesController < ApplicationController
         wcif_event[:rounds].each_with_index do |wcif_round, rd_idx|
           competition_round = competition_event&.rounds&.find { it.wcif_id == wcif_round[:id] }
 
-          round_number = rd_idx + 1
-          guessed_round_type_id = round_number == wcif_event[:rounds].count ? "f" : round_number.to_s
-
           round_scope = {
             competition_id: competition_round&.competition_id || competition.id,
             event_id: competition_round&.event_id || wcif_event[:id],
-            round_type_id: competition_round&.round_type_id || guessed_round_type_id,
+            round_number: rd_idx + 1,
           }
 
           existing_sets_count = InboxScrambleSet.where(**round_scope).count

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -14,14 +14,17 @@ class InboxScrambleSet < ApplicationRecord
 
   before_validation :backfill_round_information!, if: :matched_round_id?
 
-  delegate :wcif_id, to: :matched_round, prefix: true, allow_nil: true
-
   def backfill_round_information!
     return if matched_round.blank?
 
     self.competition_id = matched_round.competition_id
     self.event_id = matched_round.event_id
     self.round_type_id = matched_round.round_type_id
+    self.round_number = matched_round.number
+  end
+
+  def matched_round_wcif_id
+    matched_round&.wcif_id || "#{self.event_id}-r#{self.round_number}"
   end
 
   def alphabetic_group_index

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -4,7 +4,7 @@ import { activityCodeToName } from '@wca/helpers';
 import ScrambleMatch from './ScrambleMatch';
 import I18n from '../../lib/i18n';
 import Groups from './Groups';
-import { events, roundTypes } from '../../lib/wca-data.js.erb';
+import { events } from '../../lib/wca-data.js.erb';
 import { useDispatchWrapper } from './reducer';
 
 const prefixForIndex = (index) => {
@@ -13,7 +13,7 @@ const prefixForIndex = (index) => {
   return prefixForIndex(Math.floor(index / 26) - 1) + char;
 };
 
-const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} ${roundTypes.byId[scrambleSet.round_type_id].name} - ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
+const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} Round ${scrambleSet.round_number} Scramble Set ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
 
 export default function Rounds({
   wcifRounds,

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -3,7 +3,7 @@ import {
   Accordion, Button, Card, Header, Icon, List,
 } from 'semantic-ui-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { events, roundTypes } from '../../lib/wca-data.js.erb';
+import { events } from '../../lib/wca-data.js.erb';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 import { scrambleFileUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
@@ -57,9 +57,9 @@ function ScrambleFileInfo({ scrambleFile }) {
               {scrambleFile.inbox_scramble_sets.map((scrambleSet) => (
                 <List.Item key={scrambleSet.id}>
                   {events.byId[scrambleSet.event_id].name}
-                  {' '}
-                  {roundTypes.byId[scrambleSet.round_type_id].name}
-                  {' - '}
+                  {' Round '}
+                  {scrambleSet.round_number}
+                  {' Scramble Set '}
                   {String.fromCharCode(64 + scrambleSet.scramble_set_number)}
                 </List.Item>
               ))}

--- a/db/migrate/20250527130020_scrambles_matcher_change_round_type_to_number.rb
+++ b/db/migrate/20250527130020_scrambles_matcher_change_round_type_to_number.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ScramblesMatcherChangeRoundTypeToNumber < ActiveRecord::Migration[7.2]
+  def change
+    change_table :inbox_scramble_sets, bulk: true do |t|
+      t.integer :round_number, null: false, after: :round_type_id # rubocop:disable Rails/NotNullColumn
+
+      t.remove_index %i[competition_id event_id round_type_id scramble_set_number], unique: true
+      t.remove_index %i[competition_id event_id round_type_id]
+
+      t.index %i[competition_id event_id round_number]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_26_015242) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_27_130020) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -673,14 +673,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_26_015242) do
     t.string "competition_id", null: false
     t.string "event_id", null: false
     t.string "round_type_id", null: false
+    t.integer "round_number", null: false
     t.integer "scramble_set_number", null: false
     t.integer "ordered_index", null: false
     t.integer "matched_round_id"
     t.bigint "external_upload_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["competition_id", "event_id", "round_type_id", "scramble_set_number"], name: "idx_on_competition_id_event_id_round_type_id_ordere_68a2d4495c", unique: true
-    t.index ["competition_id", "event_id", "round_type_id"], name: "idx_on_competition_id_event_id_round_type_id_8b43d7b7e6"
+    t.index ["competition_id", "event_id", "round_number"], name: "idx_on_competition_id_event_id_round_number_063e808d5f"
     t.index ["competition_id"], name: "index_inbox_scramble_sets_on_competition_id"
     t.index ["event_id"], name: "fk_rails_7a55abc2f3"
     t.index ["external_upload_id"], name: "index_inbox_scramble_sets_on_external_upload_id"

--- a/lib/tasks/inbox_scramble_sets.rake
+++ b/lib/tasks/inbox_scramble_sets.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :inbox_scramble_sets do
+  desc "Backport round_number for already matched rounds"
+  task backfill_round_number: :environment do
+    InboxScrambleSet.includes(:matched_round)
+                    .where(round_number: 0)
+                    .where.not(matched_round: nil)
+                    .find_each do |ibs|
+      ibs.update!(round_number: ibs.matched_round.number)
+    end
+  end
+end


### PR DESCRIPTION
This will become a replacement of `round_type_id` once the backfilling script has been executed