### PR TITLE
Redirect `teams-committees-councils` to `teams-committees`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -801,7 +801,7 @@ en:
         wapc: "The WCA Appeals Committee (WAC) reviews and resolves appeals regarding decisions made by other WCA Volunteers. The WAC provides an independent and impartial review process to ensure that decisions are fair, reasonable, and in accordance with WCA policies and regulations."
     contacts:
       title: "WCA Contact Form"
-      faq_note_html: 'Before making an inquiry, you may wish to take a look at our <a href="/faq">Frequently Asked Questions</a>! If you wish to contact a specific committee or team not listed here, you may check their details on <a href="/teams-committees-councils">this page</a>.'
+      faq_note_html: 'Before making an inquiry, you may wish to take a look at our <a href="/faq">Frequently Asked Questions</a>! If you wish to contact a specific committee or team not listed here, you may check their details on <a href="/teams-committees">this page</a>.'
       success_message: "Email sent - we'll get back to you soon."
       prefilled: "To update your registration, you need to contact the organizers of the competition. We have prefilled the contact form with your requested changes - please submit the form."
       form:

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -1515,7 +1515,7 @@ eu:
         Kontsulta bat egin aurretik, baliteke gure <a href="/faq">Ohiko
         Galderak</a> ikusi nahi izatea! Hemen aipatu ez den komite edo talde
         jakin batekin harremanetan jarri nahi baduzu, kontsultatu zehaztasunak
-        <a href="/teams-committees-councils">orri honetan</a>.
+        <a href="/teams-committees">orri honetan</a>.
       #original_hash: ea20be0
       success_message: Mezu elektronikoa bidalita - laster itzuliko gatzaizkizu.
       #original_hash: 8fa6b95

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1451,7 +1451,7 @@ fi:
         Ennen kysymyksen lähettämistä, luethan <a href="/faq">usein kysytyt
         kysymykset</a>! Jos haluat ottaa yhteyttä tiettyyn toimikuntaan, jota ei
         ole lueteltu tässä, löydät tiedot <a
-        href="/teams-committees-councils">tältä sivulta</a>.
+        href="/teams-committees">tältä sivulta</a>.
       #original_hash: ea20be0
       success_message: Viesti lähetetty - palaamme asiaan pian.
       form:

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -1563,7 +1563,7 @@ fr-CA:
         href="/faq">Foire Aux Questions</a> ! Si vous souhaitez contacter un
         comité ou une équipe spécifique qui ne figure pas dans la liste, vous
         pouvez consulter ses coordonnées sur <a
-        href="/teams-committees-councils">cette page</a>.
+        href="/teams-committees">cette page</a>.
       #original_hash: 597b791
       success_message: Courriel envoyé - nous vous répondrons sous peu.
       #original_hash: a38a97d
@@ -5337,7 +5337,7 @@ fr-CA:
       différentes et nous n'avons pas l'intention de ralentir de sitôt! La
       communauté du cube a connu une croissance constante depuis sa création en
       2004 et nous voulons l'encourager à continuer à l'avenir en augmentant
-      l'accessibilité des compétitions dans de nouvelles régions. 
+      l'accessibilité des compétitions dans de nouvelles régions.
 
       Dans le futur, nous espérons soutenir notre communauté encore plus à
       travers des collaborations et des contacts avec ceux qui s'intéressent aux

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1563,7 +1563,7 @@ fr:
         href="/faq">Foire Aux Questions</a> ! Si vous souhaitez contacter un
         comité ou une équipe spécifique qui ne figure pas dans la liste, vous
         pouvez consulter ses coordonnées sur <a
-        href="/teams-committees-councils">cette page</a>.
+        href="/teams-committees">cette page</a>.
       #original_hash: ea20be0
       success_message: E-mail envoyé - nous vous répondrons sous peu.
       #original_hash: 8fa6b95
@@ -5336,7 +5336,7 @@ fr:
       différentes et nous n'avons pas l'intention de ralentir de sitôt! La
       communauté du cube a connu une croissance constante depuis sa création en
       2004 et nous voulons l'encourager à continuer à l'avenir en augmentant
