### PR TITLE
Fix role change email issue when leader is not present

### DIFF
--- a/app/mailers/role_change_mailer.rb
+++ b/app/mailers/role_change_mailer.rb
@@ -95,7 +95,7 @@ class RoleChangeMailer < ApplicationMailer
         ),
         UserRole::UserRoleEmailRecipient.new(
           name: 'Team/Committee Leader',
-          email: role.group.lead_user.email,
+          email: role.group.lead_user&.email,
           message: 'Informing as there is a new appointment in your Team/Committee.',
         ),
         UserRole::UserRoleEmailRecipient.new(
@@ -198,7 +198,7 @@ class RoleChangeMailer < ApplicationMailer
         ),
         UserRole::UserRoleEmailRecipient.new(
           name: 'Team/Committee Leader',
-          email: role.group.lead_user.email,
+          email: role.group.lead_user&.email,
           message: 'Informing as there was a change in your Team/Committee.',
         ),
       )
@@ -271,7 +271,7 @@ class RoleChangeMailer < ApplicationMailer
         ),
         UserRole::UserRoleEmailRecipient.new(
           name: 'Team/Committee Leader',
-          email: role.group.lead_user.email,
+          email: role.group.lead_user&.email,
           message: 'Informing as there is a role end in your Team/Committee.',
         ),
       )


### PR DESCRIPTION
New members have joined WEAT and this bug was discovered. WEAT is a team without leader, and teams/committees can exist without leaders, so raising this PR so that it won't fail if there is no leader for a team/committee.