### PR TITLE
Reuse common code between upload-json and import-live

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -54,7 +54,7 @@ class ResultsSubmissionController < ApplicationController
 
     temporary_results_data = upload_json.temporary_results_data
 
-    errors = CompetitionResults.import_temporary_results(
+    errors = CompetitionResultsImport.import_temporary_results(
       competition,
       temporary_results_data,
       mark_result_submitted: mark_result_submitted,
@@ -135,7 +135,7 @@ class ResultsSubmissionController < ApplicationController
       scrambles_to_import: scrambles_to_import,
       persons_to_import: persons_to_import,
     }
-    errors = CompetitionResults.import_temporary_results(competition, temporary_results_data)
+    errors = CompetitionResultsImport.import_temporary_results(competition, temporary_results_data)
 
     return render status: :unprocessable_entity, json: { error: errors } if errors.any?
 

--- a/app/models/upload_json.rb
+++ b/app/models/upload_json.rb
@@ -32,115 +32,88 @@ class UploadJson
     results_file.rewind
   end
 
-  # return true if successful, false if validation or record errors
-  def import_to_inbox
-    # This makes sure the json structure is valid!
-    if valid?
-      competition = Competition.includes(competition_events: [:rounds]).find(competition_id)
-      persons_to_import = []
-      parsed_json["persons"].each do |p|
-        new_person_attributes = {
-          id: p["id"],
-          wca_id: p["wcaId"],
-          competition_id: competition_id,
-          name: p["name"],
-          country_iso2: p["countryId"],
-          gender: p["gender"],
-          dob: p["dob"],
-        }
-        # mask uploaded DOB on staging to avoid accidentally importing PII
-        new_person_attributes["dob"] = "1954-12-04" if Rails.env.production? && !EnvConfig.WCA_LIVE_SITE?
-        persons_to_import << InboxPerson.new(new_person_attributes)
-      end
-      results_to_import = []
-      scrambles_to_import = []
-      parsed_json["events"].each do |event|
-        competition_event = competition.competition_events.find { |ce| ce.event_id == event["eventId"] }
-        event["rounds"].each do |round|
-          # Find the corresponding competition round and get the actual round_type_id
-          # (in case the incoming one doesn't correspond to cutoff presence).
-          incoming_round_type_id = round["roundId"]
-          competition_round = competition_event.rounds.find do |cr|
-            [incoming_round_type_id, RoundType.toggle_cutoff(incoming_round_type_id)].include?(cr.round_type_id)
-          end
-          round_type_id = competition_round&.round_type_id || incoming_round_type_id
+  def temporary_results_data
+    competition = Competition.includes(competition_events: [:rounds]).find(competition_id)
+    persons_to_import = []
+    parsed_json["persons"].each do |p|
+      new_person_attributes = {
+        id: p["id"],
+        wca_id: p["wcaId"],
+        competition_id: competition_id,
+        name: p["name"],
+        country_iso2: p["countryId"],
+        gender: p["gender"],
+        dob: p["dob"],
+      }
+      # mask uploaded DOB on staging to avoid accidentally importing PII
+      new_person_attributes["dob"] = "1954-12-04" if Rails.env.production? && !EnvConfig.WCA_LIVE_SITE?
+      persons_to_import << InboxPerson.new(new_person_attributes)
+    end
+    results_to_import = []
+    scrambles_to_import = []
+    parsed_json["events"].each do |event|
+      competition_event = competition.competition_events.find { |ce| ce.event_id == event["eventId"] }
+      event["rounds"].each do |round|
+        # Find the corresponding competition round and get the actual round_type_id
+        # (in case the incoming one doesn't correspond to cutoff presence).
+        incoming_round_type_id = round["roundId"]
+        competition_round = competition_event.rounds.find do |cr|
+          [incoming_round_type_id, RoundType.toggle_cutoff(incoming_round_type_id)].include?(cr.round_type_id)
+        end
+        round_type_id = competition_round&.round_type_id || incoming_round_type_id
 
-          # Import results for round
-          round["results"].each do |result|
-            individual_results = result["results"]
-            # Pad the results with 0 up to 5 results
-            individual_results.fill(0, individual_results.length...5)
-            new_result_attributes = {
-              person_id: result["personId"],
-              pos: result["position"],
-              event_id: event["eventId"],
-              round_type_id: round_type_id,
-              round_id: competition_round&.id,
-              format_id: round["formatId"],
-              best: result["best"],
-              average: result["average"],
-              value1: individual_results[0],
-              value2: individual_results[1],
-              value3: individual_results[2],
-              value4: individual_results[3],
-              value5: individual_results[4],
-            }
-            new_res = InboxResult.new(new_result_attributes)
-            # Using this way of setting the attribute saves one SELECT per result
-            # to validate the competition presence.
-            # (a lot of time considering all the results to import!)
-            new_res.competition = competition
-            results_to_import << new_res
-          end
+        # Import results for round
+        round["results"].each do |result|
+          individual_results = result["results"]
+          # Pad the results with 0 up to 5 results
+          individual_results.fill(0, individual_results.length...5)
+          new_result_attributes = {
+            person_id: result["personId"],
+            pos: result["position"],
+            event_id: event["eventId"],
+            round_type_id: round_type_id,
+            round_id: competition_round&.id,
+            format_id: round["formatId"],
+            best: result["best"],
+            average: result["average"],
+            value1: individual_results[0],
+            value2: individual_results[1],
+            value3: individual_results[2],
+            value4: individual_results[3],
+            value5: individual_results[4],
+          }
+          new_res = InboxResult.new(new_result_attributes)
+          # Using this way of setting the attribute saves one SELECT per result
+          # to validate the competition presence.
+          # (a lot of time considering all the results to import!)
+          new_res.competition = competition
+          results_to_import << new_res
+        end
 
-          # Import scrambles for round
-          round["groups"].each do |group|
-            %w[scrambles extraScrambles].each do |scramble_type|
-              group[scramble_type]&.each_with_index do |scramble, index|
-                new_scramble_attributes = {
-                  competition_id: competition_id,
-                  event_id: event["eventId"],
-                  round_type_id: round_type_id,
-                  round_id: competition_round&.id,
-                  group_id: group["group"],
-                  is_extra: scramble_type == "extraScrambles",
-                  scramble_num: index + 1,
-                  scramble: scramble,
-                }
-                scrambles_to_import << Scramble.new(new_scramble_attributes)
-              end
+        # Import scrambles for round
+        round["groups"].each do |group|
+          %w[scrambles extraScrambles].each do |scramble_type|
+            group[scramble_type]&.each_with_index do |scramble, index|
+              new_scramble_attributes = {
+                competition_id: competition_id,
+                event_id: event["eventId"],
+                round_type_id: round_type_id,
+                round_id: competition_round&.id,
+                group_id: group["group"],
+                is_extra: scramble_type == "extraScrambles",
+                scramble_num: index + 1,
+                scramble: scramble,
+              }
+              scrambles_to_import << Scramble.new(new_scramble_attributes)
             end
           end
         end
       end
-      begin
-        ActiveRecord::Base.transaction do
-          InboxPerson.where(competition_id: competition_id).delete_all
-          InboxResult.where(competition_id: competition_id).delete_all
-          Scramble.where(competition_id: competition_id).delete_all
-          InboxPerson.import!(persons_to_import)
-          Scramble.import!(scrambles_to_import)
-          InboxResult.import!(results_to_import)
-        end
-        true
-      rescue ActiveRecord::RecordNotUnique
-        errors.add(:results_file, "Duplicate record found while uploading results. Maybe there is a duplicate personId in the JSON?")
-        false
-      rescue ActiveRecord::RecordInvalid => e
-        object = e.record
-        if object.instance_of?(Scramble)
-          errors.add(:results_file, "Scramble in '#{Round.name_from_attributes_id(object.event_id, object.round_type_id)}' is invalid (#{e.message}), please fix it!")
-        elsif object.instance_of?(InboxPerson)
-          errors.add(:results_file, "Person #{object.name} is invalid (#{e.message}), please fix it!")
-        elsif object.instance_of?(InboxResult)
-          errors.add(:results_file, "Result for person #{object.person_id} in '#{Round.name_from_attributes_id(object.event_id, object.round_type_id)}' is invalid (#{e.message}), please fix it!")
-        else
-          errors.add(:results_file, "An invalid record prevented the results from being created: #{e.message}")
-        end
-        false
-      end
-    else
-      false
     end
+    {
+      results_to_import: results_to_import,
+      scrambles_to_import: scrambles_to_import,
+      persons_to_import: persons_to_import,
+    }
   end
 end

--- a/lib/competition_results.rb
+++ b/lib/competition_results.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module CompetitionResults
+  def self.import_temporary_results(competition, temporary_results_data, mark_result_submitted: false, store_uploaded_json: false, results_json_str: nil)
+    errors = []
+    results_to_import = temporary_results_data[:results_to_import]
+    scrambles_to_import = temporary_results_data[:scrambles_to_import]
+    persons_to_import = temporary_results_data[:persons_to_import]
+
+    ActiveRecord::Base.transaction do
+      InboxPerson.where(competition_id: competition.id).delete_all
+      InboxResult.where(competition_id: competition.id).delete_all
+      Scramble.where(competition_id: competition.id).delete_all
+      InboxPerson.import!(persons_to_import)
+      Scramble.import!(scrambles_to_import)
+      InboxResult.import!(results_to_import)
+
+      competition.touch(:results_submitted_at) if mark_result_submitted && !competition.results_submitted?
+
+      competition.uploaded_jsons.create!(json_str: results_json_str) if store_uploaded_json
+    rescue ActiveRecord::RecordNotUnique
+      errors << "Duplicate record found while uploading results. Maybe there is a duplicate personId in the JSON?"
+    rescue ActiveRecord::RecordInvalid => e
+      object = e.record
+      errors << if object.instance_of?(Scramble)
+                  "Scramble in '#{Round.name_from_attributes_id(object.event_id, object.round_type_id)}' is invalid (#{e.message}), please fix it!"
+                elsif object.instance_of?(InboxPerson)
+                  "Person #{object.name} is invalid (#{e.message}), please fix it!"
+                elsif object.instance_of?(InboxResult)
+                  "Result for person #{object.person_id} in '#{Round.name_from_attributes_id(object.event_id, object.round_type_id)}' is invalid (#{e.message}), please fix it!"
+                else
+                  "An invalid record prevented the results from being created: #{e.message}"
+                end
+    end
+
+    errors
+  end
+end

--- a/lib/competition_results_import.rb
+++ b/lib/competition_results_import.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module CompetitionResults
+module CompetitionResultsImport
   def self.import_temporary_results(competition, temporary_results_data, mark_result_submitted: false, store_uploaded_json: false, results_json_str: nil)
     errors = []
     results_to_import = temporary_results_data[:results_to_import]

--- a/spec/models/upload_json_spec.rb
+++ b/spec/models/upload_json_spec.rb
@@ -59,10 +59,17 @@ RSpec.describe UploadJson do
 
     upload_json = build(:upload_json, competition_id: competition.id, results_json_str: results_json)
     temporary_results_data = upload_json.temporary_results_data
+    CompetitionResults.import_temporary_results(
+      competition,
+      temporary_results_data,
+      mark_result_submitted: false,
+      store_uploaded_json: true,
+      results_json_str: upload_json.results_json_str,
+    )
 
-    expect(upload_json.valid?).to be true
-    expect(temporary_results_data[:results_to_import].count).to eq 1
-    inbox_result = temporary_results_data[:results_to_import].first
+    expect(upload_json).to be_valid
+    expect(InboxResult.count).to eq 1
+    inbox_result = InboxResult.first
     # There is no cutoff, so the incoming round_type_id "c" should be converted to "f"
     expect(inbox_result.round_type_id).to eq "f"
   end

--- a/spec/models/upload_json_spec.rb
+++ b/spec/models/upload_json_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe UploadJson do
 
     upload_json = build(:upload_json, competition_id: competition.id, results_json_str: results_json)
     temporary_results_data = upload_json.temporary_results_data
-    CompetitionResults.import_temporary_results(
+    CompetitionResultsImport.import_temporary_results(
       competition,
       temporary_results_data,
       mark_result_submitted: false,

--- a/spec/models/upload_json_spec.rb
+++ b/spec/models/upload_json_spec.rb
@@ -58,10 +58,11 @@ RSpec.describe UploadJson do
     }.to_json
 
     upload_json = build(:upload_json, competition_id: competition.id, results_json_str: results_json)
+    temporary_results_data = upload_json.temporary_results_data
 
-    expect(upload_json.import_to_inbox).to be true
-    expect(InboxResult.count).to eq 1
-    inbox_result = InboxResult.first
+    expect(upload_json.valid?).to be true
+    expect(temporary_results_data[:results_to_import].count).to eq 1
+    inbox_result = temporary_results_data[:results_to_import].first
     # There is no cutoff, so the incoming round_type_id "c" should be converted to "f"
     expect(inbox_result.round_type_id).to eq "f"
   end

--- a/spec/models/upload_json_spec.rb
+++ b/spec/models/upload_json_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe UploadJson do
     }.to_json
 
     upload_json = build(:upload_json, competition_id: competition.id, results_json_str: results_json)
+    expect(upload_json).to be_valid
+
     temporary_results_data = upload_json.temporary_results_data
     CompetitionResultsImport.import_temporary_results(
       competition,
@@ -67,7 +69,6 @@ RSpec.describe UploadJson do
       results_json_str: upload_json.results_json_str,
     )
 
-    expect(upload_json).to be_valid
     expect(InboxResult.count).to eq 1
     inbox_result = InboxResult.first
     # There is no cutoff, so the incoming round_type_id "c" should be converted to "f"


### PR DESCRIPTION
My initial attempt was to remove `upload_json` model. But it's pretty difficult, because lots of things are done there, and those are very very critical things as well. So I feel it's better to start very slow.

As a first step, I'm merging the common code used in both places.