### PR TITLE
move download voters to top of WIC panel

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -750,8 +750,8 @@ class User < ApplicationRecord
       wic: {
         name: 'WIC panel',
         pages: [
-          panel_pages[:bannedCompetitors],
           panel_pages[:downloadVoters],
+          panel_pages[:bannedCompetitors],
           panel_pages[:delegateProbations],
         ],
       },


### PR DESCRIPTION
WIC would like the default landing page of the WIC panel to not be "Banned Competitors".

I've moved Download Voters to the top of the panel pages list, causing the WIC panel to default to Download Voters.