### PR TITLE
Use DocumentDB compatibility layer for Payload

### DIFF
--- a/next-frontend/src/payload.config.ts
+++ b/next-frontend/src/payload.config.ts
@@ -58,16 +58,18 @@ async function plugins() {
 
 async function dbAdapter() {
   if (process.env.NODE_ENV === "production") {
-    const { mongooseAdapter } = await import("@payloadcms/db-mongodb");
+    const { mongooseAdapter, compatabilityOptions } = await import(
+      "@payloadcms/db-mongodb"
+    );
     return mongooseAdapter({
       url: process.env.DATABASE_URI || "",
-      disableIndexHints: true,
       connectOptions: {
         authMechanism: "MONGODB-AWS",
         authSource: "$external",
         tls: true,
         tlsCAFile: "/app/global-bundle.pem",
       },
+      ...compatabilityOptions.documentdb,
     });
   } else {
     const { sqliteAdapter } = await import("@payloadcms/db-sqlite");


### PR DESCRIPTION
See https://payloadcms.com/docs/database/mongodb#using-other-mongodb-implementations, recently introduced in Payload 3.48 via https://github.com/thewca/worldcubeassociation.org/pull/12038