### PR TITLE
Fix nav visibility of Duplicate checker page

### DIFF
--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -78,14 +78,14 @@
             icon: "clone",
           }
         end
+        if current_user&.can_admin_results? && !(@competition.in_progress? || @competition.probably_over?)
+          nav_items << {
+            text: t('.menu.newcomer_checks'),
+            path: competition_newcomer_checks_path(@competition),
+            icon: "users",
+          }
+        end
         if current_user&.can_upload_competition_results?(@competition)
-          if current_user&.can_admin_results? && !@competition.probably_over?
-            nav_items << {
-              text: t('.menu.newcomer_checks'),
-              path: competition_newcomer_checks_path(@competition),
-              icon: "users",
-            }
-          end
           nav_items << {
             text: t('.menu.submit_results'),
             path: competition_submit_results_edit_path(@competition),


### PR DESCRIPTION
I messed up the Duplicate Checker visibility in navigation bar a bit. Ideally it should come only when the competition has not yet started.