### PR TITLE
Few optimizations for roles and groups

### DIFF
--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -40,7 +40,7 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
     # Sorts the list of groups by name.
     groups = groups.sort_by(&:name)
 
-    render json: groups
+    render json: groups, methods: %w[lead_user]
   end
 
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1248,7 +1248,7 @@ class User < ApplicationRecord
     only: %w[id wca_id name gender
              country_iso2 created_at updated_at],
     methods: %w[url country],
-    include: %w[avatar teams],
+    include: %w[avatar],
   }.freeze
 
   def serializable_hash(options = nil)

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -332,7 +332,6 @@ class UserGroup < ApplicationRecord
 
   DEFAULT_SERIALIZE_OPTIONS = {
     include: %w[metadata],
-    methods: %w[lead_user],
   }.freeze
 
   def serializable_hash(options = nil)

--- a/spec/controllers/api/v0/user_groups_controller_spec.rb
+++ b/spec/controllers/api/v0/user_groups_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V0::UserGroupsController do
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'north-america').user_group,
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'oceania').user_group,
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'south-america').user_group,
-        ].to_json)
+        ].to_json(methods: %w[lead_user]))
       end
 
       it 'returns list of active delegate regions' do
@@ -55,7 +55,7 @@ RSpec.describe Api::V0::UserGroupsController do
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'india').user_group,
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'new-zealand').user_group,
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'oceania').user_group,
-        ].to_json)
+        ].to_json(methods: %w[lead_user]))
       end
 
       it 'returns list of inactive delegate regions' do
@@ -67,7 +67,7 @@ RSpec.describe Api::V0::UserGroupsController do
         expect(response.body).to eq([
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'north-america').user_group,
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'south-america').user_group,
-        ].to_json)
+        ].to_json(methods: %w[lead_user]))
       end
 
       it 'returns list of delegate regions under europe' do
@@ -79,7 +79,7 @@ RSpec.describe Api::V0::UserGroupsController do
         expect(response.body).to eq([
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'europe-north').user_group,
           GroupsMetadataDelegateRegions.find_by!(friendly_id: 'europe-south').user_group,
-        ].to_json)
+        ].to_json(methods: %w[lead_user]))
       end
     end
   end


### PR DESCRIPTION
This is follow-up PR to https://github.com/thewca/worldcubeassociation.org/pull/12043.

Now, the roles are loading with very less queries (except avatars - for avatars still it's doing one call for each user)

EDIT: Not just avatars, actually metadata is also loading. I tried adding in `includes` but since it's polymorphic association, it cannot do eager loading. The API is somehow doing lazy loading, but unit tests are trying to do eager loading.