-      l'accessibilité des compétitions dans de nouvelles régions. 
+      l'accessibilité des compétitions dans de nouvelles régions.
 
       Dans le futur, nous espérons soutenir notre communauté encore plus à
       travers des collaborations et des contacts avec ceux qui s'intéressent aux

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1499,7 +1499,7 @@ hr:
         Prije postavljanja upita, možda biste željeli pogledati naša <a
         href="/faq">Često postavljana pitanja</a>! Ako želite kontaktirati
         određeni odbor ili tim koji nije ovdje naveden, možete provjeriti
-        njihove podatke na <a href="/teams-committees-councils">ovoj
+        njihove podatke na <a href="/teams-committees">ovoj
         stranici</a>.
       #original_hash: ea20be0
       success_message: Email poslan - javit ćemo vam se u najbržem roku.

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1489,7 +1489,7 @@ id:
         yang Sering Diajukan</a> kami terlebih dahulu! Jika Anda ingin
         menghubungi komite atau tim spesifik yang tidak tertulis di sini, Anda
         dapat menemukan informasi kontak mereka pada <a
-        href="/teams-committees-councils">halaman ini</a>.
+        href="/teams-committees">halaman ini</a>.
       form:
         user_data:
           name:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1538,7 +1538,7 @@ it:
         Prima di fare una domanda, potresti dare un'occhiata alle nostre <a
         href="/faq">Domande Frequenti</a>! Se desideri contattare uno specifico
         team o commissione che non è elencata qui, puoi trovare i loro contatti
-        in <a href="/teams-committees-councils">questa pagina</a>.
+        in <a href="/teams-committees">questa pagina</a>.
       #original_hash: ea20be0
       success_message: Email inviata. Ti ricontatteremo presto.
       #original_hash: 8fa6b95

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1377,7 +1377,7 @@ ko:
       #original_hash: bddd3ea
       faq_note_html: >-
         문의하기 전에 <a href="/faq">자주 묻는 질문</a>을 살펴보십시오! 여기에 나열되지 않은 특정 위원회나 팀에
-        연락하려면 <a href="/teams-committees-councils">이 페이지</a>에서 자세한 내용을 확인할 수
+        연락하려면 <a href="/teams-committees">이 페이지</a>에서 자세한 내용을 확인할 수
         있습니다.
       #original_hash: ea20be0
       success_message: 이메일이 전송되었습니다. 곧 답변드리겠습니다.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1530,7 +1530,7 @@ pl:
         href="/faq">Najczęściej zadawanych pytań</a>! Jeżeli chcesz się
         skontaktować z konkretnym komitetem bądź zespołem nie podanym tutaj
         możesz znaleźć ich informacje kontaktowe na <a
-        href="/teams-committees-councils">tej stronie</a>.
+        href="/teams-committees">tej stronie</a>.
       #original_hash: ea20be0
       success_message: E-mail wysłany - odezwiemy sie do Ciebie wkrótce.
       #original_hash: 8fa6b95

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1479,7 +1479,7 @@ pt-BR:
         Antes de fazer uma questão, você pode querer dar uma olhada nas nossas
         <a href="/faq">Questõs Frequentes</a>! Se você quer contatar um comitê
         ou equipe específico não listado aqui, você pode ver os detalhes <a
-        href="/teams-committees-councils">nesta página</a>.
+        href="/teams-committees">nesta página</a>.
       #original_hash: ea20be0
       success_message: E-mail enviado - retornaremos em breve.
       form:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1517,7 +1517,7 @@ pt:
         Antes de colocar uma questão, pode dar uma olhada nas nossas <a
         href="/faq">Perguntas Frequentes</a>! Se desejar entrar em contacto com
         um comité ou equipa específica não listada aqui, poderá encontrar as
