### PR TITLE
Scrambles Matcher: Add button to move scrambles

### DIFF
--- a/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
+++ b/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
@@ -27,6 +27,7 @@ export default function FileUpload({
   competitionId,
   initialScrambleFiles,
   addScrambleFile,
+  removeScrambleFile,
 }) {
   const inputRef = useRef();
   const queryClient = useQueryClient();
@@ -114,7 +115,11 @@ export default function FileUpload({
         style={{ display: 'none' }}
         onChange={uploadNewScramble}
       />
-      <ScrambleFileList scrambleFiles={uploadedJsonFiles} isFetching={isFetching} />
+      <ScrambleFileList
+        scrambleFiles={uploadedJsonFiles}
+        isFetching={isFetching}
+        removeScrambleFile={removeScrambleFile}
+      />
     </>
   );
 }

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -4,16 +4,8 @@ import { activityCodeToName } from '@wca/helpers';
 import ScrambleMatch from './ScrambleMatch';
 import I18n from '../../lib/i18n';
 import Groups from './Groups';
-import { events } from '../../lib/wca-data.js.erb';
 import { useDispatchWrapper } from './reducer';
-
-const prefixForIndex = (index) => {
-  const char = String.fromCharCode(65 + (index % 26));
-  if (index < 26) return char;
-  return prefixForIndex(Math.floor(index / 26) - 1) + char;
-};
-
-const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} Round ${scrambleSet.round_number} Scramble Set ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
+import { scrambleSetToName } from './util';
 
 export default function Rounds({
   wcifRounds,

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -5,7 +5,7 @@ import ScrambleMatch from './ScrambleMatch';
 import I18n from '../../lib/i18n';
 import Groups from './Groups';
 import { useDispatchWrapper } from './reducer';
-import { scrambleSetToName } from './util';
+import {scrambleSetToDetails, scrambleSetToName} from './util';
 
 export default function Rounds({
   wcifRounds,
@@ -66,6 +66,7 @@ function SelectedRoundPanel({
         onRowDragCompleted={onRoundDragCompleted}
         computeDefinitionName={roundToGroupName}
         computeRowName={scrambleSetToName}
+        computeRowDetails={scrambleSetToDetails}
       />
       {showGroupsPicker && (
         <Groups

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -58,6 +58,18 @@ function SelectedRoundPanel({
     setModalPayload(null);
   }, [setModalOpen, setModalPayload]);
 
+  const onModalConfirm = useCallback((scrambleSet, newRoundId) => {
+    dispatchMatchState({
+      type: 'moveScrambleSetToRound',
+      scrambleSet,
+      fromRoundId: selectedRound.id,
+      toRoundId: newRoundId,
+    });
+
+    setModalOpen(false);
+    setModalPayload(null);
+  }, [setModalOpen, setModalPayload, dispatchMatchState, selectedRound.id]);
+
   const onRoundDragCompleted = useCallback(
     (fromIndex, toIndex) => dispatchMatchState({
       type: 'moveRoundScrambleSet',
@@ -92,6 +104,7 @@ function SelectedRoundPanel({
       <MoveScrambleSetModal
         isOpen={isModalOpen}
         onClose={onModalClose}
+        onConfirm={onModalConfirm}
         selectedScrambleSet={modalPayload}
         currentRound={selectedRound}
         availableRounds={wcifRounds}
@@ -153,7 +166,13 @@ function MoveScrambleSetModal({
       </Modal.Content>
       <Modal.Actions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button positive onClick={() => onConfirm(selectedRound)} disabled={!canMove}>Move</Button>
+        <Button
+          positive
+          onClick={() => onConfirm(selectedScrambleSet, selectedRound)}
+          disabled={!canMove}
+        >
+          Move
+        </Button>
       </Modal.Actions>
     </Modal>
   );

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -16,7 +16,7 @@ async function deleteScrambleFile(fileId) {
   return data;
 }
 
-function ScrambleFileInfo({ scrambleFile }) {
+function ScrambleFileInfo({ scrambleFile, removeScrambleFile }) {
   const queryClient = useQueryClient();
 
   const [expanded, setExpanded] = useState(false);
@@ -28,6 +28,8 @@ function ScrambleFileInfo({ scrambleFile }) {
         ['scramble-files', data.competition_id],
         (prev) => prev.filter((scrFile) => scrFile.id !== data.id),
       );
+
+      removeScrambleFile(data);
     },
   });
 
@@ -80,12 +82,16 @@ function ScrambleFileInfo({ scrambleFile }) {
   );
 }
 
-export default function ScrambleFileList({ scrambleFiles, isFetching }) {
+export default function ScrambleFileList({ scrambleFiles, isFetching, removeScrambleFile }) {
   if (isFetching) {
     return <Loading />;
   }
 
   return scrambleFiles.map((scrFile) => (
-    <ScrambleFileInfo key={scrFile.id} scrambleFile={scrFile} />
+    <ScrambleFileInfo
+      key={scrFile.id}
+      scrambleFile={scrFile}
+      removeScrambleFile={removeScrambleFile}
+    />
   ));
 }

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -3,10 +3,10 @@ import {
   Accordion, Button, Card, Header, Icon, List,
 } from 'semantic-ui-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { events } from '../../lib/wca-data.js.erb';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 import { scrambleFileUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
+import { scrambleSetToName } from './util';
 
 async function deleteScrambleFile(fileId) {
   const { data } = await fetchJsonOrError(scrambleFileUrl(fileId), {
@@ -58,11 +58,7 @@ function ScrambleFileInfo({ scrambleFile, removeScrambleFile }) {
             <List style={{ maxHeight: '400px', overflowY: 'auto' }}>
               {scrambleFile.inbox_scramble_sets.map((scrambleSet) => (
                 <List.Item key={scrambleSet.id}>
-                  {events.byId[scrambleSet.event_id].name}
-                  {' Round '}
-                  {scrambleSet.round_number}
-                  {' Scramble Set '}
-                  {String.fromCharCode(64 + scrambleSet.scramble_set_number)}
+                  {scrambleSetToName(scrambleSet)}
                 </List.Item>
               ))}
             </List>

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { Icon, Ref, Table } from 'semantic-ui-react';
+import {
+  Icon, Popup, Ref, Table,
+} from 'semantic-ui-react';
 import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd';
 
 export default function ScrambleMatch({
@@ -8,6 +10,7 @@ export default function ScrambleMatch({
   onRowDragCompleted,
   computeDefinitionName,
   computeRowName,
+  computeRowDetails = undefined,
 }) {
   const [currentDragStart, setCurrentDragStart] = useState(null);
   const [currentDragIndex, setCurrentDragIndex] = useState(null);
@@ -110,7 +113,23 @@ export default function ScrambleMatch({
                               </Table.Cell>
                               <Table.Cell {...providedDraggable.dragHandleProps}>
                                 <Icon name={hasError ? 'exclamation triangle' : 'bars'} />
-                                {hasError ? 'Missing scramble set' : computeRowName(rowData)}
+                                {hasError
+                                  ? 'Missing scramble set'
+                                  : (
+                                    <>
+                                      {computeRowName(rowData)}
+                                      {' '}
+                                      {computeRowDetails && (
+                                        <Popup
+                                          trigger={<Icon name="info circle" />}
+                                          position="right center"
+                                          style={{ whiteSpace: 'pre-line' }}
+                                        >
+                                          {computeRowDetails(rowData)}
+                                        </Popup>
+                                      )}
+                                    </>
+                                  )}
                               </Table.Cell>
                               <Table.Cell textAlign="center" collapsing icon>
                                 <Icon name="arrows alternate horizontal" />

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -11,6 +11,7 @@ export default function ScrambleMatch({
   computeDefinitionName,
   computeRowName,
   computeRowDetails = undefined,
+  moveAwayAction = undefined,
 }) {
   const [currentDragStart, setCurrentDragStart] = useState(null);
   const [currentDragIndex, setCurrentDragIndex] = useState(null);
@@ -62,7 +63,7 @@ export default function ScrambleMatch({
         <Table.Row>
           <Table.HeaderCell />
           <Table.HeaderCell>Assigned Scrambles</Table.HeaderCell>
-          <Table.HeaderCell>Move</Table.HeaderCell>
+          {moveAwayAction && (<Table.HeaderCell>Move</Table.HeaderCell>)}
         </Table.Row>
       </Table.Header>
       <DragDropContext
@@ -131,9 +132,15 @@ export default function ScrambleMatch({
                                     </>
                                   )}
                               </Table.Cell>
-                              <Table.Cell textAlign="center" collapsing icon>
-                                <Icon name="arrows alternate horizontal" />
-                              </Table.Cell>
+                              {moveAwayAction && (
+                                <Table.Cell textAlign="center" collapsing icon>
+                                  <Icon
+                                    name="arrows alternate horizontal"
+                                    link
+                                    onClick={() => moveAwayAction(rowData)}
+                                  />
+                                </Table.Cell>
+                              )}
                             </Table.Row>
                           </Ref>
                         );

--- a/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleMatch.jsx
@@ -59,6 +59,7 @@ export default function ScrambleMatch({
         <Table.Row>
           <Table.HeaderCell />
           <Table.HeaderCell>Assigned Scrambles</Table.HeaderCell>
+          <Table.HeaderCell>Move</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <DragDropContext
@@ -110,6 +111,9 @@ export default function ScrambleMatch({
                               <Table.Cell {...providedDraggable.dragHandleProps}>
                                 <Icon name={hasError ? 'exclamation triangle' : 'bars'} />
                                 {hasError ? 'Missing scramble set' : computeRowName(rowData)}
+                              </Table.Cell>
+                              <Table.Cell textAlign="center" collapsing icon>
+                                <Icon name="arrows alternate horizontal" />
                               </Table.Cell>
                             </Table.Row>
                           </Ref>

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -58,6 +58,11 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
     [dispatchMatchState],
   );
 
+  const removeScrambleFile = useCallback(
+    (scrambleFile) => dispatchMatchState({ type: 'removeScrambleFile', scrambleFile }),
+    [dispatchMatchState],
+  );
+
   const { mutate: submitMatchState, isPending: isSubmitting } = useMutation({
     mutationFn: () => submitMatchedScrambles(competitionId, matchState),
   });
@@ -72,8 +77,9 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
 
   const missingScrambleIds = useMemo(() => {
     if (_.isEmpty(matchState)) return [];
+
     return roundIds.filter((roundId) => {
-      const matchedRound = matchState[roundId];
+      const matchedRound = matchState[roundId] ?? [];
       const wcifRound = wcifEvents.flatMap((event) => event.rounds).find((r) => r.id === roundId);
       return matchedRound.length < wcifRound.scrambleSetCount;
     });
@@ -121,6 +127,7 @@ function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
         competitionId={competitionId}
         initialScrambleFiles={initialScrambleFiles}
         addScrambleFile={addScrambleFile}
+        removeScrambleFile={removeScrambleFile}
       />
       <Events
         wcifEvents={wcifEvents}

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -67,6 +67,17 @@ export default function scrambleMatchReducer(state, action) {
           action.toIndex,
         ),
       };
+    case 'moveScrambleSetToRound':
+      return {
+        ...state,
+        [action.fromRoundId]: state[action.fromRoundId].filter(
+          (scrSet) => scrSet.id !== action.scrambleSet.id,
+        ),
+        [action.toRoundId]: [
+          ...state[action.toRoundId],
+          { ...action.scrambleSet },
+        ],
+      };
     case 'moveScrambleInSet':
       return {
         ...state,

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import _ from 'lodash';
+import { moveArrayItem } from './util';
 
 export function mergeScrambleSets(state, newScrambleFile) {
   const groupedScrambleSets = _.groupBy(
@@ -40,23 +41,6 @@ function removeScrambleSet(state, oldScrambleFile) {
 
   // Throw away state entries for rounds that don't have any sets at all anymore
   return _.pickBy(withoutScrambleFile, (sets) => sets.length > 0);
-}
-
-function moveArrayItem(arr, fromIndex, toIndex) {
-  const movedItem = arr[fromIndex];
-
-  const withoutMovedItem = [
-    ...arr.slice(0, fromIndex),
-    // here we want to ignore the moved item itself, so we need the +1
-    ...arr.slice(fromIndex + 1),
-  ];
-
-  return [
-    ...withoutMovedItem.slice(0, toIndex),
-    movedItem,
-    // here we do NOT want to ignore the items that were originally there, so no +1
-    ...withoutMovedItem.slice(toIndex),
-  ];
 }
 
 export function useDispatchWrapper(originalDispatch, actionVars) {

--- a/app/webpacker/components/ScrambleMatcher/reducer.jsx
+++ b/app/webpacker/components/ScrambleMatcher/reducer.jsx
@@ -30,6 +30,18 @@ export function mergeScrambleSets(state, newScrambleFile) {
   );
 }
 
+function removeScrambleSet(state, oldScrambleFile) {
+  const withoutScrambleFile = _.mapValues(
+    state,
+    (sets) => sets.filter(
+      (set) => set.external_upload_id !== oldScrambleFile.id,
+    ),
+  );
+
+  // Throw away state entries for rounds that don't have any sets at all anymore
+  return _.pickBy(withoutScrambleFile, (sets) => sets.length > 0);
+}
+
 function moveArrayItem(arr, fromIndex, toIndex) {
   const movedItem = arr[fromIndex];
 
@@ -60,6 +72,8 @@ export default function scrambleMatchReducer(state, action) {
   switch (action.type) {
     case 'addScrambleFile':
       return mergeScrambleSets(state, action.scrambleFile);
+    case 'removeScrambleFile':
+      return removeScrambleSet(state, action.scrambleFile);
     case 'moveRoundScrambleSet':
       return {
         ...state,

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { events } from '../../lib/wca-data.js.erb';
 
 const prefixForIndex = (index) => {
@@ -8,6 +9,20 @@ const prefixForIndex = (index) => {
 };
 
 export const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} Round ${scrambleSet.round_number} Scramble Set ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
+
+export const scrambleSetToDetails = (scrambleSet) => {
+  const [extraScr, standardScr] = _.partition(scrambleSet.inbox_scrambles, 'is_extra');
+
+  const stdScrambleList = standardScr.map((scr) => scr.scramble_string).join('\n');
+
+  if (extraScr.length > 0) {
+    const extraScrambleList = extraScr.map((scr) => scr.scramble_string).join('\n');
+
+    return [stdScrambleList, extraScrambleList].join('\n\n');
+  }
+
+  return stdScrambleList;
+};
 
 export function moveArrayItem(arr, fromIndex, toIndex) {
   const movedItem = arr[fromIndex];

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -1,0 +1,27 @@
+import { events } from '../../lib/wca-data.js.erb';
+
+const prefixForIndex = (index) => {
+  const char = String.fromCharCode(65 + (index % 26));
+  if (index < 26) return char;
+
+  return prefixForIndex(Math.floor(index / 26) - 1) + char;
+};
+
+export const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} Round ${scrambleSet.round_number} Scramble Set ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
+
+export function moveArrayItem(arr, fromIndex, toIndex) {
+  const movedItem = arr[fromIndex];
+
+  const withoutMovedItem = [
+    ...arr.slice(0, fromIndex),
+    // here we want to ignore the moved item itself, so we need the +1
+    ...arr.slice(fromIndex + 1),
+  ];
+
+  return [
+    ...withoutMovedItem.slice(0, toIndex),
+    movedItem,
+    // here we do NOT want to ignore the items that were originally there, so no +1
+    ...withoutMovedItem.slice(toIndex),
+  ];
+}


### PR DESCRIPTION
This is useful and sometimes even required when uploading on-the-fly manual scrambles (for example when an incident occured).

Also fixes some bugs when removing already uploaded scrambles and introduces a small detail view which shows a group's scrambles just for fun.

![image](https://github.com/user-attachments/assets/8497dc29-b9aa-45c9-a6e4-5a5a1109c9df)
![image](https://github.com/user-attachments/assets/3ad76d7e-1481-47ff-84e4-13aa9e648716)
![image](https://github.com/user-attachments/assets/a890da01-f3c7-4184-8227-5b56ee238250)

