### PR TITLE
Move apply_fixes param from generic_validator to positions_validator

### DIFF
--- a/app/controllers/admin/scrambles_controller.rb
+++ b/app/controllers/admin/scrambles_controller.rb
@@ -35,7 +35,7 @@ module Admin
       scramble = Scramble.new(scramble_params)
       if scramble.save
         # We just inserted a new scramble, make sure we at least give it correct information.
-        validator = ResultsValidators::ScramblesValidator.new(apply_fixes: true)
+        validator = ResultsValidators::ScramblesValidator.new
         validator.validate(competition_ids: [scramble.competition_id])
         json[:messages] = ["Scramble inserted!"].concat(validator.infos.map(&:to_s))
       else
@@ -52,7 +52,7 @@ module Admin
       if scramble.update(scramble_params)
         competitions_to_validate << scramble.competition_id
         competitions_to_validate.uniq!
-        validator = ResultsValidators::ScramblesValidator.new(apply_fixes: true)
+        validator = ResultsValidators::ScramblesValidator.new
         validator.validate(competition_ids: competitions_to_validate)
         info = if scramble.saved_changes.empty?
                  ["It looks like you submitted the exact same scramble, so no changes were made."]
@@ -78,7 +78,7 @@ module Admin
       scramble.destroy!
 
       # Create a results validator to fix information if needed
-      validator = ResultsValidators::ScramblesValidator.new(apply_fixes: true)
+      validator = ResultsValidators::ScramblesValidator.new
       validator.validate(competition_ids: [competition_id])
 
       render json: {

--- a/lib/results_validators/competitions_results_validator.rb
+++ b/lib/results_validators/competitions_results_validator.rb
@@ -14,12 +14,12 @@ module ResultsValidators
 
     # Takes a list of validator classes, and if it should process real results or not.
     def initialize(validators = [], check_real_results: false, apply_fixes: false, sql_batch: nil, memory_batch: nil)
-      super(apply_fixes: apply_fixes)
+      super()
 
       @validators = validators
 
       @check_real_results = check_real_results
-
+      @apply_fixes = apply_fixes
       @sql_batch = sql_batch
       @memory_batch = memory_batch
 
@@ -96,7 +96,11 @@ module ResultsValidators
     private
 
       def load_validator(validator_class)
-        validator_class.new(apply_fixes: @apply_fixes)
+        if validator_class.class_name == PositionsValidator.class_name
+          validator_class.new(apply_fixes: @apply_fixes)
+        else
+          validator_class.new
+        end
       end
 
       def merge(other_validators)

--- a/lib/results_validators/generic_validator.rb
+++ b/lib/results_validators/generic_validator.rb
@@ -2,10 +2,9 @@
 
 module ResultsValidators
   class GenericValidator
-    attr_reader :errors, :warnings, :infos, :apply_fixes
+    attr_reader :errors, :warnings, :infos
 
-    def initialize(apply_fixes: false)
-      @apply_fixes = apply_fixes
+    def initialize
       reset_state
     end
 

--- a/lib/results_validators/positions_validator.rb
+++ b/lib/results_validators/positions_validator.rb
@@ -13,6 +13,11 @@ module ResultsValidators
       true
     end
 
+    def initialize(apply_fixes: false)
+      super()
+      @apply_fixes = apply_fixes
+    end
+
     def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition


### PR DESCRIPTION
The `apply_fixes` field of GenericValidator is not actually supposed to be generic. It's actually required only for PositionsValidator. Hence, I'm moving the parameter to PositionsValidator.