### PR TITLE
Allow to retry Duplicate checker if delayed

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -44,6 +44,11 @@ class ResultsSubmissionController < ApplicationController
   end
 
   def compute_potential_duplicates
+    last_job_run = DuplicateCheckerJobRun.find_by(competition_id: params.require(:competition_id))
+    should_fail_last_job_run = last_job_run&.run_status_not_started? || last_job_run&.run_status_in_progress?
+
+    last_job_run.update!(run_status: DuplicateCheckerJobRun.run_statuses[:failed]) if should_fail_last_job_run
+
     job_run = DuplicateCheckerJobRun.create!(competition_id: params.require(:competition_id))
     ComputePotentialDuplicates.perform_later(job_run)
 

--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -45,9 +45,9 @@ class ResultsSubmissionController < ApplicationController
 
   def compute_potential_duplicates
     last_job_run = DuplicateCheckerJobRun.find_by(competition_id: params.require(:competition_id))
-    should_fail_last_job_run = last_job_run&.run_status_not_started? || last_job_run&.run_status_in_progress?
+    job_run_running_too_long = last_job_run&.run_status_not_started? || last_job_run&.run_status_in_progress?
 
-    last_job_run.update!(run_status: DuplicateCheckerJobRun.run_statuses[:failed]) if should_fail_last_job_run
+    last_job_run.update!(run_status: DuplicateCheckerJobRun.run_statuses[:long_running_uncertain]) if job_run_running_too_long
 
     job_run = DuplicateCheckerJobRun.create!(competition_id: params.require(:competition_id))
     ComputePotentialDuplicates.perform_later(job_run)

--- a/app/models/duplicate_checker_job_run.rb
+++ b/app/models/duplicate_checker_job_run.rb
@@ -11,6 +11,7 @@ class DuplicateCheckerJobRun < ApplicationRecord
     in_progress: 'in_progress',
     success: 'success',
     failed: 'failed',
