### PR TITLE
Fix WcaSearch issue of params undefined

### DIFF
--- a/app/webpacker/components/SearchWidget/WcaSearch.jsx
+++ b/app/webpacker/components/SearchWidget/WcaSearch.jsx
@@ -110,7 +110,7 @@ export default function WcaSearch({
   multiple = true,
   disabled = false,
   model,
-  params,
+  params = {},
   label,
   removeNoResultsMessage,
 }) {


### PR DESCRIPTION
In my [recent PR](https://github.com/thewca/worldcubeassociation.org/pull/11212), I implemented admin search, where I assumed that `params` will always have a value. I've fixed it now by giving default value to `params`.