### PR TITLE
Add delegate probation panel and permissions to WEAT

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -754,6 +754,7 @@ class User < ApplicationRecord
         name: 'WEAT panel',
         pages: [
           panel_pages[:bannedCompetitors],
+          panel_pages[:delegateProbations],
         ],
       },
     }
@@ -1383,7 +1384,7 @@ class User < ApplicationRecord
   end
 
   private def can_manage_delegate_probation?
-    admin? || board_member? || senior_delegate? || can_access_wfc_senior_matters? || group_leader?(UserGroup.teams_committees_group_wic)
+    admin? || board_member? || senior_delegate? || can_access_wfc_senior_matters? || group_leader?(UserGroup.teams_committees_group_wic) || weat_team?
   end
 
   def senior_delegates


### PR DESCRIPTION
Per Nick's request in "WEAT Access to Delegate Probations":
> Can we get WEAT access to the Delegate Probation page on their panel, as well as the ability to add/remove people from the panel? Thanks!

This seems straightforward - I've tested locally and was able to (a) access the panel, and (b) add/change delegate probations.
