### PR TITLE
Add support for inactive CPIs

### DIFF
--- a/app/models/competition_payment_integration.rb
+++ b/app/models/competition_payment_integration.rb
@@ -33,4 +33,13 @@ class CompetitionPaymentIntegration < ApplicationRecord
     raise ArgumentError.new("Invalid integration name. Allowed values are: #{AVAILABLE_INTEGRATIONS.keys.join(', ')}") unless
       AVAILABLE_INTEGRATIONS.key?(integration_name)
   end
+
+  # We mark an account as inactive if a payment provider informs us that we no longer have access to that account
+  # In this case, the expected workflow is:
+  # 1. Inform the organizer via UI that the account is inactive, and ask them to remove the connected payment integration
+  # 2. Organizer removes CPI and connects a new account
+  # Thus "inactive" is a placeholder state before a CPI is removed - which is why we have no mark_active functionality
+  def mark_inactive
+    self.update(active: false)
+  end
 end

--- a/app/views/competitions/payment_integration_setup.html.erb
+++ b/app/views/competitions/payment_integration_setup.html.erb
@@ -7,23 +7,27 @@
     <% cpi = @competition.competition_payment_integrations.first %>
     <% type = CompetitionPaymentIntegration::AVAILABLE_INTEGRATIONS.invert[cpi.connected_account_type] %>
 
-    <p>
-      <%= t("payments.payment_setup.currently_connected_info", provider: t("payments.payment_providers.#{type}")) %>
-    </p>
-    <ul>
-      <% cpi.connected_account.account_details.each do |key, value| %>
-        <li><b><%= t("payments.payment_setup.account_details.#{type}.#{key}") %></b>: <%= value || t('payments.payment_setup.account_details.fallback_not_applicable') %></li>
-      <% end %>
-    </ul>
-    <p>
-      <b><%= t("payments.payment_setup.before_disconnect_warning", provider: t("payments.payment_providers.#{type}")) %></b>
-    </p>
-    <ul>
-      <li><%= link_to(t("payments.payment_setup.external_dashboard", provider: t("payments.payment_providers.#{type}")), CompetitionPaymentIntegration::INTEGRATION_DASHBOARD_URLS[type]) %></li>
-    </ul>
-    <p>
-      <%= t("payments.payment_setup.before_disconnect_info", provider: t("payments.payment_providers.#{type}")) %>
-    </p>
+    <% if cpi.active? %>
+      <p>
+        <%= t("payments.payment_setup.currently_connected_info", provider: t("payments.payment_providers.#{type}")) %>
+      </p>
+      <ul>
+        <% cpi.connected_account.account_details.each do |key, value| %>
+          <li><b><%= t("payments.payment_setup.account_details.#{type}.#{key}") %></b>: <%= value || t('payments.payment_setup.account_details.fallback_not_applicable') %></li>
+        <% end %>
+      </ul>
+      <p>
+        <b><%= t("payments.payment_setup.before_disconnect_warning", provider: t("payments.payment_providers.#{type}")) %></b>
+      </p>
+      <ul>
+        <li><%= link_to(t("payments.payment_setup.external_dashboard", provider: t("payments.payment_providers.#{type}")), CompetitionPaymentIntegration::INTEGRATION_DASHBOARD_URLS[type]) %></li>
+      </ul>
+      <p>
+        <%= t("payments.payment_setup.before_disconnect_info", provider: t("payments.payment_providers.#{type}")) %>
+      </p>
+    <% else %>
+      <p><b><%= t("payments.payment_setup.inactive_account") %></b></p>
+    <% end %>
 
     <% if current_user&.can_admin_competitions? %>
       <%= button_to(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1288,6 +1288,7 @@ en:
         amount_too_low: "The total amount must be at least the registration fees to be paid."
         amount_rather_high: "You are about to pay at least double the required amount for your registration to proceed."
       errors:
+        no_account_access: "Unable to access the organizer's payment account. Please contact the organization and ask them to confirm their Payment Setup details on the WCA website."
         registration_closed: "Registration has closed - no further payments are allowed."
         already_paid: "The charge was not placed because the registration fees are already paid."
         not_allowed: "You can't pay for that registration."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2298,6 +2298,7 @@ en:
       currently_connected_info: "This competition is set up to accept payments through %{provider}. The Delegate(s) of the competition should contact WCAT to make any changes to connected accounts."
       before_disconnect_warning: "Disconnecting on this page will make our website forget the connection to your %{provider} account. But your %{provider} dashboard (see link below) may still list the WCA website based on the authorization that you previously granted. Note that revoking authorization in the %{provider} dashboard will also affect any other competition linked to accept payments through this account!"
       before_disconnect_info: "Keep in mind that disconnecting an account should only be done in exceptional situations, such as the current account being unable to receive payments."
+      inactive_account: 'The account you had connected is no longer active - this is probably because access was revoked by the account owner. Please click the "Disconnect" button below, and connect a new account.'
       account_details:
         stripe:
           email: "Email"

--- a/db/migrate/20250529074918_add_active_to_cpi.rb
+++ b/db/migrate/20250529074918_add_active_to_cpi.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddActiveToCpi < ActiveRecord::Migration[7.2]
+  def change
+    add_column :competition_payment_integrations, :active, :boolean, after: :connected_account_id, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_27_134848) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_29_074918) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -349,6 +349,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_27_134848) do
   create_table "competition_payment_integrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "connected_account_type", null: false
     t.bigint "connected_account_id", null: false
+    t.boolean "active", default: true
     t.string "competition_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/competition_payment_integration_spec.rb
+++ b/spec/models/competition_payment_integration_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CompetitionPaymentIntegration do
+  describe '#mark_inactive' do
+    let!(:competition) { create(:competition, :stripe_connected) }
+    let(:integration) { competition.competition_payment_integrations.first }
+
+    it 'sets to inactive in the database' do
+      integration.mark_inactive
+      expect(integration.active?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
This PR: 
- [ ] Adds an `active` property to competition_payment_integrations
- [ ] Uses that property to render information on the payment setup page that a new CPI should be connected

Potential follow-ups: 
- [ ] Display message to users when CPI is inactive
  - [ ] hydrate the CPI's `active` property into the step/payment panel
- [ ] capture & act on Stripe webhook for deactived integration