### PR TITLE
Fix Clear on WcaSearch

### DIFF
--- a/app/webpacker/components/SearchWidget/WcaSearch.jsx
+++ b/app/webpacker/components/SearchWidget/WcaSearch.jsx
@@ -80,7 +80,7 @@ export function IdWcaSearch({
   const onChangeIdOnly = useCallback((evt, data) => {
     const { value: apiValues } = data;
 
-    const extractedIds = multiple ? apiValues.map((apiValue) => apiValue.id) : apiValues.id;
+    const extractedIds = multiple ? apiValues.map((apiValue) => apiValue.id) : apiValues?.id;
     const changePayload = { ...data, value: extractedIds };
 
     onChange(evt, changePayload);


### PR DESCRIPTION
When clicking the X to clear a value on WcaSearch an error would throw

> TypeError: can't access property "id", apiValues is null

Adding a simple null check fixes the error when clearing the drop down and allows it to behave correctly.