### PR TITLE
vertically center RegionSelector country name to flag

### DIFF
--- a/app/webpacker/stylesheets/override.scss
+++ b/app/webpacker/stylesheets/override.scss
@@ -118,7 +118,7 @@ body, html {
 
   // This is to vertically align region flag and name in RegionSelector dropdown
   .ui.dropdown {
-    .menu.visible.transition[role='listbox'] {
+    .menu[role='listbox'] {
       .item[role='option'] {
         display: flex;
         align-items: center;


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/11023  Minor display issue in region dropdown where countries with long names were getting wrapped under the flag.

This change makes the name stay to the right of the flag and be vertically centered, as shown below.

![wca-region-select-text-wrap](https://github.com/user-attachments/assets/d6505e8c-0757-4440-a0e3-ca2f0a431447)
