### PR TITLE
Replace result row css with style in js

### DIFF
--- a/app/webpacker/components/ResultsData/Results/ResultRow.js
+++ b/app/webpacker/components/ResultsData/Results/ResultRow.js
@@ -12,9 +12,13 @@ import { getRecordClass } from '../../../lib/helpers/competition-results';
 
 import '../../../stylesheets/competition_results.scss';
 
+const MBLD_EVENTS = ['333mbf', '333mbo'];
+
 function ResultRow({
   result, index, results, adminMode,
 }) {
+  const isMbldEvent = MBLD_EVENTS.includes(result.event_id);
+
   return (
     <Table.Row>
       <Table.Cell className={cn({ 'text-muted': index > 0 && results[index - 1].pos === result.pos })}>
@@ -37,7 +41,12 @@ function ResultRow({
       </Table.Cell>
       <Table.Cell>{result.regional_average_record}</Table.Cell>
       <Table.Cell><RegionFlag iso2={result.country_iso2} /></Table.Cell>
-      <Table.Cell className={(result.event_id === '333mbf' || result.event_id === '333mbo') ? 'table-cell-solves-mbf' : 'table-cell-solves'}>
+      <Table.Cell
+        style={{
+          verticalAlign: 'middle',
+          wordSpacing: isMbldEvent ? '2em' : '0.5em',
+        }}
+      >
         {formatAttemptsForResult(result, result.event_id)}
       </Table.Cell>
     </Table.Row>

--- a/app/webpacker/stylesheets/competition_results.scss
+++ b/app/webpacker/stylesheets/competition_results.scss
@@ -6,14 +6,6 @@
     justify-content: center;
   }
   .results-data {
-    .table-cell-solves {
-      word-spacing: 0.5em;
-      vertical-align: middle;
-    }
-    .table-cell-solves-mbf {
-      word-spacing: 2em;
-      vertical-align: middle;
-    }
     .WR {
       color : variables.$wr-color;
     }


### PR DESCRIPTION
I am not sure if this PR gets approved or not, but just giving out a try. Basically, I wanted to reuse `ResultRow` component in one of my component, and I want the table cells to have the CSS "table-cell-solves" and "table-cell-solves-mbf". But it won't work unless I add the parent classes as well. I don't feel it's necessary to add classes in parents just to get these two CSSes. So I feel one solution is to get rid of CSS, and use the style directly.  This way, I can reuse the `ResultRow` component much more easily.

I feel this is still not a good solution, but I cannot think of a better solution here.