### PR TITLE
Make rubymoney support offline

### DIFF
--- a/config/initializers/ruby_money.rb
+++ b/config/initializers/ruby_money.rb
@@ -21,7 +21,11 @@ if Rails.env.production? && EnvConfig.WCA_LIVE_SITE? && !EnvConfig.ASSETS_COMPIL
   Money.default_bank = mclb
 else
   eu_bank = EuCentralBank.new
-  eu_bank.update_rates
+  begin
+    eu_bank.update_rates
+  rescue SocketError, OpenURI::HTTPError => e
+    Rails.logger.warn "Failed to update EU Central Bank rates: #{e.message}. Using default rates."
+  end
   Money.default_bank = eu_bank
 end
 


### PR DESCRIPTION
Few months ago, there were some changes made related to RubyMoney, and because of those, currently developers cannot start server when there is no internet connection. This PR aims at silently catching no-internet error during local development.