### PR TITLE
Fixes on results submission form

### DIFF
--- a/app/webpacker/components/CompetitionResultSubmission/FormToWrt/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/FormToWrt/index.jsx
@@ -31,7 +31,7 @@ function FormToWrt({ competitionId, isErrorInPreviousUpload }) {
 
   const {
     mutate: submitToWrtMutate,
-    isLoading,
+    isPending,
     isSuccess,
     isError: isErrorInCurrentUpload,
     error: errorInSubmission,
@@ -41,7 +41,7 @@ function FormToWrt({ competitionId, isErrorInPreviousUpload }) {
     submitToWrtMutate({ competitionId, message });
   };
 
-  if (isLoading) return <Loading />;
+  if (isPending) return <Loading />;
   if (isSuccess) return <Message success>Thank you for submitting the results!</Message>;
   if (isErrorInPreviousUpload) return <Errored error={ERROR_MESSAGE_UPLOADED_RESULTS} />;
   if (isErrorInCurrentUpload) return <Errored error={errorInSubmission} />;

--- a/app/webpacker/components/CompetitionResultSubmission/api/submitToWrt.js
+++ b/app/webpacker/components/CompetitionResultSubmission/api/submitToWrt.js
@@ -1,8 +1,8 @@
-import { fetchWithAuthenticityToken } from '../../../lib/requests/fetchWithAuthenticityToken';
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
 import { actionUrls } from '../../../lib/requests/routes.js.erb';
 
 export default async function submitToWrt({ competitionId, message }) {
-  const { data } = await fetchWithAuthenticityToken(
+  const { data } = await fetchJsonOrError(
     actionUrls.competitionResultSubmission.submitToWrt(competitionId),
     {
       method: 'POST',


### PR DESCRIPTION
A couple of bugs were noticed:
1. Instead of `isPending`, I used `isLoading`.
2. I didn't knew `fetchWithAuthenticityToken` won't catch errors. When an error was thrown by backend, it was not thrown back to mutation.