### PR TITLE
Newcomer Month: Set to `false`, and add conditional display support

### DIFF
--- a/app/views/competitions/_competition_form.html.erb
+++ b/app/views/competitions/_competition_form.html.erb
@@ -6,6 +6,5 @@
   isAdminView: @competition_admin_view,
   isPersisted: @competition.persisted?,
   isSeriesPersisted: @competition.competition_series&.persisted? || false,
-  newcomerMonthEnabled: Competition::NEWCOMER_MONTH_ENABLED,
   isCloning: @competition.being_cloned_from.present?,
 }) %>

--- a/app/webpacker/components/CompetitionForm/Create.js
+++ b/app/webpacker/components/CompetitionForm/Create.js
@@ -12,7 +12,6 @@ import I18n from '../../lib/i18n';
 
 function CreateCompetition({
   competition = null,
-  newcomerMonthEnabled,
   isCloning = false,
 }) {
   const redirectHandler = useQueryRedirect();
@@ -34,7 +33,6 @@ function CreateCompetition({
       initialState={{
         isAdminView: false,
         isPersisted: false,
-        newcomerMonthEnabled,
         isSeriesPersisted: false,
       }}
     >

--- a/app/webpacker/components/CompetitionForm/Edit.js
+++ b/app/webpacker/components/CompetitionForm/Edit.js
@@ -22,7 +22,6 @@ function EditCompetition({
   storedEvents,
   isAdminView,
   isSeriesPersisted,
-  newcomerMonthEnabled,
   areResultsSubmitted,
 }) {
   const originalCompId = competition.competitionId;
@@ -106,7 +105,6 @@ function EditCompetition({
       initialState={{
         isAdminView,
         isPersisted: true,
-        newcomerMonthEnabled,
         isSeriesPersisted,
       }}
     >

--- a/app/webpacker/components/CompetitionForm/FormSections/CompetitorLimit.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/CompetitorLimit.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { InputBooleanSelect, InputNumber, InputTextArea } from '../../wca/FormBuilder/input/FormInputs';
 import ConditionalSection from './ConditionalSection';
 import SubSection from '../../wca/FormBuilder/SubSection';
+import { newcomerMonthEnabled } from '../../../lib/wca-data.js.erb';
 import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider';
 import { useStore } from '../../../lib/providers/StoreProvider';
 
@@ -13,7 +14,7 @@ export default function CompetitorLimit() {
     },
   } = useFormObject();
 
-  const { isAdminView, newcomerMonthEnabled } = useStore();
+  const { isAdminView } = useStore();
 
   return (
     <SubSection section="competitorLimit">

--- a/app/webpacker/lib/wca-data.js.erb
+++ b/app/webpacker/lib/wca-data.js.erb
@@ -180,6 +180,8 @@ export const nearbyCompetitionDistanceDanger = <%= Competition::NEARBY_DISTANCE_
 
 export const competitionMaxShortNameLength = <%= Competition::MAX_CELL_NAME_LENGTH.to_json.html_safe %>
 
+export const newcomerMonthEnabled = <%= Competition::NEWCOMER_MONTH_ENABLED.to_json.html_safe %>
+
 // ----- CHAMPIONSHIPS -----
 
 const eligibleCountryForChampionshipData = loadStaticData(<%= EligibleCountryIso2ForChampionship.all_raw.to_json.html_safe %>);


### PR DESCRIPTION
We're still displaying the newcomer month field in the competition form, even though there is no newcomer month competition planned. This PR fixes this by: 
- setting `Competition::NEWCOMER_MONTH_ENABLED` to `false`, and
- making display of the newcomer month field in the competition form conditional on `Competition::NEWCOMER_MONTH_ENABLED`