### PR TITLE
Create tickets for competition results

### DIFF
--- a/app/controllers/admin/results_controller.rb
+++ b/app/controllers/admin/results_controller.rb
@@ -47,8 +47,7 @@ module Admin
 
       ActiveRecord::Base.transaction do
         @updated_competitions.update(posting_user: current_user)
-        ticket_competition_result_ids = @updated_competitions.joins(:tickets_competition_result).pluck('tickets_competition_result.id')
-        TicketsCompetitionResult.where(id: ticket_competition_result_ids)
+        TicketsCompetitionResult.where(competition: @updated_competitions)
                                 .update_all(status: TicketsCompetitionResult.statuses[:warnings_verification])
       end
 

--- a/app/controllers/admin/results_controller.rb
+++ b/app/controllers/admin/results_controller.rb
@@ -46,9 +46,9 @@ module Admin
       return render json: { error: "No competitions to lock." } if @updated_competitions.empty?
 
       ActiveRecord::Base.transaction do
-        @updated_competitions.update(posting_user: current_user)
         TicketsCompetitionResult.where(competition: @updated_competitions)
                                 .update_all(status: TicketsCompetitionResult.statuses[:warnings_verification])
+        @updated_competitions.update(posting_user: current_user)
       end
 
       render json: { message: "Competitions successfully locked, go on posting!" }

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -120,7 +120,7 @@ class CompetitionsController < ApplicationController
       comp.registrations.accepted.each { |registration| registration.user.maybe_assign_wca_id_by_results(comp) }
       if comp.tickets_competition_result.present?
         comp.tickets_competition_result.update!(
-          status: TicketsCompetitionResult.statuses[:closed],
+          status: TicketsCompetitionResult.statuses[:posted],
         )
       end
     end

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -118,6 +118,11 @@ class CompetitionsController < ApplicationController
       comp.update!(results_posted_at: Time.now, results_posted_by: current_user.id, posting_by: nil)
       comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
       comp.registrations.accepted.each { |registration| registration.user.maybe_assign_wca_id_by_results(comp) }
+      if comp.tickets_competition_result.present?
+        comp.tickets_competition_result.update!(
+          status: TicketsCompetitionResult.statuses[:closed],
+        )
+      end
     end
 
     flash[:success] = t('competitions.messages.results_posted')

--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -151,9 +151,9 @@ class ResultsSubmissionController < ApplicationController
     message = params.require(:message)
     results_validator = ResultsValidators::CompetitionsResultsValidator.create_full_validation.validate(competition.id)
 
-    render status: :unprocessable_entity, json: { error: "Submitted results contain errors." } if results_validator.any_errors?
+    return render status: :unprocessable_entity, json: { error: "Submitted results contain errors." } if results_validator.any_errors?
 
-    render status: :unprocessable_entity, json: { error: "There is already a ticket associated, please contact WRT to update this." } if competition.result_ticket.present?
+    return render status: :unprocessable_entity, json: { error: "There is already a ticket associated, please contact WRT to update this." } if competition.result_ticket.present?
 
     CompetitionsMailer.results_submitted(competition, results_validator, message, current_user).deliver_now
 

--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -159,7 +159,7 @@ class ResultsSubmissionController < ApplicationController
 
     ActiveRecord::Base.transaction do
       competition.touch(:results_submitted_at)
-      TicketsCompetitionResult.create_ticket(competition.id, message, current_user)
+      TicketsCompetitionResult.create_ticket!(competition.id, message, current_user)
     end
 
     render status: :ok, json: { success: true }

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -41,6 +41,8 @@ class Competition < ApplicationRecord
   has_many :accepted_registrations, -> { accepted }, class_name: "Registration", foreign_key: "competition_id"
   has_many :accepted_newcomers, -> { where(wca_id: nil) }, through: :accepted_registrations, source: :user
   has_many :duplicate_checker_job_runs, dependent: :delete_all
+  has_one :tickets_competition_result
+  has_one :result_ticket, through: :tickets_competition_result, source: :ticket
 
   accepts_nested_attributes_for :competition_events, allow_destroy: true
   accepts_nested_attributes_for :championships, allow_destroy: true
