### PR TITLE
Migrate Upload Results section of admin results page to react

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -192,11 +192,11 @@ class AdminController < ApplicationController
 
     # This makes sure the json structure is valid!
     if upload_json.import_to_inbox
-      competition.update!(results_submitted_at: Time.now) if competition.results_submitted_at.nil? && mark_result_submitted
+      competition.touch(:results_submitted_at) if competition.results_submitted_at.nil? && mark_result_submitted
       render status: :ok, json: { success: true }
     else
       render status: :unprocessable_entity, json: {
-        error: "Error importing JSON file.",
+        error: upload_json.errors.full_messages,
       }
     end
   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -28,7 +28,6 @@ class AdminController < ApplicationController
 
   def new_results
     @competition = competition_from_params
-    @upload_json = UploadJson.new
     @results_validator = ResultsValidators::CompetitionsResultsValidator.create_full_validation
     @results_validator.validate(@competition.id)
   end
@@ -181,23 +180,24 @@ class AdminController < ApplicationController
   end
 
   def create_results
-    @competition = competition_from_params
+    competition = competition_from_params
 
     # Do json analysis + insert record in db, then redirect to check inbox
     # (and delete existing record if any)
-    upload_json_params = params.require(:upload_json).permit(:results_file)
-    upload_json_params[:competition_id] = @competition.id
-    @upload_json = UploadJson.new(upload_json_params)
+    upload_json = UploadJson.new({
+                                   results_file: params.require(:results_file),
+                                   competition_id: competition.id,
+                                 })
+    mark_result_submitted = ActiveRecord::Type::Boolean.new.cast(params.require(:mark_result_submitted))
 
     # This makes sure the json structure is valid!
-    if @upload_json.import_to_inbox
-      @competition.update!(results_submitted_at: Time.now) if @competition.results_submitted_at.nil?
-      flash[:success] = "JSON file has been imported."
-      redirect_to competition_admin_upload_results_edit_path
+    if upload_json.import_to_inbox
+      competition.update!(results_submitted_at: Time.now) if competition.results_submitted_at.nil? && mark_result_submitted
+      render status: :ok, json: { success: true }
     else
-      @results_validator = ResultsValidators::CompetitionsResultsValidator.create_full_validation
-      @results_validator.validate(@competition.id)
-      render :new_results
+      render status: :unprocessable_entity, json: {
+        error: "Error importing JSON file.",
+      }
     end
   end
 

--- a/app/views/admin/new_results.html.erb
+++ b/app/views/admin/new_results.html.erb
@@ -18,11 +18,11 @@
     When you are done checking the results, you can go ahead and import them <%= link_to "here", competition_admin_import_results_path(@competition.id) %>.
   </p>
 
