### PR TITLE
Make Markdown converter field `virtual`

### DIFF
--- a/next-frontend/src/app/(payload)/payload/importMap.js
+++ b/next-frontend/src/app/(payload)/payload/importMap.js
@@ -23,6 +23,7 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { AccountRowLabel as AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
 import { SignInButton as SignInButton_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
+import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -49,5 +50,6 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "payload-authjs/components#AccountRowLabel": AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e,
-  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e
+  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e,
+  "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
 }

--- a/next-frontend/src/app/(payload)/payload/importMap.js
+++ b/next-frontend/src/app/(payload)/payload/importMap.js
@@ -23,7 +23,6 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { AccountRowLabel as AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
 import { SignInButton as SignInButton_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
-import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -50,6 +49,5 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "payload-authjs/components#AccountRowLabel": AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e,
-  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e,
-  "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
+  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e
 }

--- a/next-frontend/src/collections/helpers.ts
+++ b/next-frontend/src/collections/helpers.ts
@@ -37,13 +37,7 @@ export const markdownConvertedField = (
           });
         },
       ],
-      beforeChange: [
-        ({ siblingData }) => {
-          // Ensure that the markdown field is not saved in the database
-          delete siblingData[convertedName];
-          return null;
-        },
-      ],
     },
+    virtual: true,
   };
 };

--- a/next-frontend/src/collections/helpers.ts
+++ b/next-frontend/src/collections/helpers.ts
@@ -14,6 +14,7 @@ export const markdownConvertedField = (
 ): Field => {
   return {
     name: convertedName,
+    required: true,
     type: "textarea",
     admin: {
       hidden: true,

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -201,7 +201,7 @@ export interface Testimonial {
     };
     [k: string]: unknown;
   };
-  fullTestimonialMarkdown?: string | null;
+  fullTestimonialMarkdown: string;
   whoDunnit: string;
   updatedAt: string;
   createdAt: string;
@@ -229,7 +229,7 @@ export interface Announcement {
     };
     [k: string]: unknown;
   };
-  contentMarkdown?: string | null;
+  contentMarkdown: string;
   publishedAt: string;
   publishedBy: string | User;
   updatedAt: string;
@@ -1158,7 +1158,7 @@ export interface AboutUsPage {
           };
           [k: string]: unknown;
         };
-        contentMarkdown?: string | null;
+        contentMarkdown: string;
         buttons: {
           label: string;
           url: string;
@@ -1186,7 +1186,7 @@ export interface AboutUsPage {
           };
           [k: string]: unknown;
         };
-        contentMarkdown?: string | null;
+        contentMarkdown: string;
         id?: string | null;
         blockName?: string | null;
         blockType: 'simpleItem';
@@ -1207,7 +1207,7 @@ export interface AboutUsPage {
           };
           [k: string]: unknown;
         };
-        contentMarkdown?: string | null;
+        contentMarkdown: string;
         quotedPerson: string;
         id?: string | null;
         blockName?: string | null;
@@ -1238,7 +1238,7 @@ export interface PrivacyPage {
     };
     [k: string]: unknown;
   };
-  preambleMarkdown?: string | null;
+  preambleMarkdown: string;
   blocks: {
     title: string;
     content: {
@@ -1256,7 +1256,7 @@ export interface PrivacyPage {
       };
       [k: string]: unknown;
     };
-    contentMarkdown?: string | null;
+    contentMarkdown: string;
     id?: string | null;
     blockName?: string | null;
     blockType: 'privacyItem';
@@ -1287,7 +1287,7 @@ export interface DisclaimerPage {
       };
       [k: string]: unknown;
     };
-    contentMarkdown?: string | null;
+    contentMarkdown: string;
     id?: string | null;
     blockName?: string | null;
     blockType: 'disclaimerItem';


### PR DESCRIPTION
cf. https://payloadcms.com/posts/blog/learn-how-virtual-fields-can-help-solve-common-cms-challenges

It's basically just an optimization to make sure I don't have to delete the field myself. Using `virtual: true` makes Payload not even want to store it in the DB