### PR TITLE
Enable/disable Schedule Activities based on events rendered not WCIF Activities

### DIFF
--- a/app/webpacker/components/EditSchedule/EditActivities/ActivityPicker.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/ActivityPicker.js
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import {
+  Header,
   Label,
   List,
   Popup,
@@ -13,6 +14,7 @@ import { activityToFcTitle, buildPartialActivityFromCode } from '../../../lib/ut
 
 function ActivityPicker({
   wcifEvents,
+  renderedActivityCodes,
   wcifRoom,
   listRef,
 }) {
@@ -31,6 +33,7 @@ function ActivityPicker({
                 {event.rounds.map((round) => (
                   <PickerRow
                     key={round.id}
+                    renderedActivityCodes={renderedActivityCodes}
                     wcifRoom={wcifRoom}
                     wcifEvent={event}
                     wcifRound={round}
@@ -45,12 +48,14 @@ function ActivityPicker({
         Want to add a custom activity such as lunch or registration?
         Click and select a timeframe on the calendar!
       </p>
+      <Header>Orphaned Events</Header>
     </>
   );
 }
 
 function PickerRow({
   wcifRoom,
+  renderedActivityCodes,
   wcifEvent,
   wcifRound,
 }) {
@@ -61,6 +66,7 @@ function PickerRow({
       <ActivityLabel
         key={n}
         wcifRoom={wcifRoom}
+        renderedActivityCodes={renderedActivityCodes}
         activityCode={`${wcifRound.id}-a${n + 1}`}
       />
     ));
@@ -69,6 +75,7 @@ function PickerRow({
   return (
     <ActivityLabel
       wcifRoom={wcifRoom}
+      renderedActivityCodes={renderedActivityCodes}
       activityCode={wcifRound.id}
     />
   );
@@ -76,6 +83,7 @@ function PickerRow({
 
 function ActivityLabel({
   wcifRoom,
+  renderedActivityCodes,
   activityCode,
 }) {
   const usedActivityCodes = useMemo(
@@ -83,7 +91,7 @@ function ActivityLabel({
     [wcifRoom.activities],
   );
 
-  const isEnabled = !usedActivityCodes.includes(activityCode);
+  const isEnabled = !renderedActivityCodes.includes(activityCode);
 
   const partialActivity = buildPartialActivityFromCode(activityCode);
 


### PR DESCRIPTION
This is a very sketchy proof of concept for an idea I had in response to the issue described in email thread "On-The-Spot After Competition is Over". I think the basic logic/approach has merit, but the nuances of how and when to refresh data in the React context are beyond me.

Basically, an activity on the schedule editor can be "orphaned" (impossible to access/move) if it falls out of the display date/time of the calendar. This can happen for two reasons: 
1. The dates of the competition change to not include the date/time of the activity [1]
2. The calendar settings can be edited to change the start/end time of the calendar display [2]

In such cases, we want organizers to be able to place the orphaned event on the calendar again. There are two ways we could do this: 
1. Limit the start/end time/date of the calendar to the earlier/later of the activities and competition start/end dates - this would work, but quickly encounters issues if - for example - the orphaned event happens several days/weeks outside of the competition. The calendar display would be massive and hard to work with
2. Enable/disable the draggable activity buttons based on what events the calendar is currently rendering - not based on the room's activities, like we are at the moment. This seems like the most foolproof to me, and is doable with the FullCalendar API - this is what I've implemented in the PR

[1] To which you might say: Well, that's a backend issue. Which it is - we have validations in place to prevent this, and logic that automatically offsets activities that would be orphaned when the dates of a competition change - but in some rare cases we haven't yet been able to replicate (likely to do with timezones, and the fact that the `start_date` and `end_date` of a competition don't have a timezone), orphaning still happens anyway.

[2] Organizers could just change these times back - but in larger/more complex schedules, it could be easy to miss an orphaned event 