### PR TITLE
Limit scope of allow_self_edit only to only apply to accepted registrations

### DIFF
--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -139,7 +139,10 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
       can_administer_or_current_user?(@competition, @current_user, target_user)
 
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::USER_EDITS_NOT_ALLOWED) unless
-      @competition.registration_edits_currently_permitted? || @current_user.can_manage_competition?(@competition) || user_uncancelling_registration?(@registration, new_status)
+      !(@registration.competing_status_accepted? && @competition.cannot_edit_accepted_registrations?) &&
+      @competition.registration_edits_currently_permitted? ||
+      @current_user.can_manage_competition?(@competition) ||
+      user_uncancelling_registration?(@registration, new_status)
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::REGISTRATION_IS_REJECTED) if
       user_is_rejected?(@current_user, target_user, @registration) && !organizer_modifying_own_registration?(@competition, @current_user, target_user)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1150,11 +1150,14 @@ class Competition < ApplicationRecord
     start_date.present? && start_date > Date.new(2021, 6, 24)
   end
 
+  def cannot_edit_accepted_registrations?
+    !self.allow_registration_edits?
+  end
+
   # can registration edits be done right now
   # must be allowed in general, and if the deadline field exists, is it a date and in the future
   def registration_edits_currently_permitted?
-    !started? && self.allow_registration_edits &&
-      (!event_change_deadline_date_required? || event_change_deadline_date.blank? || event_change_deadline_date > DateTime.now)
+    !started? && (!event_change_deadline_date_required? || event_change_deadline_date.blank? || event_change_deadline_date > DateTime.now)
   end
 
   private def dates_must_be_valid

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -468,14 +468,15 @@ RSpec.describe 'API Registrations' do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it 'user cant update registration if registration edits arent allowed' do
+    it 'user cant update accepted registration if registration edits arent allowed' do
       edits_not_allowed = create(:competition, :registration_open)
-      registration = create(:registration, competition: edits_not_allowed)
+      registration = create(:registration, :accepted, competition: edits_not_allowed)
 
       update_request = build(
         :update_request,
         competition_id: registration.competition_id,
         user_id: registration.user_id,
+        competing: { 'event_ids' => ['333'] },
       )
       headers = { 'Authorization' => update_request['jwt_token'] }
 
@@ -487,6 +488,23 @@ RSpec.describe 'API Registrations' do
 
       expect(response.body).to eq(error_json)
       expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'user may update non-accepted registration even when allow_registration_edits is false' do
+      edits_not_allowed = create(:competition, :registration_open)
+      registration = create(:registration, competition: edits_not_allowed)
+
+      update_request = build(
+        :update_request,
+        competition_id: registration.competition_id,
+        user_id: registration.user_id,
+        competing: { 'event_ids' => ['333'] },
+      )
+
+      headers = { 'Authorization' => update_request['jwt_token'] }
+
+      patch api_v1_registration_path(registration), params: update_request, headers: headers
+      expect(response).to be_successful
     end
 
     it 'user cant change events after comp has started' do


### PR DESCRIPTION
Changes were made in the frontend to support this, but the corresponding backend changes weren't implemented.