### PR TITLE
Scrambles Matcher: Remove round_type_id and use round_number for uniqueness instead

### DIFF
--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -3,14 +3,13 @@
 class InboxScrambleSet < ApplicationRecord
   belongs_to :competition
   belongs_to :event
-  belongs_to :round_type
 
   belongs_to :scramble_file_upload, optional: true, foreign_key: "external_upload_id", inverse_of: :inbox_scramble_sets
   belongs_to :matched_round, class_name: "Round", optional: true
 
   has_many :inbox_scrambles, dependent: :destroy
 
-  validates :scramble_set_number, uniqueness: { scope: %i[competition_id event_id round_type_id] }
+  validates :scramble_set_number, uniqueness: { scope: %i[competition_id event_id round_number] }
 
   before_validation :backfill_round_information!, if: :matched_round_id?
 
@@ -19,7 +18,6 @@ class InboxScrambleSet < ApplicationRecord
 
     self.competition_id = matched_round.competition_id
     self.event_id = matched_round.event_id
-    self.round_type_id = matched_round.round_type_id
     self.round_number = matched_round.number
   end
 

--- a/db/migrate/20250527134848_remove_scrambles_matcher_round_type_id.rb
+++ b/db/migrate/20250527134848_remove_scrambles_matcher_round_type_id.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RemoveScramblesMatcherRoundTypeId < ActiveRecord::Migration[7.2]
+  def change
+    change_table :inbox_scramble_sets, bulk: true do |t|
+      t.remove_foreign_key :round_types
+      t.remove :round_type_id, type: :string
+
+      t.index %i[competition_id event_id round_number scramble_set_number], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_27_130020) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_27_134848) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -672,7 +672,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_27_130020) do
   create_table "inbox_scramble_sets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "competition_id", null: false
     t.string "event_id", null: false
-    t.string "round_type_id", null: false
     t.integer "round_number", null: false
     t.integer "scramble_set_number", null: false
     t.integer "ordered_index", null: false
@@ -680,12 +679,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_27_130020) do
     t.bigint "external_upload_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["competition_id", "event_id", "round_number", "scramble_set_number"], name: "idx_on_competition_id_event_id_round_number_scrambl_d9248c75e4", unique: true
     t.index ["competition_id", "event_id", "round_number"], name: "idx_on_competition_id_event_id_round_number_063e808d5f"
     t.index ["competition_id"], name: "index_inbox_scramble_sets_on_competition_id"
     t.index ["event_id"], name: "fk_rails_7a55abc2f3"
     t.index ["external_upload_id"], name: "index_inbox_scramble_sets_on_external_upload_id"
     t.index ["matched_round_id"], name: "index_inbox_scramble_sets_on_matched_round_id"
-    t.index ["round_type_id"], name: "fk_rails_30f08dbdd8"
   end
 
   create_table "inbox_scrambles", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1511,7 +1510,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_27_130020) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "inbox_scramble_sets", "events"
-  add_foreign_key "inbox_scramble_sets", "round_types"
   add_foreign_key "inbox_scramble_sets", "rounds", column: "matched_round_id"
   add_foreign_key "inbox_scramble_sets", "scramble_file_uploads", column: "external_upload_id"
   add_foreign_key "inbox_scrambles", "inbox_scramble_sets"


### PR DESCRIPTION
Last part of the Scrambles Matcher upload fixes. This just gets rid of the round_type_id on a database level, whereas previous PRs already got rid of it on a code level.