### PR TITLE
Show "unsaved changes" alert in Scrambles Matcher

### DIFF
--- a/app/controllers/admin/scrambles_controller.rb
+++ b/app/controllers/admin/scrambles_controller.rb
@@ -25,7 +25,10 @@ module Admin
     end
 
     def match_scrambles
-      @competition = Competition.find(params[:competition_id])
+      @competition = Competition.includes(
+        scramble_file_uploads: ScrambleFileUpload::SERIALIZATION_INCLUDES,
+        **ScrambleFileUpload::SERIALIZATION_INCLUDES,
+      ).find(params[:competition_id])
     end
 
     def create

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -64,13 +64,12 @@ class ScrambleFilesController < ApplicationController
             round_number: competition_round&.number || parsed_round_number,
           }
 
-          existing_sets_count = InboxScrambleSet.where(**round_scope).count
           highest_ordered_index = InboxScrambleSet.where(**round_scope).maximum(:ordered_index) || 0
 
           wcif_round[:scrambleSets].each_with_index do |wcif_scramble_set, idx|
             scramble_set = scr_file_upload.inbox_scramble_sets.create!(
-              scramble_set_number: idx + existing_sets_count + 1,
-              ordered_index: idx + highest_ordered_index,
+              scramble_set_number: idx + 1,
+              ordered_index: idx + highest_ordered_index + 1,
               matched_round: competition_round,
               **round_scope,
             )

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -135,6 +135,7 @@ class ScrambleFilesController < ApplicationController
     end
 
     render json: competition.inbox_scramble_sets
+                            .includes(:inbox_scrambles, matched_round: [:competition_event])
   end
 
   private def competition_from_params

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -55,12 +55,13 @@ class ScrambleFilesController < ApplicationController
         competition_event = competition.competition_events.find_by(event_id: wcif_event[:id])
 
         wcif_event[:rounds].each_with_index do |wcif_round, rd_idx|
+          parsed_round_number = ScheduleActivity.parse_activity_code(wcif_round[:id]).fetch(:round_number, rd_idx + 1)
           competition_round = competition_event&.rounds&.find { it.wcif_id == wcif_round[:id] }
 
           round_scope = {
             competition_id: competition_round&.competition_id || competition.id,
             event_id: competition_round&.event_id || wcif_event[:id],
-            round_number: rd_idx + 1,
+            round_number: competition_round&.number || parsed_round_number,
           }
 
           existing_sets_count = InboxScrambleSet.where(**round_scope).count

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -134,7 +134,7 @@ class ScrambleFilesController < ApplicationController
       end
     end
 
-    render json: { success: :ok }
+    render json: competition.inbox_scramble_sets
   end
 
   private def competition_from_params

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -76,7 +76,7 @@ class ScrambleFilesController < ApplicationController
                 scramble_set.inbox_scrambles.create!(
                   scramble_string: wcif_scramble,
                   scramble_number: n + 1,
-                  ordered_index: n + num_persisted_scrambles + 1,
+                  ordered_index: n + num_persisted_scrambles,
                   is_extra: scramble_kind == :extraScrambles,
                 )
               end

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -9,11 +9,7 @@ class ScrambleFilesController < ApplicationController
   def index
     competition = competition_from_params
 
-    existing_files = ScrambleFileUpload
-                     .includes(inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] })
-                     .where(competition: competition)
-
-    render json: existing_files
+    render json: ScrambleFileUpload.for_upload.where(competition: competition)
   end
 
   def create
@@ -28,19 +24,17 @@ class ScrambleFilesController < ApplicationController
     generation_date = DateTime.strptime(tnoodle_json[:generationDate], "%b %d, %Y %l:%M:%S %p")
     tnoodle_version = tnoodle_json[:version]
 
-    existing_upload = ScrambleFileUpload
-                      .includes(inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] })
-                      .find_by(
-                        competition: competition,
-                        scramble_program: tnoodle_version,
-                        generated_at: generation_date,
-                      )
+    existing_upload = ScrambleFileUpload.for_upload.find_by(
+      competition: competition,
+      scramble_program: tnoodle_version,
+      generated_at: generation_date,
+    )
 
     return render json: existing_upload if existing_upload.present?
 
     tnoodle_wcif = tnoodle_json[:wcif]
 
