### PR TITLE
Add competition name to result ticket

### DIFF
--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -70,7 +70,9 @@ class TicketsCompetitionResult < ApplicationRecord
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
-    include: %w[competition],
+    include: {
+      competition: { only: %i[id name], methods: [], include: [] },
+    },
   }.freeze
 
   def serializable_hash(options = nil)

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -13,8 +13,7 @@ class TicketsCompetitionResult < ApplicationRecord
   }
 
   has_one :ticket, as: :metadata
-  belongs_to :competition
-  delegate :name, to: :competition, prefix: true
+  belongs_to :competition, -> { select(:id, :name) }
 
   def actions_allowed_for(ticket_stakeholder)
     if ticket_stakeholder.stakeholder == UserGroup.teams_committees_group_wrt
@@ -71,7 +70,9 @@ class TicketsCompetitionResult < ApplicationRecord
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
-    methods: %w[competition_name],
+    include: {
+      competition: { only: %i[id name], methods: [], include: [] },
+    },
   }.freeze
 
   def serializable_hash(options = nil)

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -14,6 +14,7 @@ class TicketsCompetitionResult < ApplicationRecord
 
   has_one :ticket, as: :metadata
   belongs_to :competition
+  delegate :name, to: :competition, prefix: true
 
   def actions_allowed_for(ticket_stakeholder)
     if ticket_stakeholder.stakeholder == UserGroup.teams_committees_group_wrt
@@ -67,5 +68,13 @@ class TicketsCompetitionResult < ApplicationRecord
 
       self.update!(status: TicketsCompetitionResult.statuses[:merged_inbox_results])
     end
+  end
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    methods: %w[competition_name],
+  }.freeze
+
+  def serializable_hash(options = nil)
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
   end
 end

--- a/app/models/tickets_competition_result.rb
+++ b/app/models/tickets_competition_result.rb
@@ -13,7 +13,7 @@ class TicketsCompetitionResult < ApplicationRecord
   }
 
   has_one :ticket, as: :metadata
-  belongs_to :competition, -> { select(:id, :name) }
+  belongs_to :competition
 
   def actions_allowed_for(ticket_stakeholder)
     if ticket_stakeholder.stakeholder == UserGroup.teams_committees_group_wrt
@@ -70,9 +70,7 @@ class TicketsCompetitionResult < ApplicationRecord
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
-    include: {
-      competition: { only: %i[id name], methods: [], include: [] },
-    },
+    include: %w[competition],
   }.freeze
 
   def serializable_hash(options = nil)

--- a/app/webpacker/components/Tickets/TicketHeader/index.jsx
+++ b/app/webpacker/components/Tickets/TicketHeader/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, Header } from 'semantic-ui-react';
 import StatusView from './StatusView';
+import { ticketTypes } from '../../../lib/wca-data.js.erb';
 
 export default function TicketHeader({ ticketDetails, currentStakeholder, updateStatus }) {
   const { ticket: { id } } = ticketDetails;
@@ -8,7 +9,10 @@ export default function TicketHeader({ ticketDetails, currentStakeholder, update
   return (
     <Card fluid>
       <Card.Content>
-        <Header as="h1">{`Ticket #${id}`}</Header>
+        <Header as="h1">
+          {`Ticket #${id}: `}
+          <Heading ticketDetails={ticketDetails} />
+        </Header>
         <StatusView
           ticketDetails={ticketDetails}
           currentStakeholder={currentStakeholder}
@@ -17,4 +21,17 @@ export default function TicketHeader({ ticketDetails, currentStakeholder, update
       </Card.Content>
     </Card>
   );
+}
+
+function Heading({ ticketDetails }) {
+  const { ticket: { metadata_type: ticketType, metadata } } = ticketDetails;
+
+  switch (ticketType) {
+    case ticketTypes.edit_person:
+      return 'Edit Person';
+    case ticketTypes.competition_result:
+      return metadata.competition_name;
+    default:
+      return 'Unknown Ticket';
+  }
 }

--- a/app/webpacker/components/Tickets/TicketHeader/index.jsx
+++ b/app/webpacker/components/Tickets/TicketHeader/index.jsx
@@ -1,17 +1,28 @@
 import React from 'react';
 import { Card, Header } from 'semantic-ui-react';
+import _ from 'lodash';
 import StatusView from './StatusView';
 import { ticketTypes } from '../../../lib/wca-data.js.erb';
+import I18n from '../../../lib/i18n';
+import { personUrl, competitionUrl } from '../../../lib/requests/routes.js.erb';
+
+// let i18n-tasks know the key is used
+// i18n-tasks-use t('tickets.type.edit_person')
+// i18n-tasks-use t('tickets.type.competition_result')
 
 export default function TicketHeader({ ticketDetails, currentStakeholder, updateStatus }) {
-  const { ticket: { id } } = ticketDetails;
+  const { ticket: { id, metadata_type: ticketType } } = ticketDetails;
 
   return (
     <Card fluid>
       <Card.Content>
         <Header as="h1">
-          {`Ticket #${id}: `}
-          <Heading ticketDetails={ticketDetails} />
+          {`Ticket #${id}: ${I18n.t(`tickets.type.${
+            _.findKey(ticketTypes, (ticketTypeParam) => ticketTypeParam === ticketType)
+          }`)}`}
+        </Header>
+        <Header as="h3">
+          <SubHeading ticketDetails={ticketDetails} />
         </Header>
         <StatusView
           ticketDetails={ticketDetails}
@@ -23,14 +34,38 @@ export default function TicketHeader({ ticketDetails, currentStakeholder, update
   );
 }
 
-function Heading({ ticketDetails }) {
+function SubHeading({ ticketDetails }) {
   const { ticket: { metadata_type: ticketType, metadata } } = ticketDetails;
 
   switch (ticketType) {
     case ticketTypes.edit_person:
-      return 'Edit Person';
+      return (
+        <>
+          WCA ID:
+          {' '}
+          <a
+            href={personUrl(metadata.wca_id)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {metadata.wca_id}
+          </a>
+        </>
+      );
     case ticketTypes.competition_result:
-      return metadata.competition.name;
+      return (
+        <>
+          Competition name:
+          {' '}
+          <a
+            href={competitionUrl(metadata.competition.id)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {metadata.competition.name}
+          </a>
+        </>
+      );
     default:
       return 'Unknown Ticket';
   }

--- a/app/webpacker/components/Tickets/TicketHeader/index.jsx
+++ b/app/webpacker/components/Tickets/TicketHeader/index.jsx
@@ -30,7 +30,7 @@ function Heading({ ticketDetails }) {
     case ticketTypes.edit_person:
       return 'Edit Person';
     case ticketTypes.competition_result:
-      return metadata.competition_name;
+      return metadata.competition.name;
     default:
       return 'Unknown Ticket';
   }

--- a/config/i18n.yml
+++ b/config/i18n.yml
@@ -82,3 +82,4 @@ translations:
       - "*.cronjobs.*"
       - "*.payments.*"
       - "*.misc.*"
+      - "*.tickets.*"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2935,3 +2935,7 @@ en:
       missing_scrambles_for_multi_error: "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
       multiple_fmc_groups_warning: "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
       wrong_number_of_scramble_sets_error: "[%{round_id}] This round has a different number of scramble sets than specified on the Manage Events tab. Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
+  tickets:
+    type:
+      edit_person: "Edit Person"
+      competition_result: "Competition Result"


### PR DESCRIPTION
This is to let WRT know which competition they are posting, this is useful when they are working on multiple results in parallel.