### PR TITLE
Move WCA_FRONTEND_API_URL to be frontend accessible in next

### DIFF
--- a/next-frontend/.env.sample
+++ b/next-frontend/.env.sample
@@ -6,4 +6,4 @@ DATABASE_URI=file:./next-frontend.db
 PAYLOAD_SECRET="amazing-payload-secret"
 # These are the same in prod, but different in dev due to docker
 WCA_BACKEND_API_URL="http://wca_on_rails:3000/api/v0/"
-WCA_FRONTEND_API_URL="http://localhost:3000/api/v0/"
+NEXT_PUBLIC_WCA_FRONTEND_API_URL="http://localhost:3000/api/v0/"

--- a/next-frontend/Dockerfile
+++ b/next-frontend/Dockerfile
@@ -25,7 +25,7 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN corepack enable
 # Create the types and build
-RUN yarn run chakra:types && NODE_ENV=production yarn run build
+RUN yarn run chakra:types && NODE_ENV=production NEXT_PUBLIC_WCA_FRONTEND_API_URL='https://www.worldcubeassociation.org/api/v0/' yarn run build
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/next-frontend/src/lib/wca/wcaAPI.ts
+++ b/next-frontend/src/lib/wca/wcaAPI.ts
@@ -6,12 +6,12 @@ export const serverClient = createClient<paths>({
   headers: { "Content-Type": "application/json" },
 });
 export const unauthenticatedClient = createClient<paths>({
-  baseUrl: process.env.WCA_FRONTEND_API_URL,
+  baseUrl: process.env.NEXT_PUBLIC_WCA_FRONTEND_API_URL,
   headers: { "Content-Type": "application/json" },
 });
 export const authenticatedClient = (token: string) =>
   createClient<paths>({
-    baseUrl: process.env.WCA_FRONTEND_API_URL,
+    baseUrl: process.env.NEXT_PUBLIC_WCA_FRONTEND_API_URL,
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,


### PR DESCRIPTION
I noticed that we are getting a 404 when trying to fetch permissions. This was because env variables that need to be accessible through the frontend need to be injected into the build using the NEXT_PUBLIC_WCA_FRONTEND_API_URL syntax as per https://nextjs.org/docs/pages/guides/environment-variables#bundling-environment-variables-for-the-browser

Now we are 'just' getting a 401 because we are trying to use staging credentials for production APIs but that is fine for now