### PR TITLE
Hide competitor tab before reg opens

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1003,12 +1003,12 @@ class Competition < ApplicationRecord
     true
   end
 
-  def registration_currently_open?
-    use_wca_registration? && !cancelled? && !registration_not_yet_opened? && !registration_past?
-  end
-
   def after_registration_open?
     use_wca_registration? && !cancelled? && !registration_not_yet_opened?
+  end
+
+  def registration_currently_open?
+    after_registration_open? && !registration_past?
   end
 
   def registration_not_yet_opened?

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1007,6 +1007,10 @@ class Competition < ApplicationRecord
     use_wca_registration? && !cancelled? && !registration_not_yet_opened? && !registration_past?
   end
 
+  def after_registration_open?
+    use_wca_registration? && !cancelled? && !registration_not_yet_opened?
+  end
+
   def registration_not_yet_opened?
     registration_open && Time.now < registration_open
   end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1011,12 +1011,20 @@ class Competition < ApplicationRecord
     after_registration_open? && !registration_past?
   end
 
+  def after_registration_open?
+    use_wca_registration? && !cancelled? && !registration_not_yet_opened? && any_registrations?
+  end
+
   def registration_not_yet_opened?
     registration_open && Time.now < registration_open
   end
 
   def registration_past?
     registration_close && registration_close < Time.now
+  end
+
+  def can_show_competitors_page?
+    after_registration_open? && registrations.competing_status_accepted.competing.any?
   end
 
   def registration_status

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1011,10 +1011,6 @@ class Competition < ApplicationRecord
     after_registration_open? && !registration_past?
   end
 
-  def after_registration_open?
-    use_wca_registration? && !cancelled? && !registration_not_yet_opened? && any_registrations?
-  end
-
   def registration_not_yet_opened?
     registration_open && Time.now < registration_open
   end

--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -143,7 +143,7 @@
             }
           end
 
-          if @competition.any_registrations?
+          if @competition.any_registrations? && @competition.after_registration_open?
             nav_items << {
               text: t('.menu.competitors'),
               path: competition_registrations_path(@competition),

--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -143,7 +143,7 @@
             }
           end
 
-          if @competition.any_registrations? && @competition.after_registration_open?
+          if @competition.can_show_competitors_page?
             nav_items << {
               text: t('.menu.competitors'),
               path: competition_registrations_path(@competition),


### PR DESCRIPTION
A common complaint from organizers re auto accept is that they don't want to pre-accept organizers/delegates because it leads to the Competitors tab displaying before reg has opened, and them needing to deal with queries from confused prospective competitors.

We had already implemented this, and then we had to revert it because WC2025 would have its competitor list disappear between registration periods. We no longer have that issue, so we're free to re-implement this.