-        suas informações de contacto <a href="/teams-committees-councils">nesta
+        suas informações de contacto <a href="/teams-committees">nesta
         página</a>.
       #original_hash: ea20be0
       success_message: Email enviado - entraremos em contacto em breve.

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1037,7 +1037,7 @@ th:
             #original_hash: f82488f
             2fa_attempt: >-
               คุณกำลังเข้าระบบของ WCA, คุณได้เปิดการใช้งานการยืนยันตัวตน 2
-              ขั้นตอน และคุณเพิ่งจะขอให้ส่ง one-time password ด้วย email 
+              ขั้นตอน และคุณเพิ่งจะขอให้ส่ง one-time password ด้วย email
               กรุณาดูด้านล่าง
             #original_hash: 8aeccbf
             disclaimer: >-
@@ -1484,7 +1484,7 @@ th:
         ของเรา!
         หากคุณต้องการติดต่อคณะกรรมการหรือทีมใดโดยเฉพาะที่ไม่ได้ระบุไว้ที่นี่
         คุณสามารถดูข้อมูลติดต่อได้ที่<a
-        href="/teams-committees-councils">หน้านี้</a>
+        href="/teams-committees">หน้านี้</a>
       #original_hash: ea20be0
       success_message: ส่งอีเมลแล้ว - เราจะติดต่อกลับโดยเร็วที่สุด
       #original_hash: 8fa6b95
@@ -1919,7 +1919,7 @@ th:
       have_wca_id_html: 'WCA ID ของคุณคือ %{link_id}'
       #original_hash: bf654e1
       account_is_special: >-
-        WCA ID และบัญชีผู้ใช้ได้เชื่อมต่อกันแล้วด้วยตำแหน่งพิเศษ (เช่น 
+        WCA ID และบัญชีผู้ใช้ได้เชื่อมต่อกันแล้วด้วยตำแหน่งพิเศษ (เช่น
         delegate, ผู้จัดการแข่งขัน, สมาชิกทีม) และไม่สามารถลบได้ กรุณาส่ง email
         มาที่ WCA Result Team เพื่อช่วยเปลี่ยน WCA ID ไปยังบัญชีผู้ใช้อื่น
       cannot_edit:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1489,7 +1489,7 @@ vi:
         Trước khi gửi đơn, bạn nên xem qua các <a href="/faq">Câu hỏi Thường
         gặp!</a>! Nếu bạn muốn liên hệ một ủy ban hoặc đội ngũ không có tên ở
         đây, vui lòng xem thông tin liên lạck tại <a
-        href="/teams-committees-councils">trang này</a>.
+        href="/teams-committees">trang này</a>.
       #original_hash: ea20be0
       success_message: Đã gửi email - chúng tôi sẽ sớm hồi âm lại đến bạn.
       #original_hash: 8fa6b95

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1309,7 +1309,7 @@ zh-TW:
       #original_hash: bddd3ea
       faq_note_html: >-
         在詢問前，也許您可以先看看我們的<a href="/faq">常見問題</a>！如果您想要聯絡這邊沒有列出的特定委員會或團隊，你可以試試在<a
-        href="/teams-committees-councils">這個頁面</a>找到詳細資訊。
+        href="/teams-committees">這個頁面</a>找到詳細資訊。
       #original_hash: ea20be0
       success_message: 已送出電子郵件 - 我們會盡快回覆您。
       #original_hash: 8fa6b95

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -452,7 +452,7 @@ Rails.application.routes.draw do
   end
 
   # Deprecated Links
-  get 'teams-committees' => redirect('teams-committees-councils')
+  get 'teams-committees-councils' => redirect('teams-committees')
   get 'panel/delegate-crash-course' => redirect('panel/delegate#delegate-handbook')
   get 'panel' => redirect('panel/volunteer')
 end


### PR DESCRIPTION
`/teams-committees-councils` still get used occasionally, generating support queries - hardlinks somewhere on the internet, I guess. This redirect makes use of an old (now irrelevant) redirect from when the page was initially changed to `teams-committees-councils` - which we've now changed back, so we can swap the redirect 