### PR TITLE
Correctly pass through competitionId in RunValidatorsForm

### DIFF
--- a/app/webpacker/components/Panel/pages/RunValidatorsPage/RunValidatorsForm.jsx
+++ b/app/webpacker/components/Panel/pages/RunValidatorsPage/RunValidatorsForm.jsx
@@ -27,10 +27,10 @@ const COMPETITION_SELECTION_OPTIONS_TEXT = {
 
 const COMPETITION_SELECTION_OPTIONS = Object.keys(COMPETITION_SELECTION_OPTIONS_TEXT);
 
-export default function Wrapper() {
+export default function Wrapper({ competitionIds }) {
   return (
     <WCAQueryClientProvider>
-      <RunValidatorsForm />
+      <RunValidatorsForm competitionIds={competitionIds} />
     </WCAQueryClientProvider>
   );
 }


### PR DESCRIPTION
See title. We already provided the prop correctly on Rails' side, but React never picked it up because the `Wrapper` entry point (that gives a fetching client) didn't specify the parameter in its props.

CC @danieljames-dj 