### PR TITLE
Remove polymorphic 'holder' columns from schedule_activities

### DIFF
--- a/db/migrate/20250529013508_remove_holder_columns_from_schedule.rb
+++ b/db/migrate/20250529013508_remove_holder_columns_from_schedule.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveHolderColumnsFromSchedule < ActiveRecord::Migration[7.2]
+  def change
+    change_table :schedule_activities, bulk: true do |t|
+      t.remove :holder_type, type: :string
+      t.remove :holder_id, type: :bigint
+
+      t.change_null :venue_room_id, false
+
+      t.index %i[venue_room_id wcif_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_27_134848) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_29_013508) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1182,9 +1182,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_27_134848) do
   end
 
   create_table "schedule_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "holder_type"
-    t.bigint "holder_id"
-    t.bigint "venue_room_id"
+    t.bigint "venue_room_id", null: false
     t.bigint "parent_activity_id"
     t.integer "wcif_id", null: false
     t.string "name", null: false
@@ -1197,6 +1195,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_27_134848) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["parent_activity_id"], name: "index_schedule_activities_on_parent_activity_id"
     t.index ["round_id"], name: "index_schedule_activities_on_round_id"
+    t.index ["venue_room_id", "wcif_id"], name: "index_schedule_activities_on_venue_room_id_and_wcif_id", unique: true
     t.index ["venue_room_id"], name: "index_schedule_activities_on_venue_room_id"
   end
 

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -458,8 +458,6 @@ module DatabaseDumper
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w[
           id
-          holder_type
-          holder_id
           venue_room_id
           parent_activity_id
           wcif_id


### PR DESCRIPTION
Simple cleanup as a follow-up to #11643. Not much to see here, just schema changes.