### PR TITLE
v1 API camelCase key support

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -15,6 +15,7 @@ class Api::V1::ApiController < ActionController::API
   skip_before_action :validate_jwt_token
   def test_action
     return head :not_found if Rails.env.production? && EnvConfig.WCA_LIVE_SITE?
+
     params.delete(:action)
     params.delete(:api) # TODO: ChatGPT claims I shouldn't be getting this key - but for now I'm just trying to get the tests passing
     params.delete(:controller)

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -55,6 +55,7 @@ class Api::V1::ApiController < ActionController::API
   def test_snake_case
     return head :not_found if Rails.env.production? && EnvConfig.WCA_LIVE_SITE?
 
+    puts params.inspect
     params.delete(:action)
     params.delete(:api) # TODO: ChatGPT claims I shouldn't be getting this key - but for now I'm just trying to get the tests passing
     params.delete(:controller)
@@ -62,7 +63,8 @@ class Api::V1::ApiController < ActionController::API
   end
 
   private def snake_case_params!
-    # TODO: Apparently if the endpoint gets given a JSON array, it puts it in a _json param - I want to research this more, for now, this gets tests passing
+    # If Rails receives a JSON array (ie, started with [] instead of {}), it puts it in a `_json` parameter
+    # I wasn't able to find this behaviour documented/discussed anywhere, but asserts it is normal behaviour
     if params[:_json].is_a?(Array)
       params[:_json].map! { it.deep_transform_keys(&:underscore) }
     else

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,26 +3,24 @@
 class Api::V1::ApiController < ActionController::API
   prepend_before_action :validate_jwt_token
   before_action :snake_case_params!
+  skip_before_action :validate_jwt_token, only: [:test_snake_case]
 
   # Manually include new Relic because we don't derive from ActionController::Base
   include NewRelic::Agent::Instrumentation::ControllerInstrumentation if Rails.env.production?
 
-  skip_before_action :validate_jwt_token
-  def test_snake_case
-    return head :not_found if Rails.env.production? && EnvConfig.WCA_LIVE_SITE?
+  def validate_jwt_token
+    auth_header = request.headers['Authorization']
+    return render json: { error: Registrations::ErrorCodes::MISSING_AUTHENTICATION }, status: :unauthorized if auth_header.blank?
 
-    params.delete(:action)
-    params.delete(:api) # TODO: ChatGPT claims I shouldn't be getting this key - but for now I'm just trying to get the tests passing
-    params.delete(:controller)
-    render json: params.to_unsafe_h
-  end
-
-  private def snake_case_params!
-    # TODO: Apparently if the endpoint gets given a JSON array, it puts it in a _json param - I want to research this more, for now, this gets tests passing
-    if params[:_json].is_a?(Array)
-      params[:_json].map! { it.deep_transform_keys(&:underscore) }
-    else
-      params.deep_transform_keys!(&:underscore)
+    token = auth_header.split[1]
+    begin
+      decode_result = JWT.decode token, AppSecrets.JWT_KEY, true, { algorithm: 'HS256' }
+      decoded_token = decode_result[0]
+      @current_user = User.find(decoded_token['user_id'].to_i)
+    rescue JWT::VerificationError, JWT::InvalidJtiError
+      render json: { error: Registrations::ErrorCodes::INVALID_TOKEN }, status: :unauthorized
+    rescue JWT::ExpiredSignature
+      render json: { error: Registrations::ErrorCodes::EXPIRED_TOKEN }, status: :unauthorized
     end
   end
 
@@ -42,22 +40,6 @@ class Api::V1::ApiController < ActionController::API
     end
   end
 
