### PR TITLE
Fixes in results ticket page

### DIFF
--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -27,10 +27,12 @@ function CompetitionResultSubmission(
   },
 ) {
   if (resultsSubmitted) {
-    <Message positive>
-      The results have already been submitted. If you have any more questions or
-      comments please reply to the email sent with the first results submission.
-    </Message>;
+    return (
+      <Message positive>
+        The results have already been submitted. If you have any more questions or
+        comments please reply to the email sent with the first results submission.
+      </Message>
+    );
   }
 
   return (

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/FinalSteps.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/FinalSteps.jsx
@@ -5,7 +5,7 @@ import Loading from '../../../Requests/Loading';
 import Errored from '../../../Requests/Errored';
 import postResults from '../../api/competitionResult/postResults';
 import { ticketsCompetitionResultStatuses } from '../../../../lib/wca-data.js.erb';
-import { viewUrls, competitionUrl } from '../../../../lib/requests/routes.js.erb';
+import { viewUrls, competitionAllResultsUrl } from '../../../../lib/requests/routes.js.erb';
 
 export default function FinalSteps({ ticketDetails }) {
   const { ticket: { id, metadata: { competition_id: competitionId } } } = ticketDetails;
@@ -69,10 +69,10 @@ export default function FinalSteps({ ticketDetails }) {
           <Button
             as="a"
             primary
-            href={competitionUrl(competitionId)}
+            href={competitionAllResultsUrl(competitionId, 'all')}
             target="_blank"
           >
-            Competitions Page
+            Public results page
           </Button>
           You can click this to visit the competition page as an additional sanity check.
           Once you are sure, you can post the results using the button below.

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/ResultsPreview.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/ResultsPreview.jsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import React, { useMemo, useState } from 'react';
 import _ from 'lodash';
-import { Accordion } from 'semantic-ui-react';
+import { Accordion, Message } from 'semantic-ui-react';
 import getImportedTemporaryResults from '../../api/competitionResult/getImportedTemporaryResults';
 import Errored from '../../../Requests/Errored';
 import Loading from '../../../Requests/Loading';
@@ -65,6 +65,11 @@ export function ResultsPreview({ competitionId }) {
         Preview imported results
       </Accordion.Title>
       <Accordion.Content active={activeAccordion}>
+        <Message positive>
+          Total no. of temporary results:
+          {' '}
+          {importedTemporaryResults.length}
+        </Message>
         <ResultsPreviewAccordion roundDetails={roundDetails} groupedResults={groupedResults} />
       </Accordion.Content>
     </Accordion>


### PR DESCRIPTION
Doing the following fixes in this PR:

1. Forgot to add a return for a message render earlier, fixed it now.
2. In "Final steps" page, the link should have been to the 'all results page' and not 'competitions page', fixed it now.
3. Showing total number of results in Results Preview table.