### PR TITLE
Merged regulations

### DIFF
--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -82,10 +82,8 @@
         <ul class="dropdown-menu" role="menu">
           <li><a href="/regulations/about"><%= ui_icon('info circle') %> <%= t '.about_regulations' %></a></li>
           <li class="divider"></li>
-          <li><a href="/regulations/full"><%= ui_icon('book') %> <%= t '.regulations_full' %></a></li>
+          <li><a href="/regulations"><%= ui_icon('book') %> <%= t '.regulations_full' %></a></li>
           <li class="divider"></li>
-          <li><a href="/regulations/"><%= ui_icon('file text') %> <%= t '.regulations' %></a></li>
-          <li><a href="/regulations/guidelines.html"><%= ui_icon('plus square') %> <%= t '.guidelines' %></a></li>
           <li><a href="/regulations/scrambles/"><%= ui_icon('random') %> <%= t '.scrambles' %></a></li>
           <li>
             <%= link_to(incidents_path) do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,13 +288,13 @@ Rails.application.routes.draw do
   end
 
   get '/regulations' => 'regulations#show', id: 'index'
-  get '/regulations/wca-regulations-and-guidelines', to: redirect('https://regulations.worldcubeassociation.org/wca-regulations-and-guidelines.pdf', status: 302)
-  get '/regulations/full/wca-regulations-and-guidelines.merged', to: redirect('https://regulations.worldcubeassociation.org/wca-regulations-and-guidelines.merged.pdf', status: 302)
+  get '/regulations/wca-regulations-and-guidelines', to: redirect('https://regulations.worldcubeassociation.org/wca-regulations.pdf', status: 302)
+  get '/regulations/full/wca-regulations-and-guidelines.merged', to: redirect('https://regulations.worldcubeassociation.org/wca-regulations.pdf', status: 302)
   get '/regulations/about' => 'regulations#about'
   get '/regulations/countries' => 'regulations#countries'
   get '/regulations/scrambles' => 'regulations#scrambles'
-  get '/regulations/guidelines' => 'regulations#guidelines'
-  get '/regulations/full' => 'regulations#full'
+  get '/regulations/guidelines' => 'regulations#regulations'
+  get '/regulations/full' => 'regulations#regulations'
   get '/regulations/translations' => 'regulations#translations'
   get '/regulations/translations/:language' => 'regulations_translations#translated_regulation'
   get '/regulations/translations/:language/guidelines' => 'regulations_translations#translated_guidelines'


### PR DESCRIPTION
This can only be merged once the regulations index.html.erb is the merged one.

The only thing that I don't really know how to handle is translations.
Can I just redirect
`get '/regulations/translations/:language/guidelines' => 'regulations_translations#translated_regulation'`
or do we need to wait until the newly regulations are translated again?