-  def validate_jwt_token
-    auth_header = request.headers['Authorization']
-    return render json: { error: Registrations::ErrorCodes::MISSING_AUTHENTICATION }, status: :unauthorized if auth_header.blank?
-
-    token = auth_header.split[1]
-    begin
-      decode_result = JWT.decode token, AppSecrets.JWT_KEY, true, { algorithm: 'HS256' }
-      decoded_token = decode_result[0]
-      @current_user = User.find(decoded_token['user_id'].to_i)
-    rescue JWT::VerificationError, JWT::InvalidJtiError
-      render json: { error: Registrations::ErrorCodes::INVALID_TOKEN }, status: :unauthorized
-    rescue JWT::ExpiredSignature
-      render json: { error: Registrations::ErrorCodes::EXPIRED_TOKEN }, status: :unauthorized
-    end
-  end
-
   def render_error(http_status, error, data = nil)
     if data.present?
       render json: { error: error, data: data }, status: http_status
@@ -69,4 +51,23 @@ class Api::V1::ApiController < ActionController::API
   rescue_from ActionController::ParameterMissing do |_e|
     render json: { error: Registrations::ErrorCodes::INVALID_REQUEST_DATA }, status: :bad_request
   end
+
+  def test_snake_case
+    return head :not_found if Rails.env.production? && EnvConfig.WCA_LIVE_SITE?
+
+    params.delete(:action)
+    params.delete(:api) # TODO: ChatGPT claims I shouldn't be getting this key - but for now I'm just trying to get the tests passing
+    params.delete(:controller)
+    render json: params.to_unsafe_h
+  end
+
+  private def snake_case_params!
+    # TODO: Apparently if the endpoint gets given a JSON array, it puts it in a _json param - I want to research this more, for now, this gets tests passing
+    if params[:_json].is_a?(Array)
+      params[:_json].map! { it.deep_transform_keys(&:underscore) }
+    else
+      params.deep_transform_keys!(&:underscore)
+    end
+  end
+
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::ApiController < ActionController::API
       payload.map { camelize_keys(it) }
     when Hash
       payload.transform_keys { it.to_s.camelize(:lower) }
-         .transform_values { camelize_keys(it) }
+             .transform_values { camelize_keys(it) }
     else
       payload
     end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -55,7 +55,6 @@ class Api::V1::ApiController < ActionController::API
   def test_snake_case
     return head :not_found if Rails.env.production? && EnvConfig.WCA_LIVE_SITE?
 
-    puts params.inspect
     params.delete(:action)
     params.delete(:api)
     params.delete(:controller)
@@ -71,5 +70,4 @@ class Api::V1::ApiController < ActionController::API
       params.deep_transform_keys!(&:underscore)
     end
   end
-
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -57,7 +57,7 @@ class Api::V1::ApiController < ActionController::API
 
     puts params.inspect
     params.delete(:action)
-    params.delete(:api) # TODO: ChatGPT claims I shouldn't be getting this key - but for now I'm just trying to get the tests passing
+    params.delete(:api)
     params.delete(:controller)
     render json: params.to_unsafe_h
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -349,7 +349,8 @@ Rails.application.routes.draw do
     # While this is the start of a v1 API, this is currently not usable by outside developers as
     # getting a JWT token requires you to be logged in through the Website
     namespace :v1 do
-      post "/test_action", to: "api#test_action" if Rails.env.test?
+      post "/test_snake_case", to: "api#test_snake_case" if Rails.env.test?
+      post "/test_camel_case", to: "api#test_camel_case" if Rails.env.test?
       resources :competitions, only: [] do
         resources :registrations, only: %i[index show create update], shallow: true do
           resource :history, only: %i[show], controller: :registration_history

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -349,6 +349,7 @@ Rails.application.routes.draw do
     # While this is the start of a v1 API, this is currently not usable by outside developers as
     # getting a JWT token requires you to be logged in through the Website
     namespace :v1 do
+      post "/test_action", to: "api#test_action" if Rails.env.test?
       resources :competitions, only: [] do
         resources :registrations, only: %i[index show create update], shallow: true do
           resource :history, only: %i[show], controller: :registration_history

