### PR TITLE
Remember toggles on reg admin page

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationList.jsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import React, {
-  useMemo, useReducer, useRef, useState,
+  useMemo, useRef, useState,
 } from 'react';
 import {
   Accordion, Button, Checkbox, Divider, Form, Header, Icon, List, Modal, Segment, Sticky,
@@ -18,6 +18,7 @@ import bulkAutoAccept from '../api/registration/patch/bulk_auto_accept';
 import RegistrationAdministrationTable from './RegistrationsAdministrationTable';
 import useCheckboxState from '../../../lib/hooks/useCheckboxState';
 import useOrderedSet from '../../../lib/hooks/useOrderedSet';
+import useStoredReducer from '../../../lib/hooks/useStoredReducer';
 import {
   APPROVED_COLOR, APPROVED_ICON,
   CANCELLED_COLOR, CANCELLED_ICON,
@@ -57,9 +58,10 @@ const expandedColumnsReducer = (state, action) => {
 };
 
 export default function RegistrationAdministrationList({ competitionInfo }) {
-  const [expandedColumns, dispatchExpandedColumns] = useReducer(
+  const [expandedColumns, dispatchExpandedColumns] = useStoredReducer(
     expandedColumnsReducer,
     initialExpandedColumns,
+    'reg-admin-expanded-columns',
   );
 
   const [waitlistEditModeEnabled, setWaitlistEditModeEnabled] = useCheckboxState(false);

--- a/app/webpacker/lib/hooks/useStoredReducer.js
+++ b/app/webpacker/lib/hooks/useStoredReducer.js
@@ -11,7 +11,7 @@ import { getJsonItem, setJsonItem } from '../utils/localStorage';
 export default function useStoredReducer(reducer, initialState, key) {
   function augmentedReducer(state, action) {
     const newState = reducer(state, action);
-    localStorage.setItem(key, JSON.stringify(newState));
+    setJsonItem(key, newState);
     return newState;
   }
 

--- a/app/webpacker/lib/hooks/useStoredReducer.js
+++ b/app/webpacker/lib/hooks/useStoredReducer.js
@@ -1,0 +1,33 @@
+import { useReducer } from 'react';
+
+/**
+ * This functions like the useReducer hook, but it fetches the state stored in
+ * local storage, via the given key, on subsequent uses.
+ *
+ * Do NOT call this twice with the same key - updating one of such a pair
+ * will not update the other's state.
+ */
+export default function useStoredReducer(reducer, initialState, key) {
+  let storedState;
+  try {
+    storedState = JSON.parse(localStorage.getItem(key));
+  } catch {
+    storedState = null;
+  }
+
+  function augmentedReducer(state, action) {
+    const newState = reducer(state, action);
+    localStorage.setItem(key, JSON.stringify(newState));
+    return newState;
+  }
+
+  const [state, dispatch] = useReducer(augmentedReducer, initialState, (value) => {
+    if (storedState === null) {
+      localStorage.setItem(key, JSON.stringify(value));
+      return value;
+    }
+    return storedState;
+  });
+
+  return [state, dispatch];
+}

--- a/app/webpacker/lib/hooks/useStoredReducer.js
+++ b/app/webpacker/lib/hooks/useStoredReducer.js
@@ -1,5 +1,5 @@
 import { useReducer } from 'react';
-import { getJsonItem } from '../utils/localStorage';
+import { getJsonItem, setJsonItem } from '../utils/localStorage';
 
 /**
  * This functions like the useReducer hook, but it fetches the state stored in
@@ -19,7 +19,7 @@ export default function useStoredReducer(reducer, initialState, key) {
     const storedState = getJsonItem(key);
 
     if (storedState === null) {
-      localStorage.setItem(key, JSON.stringify(value));
+      setJsonItem(key, value);
       return value;
     }
     return storedState;

--- a/app/webpacker/lib/hooks/useStoredReducer.js
+++ b/app/webpacker/lib/hooks/useStoredReducer.js
@@ -8,13 +8,6 @@ import { useReducer } from 'react';
  * will not update the other's state.
  */
 export default function useStoredReducer(reducer, initialState, key) {
-  let storedState;
-  try {
-    storedState = JSON.parse(localStorage.getItem(key));
-  } catch {
-    storedState = null;
-  }
-
   function augmentedReducer(state, action) {
     const newState = reducer(state, action);
     localStorage.setItem(key, JSON.stringify(newState));
@@ -22,6 +15,13 @@ export default function useStoredReducer(reducer, initialState, key) {
   }
 
   const [state, dispatch] = useReducer(augmentedReducer, initialState, (value) => {
+    let storedState;
+    try {
+      storedState = JSON.parse(localStorage.getItem(key));
+    } catch {
+      storedState = null;
+    }
+
     if (storedState === null) {
       localStorage.setItem(key, JSON.stringify(value));
       return value;

--- a/app/webpacker/lib/hooks/useStoredReducer.js
+++ b/app/webpacker/lib/hooks/useStoredReducer.js
@@ -1,4 +1,5 @@
 import { useReducer } from 'react';
+import { getJsonItem } from '../utils/localStorage';
 
 /**
  * This functions like the useReducer hook, but it fetches the state stored in
@@ -15,12 +16,7 @@ export default function useStoredReducer(reducer, initialState, key) {
   }
 
   const [state, dispatch] = useReducer(augmentedReducer, initialState, (value) => {
-    let storedState;
-    try {
-      storedState = JSON.parse(localStorage.getItem(key));
-    } catch {
-      storedState = null;
-    }
+    const storedState = getJsonItem(key);
 
     if (storedState === null) {
       localStorage.setItem(key, JSON.stringify(value));

--- a/app/webpacker/lib/hooks/useStoredState.js
+++ b/app/webpacker/lib/hooks/useStoredState.js
@@ -13,7 +13,7 @@ export default function useStoredState(initialState, key) {
     const storedState = getJsonItem(key);
 
     if (storedState === null) {
-      localStorage.setItem(key, JSON.stringify(initialState));
+      setJsonItem(key, initialState);
       return initialState;
     }
     return storedState;

--- a/app/webpacker/lib/hooks/useStoredState.js
+++ b/app/webpacker/lib/hooks/useStoredState.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { getJsonItem } from '../utils/localStorage';
 
 /**
  * This functions like the useState hook, but it fetches the state stored in
@@ -9,12 +10,7 @@ import { useState } from 'react';
  */
 export default function useStoredState(initialState, key) {
   const [state, setState] = useState(() => {
-    let storedState;
-    try {
-      storedState = JSON.parse(localStorage.getItem(key));
-    } catch {
-      storedState = null;
-    }
+    const storedState = getJsonItem(key);
 
     if (storedState === null) {
       localStorage.setItem(key, JSON.stringify(initialState));

--- a/app/webpacker/lib/hooks/useStoredState.js
+++ b/app/webpacker/lib/hooks/useStoredState.js
@@ -8,14 +8,14 @@ import { useState } from 'react';
  * will not update the other's state.
  */
 export default function useStoredState(initialState, key) {
-  let storedState;
-  try {
-    storedState = JSON.parse(localStorage.getItem(key));
-  } catch {
-    storedState = null;
-  }
-
   const [state, setState] = useState(() => {
+    let storedState;
+    try {
+      storedState = JSON.parse(localStorage.getItem(key));
+    } catch {
+      storedState = null;
+    }
+
     if (storedState === null) {
       localStorage.setItem(key, JSON.stringify(initialState));
       return initialState;

--- a/app/webpacker/lib/hooks/useStoredState.js
+++ b/app/webpacker/lib/hooks/useStoredState.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { getJsonItem } from '../utils/localStorage';
+import { getJsonItem, setJsonItem } from '../utils/localStorage';
 
 /**
  * This functions like the useState hook, but it fetches the state stored in
@@ -21,7 +21,7 @@ export default function useStoredState(initialState, key) {
 
   function setAndStoreState(newState) {
     setState(newState);
-    localStorage.setItem(key, JSON.stringify(newState));
+    setJsonItem(key, newState);
   }
 
   return [state, setAndStoreState];

--- a/app/webpacker/lib/utils/localStorage.js
+++ b/app/webpacker/lib/utils/localStorage.js
@@ -8,3 +8,7 @@ export function getJsonItem(key) {
   }
   return parsedItem;
 }
+
+export function setJsonItem(key, obj) {
+  localStorage.setItem(key, JSON.stringify(obj));
+}

--- a/app/webpacker/lib/utils/localStorage.js
+++ b/app/webpacker/lib/utils/localStorage.js
@@ -1,0 +1,10 @@
+export function getJsonItem(key) {
+  const item = localStorage.getItem(key);
+  let parsedItem;
+  try {
+    parsedItem = JSON.parse(item);
+  } catch {
+    parsedItem = null;
+  }
+  return parsedItem;
+}

--- a/app/webpacker/lib/utils/localStorage.js
+++ b/app/webpacker/lib/utils/localStorage.js
@@ -1,12 +1,10 @@
 export function getJsonItem(key) {
   const item = localStorage.getItem(key);
-  let parsedItem;
   try {
-    parsedItem = JSON.parse(item);
+    return JSON.parse(item);
   } catch {
-    parsedItem = null;
+    return null;
   }
-  return parsedItem;
 }
 
 export function setJsonItem(key, obj) {


### PR DESCRIPTION
One of the medium priorities left on #10542.

Like `useStoredState`, this stores in local storage, so is specific to the device.

I think the only potential concern is that we intentionally made birthdays hidden by default on this page a few years ago (before it got migrated to React). I'm not sure this is a major concern, but if it is then I could allow passing a sanitizer function which processes the value that comes out of storage (which could toggle birthday to off in this case).