### PR TITLE
Reverse past banned competitors sort order

### DIFF
--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
@@ -27,7 +27,7 @@ export default function BannedCompetitorsPage() {
   } = useLoadedData(apiV0Urls.userRoles.list({
     isActive: false,
     groupType: groupTypes.banned_competitors,
-  }, 'startDate'));
+  }, 'startDate:desc'));
   const {
     data: bannedGroups,
     loading: bannedGroupLoading,


### PR DESCRIPTION
This is to improve user experience for WIC.