--- a/spec/controllers/api/v1/api_controller_spec.rb
+++ b/spec/controllers/api/v1/api_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::V1::ApiController, type: :controller do
+  let(:controller_instance) { described_class.new }
+
+  describe '#camelize_keys' do
+    it 'camelizes nested hash keys' do
+      input = { some_key: { nested_key: 'value' }, array_key: [{ another_key: 'val' }] }
+      expected = { 'someKey' => { 'nestedKey' => 'value' }, 'arrayKey' => [{ 'anotherKey' => 'val' }] }
+
+      result = controller_instance.send(:camelize_keys, input)
+      expect(result).to eq(expected)
+    end
+
+    it 'camelizes nested array keys' do
+      input = [ { some_key: { nested_key: 'value' } }, { array_key: [{ another_key: 'val' }] } ]
+      expected = [ { 'someKey' => { 'nestedKey' => 'value' } }, { 'arrayKey' => [{ 'anotherKey' => 'val' }] } ]
+
+      result = controller_instance.send(:camelize_keys, input)
+      expect(result).to eq(expected)
+    end
+  end
+end

--- a/spec/controllers/api/v1/api_controller_spec.rb
+++ b/spec/controllers/api/v1/api_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Api::V1::ApiController, type: :controller do
+RSpec.describe Api::V1::ApiController do
   let(:controller_instance) { described_class.new }
 
   describe '#camelize_keys' do
@@ -13,8 +13,8 @@ RSpec.describe Api::V1::ApiController, type: :controller do
     end
 
     it 'camelizes nested array keys' do
-      input = [ { some_key: { nested_key: 'value' } }, { array_key: [{ another_key: 'val' }] } ]
-      expected = [ { 'someKey' => { 'nestedKey' => 'value' } }, { 'arrayKey' => [{ 'anotherKey' => 'val' }] } ]
+      input = [{ some_key: { nested_key: 'value' } }, { array_key: [{ another_key: 'val' }] }]
+      expected = [{ 'someKey' => { 'nestedKey' => 'value' } }, { 'arrayKey' => [{ 'anotherKey' => 'val' }] }]
 
       result = controller_instance.send(:camelize_keys, input)
       expect(result).to eq(expected)

--- a/spec/requests/v1_api_controller_spec.rb
+++ b/spec/requests/v1_api_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'v1_api_controller' do
         secondExample: "secondExample",
       }
 
