### PR TITLE
Allow competitions to be stakeholders of tickets

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -155,7 +155,7 @@ class ResultsSubmissionController < ApplicationController
 
     ActiveRecord::Base.transaction do
       competition.touch(:results_submitted_at)
-      TicketsCompetitionResult.create_ticket!(competition.id, message, current_user)
+      TicketsCompetitionResult.create_ticket!(competition, message, current_user)
     end
 
     render status: :ok, json: { success: true }

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -21,7 +21,9 @@ class Ticket < ApplicationRecord
   def user_stakeholders(user)
     return [] if user.nil?
 
-    ticket_stakeholders.belongs_to_user(user).or(ticket_stakeholders.belongs_to_groups(user.active_groups))
+    ticket_stakeholders.belongs_to_user(user)
+                       .or(ticket_stakeholders.belongs_to_groups(user.active_groups))
+                       .or(ticket_stakeholders.belongs_to_competitions(user.delegated_competitions))
   end
 
   def can_user_access?(user)

--- a/app/models/ticket_stakeholder.rb
+++ b/app/models/ticket_stakeholder.rb
@@ -22,6 +22,10 @@ class TicketStakeholder < ApplicationRecord
     where(stakeholder_type: "UserGroup", stakeholder_id: group_ids)
   }
 
+  scope :belongs_to_competitions, lambda { |competition_ids|
+    where(stakeholder_type: "Competition", stakeholder_id: competition_ids)
+  }
+
   def user_group_stakeholder?
     stakeholder_type == "UserGroup"
   end

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -23,10 +23,10 @@ class TicketsCompetitionResult < ApplicationRecord
     end
   end
 
-  def self.create_ticket!(competition_id, delegate_message, submitted_delegate)
+  def self.create_ticket!(competition, delegate_message, submitted_delegate)
     ticket_metadata = TicketsCompetitionResult.create!(
       status: TicketsCompetitionResult.statuses[:submitted],
-      competition_id: competition_id,
+      competition_id: competition.id,
       delegate_message: delegate_message,
     )
 
@@ -40,9 +40,9 @@ class TicketsCompetitionResult < ApplicationRecord
       is_active: true,
     )
 
-    submitted_delegate_stakeholder = TicketStakeholder.create!(
+    competition_stakeholder = TicketStakeholder.create!(
       ticket_id: ticket.id,
-      stakeholder: submitted_delegate,
+      stakeholder: competition,
       connection: TicketStakeholder.connections[:cc],
       stakeholder_role: TicketStakeholder.stakeholder_roles[:requester],
       is_active: true,
@@ -53,7 +53,7 @@ class TicketsCompetitionResult < ApplicationRecord
       action_type: TicketLog.action_types[:update_status],
       action_value: ticket_metadata.status,
       acting_user_id: submitted_delegate.id,
-      acting_stakeholder_id: submitted_delegate_stakeholder.id,
+      acting_stakeholder_id: competition_stakeholder.id,
     )
   end
 end

--- a/db/migrate/20250722024728_change_stakeholder_id_to_string_in_ticket_stakeholders.rb
+++ b/db/migrate/20250722024728_change_stakeholder_id_to_string_in_ticket_stakeholders.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ChangeStakeholderIdToStringInTicketStakeholders < ActiveRecord::Migration[7.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_column :ticket_stakeholders, :stakeholder_id, :string, limit: 255
+      end
+
+      dir.down do
+        change_column :ticket_stakeholders, :stakeholder_id, :bigint
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_19_140801) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_22_024728) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1339,7 +1339,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_19_140801) do
   create_table "ticket_stakeholders", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "ticket_id", null: false
     t.string "stakeholder_type", null: false
-    t.bigint "stakeholder_id", null: false
+    t.string "stakeholder_id", limit: 255, null: false
     t.string "connection", null: false
     t.boolean "is_active", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Currently a competition cannot be added directly as a stakeholder of a ticket. This ticket aims at the same, so that the Delegates of a competition will have access to the ticket.