### PR TITLE
Use registrant_id from table in code

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -60,20 +60,18 @@ class ResultsSubmissionController < ApplicationController
 
     person_with_results = results_to_import.map(&:person_id).uniq
 
-    persons_to_import = @competition.registrations.wcif_ordered
-                                    .includes([:user])
-                                    .to_enum
-                                    .with_index(1)
-                                    .select { |r, registrant_id| r.wcif_status == "accepted" && person_with_results.include?(registrant_id.to_s) }
-                                    .map do |r, registrant_id|
+    persons_to_import = @competition.registrations
+                                    .includes(:user)
+                                    .select { it.wcif_status == "accepted" && person_with_results.include?(it.registrant_id.to_s) }
+                                    .map do
       InboxPerson.new({
-                        id: registrant_id,
-                        wca_id: r.wca_id || '',
+                        id: it.registrant_id,
+                        wca_id: it.wca_id || '',
                         competition_id: @competition.id,
-                        name: r.name,
-                        country_iso2: r.country.iso2,
-                        gender: r.gender,
-                        dob: r.dob,
+                        name: it.name,
+                        country_iso2: it.country.iso2,
+                        gender: it.gender,
+                        dob: it.dob,
                       })
     end
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1841,18 +1841,16 @@ class Competition < ApplicationRecord
     # NOTE: we're including non-competing registrations so that they can have job
     # assignments as well. These registrations don't have accepted?, but they
     # should appear in the WCIF.
-    persons_wcif = self.registrations.wcif_ordered
+    persons_wcif = self.registrations
                        .includes(includes_associations)
-                       .to_enum
-                       .with_index(1)
-                       .select { |r, _registrant_id| authorized || r.wcif_status == "accepted" }
-                       .map do |r, registrant_id|
-      managers.delete(r.user)
-      r.user.to_wcif(self, r, registrant_id, authorized: authorized)
+                       .select { authorized || it.wcif_status == "accepted" }
+                       .map do
+      managers.delete(it.user)
+      it.user.to_wcif(self, it, authorized: authorized)
     end
     # NOTE: unregistered managers may generate N+1 queries on their personal bests,
     # but that's fine because there are very few of them!
-    persons_wcif + managers.map { |m| m.to_wcif(self, authorized: authorized) }
+    persons_wcif + managers.map { it.to_wcif(self, authorized: authorized) }
   end
 
   def events_wcif

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -163,18 +163,13 @@ class Round < ApplicationRecord
     if number == 1
       registrations.includes(:user)
                    .accepted
-                   .wcif_ordered
-                   .to_enum
-                   .with_index(1)
-                   .map { |r, registrant_id| r.as_json({ include: [user: { only: [:name], methods: [], include: [] }] }).merge("registration_id" => registrant_id) }
+                   .map { it.as_json({ include: [user: { only: [:name], methods: [], include: [] }] }).merge("registration_id" => r.registrant_id) }
     else
       advancing = previous_round.live_results.where(advancing: true).pluck(:registration_id)
+
       Registration.includes(:user)
-                  .where(id: advancing)
-                  .wcif_ordered
-                  .to_enum
-                  .with_index(1)
-                  .map { |r, registrant_id| r.as_json({ include: [user: { only: [:name], methods: [], include: [] }] }).merge("registration_id" => registrant_id) }
+                  .find(advancing)
+                  .map { it.as_json({ include: [user: { only: [:name], methods: [], include: [] }] }).merge("registration_id" => r.registrant_id) }
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1261,7 +1261,7 @@ class User < ApplicationRecord
     json
   end
 
-  def to_wcif(competition, registration = nil, registrant_id = nil, authorized: false)
+  def to_wcif(competition, registration = nil, authorized: false)
     roles = registration&.roles || []
     roles << "delegate" if competition.staff_delegates.include?(self)
     roles << "trainee-delegate" if competition.trainee_delegates.include?(self)
@@ -1274,7 +1274,7 @@ class User < ApplicationRecord
       "name" => name,
       "wcaUserId" => id,
       "wcaId" => wca_id,
-      "registrantId" => registrant_id,
+      "registrantId" => registration&.registrant_id,
       "countryIso2" => country_iso2,
       "gender" => gender,
       "registration" => registration&.to_wcif(authorized: authorized),


### PR DESCRIPTION
See title. Gets rid of all (relevant, except for Rake tasks) usages of `wcif_ordered` scope.