### PR TITLE
Create CompetitionResultSubmission admin react page

### DIFF
--- a/app/views/admin/new_results.html.erb
+++ b/app/views/admin/new_results.html.erb
@@ -1,18 +1,10 @@
 <% provide(:title, "Upload results") %>
 <%= render layout: 'competitions/nav' do %>
   <h1><%= yield(:title) %></h1>
-  <p>
-    Import the results JSON for this competition.
-    The server will check for any error compared to the declared rounds, cutoffs, and time limits.
-  </p>
-  <p>
-    When you are done checking the results, you can go ahead and import them <%= link_to "here", competition_admin_import_results_path(@competition.id) %>.
-  </p>
-
-  <%= react_component("CompetitionResultSubmission/ImportResultsData", {
+  <%= react_component("CompetitionResultSubmissionAdmin", {
     competitionId: @competition.id,
-    alreadyHasSubmittedResult: @results_validator.any_results?,
-    isAdminView: true,
+    hasTemporaryResults: @competition.inbox_results.present?,
+    ticketId: @competition.result_ticket&.id,
   }) %>
 
   <%= render "results_submission/check_results_panel", results_validator: @results_validator %>

--- a/app/webpacker/components/CompetitionResultSubmissionAdmin/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmissionAdmin/index.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Message } from 'semantic-ui-react';
+import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
+import { ImportResultsData } from '../CompetitionResultSubmission/ImportResultsData';
+import { adminImportResultsUrl, viewUrls } from '../../lib/requests/routes.js.erb';
+
+export default function Wrapper({ competitionId, hasTemporaryResults, ticketId }) {
+  return (
+    <WCAQueryClientProvider>
+      <CompetitionResultSubmissionAdmin
+        competitionId={competitionId}
+        hasTemporaryResults={hasTemporaryResults}
+        ticketId={ticketId}
+      />
+    </WCAQueryClientProvider>
+  );
+}
+
+function CompetitionResultSubmissionAdmin({ competitionId, hasTemporaryResults, ticketId }) {
+  if (!ticketId) {
+    return (
+      <Message error>
+        There are no tickets associated with this competition. WRT can re-import results only
+        when the Delegates submit the results. If the Delegates has already submitted the
+        results and if you are still seeing this message, then please contact WST.
+      </Message>
+    );
+  }
+  return (
+    <>
+      <p>
+        When you are done checking the results, you can go ahead with posting process using
+        {' '}
+        <a href={adminImportResultsUrl(competitionId)}>import results page</a>
+        {' '}
+        or
+        {' '}
+        <a href={viewUrls.tickets.show(ticketId)}>tickets page</a>
+        .
+      </p>
+      <ImportResultsData
+        competitionId={competitionId}
+        hasTemporaryResults={hasTemporaryResults}
+        isAdminView
+      />
+    </>
+  );
+}


### PR DESCRIPTION
The existing admin results page is rails HTML. Some portion of it will be removed soon, the portion that is not going to removed is moved to it's own react component.