### PR TITLE
Bulk Auto Accept: Show user's name in modal instead of registration_id

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -447,7 +447,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
                   {Object.entries(modalData).map(([key, value]) => (
                     <List.Item key={key}>
                       {registrations.find(
-                        registration => (registration.id === Number(key))
+                        (registration) => registration.id === Number(key),
                       )?.user.name}
                       {' - '}
                       <b>Succeeded</b>

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -446,7 +446,7 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
                 <List bulleted>
                   {Object.entries(modalData).map(([key, value]) => (
                     <List.Item key={key}>
-                      {key}
+                      {registrations.find(registration => registration.id === Number(key))?.user.name}
                       {' - '}
                       <b>Succeeded</b>
                       {': '}

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -446,7 +446,9 @@ export default function RegistrationAdministrationList({ competitionInfo }) {
                 <List bulleted>
                   {Object.entries(modalData).map(([key, value]) => (
                     <List.Item key={key}>
-                      {registrations.find(registration => registration.id === Number(key))?.user.name}
+                      {registrations.find(
+                        registration => (registration.id === Number(key))
+                      )?.user.name}
                       {' - '}
                       <b>Succeeded</b>
                       {': '}


### PR DESCRIPTION
Previously, we showed the registration_id in the info popup - this shows the user's name instead, which will be much easier for organizers to parse. Realized we should make this change before enabling globally