### PR TITLE
Stream Results Dump TSV directly to output file

### DIFF
--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -1311,7 +1311,7 @@ module DatabaseDumper
   end
 
   def self.mysqldump_tsv(database, command, dest_filename)
-    system_pipefail!("mysql #{self.mysql_cli_creds} #{database} --batch -e \"#{command}\" #{filter_out_mysql_warning dest_filename}")
+    system_pipefail!("mysql #{self.mysql_cli_creds} #{database} --batch --quick -e \"#{command}\" #{filter_out_mysql_warning dest_filename}")
   end
 
   def self.mysqldump(db_name, dest_filename)


### PR DESCRIPTION
Reading documentation helps!
> If you have problems due to insufficient memory for large result sets, use the [--quick](https://dev.mysql.com/doc/refman/8.4/en/mysql-command-options.html#option_mysql_quick) option. This forces [mysql](https://dev.mysql.com/doc/refman/8.4/en/mysql.html) to retrieve results from the server a row at a time rather than retrieving the entire result set and buffering it in memory before displaying it.

-- via https://dev.mysql.com/doc/refman/8.4/en/mysql.html