### PR TITLE
Add disableIndexHints to mongodb adapter as per documentation

### DIFF
--- a/next-frontend/src/payload.config.ts
+++ b/next-frontend/src/payload.config.ts
@@ -25,6 +25,7 @@ async function dbAdapter() {
     const { mongooseAdapter } = await import("@payloadcms/db-mongodb");
     return mongooseAdapter({
       url: process.env.DATABASE_URI || "",
+      disableIndexHints: true,
       connectOptions: {
         authMechanism: "MONGODB-AWS",
         authSource: "$external",


### PR DESCRIPTION
Just saw this in the [documentation](https://payloadcms.com/docs/database/mongodb#using-other-mongodb-implementations):
For DocumentDB pass `disableIndexHints: true` to disable hinting to the DB to use `id` as index which can cause problems with DocumentDB.