### PR TITLE
Run topological sort over table foreign keys during dev dump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ gem 'puma'
 gem "tzf"
 gem 'playwright-ruby-client', require: 'playwright'
 gem 'hash_diff'
+gem 'tsort'
 
 group :development, :test do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -900,6 +900,7 @@ GEM
     trailblazer-option (0.1.2)
     translighterate (0.3.0)
       actionview (>= 6.0)
+    tsort (0.2.0)
     twitter_cldr (6.14.0)
       base64
       camertron-eprun
@@ -967,7 +968,6 @@ PLATFORMS
   riscv64-linux-android
   riscv64-linux-gnu
   riscv64-linux-musl
-  ruby
   x86-linux
   x86-linux-gnu
   x86-linux-musl
@@ -1100,6 +1100,7 @@ DEPENDENCIES
   time_will_tell!
   timecop
   translighterate
+  tsort
   twitter_cldr
   tzf
   valid_email
@@ -1456,6 +1457,7 @@ CHECKSUMS
   timeout (0.4.3) sha256=9509f079b2b55fe4236d79633bd75e34c1c1e7e3fb4b56cb5fda61f80a0fe30e
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   translighterate (0.3.0) sha256=484ec67fab8c7ad5666aa9b1892b9c704446364805f576fabaefca553a4aff82
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   twitter_cldr (6.14.0) sha256=5d18c23097008bcda542a260535766fdfc49d982d5eedf2486d19f368aa8c7a4
   tzf (1.3.0) sha256=aeb3a5a5962a54769735a6f1ded2b1a7402d2760fbdd0f6e8ed7a1c735a73b56
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -52,6 +52,8 @@ Rails.configuration.to_prepare do
   end
 
   Hash.class_eval do
+    include TSort
+
     def merge_serialization_opts(other = nil)
       self.to_h do |key, value|
         # Try to read `key` from the other hash, fall back to empty array.
@@ -63,6 +65,14 @@ Rails.configuration.to_prepare do
         # Return the merged result associated with the original (common) key
         [key, merged_value]
       end
+    end
+
+    # The following enables topological sorting on dependency hashes.
+    #   Snippet stolen from https://github.com/ruby/tsort
+    alias_method :tsort_each_node, :each_key
+
+    def tsort_each_child(node, &)
+      fetch(node).each(&)
     end
   end
 

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -1209,8 +1209,14 @@ module DatabaseDumper
       ActiveRecord::Base.connection.execute("SET SESSION group_concat_max_len = 1048576")
     end
 
+    ordered_table_names = dump_sanitizers.keys
+                                         .index_with { ActiveRecord::Base.connection.foreign_keys(it).pluck(:to_table) }
+                                         .tsort
+
     LogTask.log_task "Populating sanitized tables in '#{dump_db_name}'" do
-      dump_sanitizers.each do |table_name, table_sanitizer|
+      ordered_table_names.each do |table_name|
+        table_sanitizer = dump_sanitizers[table_name]
+
         next if table_sanitizer == :skip_all_rows
 
         # Give an option to override source table name if schemas diverge


### PR DESCRIPTION
We're introducing more and more foreign keys, which is great for data consistency and maintenance. But it currently messes with our dev dump routine, because we're using manually glued-together dumpers which run and mask data while foreign key checks are still active.

This can lead to crashes if a table A that points to table B is being dumped first, before table B has been dumped. Then MySQL (correctly) explodes with a "foreign key constraint not met" error.

The simple solution that I chose here is topological sort. There are caveats when we ever start introducing cyclical foreign keys, but I'd say let's cross that bridge when we get there