### PR TITLE
Disable edit icon if hyperlink is not available

### DIFF
--- a/app/webpacker/components/RolesTab/ActiveRoles.jsx
+++ b/app/webpacker/components/RolesTab/ActiveRoles.jsx
@@ -36,27 +36,30 @@ export default function ActiveRoles({ activeRoles }) {
     <>
       <Header>Active Roles</Header>
       <List divided relaxed>
-        {activeRoles?.map((role) => (
-          <List.Item
-            key={role.id}
-            disabled={!loggedInUserPermissions.canEditGroup(role.group.id)}
-          >
-            <List.Content
-              floated="left"
-              href={hyperlink(role)}
+        {activeRoles?.map((role) => {
+          const editUrl = hyperlink(role);
+          return (
+            <List.Item
+              key={role.id}
+              disabled={!(loggedInUserPermissions.canEditGroup(role.group.id) && editUrl)}
             >
-              <Icon
-                name="edit"
-                size="large"
-                link
-              />
-            </List.Content>
-            <List.Content>
-              <List.Header>{getRoleDescription(role)}</List.Header>
-              <List.Description>{getRoleSubDescription(role)}</List.Description>
-            </List.Content>
-          </List.Item>
-        ))}
+              <List.Content
+                floated="left"
+                href={editUrl}
+              >
+                <Icon
+                  name="edit"
+                  size="large"
+                  link
+                />
+              </List.Content>
+              <List.Content>
+                <List.Header>{getRoleDescription(role)}</List.Header>
+                <List.Description>{getRoleSubDescription(role)}</List.Description>
+              </List.Content>
+            </List.Item>
+          );
+        })}
       </List>
     </>
   );


### PR DESCRIPTION
This is indeed not a long term fix. This is temporarily to avoid confusions with 401 errors.

I'll be properly planning edit features for the roles in a later stage. That work also includes making the panel pages less confusing for Board because currently Board has access to many pages which are not having proper page names as well.