### PR TITLE
Clean up Payload homepage types

### DIFF
--- a/next-frontend/src/app/(payload)/payload/importMap.js
+++ b/next-frontend/src/app/(payload)/payload/importMap.js
@@ -23,6 +23,7 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { AccountRowLabel as AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
 import { SignInButton as SignInButton_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
+import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -49,5 +50,6 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "payload-authjs/components#AccountRowLabel": AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e,
-  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e
+  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e,
+  "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
 }

--- a/next-frontend/src/app/(payload)/payload/importMap.js
+++ b/next-frontend/src/app/(payload)/payload/importMap.js
@@ -23,7 +23,6 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { AccountRowLabel as AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
 import { SignInButton as SignInButton_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
-import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -50,6 +49,5 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "payload-authjs/components#AccountRowLabel": AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e,
-  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e,
-  "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
+  "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e
 }

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -17,6 +17,7 @@ import {
   Link as ChakraLink,
   Center,
 } from "@chakra-ui/react";
+import { MarkdownProse } from "@/components/Markdown";
 import AnnouncementsCard from "@/components/AnnouncementsCard";
 import { getPayload } from "payload";
 import config from "@payload-config";
@@ -65,7 +66,9 @@ const TextCard = ({ block }: { block: TextCardBlock }) => {
       <Card.Body>
         <Card.Title>{block.heading}</Card.Title>
         {block.separatorAfterHeading && <Separator size="md" />}
-        <Card.Description>{block.bodyMarkdown}</Card.Description>
+        <Card.Description>
+          <MarkdownProse content={block.bodyMarkdown} color="colorPalette.fg" />
+        </Card.Description>
         {block.buttonText?.trim() && (
           <Button mr="auto" asChild>
             <ChakraLink asChild>
@@ -164,9 +167,11 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
         >
           {block.heading}
         </Heading>
-        <Text fontSize="md" color="colorPalette.fg">
-          {block.bodyMarkdown}
-        </Text>
+        <MarkdownProse
+          content={block.bodyMarkdown}
+          color="colorPalette.fg"
+          fontSize="md"
+        />
       </Card.Body>
     </Card.Root>
   );
@@ -328,7 +333,10 @@ const TestimonialsSpinner = ({ block }: { block: TestimonialsBlock }) => {
                   <Card.Title>{testimonial.punchline}</Card.Title>
                   <Separator size="md" />
                   <Card.Description>
-                    {testimonial.fullTestimonialMarkdown}
+                    <MarkdownProse
+                      content={testimonial.fullTestimonialMarkdown}
+                      color="colorPalette.fg"
+                    />
                   </Card.Description>
                   <Text>{testimonial.whoDunnit}</Text>
                 </Card.Body>

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -65,7 +65,7 @@ const TextCard = ({ block }: { block: TextCardBlock }) => {
       <Card.Body>
         <Card.Title>{block.heading}</Card.Title>
         {block.separatorAfterHeading && <Separator size="md" />}
-        <Card.Description>{block.body}</Card.Description>
+        <Card.Description>{block.bodyMarkdown}</Card.Description>
         {block.buttonText?.trim() && (
           <Button mr="auto" asChild>
             <ChakraLink asChild>
@@ -165,7 +165,7 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
           {block.heading}
         </Heading>
         <Text fontSize="md" color="colorPalette.fg">
-          {block.body}
+          {block.bodyMarkdown}
         </Text>
       </Card.Body>
     </Card.Root>

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -8,7 +8,7 @@ import {
   Card,
   Separator,
   Box,
-  Image,
+  Image as ChakraImage,
   Heading,
   Text,
   Tabs,
@@ -40,43 +40,12 @@ import type {
   TwoBlocksBlock,
   TwoBlocksBranchBlock,
   TwoBlocksLeafBlock,
-  ColorSelect,
   Testimonial,
   AnnouncementsSectionBlock,
   Announcement,
   User,
 } from "@/types/payload";
 import Link from "next/link";
-
-const colorMap: Record<ColorSelect, string> = {
-  blue: "blue.50",
-  red: "red.50",
-  green: "green.50",
-  orange: "orange.50",
-  yellow: "yellow.50",
-  darkBlue: "blue.100",
-  darkRed: "red.100",
-  darkGreen: "green.100",
-  darkOrange: "orange.100",
-  darkYellow: "yellow.100",
-  white: "supplementary.texts.light",
-  black: "supplementary.texts.dark",
-};
-
-const colorGradientMap: Record<ColorSelect, string> = {
-  blue: "blue-50",
-  red: "red-50",
-  green: "green-50",
-  orange: "orange-50",
-  yellow: "yellow-50",
-  darkBlue: "blue-100",
-  darkRed: "red-100",
-  darkGreen: "green-100",
-  darkOrange: "orange-100",
-  darkYellow: "yellow-100",
-  white: "white-100",
-  black: "black-100",
-};
 
 const TextCard = ({ block }: { block: TextCardBlock }) => {
   return (
@@ -87,7 +56,7 @@ const TextCard = ({ block }: { block: TextCardBlock }) => {
       width="full"
     >
       {block.headerImage && (
-        <Image
+        <ChakraImage
           src={(block.headerImage as Media).url ?? undefined}
           alt={(block.headerImage as Media).alt ?? undefined}
           aspectRatio="3/1"
@@ -138,6 +107,9 @@ const AnnouncementsSection = ({
 };
 
 const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
+  const colorPaletteTone = block.colorPaletteDarker ? 100 : 50;
+  const headingColorPalette = block.headingColor ?? "colorPalette";
+
   return (
     <Card.Root
       variant="info"
@@ -146,25 +118,23 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
       colorPalette={block.colorPalette}
       size="lg"
     >
-      <Box position="relative" flex="1" minW="50%" maxW="50%" overflow="hidden">
-        <Image
+      <Box position="relative" width="50%" overflow="hidden">
+        <ChakraImage
           src={(block.mainImage as Media).url ?? undefined}
           alt={(block.mainImage as Media).alt ?? undefined}
           objectFit="cover"
           width="100%"
           height="40vh"
-          bg={colorMap[block.bgColor]}
+          bg={`colorPalette.${colorPaletteTone}`}
         />
-        {/* Blue Gradient Overlay */}
+        {/* Gradient Overlay */}
         <Box
           position="absolute"
           top="0"
           right="0"
           bottom="0"
           left="50%"
-          style={{
-            backgroundImage: `linear-gradient(to right, transparent, var(--chakra-colors-${colorGradientMap[block.bgColor]}))`,
-          }}
+          bgImage={`linear-gradient(to right, transparent, {colors.colorPalette.${colorPaletteTone}})`}
           zIndex="1"
         />
       </Box>
@@ -174,7 +144,7 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
         zIndex="2"
         color="white"
         p="8"
-        bg={colorMap[block.bgColor]}
+        bg={`colorPalette.${colorPaletteTone}`}
         justifyContent="center"
         pr="15%"
         backgroundImage={
@@ -188,13 +158,13 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
       >
         <Heading
           size="4xl"
-          color={colorMap[block.headingColor]}
+          color={`${headingColorPalette}.emphasized`}
           mb="4"
           textTransform="uppercase"
         >
           {block.heading}
         </Heading>
-        <Text fontSize="md" color={colorMap[block.textColor]}>
+        <Text fontSize="md" color="colorPalette.fg">
           {block.body}
         </Text>
       </Card.Body>
@@ -210,7 +180,7 @@ const ImageOnlyCard = ({ block }: { block: ImageOnlyCardBlock }) => {
       colorPalette={block.colorPalette}
       width="full"
     >
-      <Image
+      <ChakraImage
         src={(block.mainImage as Media).url ?? undefined}
         alt={(block.mainImage as Media).alt ?? block.heading ?? undefined}
         aspectRatio="2/1"
@@ -346,7 +316,7 @@ const TestimonialsSpinner = ({ block }: { block: TestimonialsBlock }) => {
                 overflow="hidden"
                 colorPalette={slide.colorPalette}
               >
-                <Image
+                <ChakraImage
                   src={
                     testimonial.image != null
                       ? ((testimonial.image as Media).url ?? undefined)

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -146,20 +146,20 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
         p="8"
         bg={`colorPalette.${colorPaletteTone}`}
         justifyContent="center"
-        pr="15%"
+        paddingRight="15%"
         backgroundImage={
           block.bgImage != null
             ? `url('${(block.bgImage as Media).url}')`
             : undefined
         }
-        backgroundSize={block.bgSize != null ? `${block.bgSize}%` : undefined}
-        backgroundPosition={block.bgPos ?? undefined}
+        backgroundSize={`${block.bgSize}%`}
+        backgroundPosition={block.bgPos}
         backgroundRepeat="no-repeat"
       >
         <Heading
           size="4xl"
           color={`${headingColorPalette}.emphasized`}
-          mb="4"
+          marginBottom="4"
           textTransform="uppercase"
         >
           {block.heading}

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -208,61 +208,54 @@ const FeaturedCompetitions = ({
           Featured Upcoming Competitions
           <Button variant="outline">View all Competitions</Button>
         </Card.Title>
-        <SimpleGrid columns={2} gap={4}>
-          <Card.Root variant="info" colorPalette={block.colorPalette1}>
-            <Card.Body>
-              <Heading size="3xl">{block.Competition1ID}</Heading>
-              <VStack alignItems="start">
-                <Badge variant="information" colorPalette={block.colorPalette1}>
-                  <Flag code={"US"} fallback={"US"} />
-                  <CountryMap code="US" bold /> Seattle
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette1}>
-                  <CompRegoCloseDateIcon />
-                  <Text>Jul 3 - 6, 2025</Text>
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette1}>
-                  <CompetitorsIcon />
-                  2000 Competitor Limit
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette1}>
-                  <RegisterIcon />0 Spots Left
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette1}>
-                  <LocationIcon />
-                  Seattle Convention Center
-                </Badge>
-              </VStack>
-            </Card.Body>
-          </Card.Root>
-
-          <Card.Root variant="info" colorPalette="yellow">
-            <Card.Body>
-              <Heading size="3xl">{block.Competition2ID}</Heading>
-              <VStack alignItems="start">
-                <Badge variant="information" colorPalette={block.colorPalette2}>
-                  <Flag code={"NZ"} fallback={"NZ"} />
-                  <CountryMap code="NZ" bold /> Auckland
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette2}>
-                  <CompRegoCloseDateIcon />
-                  <Text>Dec 12 - 14, 2025</Text>
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette2}>
-                  <CompetitorsIcon />
-                  300 Competitor Limit
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette2}>
-                  <RegisterIcon />
-                  300 Spots Left
-                </Badge>
-                <Badge variant="information" colorPalette={block.colorPalette2}>
-                  <LocationIcon />
-                  Auckland Netball Centre
-                </Badge>
-              </VStack>
-            </Card.Body>
-          </Card.Root>
+        <SimpleGrid columns={block.competitions?.length} gap={4}>
+          {block.competitions?.map((featuredComp) => (
+            <Card.Root
+              key={featuredComp.competitionId}
+              variant="info"
+              colorPalette={featuredComp.colorPalette}
+            >
+              <Card.Body>
+                <Heading size="3xl">{featuredComp.competitionId}</Heading>
+                <VStack alignItems="start">
+                  <Badge
+                    variant="information"
+                    colorPalette={featuredComp.colorPalette}
+                  >
+                    <Flag code={"US"} fallback={"US"} />
+                    <CountryMap code="US" bold /> Seattle
+                  </Badge>
+                  <Badge
+                    variant="information"
+                    colorPalette={featuredComp.colorPalette}
+                  >
+                    <CompRegoCloseDateIcon />
+                    <Text>Jul 3 - 6, 2025</Text>
+                  </Badge>
+                  <Badge
+                    variant="information"
+                    colorPalette={featuredComp.colorPalette}
+                  >
+                    <CompetitorsIcon />
+                    2000 Competitor Limit
+                  </Badge>
+                  <Badge
+                    variant="information"
+                    colorPalette={featuredComp.colorPalette}
+                  >
+                    <RegisterIcon />0 Spots Left
+                  </Badge>
+                  <Badge
+                    variant="information"
+                    colorPalette={featuredComp.colorPalette}
+                  >
+                    <LocationIcon />
+                    Seattle Convention Center
+                  </Badge>
+                </VStack>
+              </Card.Body>
+            </Card.Root>
+          ))}
         </SimpleGrid>
       </Card.Body>
     </Card.Root>
@@ -270,7 +263,8 @@ const FeaturedCompetitions = ({
 };
 
 const TestimonialsSpinner = ({ block }: { block: TestimonialsBlock }) => {
-  const slides = block.blocks;
+  const slides = block.slides;
+
   return (
     <Tabs.Root
       defaultValue={slides[0].id}

--- a/next-frontend/src/collections/helpers.ts
+++ b/next-frontend/src/collections/helpers.ts
@@ -14,7 +14,6 @@ export const markdownConvertedField = (
 ): Field => {
   return {
     name: convertedName,
-    required: true,
     type: "textarea",
     admin: {
       hidden: true,

--- a/next-frontend/src/components/Markdown.tsx
+++ b/next-frontend/src/components/Markdown.tsx
@@ -3,19 +3,32 @@ import Markdown from "react-markdown";
 import { Link as ChakraLink } from "@chakra-ui/react";
 import Link from "next/link";
 
-import type { ElementType } from "react";
+import type {
+  ComponentPropsWithoutRef,
+  ElementType,
+  ReactElement,
+} from "react";
 
-interface MarkdownProseProps {
+type MarkdownProseOwnProps = {
   content: string;
-  as?: ElementType;
-}
+};
 
-export const MarkdownProse = ({
+type PolymorphicMarkdownProseProps<T extends ElementType> =
+  MarkdownProseOwnProps & {
+    as?: T;
+  } & Omit<ComponentPropsWithoutRef<T>, keyof MarkdownProseOwnProps | "as">;
+
+type MarkdownProseComponent = <T extends ElementType = typeof Prose>(
+  props: PolymorphicMarkdownProseProps<T>,
+) => ReactElement | null;
+
+export const MarkdownProse: MarkdownProseComponent = ({
   content,
   as: RenderAs = Prose,
-}: MarkdownProseProps) => {
+  ...restProps
+}) => {
   return (
-    <RenderAs>
+    <RenderAs {...restProps}>
       <Markdown
         components={{
           a: ({ href, children }) => (

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -1,25 +1,4 @@
-import { Block, GlobalConfig, SelectField } from "payload";
-
-const colorSelect: SelectField = {
-  name: "color",
-  type: "select",
-  required: true,
-  interfaceName: "ColorSelect",
-  options: [
-    "darkBlue",
-    "darkRed",
-    "darkGreen",
-    "darkOrange",
-    "darkYellow",
-    "blue",
-    "red",
-    "green",
-    "orange",
-    "yellow",
-    "white",
-    "black",
-  ],
-};
+import { Block, CheckboxField, GlobalConfig, SelectField } from "payload";
 
 const colorPaletteSelect: SelectField = {
   name: "colorPalette",
@@ -27,6 +6,14 @@ const colorPaletteSelect: SelectField = {
   required: true,
   interfaceName: "ColorPaletteSelect",
   options: ["blue", "red", "green", "orange", "yellow", "grey"],
+};
+
+const colorPaletteToneToggle: CheckboxField = {
+  name: "colorPaletteDarker",
+  type: "checkbox",
+  admin: {
+    description: "Use a slightly darker nuance of the color palette",
+  },
 };
 
 const TextCard: Block = {
@@ -98,17 +85,15 @@ const ImageBanner: Block = {
       required: true,
     },
     colorPaletteSelect,
+    colorPaletteToneToggle,
     {
-      ...colorSelect,
-      name: "bgColor",
-    },
-    {
-      ...colorSelect,
+      ...colorPaletteSelect,
       name: "headingColor",
-    },
-    {
-      ...colorSelect,
-      name: "textColor",
+      required: false,
+      admin: {
+        description:
+          "Color for the heading. Will follow the overall color palette by default, only use this field if you want to purposely override (for example, to achieve a more striking contrast that garners attention)",
+      },
     },
     {
       name: "bgImage",

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -106,12 +106,20 @@ const ImageBanner: Block = {
     {
       name: "bgSize",
       type: "number",
+      min: 10,
+      max: 100,
       defaultValue: 100,
+      required: true,
+      admin: {
+        description: "The size of the background image in percent (%)",
+      },
     },
     {
       name: "bgPos",
-      type: "text",
+      type: "select",
+      options: ["right", "left"],
       defaultValue: "right",
+      required: true,
     },
   ],
 };

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -149,22 +149,16 @@ const FeaturedCompetitions: Block = {
   imageURL: "/payload/featured_upcoming_competitions.png",
   fields: [
     {
-      name: "Competition1ID",
-      type: "text",
-      required: true,
-    },
-    {
-      ...colorPaletteSelect,
-      name: "colorPalette1",
-    },
-    {
-      name: "Competition2ID",
-      type: "text",
-      required: true,
-    },
-    {
-      ...colorPaletteSelect,
-      name: "colorPalette2",
+      name: "competitions",
+      type: "array",
+      fields: [
+        {
+          name: "competitionId",
+          type: "text",
+          required: true,
+        },
+        colorPaletteSelect,
+      ],
     },
   ],
 };
@@ -190,24 +184,6 @@ const AnnouncementsSection: Block = {
   ],
 };
 
-const TestimonialSlide: Block = {
-  slug: "TestimonialSlide",
-  interfaceName: "TestimonialSlideBlock",
-  labels: {
-    singular: "Testimonial",
-    plural: "Testimonials",
-  },
-  fields: [
-    {
-      name: "testimonial",
-      type: "relationship",
-      relationTo: "testimonials",
-      required: true,
-    },
-    colorPaletteSelect,
-  ],
-};
-
 const TestimonialsSpinner: Block = {
   slug: "TestimonialsSpinner",
   interfaceName: "TestimonialsBlock",
@@ -218,9 +194,17 @@ const TestimonialsSpinner: Block = {
   },
   fields: [
     {
-      name: "blocks",
-      type: "blocks",
-      blocks: [TestimonialSlide],
+      name: "slides",
+      type: "array",
+      fields: [
+        {
+          name: "testimonial",
+          type: "relationship",
+          relationTo: "testimonials",
+          required: true,
+        },
+        colorPaletteSelect,
+      ],
       required: true,
       minRows: 1,
     },

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -1,4 +1,5 @@
 import { Block, CheckboxField, GlobalConfig, SelectField } from "payload";
+import { markdownConvertedField } from "@/collections/helpers";
 
 const colorPaletteSelect: SelectField = {
   name: "colorPalette",
@@ -28,9 +29,10 @@ const TextCard: Block = {
     },
     {
       name: "body",
-      type: "textarea",
+      type: "richText",
       required: true,
     },
+    markdownConvertedField("body"),
     {
       name: "variant",
       type: "select",
@@ -75,9 +77,10 @@ const ImageBanner: Block = {
     },
     {
       name: "body",
-      type: "textarea",
+      type: "richText",
       required: true,
     },
+    markdownConvertedField("body"),
     {
       name: "mainImage",
       type: "upload",

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -144,7 +144,7 @@ const ImageOnlyCard: Block = {
 };
 
 const FeaturedCompetitions: Block = {
-  slug: "FeaturedCompetitions",
+  slug: "FeaturedComps", // intentionally short to avoid Payload internally assigning a long table name
   interfaceName: "FeaturedCompetitionsBlock",
   imageURL: "/payload/featured_upcoming_competitions.png",
   fields: [

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -897,31 +897,27 @@ export interface ImageOnlyCardBlock {
  * via the `definition` "TestimonialsBlock".
  */
 export interface TestimonialsBlock {
-  blocks: TestimonialSlideBlock[];
+  slides: {
+    testimonial: number | Testimonial;
+    colorPalette: ColorPaletteSelect;
+    id?: string | null;
+  }[];
   id?: string | null;
   blockName?: string | null;
   blockType: 'TestimonialsSpinner';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TestimonialSlideBlock".
- */
-export interface TestimonialSlideBlock {
-  testimonial: number | Testimonial;
-  colorPalette: ColorPaletteSelect;
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'TestimonialSlide';
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "FeaturedCompetitionsBlock".
  */
 export interface FeaturedCompetitionsBlock {
-  Competition1ID: string;
-  colorPalette1: ColorPaletteSelect;
-  Competition2ID: string;
-  colorPalette2: ColorPaletteSelect;
+  competitions?:
+    | {
+        competitionId: string;
+        colorPalette: ColorPaletteSelect;
+        id?: string | null;
+      }[]
+    | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'FeaturedCompetitions';
@@ -1402,21 +1398,13 @@ export interface ImageOnlyCardBlockSelect<T extends boolean = true> {
  * via the `definition` "TestimonialsBlock_select".
  */
 export interface TestimonialsBlockSelect<T extends boolean = true> {
-  blocks?:
+  slides?:
     | T
     | {
-        TestimonialSlide?: T | TestimonialSlideBlockSelect<T>;
+        testimonial?: T;
+        colorPalette?: T;
+        id?: T;
       };
-  id?: T;
-  blockName?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TestimonialSlideBlock_select".
- */
-export interface TestimonialSlideBlockSelect<T extends boolean = true> {
-  testimonial?: T;
-  colorPalette?: T;
   id?: T;
   blockName?: T;
 }
@@ -1425,10 +1413,13 @@ export interface TestimonialSlideBlockSelect<T extends boolean = true> {
  * via the `definition` "FeaturedCompetitionsBlock_select".
  */
 export interface FeaturedCompetitionsBlockSelect<T extends boolean = true> {
-  Competition1ID?: T;
-  colorPalette1?: T;
-  Competition2ID?: T;
-  colorPalette2?: T;
+  competitions?:
+    | T
+    | {
+        competitionId?: T;
+        colorPalette?: T;
+        id?: T;
+      };
   id?: T;
   blockName?: T;
 }

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -871,8 +871,11 @@ export interface ImageBannerBlock {
   colorPaletteDarker?: boolean | null;
   headingColor?: ColorPaletteSelect;
   bgImage?: (number | null) | Media;
-  bgSize?: number | null;
-  bgPos?: string | null;
+  /**
+   * The size of the background image in percent (%)
+   */
+  bgSize: number;
+  bgPos: 'right' | 'left';
   id?: string | null;
   blockName?: string | null;
   blockType: 'ImageBanner';

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -803,7 +803,22 @@ export interface TwoBlocksBlock {
  */
 export interface TextCardBlock {
   heading: string;
-  body: string;
+  body: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  bodyMarkdown: string;
   variant: 'info' | 'hero';
   separatorAfterHeading: boolean;
   buttonText?: string | null;
@@ -832,7 +847,22 @@ export interface AnnouncementsSectionBlock {
  */
 export interface ImageBannerBlock {
   heading: string;
-  body: string;
+  body: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  bodyMarkdown: string;
   mainImage: number | Media;
   colorPalette: ColorPaletteSelect;
   /**
@@ -1314,6 +1344,7 @@ export interface TwoBlocksBlockSelect<T extends boolean = true> {
 export interface TextCardBlockSelect<T extends boolean = true> {
   heading?: T;
   body?: T;
+  bodyMarkdown?: T;
   variant?: T;
   separatorAfterHeading?: T;
   buttonText?: T;
@@ -1341,6 +1372,7 @@ export interface AnnouncementsSectionBlockSelect<T extends boolean = true> {
 export interface ImageBannerBlockSelect<T extends boolean = true> {
   heading?: T;
   body?: T;
+  bodyMarkdown?: T;
   mainImage?: T;
   colorPalette?: T;
   colorPaletteDarker?: T;

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -121,23 +121,6 @@ export type IconName =
   | 'SkewbIcon'
   | 'Sq1Icon';
 /**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "ColorSelect".
- */
-export type ColorSelect =
-  | 'darkBlue'
-  | 'darkRed'
-  | 'darkGreen'
-  | 'darkOrange'
-  | 'darkYellow'
-  | 'blue'
-  | 'red'
-  | 'green'
-  | 'orange'
-  | 'yellow'
-  | 'white'
-  | 'black';
-/**
  * Supported timezones in IANA format.
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -852,9 +835,11 @@ export interface ImageBannerBlock {
   body: string;
   mainImage: number | Media;
   colorPalette: ColorPaletteSelect;
-  bgColor: ColorSelect;
-  headingColor: ColorSelect;
-  textColor: ColorSelect;
+  /**
+   * Use a slightly darker nuance of the color palette
+   */
+  colorPaletteDarker?: boolean | null;
+  headingColor?: ColorPaletteSelect;
   bgImage?: (number | null) | Media;
   bgSize?: number | null;
   bgPos?: string | null;
@@ -1358,9 +1343,8 @@ export interface ImageBannerBlockSelect<T extends boolean = true> {
   body?: T;
   mainImage?: T;
   colorPalette?: T;
-  bgColor?: T;
+  colorPaletteDarker?: T;
   headingColor?: T;
-  textColor?: T;
   bgImage?: T;
   bgSize?: T;
   bgPos?: T;


### PR DESCRIPTION
The Bento box block types for the homepage CMS were a little bit "too individual". The options needed sensible defaults and the color pickers needed coherence. This PR contains several small fixes, most notably:
- Consistent color schemes everywhere
- ChakraUI shorthands instead of manually injected CSS
- Styled markdown according to the color scheme