### PR TITLE
fix missing delegate report warning for team members

### DIFF
--- a/app/webpacker/components/MyCompetitions/TableCells.jsx
+++ b/app/webpacker/components/MyCompetitions/TableCells.jsx
@@ -39,6 +39,7 @@ export function ReportTableCell({
 }) {
   const canViewDelegateReport = permissions.can_view_delegate_report.scope === '*' || permissions.can_view_delegate_report.scope.includes(competitionId);
   const canEditDelegateReport = permissions.can_edit_delegate_report.scope === '*' || permissions.can_edit_delegate_report.scope.includes(competitionId);
+  const canSeeMissingReport = permissions.can_administer_competitions.scope === '*' || permissions.can_administer_competitions.scope.includes(competitionId);
   if (!canViewDelegateReport) {
     return <Table.Cell />;
   }
@@ -66,8 +67,7 @@ export function ReportTableCell({
             />
           )}
 
-        { isPastCompetition && !isReportPosted
-          && permissions.can_administer_competitions.scope.includes(competitionId) && (
+        { isPastCompetition && !isReportPosted && canSeeMissingReport && (
             <Popup
               content={I18n.t('competitions.my_competitions_table.missing_report')}
               trigger={(


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/11672 where members of WRT, WST, WCAT, and Board would not see warning icon for missing delegate reports.
For these users, `permissions.can_administer_competitions.scope` would return `*`, so calling `.includes(competitionId)` would always return false. This has been fixed to check the scope for `*`  or check if the competitionId in included in the scope, similar to the view and edit check.
The way `can_administer_competitions` permission is defined, anyone on one of the teams listed above will see the missing report warning on competitions, regardless if they are a delegate for that competition, which seems like the intention.
