### PR TITLE
Add groupings for NextJS dependabot dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,18 @@ updates:
   directory: "/next-frontend"
   schedule:
     interval: weekly
+  groups:
+    react:
+      patterns:
+        - "react"
+        - "react-dom"
+    payload:
+      patterns:
+        - "payload"
+        - "@payloadcms/*"
+    chakra-ui:
+      patterns:
+        - "@chakra-ui/*"
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
Per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates, because I'm tired of updating a gazillion PayloadCMS dependencies individually and waiting for a 20 minute rebase each time because there's a conflict on the Yarn lockfile after (almost) each one