### PR TITLE
Fixed WC2025 banner issues at very small screen widths

### DIFF
--- a/app/views/posts/_wc2025.html.erb
+++ b/app/views/posts/_wc2025.html.erb
@@ -1,6 +1,6 @@
 <!-- I tried jumbotron-in-jumbotron, but it doesn't lead to the a visual distinction between the outer and inner boxes -->
 <div class="wc2025" id="wc2025-container">
-  <h2 class="wc2025-header">
+  <h2 class="wc2025-header hidden-xs">
     <%= "JULY 3-6: RUBIK'S WCA WORLD CHAMPIONSHIP 2025" %>
   </h2>
 

--- a/app/webpacker/stylesheets/homepage.scss
+++ b/app/webpacker/stylesheets/homepage.scss
@@ -129,6 +129,11 @@ footer {
     align-items: center;
     flex-wrap: wrap;
   }
+
+  .wc2025 {
+    padding: 1rem;
+    margin: 1rem auto;
+  }
 }
 
 .column-gap {


### PR DESCRIPTION
* Hide header at xs screen size
* Reduce padding/margin on `wc2025` parent component to stop logo/buttons colliding