@@ -709,7 +711,9 @@ class Competition < ApplicationRecord
              'scramble_file_uploads',
              'accepted_registrations',
              'accepted_newcomers',
-             'duplicate_checker_job_runs'
+             'duplicate_checker_job_runs',
+             'tickets_competition_result',
+             'result_ticket'
           # Do nothing as they shouldn't be cloned.
         when 'organizers'
           clone.organizers = organizers

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -3,6 +3,7 @@
 class Ticket < ApplicationRecord
   TICKET_TYPES = {
     edit_person: "TicketsEditPerson",
+    competition_result: "TicketsCompetitionResult",
   }.freeze
 
   has_many :ticket_comments

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -19,7 +19,7 @@ class TicketsCompetitionResult < ApplicationRecord
     end
   end
 
-  def self.create_ticket(competition_id, delegate_message, submitted_delegate)
+  def self.create_ticket!(competition_id, delegate_message, submitted_delegate)
     ticket_metadata = TicketsCompetitionResult.create!(
       status: TicketsCompetitionResult.statuses[:submitted],
       competition_id: competition_id,

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -7,7 +7,7 @@ class TicketsCompetitionResult < ApplicationRecord
     submitted: "submitted",
     warnings_verification: "warnings_verification",
     results_verification: "results_verification",
-    closed: "closed",
+    posted: "posted",
   }
 
   has_one :ticket, as: :metadata

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class TicketsCompetitionResult < ApplicationRecord
+  self.table_name = "tickets_competition_result"
+
+  enum :status, {
+    submitted: "submitted",
+    warnings_verification: "warnings_verification",
+    results_verification: "results_verification",
+    closed: "closed",
+  }
+
+  has_one :ticket, as: :metadata
+
+  def action_user_groups(action)
+    case action
+    when :update_status
+      [UserGroup.teams_committees_group_wrt]
+    end
+  end
+
+  def self.create_ticket(competition_id, delegate_message, submitted_delegate)
+    ticket_metadata = TicketsCompetitionResult.create!(
+      status: TicketsCompetitionResult.statuses[:submitted],
+      competition_id: competition_id,
+      delegate_message: delegate_message,
+    )
+
+    ticket = Ticket.create!(metadata: ticket_metadata)
+
+    TicketStakeholder.create!(
+      ticket_id: ticket.id,
+      stakeholder: UserGroup.teams_committees_group_wrt,
+      connection: TicketStakeholder.connections[:assigned],
+      stakeholder_role: TicketStakeholder.stakeholder_roles[:actioner],
+      is_active: true,
+    )
+
+    submitted_delegate_stakeholder = TicketStakeholder.create!(
+      ticket_id: ticket.id,
+      stakeholder: submitted_delegate,
+      connection: TicketStakeholder.connections[:cc],
+      stakeholder_role: TicketStakeholder.stakeholder_roles[:requester],
+      is_active: true,
+    )
+
+    TicketLog.create!(
+      ticket_id: ticket.id,
+      action_type: TicketLog.action_types[:status_updated],
+      action_value: ticket_metadata.status,
+      acting_user_id: submitted_delegate.id,
+      acting_stakeholder_id: submitted_delegate_stakeholder.id,
+    )
+  end
+end

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -11,6 +11,7 @@ class TicketsCompetitionResult < ApplicationRecord
   }
 
   has_one :ticket, as: :metadata
+  belongs_to :competition
 
   def action_user_groups(action)
     case action

