### PR TITLE
Update Delegate Report reminder/nag wording per WEAT request

### DIFF
--- a/app/views/competitions_mailer/submit_report_nag.html.erb
+++ b/app/views/competitions_mailer/submit_report_nag.html.erb
@@ -13,6 +13,12 @@
 </p>
 
 <p>
+  <b>
+    As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, Delegates who are listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation.
+  </b>
+</p>
+
+<p>
   @Senior Delegate: You can view the <%= "history".pluralize(@competition.delegates.count) %> of the <%= "Delegate".pluralize(@competition.delegates.count) %> here:
   <ul>
     <% @competition.delegates.each do |delegate| %>

--- a/app/views/competitions_mailer/submit_report_reminder.html.erb
+++ b/app/views/competitions_mailer/submit_report_reminder.html.erb
@@ -9,6 +9,12 @@
 </p>
 
 <p>
+  <b>
+    As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, Delegates who are listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation.
+  </b>
+</p>
+
+<p>
   Regards,
   The WCA Executive Assistants Team.
 </p>


### PR DESCRIPTION
WEAT has request updated wording for the delegate report reminder (6-day) and nag (8-day) emails in the email thread "Change Request: Automated Delegate Report Reminder Emails". 

I've implemented it in this PR - draft until they confirm they are happy with our implementation as requested in the email thread