### PR TITLE
Fix ticket creation log

### DIFF
--- a/app/models/ticket_log.rb
+++ b/app/models/ticket_log.rb
@@ -2,6 +2,7 @@
 
 class TicketLog < ApplicationRecord
   enum :action_type, {
+    created: "created",
     status_updated: "status_updated",
   }
   belongs_to :ticket

--- a/app/models/tickets_edit_person.rb
+++ b/app/models/tickets_edit_person.rb
@@ -53,8 +53,7 @@ class TicketsEditPerson < ApplicationRecord
 
       TicketLog.create!(
         ticket_id: ticket.id,
-        action_type: TicketLog.action_types[:status_updated],
-        action_value: TicketsEditPerson.statuses[:open],
+        action_type: TicketLog.action_types[:created],
         acting_user_id: requester.id,
         acting_stakeholder_id: requester_stakeholder.id,
       )

--- a/app/webpacker/components/Tickets/TicketLogs.jsx
+++ b/app/webpacker/components/Tickets/TicketLogs.jsx
@@ -14,6 +14,8 @@ export default function TicketLogs({ ticketId }) {
 
   function logText(actionType, actionValue) {
     switch (actionType) {
+      case ticketLogActionTypes.created:
+        return 'Ticket created.';
       case ticketLogActionTypes.status_updated:
         return `Status updated to ${actionValue}`;
       default:


### PR DESCRIPTION
Earlier, while creating the ticket, the log added was "update status" which was not right. So now fixing it by creating a new log type which is to create log.