-      post api_v1_test_action_path, params: test_payload, as: :json
+      post api_v1_test_snake_case_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({
         first_example: "firstExample",
         second_example: "secondExample",
@@ -23,7 +23,7 @@ RSpec.describe 'v1_api_controller' do
         second_example: "secondExample",
       }
 
-      post api_v1_test_action_path, params: test_payload, as: :json
+      post api_v1_test_snake_case_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({
         first_example: "firstExample",
         second_example: "secondExample",
@@ -36,7 +36,7 @@ RSpec.describe 'v1_api_controller' do
         second_example: "secondExample",
       }
 
-      post api_v1_test_action_path, params: test_payload, as: :json
+      post api_v1_test_snake_case_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({
         first_example: "firstExample",
         second_example: "secondExample",
@@ -49,7 +49,7 @@ RSpec.describe 'v1_api_controller' do
         { secondExample: "secondExample" },
       ]
 
-      post api_v1_test_action_path, params: test_payload, as: :json
+      post api_v1_test_snake_case_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({ _json: [
         { first_example: "firstExample" },
         { second_example: "secondExample" },
@@ -62,7 +62,7 @@ RSpec.describe 'v1_api_controller' do
         secondExample: { thirdNest: { fourthNest: 'value2' } },
       }
 
-      post api_v1_test_action_path, params: test_payload, as: :json
+      post api_v1_test_snake_case_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({
         first_example: { first_nest: { second_nest: 'value1' } },
         second_example: { third_nest: { fourth_nest: 'value2' } },
@@ -75,7 +75,7 @@ RSpec.describe 'v1_api_controller' do
         secondExample: [thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' }],
       ]
 
-      post api_v1_test_action_path, params: test_payload, as: :json
+      post api_v1_test_snake_case_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({ _json: [
         first_example: [first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' }],
         second_example: [third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' }],
@@ -88,7 +88,7 @@ RSpec.describe 'v1_api_controller' do
         secondExample: [thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' }],
       }
 
-      post api_v1_test_action_path, params: test_payload, as: :json
+      post api_v1_test_snake_case_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({
         first_example: [first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' }],
         second_example: [third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' }],

--- a/spec/requests/v1_api_controller_spec.rb
+++ b/spec/requests/v1_api_controller_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe 'v1_api_controller' do
       ]
 
       post api_v1_test_action_path, params: test_payload, as: :json
-      expect(response.parsed_body).to eq({_json: [
+      expect(response.parsed_body).to eq({ _json: [
         { first_example: "firstExample" },
         { second_example: "secondExample" },
-      ]}.deep_stringify_keys)
+      ] }.deep_stringify_keys)
     end
 
     it 'keys in a nested hash get converted' do
@@ -71,27 +71,27 @@ RSpec.describe 'v1_api_controller' do
 
     it 'deeply nested array of hashes/arrays keys all get converted' do
       test_payload = [
-        firstExample: [ firstNest: { secondNest: 'value1' }, anotherNest: { anotherNestKey: 'another nest val' } ],
-        secondExample: [ thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' } ],
+        firstExample: [firstNest: { secondNest: 'value1' }, anotherNest: { anotherNestKey: 'another nest val' }],
+        secondExample: [thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' }],
       ]
 
       post api_v1_test_action_path, params: test_payload, as: :json
-      expect(response.parsed_body).to eq({_json: [
-        first_example: [ first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' } ],
-        second_example: [ third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' } ],
-      ]}.deep_stringify_keys)
+      expect(response.parsed_body).to eq({ _json: [
+        first_example: [first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' }],
+        second_example: [third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' }],
+      ] }.deep_stringify_keys)
     end
 
     it 'deeply nested hash of hashes/arrays keys all get converted' do
       test_payload = {
-        firstExample: [ firstNest: { secondNest: 'value1' }, anotherNest: { anotherNestKey: 'another nest val' } ],
-        secondExample: [ thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' } ],
+        firstExample: [firstNest: { secondNest: 'value1' }, anotherNest: { anotherNestKey: 'another nest val' }],
+        secondExample: [thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' }],
       }
 
       post api_v1_test_action_path, params: test_payload, as: :json
       expect(response.parsed_body).to eq({
-        first_example: [ first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' } ],
-        second_example: [ third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' } ],
+        first_example: [first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' }],
+        second_example: [third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' }],
       }.deep_stringify_keys)
     end
   end

--- a/spec/requests/v1_api_controller_spec.rb
+++ b/spec/requests/v1_api_controller_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'v1_api_controller' do
+  describe '#snake_case_params!' do
+    it 'sets camelCase keys only to snake_case' do
+      test_payload = {
+        firstExample: "firstExample",
+        secondExample: "secondExample",
+      }
+
+      post api_v1_test_action_path, params: test_payload, as: :json
+      expect(response.parsed_body).to eq({
+        first_example: "firstExample",
+        second_example: "secondExample",
+      }.stringify_keys)
+    end
+
+    it 'snake_case params are unchanged' do
+      test_payload = {
+        first_example: "firstExample",
+        second_example: "secondExample",
+      }
+
+      post api_v1_test_action_path, params: test_payload, as: :json
+      expect(response.parsed_body).to eq({
+        first_example: "firstExample",
+        second_example: "secondExample",
+      }.stringify_keys)
+    end
+
+    it 'mix of snake_case and camelCase gets converted to all snake_case' do
+      test_payload = {
+        firstExample: "firstExample",
+        second_example: "secondExample",
+      }
+
+      post api_v1_test_action_path, params: test_payload, as: :json
+      expect(response.parsed_body).to eq({
+        first_example: "firstExample",
+        second_example: "secondExample",
+      }.stringify_keys)
+    end
+
+    it 'keys in an array of hashes get converted' do
+      test_payload = [
+        { firstExample: "firstExample" },
+        { secondExample: "secondExample" },
+      ]
+
+      post api_v1_test_action_path, params: test_payload, as: :json
+      expect(response.parsed_body).to eq({_json: [
+        { first_example: "firstExample" },
+        { second_example: "secondExample" },
+      ]}.deep_stringify_keys)
+    end
+
+    it 'keys in a nested hash get converted' do
+      test_payload = {
+        firstExample: { firstNest: { secondNest: 'value1' } },
+        secondExample: { thirdNest: { fourthNest: 'value2' } },
+      }
+
+      post api_v1_test_action_path, params: test_payload, as: :json
+      expect(response.parsed_body).to eq({
+        first_example: { first_nest: { second_nest: 'value1' } },
+        second_example: { third_nest: { fourth_nest: 'value2' } },
+      }.deep_stringify_keys)
+    end
+
+    it 'deeply nested array of hashes/arrays keys all get converted' do
+      test_payload = [
+        firstExample: [ firstNest: { secondNest: 'value1' }, anotherNest: { anotherNestKey: 'another nest val' } ],
+        secondExample: [ thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' } ],
+      ]
+
+      post api_v1_test_action_path, params: test_payload, as: :json
+      expect(response.parsed_body).to eq({_json: [
+        first_example: [ first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' } ],
+        second_example: [ third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' } ],
+      ]}.deep_stringify_keys)
+    end
+
+    it 'deeply nested hash of hashes/arrays keys all get converted' do
+      test_payload = {
+        firstExample: [ firstNest: { secondNest: 'value1' }, anotherNest: { anotherNestKey: 'another nest val' } ],
+        secondExample: [ thirdNest: { fourthNest: 'value2' }, fifthNest: { fifthNestKey: 'fifth nest val' } ],
+      }
+
+      post api_v1_test_action_path, params: test_payload, as: :json
+      expect(response.parsed_body).to eq({
+        first_example: [ first_nest: { second_nest: 'value1' }, another_nest: { another_nest_key: 'another nest val' } ],
+        second_example: [ third_nest: { fourth_nest: 'value2' }, fifth_nest: { fifth_nest_key: 'fifth nest val' } ],
+      }.deep_stringify_keys)
+    end
+  end
+end


### PR DESCRIPTION
This PR does the following: 
- [x] Converts incoming camelCase to snake_case in the v1 api_controller (with tests asserting behaviour)
- [x] Adds a `render_as_camel_case` method to the v1 api_controller (with tests asserting behaviour)

## Research Findings

### Summary
- There aren't any standard Rails-y ways to handle this that I could find (although there are more appropriate ways to do it if we used certain gems which we don't currently use
- But it's pretty easy to roll our own, and that's a common recommendation for our (not uncommon) use case
- Came across two gems that may be of interest to us at some point
  - [JBuilder](https://github.com/rails/jbuilder) (a DSL for building JSON payloads)
  - [active_model_serializers](https://github.com/rails-api/active_model_serializers) (helps with serializing model objects into JSON, as the name suggests. AFAIK we do this "manually" at the moment, and this gem _may_ make it more dev-friendly

### Sources
- https://www.reddit.com/r/rails/comments/10qnxhb/snakecamel_case_conversion_gem/
- https://mnishiguchi-2019.netlify.app/2017/11/29/rails-hash-camelize-and-underscore-keys/
- https://stackoverflow.com/questions/37569439/automatically-convert-hash-keys-to-camelcase-in-jbuilder
- https://discuss.rubyonrails.org/t/rails-with-snakecase-camelcase-conversion-frontend-adapter-pattern/75064/3
- https://stackoverflow.com/questions/1509915/converting-camel-case-to-underscore-case-in-ruby
- Conversation with ChatGPT (which confirmed my general impression from the above sources) 