-    scr_file_upload = ScrambleFileUpload.create!(
+    scr_file_upload = ScrambleFileUpload.for_upload.create!(
       uploaded_by_user: current_user,
       uploaded_at: DateTime.now,
       competition: competition,

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -59,7 +59,7 @@ class ScrambleFilesController < ApplicationController
           }
 
           highest_ordered_index = InboxScrambleSet.where(**round_scope).maximum(:ordered_index)
-          ordered_index_offset = highest_ordered_index&.plus(1) || 0
+          ordered_index_offset = highest_ordered_index&.succ || 0
 
           wcif_round[:scrambleSets].each_with_index do |wcif_scramble_set, idx|
             scramble_set = scr_file_upload.inbox_scramble_sets.create!(

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -9,7 +9,7 @@ class ScrambleFilesController < ApplicationController
   def index
     competition = competition_from_params
 
-    render json: ScrambleFileUpload.for_upload.where(competition: competition)
+    render json: ScrambleFileUpload.for_serialization.where(competition: competition)
   end
 
   def create
@@ -24,7 +24,7 @@ class ScrambleFilesController < ApplicationController
     generation_date = DateTime.strptime(tnoodle_json[:generationDate], "%b %d, %Y %l:%M:%S %p")
     tnoodle_version = tnoodle_json[:version]
 
-    existing_upload = ScrambleFileUpload.for_upload.find_by(
+    existing_upload = ScrambleFileUpload.for_serialization.find_by(
       competition: competition,
       scramble_program: tnoodle_version,
       generated_at: generation_date,
@@ -34,7 +34,7 @@ class ScrambleFilesController < ApplicationController
 
     tnoodle_wcif = tnoodle_json[:wcif]
 
-    scr_file_upload = ScrambleFileUpload.for_upload.create!(
+    scr_file_upload = ScrambleFileUpload.for_serialization.create!(
       uploaded_by_user: current_user,
       uploaded_at: DateTime.now,
       competition: competition,

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -34,10 +34,11 @@ class Competition < ApplicationRecord
   belongs_to :posting_user, optional: true, foreign_key: 'posting_by', class_name: "User"
   has_many :inbox_results, dependent: :delete_all
   has_many :inbox_persons, dependent: :delete_all
+  has_many :inbox_scramble_sets, dependent: :delete_all
   belongs_to :announced_by_user, optional: true, foreign_key: "announced_by", class_name: "User"
   belongs_to :cancelled_by_user, optional: true, foreign_key: "cancelled_by", class_name: "User"
   has_many :competition_payment_integrations
-  has_many :scramble_file_uploads
+  has_many :scramble_file_uploads, dependent: :delete_all
   has_many :accepted_registrations, -> { accepted }, class_name: "Registration", foreign_key: "competition_id"
   has_many :accepted_newcomers, -> { where(wca_id: nil) }, through: :accepted_registrations, source: :user
   has_many :duplicate_checker_job_runs, dependent: :delete_all

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -703,6 +703,7 @@ class Competition < ApplicationRecord
              'posting_user',
              'inbox_results',
              'inbox_persons',
+             'inbox_scramble_sets',
              'announced_by_user',
              'cancelled_by_user',
              'competition_payment_integrations',

--- a/app/models/inbox_scramble.rb
+++ b/app/models/inbox_scramble.rb
@@ -4,4 +4,5 @@ class InboxScramble < ApplicationRecord
   belongs_to :inbox_scramble_set
 
   validates :scramble_number, uniqueness: { scope: %i[is_extra inbox_scramble_set_id] }
+  validates :ordered_index, uniqueness: { scope: :inbox_scramble_set_id }
 end

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -9,7 +9,7 @@ class InboxScrambleSet < ApplicationRecord
 
   has_many :inbox_scrambles, dependent: :destroy
 
-  validates :scramble_set_number, uniqueness: { scope: %i[competition_id event_id round_number] }
+  validates :ordered_index, uniqueness: { scope: %i[competition_id event_id round_number] }
 
   before_validation :backfill_round_information!, if: :matched_round_id?
 

--- a/app/models/scramble_file_upload.rb
+++ b/app/models/scramble_file_upload.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class ScrambleFileUpload < ApplicationRecord
+  SERIALIZATION_INCLUDES = { inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] } }.freeze
+
   belongs_to :uploaded_by_user, foreign_key: "uploaded_by", class_name: "User"
   belongs_to :competition
 
   has_many :inbox_scramble_sets, inverse_of: :scramble_file_upload, dependent: :destroy
 
-  scope :for_upload, -> { includes(inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] }) }
+  scope :for_serialization, -> { includes(**SERIALIZATION_INCLUDES) }
 
   serialize :raw_wcif, coder: JSON
 

--- a/app/models/scramble_file_upload.rb
+++ b/app/models/scramble_file_upload.rb
@@ -6,6 +6,8 @@ class ScrambleFileUpload < ApplicationRecord
 
   has_many :inbox_scramble_sets, inverse_of: :scramble_file_upload, dependent: :destroy
 
+  scope :for_upload, -> { includes(inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] }) }
+
   serialize :raw_wcif, coder: JSON
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/app/views/admin/scrambles/match_scrambles.erb
+++ b/app/views/admin/scrambles/match_scrambles.erb
@@ -3,5 +3,6 @@
     wcifEvents: @competition.events_wcif,
     competitionId: @competition.id,
     initialScrambleFiles: @competition.scramble_file_uploads,
