### PR TITLE
Correctly cast boolean param for applyFix checkbox in validators

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -53,7 +53,9 @@ class PanelController < ApplicationController
     validators = params.require(:selectedValidators).split(',').map do |validator_name|
       ResultsValidators::Utils.validator_class_from_name(validator_name)
     end
-    apply_fix_when_possible = params.require(:applyFixWhenPossible)
+
+    apply_fix_when_possible_raw = params.require(:applyFixWhenPossible)
+    apply_fix_when_possible = ActiveRecord::Type::Boolean.new.cast(apply_fix_when_possible_raw)
 
     results_validator = ResultsValidators::CompetitionsResultsValidator.new(
       validators,


### PR DESCRIPTION
The frontend was using a correctly typed Boolean, but then when passing it to `jsonToQueryString` to transport as URL parameter, it gets automatically cast into a string.

The Rails backend also reads everything from the URL query as string, so it was interpreting `if "false"` (note the quotes marking it as string!) which behaves like `true` because the string is not empty.