### PR TITLE
Use existing singular plural logic in registration admin page

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { Table } from 'semantic-ui-react';
 import React from 'react';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
-import I18n from "../../../lib/i18n";
+import I18n from '../../../lib/i18n';
 
 const moneyCountHumanReadable = (registrations, competitionInfo) => {
   const moneyCount = _.sum(registrations.map((r) => r.payment.paid_amount_iso));

--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { Table } from 'semantic-ui-react';
 import React from 'react';
 import { isoMoneyToHumanReadable } from '../../../lib/helpers/money';
+import I18n from "../../../lib/i18n";
 
 const moneyCountHumanReadable = (registrations, competitionInfo) => {
   const moneyCount = _.sum(registrations.map((r) => r.payment.paid_amount_iso));
@@ -45,11 +46,25 @@ export default function RegistrationAdministrationTableFooter({
   return (
     <Table.Row>
       <Table.Cell colSpan={withPosition ? 5 : 4}>
-        {`${newcomerCount} First-Timers + ${
-          registrations.length - newcomerCount
-        } Returners = ${registrations.length} People`}
+        {
+          `${
+            newcomerCount
+          } ${
+            I18n.t('registrations.registration_info_people.newcomer', { count: newcomerCount })
+          } + ${
+            registrations.length - newcomerCount
+          } ${
+            I18n.t('registrations.registration_info_people.returner', { count: registrations.length - newcomerCount })
+          } = ${
+            registrations.length
+          } ${
+            I18n.t('registrations.registration_info_people.person', { count: registrations.length })
+          }`
+        }
       </Table.Cell>
-      <Table.Cell>{`${countryCount} Countries`}</Table.Cell>
+      <Table.Cell>
+        {`${I18n.t('registrations.list.country_plural', { count: countryCount })}`}
+      </Table.Cell>
       <Table.Cell key="registered on" />
       {competitionInfo['using_payment_integrations?'] && (
         <Table.Cell>{moneyCountHumanReadable(registrations, competitionInfo)}</Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationEditor.jsx
@@ -155,7 +155,7 @@ export default function RegistrationEditor({ registrationId, competitor, competi
           {competitor.wca_id ? (
             <a href={personUrl(competitor.wca_id)} target="_blank" rel="noreferrer" className="hide-new-window-icon">{competitor.wca_id}</a>
           ) : (
-            I18n.t('registrations.registration_info_people.newcomer.one')
+            I18n.t('registrations.registration_info_people.newcomer', { count: 1 })
           )}
           {') '}
           <a href={editPersonUrl(competitor.id)} target="_blank" rel="noreferrer" className="hide-new-window-icon"><Icon name="edit" /></a>


### PR DESCRIPTION
<img width="1227" height="715" alt="image" src="https://github.com/user-attachments/assets/f860afa6-d53a-429d-9dae-08b09e5f52a4" />

Implementation is already existing on the public competitiors page. Did some copy pasta from `Competitors.jsx` and `PreTableInfo.jsx`
