### PR TITLE
Remove Board permission for older TNoodle usage

### DIFF
--- a/app/views/regulations/scrambles.html.erb
+++ b/app/views/regulations/scrambles.html.erb
@@ -49,7 +49,7 @@
   <h2>About TNoodle</h2>
   <p>TNoodle uses code developed or adapted by Jeremy Fleischman, Ryan Zheng, Cl&#233;ment Gallet, Shuang Chen, Bruce Norskog, and Lucas Garron. View the <%= link_to "TNoodle project on GitHub", "https://github.com/thewca/tnoodle" %> to view the source, report an issue, or contribute to its development.</p>
   <h2>History of Official Releases</h2>
-  <p>Old versions must not be used without permission from the WCA Board. These are provided in case you want to check the behaviour of an older version.</p>
+  <p>Old versions must not be used. These are provided in case you want to check the behaviour of an older version.</p>
   <ul>
     <li><%= link_to "TNoodle-0.7.4", "https://github.com/thewca/tnoodle/releases/download/v0.7.4/TNoodle-0.7.4.jar" %> (2013-01-01)</li>
     <li><%= link_to "TNoodle-0.7.5", "https://github.com/thewca/tnoodle/releases/download/v0.7.5/TNoodle-0.7.5.jar" %> (2013-02-26)</li>

--- a/next-frontend/src/app/(wca)/regulations/scrambles/page.tsx
+++ b/next-frontend/src/app/(wca)/regulations/scrambles/page.tsx
@@ -155,9 +155,8 @@ export default async function ScramblesPage() {
         </Text>
         <Heading size="2xl">History of Official Releases</Heading>
         <Text>
-          Old versions must not be used without permission from the WCA Board.
-          These are provided in case you want to check the behaviour of an older
-          version.
+          Old versions must not be used. These are provided in case you want 
+          to check the behaviour of an older version.
         </Text>
         <List.Root>
           <List.Item>


### PR DESCRIPTION
The existing text is not in line with current practice. The Board have agreed with their removal from this page.