### PR TITLE
Add support for displaying scramble sets where the first scramble is missing

### DIFF
--- a/app/webpacker/components/ResultsData/Scrambles/ScrambleRowBody.js
+++ b/app/webpacker/components/ResultsData/Scrambles/ScrambleRowBody.js
@@ -15,6 +15,8 @@ function ScrambleRowBody({ round, adminMode }) {
             scramble={scramble}
             scrambles={iterScrambles}
             adminMode={adminMode}
+            singleRowOverride={index === 0 && scramble.scramble_num !== 1}
+
           />
         ))
       ))}


### PR DESCRIPTION
Email thread reference: "Re: Results for MBLD Madness in Dobřejovice 2025"

Essentially, what happened is that only the second and third scrambles from a set of MBLD scrambles were used. WRT would like to delete the first one, but there are two problems: 
1. This automatically changes the numbers of the subsequent scrambles in the database[1] - this can be worked around by editing the scramble after a given scramble is deleted, but
2. When the first scramble_num !== 1, the first row of the table doesn't format properly

We can ask WRT whether (1) is desired behaviour, but at the very least we want to be able to correctly display scrambles where the first scramble_num in the list is !== 1 - that's what this PR does; makes use of the SingleRowOverride to format correctly the first row of a scramble set where it doesn't start with `scramble_num` 1

[1] ie, there are three scrambles with `scramble_num` 1, 2 and 3 respectively. Deleting the scramble with `scramble_num` 1 would decrement the others as follows: `scramble_num` 2 -> 1, `scramble_num` 3 -> 2