### PR TITLE
Use composite keys for InboxPerson lookup

### DIFF
--- a/app/models/inbox_result.rb
+++ b/app/models/inbox_result.rb
@@ -4,13 +4,9 @@ class InboxResult < ApplicationRecord
   include Resultable
 
   # see result.rb for explanation of the scope
-  belongs_to :inbox_person, ->(ibr) { where(competition_id: ibr.competition_id) }, primary_key: :id, foreign_key: :person_id, optional: true
+  belongs_to :inbox_person, primary_key: %i[id competition_id], foreign_key: %i[person_id competition_id], optional: true
 
-  # NOTE: don't use these too often, as it triggers one person load per call!
-  # If you need names for a batch of InboxResult, consider joining the InboxPerson table.
-  def person
-    InboxPerson.find_by(id: person_id, competition_id: competition_id)
-  end
+  alias_method :person, :inbox_person
 
   def person_name
     inbox_person&.name || "<person_id=#{person_id}>"

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -8,9 +8,10 @@ class Result < ApplicationRecord
   belongs_to :country
   has_one :continent, through: :country
   delegate :continent_id, :continent, to: :country
+
   # InboxPerson IDs are only unique per competition. So in addition to querying the ID itself (which is guaranteed by :foreign_key)
-  # we also need sure to query the correct competition as well through a custom scope.
-  belongs_to :inbox_person, ->(res) { where(competition_id: res.competition_id) }, primary_key: :id, foreign_key: :person_id, optional: true
+  # we also need sure to query the correct competition as well through a composite key.
+  belongs_to :inbox_person, primary_key: %i[id competition_id], foreign_key: %i[person_id competition_id], optional: true
 
   has_many :result_attempts
 


### PR DESCRIPTION
Small optimization to help with #12045.

I have compared the queries generated by Rails manually in the console using individual rows, but let's see whether everything works as expected in the CI as well.

The main advantage is that you can now do stuff like `my_competition.inbox_results.join(:inbox_person)`, which was not possible before.