### PR TITLE
Remove import results button from posting dashboard & admin page

### DIFF
--- a/app/webpacker/components/CompetitionResultSubmissionAdmin/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmissionAdmin/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Message } from 'semantic-ui-react';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
 import { ImportResultsData } from '../CompetitionResultSubmission/ImportResultsData';
-import { adminImportResultsUrl, viewUrls } from '../../lib/requests/routes.js.erb';
+import { viewUrls } from '../../lib/requests/routes.js.erb';
 
 export default function Wrapper({ competitionId, hasTemporaryResults, ticketId }) {
   return (
@@ -30,10 +30,6 @@ function CompetitionResultSubmissionAdmin({ competitionId, hasTemporaryResults, 
     <>
       <p>
         When you are done checking the results, you can go ahead with posting process using
-        {' '}
-        <a href={adminImportResultsUrl(competitionId)}>import results page</a>
-        {' '}
-        or
         {' '}
         <a href={viewUrls.tickets.show(ticketId)}>tickets page</a>
         .

--- a/app/webpacker/components/PostingCompetitions/index.js
+++ b/app/webpacker/components/PostingCompetitions/index.js
@@ -13,7 +13,6 @@ import RegionFlag from '../wca/RegionFlag';
 import {
   adminCheckUploadedResults,
   adminPostingCompetitionsUrl,
-  adminImportResultsUrl,
   adminStartPostingUrl,
   competitionUrl,
   viewUrls,
@@ -100,20 +99,13 @@ function PostingCompetitionsIndex({
                   >
                     Check results page
                   </Button>
-                  <Button
-                    target="_blank"
-                    color="green"
-                    href={adminImportResultsUrl(c.id)}
-                  >
-                    Import results page
-                  </Button>
                   {c.result_ticket && (
                     <Button
                       target="_blank"
-                      color="red"
+                      color="green"
                       href={viewUrls.tickets.show(c.result_ticket.id)}
                     >
-                      Tickets page
+                      Post through Tickets page
                     </Button>
                   )}
                 </>

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -156,8 +156,6 @@ export const clearResultsSubmissionUrl = (competitionId) => `<%= CGI.unescape(Ra
 
 export const adminDeleteResultsDataUrl = (competitionId, roundId, model) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_delete_results_data_path("${competitionId}")) %>?${jsonToQueryString({ roundId, model })}`;
 
-export const adminImportResultsUrl = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_import_results_path("${competitionId}")) %>`;
-
 export const adminCheckUploadedResults = (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_admin_upload_results_edit_path("${competitionId}"))%>`;
 
 export const fetchUserGroupsUrl = (groupType) => {


### PR DESCRIPTION
This change is to force WRT to post results through tickets, and use old import-results page only if it's really necessary. The old import-results page is still accessible through competition nav.

We can keep this for few days (maybe a week or so) and if we don't receive any complaints from WRT, the import-results page can be removed completely.