### PR TITLE
Add Form Alert For Unsaved Changes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -293,3 +293,21 @@ $(function() {
     form.submit();
   });
 });
+
+// Tracks changes on form and warns user before navigating away with unsaved changes
+function unsavedFormAlert(form) {
+  if (form) {
+      let unsavedChanges = false;
+      const markUnsaved = () => { unsavedChanges = true; }
+
+      form.addEventListener("change", markUnsaved);
+      form.addEventListener("input", markUnsaved);
+      form.addEventListener("submit", () => { unsavedChanges = false });
+
+      window.addEventListener("beforeunload", (e) => {
+        if (unsavedChanges) {
+          e.preventDefault();
+        }
+      });
+    }
+}

--- a/app/views/delegate_reports/edit.html.erb
+++ b/app/views/delegate_reports/edit.html.erb
@@ -6,7 +6,7 @@
 <%= render layout: 'nav' do %>
   <h2>Editing Delegate Report for <%= @competition.name%></h2>
   <%= simple_form_for @delegate_report, url: delegate_report_path(@competition.id),
-                                        html: { class: "delegate-report" } do |f| %>
+                                        html: { class: "delegate-report", id: "delegate-report-form" } do |f| %>
     <%= f.hidden_field :updated_at %>
 
     <% if @delegate_report.posted? %>
@@ -68,6 +68,7 @@
 
 <script>
   document.addEventListener("DOMContentLoaded", function () {
+    unsavedFormAlert(document.getElementById("delegate-report-form"));
     const checkbox = document.getElementById("wic_feedback_checkbox");
 
     if (checkbox) {

--- a/app/views/incidents/_form.html.erb
+++ b/app/views/incidents/_form.html.erb
@@ -1,6 +1,6 @@
 <% add_to_packs("markdown_editor") %>
 
-<%= horizontal_simple_form_for(@incident, html: { class: "incident-form" }) do |f| %>
+<%= horizontal_simple_form_for(@incident, html: { class: "incident-form", id: "incident-report-form" }) do |f| %>
 
   <div class="form-inputs">
     <%= f.input :title %>
@@ -34,3 +34,9 @@
     <%= f.button :submit, class: "btn-primary" %>
   </div>
 <% end %>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    unsavedFormAlert(document.getElementById("incident-report-form"));
+  });
+</script>

--- a/app/webpacker/components/Posts/PostForm.jsx
+++ b/app/webpacker/components/Posts/PostForm.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import {
   Button, Checkbox, Form, FormField, FormGroup, Header, Message,
 } from 'semantic-ui-react';
@@ -83,12 +83,16 @@ export default function PostForm({
     postId,
   ]);
 
+  useEffect(() => {
+    unsavedFormAlert(document.getElementById('post-form'));
+  }, []);
+
   return (
     <>
       <Header>
         {header}
       </Header>
-      <Form onSubmit={onSubmit}>
+      <Form id="post-form" onSubmit={onSubmit}>
         <Form.Input label={I18n.t('activerecord.attributes.post.title')} onChange={setFormTitle} value={formTitle} />
         <FormField>
           <label htmlFor="post-body">{I18n.t('activerecord.attributes.post.body')}</label>


### PR DESCRIPTION
Closes https://github.com/thewca/worldcubeassociation.org/issues/7400

Created a JavaScript function that tracks if a form has been changed and triggers the default browser alert of "You have unsaved changes. Are you sure you want to leave?" alert when navigating away. This is done simply by calling `event.preventDefault()` before page unload.

This function is applied to delegate reports, incident logs, and front page announcements.

Resolves https://github.com/thewca/worldcubeassociation.org/issues/10927 as this alert would appear when clicking delete image with unsaved changes.