+    inboxScrambleSets: @competition.inbox_scramble_sets,
   }) %>
 <% end %>

--- a/app/webpacker/components/EditEvents/index.js
+++ b/app/webpacker/components/EditEvents/index.js
@@ -1,8 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-} from 'react';
+import React, { useCallback, useMemo } from 'react';
 import _ from 'lodash';
 
 import { Button, Card, Message } from 'semantic-ui-react';
@@ -14,6 +10,7 @@ import { changesSaved } from './store/actions';
 import wcifEventsReducer from './store/reducer';
 import Store, { useDispatch, useStore } from '../../lib/providers/StoreProvider';
 import ConfirmProvider from '../../lib/providers/ConfirmProvider';
+import useUnsavedChangesAlert from '../../lib/hooks/useUnsavedChangesAlert';
 
 function EditEvents() {
   const {
@@ -25,24 +22,7 @@ function EditEvents() {
     !_.isEqual(wcifEvents, initialWcifEvents)
   ), [wcifEvents, initialWcifEvents]);
 
-  const onUnload = useCallback((e) => {
-    // Prompt the user before letting them navigate away from this page with unsaved changes.
-    if (unsavedChanges) {
-      const confirmationMessage = 'You have unsaved changes, are you sure you want to leave?';
-      e.returnValue = confirmationMessage;
-      return confirmationMessage;
-    }
-
-    return null;
-  }, [unsavedChanges]);
-
-  useEffect(() => {
-    window.addEventListener('beforeunload', onUnload);
-
-    return () => {
-      window.removeEventListener('beforeunload', onUnload);
-    };
-  }, [onUnload]);
+  useUnsavedChangesAlert(unsavedChanges);
 
   const { saveWcif, saving } = useSaveWcifAction();
 

--- a/app/webpacker/components/EditSchedule/index.js
+++ b/app/webpacker/components/EditSchedule/index.js
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import {
   Accordion,
@@ -22,6 +17,7 @@ import ConfirmProvider from '../../lib/providers/ConfirmProvider';
 import EditVenues from './EditVenues';
 import EditActivities from './EditActivities';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
+import useUnsavedChangesAlert from '../../lib/hooks/useUnsavedChangesAlert';
 
 function EditSchedule({
   wcifEvents,
@@ -43,24 +39,7 @@ function EditSchedule({
     !_.isEqual(wcifSchedule, initialWcifSchedule)
   ), [wcifSchedule, initialWcifSchedule]);
 
-  const onUnload = useCallback((e) => {
-    // Prompt the user before letting them navigate away from this page with unsaved changes.
-    if (unsavedChanges) {
-      const confirmationMessage = 'You have unsaved changes, are you sure you want to leave?';
-      e.returnValue = confirmationMessage;
-      return confirmationMessage;
-    }
-
-    return null;
-  }, [unsavedChanges]);
-
-  useEffect(() => {
-    window.addEventListener('beforeunload', onUnload);
-
-    return () => {
-      window.removeEventListener('beforeunload', onUnload);
-    };
-  }, [onUnload]);
+  useUnsavedChangesAlert(unsavedChanges);
 
   const { saveWcif, saving } = useSaveWcifAction();
 

--- a/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
+++ b/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
@@ -11,7 +11,7 @@ async function listScrambleFiles(competitionId) {
   return data;
 }
 
-async function uploadScrambleFile(competitionId, file) {
+async function uploadScrambleFile({ competitionId, file }) {
   const formData = new FormData();
   formData.append('tnoodle[json]', file);
 
@@ -42,7 +42,7 @@ export default function FileUpload({
   });
 
   const { mutateAsync, isPending } = useMutation({
-    mutationFn: (file) => uploadScrambleFile(competitionId, file),
+    mutationFn: uploadScrambleFile,
     onSuccess: (data) => {
       queryClient.setQueryData(
         ['scramble-files', competitionId],
@@ -65,11 +65,11 @@ export default function FileUpload({
 
   const uploadNewScramble = useCallback((ev) => {
     const filesArr = Array.from(ev.target.files);
-    const uploadPromises = filesArr.map((f) => mutateAsync(f));
+    const uploadPromises = filesArr.map((file) => mutateAsync({ competitionId, file }));
 
     return Promise.all(uploadPromises)
       .finally(resetFileUpload);
-  }, [mutateAsync, resetFileUpload]);
+  }, [competitionId, mutateAsync, resetFileUpload]);
 
   const clickOnInput = () => {
     inputRef.current?.click();

--- a/app/webpacker/components/ScrambleMatcher/Groups.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Groups.jsx
@@ -9,6 +9,7 @@ const scrambleToName = (scramble) => `Scramble ${scramble.scramble_number} (${sc
 export default function Groups({
   scrambleSetCount,
   scrambleSets,
+  expectedSolveCount,
   dispatchMatchState,
 }) {
   if (scrambleSetCount === 1) {
@@ -16,6 +17,7 @@ export default function Groups({
       <SelectedGroupPanel
         selectedGroupNumber={0}
         scrambleSets={scrambleSets}
+        expectedSolveCount={expectedSolveCount}
         dispatchMatchState={dispatchMatchState}
       />
     );
@@ -25,12 +27,18 @@ export default function Groups({
     <GroupsPicker
       scrambleSetCount={scrambleSetCount}
       scrambleSets={scrambleSets}
+      expectedSolveCount={expectedSolveCount}
       dispatchMatchState={dispatchMatchState}
     />
   );
 }
 
-function GroupsPicker({ dispatchMatchState, scrambleSetCount, scrambleSets }) {
+function GroupsPicker({
+  dispatchMatchState,
+  scrambleSetCount,
+  scrambleSets,
+  expectedSolveCount,
+}) {
   const [selectedGroupNumber, setSelectedGroupNumber] = useState(null);
 
   const availableGroups = useMemo(
@@ -71,13 +79,19 @@ function GroupsPicker({ dispatchMatchState, scrambleSetCount, scrambleSets }) {
           dispatchMatchState={dispatchMatchState}
           selectedGroupNumber={selectedGroupNumber}
           scrambleSets={scrambleSets}
+          expectedSolveCount={expectedSolveCount}
         />
       )}
     </>
   );
 }
 
-function SelectedGroupPanel({ dispatchMatchState, selectedGroupNumber, scrambleSets = [] }) {
+function SelectedGroupPanel({
+  dispatchMatchState,
+  scrambleSets = [],
+  selectedGroupNumber,
+  expectedSolveCount,
+}) {
   const onGroupDragCompleted = useCallback(
     (fromIndex, toIndex) => dispatchMatchState({
       type: 'moveScrambleInSet',
@@ -96,6 +110,7 @@ function SelectedGroupPanel({ dispatchMatchState, selectedGroupNumber, scrambleS
   return (
     <ScrambleMatch
       matchableRows={scrambleSets[selectedGroupNumber]?.inbox_scrambles}
+      expectedNumOfRows={expectedSolveCount}
       onRowDragCompleted={onGroupDragCompleted}
       computeDefinitionName={groupScrambleToName}
       computeRowName={scrambleToName}

--- a/app/webpacker/components/ScrambleMatcher/Groups.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Groups.jsx
@@ -20,6 +20,7 @@ export default function Groups({
       />
     );
   }
+
   return (
     <GroupsPicker
       scrambleSetCount={scrambleSetCount}
@@ -76,7 +77,7 @@ function GroupsPicker({ dispatchMatchState, scrambleSetCount, scrambleSets }) {
   );
 }
 
-function SelectedGroupPanel({ dispatchMatchState, selectedGroupNumber, scrambleSets }) {
+function SelectedGroupPanel({ dispatchMatchState, selectedGroupNumber, scrambleSets = [] }) {
   const onGroupDragCompleted = useCallback(
     (fromIndex, toIndex) => dispatchMatchState({
       type: 'moveScrambleInSet',
@@ -94,7 +95,7 @@ function SelectedGroupPanel({ dispatchMatchState, selectedGroupNumber, scrambleS
 
   return (
     <ScrambleMatch
-      matchableRows={scrambleSets[selectedGroupNumber].inbox_scrambles}
+      matchableRows={scrambleSets[selectedGroupNumber]?.inbox_scrambles}
       onRowDragCompleted={onGroupDragCompleted}
       computeDefinitionName={groupScrambleToName}
       computeRowName={scrambleToName}

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -9,6 +9,7 @@ import Groups from './Groups';
 import { useDispatchWrapper } from './reducer';
 import { scrambleSetToDetails, scrambleSetToName } from './util';
 import useInputState from '../../lib/hooks/useInputState';
+import { formats } from '../../lib/wca-data.js.erb';
 
 export default function Rounds({
   wcifRounds,
@@ -90,6 +91,11 @@ function SelectedRoundPanel({
     [selectedRound.id],
   );
 
+  const selectedRoundFormat = useMemo(
+    () => formats.byId[selectedRound.format],
+    [selectedRound.format],
+  );
+
   return (
     <>
       <ScrambleMatch
@@ -113,6 +119,7 @@ function SelectedRoundPanel({
         <Groups
           scrambleSetCount={selectedRound.scrambleSetCount}
           scrambleSets={matchState[selectedRound.id]}
+          expectedSolveCount={selectedRoundFormat?.expectedSolveCount}
           dispatchMatchState={wrappedDispatch}
         />
       )}

--- a/app/webpacker/components/ScrambleMatcher/Rounds.jsx
+++ b/app/webpacker/components/ScrambleMatcher/Rounds.jsx
@@ -185,6 +185,7 @@ function RoundsPicker({
   showGroupsPicker = false,
 }) {
   const [selectedRoundId, setSelectedRoundId] = useState();
+
   const selectedRound = useMemo(
     () => wcifRounds.find((r) => r.id === selectedRoundId),
     [wcifRounds, selectedRoundId],

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   Accordion, Button, Header, List,
 } from 'semantic-ui-react';
@@ -8,7 +8,7 @@ import { scrambleFileUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
 import { scrambleSetToName } from './util';
 
-async function deleteScrambleFile(fileId) {
+async function deleteScrambleFile({ fileId }) {
   const { data } = await fetchJsonOrError(scrambleFileUrl(fileId), {
     method: 'DELETE',
   });
@@ -37,7 +37,7 @@ function ScrambleFileBody({ scrambleFile, removeScrambleFile }) {
   const queryClient = useQueryClient();
 
   const { mutate: deleteMutation, isPending: isDeleting } = useMutation({
-    mutationFn: () => deleteScrambleFile(scrambleFile.id),
+    mutationFn: deleteScrambleFile,
     onSuccess: (data) => {
       queryClient.setQueryData(
         ['scramble-files', data.competition_id],
@@ -47,6 +47,11 @@ function ScrambleFileBody({ scrambleFile, removeScrambleFile }) {
       removeScrambleFile(data);
     },
   });
+
+  const deleteAction = useCallback(
+    () => deleteMutation({ fileId: scrambleFile.id }),
+    [deleteMutation, scrambleFile.id],
+  );
 
   return (
     <>
@@ -62,7 +67,7 @@ function ScrambleFileBody({ scrambleFile, removeScrambleFile }) {
         negative
         icon="trash"
         content="Delete"
-        onClick={deleteMutation}
+        onClick={deleteAction}
         disabled={isDeleting}
         loading={isDeleting}
       />

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -89,10 +89,10 @@ function ScrambleMatcher({
 
   const { mutate: submitMatchState, isPending: isSubmitting } = useMutation({
     mutationFn: submitMatchedScrambles,
-    onSuccess: (
-      _response,
-      { matchState: submittedMatchState },
-    ) => setPersistedMatchingState(submittedMatchState),
+    onSuccess: (data) => {
+      const groupedAndSortedScrambles = groupAndSortScrambles(data);
+      setPersistedMatchingState(groupedAndSortedScrambles);
+    },
   });
 
   const roundIds = useMemo(() => wcifEvents.flatMap((event) => event.rounds)

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -157,6 +157,7 @@ function ScrambleMatcher({
         addScrambleFile={addScrambleFile}
         removeScrambleFile={removeScrambleFile}
       />
+      <Divider />
       {hasUnsavedChanges && (
         <Message info content="You have unsaved changes. Don't forget to Save below!" />
       )}

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -59,16 +59,19 @@ function ScrambleMatcher({
   initialScrambleFiles,
   inboxScrambleSets,
 }) {
-  const [storedMatching, setStoredMatching] = useState(groupAndSortScrambles(inboxScrambleSets));
+  const [
+    persistedMatchingState,
+    setPersistedMatchingState,
+  ] = useState(groupAndSortScrambles(inboxScrambleSets));
 
   const [matchState, dispatchMatchState] = useReducer(
     scrambleMatchReducer,
-    storedMatching,
+    persistedMatchingState,
   );
 
   const hasUnsavedChanges = useMemo(
-    () => !_.isEqual(storedMatching, matchState),
-    [storedMatching, matchState],
+    () => !_.isEqual(persistedMatchingState, matchState),
+    [persistedMatchingState, matchState],
   );
 
   const onUnload = useCallback((e) => {
@@ -105,7 +108,7 @@ function ScrambleMatcher({
     onSuccess: (
       _response,
       { matchState: submittedMatchState },
-    ) => setStoredMatching(submittedMatchState),
+    ) => setPersistedMatchingState(submittedMatchState),
   });
 
   const roundIds = useMemo(() => wcifEvents.flatMap((event) => event.rounds)

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -8,12 +8,13 @@ import FileUpload from './FileUpload';
 import Events from './Events';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 import { scramblesUpdateRoundMatchingUrl } from '../../lib/requests/routes.js.erb';
-import scrambleMatchReducer, { mergeScrambleSets } from './reducer';
+import scrambleMatchReducer, { groupAndSortScrambles } from './reducer';
 
 export default function Wrapper({
   wcifEvents,
   competitionId,
   initialScrambleFiles,
+  inboxScrambleSets,
 }) {
   return (
     <WCAQueryClientProvider>
@@ -21,6 +22,7 @@ export default function Wrapper({
         wcifEvents={wcifEvents}
         competitionId={competitionId}
         initialScrambleFiles={initialScrambleFiles}
+        inboxScrambleSets={inboxScrambleSets}
       />
     </WCAQueryClientProvider>
   );
@@ -46,11 +48,15 @@ async function submitMatchedScrambles(competitionId, matchState) {
   return data;
 }
 
-function ScrambleMatcher({ wcifEvents, competitionId, initialScrambleFiles }) {
+function ScrambleMatcher({
+  wcifEvents,
+  competitionId,
+  initialScrambleFiles,
+  inboxScrambleSets,
+}) {
   const [matchState, dispatchMatchState] = useReducer(
     scrambleMatchReducer,
-    initialScrambleFiles,
-    (files) => files.reduce(mergeScrambleSets, {}),
+    groupAndSortScrambles(inboxScrambleSets),
   );
 
   const addScrambleFile = useCallback(

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect,
+  useCallback,
   useMemo,
   useReducer,
   useState,
@@ -14,6 +14,7 @@ import Events from './Events';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 import { scramblesUpdateRoundMatchingUrl } from '../../lib/requests/routes.js.erb';
 import scrambleMatchReducer, { groupAndSortScrambles } from './reducer';
+import useUnsavedChangesAlert from '../../lib/hooks/useUnsavedChangesAlert';
 
 export default function Wrapper({
   wcifEvents,
@@ -74,24 +75,7 @@ function ScrambleMatcher({
     [persistedMatchingState, matchState],
   );
 
-  const onUnload = useCallback((e) => {
-    // Prompt the user before letting them navigate away from this page with unsaved changes.
-    if (hasUnsavedChanges) {
-      const confirmationMessage = 'You have unsaved changes, are you sure you want to leave?';
-      e.returnValue = confirmationMessage;
-      return confirmationMessage;
-    }
-
-    return null;
-  }, [hasUnsavedChanges]);
-
-  useEffect(() => {
-    window.addEventListener('beforeunload', onUnload);
-
-    return () => {
-      window.removeEventListener('beforeunload', onUnload);
-    };
-  }, [onUnload]);
+  useUnsavedChangesAlert(hasUnsavedChanges);
 
   const addScrambleFile = useCallback(
     (scrambleFile) => dispatchMatchState({ type: 'addScrambleFile', scrambleFile }),

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -18,21 +18,6 @@ export function groupAndSortScrambles(scrambleSets) {
   );
 }
 
-function applyAction(state, keys, action) {
-  return keys.reduce((accState, key) => ({
-    ...accState,
-    [key]: action(state[key]),
-  }), state);
-}
-
-export function initializeState(scrambleSets) {
-  return applyAction(
-    {},
-    ['initial', 'current'],
-    () => groupAndSortScrambles(scrambleSets),
-  );
-}
-
 function mergeScrambleSets(sortedScramblesOld, sortedScramblesNew) {
   return _.mergeWith(
     sortedScramblesOld,
@@ -45,6 +30,21 @@ function mergeScrambleSets(sortedScramblesOld, sortedScramblesNew) {
 
       return _.uniqBy(merged, 'id');
     },
+  );
+}
+
+function applyAction(state, keys, action) {
+  return keys.reduce((accState, key) => ({
+    ...accState,
+    [key]: action(state[key]),
+  }), state);
+}
+
+export function initializeState(scrambleSets) {
+  return applyAction(
+    {},
+    ['initial', 'current'],
+    () => groupAndSortScrambles(scrambleSets),
   );
 }
 

--- a/app/webpacker/components/wca/FormBuilder/EditForm.jsx
+++ b/app/webpacker/components/wca/FormBuilder/EditForm.jsx
@@ -1,8 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-} from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   Button,
   Dimmer,
@@ -15,6 +11,7 @@ import {
 import FormErrors from './FormErrors';
 import FormObjectProvider, { useFormContext, useFormObject } from './provider/FormObjectProvider';
 import ConfirmProvider, { useConfirm } from '../../../lib/providers/ConfirmProvider';
+import useUnsavedChangesAlert from '../../../lib/hooks/useUnsavedChangesAlert';
 
 function useSafeMutation(mutation, mutationArgs, unloadListener) {
   const { onSuccess: onFormSuccess, onError } = useFormContext();
@@ -90,22 +87,7 @@ function EditForm({
     errors,
   } = useFormContext();
 
-  const onUnload = useCallback((e) => {
-    // Prompt the user before letting them navigate away from this page with unsaved changes.
-    if (unsavedChanges) {
-      const confirmationMessage = 'You have unsaved changes, are you sure you want to leave?';
-      e.returnValue = confirmationMessage;
-      return confirmationMessage;
-    }
-
-    return null;
-  }, [unsavedChanges]);
-
-  useEffect(() => {
-    window.addEventListener('beforeunload', onUnload);
-
-    return () => window.removeEventListener('beforeunload', onUnload);
-  }, [onUnload]);
+  useUnsavedChangesAlert(unsavedChanges);
 
   const renderSaveButton = (buttonText) => (
     <FormActionButton

--- a/app/webpacker/components/wca/FormBuilder/EditForm.jsx
+++ b/app/webpacker/components/wca/FormBuilder/EditForm.jsx
@@ -87,7 +87,7 @@ function EditForm({
     errors,
   } = useFormContext();
 
-  useUnsavedChangesAlert(unsavedChanges);
+  const onUnload = useUnsavedChangesAlert(unsavedChanges);
 
   const renderSaveButton = (buttonText) => (
     <FormActionButton

--- a/app/webpacker/lib/hooks/useUnsavedChangesAlert.js
+++ b/app/webpacker/lib/hooks/useUnsavedChangesAlert.js
@@ -12,13 +12,15 @@ const useUnsavedChangesAlert = (hasUnsavedChanges) => {
     return null;
   }, [hasUnsavedChanges]);
 
-  return useEffect(() => {
+  useEffect(() => {
     window.addEventListener('beforeunload', onUnload);
 
     return () => {
       window.removeEventListener('beforeunload', onUnload);
     };
   }, [onUnload]);
+
+  return onUnload;
 };
 
 export default useUnsavedChangesAlert;

--- a/app/webpacker/lib/hooks/useUnsavedChangesAlert.js
+++ b/app/webpacker/lib/hooks/useUnsavedChangesAlert.js
@@ -1,0 +1,24 @@
+import { useCallback, useEffect } from 'react';
+
+const useUnsavedChangesAlert = (hasUnsavedChanges) => {
+  const onUnload = useCallback((e) => {
+    // Prompt the user before letting them navigate away from this page with unsaved changes.
+    if (hasUnsavedChanges) {
+      const confirmationMessage = 'You have unsaved changes, are you sure you want to leave?';
+      e.returnValue = confirmationMessage;
+      return confirmationMessage;
+    }
+
+    return null;
+  }, [hasUnsavedChanges]);
+
+  return useEffect(() => {
+    window.addEventListener('beforeunload', onUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', onUnload);
+    };
+  }, [onUnload]);
+};
+
+export default useUnsavedChangesAlert;

--- a/db/migrate/20250726030259_change_unique_index_on_inbox_scramble_sets.rb
+++ b/db/migrate/20250726030259_change_unique_index_on_inbox_scramble_sets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ChangeUniqueIndexOnInboxScrambleSets < ActiveRecord::Migration[7.2]
+  def change
+    change_table :inbox_scramble_sets, bulk: true do |t|
+      t.remove_index %i[competition_id event_id round_number scramble_set_number], unique: true
+      t.index %i[competition_id event_id round_number ordered_index], unique: true
+    end
+  end
+end

--- a/db/migrate/20250726030259_change_unique_index_on_inbox_scramble_sets.rb
+++ b/db/migrate/20250726030259_change_unique_index_on_inbox_scramble_sets.rb
@@ -2,9 +2,6 @@
 
 class ChangeUniqueIndexOnInboxScrambleSets < ActiveRecord::Migration[7.2]
   def change
-    change_table :inbox_scramble_sets, bulk: true do |t|
-      t.remove_index %i[competition_id event_id round_number scramble_set_number], unique: true
-      t.index %i[competition_id event_id round_number ordered_index], unique: true
-    end
+    remove_index :inbox_scramble_sets, %i[competition_id event_id round_number scramble_set_number], unique: true
   end
 end

--- a/db/migrate/20250726044928_add_unique_index_on_inbox_scrambles.rb
+++ b/db/migrate/20250726044928_add_unique_index_on_inbox_scrambles.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddUniqueIndexOnInboxScrambles < ActiveRecord::Migration[7.2]
-  def change
-    add_index :inbox_scrambles, %i[inbox_scramble_set_id ordered_index], unique: true
-  end
-end

--- a/db/migrate/20250726044928_add_unique_index_on_inbox_scrambles.rb
+++ b/db/migrate/20250726044928_add_unique_index_on_inbox_scrambles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnInboxScrambles < ActiveRecord::Migration[7.2]
+  def change
+    add_index :inbox_scrambles, %i[inbox_scramble_set_id ordered_index], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_26_044928) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_26_030259) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -692,7 +692,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_26_044928) do
     t.bigint "external_upload_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["competition_id", "event_id", "round_number", "ordered_index"], name: "idx_on_competition_id_event_id_round_number_ordered_d6c176de9e", unique: true
     t.index ["competition_id", "event_id", "round_number"], name: "idx_on_competition_id_event_id_round_number_063e808d5f"
     t.index ["competition_id"], name: "index_inbox_scramble_sets_on_competition_id"
     t.index ["event_id"], name: "fk_rails_7a55abc2f3"
@@ -708,7 +707,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_26_044928) do
     t.text "scramble_string", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["inbox_scramble_set_id", "ordered_index"], name: "idx_on_inbox_scramble_set_id_ordered_index_56858b27bf", unique: true
     t.index ["inbox_scramble_set_id", "scramble_number", "is_extra"], name: "idx_on_inbox_scramble_set_id_scramble_number_is_ext_bd518aa059", unique: true
     t.index ["inbox_scramble_set_id"], name: "index_inbox_scrambles_on_inbox_scramble_set_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_25_060536) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_26_030259) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -692,7 +692,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_25_060536) do
     t.bigint "external_upload_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["competition_id", "event_id", "round_number", "scramble_set_number"], name: "idx_on_competition_id_event_id_round_number_scrambl_d9248c75e4", unique: true
+    t.index ["competition_id", "event_id", "round_number", "ordered_index"], name: "idx_on_competition_id_event_id_round_number_ordered_d6c176de9e", unique: true
     t.index ["competition_id", "event_id", "round_number"], name: "idx_on_competition_id_event_id_round_number_063e808d5f"
     t.index ["competition_id"], name: "index_inbox_scramble_sets_on_competition_id"
     t.index ["event_id"], name: "fk_rails_7a55abc2f3"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_26_030259) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_26_044928) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -708,6 +708,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_26_030259) do
     t.text "scramble_string", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["inbox_scramble_set_id", "ordered_index"], name: "idx_on_inbox_scramble_set_id_ordered_index_56858b27bf", unique: true
     t.index ["inbox_scramble_set_id", "scramble_number", "is_extra"], name: "idx_on_inbox_scramble_set_id_scramble_number_is_ext_bd518aa059", unique: true
     t.index ["inbox_scramble_set_id"], name: "index_inbox_scrambles_on_inbox_scramble_set_id"
   end


### PR DESCRIPTION
To make this possible, the variables stored in the backend had to be stored a little. Short version: When uploading a "main" scramble set and a "whoopsie" extra incident scramble set, which has overlap with the original main set, then these scrambles would have looked identical to the comparison, when a warning message should be shown.

So we rely more on `ordered_index` now. The rest is also a bit of code reuse here and there, so I refactored and cleaned up where I could to make the move to NextJS easier.