### PR TITLE
Remove unused `:unpaid` trait

### DIFF
--- a/spec/factories/registrations.rb
+++ b/spec/factories/registrations.rb
@@ -112,12 +112,6 @@ FactoryBot.define do
       end
     end
 
-    trait :unpaid do
-      after(:create) do |registration|
-        FactoryBot.create(:registration_payment, registration: registration, user: registration.user)
-      end
-    end
-
     trait :paid_pending do
       competing_status { Registrations::Helper::STATUS_PENDING }
       paid


### PR DESCRIPTION
Checking what happens if I remove this trait from the `registration_payment` factory - as far as I can tell, it isn't used in the code