### PR TITLE
Include Regional Delegates in reminder & nag emails

### DIFF
--- a/app/mailers/competitions_mailer.rb
+++ b/app/mailers/competitions_mailer.rb
@@ -109,10 +109,11 @@ class CompetitionsMailer < ApplicationMailer
 
   def submit_results_nag(competition)
     @competition = competition
+    senior_and_regional_delegates = delegates_to_senior_and_regional_delegates_email(competition.delegates)
     mail(
       from: UserGroup.teams_committees_group_weat.metadata.email,
       to: competition.delegates.pluck(:email),
-      cc: ["results@worldcubeassociation.org", "assistants@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
+      cc: ["results@worldcubeassociation.org", "assistants@worldcubeassociation.org"] + senior_and_regional_delegates,
       reply_to: "results@worldcubeassociation.org",
       subject: "#{competition.name} Results",
     )
@@ -120,21 +121,23 @@ class CompetitionsMailer < ApplicationMailer
 
   def submit_report_nag(competition)
     @competition = competition
+    senior_and_regional_delegates = delegates_to_senior_and_regional_delegates_email(competition.delegates)
     mail(
       from: UserGroup.teams_committees_group_weat.metadata.email,
       to: competition.delegates.pluck(:email),
-      cc: ["assistants@worldcubeassociation.org"] + delegates_to_senior_delegates_email(competition.delegates),
-      reply_to: delegates_to_senior_delegates_email(competition.delegates),
+      cc: ["assistants@worldcubeassociation.org"] + senior_and_regional_delegates,
+      reply_to: senior_and_regional_delegates,
       subject: "#{competition.name} Delegate Report",
     )
   end
 
   def submit_report_reminder(competition)
     @competition = competition
+    senior_and_regional_delegates = delegates_to_senior_and_regional_delegates_email(competition.delegates)
     mail(
       from: UserGroup.teams_committees_group_weat.metadata.email,
       to: competition.delegates.pluck(:email),
-      reply_to: delegates_to_senior_delegates_email(competition.delegates),
+      reply_to: senior_and_regional_delegates,
       subject: "Friendly reminder to submit #{competition.name} Delegate Report",
     )
   end
@@ -169,6 +172,12 @@ class CompetitionsMailer < ApplicationMailer
                    -> { I18n.t('users.mailer.registration_reminder_email.header', competition: competition.name) },
                    to: user.email,
                    reply_to: competition.organizers.pluck(:email)
+  end
+
+  private def delegates_to_senior_and_regional_delegates_email(delegates)
+    seniors = delegates.flat_map { |delegate| delegate.senior_delegates.map(&:email) }
+    regionals = delegates.flat_map { |delegate| delegate.regional_delegates.map(&:email) }
+    (seniors + regionals).uniq.compact
   end
 
   private def delegates_to_senior_delegates_email(delegates)


### PR DESCRIPTION
Originated by Guido's request in "Adding Regionals to Delay Warning Email" - logically, anywhere that a Senior Delegate is emailed, a Regional Delegate should also be emailed (otherwise, the Senior will just have to inform the regional delegate themselves). 

Thus, this PR 
- introduces a method to produce all senior and regional delegate emails for a given list of delegates
- removes the old methods that produced separate lists of seniors and regionals
- replaces all instances of senior delegate email generation with senior + regional delegate email generation (and moves to a variable for easier readability)