### PR TITLE
Make -b optional in server connect script

### DIFF
--- a/rel/console.sh
+++ b/rel/console.sh
@@ -57,7 +57,7 @@ fi
 nextjs=false
 environment=""
 command="/rails/bin/rails c"
-while getopts ":e:b:nh" opt; do
+while getopts ":e:bnh" opt; do
   case $opt in
     e)
       environment=$OPTARG


### PR DESCRIPTION
Without this PR, it's not possible to run `./rel/console.sh -b -e staging`; `-b` expects an argument, it takes `-e` as the argument, and then specifying the environment fails. 

The PR's change makes an argument for `-b` optional