-  <%= render "results_submission/submit_json_panel",
-    upload_json: @upload_json,
-    action: competition_admin_upload_results_path,
-    already_has_submitted_result: @results_validator.any_results?
-  %>
+  <%= react_component("CompetitionResultSubmission/ImportResultsData", {
+    competitionId: @competition.id,
+    alreadyHasSubmittedResult: @results_validator.any_results?,
+    isWrtViewing: true,
+  }) %>
 
   <%= render "results_submission/check_results_panel", results_validator: @results_validator %>
 

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { Accordion, Container, Message } from 'semantic-ui-react';
+import UploadResultsJson from '../UploadResultsJson';
+import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvider';
+
+export default function Wrapper({
+  competitionId,
+  alreadyHasSubmittedResult,
+  isWrtViewing,
+}) {
+  return (
+    <WCAQueryClientProvider>
+      <ImportResultsData
+        competitionId={competitionId}
+        alreadyHasSubmittedResult={alreadyHasSubmittedResult}
+        isWrtViewing={isWrtViewing}
+      />
+    </WCAQueryClientProvider>
+  );
+}
+
+function ImportResultsData({
+  competitionId,
+  alreadyHasSubmittedResult,
+  isWrtViewing,
+}) {
+  const [activeAccordion, setActiveAccordion] = useState(!alreadyHasSubmittedResult);
+
+  return (
+    <Container fluid>
+      <Accordion fluid styled>
+        <Accordion.Title
+          active={activeAccordion}
+          onClick={() => setActiveAccordion((prevValue) => !prevValue)}
+        >
+          Import Results Data
+        </Accordion.Title>
+        <Accordion.Content active={activeAccordion}>
+          {alreadyHasSubmittedResult
+            ? (
+              <Message warning>
+                Some results are already there, importing results data again will override all
+                of them!
+              </Message>
+            )
+            : (
+              <Message info>
+                Please start by selecting a JSON file to import.
+              </Message>
+            )}
+          <UploadResultsJson
+            competitionId={competitionId}
+            isWrtViewing={isWrtViewing}
+          />
+        </Accordion.Content>
+      </Accordion>
+    </Container>
+  );
+}

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
@@ -36,18 +36,14 @@ function ImportResultsData({
           Import Results Data
         </Accordion.Title>
         <Accordion.Content active={activeAccordion}>
-          {alreadyHasSubmittedResult
-            ? (
-              <Message warning>
-                Some results are already there, importing results data again will override all
-                of them!
-              </Message>
-            )
-            : (
-              <Message info>
-                Please start by selecting a JSON file to import.
-              </Message>
-            )}
+          <Message
+            warning={alreadyHasSubmittedResult}
+            info={!alreadyHasSubmittedResult}
+          >
+            {alreadyHasSubmittedResult
+              ? 'Some results have already been uploaded before, importing results data again will override all of them!'
+              : 'Please start by selecting a JSON file to import.'}
+          </Message>
           <UploadResultsJson
             competitionId={competitionId}
             isWrtViewing={isWrtViewing}

--- a/app/webpacker/components/CompetitionResultSubmission/UploadResultsJson.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/UploadResultsJson.jsx
@@ -12,6 +12,9 @@ export default function UploadResultsJson({ competitionId, isWrtViewing }) {
   const { mutate: uploadResultsJsonMutate, error, isError } = useMutation({
     mutationFn: () => uploadResultsJson({ competitionId, resultFile, markResultSubmitted }),
     onSuccess: () => {
+      // Ideally page should not be reloaded, but this is currently required to re-render
+      // the rails HTML portion. Once that rails HTML portion is also migrated to React,
+      // then this reload will be removed.
       window.location.reload();
     },
   });
@@ -19,7 +22,7 @@ export default function UploadResultsJson({ competitionId, isWrtViewing }) {
   if (isError) return <Errored error={error} />;
 
   return (
-    <Form>
+    <Form onSubmit={uploadResultsJsonMutate}>
       <Form.Input
         type="file"
         onChange={(event) => setResultFile(event.target.files[0])}
@@ -33,7 +36,7 @@ export default function UploadResultsJson({ competitionId, isWrtViewing }) {
       )}
       <Form.Button
         disabled={!resultFile}
-        onClick={uploadResultsJsonMutate}
+        type="submit"
       >
         Upload JSON
       </Form.Button>

--- a/app/webpacker/components/CompetitionResultSubmission/UploadResultsJson.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/UploadResultsJson.jsx
@@ -1,0 +1,42 @@
+import { useMutation } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { Form } from 'semantic-ui-react';
+import uploadResultsJson from './api/uploadResultsJson';
+import useCheckboxState from '../../lib/hooks/useCheckboxState';
+import Errored from '../Requests/Errored';
+
+export default function UploadResultsJson({ competitionId, isWrtViewing }) {
+  const [resultFile, setResultFile] = useState();
+  const [markResultSubmitted, setMarkResultSubmitted] = useCheckboxState(isWrtViewing);
+
+  const { mutate: uploadResultsJsonMutate, error, isError } = useMutation({
+    mutationFn: () => uploadResultsJson({ competitionId, resultFile, markResultSubmitted }),
+    onSuccess: () => {
+      window.location.reload();
+    },
+  });
+
+  if (isError) return <Errored error={error} />;
+
+  return (
+    <Form>
+      <Form.Input
+        type="file"
+        onChange={(event) => setResultFile(event.target.files[0])}
+      />
+      {isWrtViewing && (
+        <Form.Checkbox
+          checked={markResultSubmitted}
+          onChange={setMarkResultSubmitted}
+          label="If results are not marked as submitted, mark it as submitted (this is only visible to WRT)"
+        />
+      )}
+      <Form.Button
+        disabled={!resultFile}
+        onClick={uploadResultsJsonMutate}
+      >
+        Upload JSON
+      </Form.Button>
+    </Form>
+  );
+}

--- a/app/webpacker/components/CompetitionResultSubmission/api/uploadResultsJson.js
+++ b/app/webpacker/components/CompetitionResultSubmission/api/uploadResultsJson.js
@@ -1,0 +1,23 @@
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+import { actionUrls } from '../../../lib/requests/routes.js.erb';
+
+export default async function uploadResultsJson({
+  competitionId,
+  resultFile,
+  markResultSubmitted,
+}) {
+  const formData = new FormData();
+  formData.append('results_file', resultFile);
+  formData.append('competition_id', competitionId);
+  formData.append('mark_result_submitted', markResultSubmitted);
+
+  const { data } = await fetchJsonOrError(
+    actionUrls.competitionResultSubmission.uploadResultsJson(competitionId),
+    {
+      method: 'POST',
+      body: formData,
+    },
+  );
+
+  return data;
+}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -306,13 +306,11 @@ export const actionUrls = {
   },
   competitionResultSubmission: {
     submitToWrt: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_submit_results_path("${competitionId}")) %>`,
+    uploadResultsJson: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_upload_results_path("${competitionId}")) %>`,
   },
   cronjob: {
     run: (cronjobName) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_cronjob_run_path(cronjob_name: "${cronjobName}")) %>`,
     reset: (cronjobName) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_cronjob_reset_path(cronjob_name: "${cronjobName}")) %>`,
-  },
-  competitionResultSubmission: {
-    uploadResultsJson: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_upload_results_path("${competitionId}")) %>`,
   },
 }
 

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -311,6 +311,9 @@ export const actionUrls = {
     run: (cronjobName) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_cronjob_run_path(cronjob_name: "${cronjobName}")) %>`,
     reset: (cronjobName) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_cronjob_reset_path(cronjob_name: "${cronjobName}")) %>`,
   },
+  competitionResultSubmission: {
+    uploadResultsJson: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_upload_results_path("${competitionId}")) %>`,
+  },
 }
 
 export const liveUrls = {


### PR DESCRIPTION
"Upload results" is a section through which the results JSON can be uploaded. This section is present in two different pages for two different set of users:
1. For Delegates - In competition page, open 'Submit Results'
2. For WRT - In competition page, open 'Admin Results' -> 'Upload and check results'

This PR is aimed at migrating just the WRT's view. The Delegate's view will be migrated in a later PR because currently anyway both have very separate backend controllers, and if both pages are migrated, it will change two controllers and there will be significant change in backend which I'm trying to avoid for now.

UI before uploading:
<img width="1277" alt="Screenshot 2025-06-16 at 16 11 23" src="https://github.com/user-attachments/assets/91926a04-9b77-490f-bac4-f4d377e1637f" />

Screen recording after upload:

https://github.com/user-attachments/assets/a959a728-c313-42aa-8290-57465114f3ad

Error case:

https://github.com/user-attachments/assets/82bc21d2-0cc6-4727-9f31-8c3957dcd65b

