### PR TITLE
Add round_id foreign keys to results and scrambles table

### DIFF
--- a/db/migrate/20250603030429_add_foreign_key_to_results.rb
+++ b/db/migrate/20250603030429_add_foreign_key_to_results.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddForeignKeyToResults < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :results, :rounds
+    add_foreign_key :scrambles, :rounds
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_29_061324) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_03_030429) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1525,12 +1525,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_29_061324) do
   add_foreign_key "paypal_records", "paypal_records", column: "parent_record_id"
   add_foreign_key "regional_records_lookup", "results", on_update: :cascade, on_delete: :cascade
   add_foreign_key "registration_history_changes", "registration_history_entries"
+  add_foreign_key "results", "rounds"
   add_foreign_key "sanity_check_exclusions", "sanity_checks"
   add_foreign_key "sanity_checks", "sanity_check_categories"
   add_foreign_key "schedule_activities", "rounds"
   add_foreign_key "schedule_activities", "schedule_activities", column: "parent_activity_id"
   add_foreign_key "schedule_activities", "venue_rooms"
   add_foreign_key "scramble_file_uploads", "users", column: "uploaded_by"
+  add_foreign_key "scrambles", "rounds"
   add_foreign_key "stripe_records", "stripe_records", column: "parent_record_id"
   add_foreign_key "stripe_webhook_events", "stripe_records"
   add_foreign_key "ticket_comments", "ticket_stakeholders", column: "acting_stakeholder_id"


### PR DESCRIPTION
Migration step that was originally planned for the previous backfilling PR, but took such a long time that we couldn't run it as part of the normal deployment migrations.

My idea for this PR is to add the code change here on GitHub for consistency, but to actually execute the change manually through the console and insert the corresponding row into `schema_migrations`. That way, we don't run into timeouts of the automated deployment 5-minute blue-green time window. 