### PR TITLE
Fix nextjs types in chakra themes

### DIFF
--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -20,9 +20,11 @@ jobs:
         run: corepack enable # this allows NPM to use its own Yarn. It is crucial that this is run BEFORE the Node setup!
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'yarn'
       - name: Install fresh Yarn packages
         run: yarn install
+      - name: Check types
+        run: yarn run chakra:types && yarn run check:types
       - name: Run Lint
         run: yarn run lint

--- a/next-frontend/package.json
+++ b/next-frontend/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "check:types": "tsc --noEmit",
     "build": "next build",
     "start": "next start",
     "build:types": "openapi-typescript public/wcaAPI.yaml -o src/lib/wca/wcaSchema.ts",
+    "chakra:types": "chakra typegen ./src/theme.ts",
     "lint": "next lint",
     "lint:fix": "next lint --fix"
   },

--- a/next-frontend/src/app/(wca)/navbar.tsx
+++ b/next-frontend/src/app/(wca)/navbar.tsx
@@ -9,14 +9,19 @@ import { RefreshRouteOnSave } from "@/components/RefreshRouteOnSave";
 import { ColorModeButton } from "@/components/ui/color-mode";
 import { LuChevronDown, LuHouse } from "react-icons/lu";
 
-import { iconMap } from "@/components/icons/iconMap";
+import { iconMap, IconName } from "@/components/icons/iconMap";
+
+interface IconDisplayProps {
+  name: IconName | undefined | null;
+  fallback?: boolean;
+}
 
 const IconDisplay = ({ name, fallback = true }: IconDisplayProps) => {
-  const IconComponent = iconMap[name];
-
-  if (!IconComponent) {
+  if (!name) {
     return fallback ? <div>No_Icon</div> : null;
   }
+
+  const IconComponent = iconMap[name];
 
   return <IconComponent />;
 };

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@chakra-ui/react";
 import Link from "next/link";
 
-import { iconMap, IconName } from "@/components/icons/iconMap";
+import { iconMap } from "@/components/icons/iconMap";
 
 export default function Home() {
   const { data: session } = useSession();
@@ -65,17 +65,15 @@ export default function Home() {
               WCA Icon Gallery
             </Text>
           </Box>
-          <SimpleGrid columns={{ base: 2, sm: 3, md: 4, lg: 6 }} spacing={6}>
-            {(Object.entries(iconMap) as [IconName, React.ComponentType][]).map(
-              ([iconName, IconComponent], index) => (
-                <Box textAlign="center" key={index}>
-                  <IconComponent w="6" h="6" />
-                  <Text mt="2" fontSize="sm">
-                    {iconName}
-                  </Text>
-                </Box>
-              ),
-            )}
+          <SimpleGrid columns={{ base: 2, sm: 3, md: 4, lg: 6 }}>
+            {Object.entries(iconMap).map(([iconName, IconComponent], index) => (
+              <Box textAlign="center" key={index}>
+                <IconComponent w="6" h="6" />
+                <Text mt="2" fontSize="sm">
+                  {iconName}
+                </Text>
+              </Box>
+            ))}
           </SimpleGrid>
         </Card.Body>
       </Card.Root>

--- a/next-frontend/src/auth.config.ts
+++ b/next-frontend/src/auth.config.ts
@@ -32,8 +32,9 @@ export const authConfig: NextAuthConfig = {
       }
     },
     async session({ session, token }) {
+      // @ts-expect-error TODO: Fix this
       session.accessToken = token.access_token;
-      session.user.id = token.userId;
+      session.user.id = token.userId as string;
       return session;
     },
   },

--- a/next-frontend/src/components/icons/iconMap.tsx
+++ b/next-frontend/src/components/icons/iconMap.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import AboutTheRegulationsIcon from "@/components/icons/AboutTheRegulationsIcon";
 import AboutTheWcaIcon from "@/components/icons/AboutTheWcaIcon";
 import AdminResultsIcon from "@/components/icons/AdminResultsIcon";

--- a/next-frontend/src/components/icons/iconMap.tsx
+++ b/next-frontend/src/components/icons/iconMap.tsx
@@ -207,7 +207,7 @@ export type IconName =
   | "SkewbIcon"
   | "Sq1Icon";
 
-export const iconMap: Record<IconName, React.ComponentType> = {
+export const iconMap = {
   "About the Regulations": AboutTheRegulationsIcon,
   "About the WCA": AboutTheWcaIcon,
   "Admin Results": AdminResultsIcon,

--- a/next-frontend/src/lib/wca/useAPI.ts
+++ b/next-frontend/src/lib/wca/useAPI.ts
@@ -7,6 +7,7 @@ export default function useAPI() {
 
   return useMemo(() => {
     if (session) {
+      // @ts-expect-error TODO: Fix this
       return authenticatedClient(session.accessToken);
     } else {
       return unauthenticatedClient;

--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -424,6 +424,7 @@ const customConfig = defineConfig({
           },
         },
         defaultVariants: {
+          // @ts-expect-error TODO: Fix this
           variant: "solid",
           size: "lg",
         },
@@ -523,6 +524,7 @@ const customConfig = defineConfig({
           },
         },
         defaultVariants: {
+          // @ts-expect-error TODO: Fix this
           variant: "wcaLink",
           hoverArrow: "false",
         },
@@ -544,6 +546,7 @@ const customConfig = defineConfig({
             variant: "achievement",
             css: {
               textStyle: "lg", //needed to supercede the default textStyle
+              // @ts-expect-error TODO: Fix this
               svg: {
                 height: "1.25em",
                 width: "1.25em",
@@ -574,6 +577,7 @@ const customConfig = defineConfig({
           },
         },
         defaultVariants: {
+          // @ts-expect-error TODO: Fix this
           size: "sm",
         },
         variants: {
@@ -640,6 +644,7 @@ const customConfig = defineConfig({
             variant: "infoSnippet",
             css: {
               header: {
+                // @ts-expect-error TODO: Fix this
                 svg: {
                   height: "1.15em",
                   width: "1.15em",

--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -650,6 +650,7 @@ const customConfig = defineConfig({
         ],
       },
       accordion: {
+        slots: [],
         variants: {
           variant: {
             subtle: {
@@ -692,6 +693,7 @@ const customConfig = defineConfig({
         },
       },
       table: {
+        slots: [],
         variants: {
           variant: {
             results: {
@@ -743,6 +745,7 @@ const customConfig = defineConfig({
         },
       },
       drawer: {
+        slots: [],
         variants: {
           variant: {
             competitionInfo: {
@@ -756,6 +759,7 @@ const customConfig = defineConfig({
         },
       },
       tabs: {
+        slots: [],
         variants: {
           variant: {
             enclosed: {


### PR DESCRIPTION
I did a mix of fixing these and adding exceptions for `defaultVariants` as I couldn't figure out why it wasn't taking the `RecipeSelection<T>`  bit from 
```
defaultVariants?: RecipeSelection<T> & {
        colorPalette?: ColorPalette;
    };
```
I also added a type check to the test action