### PR TITLE
Remove schedule from result submission view

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -125,7 +125,7 @@ class ResultsSubmissionController < ApplicationController
     # Check inbox, create submission, send email
     @competition = competition_from_params
 
-    submit_results_params = params.require(:results_submission).permit(:message, :schedule_url, :confirm_information)
+    submit_results_params = params.require(:results_submission).permit(:message, :confirm_information)
     submit_results_params[:competition_id] = @competition.id
     @results_submission = ResultsSubmission.new(submit_results_params)
     # This validates also that results in Inboxes are all good

--- a/app/models/results_submission.rb
+++ b/app/models/results_submission.rb
@@ -3,13 +3,12 @@
 class ResultsSubmission
   include ActiveModel::Model
 
-  attr_accessor :message, :schedule_url, :competition_id, :confirm_information
+  attr_accessor :message, :competition_id, :confirm_information
 
   validates :message, presence: true
   validates :competition_id, presence: true
   CONFIRM_INFORMATION_ERROR = "You must confirm the information is accurate"
   validates :confirm_information, acceptance: { message: CONFIRM_INFORMATION_ERROR, allow_nil: false }
-  validates :schedule_url, presence: true, url: true
 
   validate do
     if results_validator.any_errors?

--- a/app/views/results_submission/_results_submission_panel.html.erb
+++ b/app/views/results_submission/_results_submission_panel.html.erb
@@ -1,12 +1,6 @@
 <%
   has_errors ||= false
   results_submission ||= ResultsSubmission.new
-  schedule_url_kwargs = {
-    readonly: true,
-    input_html: {
-      value: link_to_competition_schedule_tab(competition),
-    },
-  }
 %>
 <div class="panel panel-default">
   <div class="panel-heading heading-as-link <%= "collapsed" if has_errors %>" data-toggle="collapse" data-target="#collapse-submit-results">
@@ -26,7 +20,6 @@
       </p>
 
       <%= simple_form_for results_submission, url: competition_submit_results_path do |f| %>
-        <%= f.input :schedule_url, **schedule_url_kwargs %>
         <%= f.input :message, as: :text, input_html: { class: "markdown-editor" } %>
         <%= f.input :confirm_information, as: :boolean, label: "I confirm the information displayed on the WCA website's events page and on the competition's schedule page reflect what happened during the competition." %>
         <%= f.submit "Submit", class: "btn btn-primary" %>

--- a/spec/factories/results_submission.rb
+++ b/spec/factories/results_submission.rb
@@ -4,8 +4,6 @@ FactoryBot.define do
   factory :results_submission do
     competition_id { FactoryBot.create(:competition, :with_valid_submitted_results).id }
 
-    schedule_url { "https://example.com/schedule" }
-
     message { "Here are the results.\nThey look good." }
 
     confirm_information { true }

--- a/spec/models/results_submission_spec.rb
+++ b/spec/models/results_submission_spec.rb
@@ -18,12 +18,4 @@ RSpec.describe ResultsSubmission do
     results_submission.confirm_information = nil
     expect(results_submission).to be_invalid_with_errors(confirm_information: [ResultsSubmission::CONFIRM_INFORMATION_ERROR])
   end
-
-  it "requires schedule url looks like a url" do
-    results_submission.schedule_url = nil
-    expect(results_submission).to be_invalid_with_errors(schedule_url: ["can't be blank"])
-
-    results_submission.schedule_url = "i am clearly not a url"
-    expect(results_submission).to be_invalid_with_errors(schedule_url: ["must be a valid url starting with http:// or https://"])
-  end
 end

--- a/spec/requests/results_submission_spec.rb
+++ b/spec/requests/results_submission_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ResultsSubmissionController do
 
     describe "Posting results" do
       let(:results_submission_params) do
-        { message: submission_message, schedule_url: "https://example.com/schedule", confirm_information: 1, competition_id: comp.id }
+        { message: submission_message, confirm_information: 1, competition_id: comp.id }
       end
 
       it "sends the 'results submitted' email immediately" do


### PR DESCRIPTION
The schedule is no longer needed in results submission, hence removing it.