--- a/app/webpacker/components/PostingCompetitions/index.js
+++ b/app/webpacker/components/PostingCompetitions/index.js
@@ -16,6 +16,7 @@ import {
   adminImportResultsUrl,
   adminStartPostingUrl,
   competitionUrl,
+  viewUrls,
 } from '../../lib/requests/routes.js.erb';
 
 function stateReducer(accumulated, current) {
@@ -105,6 +106,13 @@ function PostingCompetitionsIndex({
                     href={adminImportResultsUrl(c.id)}
                   >
                     Import results page
+                  </Button>
+                  <Button
+                    target="_blank"
+                    color="red"
+                    href={viewUrls.tickets.show(c.result_ticket.id)}
+                  >
+                    Tickets page
                   </Button>
                 </>
               )}

--- a/app/webpacker/components/PostingCompetitions/index.js
+++ b/app/webpacker/components/PostingCompetitions/index.js
@@ -107,13 +107,15 @@ function PostingCompetitionsIndex({
                   >
                     Import results page
                   </Button>
-                  <Button
-                    target="_blank"
-                    color="red"
-                    href={viewUrls.tickets.show(c.result_ticket.id)}
-                  >
-                    Tickets page
-                  </Button>
+                  {c.result_ticket && (
+                    <Button
+                      target="_blank"
+                      color="red"
+                      href={viewUrls.tickets.show(c.result_ticket.id)}
+                    >
+                      Tickets page
+                    </Button>
+                  )}
                 </>
               )}
             </Button.Group>

--- a/app/webpacker/components/Tickets/TicketWorkbenches.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches.jsx
@@ -1,8 +1,14 @@
 import { ticketTypes, ticketStakeholderRoles } from '../../lib/wca-data.js.erb';
+import CompetitionResultActionerView from './TicketWorkbenches/CompetitionResultActionerView';
+import CompetitionResultRequesterView from './TicketWorkbenches/CompetitionResultRequesterView';
 import EditPersonActionerView from './TicketWorkbenches/EditPersonActionerView';
 
 export default {
   [ticketTypes.edit_person]: {
     [ticketStakeholderRoles.actioner]: EditPersonActionerView,
+  },
+  [ticketTypes.competition_result]: {
+    [ticketStakeholderRoles.actioner]: CompetitionResultActionerView,
+    [ticketStakeholderRoles.requester]: CompetitionResultRequesterView,
   },
 };

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/WarningsVerification.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/WarningsVerification.jsx
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+import { Button, Header, Segment } from 'semantic-ui-react';
+import runValidatorsForCompetitionList from '../../../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
+import { ALL_VALIDATORS, ticketsCompetitionResultStatuses } from '../../../../lib/wca-data.js.erb';
+import ValidationOutput from '../../../Panel/pages/RunValidatorsPage/ValidationOutput';
+
+export default function WarningsVerification({ ticketDetails, updateStatus }) {
+  const { ticket: { id, metadata } } = ticketDetails;
+  const {
+    data: validationOutput, isPending, isError, error,
+  } = useQuery({
+    queryKey: ['ticketCompetitionResultValidationOutput', id],
+    queryFn: () => runValidatorsForCompetitionList(metadata.competition_id, ALL_VALIDATORS, false),
+  });
+
+  return (
+    <>
+      <ValidationOutput
+        validationOutput={validationOutput}
+        isPending={isPending}
+        isError={isError}
+        error={error}
+      />
+      <Header>Delegate&apos;s message</Header>
+      <Segment>{ticketDetails.ticket.metadata.delegate_message}</Segment>
+      <Button
+        primary
+        onClick={() => updateStatus(ticketsCompetitionResultStatuses.results_verification)}
+      >
+        Warnings verified
+      </Button>
+    </>
+  );
+}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ticketsCompetitionResultStatuses } from '../../../../lib/wca-data.js.erb';
+import WarningsVerification from './WarningsVerification';
+import { adminImportResultsUrl } from '../../../../lib/requests/routes.js.erb';
+
+export default function CompetitionResultActionerView({ ticketDetails, updateStatus }) {
+  const { ticket: { metadata: { status, competition_id: competitionId } } } = ticketDetails;
+
+  switch (status) {
+    case ticketsCompetitionResultStatuses.submitted:
+      return <>Please lock the competition results from the Posting dashboard.</>;
+
+    case ticketsCompetitionResultStatuses.warnings_verification:
+      return (
+        <WarningsVerification
+          ticketDetails={ticketDetails}
+          updateStatus={updateStatus}
+        />
+      );
+
+    case ticketsCompetitionResultStatuses.results_verification:
+      return (
+        <>
+          Please finish the remaining steps in
+          {' '}
+          <a href={adminImportResultsUrl(competitionId)}>import results page</a>
+          .
+        </>
+      );
+
+    default:
+      return <>Unknown status</>;
+  }
+}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/index.jsx
@@ -8,7 +8,7 @@ export default function CompetitionResultActionerView({ ticketDetails, updateSta
 
   switch (status) {
     case ticketsCompetitionResultStatuses.submitted:
-      return <>Please lock the competition results from the Posting dashboard.</>;
+      return <p>Please lock the competition results from the Posting dashboard.</p>;
 
     case ticketsCompetitionResultStatuses.warnings_verification:
       return (
@@ -20,15 +20,15 @@ export default function CompetitionResultActionerView({ ticketDetails, updateSta
 
     case ticketsCompetitionResultStatuses.results_verification:
       return (
-        <>
+        <p>
           Please finish the remaining steps in
           {' '}
           <a href={adminImportResultsUrl(competitionId)}>import results page</a>
           .
-        </>
+        </p>
       );
 
     default:
-      return <>Unknown status</>;
+      return <p>Unknown status</p>;
   }
 }

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultRequesterView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultRequesterView/index.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 export default function CompetitionResultRequesterView() {
   return (
-    <>
+    <p>
       This ticket is only for WRT use. For any queries/requests, please message in
       the competition results email thread.
-    </>
+    </p>
   );
 }

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultRequesterView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultRequesterView/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function CompetitionResultRequesterView() {
+  return (
+    <>
+      This ticket is only for WRT use. For any queries/requests, please message in
+      the competition results email thread.
+    </>
+  );
+}

--- a/app/webpacker/lib/wca-data.js.erb
+++ b/app/webpacker/lib/wca-data.js.erb
@@ -237,6 +237,7 @@ export const ticketTypes = <%= Ticket::TICKET_TYPES.to_json %>;
 export const ticketStatuses = <%= Ticket::TICKET_TYPES.transform_values { |value| value.safe_constantize&.statuses }.to_json %>;
 export const ticketLogActionTypes = <%= TicketLog.action_types.to_json %>;
 export const ticketStakeholderRoles = <%= TicketStakeholder.stakeholder_roles.to_json %>;
+export const ticketsCompetitionResultStatuses = <%= TicketsCompetitionResult.statuses.to_json %>
 
 // ----- VALIDATORS -----
 export const ALL_VALIDATORS = <%= ResultsValidators::Utils::ALL_VALIDATORS.map(&:class_name) %>;

--- a/db/migrate/20250710084311_create_tickets_competition_result.rb
+++ b/db/migrate/20250710084311_create_tickets_competition_result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateTicketsCompetitionResult < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tickets_competition_result do |t|
+      t.string :status, null: false
+      t.references :competition, null: false, type: :string, foreign_key: true
+      t.text :delegate_message, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_20_074209) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_10_084311) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1357,6 +1357,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_20_074209) do
     t.index ["metadata_type", "metadata_id"], name: "index_tickets_on_metadata"
   end
 
+  create_table "tickets_competition_result", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "status", null: false
+    t.string "competition_id", null: false
+    t.text "delegate_message", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["competition_id"], name: "index_tickets_competition_result_on_competition_id"
+  end
+
   create_table "tickets_edit_person", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "status", null: false
     t.string "wca_id", null: false
@@ -1568,6 +1577,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_20_074209) do
   add_foreign_key "ticket_comments", "users", column: "acting_user_id"
   add_foreign_key "ticket_logs", "ticket_stakeholders", column: "acting_stakeholder_id"
   add_foreign_key "ticket_logs", "users", column: "acting_user_id"
+  add_foreign_key "tickets_competition_result", "competitions"
   add_foreign_key "user_avatars", "users"
   add_foreign_key "user_groups", "user_groups", column: "parent_group_id"
   add_foreign_key "user_roles", "user_groups", column: "group_id"

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -964,6 +964,7 @@ module DatabaseDumper
     "tickets_edit_person_fields" => :skip_all_rows,
     "duplicate_checker_job_runs" => :skip_all_rows,
     "potential_duplicate_persons" => :skip_all_rows,
+    "tickets_competition_result" => :skip_all_rows,
   }.freeze
 
   RESULTS_SANITIZERS = {


### PR DESCRIPTION
There is no significant impact as of now. WRT can still post the results the old way. This is basically the MVP, will eventually add more features.

The immediate improvement for WRT is that now WRT can view the warnings & delegate's message in the website itself.