### PR TITLE
Only set foreign_key_checks to false in dev dump

### DIFF
--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -1227,9 +1227,7 @@ module DatabaseDumper
 
     # Turn of foreign key checking to avoid errors when dumping data caused by foreign keys referencing not yet
     # existing rows.
-    ActiveRecord::Base.connection.execute("SET unique_checks=0")
     ActiveRecord::Base.connection.execute("SET foreign_key_checks=0")
-    ActiveRecord::Base.connection.execute("SET autocommit=0")
 
     LogTask.log_task "Populating sanitized tables in '#{dump_db_name}'" do
       ordered_table_names.each do |table_name|
@@ -1261,9 +1259,7 @@ module DatabaseDumper
       ActiveRecord::Base.connection.execute("INSERT INTO #{dump_db_name}.server_settings (name, value, created_at, updated_at) VALUES ('#{dump_ts_name}', UNIX_TIMESTAMP(), NOW(), NOW())") if dump_ts_name.present?
 
       # Turn these back on. We do establish a new connection again in the ensure block, but just in case this carries over
-      ActiveRecord::Base.connection.execute("SET unique_checks=1")
       ActiveRecord::Base.connection.execute("SET foreign_key_checks=1")
-      ActiveRecord::Base.connection.execute("SET autocommit=1")
     end
 
     yield dump_db_name


### PR DESCRIPTION
I think we just tanked the database by not committing the results and other big tables immediately when exporting it. 

<img width="1890" height="509" alt="image" src="https://github.com/user-attachments/assets/214b2599-239a-4700-b5d3-94561c073051" />

These other two options were necessary in the dev dump load, but not here