### PR TITLE
Try to replicate db dump failure in test

### DIFF
--- a/spec/lib/database_dumper_spec.rb
+++ b/spec/lib/database_dumper_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe "DatabaseDumper" do
       end_time: last_schedule_activity.end_time,
     )
 
+    expect(first_schedule_activity.id).to be < first_schedule_activity.parent_activity_id
     expect {
       dump_file = Tempfile.new
       before_dump = Time.now.change(usec: 0) # Truncate the sub second part of the datetime, since mysql only stores 1 second granularity.


### PR DESCRIPTION
This sets up a test that I _expect_ to replicate the failure we're seeing in the dev dump in prod - note the explicit confirmation in this line that the record's `id` is less than its `parent_activity_id`: 
```ruby
    expect(first_schedule_activity.id).to be < first_schedule_activity.parent_activity_id
```

I'm not sure why this isn't triggering the foreign key error we're seeing in prod[1]. Possibilities:
- size of db in prod changes the behaviour (maybe there's some kind of row batching that we exceed the bounds of in prod?)
- Finn's change to fk behaviour actually works in test but doesn't work in prod 
  - Weren't we having issues with Sidekiq not always deploying, or needing to be deployed separately or something? Or was that only in staging? 

Lots of unknowns in those possibilities that I'm not well-equipped to figure out - so not investigating further for now

[1] Error as follows: 
```bash
Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails (`developer_dump`.`schedule_activities`, CONSTRAINT `fk_rails_999dc22d7e` FOREIGN KEY (`parent_activity_id`) REFERENCES `schedule_activities` (`id`))
```