### PR TITLE
Fix details of cronjob warning cronjob

### DIFF
--- a/app/jobs/wca_cronjob.rb
+++ b/app/jobs/wca_cronjob.rb
@@ -77,9 +77,9 @@ class WcaCronjob < ApplicationJob
         runtime = (statistics.run_end.to_f - statistics.run_start.to_f).in_milliseconds
 
         current_average = statistics.average_runtime || 0
-        new_average = (current_average + runtime.round) / statistics.times_completed
+        new_average = current_average + ((runtime - current_average) / statistics.times_completed)
 
-        statistics.average_runtime = new_average
+        statistics.average_runtime = new_average.round
         statistics.recently_errored = 0
       else
         statistics.increment :recently_errored


### PR DESCRIPTION
The most "prominent" issue that caused creation of this warning cronjob -- the Results Dump being mysteriously stuck in deployment hell -- was actually not covered. It just checked whether it started as intended, and that's it. The key point however is to check whether it also terminated as intended.

Bonus: Fix an error in the average calculation. See https://en.wikipedia.org/wiki/Moving_average#Cumulative_average for details.