+    long_running_uncertain: 'long_running_uncertain',
   }, prefix: true, default: :not_started
 
   DEFAULT_SERIALIZE_OPTIONS = {

--- a/app/webpacker/components/NewcomerChecks/DuplicateChecker.jsx
+++ b/app/webpacker/components/NewcomerChecks/DuplicateChecker.jsx
@@ -11,7 +11,13 @@ import MergeModal from './MergeModal';
 import EditUser from '../EditUser';
 
 export default function DuplicateChecker({ competitionId }) {
-  const { data: lastDuplicateCheckerJobRun, isLoading, isError } = useQuery({
+  const {
+    data: lastDuplicateCheckerJobRun,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ['last-duplicate-checker-job', competitionId],
     queryFn: () => getLastDuplicateCheckerJobRun({ competitionId }),
   });
@@ -46,14 +52,15 @@ export default function DuplicateChecker({ competitionId }) {
   const [potentialDuplicatePerson, setPotentialDuplicatePerson] = useState();
   const [userIdToEdit, setUserIdToEdit] = useState();
 
-  if (isLoading) return <Loading />;
-  if (isError) return <Errored />;
+  if (isFetching) return <Loading />;
+  if (isError) return <Errored error={error} />;
 
   return (
     <>
       <DuplicateCheckerHeader
         lastDuplicateCheckerJobRun={lastDuplicateCheckerJobRun}
         run={() => computePotentialDuplicatesMutate({ competitionId })}
+        refetch={refetch}
       />
       <SimilarPersons
         similarPersons={lastDuplicateCheckerJobRun.potential_duplicate_persons}

--- a/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
+++ b/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
@@ -3,6 +3,8 @@ import { DateTime } from 'luxon';
 import { Button, Message } from 'semantic-ui-react';
 import { duplicateCheckerJobRunStatuses } from '../../lib/wca-data.js.erb';
 
+// Usually this job should run in less than 5 minutes in most of the cases. It
+// can increase sometimes. A safe definition of "delay" looks like 10 minutes.
 const JOB_RUN_DELAY_MINUTES = 10;
 
 function isJobRunDelayed(lastDuplicateCheckerJobRun) {
@@ -33,21 +35,27 @@ export default function DuplicateCheckerHeader({
         <Button onClick={run}>Retry</Button>
       </Message>
     );
-  } if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.not_started) {
+  }
+
+  if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.not_started) {
     return (
       <Message info>
         Duplicate Checker will start soon. Please check after sometime.
         <Button onClick={refetch}>Refresh</Button>
       </Message>
     );
-  } if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.in_progress) {
+  }
+
+  if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.in_progress) {
     return (
       <Message info>
         Duplicate Checker is currently running. Please check after sometime.
         <Button onClick={refetch}>Refresh</Button>
       </Message>
     );
-  } if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.success) {
+  }
+
+  if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.success) {
     return (
       <Message positive>
         {`Duplicate Checker ran successfully at ${
@@ -55,7 +63,9 @@ export default function DuplicateCheckerHeader({
         <Button onClick={run}>Re-run now</Button>
       </Message>
     );
-  } if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.failed) {
+  }
+
+  if (lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.failed) {
     return (
       <Message negative>
         Something went wrong. Please try running again.
@@ -63,6 +73,7 @@ export default function DuplicateCheckerHeader({
       </Message>
     );
   }
+
   return (
     <Message positive>
       Duplicate Checker has not yet ran.

--- a/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
+++ b/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
@@ -3,13 +3,14 @@ import { DateTime } from 'luxon';
 import { Button, Message } from 'semantic-ui-react';
 import { duplicateCheckerJobRunStatuses } from '../../lib/wca-data.js.erb';
 
-// As per the specification of server while writing this comment, for each
-// server, it will take approx 2 seconds. The number of newcomers will be
-// usually 150 in very big competitions. It can go up as well. Considering 150,
-// the time taken will be around 5 minutes. I'm ignoring the uncertainties and
-// expecting that number of newcomers will get doubled over next few years. So
-// defining the delay as 10 minutes.
-const JOB_RUN_DELAY_MINUTES = 10;
+// This is the average estimate runtime for a person as of July 2025.
+const ESTIMATE_RUNTIME_SECONDS_PER_PERSON = 2;
+
+// This is the approx number of newcomers in very big competitions as of July 2025.
+const NEWCOMER_COUNT_THRESHOLD = 150;
+
+// This is the number of minutes after which we consider the job to be delayed.
+const JOB_RUN_DELAY_MINUTES = (NEWCOMER_COUNT_THRESHOLD * ESTIMATE_RUNTIME_SECONDS_PER_PERSON) / 60;
 
 function isJobRunDelayed(lastDuplicateCheckerJobRun) {
   const jobNotStartedOrInProgress = (
@@ -35,11 +36,15 @@ export default function DuplicateCheckerHeader({
   if (jobRunDelayed) {
     return (
       <Message warning>
-        {`Job running longer than ${JOB_RUN_DELAY_MINUTES} minutes. Click "Retry" if it appears
-        stuck. (Please note - retry option is available because it's running for more than
-        ${JOB_RUN_DELAY_MINUTES} minutes). If your competitions has a very high number of newcomers
-        (more than 150), it may be possible that your job actually needs more time to run. Please
-        use this button at your own discretion.`}
+        Job appears stuck, because it has been running longer than
+        {JOB_RUN_DELAY_MINUTES}
+        minutes. Click &quot;Retry&quot; below if you would like to cancel this job run and start
+        a new check.
+        Please note: If your competition has an unusually high number of newcomers (more than
+        {' '}
+        {NEWCOMER_COUNT_THRESHOLD}
+        ), it may be possible that your job actually needs more time to run.
+        Please use the button at your own discretion.
         <Button onClick={run}>Retry</Button>
       </Message>
     );

--- a/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
+++ b/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
@@ -3,8 +3,12 @@ import { DateTime } from 'luxon';
 import { Button, Message } from 'semantic-ui-react';
 import { duplicateCheckerJobRunStatuses } from '../../lib/wca-data.js.erb';
 
-// Usually this job should run in less than 5 minutes in most of the cases. It
-// can increase sometimes. A safe definition of "delay" looks like 10 minutes.
+// As per the specification of server while writing this comment, for each
+// server, it will take approx 2 seconds. The number of newcomers will be
+// usually 150 in very big competitions. It can go up as well. Considering 150,
+// the time taken will be around 5 minutes. I'm ignoring the uncertainties and
+// expecting that number of newcomers will get doubled over next few years. So
+// defining the delay as 10 minutes.
 const JOB_RUN_DELAY_MINUTES = 10;
 
 function isJobRunDelayed(lastDuplicateCheckerJobRun) {

--- a/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
+++ b/app/webpacker/components/NewcomerChecks/DuplicateCheckerHeader.jsx
@@ -35,7 +35,11 @@ export default function DuplicateCheckerHeader({
   if (jobRunDelayed) {
     return (
       <Message warning>
-        Job running longer than expected. Click &apos;Retry&apos; if it appears stuck.
+        {`Job running longer than ${JOB_RUN_DELAY_MINUTES} minutes. Click "Retry" if it appears
+        stuck. (Please note - retry option is available because it's running for more than
+        ${JOB_RUN_DELAY_MINUTES} minutes). If your competitions has a very high number of newcomers
+        (more than 150), it may be possible that your job actually needs more time to run. Please
+        use this button at your own discretion.`}
         <Button onClick={run}>Retry</Button>
       </Message>
     );


### PR DESCRIPTION
Currently if a job is stuck due to some unknown reason, Delegates won't have any way to retry. This PR is providing a "Retry" button.

Also did some cleanups related to the same files.