### PR TITLE
Create tickets once the competition ends

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -149,7 +149,7 @@ class ResultsSubmissionController < ApplicationController
 
     return render status: :unprocessable_entity, json: { error: "Submitted results contain errors." } if results_validator.any_errors?
 
-    return render status: :unprocessable_entity, json: { error: "There is no ticket associated, please contact WST." } if competition.result_ticket.nil?
+    return render status: :not_found, json: { error: "There is no ticket associated, please contact WST." } if competition.result_ticket.nil?
 
     CompetitionsMailer.results_submitted(competition, results_validator, message, current_user).deliver_now
 
@@ -177,7 +177,7 @@ class ResultsSubmissionController < ApplicationController
 
     if @competition.tickets_competition_result.present?
       return render status: :bad_request, json: {
-        error: "Ticket for result submission already exists.",
+        error: "Ticket for result submission already exists. Please refresh your page.",
       }
     end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -29,9 +29,20 @@ class Ticket < ApplicationRecord
   def can_user_access?(user)
     return false if user.nil?
 
-    ticket_stakeholders.belongs_to_user(user).any? ||
-      ticket_stakeholders.belongs_to_groups(user.active_groups).any? ||
-      ticket_stakeholders.belongs_to_competitions(user.delegated_competitions).any?
+    stakeholder_types = ticket_stakeholders.distinct.pluck(:stakeholder_type)
+
+    stakeholder_types.any? do |stakeholder_type|
+      case stakeholder_type
+      when "User"
+        ticket_stakeholders.belongs_to_user(user).any?
+      when "UserGroup"
+        ticket_stakeholders.belongs_to_groups(user.active_groups).any?
+      when "Competition"
+        ticket_stakeholders.belongs_to_competitions(user.delegated_competitions).any?
+      else
+        false
+      end
+    end
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -30,7 +30,8 @@ class Ticket < ApplicationRecord
     return false if user.nil?
 
     ticket_stakeholders.belongs_to_user(user).any? ||
-      ticket_stakeholders.belongs_to_groups(user.active_groups).any?
+      ticket_stakeholders.belongs_to_groups(user.active_groups).any? ||
+      ticket_stakeholders.belongs_to_competitions(user.delegated_competitions).any?
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/app/views/results_submission/new.html.erb
+++ b/app/views/results_submission/new.html.erb
@@ -6,6 +6,14 @@
 
   <% if @competition.results_submitted? %>
     <p>The results have already been submitted. If you have any more questions or comments please reply to the email sent with the first results submission.</p>
+  <% elsif @competition.tickets_competition_result.nil? %>
+    <%= button_to competition_start_result_submission_process_path,
+                  title: "Start result submission process",
+                  class: "btn btn-primary",
+                  method: :post do
+    %>
+      Start result submission process
+    <% end %>
   <% else %>
     <p>
       The result submission process has two steps:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
     get 'submit-scrambles' => 'admin/scrambles#match_scrambles', as: :match_scrambles
     post 'submit-results' => 'results_submission#create', as: :submit_results
     post 'import-wca-live-results' => 'results_submission#import_from_live'
+    post 'start-result-submission-process' => 'results_submission#start_result_submission_process', as: :start_result_submission_process
     resources :scramble_files, only: %i[index create destroy], shallow: true do
       patch 'update-round-matching' => 'scramble_files#update_round_matching', on: :collection
     end

--- a/db/migrate/20250724025857_make_results_ticket_delegate_message_nullable.rb
+++ b/db/migrate/20250724025857_make_results_ticket_delegate_message_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeResultsTicketDelegateMessageNullable < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :tickets_competition_result, :delegate_message, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_22_052451) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_24_025857) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1360,7 +1360,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_22_052451) do
   create_table "tickets_competition_result", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "status", null: false
     t.string "competition_id", null: false
-    t.text "delegate_message", null: false
+    t.text "delegate_message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["competition_id"], name: "index_tickets_competition_result_on_competition_id"

--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -386,6 +386,12 @@ FactoryBot.define do
       championship_types { ["world"] }
     end
 
+    trait :results_ticket_pending_import do
+      after(:create) do |competition|
+        create(:competition_result_ticket, competition: competition)
+      end
+    end
+
     after(:build) do |competition, evaluator|
       if evaluator.series_base
         series_base = evaluator.series_base

--- a/spec/factories/tickets_competition_result.rb
+++ b/spec/factories/tickets_competition_result.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tickets_competition_result do
+    trait :newly_created do
+      after(:create) do |competition_result_ticket|
+        competition_result_ticket.ticket = create(:ticket, metadata: competition_result_ticket)
+        create(
+          :ticket_stakeholder,
+          ticket: competition_result_ticket.ticket,
+          stakeholder: competition_result_ticket.competition,
+          connection: :assigned,
+          stakeholder_role: TicketStakeholder.stakeholder_roles[:requester],
+          is_active: true,
+        )
+      end
+    end
+
+    factory :competition_result_ticket, traits: [:newly_created]
+  end
+end

--- a/spec/requests/results_submission_spec.rb
+++ b/spec/requests/results_submission_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ResultsSubmissionController do
   let(:delegate) { create(:delegate) }
-  let(:comp) { create(:competition, :with_valid_submitted_results, delegates: [delegate]) }
+  let(:comp) { create(:competition, :with_valid_submitted_results, :results_ticket_pending_import, delegates: [delegate]) }
 
   context "not logged in" do
     it "redirects to sign in" do


### PR DESCRIPTION
Currently ticket for results are created only when the Delegate submits results. Now it's changed to a bit early stage. Delegate will be asked to click a button asking to 'start result submission process', and that point the ticket will be created.

With this, now we can move the results submission process of Delegates to the ticket (as a beta feature).