### PR TITLE
Actually use stylistic package for linting

### DIFF
--- a/next-frontend/eslint.config.mjs
+++ b/next-frontend/eslint.config.mjs
@@ -4,6 +4,7 @@ import { FlatCompat } from "@eslint/eslintrc";
 import { globalIgnores } from "eslint/config";
 import stylistic from "@stylistic/eslint-plugin";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import eslintConfigPrettier from "eslint-config-prettier/flat";
 import pluginQuery from "@tanstack/eslint-plugin-query";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -15,13 +16,10 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
-  {
-    plugins: {
-      "@stylistic": stylistic,
-    },
-  },
   eslintPluginPrettierRecommended,
   ...pluginQuery.configs["flat/recommended"],
+  stylistic.configs.recommended,
+  eslintConfigPrettier,
   globalIgnores(["src/types"]),
 ];
 

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/admin/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/admin/page.tsx
@@ -26,7 +26,7 @@ export default async function CompetitionOverview({
     <Container centerContent>
       <Heading>{competitionInfo.name}</Heading>
       <PermissionCheck
-        requiredPermission={"canAdministerCompetition"}
+        requiredPermission="canAdministerCompetition"
         item={competitionId}
       >
         <Text>You are administering this competition</Text>

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/page.tsx
@@ -124,7 +124,7 @@ export default async function CompetitionOverView({
       <Tabs.Root
         variant="enclosed"
         w="100%"
-        defaultValue={"general"}
+        defaultValue="general"
         orientation="vertical"
         lazyMount
         unmountOnExit

--- a/next-frontend/src/app/(wca)/delegates/page.tsx
+++ b/next-frontend/src/app/(wca)/delegates/page.tsx
@@ -32,7 +32,7 @@ export default async function DelegatesPage() {
 
   return (
     <Container>
-      <VStack align={"left"} gap="8" width="full" pt="8" alignItems="left">
+      <VStack align="left" gap="8" width="full" pt="8" alignItems="left">
         <Heading size="5xl">{t("delegates_page.title")}</Heading>
         <I18nHTMLTranslate
           i18nKey="about.structure.delegates_html"
@@ -55,7 +55,7 @@ export default async function DelegatesPage() {
             ))}
           </Tabs.List>
           {rootGroups.map((group) => (
-            <Tabs.Content value={group.name} key={group.id} w={"full"}>
+            <Tabs.Content value={group.name} key={group.id} w="full">
               <DelegateTab group={group} />
             </Tabs.Content>
           ))}
@@ -70,7 +70,7 @@ function DelegateTab({ group }: { group: components["schemas"]["UserGroup"] }) {
   const { email } = metadata!;
 
   return (
-    <VStack align={"left"}>
+    <VStack align="left">
       <Heading size="2xl">{name}</Heading>
       <Link href={`mailto:${email}`}>{email}</Link>
       <Center>
@@ -97,7 +97,7 @@ async function MemberTable({ id }: { id: number }) {
 
   return _.map(roles, (delegates, region) => (
     <VStack>
-      <Heading size={"xl"}>{region}</Heading>
+      <Heading size="xl">{region}</Heading>
       <Table.Root>
         <Table.Header>
           <Table.Row>

--- a/next-frontend/src/app/(wca)/documents/page.tsx
+++ b/next-frontend/src/app/(wca)/documents/page.tsx
@@ -55,7 +55,7 @@ export default async function Documents() {
               </Accordion.ItemTrigger>
               <Accordion.ItemContent>
                 <Accordion.ItemBody>
-                  <List.Root pl={"10"}>
+                  <List.Root pl="10">
                     {docs
                       .toSorted((a, b) => a.title.localeCompare(b.title))
                       .map((doc) => (

--- a/next-frontend/src/app/(wca)/export/developer/page.tsx
+++ b/next-frontend/src/app/(wca)/export/developer/page.tsx
@@ -20,7 +20,7 @@ export default async function ResultExportPage() {
         <Heading size="5xl">{t("database.developer_export.heading")}</Heading>
         <I18nHTMLTranslate
           as={Text}
-          i18nKey={"database.developer_export.description_html"}
+          i18nKey="database.developer_export.description_html"
           options={{
             github_link:
               "<a href='https://github.com/thewca/worldcubeassociation.org/wiki/Developer-database-export'>GitHub</a>",

--- a/next-frontend/src/app/(wca)/incidents/page.tsx
+++ b/next-frontend/src/app/(wca)/incidents/page.tsx
@@ -103,10 +103,10 @@ export default function IncidentsPage() {
 
   return (
     <Container>
-      <VStack align={"left"}>
+      <VStack align="left">
         <Heading size="5xl">Incidents Log</Heading>
         <Input
-          placeholder={"Search"}
+          placeholder="Search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />

--- a/next-frontend/src/app/(wca)/officers-and-board/page.tsx
+++ b/next-frontend/src/app/(wca)/officers-and-board/page.tsx
@@ -35,9 +35,9 @@ export default async function OfficersAndBoard() {
 
   return (
     <Container>
-      <VStack align={"left"}>
-        <Heading size={"5xl"}>{t("page.officers_and_board.title")}</Heading>
-        <Heading size={"2xl"}>{t("user_groups.group_types.officers")}</Heading>
+      <VStack align="left">
+        <Heading size="5xl">{t("page.officers_and_board.title")}</Heading>
+        <Heading size="2xl">{t("user_groups.group_types.officers")}</Heading>
         <Text>{t("page.officers_and_board.officers_description")}</Text>
         <SimpleGrid columns={3} gap="16px">
           {officers.map((officer) => (
@@ -55,7 +55,7 @@ export default async function OfficersAndBoard() {
             />
           ))}
         </SimpleGrid>
-        <Heading size={"2xl"}>
+        <Heading size="2xl">
           {t("user_groups.group_types.board")}{" "}
           <Link href={boardRoles[0].group.metadata!.email}>
             <MdMarkEmailUnread />

--- a/next-frontend/src/app/(wca)/organizations/page.tsx
+++ b/next-frontend/src/app/(wca)/organizations/page.tsx
@@ -32,8 +32,8 @@ export default async function RegionalOrganizations() {
 
   return (
     <Container>
-      <VStack align={"left"}>
-        <Heading size={"5xl"}>{I18n.t("regional_organizations.title")}</Heading>
+      <VStack align="left">
+        <Heading size="5xl">{I18n.t("regional_organizations.title")}</Heading>
         <Text>{I18n.t("regional_organizations.content")}</Text>
         <SimpleGrid columns={3} columnGap={4} rowGap={6}>
           {organizations.map((org) => (
@@ -89,12 +89,12 @@ export default async function RegionalOrganizations() {
             </LinkBox>
           ))}
         </SimpleGrid>
-        <Heading size={"2xl"}>
+        <Heading size="2xl">
           {I18n.t("regional_organizations.how_to.title")}
         </Heading>
         <Text>{I18n.t("regional_organizations.how_to.description")}</Text>
 
-        <Heading size={"xl"}>
+        <Heading size="xl">
           {I18n.t("regional_organizations.requirements.title")}
         </Heading>
         <List.Root>
@@ -109,7 +109,7 @@ export default async function RegionalOrganizations() {
           ))}
         </List.Root>
 
-        <Heading size={"xl"}>
+        <Heading size="xl">
           {I18n.t("regional_organizations.application_instructions.title")}
         </Heading>
         <I18nHTMLTranslate i18nKey="regional_organizations.application_instructions.description_html" />

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -229,7 +229,7 @@ const FeaturedCompetitions = ({
                     variant="information"
                     colorPalette={featuredComp.colorPalette}
                   >
-                    <Flag code={"US"} fallback={"US"} />
+                    <Flag code="US" fallback="US" />
                     <CountryMap code="US" bold /> Seattle
                   </Badge>
                   <Badge

--- a/next-frontend/src/app/(wca)/persons/[wcaId]/page.tsx
+++ b/next-frontend/src/app/(wca)/persons/[wcaId]/page.tsx
@@ -232,7 +232,7 @@ export default async function PersonOverview({
   return (
     <Container centerContent maxW="1800px">
       {/* Profile Section */}
-      {/* TODO SLATE - stick the bottom of this Profile card to the bottom of the page*/}
+      {/* TODO SLATE - stick the bottom of this Profile card to the bottom of the page */}
       <SimpleGrid gap={8} columns={24} padding={5}>
         <GridItem colSpan={7} h="80lvh" position="sticky" top="0px" pt="20px">
           <ProfileCard

--- a/next-frontend/src/app/(wca)/regulations/history/official/[version]/page.tsx
+++ b/next-frontend/src/app/(wca)/regulations/history/official/[version]/page.tsx
@@ -11,7 +11,7 @@ export default async function HistoricalRegulation({
     <Container>
       <AspectRatio>
         <iframe
-          width={"100%"}
+          width="100%"
           src={`https://regulations.worldcubeassociation.org/history/official/${version}/index.html`}
         ></iframe>
       </AspectRatio>

--- a/next-frontend/src/app/(wca)/regulations/translations/page.tsx
+++ b/next-frontend/src/app/(wca)/regulations/translations/page.tsx
@@ -24,24 +24,22 @@ export default async function RegulationsTranslations() {
 
   return (
     <Container>
-      <VStack align={"left"}>
+      <VStack align="left">
         <Heading size="5xl">{t("regulations_translations.title")}</Heading>
         <Text>{t("regulations_translations.paragraph1")}</Text>
         <Text>{t("regulations_translations.paragraph2")}</Text>
 
-        <Heading size={"2xl"}>
+        <Heading size="2xl">
           {t("regulations_translations.translations")}
         </Heading>
-        <Heading size={"xl"}>{t("regulations_translations.current")}</Heading>
+        <Heading size="xl">{t("regulations_translations.current")}</Heading>
         <TranslationList translations={current} />
-        <Heading size={"xl"}>{t("regulations_translations.old")}</Heading>
-        <Heading size={"2xl"}>
+        <Heading size="xl">{t("regulations_translations.old")}</Heading>
+        <Heading size="2xl">
           {t("regulations_translations.translating")}
         </Heading>
         <TranslationList translations={outdated} />
-        <I18nHTMLTranslate
-          i18nKey={"regulations_translations.paragraph3_html"}
-        />
+        <I18nHTMLTranslate i18nKey="regulations_translations.paragraph3_html" />
       </VStack>
     </Container>
   );

--- a/next-frontend/src/app/(wca)/score-tools/page.tsx
+++ b/next-frontend/src/app/(wca)/score-tools/page.tsx
@@ -48,17 +48,17 @@ export default async function ScoreTools() {
         <Text>{t("score_tools.intro.desc")}</Text>
         <Text>{t("score_tools.intro.disclaimer")}</Text>
         <Text>{t("score_tools.intro.used")}</Text>
-        <Heading size={"2xl"}>{t("score_tools.before.title")}</Heading>
+        <Heading size="2xl">{t("score_tools.before.title")}</Heading>
         <Text>{t("score_tools.before.desc")}</Text>
         {toolsByCategory["before"]?.map((tool) => (
           <ToolCard key={tool.id} tool={tool} />
         ))}
-        <Heading size={"2xl"}>{t("score_tools.during.title")}</Heading>
+        <Heading size="2xl">{t("score_tools.during.title")}</Heading>
         <Text>{t("score_tools.during.desc")}</Text>
         {toolsByCategory["during"]?.map((tool) => (
           <ToolCard key={tool.id} tool={tool} />
         ))}
-        <Heading size={"2xl"}>{t("score_tools.after.title")}</Heading>
+        <Heading size="2xl">{t("score_tools.after.title")}</Heading>
         <Text>{t("score_tools.after.desc")}</Text>
         {toolsByCategory["after"]?.map((tool) => (
           <ToolCard key={tool.id} tool={tool} />

--- a/next-frontend/src/app/(wca)/teams-committees/page.tsx
+++ b/next-frontend/src/app/(wca)/teams-committees/page.tsx
@@ -27,7 +27,7 @@ export default async function TeamsCommitteesPage() {
 
   return (
     <Container>
-      <VStack align={"left"} gap="8" width="full" pt="8" alignItems="left">
+      <VStack align="left" gap="8" width="full" pt="8" alignItems="left">
         <Heading size="5xl">
           {t("page.teams_committees_councils.title")}
         </Heading>
@@ -47,7 +47,7 @@ export default async function TeamsCommitteesPage() {
             ))}
           </Tabs.List>
           {teamsCommittees.map((group) => (
-            <Tabs.Content value={group.name} key={group.id} w={"full"}>
+            <Tabs.Content value={group.name} key={group.id} w="full">
               <TeamTab group={group} />
             </Tabs.Content>
           ))}
@@ -71,7 +71,7 @@ async function TeamTab({
   const canReadGroupPast = permissions?.canReadGroupPast(group.name);
 
   return (
-    <VStack align={"left"}>
+    <VStack align="left">
       <Heading size="2xl">{name}</Heading>
       <Text>
         {t(`page.teams_committees_councils.groups_description.${friendly_id}`)}
@@ -80,7 +80,7 @@ async function TeamTab({
       <MemberTable id={id} />
       {canReadGroupPast && (
         <>
-          <Heading size={"xl"}>Past Roles</Heading>
+          <Heading size="xl">Past Roles</Heading>
           <MemberTable id={id} isActive={false} />
         </>
       )}
@@ -102,7 +102,7 @@ async function MemberTable({
   if (error) return <Errored error={error} />;
 
   return (
-    <SimpleGrid columns={{ md: 1, sm: 1, lg: 2 }} gap={"20px"}>
+    <SimpleGrid columns={{ md: 1, sm: 1, lg: 2 }} gap="20px">
       {roles.map((role) => (
         <UserBadge
           key={role.id}

--- a/next-frontend/src/app/(wca)/translators/page.tsx
+++ b/next-frontend/src/app/(wca)/translators/page.tsx
@@ -15,15 +15,15 @@ export default async function TranslatorsPage() {
   const translatorsByLanguage = _.groupBy(translatorRoles, "group.name");
 
   if (!translatorsByLanguage)
-    return <Errored error={"Error Loading Translators"} />;
+    return <Errored error="Error Loading Translators" />;
 
   return (
     <Container>
-      <VStack align={"left"}>
-        <Heading size={"5xl"}>{t("page.translators.title")}</Heading>
+      <VStack align="left">
+        <Heading size="5xl">{t("page.translators.title")}</Heading>
         {_.map(translatorsByLanguage, (translators, language) => (
-          <VStack align={"left"} key={language}>
-            <Heading size={"2xl"} marginY={2}>
+          <VStack align="left" key={language}>
+            <Heading size="2xl" marginY={2}>
               {language}
             </Heading>
             <SimpleGrid columns={3} gap="16px">

--- a/next-frontend/src/components/UserBadge.tsx
+++ b/next-frontend/src/components/UserBadge.tsx
@@ -69,7 +69,7 @@ const UserBadge: React.FC<UserBadgeData> = ({
                     teamRole={role.teamRole}
                     teamText={role.teamText ?? ""}
                     staffColor={role.staffColor}
-                    fontSize={"0.7em"}
+                    fontSize="0.7em"
                   />
                 ))}
               </HStack>

--- a/next-frontend/src/components/about/AboutUsItem.tsx
+++ b/next-frontend/src/components/about/AboutUsItem.tsx
@@ -27,7 +27,7 @@ export default function AboutUsItem({
 
       {image?.url && (
         <Box position="relative" maxW="500px" w="full">
-          <ChakraImage asChild borderRadius={"1rem"}>
+          <ChakraImage asChild borderRadius="1rem">
             <Image src={image.url} alt={image.alt || title} fill />
           </ChakraImage>
         </Box>

--- a/next-frontend/src/components/about/CallToAction.tsx
+++ b/next-frontend/src/components/about/CallToAction.tsx
@@ -40,7 +40,7 @@ export function CallToActionBlock({
           <ButtonGroup colorScheme="blue" size="lg">
             {buttons.map((button, i) => (
               <Button key={i} variant={i === 0 ? "solid" : "outline"} asChild>
-                <Link href={button.url} target={"_blank"} rel={"noopener"}>
+                <Link href={button.url} target="_blank" rel="noopener">
                   {button.label}
                 </Link>
               </Button>

--- a/next-frontend/src/components/persons/ProfileCard.tsx
+++ b/next-frontend/src/components/persons/ProfileCard.tsx
@@ -99,7 +99,7 @@ const ProfileCard: React.FC<ProfileData> = ({
         <Flex flexDirection="row" alignItems="flex-end">
           <Flex flexWrap="wrap">
             {" "}
-            {/* TODO SLATE - fill out these badges with real info*/}
+            {/* TODO SLATE - fill out these badges with real info */}
             <Badge size="lg" variant="achievement">
               <NationalChampionshipIcon />
               147 Championship Titles

--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -477,33 +477,33 @@ const customConfig = defineConfig({
         variants: {
           size: {
             sm: {
-              fontWeight: "medium", //Not used in styleguide
+              fontWeight: "medium", // Not used in styleguide
             },
             md: {
-              fontWeight: "medium", //Subheading 2
-              textStyle: "lg", //same size as lg, just thinner
+              fontWeight: "medium", // Subheading 2
+              textStyle: "lg", // same size as lg, just thinner
             },
             lg: {
-              fontWeight: "bold", //Subheading 1
+              fontWeight: "bold", // Subheading 1
             },
             xl: {
-              fontWeight: "bold", //Not used in styleguide
+              fontWeight: "bold", // Not used in styleguide
             },
             "2xl": {
-              fontWeight: "extrabold", //H4
+              fontWeight: "extrabold", // H4
             },
             "3xl": {
-              fontWeight: "extrabold", //H3
+              fontWeight: "extrabold", // H3
             },
             "4xl": {
-              fontWeight: "extrabold", //H2
+              fontWeight: "extrabold", // H2
             },
             "5xl": {
-              fontWeight: "extrabold", //H1
+              fontWeight: "extrabold", // H1
               textTransform: "uppercase",
             },
             "6xl": {
-              fontWeight: "extrabold", //Not used in styleguide
+              fontWeight: "extrabold", // Not used in styleguide
             },
           },
         },
@@ -595,7 +595,7 @@ const customConfig = defineConfig({
           {
             variant: "achievement",
             css: {
-              textStyle: "lg", //needed to supercede the default textStyle
+              textStyle: "lg", // needed to supercede the default textStyle
               // @ts-expect-error TODO: Fix this
               svg: {
                 height: "1.25em",
@@ -606,7 +606,7 @@ const customConfig = defineConfig({
           {
             variant: "information",
             css: {
-              textStyle: "md", //needed to supercede the default textStyle
+              textStyle: "md", // needed to supercede the default textStyle
               // @ts-expect-error TODO: Fix this
               svg: {
                 height: "1.1em",
@@ -711,7 +711,7 @@ const customConfig = defineConfig({
           {
             variant: "info",
             css: {
-              title: { textStyle: "4xl" }, //needed to supercede the default textStyle
+              title: { textStyle: "4xl" }, // needed to supercede the default textStyle
             },
           },
           {


### PR DESCRIPTION
We had installed the `stylistic` linter in our dependencies for quite a while, but we never correctly used it. We registered a plugin namespace for `@stylistic`, but we never actually activated any _rules_ for that namespace.

Instead, this PR introduces the recommended ruleset (which in itself also encapsulates the `plugins` definition, so our manual "useless" definition can go).

As a side-effect, Prettier and Stylistic have different opinions for example when it comes to single-quotes VS double-quoutes. Luckily, there is `eslint-config-prettier`, which configures Prettier to "silence" all other linter rules that would override its preferences (fun fact: We also had already installed this in our dependencies but never correctly used it). So with regards to Prettier, we don't destroy anything, and we only "gain" the good parts from Stylistic.