### PR TITLE
Only load new relic instrumentation in prod

### DIFF
--- a/next-frontend/src/instrumentation.ts
+++ b/next-frontend/src/instrumentation.ts
@@ -1,5 +1,8 @@
 export async function register() {
-  if (process.env.NEXT_RUNTIME === "nodejs") {
+  if (
+    process.env.NEXT_RUNTIME === "nodejs" &&
+    process.env.NODE_ENV === "production"
+  ) {
     await import("newrelic");
   }
 }


### PR DESCRIPTION
oopsie, otherwise new relic complaints everytime you run `yarn dev`