### PR TITLE
Display competitor list regardless of whether using WCA reg or not

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1004,11 +1004,11 @@ class Competition < ApplicationRecord
   end
 
   def after_registration_open?
-    use_wca_registration? && !cancelled? && !registration_not_yet_opened?
+    !registration_not_yet_opened?
   end
 
   def registration_currently_open?
-    after_registration_open? && !registration_past?
+    use_wca_registration? && !cancelled? && after_registration_open? && !registration_past?
   end
 
   def registration_not_yet_opened?


### PR DESCRIPTION
Fixes a critical bug where registrations that are not on our system are not showing registrations, even after successfully uploading a CSV.

The registrations are there, but due to #12076 they are hidden.

In the diff of that PR, you can see that we pulled out "too much" of the previous `registration_currently_open?` method into a new, refactored `after_registration_open?` method. In particular, the check whether a competition is using WCA system or not should not influence whether we consider a competition as "after registration open" or not.

I am not sure how to proceed about the `cancelled` part, so I am leaving this here as a PR for review rather than pushing a hotfix directly to `main`.