### PR TITLE
Serve Nextjs image assets through cloudfront

### DIFF
--- a/infra/wca_on_rails/production/nextjs.tf
+++ b/infra/wca_on_rails/production/nextjs.tf
@@ -26,6 +26,10 @@ locals {
       value = aws_s3_bucket.next-media.id
     },
     {
+      name = "MEDIA_BUCKET_CDN"
+      value = "https://assets-nextjs.worldcubeassociation.org"
+    },
+    {
       name  = "OIDC_ISSUER"
       value = "https://www.worldcubeassociation.org/"
     },

--- a/next-frontend/src/payload.config.ts
+++ b/next-frontend/src/payload.config.ts
@@ -45,7 +45,11 @@ async function plugins() {
       ...defaultPlugins,
       s3Storage({
         collections: {
-          media: true,
+          media: {
+            generateFileURL: (file) => {
+              return `${process.env.MEDIA_BUCKET_CDN!}/${file.prefix}/${file.filename}`;
+            },
+          },
         },
         bucket: process.env.MEDIA_BUCKET!,
         config: {


### PR DESCRIPTION
I already ran terraform and created the cloudfront distribution, so files can be accessed like this https://assets-nextjs.worldcubeassociation.org/_MG_2425.jpg already.

So this should just work once deployed?