### PR TITLE
Add option to delete sets from scramble matching

### DIFF
--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -135,7 +135,7 @@ class ScrambleFilesController < ApplicationController
     end
 
     render json: competition.inbox_scramble_sets
-                            .includes(:inbox_scrambles, matched_round: [:competition_event])
+                            .includes(**InboxScrambleSet::SERIALIZATION_INCLUDES)
   end
 
   private def competition_from_params

--- a/app/controllers/scramble_files_controller.rb
+++ b/app/controllers/scramble_files_controller.rb
@@ -78,6 +78,7 @@ class ScrambleFilesController < ApplicationController
                   scramble_number: n + 1,
                   ordered_index: n + num_persisted_scrambles,
                   is_extra: scramble_kind == :extraScrambles,
+                  matched_scramble_set: scramble_set,
                 )
               end
             end
@@ -109,26 +110,27 @@ class ScrambleFilesController < ApplicationController
 
         next if updated_sets.blank?
 
-        round.inbox_scramble_sets.update_all(matched_round_id: nil)
         updated_set_ids = updated_sets.pluck(:id)
+        updated_sets_by_id = updated_sets.index_by { it[:id] }
+
+        round.inbox_scramble_sets.update_all(matched_round_id: nil)
 
         # This avoids validation issues when reassigning the indices one by one in the `each` loop below
         InboxScrambleSet.where(id: updated_set_ids).update_all(ordered_index: -1)
 
         InboxScrambleSet.find(updated_set_ids)
-                        .each_with_index do |scramble_set, idx|
-          scramble_set.update!(matched_round: round, ordered_index: idx)
-        end
+                        .each_with_index do |scramble_set, set_idx|
+          scramble_set.update!(matched_round: round, ordered_index: set_idx)
 
-        updated_sets.each do |updated_set|
-          updated_scramble_ids = updated_set[:inbox_scrambles]
+          updated_scramble_ids = updated_sets_by_id[scramble_set.id][:inbox_scrambles]
+          scramble_set.matched_inbox_scrambles.update_all(matched_scramble_set_id: nil)
 
           # This avoids validation issues when reassigning the indices one by one in the `each` loop below
           InboxScramble.where(id: updated_scramble_ids).update_all(ordered_index: -1)
 
           InboxScramble.find(updated_scramble_ids)
                        .each_with_index do |scramble, idx|
-            scramble.update!(ordered_index: idx)
+            scramble.update!(matched_scramble_set: scramble_set, ordered_index: idx)
           end
         end
       end

--- a/app/models/inbox_scramble.rb
+++ b/app/models/inbox_scramble.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class InboxScramble < ApplicationRecord
-  belongs_to :inbox_scramble_set
+  belongs_to :inbox_scramble_set, inverse_of: :inbox_scrambles
+  belongs_to :matched_scramble_set, class_name: "InboxScrambleSet", optional: true, inverse_of: :matched_inbox_scrambles
 
   validates :scramble_number, uniqueness: { scope: %i[is_extra inbox_scramble_set_id] }
-  validates :ordered_index, uniqueness: { scope: :inbox_scramble_set_id }
+  validates :ordered_index, uniqueness: { scope: :matched_scramble_set_id }
 end

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class InboxScrambleSet < ApplicationRecord
+  SERIALIZATION_INCLUDES = { inbox_scrambles: [], scramble_file_upload: [], matched_round: [:competition_event] }.freeze
+
   belongs_to :competition
   belongs_to :event
 

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -11,19 +11,9 @@ class InboxScrambleSet < ApplicationRecord
 
   has_many :inbox_scrambles, dependent: :destroy
 
-  validates :ordered_index, uniqueness: { scope: %i[competition_id event_id round_number] }
-
-  before_validation :backfill_round_information!, if: :matched_round_id?
+  validates :ordered_index, uniqueness: { scope: :matched_round_id }
 
   delegate :original_filename, to: :scramble_file_upload, allow_nil: true
-
-  def backfill_round_information!
-    return if matched_round.blank?
-
-    self.competition_id = matched_round.competition_id
-    self.event_id = matched_round.event_id
-    self.round_number = matched_round.number
-  end
 
   def matched_round_wcif_id
     matched_round&.wcif_id || "#{self.event_id}-r#{self.round_number}"

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -3,7 +3,7 @@
 class InboxScrambleSet < ApplicationRecord
   SERIALIZATION_INCLUDES = { inbox_scrambles: [], scramble_file_upload: [], matched_round: [:competition_event] }.freeze
 
-  belongs_to :competition
+  belongs_to :competition, inverse_of: :inbox_scramble_sets
   belongs_to :event
 
   belongs_to :scramble_file_upload, optional: true, foreign_key: "external_upload_id", inverse_of: :inbox_scramble_sets
@@ -15,6 +15,10 @@ class InboxScrambleSet < ApplicationRecord
   validates :ordered_index, uniqueness: { scope: :matched_round_id }
 
   delegate :original_filename, to: :scramble_file_upload, allow_nil: true
+
+  def event
+    Event.c_find(self.event_id)
+  end
 
   def matched_round_wcif_id
     matched_round&.wcif_id || "#{self.event_id}-r#{self.round_number}"

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -14,14 +14,11 @@ class InboxScrambleSet < ApplicationRecord
 
   validates :ordered_index, uniqueness: { scope: :matched_round_id }
 
+  delegate :wcif_id, to: :matched_round, allow_nil: true, prefix: true
   delegate :original_filename, to: :scramble_file_upload, allow_nil: true
 
   def event
     Event.c_find(self.event_id)
-  end
-
-  def matched_round_wcif_id
-    matched_round&.wcif_id || "#{self.event_id}-r#{self.round_number}"
   end
 
   def alphabetic_group_index

--- a/app/models/inbox_scramble_set.rb
+++ b/app/models/inbox_scramble_set.rb
@@ -7,9 +7,10 @@ class InboxScrambleSet < ApplicationRecord
   belongs_to :event
 
   belongs_to :scramble_file_upload, optional: true, foreign_key: "external_upload_id", inverse_of: :inbox_scramble_sets
-  belongs_to :matched_round, class_name: "Round", optional: true
+  belongs_to :matched_round, class_name: "Round", optional: true, inverse_of: :inbox_scramble_sets
 
-  has_many :inbox_scrambles, dependent: :destroy
+  has_many :inbox_scrambles, inverse_of: :inbox_scramble_set, dependent: :destroy
+  has_many :matched_inbox_scrambles, class_name: "InboxScramble", inverse_of: :matched_scramble_set, dependent: :nullify
 
   validates :ordered_index, uniqueness: { scope: :matched_round_id }
 

--- a/app/models/scramble_file_upload.rb
+++ b/app/models/scramble_file_upload.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ScrambleFileUpload < ApplicationRecord
-  SERIALIZATION_INCLUDES = { inbox_scramble_sets: { inbox_scrambles: [], matched_round: [:competition_event] } }.freeze
+  SERIALIZATION_INCLUDES = { inbox_scramble_sets: InboxScrambleSet::SERIALIZATION_INCLUDES }.freeze
 
   belongs_to :uploaded_by_user, foreign_key: "uploaded_by", class_name: "User"
   belongs_to :competition

--- a/app/webpacker/components/ScrambleMatcher/ButtonGroupPicker.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ButtonGroupPicker.jsx
@@ -31,7 +31,7 @@ export default function ButtonGroupPicker({
             active={entity.id === selectedEntityId}
             onClick={() => onEntityIdSelected(entity.id)}
           >
-            {computeEntityName(entity, idx)}
+            {computeEntityName(entity.id, idx)}
           </Button>
         ))}
       </Button.Group>

--- a/app/webpacker/components/ScrambleMatcher/ButtonGroupPicker.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ButtonGroupPicker.jsx
@@ -7,13 +7,13 @@ export default function ButtonGroupPicker({
   entityChoices,
   selectedEntityId,
   onEntityIdSelected,
-  headerLabel,
+  pickerLabel,
   computeEntityName,
 }) {
   return (
     <>
       <Header as="h4">
-        {headerLabel}
+        {pickerLabel}
         {' '}
         <Button
           size="mini"

--- a/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
+++ b/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
@@ -1,9 +1,16 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Button, Header, Message } from 'semantic-ui-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 import { competitionScrambleFilesUrl } from '../../lib/requests/routes.js.erb';
 import ScrambleFileList from './ScrambleFileList';
+import UnusedScramblesPanel from './UnusedScramblesPanel';
+import { buildLightHistory } from './util';
 
 async function listScrambleFiles(competitionId) {
   const { data } = await fetchJsonOrError(competitionScrambleFilesUrl(competitionId));
@@ -75,6 +82,19 @@ export default function FileUpload({
     inputRef.current?.click();
   };
 
+  const unfoldedMatchState = useMemo(() => matchState.events.flatMap(
+    (event, eventIdx) => event.rounds.flatMap(
+      (round, roundIdx) => round.scrambleSets.flatMap(
+        (scrSet, scrSetIdx) => scrSet.inbox_scrambles.map((scr, scrIdx) => [
+          buildLightHistory('events', event.id, eventIdx),
+          buildLightHistory('rounds', round.id, roundIdx),
+          buildLightHistory('scrambleSets', scrSet.id, scrSetIdx),
+          buildLightHistory('inbox_scrambles', scr.id, scrIdx),
+        ]),
+      ),
+    ),
+  ), [matchState.events]);
+
   return (
     <>
       <Header>
@@ -118,7 +138,12 @@ export default function FileUpload({
       <ScrambleFileList
         scrambleFiles={uploadedJsonFiles}
         isFetching={isFetching}
-        matchState={matchState}
+        unfoldedMatchState={unfoldedMatchState}
+        dispatchMatchState={dispatchMatchState}
+      />
+      <UnusedScramblesPanel
+        scrambleFiles={uploadedJsonFiles}
+        unfoldedMatchState={unfoldedMatchState}
         dispatchMatchState={dispatchMatchState}
       />
     </>

--- a/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
+++ b/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -10,7 +9,6 @@ import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken'
 import { competitionScrambleFilesUrl } from '../../lib/requests/routes.js.erb';
 import ScrambleFileList from './ScrambleFileList';
 import UnusedScramblesPanel from './UnusedScramblesPanel';
-import { groupScrambleSetsIntoWcif } from './util';
 
 async function listScrambleFiles(competitionId) {
   const { data } = await fetchJsonOrError(competitionScrambleFilesUrl(competitionId));
@@ -82,12 +80,6 @@ export default function FileUpload({
     inputRef.current?.click();
   };
 
-  const scrambleFilesTree = useMemo(() => {
-    const allScrambleSets = uploadedJsonFiles.flatMap((file) => file.inbox_scramble_sets);
-
-    return groupScrambleSetsIntoWcif(allScrambleSets);
-  }, [uploadedJsonFiles]);
-
   return (
     <>
       <Header>
@@ -137,7 +129,6 @@ export default function FileUpload({
       <UnusedScramblesPanel
         scrambleFiles={uploadedJsonFiles}
         matchState={matchState}
-        scrambleFilesTree={scrambleFilesTree}
         dispatchMatchState={dispatchMatchState}
       />
     </>

--- a/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
+++ b/app/webpacker/components/ScrambleMatcher/FileUpload.jsx
@@ -26,8 +26,8 @@ async function uploadScrambleFile({ competitionId, file }) {
 export default function FileUpload({
   competitionId,
   initialScrambleFiles,
-  addScrambleFile,
-  removeScrambleFile,
+  matchState,
+  dispatchMatchState,
 }) {
   const inputRef = useRef();
   const queryClient = useQueryClient();
@@ -52,7 +52,7 @@ export default function FileUpload({
         ],
       );
 
-      addScrambleFile(data);
+      dispatchMatchState({ type: 'addScrambleFile', scrambleFile: data });
     },
     onError: (responseError) => setError(responseError.message),
   });
@@ -118,7 +118,8 @@ export default function FileUpload({
       <ScrambleFileList
         scrambleFiles={uploadedJsonFiles}
         isFetching={isFetching}
-        removeScrambleFile={removeScrambleFile}
+        matchState={matchState}
+        dispatchMatchState={dispatchMatchState}
       />
     </>
   );

--- a/app/webpacker/components/ScrambleMatcher/MatchingTableDnd.jsx
+++ b/app/webpacker/components/ScrambleMatcher/MatchingTableDnd.jsx
@@ -18,6 +18,7 @@ export default function MatchingTableDnd({
   computeCellDetails = undefined,
   cellDetailsAreData = false,
   onClickMoveAction = undefined,
+  onClickDeleteAction = undefined,
 }) {
   const [currentDragStart, setCurrentDragStart] = useState(null);
   const [currentDragIndex, setCurrentDragIndex] = useState(null);
@@ -70,6 +71,7 @@ export default function MatchingTableDnd({
           <Table.HeaderCell />
           <Table.HeaderCell>Assigned Scrambles</Table.HeaderCell>
           {onClickMoveAction && (<Table.HeaderCell>Move</Table.HeaderCell>)}
+          {onClickDeleteAction && (<Table.HeaderCell>Delete</Table.HeaderCell>)}
         </Table.Row>
       </Table.Header>
       <DragDropContext
@@ -105,13 +107,13 @@ export default function MatchingTableDnd({
                             <Table.Row
                               key={key}
                               {...providedDraggable.draggableProps}
-                              negative={hasError || isExtra}
+                              negative={hasError}
                             >
                               <Table.Cell textAlign="center" collapsing verticalAlign="middle">
                                 {isExpected && computeDefinitionName(definitionIndex)}
                                 {isExtra && (
                                   <Popup
-                                    trigger={<Icon name="exclamation triangle" />}
+                                    trigger={<Icon name="exclamation triangle" color="red" />}
                                     content="This entry is unexpected"
                                     position="top center"
                                   />
@@ -143,6 +145,17 @@ export default function MatchingTableDnd({
                                     size="large"
                                     link
                                     onClick={() => onClickMoveAction(rowData)}
+                                    disabled={hasError}
+                                  />
+                                </Table.Cell>
+                              )}
+                              {onClickDeleteAction && (
+                                <Table.Cell textAlign="center" verticalAlign="middle" collapsing>
+                                  <Icon
+                                    name="trash"
+                                    size="large"
+                                    link
+                                    onClick={() => onClickDeleteAction(rowData)}
                                     disabled={hasError}
                                   />
                                 </Table.Cell>

--- a/app/webpacker/components/ScrambleMatcher/MatchingTableDnd.jsx
+++ b/app/webpacker/components/ScrambleMatcher/MatchingTableDnd.jsx
@@ -119,13 +119,12 @@ export default function MatchingTableDnd({
                                   />
                                 )}
                               </Table.Cell>
-                              <Table.Cell {...providedDraggable.dragHandleProps}>
-                                {hasError
-                                  ? 'Missing row'
-                                  : (
-                                    <Header size="small">
-                                      <Icon name={hasError ? 'exclamation triangle' : 'bars'} />
-                                      <Header.Content>
+                              <Table.Cell {...providedDraggable.dragHandleProps} verticalAlign="middle">
+                                <Header size="small" color={hasError ? 'red' : undefined}>
+                                  <Icon name={hasError ? 'exclamation triangle' : 'bars'} />
+                                  <Header.Content>
+                                    {hasError ? 'Missing Row' : (
+                                      <>
                                         {computeCellName(rowData)}
                                         {computeCellDetails && (
                                           <Header.Subheader
@@ -134,9 +133,10 @@ export default function MatchingTableDnd({
                                             {computeCellDetails(rowData)}
                                           </Header.Subheader>
                                         )}
-                                      </Header.Content>
-                                    </Header>
-                                  )}
+                                      </>
+                                    )}
+                                  </Header.Content>
+                                </Header>
                               </Table.Cell>
                               {onClickMoveAction && (
                                 <Table.Cell textAlign="center" verticalAlign="middle" collapsing>

--- a/app/webpacker/components/ScrambleMatcher/MoveMatchingEntityModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/MoveMatchingEntityModal.jsx
@@ -48,7 +48,7 @@ function MatchingSelect({
 
   const roundsSelectOptions = useMemo(() => selectableEntities.map((ent, idx) => ({
     key: ent.id,
-    text: computeEntityName(ent, idx),
+    text: computeEntityName(ent.id, idx),
     value: ent.id,
   })), [selectableEntities, computeEntityName]);
 

--- a/app/webpacker/components/ScrambleMatcher/MoveMatchingEntityModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/MoveMatchingEntityModal.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Button, Form, Modal } from 'semantic-ui-react';
 import _ from 'lodash';
 import { useInputUpdater } from '../../lib/hooks/useInputState';
-import { applyPickerHistory, pickerLocalizationConfig } from './util';
+import { applyPickerHistory, matchingDndConfig, pickerLocalizationConfig } from './util';
 
 function navigationToDescriptor(pickerNavigation) {
   return pickerNavigation.reduce((acc, historyStep) => ({
@@ -74,8 +74,9 @@ export default function MoveMatchingEntityModal({
   rootMatchState,
   pickerHistory,
   matchingKey,
-  entityToName,
 }) {
+  const { computeCellName: entityToName } = matchingDndConfig[matchingKey];
+
   const baseDescriptor = useMemo(() => navigationToDescriptor(pickerHistory), [pickerHistory]);
 
   const [targetDescriptor, setTargetDescriptor] = useState(baseDescriptor);
@@ -94,7 +95,13 @@ export default function MoveMatchingEntityModal({
     });
 
     onClose();
-  }, [dispatchMatchState, pickerHistory, rootMatchState, matchingKey, onClose]);
+  }, [
+    dispatchMatchState,
+    pickerHistory,
+    rootMatchState,
+    matchingKey,
+    onClose,
+  ]);
 
   const computeChoices = useCallback((historyIdx, descriptor) => {
     const currentKey = pickerHistory[historyIdx].key;

--- a/app/webpacker/components/ScrambleMatcher/MoveMatchingEntityModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/MoveMatchingEntityModal.jsx
@@ -81,8 +81,8 @@ export default function MoveMatchingEntityModal({
 }) {
   const { computeCellName: entityToName } = matchingDndConfig[matchingKey];
 
-  const pickerConfigForMatching = Object.values(pickerStepConfig).find((cfg) => cfg.matchingConfigKey === matchingKey);
-  const { enabledCondition } = pickerConfigForMatching || {};
+  const matchingConfig = _.find(pickerStepConfig, (cfg) => cfg.matchingConfigKey === matchingKey);
+  const { enabledCondition } = matchingConfig || {};
 
   const baseDescriptor = useMemo(() => navigationToDescriptor(pickerHistory), [pickerHistory]);
   const [targetDescriptor, setTargetDescriptor] = useState(baseDescriptor);

--- a/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
+++ b/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
@@ -57,6 +57,7 @@ function EntityPicker({
   const {
     computeEntityName,
     headerLabel,
+    pickerLabel = headerLabel,
   } = pickerLocalizationConfig[pickerKey];
 
   const { pickerComponent: PickerComponent = ButtonGroupPicker } = pickerStepConfig[pickerKey];
@@ -73,7 +74,7 @@ function EntityPicker({
         selectedEntityId={selectedEntityId}
         onEntityIdSelected={setSelectedEntityId}
         computeEntityName={computeEntityName}
-        headerLabel={headerLabel}
+        pickerLabel={pickerLabel}
       />
       {selectedEntity && (
         <WrapHistory

--- a/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
+++ b/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
@@ -10,12 +10,16 @@ export default function PickerWithMatching({
   pickerHistory = [],
   pickerKey,
 }) {
+  const { enabledCondition } = pickerStepConfig[pickerKey];
+
+  const isEnabled = enabledCondition?.(pickerHistory) ?? true;
+
   const entityChoices = useMemo(
     () => matchState[pickerKey],
     [matchState, pickerKey],
   );
 
-  if (entityChoices === undefined) {
+  if (entityChoices === undefined || !isEnabled) {
     return null;
   }
 
@@ -112,13 +116,8 @@ function WrapHistory({
     ];
   }, [entityChoices, pickerHistory, pickerKey, selectedEntity]);
 
-  const { matchingConfigKey, nestedPicker, nestingCondition } = pickerStepConfig[pickerKey];
+  const { matchingConfigKey, nestedPicker } = pickerStepConfig[pickerKey];
   const matchingConfig = matchingDndConfig[matchingConfigKey];
-
-  const isUsingNesting = useMemo(
-    () => nestingCondition?.(nextHistory) ?? true,
-    [nestingCondition, nextHistory],
-  );
 
   return (
     <>
@@ -133,7 +132,7 @@ function WrapHistory({
           matchingConfig={matchingConfig}
         />
       )}
-      {nestedPicker && isUsingNesting && (
+      {nestedPicker && (
         <PickerWithMatching
           matchState={selectedEntity}
           rootMatchState={rootMatchState}

--- a/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
+++ b/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { matchingDndConfig, pickerLocalizationConfig, pickerStepConfig } from './util';
+import {buildHistoryStep, matchingDndConfig, pickerLocalizationConfig, pickerStepConfig} from './util';
 import ButtonGroupPicker from './ButtonGroupPicker';
 import TableAndModal from './TableAndModal';
 
@@ -107,12 +107,7 @@ function WrapHistory({
 
     return [
       ...pickerHistory,
-      {
-        key: pickerKey,
-        id: selectedEntity.id,
-        index: selectedEntityIdx,
-        entity: selectedEntity,
-      },
+      buildHistoryStep(pickerKey, selectedEntity, selectedEntityIdx),
     ];
   }, [entityChoices, pickerHistory, pickerKey, selectedEntity]);
 

--- a/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
+++ b/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { pickerLocalizationConfig, pickerStepConfig } from './util';
+import {matchingDndConfig, pickerLocalizationConfig, pickerStepConfig} from './util';
 import ButtonGroupPicker from './ButtonGroupPicker';
 import TableAndModal from './TableAndModal';
 
@@ -111,7 +111,8 @@ function WrapHistory({
     ];
   }, [entityChoices, pickerHistory, pickerKey, selectedEntity]);
 
-  const { matchingConfig, nestedPicker, nestingCondition } = pickerStepConfig[pickerKey];
+  const { matchingConfigKey, nestedPicker, nestingCondition } = pickerStepConfig[pickerKey];
+  const matchingConfig = matchingDndConfig[matchingConfigKey];
 
   const isUsingNesting = useMemo(
     () => nestingCondition?.(nextHistory) ?? true,
@@ -127,6 +128,7 @@ function WrapHistory({
           rootMatchState={rootMatchState}
           dispatchMatchState={dispatchMatchState}
           pickerHistory={nextHistory}
+          matchingKey={matchingConfigKey}
           matchingConfig={matchingConfig}
         />
       )}

--- a/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
+++ b/app/webpacker/components/ScrambleMatcher/PickerWithMatching.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import {matchingDndConfig, pickerLocalizationConfig, pickerStepConfig} from './util';
+import { matchingDndConfig, pickerLocalizationConfig, pickerStepConfig } from './util';
 import ButtonGroupPicker from './ButtonGroupPicker';
 import TableAndModal from './TableAndModal';
 

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -10,7 +10,8 @@ import {
   groupScrambleSetsIntoWcif,
   matchingDndConfig,
   pickerLocalizationConfig,
-  pickerStepConfig, searchRecursive,
+  pickerStepConfig,
+  searchRecursive,
 } from './util';
 import { events } from '../../lib/wca-data.js.erb';
 import { getFullDateTimeString } from '../../lib/utils/dates';
@@ -179,10 +180,10 @@ function BodyForMatching({
           .filter((laterRow) => laterRow[stepIdx].id === step.id)
           .length;
 
-        const actualNavigation = searchRecursive(matchState, matchingKey, step);
+        const actualNavigation = searchRecursive(matchState, step);
 
         const autoInsertTarget = stepIdx > 0 ? allSteps[stepIdx - 1] : {};
-        const autoInsertNavigation = searchRecursive(matchState, matchingKey, autoInsertTarget);
+        const autoInsertNavigation = searchRecursive(matchState, autoInsertTarget);
 
         const reactKey = `${step.key}-${step.id}`;
 

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -1,12 +1,14 @@
 import React, { useCallback } from 'react';
 import {
-  Accordion, Button, Header, List,
+  Accordion, Button, Header, Icon, Popup, Table,
 } from 'semantic-ui-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import _ from 'lodash';
 import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken';
 import { scrambleFileUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
-import { scrambleSetToName } from './util';
+import { ATTEMPT_BASED_EVENTS, scrambleSetToName, scrambleToName } from './util';
+import { events } from '../../lib/wca-data.js.erb';
 
 async function deleteScrambleFile({ fileId }) {
   const { data } = await fetchJsonOrError(scrambleFileUrl(fileId), {
@@ -14,6 +16,24 @@ async function deleteScrambleFile({ fileId }) {
   });
 
   return data;
+}
+
+const DUMMY_SCRAMBLE_ID = 0;
+const DUMMY_SCRAMBLE = { id: DUMMY_SCRAMBLE_ID };
+const DUMMY_SCRAMBLE_SET = [DUMMY_SCRAMBLE];
+
+function groupAndIterate(list, iteratee, fn) {
+  return Object.entries(
+    _.groupBy(list, iteratee),
+  ).flatMap(([key, values], ...args) => fn(key, values, ...args));
+}
+
+function reduceSetLength(scrSets, isAttemptBasedEvent = false) {
+  return scrSets.reduce((sum, set) => sum + (
+    isAttemptBasedEvent
+      ? set.inbox_scrambles.length
+      : 1
+  ), 0);
 }
 
 function ScrambleFileHeader({ scrambleFile }) {
@@ -55,13 +75,87 @@ function ScrambleFileBody({ scrambleFile, removeScrambleFile }) {
 
   return (
     <>
-      <List style={{ maxHeight: '400px', overflowY: 'auto' }}>
-        {scrambleFile.inbox_scramble_sets.map((scrambleSet) => (
-          <List.Item key={scrambleSet.id}>
-            {scrambleSetToName(scrambleSet)}
-          </List.Item>
-        ))}
-      </List>
+      <Table celled structured compact>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell collapsing>Event</Table.HeaderCell>
+            <Table.HeaderCell collapsing>Round</Table.HeaderCell>
+            <Table.HeaderCell colSpan={2}>Scramble Set Details</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {groupAndIterate(
+            scrambleFile.inbox_scramble_sets,
+            'event_id',
+            (eventId, eventScrambleSets) => groupAndIterate(
+              eventScrambleSets,
+              'round_number',
+              (roundNum, roundScrambleSets, roundIdx) => {
+                const isAttemptBasedEvent = ATTEMPT_BASED_EVENTS.includes(eventId);
+
+                return roundScrambleSets.flatMap(
+                  (scrSet, setIdx) => {
+                    const scrambleSets = isAttemptBasedEvent
+                      ? scrSet.inbox_scrambles
+                      : DUMMY_SCRAMBLE_SET;
+
+                    return scrambleSets.map((scr, scrIdx, scrambles) => (
+                      (
+                        <Table.Row key={`${scrSet.id}--${scr.id}`}>
+                          {scrIdx === 0 && (
+                            <>
+                              {setIdx === 0 && (
+                                <>
+                                  {roundIdx === 0 && (
+                                    <Table.Cell
+                                      rowSpan={reduceSetLength(
+                                        eventScrambleSets,
+                                        isAttemptBasedEvent,
+                                      )}
+                                      verticalAlign="middle"
+                                      textAlign="center"
+                                    >
+                                      <Popup
+                                        content={events.byId[eventId].name}
+                                        trigger={<Icon size="large" className={`cubing-icon event-${eventId}`} />}
+                                        position="top center"
+                                      />
+                                    </Table.Cell>
+                                  )}
+                                  <Table.Cell
+                                    rowSpan={reduceSetLength(
+                                      roundScrambleSets,
+                                      isAttemptBasedEvent,
+                                    )}
+                                    verticalAlign="middle"
+                                    textAlign="center"
+                                  >
+                                    {roundNum}
+                                  </Table.Cell>
+                                </>
+                              )}
+                              <Table.Cell
+                                rowSpan={scrambles.length}
+                                colSpan={scr.id === DUMMY_SCRAMBLE_ID ? 2 : 1}
+                                verticalAlign="middle"
+                              >
+                                {scrambleSetToName(scrSet)}
+                              </Table.Cell>
+                            </>
+                          )}
+                          {scr.id !== DUMMY_SCRAMBLE_ID && (
+                            <Table.Cell>{scrambleToName(scr)}</Table.Cell>
+                          )}
+                        </Table.Row>
+                      )
+                    ));
+                  },
+                );
+              },
+            ),
+          )}
+        </Table.Body>
+      </Table>
       <Button
         fluid
         negative

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -128,7 +128,6 @@ function buildTableRows(
         entity: rowEntity,
         index: i,
         hasPicker: previousMatching === matchingKey,
-        tableStatusEnabled,
       },
     ];
 

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   Accordion, Breadcrumb, Button, Header, Icon, Popup, Table,
 } from 'semantic-ui-react';
@@ -15,7 +15,6 @@ import {
 } from './util';
 import { events } from '../../lib/wca-data.js.erb';
 import { getFullDateTimeString } from '../../lib/utils/dates';
-import MoveMatchingEntityModal from './MoveMatchingEntityModal';
 import { UnusedEntityButtonGroup } from './UnusedScramblesPanel';
 
 async function deleteScrambleFile({ fileId }) {
@@ -112,12 +111,6 @@ function MatchingTableCellContent({
   matchState,
   dispatchMatchState,
 }) {
-  const [modalEntity, setModalEntity] = useState(null);
-
-  const onModalClose = useCallback(() => {
-    setModalEntity(null);
-  }, [setModalEntity]);
-
   const remainingSteps = allSteps.slice(stepIdx + 1);
   const isDefCell = remainingSteps.every((remStep) => remStep.index === 0);
 
@@ -140,8 +133,6 @@ function MatchingTableCellContent({
     .length;
 
   const actualNavigation = searchRecursive(matchState, step);
-
-  const pathToStepEntity = allSteps.slice(0, stepIdx + 1);
 
   if (step.id === DUMMY_ENTITY_ID) {
     if (stepIdx > 0 && allSteps[stepIdx - 1].id === DUMMY_ENTITY_ID) {
@@ -190,25 +181,13 @@ function MatchingTableCellContent({
                 ))}
               </Breadcrumb>
             ) : (
-              <>
-                <UnusedEntityButtonGroup
-                  entity={step.entity}
-                  fullPathToEntity={pathToStepEntity}
-                  referenceMatchState={matchState}
-                  onClickAutoAssign={addEntityBack}
-                  onClickManualAssign={setModalEntity}
-                />
-                <MoveMatchingEntityModal
-                  isOpen={modalEntity !== null}
-                  onClose={onModalClose}
-                  onConfirm={addEntityBack}
-                  selectedMatchingEntity={modalEntity}
-                  rootMatchState={matchState}
-                  pickerHistory={allSteps.slice(0, stepIdx)}
-                  matchingKey={step.key}
-                  isAddMode
-                />
-              </>
+              <UnusedEntityButtonGroup
+                entity={step.entity}
+                matchingKey={step.key}
+                pickerHistory={allSteps.slice(0, stepIdx)}
+                referenceMatchState={matchState}
+                moveEntity={addEntityBack}
+              />
             )}
         </Table.Cell>
       )}

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -77,10 +77,13 @@ function ScrambleFileBody({ scrambleFile, removeScrambleFile }) {
     <>
       <Table celled structured compact>
         <Table.Header>
-          <Table.Row>
+          <Table.Row textAlign="center">
             <Table.HeaderCell collapsing>Event</Table.HeaderCell>
             <Table.HeaderCell collapsing>Round</Table.HeaderCell>
-            <Table.HeaderCell colSpan={2}>Scramble Set Details</Table.HeaderCell>
+            <Table.HeaderCell>Scramble Set</Table.HeaderCell>
+            <Table.HeaderCell>Current Status</Table.HeaderCell>
+            <Table.HeaderCell>Scramble</Table.HeaderCell>
+            <Table.HeaderCell>Current Status</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -136,15 +139,28 @@ function ScrambleFileBody({ scrambleFile, removeScrambleFile }) {
                               )}
                               <Table.Cell
                                 rowSpan={scrambles.length}
-                                colSpan={scr.id === DUMMY_SCRAMBLE_ID ? 2 : 1}
                                 verticalAlign="middle"
+                                textAlign="right"
                               >
                                 {scrambleSetToName(scrSet)}
+                              </Table.Cell>
+                              <Table.Cell
+                                rowSpan={scrambles.length}
+                                verticalAlign="middle"
+                                textAlign="left"
+                                colSpan={scr.id === DUMMY_SCRAMBLE_ID ? 3 : 1}
+                              >
+                                <Button positive basic compact>Reinstate</Button>
                               </Table.Cell>
                             </>
                           )}
                           {scr.id !== DUMMY_SCRAMBLE_ID && (
-                            <Table.Cell>{scrambleToName(scr)}</Table.Cell>
+                            <>
+                              <Table.Cell verticalAlign="middle" textAlign="right">{scrambleToName(scr)}</Table.Cell>
+                              <Table.Cell verticalAlign="middle">
+                                <Button positive basic compact>Reinstate</Button>
+                              </Table.Cell>
+                            </>
                           )}
                         </Table.Row>
                       )

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -10,7 +10,7 @@ import {
   groupScrambleSetsIntoWcif,
   matchingDndConfig,
   pickerLocalizationConfig,
-  pickerStepConfig,
+  pickerStepConfig, searchRecursive,
 } from './util';
 import { events } from '../../lib/wca-data.js.erb';
 import { getFullDateTimeString } from '../../lib/utils/dates';
@@ -148,6 +148,7 @@ function buildTableRows(
 function BodyForMatching({
   matchingKey,
   matchEntity,
+  matchState,
 }) {
   const tableRows = buildTableRows(matchingKey, matchEntity);
 
@@ -166,7 +167,7 @@ function BodyForMatching({
           .filter((laterRow) => laterRow[stepIdx].id === step.id)
           .length;
 
-        const actualNavigation = null; // TODO
+        const actualNavigation = searchRecursive(matchState, matchingKey, step);
 
         const reactKey = `${step.key}-${step.id}`;
 
@@ -284,6 +285,7 @@ function ScrambleFileBody({
           <BodyForMatching
             matchingKey="events"
             matchEntity={scrambleFileTree}
+            matchState={matchState}
           />
         </Table.Body>
       </Table>

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -7,6 +7,7 @@ import { fetchJsonOrError } from '../../lib/requests/fetchWithAuthenticityToken'
 import { scrambleFileUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../Requests/Loading';
 import {
+  buildHistoryStep,
   groupScrambleSetsIntoWcif,
   matchingDndConfig,
   pickerLocalizationConfig,
@@ -217,10 +218,7 @@ function buildTableRows(
     const nextHistory = [
       ...history,
       {
-        key: matchingKey,
-        id: rowEntity.id,
-        entity: rowEntity,
-        index: i,
+        ...buildHistoryStep(matchingKey, rowEntity, i),
         hasPicker: previousMatching === matchingKey,
       },
     ];

--- a/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
+++ b/app/webpacker/components/ScrambleMatcher/ScrambleFileList.jsx
@@ -114,6 +114,8 @@ function MatchingTableCellContent({
   const remainingSteps = allSteps.slice(stepIdx + 1);
   const isDefCell = remainingSteps.every((remStep) => remStep.index === 0);
 
+  const actualNavigation = useMemo(() => searchRecursive(matchState, step), [matchState, step]);
+
   const addEntityBack = useCallback((entity, pickerHistory) => {
     dispatchMatchState({
       type: 'addEntityToMatching',
@@ -126,13 +128,6 @@ function MatchingTableCellContent({
   if (!isDefCell) {
     return null;
   }
-
-  const defRowSpan = allRows
-    .slice(rowIdx)
-    .filter((laterRow) => laterRow[stepIdx].id === step.id)
-    .length;
-
-  const actualNavigation = searchRecursive(matchState, step);
 
   if (step.id === DUMMY_ENTITY_ID) {
     if (stepIdx > 0 && allSteps[stepIdx - 1].id === DUMMY_ENTITY_ID) {
@@ -154,6 +149,11 @@ function MatchingTableCellContent({
       </Table.Cell>
     );
   }
+
+  const defRowSpan = allRows
+    .slice(rowIdx)
+    .filter((laterRow) => laterRow[stepIdx].id === step.id)
+    .length;
 
   return (
     <>

--- a/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
@@ -79,7 +79,6 @@ export default function TableAndModal({
         rootMatchState={rootMatchState}
         pickerHistory={pickerHistory}
         matchingKey={matchingKey}
-        entityToName={computeCellName}
       />
     </>
   );

--- a/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
@@ -8,10 +8,10 @@ export default function TableAndModal({
   rootMatchState,
   dispatchMatchState,
   pickerHistory,
+  matchingKey,
   matchingConfig,
 }) {
   const {
-    key: matchingKey,
     computeCellName,
     computeCellDetails,
     cellDetailsAreData,

--- a/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
@@ -47,6 +47,17 @@ export default function TableAndModal({
     [dispatchMatchState, pickerHistory, matchingKey],
   );
 
+  const moveSelectedEntity = useCallback(
+    (entity, targetHistory) => dispatchMatchState({
+      type: 'moveMatchingEntity',
+      entity,
+      fromNavigation: pickerHistory,
+      toNavigation: targetHistory,
+      matchingKey,
+    }),
+    [dispatchMatchState, pickerHistory, matchingKey],
+  );
+
   const deleteEntityFromMatching = useCallback(
     (entity) => dispatchMatchState({
       type: 'deleteEntityFromMatching',
@@ -74,7 +85,7 @@ export default function TableAndModal({
         key={modalPayload?.id}
         isOpen={modalPayload !== null}
         onClose={onModalClose}
-        dispatchMatchState={dispatchMatchState}
+        onConfirm={moveSelectedEntity}
         selectedMatchingEntity={modalPayload}
         rootMatchState={rootMatchState}
         pickerHistory={pickerHistory}

--- a/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
@@ -47,6 +47,16 @@ export default function TableAndModal({
     [dispatchMatchState, pickerHistory, matchingKey],
   );
 
+  const deleteEntityFromMatching = useCallback(
+    (entity) => dispatchMatchState({
+      type: 'deleteEntityFromMatching',
+      entity,
+      pickerHistory,
+      matchingKey,
+    }),
+    [dispatchMatchState, pickerHistory, matchingKey],
+  );
+
   return (
     <>
       <MatchingTableDnd
@@ -58,6 +68,7 @@ export default function TableAndModal({
         computeCellDetails={computeCellDetails}
         cellDetailsAreData={cellDetailsAreData}
         onClickMoveAction={setModalPayload}
+        onClickDeleteAction={deleteEntityFromMatching}
       />
       <MoveMatchingEntityModal
         key={modalPayload?.id}

--- a/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
+++ b/app/webpacker/components/ScrambleMatcher/TableAndModal.jsx
@@ -21,8 +21,8 @@ export default function TableAndModal({
   const { computeEntityName } = pickerLocalizationConfig[matchingKey];
 
   const computeDefinitionName = useCallback(
-    (idx) => computeEntityName(matchState, idx),
-    [computeEntityName, matchState],
+    (idx) => computeEntityName(matchState.id, idx),
+    [computeEntityName, matchState.id],
   );
 
   const expectedNumOfRows = useMemo(

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -1,0 +1,131 @@
+import React, { useCallback, useState } from 'react';
+import {
+  Button, Card, Divider, Header, Segment,
+} from 'semantic-ui-react';
+import _ from 'lodash';
+import { ATTEMPT_BASED_EVENTS, matchingDndConfig, pickerLocalizationConfig } from './util';
+import MoveMatchingEntityModal from './MoveMatchingEntityModal';
+
+function computeUnused(lookup, allEntities) {
+  const alreadyUsedKeys = Object.keys(lookup);
+
+  return allEntities.filter((entity) => !alreadyUsedKeys.includes(entity.id.toString()));
+}
+
+function UnusedEntitiesPanel({
+  matchingKey,
+  unusedEntities,
+  dispatchMatchState,
+}) {
+  const {
+    computeCellName,
+    indexAccessKey,
+    computeCellDetails,
+    cellDetailsAreData = false,
+  } = matchingDndConfig[matchingKey];
+
+  const { headerLabel } = pickerLocalizationConfig[matchingKey];
+
+  const [modalPayload, setModalPayload] = useState(null);
+
+  const onModalClose = useCallback(() => {
+    setModalPayload(null);
+  }, [setModalPayload]);
+
+  const autoAssignEntity = useCallback((entity) => dispatchMatchState({
+    type: 'addEntityToMatching',
+    entity,
+    pickerHistory: expectedNavigation,
+    matchingKey,
+    targetIndex: entity[indexAccessKey],
+  }), [dispatchMatchState, matchingKey, indexAccessKey]);
+
+  if (unusedEntities.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Header attached="top">
+        Unused
+        {' '}
+        {headerLabel}
+        {' '}
+        <Button positive compact basic icon="magic" content="Assign all" />
+      </Header>
+      <Segment attached>
+        <Card.Group>
+          {unusedEntities.map((entity) => (
+            <Card>
+              <Card.Content>
+                <Card.Header>{computeCellName(entity)}</Card.Header>
+                {computeCellDetails && !cellDetailsAreData && (
+                  <Card.Meta>{computeCellDetails(entity)}</Card.Meta>
+                )}
+              </Card.Content>
+              <Card.Content extra>
+                <Button.Group compact widths={2}>
+                  <Button icon="magic" content="Assign" positive basic onClick={() => autoAssignEntity(entity)} />
+                  <Button icon="pen" content="Manual" primary basic onClick={() => setModalPayload(entity)} />
+                </Button.Group>
+              </Card.Content>
+            </Card>
+          ))}
+        </Card.Group>
+      </Segment>
+      <MoveMatchingEntityModal
+        key={modalPayload?.id}
+        isOpen={modalPayload !== null}
+        onClose={onModalClose}
+        matchingKey={matchingKey}
+        dispatchMatchState={dispatchMatchState}
+        selectedMatchingEntity={modalPayload}
+      />
+    </>
+  );
+}
+
+export default function UnusedScramblesPanel({
+  scrambleFiles,
+  unfoldedMatchState,
+  dispatchMatchState,
+}) {
+  const allScrambleSets = scrambleFiles.flatMap((scrFile) => scrFile.inbox_scramble_sets);
+
+  const allScrambles = allScrambleSets
+    .filter((scrSet) => ATTEMPT_BASED_EVENTS.includes(scrSet.event_id))
+    .flatMap((scrSet) => scrSet.inbox_scrambles);
+
+  const scrambleSetLookup = _.keyBy(
+    unfoldedMatchState.map((nav) => nav.slice(0, -1)),
+    (hist) => hist.find((nav) => nav.key === 'scrambleSets').id,
+  );
+
+  const scramblesLookup = _.keyBy(
+    unfoldedMatchState,
+    (hist) => hist.find((nav) => nav.key === 'inbox_scrambles').id,
+  );
+
+  const unusedScrambleSets = computeUnused(scrambleSetLookup, allScrambleSets);
+  const unusedScrambles = computeUnused(scramblesLookup, allScrambles);
+
+  const anyUnusedEntries = unusedScrambleSets.length > 0 || unusedScrambles.length > 0;
+
+  return (
+    <>
+      {anyUnusedEntries && <Divider />}
+      <>
+        <UnusedEntitiesPanel
+          matchingKey="scrambleSets"
+          unusedEntities={unusedScrambleSets}
+          dispatchMatchState={dispatchMatchState}
+        />
+        <UnusedEntitiesPanel
+          matchingKey="inbox_scrambles"
+          unusedEntities={unusedScrambles}
+          dispatchMatchState={dispatchMatchState}
+        />
+      </>
+    </>
+  );
+}

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -102,9 +102,11 @@ export function UnusedEntityButtonGroup({
     setModalPayload(null);
   }, [setModalPayload]);
 
-  const autoInsertTarget = pickerHistory[pickerHistory.length - 1];
+  const autoInsertNavigation = useMemo(() => {
+    const autoInsertTarget = pickerHistory[pickerHistory.length - 1];
 
-  const autoInsertNavigation = searchRecursive(referenceMatchState, autoInsertTarget);
+    return searchRecursive(referenceMatchState, autoInsertTarget);
+  }, [pickerHistory, referenceMatchState]);
 
   return (
     <>

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -2,19 +2,84 @@ import React, { useCallback, useMemo, useState } from 'react';
 import {
   Button, Card, Divider, Header, Segment,
 } from 'semantic-ui-react';
+import _ from 'lodash';
 import {
-  ATTEMPT_BASED_EVENTS,
-  flattenToLevel, groupScrambleSetsIntoWcif,
+  groupScrambleSetsIntoWcif,
   matchingDndConfig,
-  pickerLocalizationConfig, searchRecursive,
+  pickerLocalizationConfig,
+  pickerStepConfig,
+  searchRecursive,
 } from './util';
 import MoveMatchingEntityModal from './MoveMatchingEntityModal';
 
-function computeUnused(matchState, depthKey, referenceEntities) {
-  const usedInMatchState = flattenToLevel(matchState, 'events', depthKey).map((ent) => ent.id);
+const filterUnusedItems = (
+  scrambleFileMaster,
+  matchState,
+  history = [],
+  currentKey = 'events',
+  previousMatcher = undefined,
+) => {
+  if (!currentKey || !scrambleFileMaster) {
+    return [];
+  }
 
-  return referenceEntities.filter((entity) => !usedInMatchState.includes(entity.id));
-}
+  const {
+    enabledCondition,
+    matchingConfigKey,
+    nestedPicker = matchingConfigKey,
+  } = pickerStepConfig[currentKey] || {};
+
+  const currentPickerEnabled = enabledCondition?.(history) ?? true;
+
+  const masterItems = scrambleFileMaster[currentKey];
+  const workingItems = matchState?.[currentKey];
+
+  const usedIds = workingItems?.map((itm) => itm.id);
+  const unusedItems = masterItems.filter((masterItem) => !usedIds?.includes(masterItem.id));
+
+  const currentStepReturn = { key: currentKey, unused: unusedItems };
+
+  if (!nestedPicker || !currentPickerEnabled) {
+    return [currentStepReturn];
+  }
+
+  const unusedBranches = masterItems.map((masterItem, i) => {
+    const workingItemCandidate = workingItems?.find((itm) => itm.id === masterItem.id);
+
+    const nextHistory = [
+      ...history,
+      {
+        key: currentKey,
+        id: masterItem.id,
+        entity: masterItem,
+        index: i,
+      },
+    ];
+
+    return filterUnusedItems(
+      masterItem,
+      workingItemCandidate,
+      nextHistory,
+      nestedPicker,
+      matchingConfigKey,
+    );
+  });
+
+  const combinedUnused = _.chain(unusedBranches)
+    .flatten()
+    .groupBy('key')
+    .map((group, key) => ({
+      key,
+      unused: group.flatMap((gr) => gr.unused),
+    }))
+    .value();
+
+  if (previousMatcher !== currentKey) {
+    return combinedUnused;
+  }
+
+  return [currentStepReturn, ...combinedUnused];
+};
 
 function UnusedEntitiesPanel({
   matchingKey,
@@ -58,10 +123,10 @@ function UnusedEntitiesPanel({
       <Segment attached>
         <Card.Group>
           {unusedEntities.map((entity) => {
-            const pathToUnusedEntity = searchRecursive(scrambleFilesTree, 'events', { key: matchingKey, id: entity.id });
+            const pathToUnusedEntity = searchRecursive(scrambleFilesTree, { key: matchingKey, id: entity.id });
             const autoInsertTarget = pathToUnusedEntity[pathToUnusedEntity.length - 2];
 
-            const autoInsertNavigation = searchRecursive(rootMatchState, 'events', autoInsertTarget);
+            const autoInsertNavigation = searchRecursive(rootMatchState, autoInsertTarget);
 
             return (
               <Card>
@@ -109,36 +174,22 @@ export default function UnusedScramblesPanel({
     return groupScrambleSetsIntoWcif(allScrambleSets);
   }, [scrambleFiles]);
 
-  const allScrambleSets = flattenToLevel(scrambleFilesTree, 'events', 'scrambleSets');
-
-  const allAttemptScrambles = allScrambleSets
-    .filter((scrSet) => ATTEMPT_BASED_EVENTS.includes(scrSet.event_id))
-    .flatMap((scrSet) => scrSet.inbox_scrambles);
-
-  const unusedScrambleSets = computeUnused(matchState, 'scrambleSets', allScrambleSets);
-  const unusedScrambles = computeUnused(matchState, 'inbox_scrambles', allAttemptScrambles);
-
-  const anyUnusedEntries = unusedScrambleSets.length > 0 || unusedScrambles.length > 0;
+  const unusedPickerEntities = filterUnusedItems(scrambleFilesTree, matchState);
+  const anyUnusedEntries = unusedPickerEntities.some((step) => step.unused.length > 0);
 
   return (
     <>
       {anyUnusedEntries && <Divider />}
-      <>
+      {unusedPickerEntities.map((unusedStep) => (
         <UnusedEntitiesPanel
-          matchingKey="scrambleSets"
-          unusedEntities={unusedScrambleSets}
+          key={unusedStep.key}
+          matchingKey={unusedStep.key}
+          unusedEntities={unusedStep.unused}
           dispatchMatchState={dispatchMatchState}
           scrambleFilesTree={scrambleFilesTree}
           rootMatchState={matchState}
         />
-        <UnusedEntitiesPanel
-          matchingKey="inbox_scrambles"
-          unusedEntities={unusedScrambles}
-          dispatchMatchState={dispatchMatchState}
-          scrambleFilesTree={scrambleFilesTree}
-          rootMatchState={matchState}
-        />
-      </>
+      ))}
     </>
   );
 }

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -90,35 +90,54 @@ const filterUnusedItems = (
 
 export function UnusedEntityButtonGroup({
   entity,
-  fullPathToEntity,
+  pickerHistory,
+  matchingKey,
   referenceMatchState,
-  onClickAutoAssign,
-  onClickManualAssign,
+  moveEntity,
   fluid = undefined,
 }) {
-  const autoInsertTarget = fullPathToEntity[fullPathToEntity.length - 2];
+  const [modalPayload, setModalPayload] = useState(null);
+
+  const onModalClose = useCallback(() => {
+    setModalPayload(null);
+  }, [setModalPayload]);
+
+  const autoInsertTarget = pickerHistory[pickerHistory.length - 1];
 
   const autoInsertNavigation = searchRecursive(referenceMatchState, autoInsertTarget);
 
   return (
-    <Button.Group compact fluid={fluid}>
-      {autoInsertNavigation && (
+    <>
+      <Button.Group compact fluid={fluid}>
+        {autoInsertNavigation && (
+          <Button
+            positive
+            basic
+            icon="magic"
+            content="Auto-Assign"
+            onClick={() => moveEntity(entity, autoInsertNavigation)}
+          />
+        )}
         <Button
-          positive
+          primary
           basic
-          icon="magic"
-          content="Auto-Assign"
-          onClick={() => onClickAutoAssign(entity, autoInsertNavigation)}
+          icon="pen"
+          content="Manual"
+          onClick={setModalPayload}
         />
-      )}
-      <Button
-        primary
-        basic
-        icon="pen"
-        content="Manual"
-        onClick={() => onClickManualAssign(entity)}
+      </Button.Group>
+      <MoveMatchingEntityModal
+        key={modalPayload?.id}
+        isOpen={modalPayload !== null}
+        onClose={onModalClose}
+        onConfirm={moveEntity}
+        selectedMatchingEntity={modalPayload}
+        rootMatchState={referenceMatchState}
+        pickerHistory={pickerHistory}
+        matchingKey={matchingKey}
+        isAddMode
       />
-    </Button.Group>
+    </>
   );
 }
 
@@ -136,12 +155,6 @@ function UnusedEntitiesPanel({
   } = matchingDndConfig[matchingKey];
 
   const { headerLabel } = pickerLocalizationConfig[matchingKey];
-
-  const [modalPayload, setModalPayload] = useState(null);
-
-  const onModalClose = useCallback(() => {
-    setModalPayload(null);
-  }, [setModalPayload]);
 
   const addBackEntity = useCallback((entity, pickerHistory) => dispatchMatchState({
     type: 'addEntityToMatching',
@@ -180,22 +193,11 @@ function UnusedEntitiesPanel({
                 <Card.Content extra>
                   <UnusedEntityButtonGroup
                     entity={entity}
-                    fullPathToEntity={pathToUnusedEntity}
-                    referenceMatchState={rootMatchState}
-                    onClickAutoAssign={addBackEntity}
-                    onClickManualAssign={setModalPayload}
-                    fluid
-                  />
-                  <MoveMatchingEntityModal
-                    key={modalPayload?.id}
-                    isOpen={modalPayload !== null}
-                    onClose={onModalClose}
-                    onConfirm={addBackEntity}
-                    selectedMatchingEntity={modalPayload}
-                    rootMatchState={rootMatchState}
                     pickerHistory={pathToUnusedEntity.slice(0, -1)}
                     matchingKey={matchingKey}
-                    isAddMode
+                    referenceMatchState={rootMatchState}
+                    moveEntity={addBackEntity}
+                    fluid
                   />
                 </Card.Content>
               </Card>

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -81,6 +81,39 @@ const filterUnusedItems = (
   return [currentStepReturn, ...combinedUnused];
 };
 
+export function UnusedEntityButtonGroup({
+  entity,
+  fullPathToEntity,
+  referenceMatchState,
+  onClickAutoAssign,
+  onClickManualAssign,
+}) {
+  const autoInsertTarget = fullPathToEntity[fullPathToEntity.length - 2];
+
+  const autoInsertNavigation = searchRecursive(referenceMatchState, autoInsertTarget);
+
+  return (
+    <Button.Group compact widths={2}>
+      {autoInsertNavigation && (
+        <Button
+          positive
+          basic
+          icon="magic"
+          content="Auto-Assign"
+          onClick={() => onClickAutoAssign(entity, autoInsertNavigation)}
+        />
+      )}
+      <Button
+        primary
+        basic
+        icon="pen"
+        content="Manual"
+        onClick={() => onClickManualAssign(entity)}
+      />
+    </Button.Group>
+  );
+}
+
 function UnusedEntitiesPanel({
   matchingKey,
   unusedEntities,
@@ -123,13 +156,13 @@ function UnusedEntitiesPanel({
       <Segment attached>
         <Card.Group>
           {unusedEntities.map((entity) => {
-            const pathToUnusedEntity = searchRecursive(scrambleFilesTree, { key: matchingKey, id: entity.id });
-            const autoInsertTarget = pathToUnusedEntity[pathToUnusedEntity.length - 2];
-
-            const autoInsertNavigation = searchRecursive(rootMatchState, autoInsertTarget);
+            const pathToUnusedEntity = searchRecursive(
+              scrambleFilesTree,
+              { key: matchingKey, id: entity.id },
+            );
 
             return (
-              <Card>
+              <Card key={entity.id}>
                 <Card.Content>
                   <Card.Header>{computeCellName(entity)}</Card.Header>
                   {computeCellDetails && !cellDetailsAreData && (
@@ -137,12 +170,13 @@ function UnusedEntitiesPanel({
                   )}
                 </Card.Content>
                 <Card.Content extra>
-                  <Button.Group compact widths={2}>
-                    {autoInsertNavigation && (
-                      <Button icon="magic" content="Assign" positive basic onClick={() => autoAssignEntity(entity, autoInsertNavigation)} />
-                    )}
-                    <Button icon="pen" content="Manual" primary basic onClick={() => setModalPayload(entity)} />
-                  </Button.Group>
+                  <UnusedEntityButtonGroup
+                    entity={entity}
+                    fullPathToEntity={pathToUnusedEntity}
+                    referenceMatchState={rootMatchState}
+                    onClickAutoAssign={autoAssignEntity}
+                    onClickManualAssign={setModalPayload}
+                  />
                 </Card.Content>
               </Card>
             );

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -4,6 +4,7 @@ import {
 } from 'semantic-ui-react';
 import _ from 'lodash';
 import {
+  buildHistoryStep,
   groupScrambleSetsIntoWcif,
   matchingDndConfig,
   pickerLocalizationConfig,
@@ -57,12 +58,7 @@ const filterUnusedItems = (
 
     const nextHistory = [
       ...history,
-      {
-        key: currentKey,
-        id: masterItem.id,
-        entity: masterItem,
-        index: i,
-      },
+      buildHistoryStep(currentKey, masterItem, i),
     ];
 
     return filterUnusedItems(
@@ -179,28 +175,26 @@ function UnusedEntitiesPanel({
       </Header>
       <Segment attached>
         <Card.Group>
-          {unusedEntries.map(({ entity, pickerHistory }) => {
-            return (
-              <Card key={entity.id}>
-                <Card.Content>
-                  <Card.Header>{computeCellName(entity)}</Card.Header>
-                  {computeCellDetails && !cellDetailsAreData && (
-                    <Card.Meta>{computeCellDetails(entity)}</Card.Meta>
-                  )}
-                </Card.Content>
-                <Card.Content extra>
-                  <UnusedEntityButtonGroup
-                    entity={entity}
-                    pickerHistory={pickerHistory}
-                    matchingKey={matchingKey}
-                    referenceMatchState={rootMatchState}
-                    moveEntity={addBackEntity}
-                    fluid
-                  />
-                </Card.Content>
-              </Card>
-            );
-          })}
+          {unusedEntries.map(({ entity, pickerHistory }) => (
+            <Card key={entity.id}>
+              <Card.Content>
+                <Card.Header>{computeCellName(entity)}</Card.Header>
+                {computeCellDetails && !cellDetailsAreData && (
+                <Card.Meta>{computeCellDetails(entity)}</Card.Meta>
+                )}
+              </Card.Content>
+              <Card.Content extra>
+                <UnusedEntityButtonGroup
+                  entity={entity}
+                  pickerHistory={pickerHistory}
+                  matchingKey={matchingKey}
+                  referenceMatchState={rootMatchState}
+                  moveEntity={addBackEntity}
+                  fluid
+                />
+              </Card.Content>
+            </Card>
+          ))}
         </Card.Group>
       </Segment>
     </>

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -44,7 +44,14 @@ const filterUnusedItems = (
   }
 
   const unusedBranches = masterItems.map((masterItem, i) => {
-    const workingItemCandidate = workingItems?.find((itm) => itm.id === masterItem.id);
+    const mergedWorkingItems = workingItems?.reduce((acc, workingItem) => ({
+      ...acc,
+      ...workingItem,
+      [nestedPicker]: [
+        ...acc[nestedPicker],
+        ...workingItem[nestedPicker],
+      ],
+    }));
 
     const nextHistory = [
       ...history,
@@ -58,7 +65,7 @@ const filterUnusedItems = (
 
     return filterUnusedItems(
       masterItem,
-      workingItemCandidate,
+      mergedWorkingItems,
       nextHistory,
       nestedPicker,
       matchingConfigKey,
@@ -87,13 +94,14 @@ export function UnusedEntityButtonGroup({
   referenceMatchState,
   onClickAutoAssign,
   onClickManualAssign,
+  fluid = undefined,
 }) {
   const autoInsertTarget = fullPathToEntity[fullPathToEntity.length - 2];
 
   const autoInsertNavigation = searchRecursive(referenceMatchState, autoInsertTarget);
 
   return (
-    <Button.Group compact widths={2}>
+    <Button.Group compact fluid={fluid}>
       {autoInsertNavigation && (
         <Button
           positive
@@ -176,6 +184,7 @@ function UnusedEntitiesPanel({
                     referenceMatchState={rootMatchState}
                     onClickAutoAssign={addBackEntity}
                     onClickManualAssign={setModalPayload}
+                    fluid
                   />
                   <MoveMatchingEntityModal
                     key={modalPayload?.id}
@@ -209,7 +218,11 @@ export default function UnusedScramblesPanel({
     return groupScrambleSetsIntoWcif(allScrambleSets);
   }, [scrambleFiles]);
 
-  const unusedPickerEntities = filterUnusedItems(scrambleFilesTree, matchState);
+  const unusedPickerEntities = useMemo(
+    () => filterUnusedItems(scrambleFilesTree, matchState),
+    [scrambleFilesTree, matchState],
+  );
+
   const anyUnusedEntries = unusedPickerEntities.some((step) => step.unused.length > 0);
 
   return (

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react';
 import {
   Button, Card, Divider, Header, Segment,
 } from 'semantic-ui-react';
-import _ from 'lodash';
 import { ATTEMPT_BASED_EVENTS, matchingDndConfig, pickerLocalizationConfig } from './util';
 import MoveMatchingEntityModal from './MoveMatchingEntityModal';
 
@@ -87,27 +86,20 @@ function UnusedEntitiesPanel({
 
 export default function UnusedScramblesPanel({
   scrambleFiles,
-  unfoldedMatchState,
+  matchState,
+  scrambleFilesTree,
   dispatchMatchState,
 }) {
+  return null;
+
   const allScrambleSets = scrambleFiles.flatMap((scrFile) => scrFile.inbox_scramble_sets);
 
-  const allScrambles = allScrambleSets
+  const allAttemptScrambles = allScrambleSets
     .filter((scrSet) => ATTEMPT_BASED_EVENTS.includes(scrSet.event_id))
     .flatMap((scrSet) => scrSet.inbox_scrambles);
 
-  const scrambleSetLookup = _.keyBy(
-    unfoldedMatchState.map((nav) => nav.slice(0, -1)),
-    (hist) => hist.find((nav) => nav.key === 'scrambleSets').id,
-  );
-
-  const scramblesLookup = _.keyBy(
-    unfoldedMatchState,
-    (hist) => hist.find((nav) => nav.key === 'inbox_scrambles').id,
-  );
-
   const unusedScrambleSets = computeUnused(scrambleSetLookup, allScrambleSets);
-  const unusedScrambles = computeUnused(scramblesLookup, allScrambles);
+  const unusedScrambles = computeUnused(scramblesLookup, allAttemptScrambles);
 
   const anyUnusedEntries = unusedScrambleSets.length > 0 || unusedScrambles.length > 0;
 

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -35,9 +35,11 @@ const filterUnusedItems = (
   const workingItems = matchState?.[currentKey];
 
   const usedIds = workingItems?.map((itm) => itm.id);
-  const unusedItems = masterItems.filter((masterItem) => !usedIds?.includes(masterItem.id));
 
-  const currentStepReturn = { key: currentKey, unused: unusedItems };
+  const unusedItems = masterItems.filter((masterItem) => !usedIds?.includes(masterItem.id));
+  const unusedResult = unusedItems.map((entity) => ({ entity, pickerHistory: history }));
+
+  const currentStepReturn = { key: currentKey, unused: unusedResult };
 
   if (!nestedPicker || !currentPickerEnabled) {
     return [currentStepReturn];
@@ -125,7 +127,7 @@ export function UnusedEntityButtonGroup({
           basic
           icon="pen"
           content="Manual"
-          onClick={setModalPayload}
+          onClick={() => setModalPayload(entity)}
         />
       </Button.Group>
       <MoveMatchingEntityModal
@@ -145,9 +147,8 @@ export function UnusedEntityButtonGroup({
 
 function UnusedEntitiesPanel({
   matchingKey,
-  unusedEntities,
+  unusedEntries,
   dispatchMatchState,
-  scrambleFilesTree,
   rootMatchState,
 }) {
   const {
@@ -165,7 +166,7 @@ function UnusedEntitiesPanel({
     matchingKey,
   }), [dispatchMatchState, matchingKey]);
 
-  if (unusedEntities.length === 0) {
+  if (unusedEntries.length === 0) {
     return null;
   }
 
@@ -178,12 +179,7 @@ function UnusedEntitiesPanel({
       </Header>
       <Segment attached>
         <Card.Group>
-          {unusedEntities.map((entity) => {
-            const pathToUnusedEntity = searchRecursive(
-              scrambleFilesTree,
-              { key: matchingKey, id: entity.id },
-            );
-
+          {unusedEntries.map(({ entity, pickerHistory }) => {
             return (
               <Card key={entity.id}>
                 <Card.Content>
@@ -195,7 +191,7 @@ function UnusedEntitiesPanel({
                 <Card.Content extra>
                   <UnusedEntityButtonGroup
                     entity={entity}
-                    pickerHistory={pathToUnusedEntity.slice(0, -1)}
+                    pickerHistory={pickerHistory}
                     matchingKey={matchingKey}
                     referenceMatchState={rootMatchState}
                     moveEntity={addBackEntity}
@@ -236,9 +232,8 @@ export default function UnusedScramblesPanel({
         <UnusedEntitiesPanel
           key={unusedStep.key}
           matchingKey={unusedStep.key}
-          unusedEntities={unusedStep.unused}
+          unusedEntries={unusedStep.unused}
           dispatchMatchState={dispatchMatchState}
-          scrambleFilesTree={scrambleFilesTree}
           rootMatchState={matchState}
         />
       ))}

--- a/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
+++ b/app/webpacker/components/ScrambleMatcher/UnusedScramblesPanel.jsx
@@ -135,7 +135,7 @@ function UnusedEntitiesPanel({
     setModalPayload(null);
   }, [setModalPayload]);
 
-  const autoAssignEntity = useCallback((entity, pickerHistory) => dispatchMatchState({
+  const addBackEntity = useCallback((entity, pickerHistory) => dispatchMatchState({
     type: 'addEntityToMatching',
     entity,
     pickerHistory,
@@ -174,8 +174,19 @@ function UnusedEntitiesPanel({
                     entity={entity}
                     fullPathToEntity={pathToUnusedEntity}
                     referenceMatchState={rootMatchState}
-                    onClickAutoAssign={autoAssignEntity}
+                    onClickAutoAssign={addBackEntity}
                     onClickManualAssign={setModalPayload}
+                  />
+                  <MoveMatchingEntityModal
+                    key={modalPayload?.id}
+                    isOpen={modalPayload !== null}
+                    onClose={onModalClose}
+                    onConfirm={addBackEntity}
+                    selectedMatchingEntity={modalPayload}
+                    rootMatchState={rootMatchState}
+                    pickerHistory={pathToUnusedEntity.slice(0, -1)}
+                    matchingKey={matchingKey}
+                    isAddMode
                   />
                 </Card.Content>
               </Card>
@@ -183,16 +194,6 @@ function UnusedEntitiesPanel({
           })}
         </Card.Group>
       </Segment>
-      <MoveMatchingEntityModal
-        key={modalPayload?.id}
-        isOpen={modalPayload !== null}
-        onClose={onModalClose}
-        dispatchMatchState={dispatchMatchState}
-        selectedMatchingEntity={modalPayload}
-        rootMatchState={rootMatchState}
-        pickerHistory={[]}
-        matchingKey={matchingKey}
-      />
     </>
   );
 }

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -145,6 +145,9 @@ function ScrambleMatcher({
         <Message info content="You have unsaved changes. Don't forget to Save below!" />
       )}
       <Divider />
+      <MatchingProgressMessage
+        roundMatchingProgress={roundMatchingProgress}
+      />
       <Button.Group>
         {renderSubmitButton('Save Changes', !hasUnsavedChanges)}
         <Button secondary basic content="Reset" icon="refresh" onClick={() => dispatchMatchState({ type: 'resetToInitial' })} />

--- a/app/webpacker/components/ScrambleMatcher/index.jsx
+++ b/app/webpacker/components/ScrambleMatcher/index.jsx
@@ -83,16 +83,6 @@ function ScrambleMatcher({
 
   useUnsavedChangesAlert(hasUnsavedChanges);
 
-  const addScrambleFile = useCallback(
-    (scrambleFile) => dispatchMatchState({ type: 'addScrambleFile', scrambleFile }),
-    [dispatchMatchState],
-  );
-
-  const removeScrambleFile = useCallback(
-    (scrambleFile) => dispatchMatchState({ type: 'removeScrambleFile', scrambleFile }),
-    [dispatchMatchState],
-  );
-
   const { mutate: submitMatchState, isPending: isSubmitting } = useMutation({
     mutationFn: submitMatchedScrambles,
     onSuccess: (data) => dispatchMatchState({ type: 'resetAfterSave', scrambleSets: data }),
@@ -134,8 +124,8 @@ function ScrambleMatcher({
       <FileUpload
         competitionId={competitionId}
         initialScrambleFiles={initialScrambleFiles}
-        addScrambleFile={addScrambleFile}
-        removeScrambleFile={removeScrambleFile}
+        matchState={matchState}
+        dispatchMatchState={dispatchMatchState}
       />
       <Divider />
       {hasUnsavedChanges && (

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { addItemToArray, moveArrayItem } from './util';
 
-function addScrambleSetsToEvents(wcifEvents, scrambleSets) {
+function addScrambleSetsToEvents(wcifEvents, scrambleSets, keepExistingSets = true) {
   const groupedScrambleSets = _.groupBy(
     scrambleSets,
     'matched_round_wcif_id',
@@ -18,7 +18,7 @@ function addScrambleSetsToEvents(wcifEvents, scrambleSets) {
             //   Lodash keeps only the first appearance, so we need to list
             //   the newest possible entries first, followed by existing entries.
             ...(groupedScrambleSets[round.id] ?? []),
-            ...(round.scrambleSets ?? []),
+            ...(keepExistingSets ? (round.scrambleSets ?? []) : []),
           ], 'id').map((scrSet) => ({
             ...scrSet,
             inbox_scrambles: _.sortBy(
@@ -44,7 +44,7 @@ export function initializeState({ wcifEvents, scrambleSets }) {
   return applyAction(
     {},
     ['initial', 'current'],
-    () => addScrambleSetsToEvents(wcifEvents, scrambleSets),
+    () => addScrambleSetsToEvents(wcifEvents, scrambleSets, false),
   );
 }
 

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -67,25 +67,6 @@ function removeScrambleFile(state, oldScrambleFile) {
   };
 }
 
-function deriveFullNavigation(lightNavigation, rootState) {
-  return lightNavigation.reduce((acc, nav) => {
-    const lookupChoices = acc.lookup[nav.key];
-
-    const entityIndex = lookupChoices.findIndex((ent) => ent.id === nav.id);
-    const nextEntity = lookupChoices[entityIndex];
-
-    const currentNav = { ...nav, index: entityIndex, entity: nextEntity };
-
-    return {
-      lookup: nextEntity,
-      fullNav: [...acc.fullNav, currentNav],
-    };
-  }, {
-    lookup: rootState,
-    fullNav: [],
-  }).fullNav;
-}
-
 function navigationToLodash(actionWithNav, selector) {
   return [
     ...actionWithNav[selector].flatMap((step) => [step.key, step.index]),
@@ -145,12 +126,7 @@ export default function scrambleMatchReducer(state, action) {
       });
     case 'addEntityToMatching':
       return applyAction(state, ['current'], (subState) => {
-        const developedNavigation = deriveFullNavigation(action.pickerHistory, subState);
-
-        const lodashPath = navigationToLodash({
-          ...action,
-          pickerHistory: developedNavigation,
-        }, 'pickerHistory');
+        const lodashPath = navigationToLodash(action, 'pickerHistory');
 
         return _.chain(subState)
           .cloneDeep()

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {addItemToArray, moveArrayItem} from './util';
+import { addItemToArray, moveArrayItem } from './util';
 
 function addScrambleSetsToEvents(wcifEvents, scrambleSets) {
   const groupedScrambleSets = _.groupBy(
@@ -122,7 +122,7 @@ export default function scrambleMatchReducer(state, action) {
         return _.chain(subState)
           .cloneDeep()
           .update(oldPath, (arr) => arr.filter((ent) => ent.id !== action.entity.id))
-          .update(newPath, (arr = []) => [...arr, action.entity])
+          .update(newPath, (arr = []) => addItemToArray(arr, action.entity))
           .value();
       });
     case 'reorderMatchingEntities':

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -118,6 +118,18 @@ export default function scrambleMatchReducer(state, action) {
           .set(lodashPath, movedItemState)
           .value();
       });
+    case 'deleteEntityFromMatching':
+      return applyAction(state, ['current'], (subState) => {
+        const lodashPath = navigationToLodash(action, 'pickerHistory');
+
+        const currentList = applyPickerHistory(subState, action.pickerHistory)[action.matchingKey];
+        const filteredItemState = currentList.filter((ent) => ent.id !== action.entity.id);
+
+        return _.chain(subState)
+          .cloneDeep()
+          .set(lodashPath, filteredItemState)
+          .value();
+      });
     default:
       throw new Error(`Unhandled action type: ${action.type}`);
   }

--- a/app/webpacker/components/ScrambleMatcher/reducer.js
+++ b/app/webpacker/components/ScrambleMatcher/reducer.js
@@ -67,7 +67,7 @@ function removeScrambleFile(state, oldScrambleFile) {
   };
 }
 
-function unwrapActionNavigation(actionWithNav, selector) {
+function navigationToLodash(actionWithNav, selector) {
   return [
     ...actionWithNav[selector].flatMap((step) => [step.key, step.index]),
     actionWithNav.matchingKey,
@@ -97,8 +97,8 @@ export default function scrambleMatchReducer(state, action) {
       return applyAction(state, ['current'], () => state.initial);
     case 'moveMatchingEntity':
       return applyAction(state, ['current'], (subState) => {
-        const oldPath = unwrapActionNavigation(action, 'fromNavigation');
-        const newPath = unwrapActionNavigation(action, 'toNavigation');
+        const oldPath = navigationToLodash(action, 'fromNavigation');
+        const newPath = navigationToLodash(action, 'toNavigation');
 
         return _.chain(subState)
           .cloneDeep()
@@ -108,7 +108,7 @@ export default function scrambleMatchReducer(state, action) {
       });
     case 'reorderMatchingEntities':
       return applyAction(state, ['current'], (subState) => {
-        const lodashPath = unwrapActionNavigation(action, 'pickerHistory');
+        const lodashPath = navigationToLodash(action, 'pickerHistory');
 
         const currentOrder = applyPickerHistory(subState, action.pickerHistory)[action.matchingKey];
         const movedItemState = moveArrayItem(currentOrder, action.fromIndex, action.toIndex);

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -55,23 +55,27 @@ export const pickerStepConfig = {
     nestedPicker: 'rounds',
   },
   rounds: {
-    matchingConfig: {
-      key: 'scrambleSets',
-      computeCellName: scrambleSetToTitle,
-      computeCellDetails: (scrSet) => scrSet.original_filename,
-      computeExpectedRowCount: (round) => round.scrambleSetCount,
-    },
+    matchingConfigKey: 'scrambleSets',
     nestedPicker: 'scrambleSets',
     nestingCondition: (history) => isForAttemptBasedEvent(history),
   },
   scrambleSets: {
-    matchingConfig: {
-      key: 'inbox_scrambles',
-      computeCellName: scrambleToName,
-      computeCellDetails: (scr) => scr.scramble_string,
-      cellDetailsAreData: true,
-      computeExpectedRowCount: (scrambleSet, history) => inferExpectedSolveCount(history),
-    },
+    matchingConfigKey: 'inbox_scrambles',
+  },
+};
+
+export const matchingDndConfig = {
+  scrambleSets: {
+    computeCellName: scrambleSetToTitle,
+    computeTableName: scrambleSetToName,
+    computeCellDetails: (scrSet) => scrSet.original_filename,
+    computeExpectedRowCount: (round) => round.scrambleSetCount,
+  },
+  inbox_scrambles: {
+    computeCellName: scrambleToName,
+    computeCellDetails: (scr) => scr.scramble_string,
+    cellDetailsAreData: true,
+    computeExpectedRowCount: (scrambleSet, history) => inferExpectedSolveCount(history),
   },
 };
 
@@ -90,6 +94,10 @@ export function moveArrayItem(arr, fromIndex, toIndex) {
     // here we do NOT want to ignore the items that were originally there, so no +1
     ...withoutMovedItem.slice(toIndex),
   ];
+}
+
+export function addItemToArray(arr, entity, targetIdx = arr.length) {
+  return arr.toSpliced(targetIdx, 0, entity);
 }
 
 export function applyPickerHistory(rootState, pickerHistory) {

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -2,7 +2,7 @@ import { events, formats } from '../../lib/wca-data.js.erb';
 import { humanizeActivityCode } from '../../lib/utils/wcif';
 import { EventsPickerCompat } from './ButtonGroupPicker';
 
-const ATTEMPT_BASED_EVENTS = ['333fm', '333mbf'];
+export const ATTEMPT_BASED_EVENTS = ['333fm', '333mbf'];
 
 export const pickerLocalizationConfig = {
   events: {
@@ -34,7 +34,8 @@ const prefixForIndex = (index) => {
   return prefixForIndex(Math.floor(index / 26) - 1) + char;
 };
 
-export const scrambleSetToName = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} Round ${scrambleSet.round_number} Scramble Set ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
+export const scrambleSetToName = (scrambleSet) => `Scramble Set ${prefixForIndex(scrambleSet.scramble_set_number - 1)}`;
+const scrambleSetToTitle = (scrambleSet) => `${events.byId[scrambleSet.event_id].name} Round ${scrambleSet.round_number} ${scrambleSetToName(scrambleSet)}`;
 
 export const scrambleToName = (scramble) => `Scramble ${scramble.scramble_number}`;
 
@@ -56,7 +57,7 @@ export const pickerStepConfig = {
   rounds: {
     matchingConfig: {
       key: 'scrambleSets',
-      computeCellName: scrambleSetToName,
+      computeCellName: scrambleSetToTitle,
       computeCellDetails: (scrSet) => scrSet.original_filename,
       computeExpectedRowCount: (round) => round.scrambleSetCount,
     },

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -72,14 +72,12 @@ export const matchingDndConfig = {
     computeTableName: scrambleSetToName,
     computeCellDetails: (scrSet) => scrSet.original_filename,
     computeExpectedRowCount: (round) => round.scrambleSetCount,
-    indexAccessKey: 'scramble_set_number',
   },
   inbox_scrambles: {
     computeCellName: scrambleToName,
     computeCellDetails: (scr) => scr.scramble_string,
     cellDetailsAreData: true,
     computeExpectedRowCount: (scrambleSet, history) => inferExpectedSolveCount(history),
-    indexAccessKey: 'scramble_number',
   },
 };
 
@@ -138,6 +136,22 @@ export const searchRecursive = (data, currentKey, targetStep, searchHistory = []
 
     return null;
   }, null);
+};
+
+export const flattenToLevel = (data, currentKey, targetKey) => {
+  const items = data[currentKey];
+
+  if (currentKey === targetKey) {
+    return items;
+  }
+
+  const { nestedPicker, matchingConfigKey = nestedPicker } = pickerStepConfig[currentKey] || {};
+
+  if (!matchingConfigKey || !items) {
+    return [];
+  }
+
+  return items?.flatMap((item) => flattenToLevel(item, matchingConfigKey, targetKey));
 };
 
 export function groupScrambleSetsIntoWcif(scrambleSets) {

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -48,7 +48,7 @@ export const isForAttemptBasedEvent = (pickerHistory) => {
 
 const inferExpectedSolveCount = (pickerHistory) => {
   const roundsStep = pickerHistory.find((step) => step.key === 'rounds');
-  return formats.byId[roundsStep.entity.format].expected_solve_count;
+  return formats.byId[roundsStep.entity.format].expectedSolveCount;
 };
 
 export const pickerStepConfig = {
@@ -159,7 +159,7 @@ export function computeMatchingProgress(wcifEvents) {
   return wcifEvents.flatMap(
     (wcifEvent) => wcifEvent.rounds.map(
       (wcifRound) => {
-        const formatExpectedSolveCount = formats.byId[wcifRound.format]?.expected_solve_count;
+        const formatExpectedSolveCount = formats.byId[wcifRound.format]?.expectedSolveCount;
 
         return {
           id: wcifRound.id,

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -81,10 +81,6 @@ export const matchingDndConfig = {
   },
 };
 
-export function buildLightHistory(key, id, index = undefined) {
-  return { key, id, index };
-}
-
 export function moveArrayItem(arr, fromIndex, toIndex) {
   const movedItem = arr[fromIndex];
 
@@ -104,13 +100,6 @@ export function moveArrayItem(arr, fromIndex, toIndex) {
 
 export function addItemToArray(arr, entity, targetIdx = arr.length) {
   return arr.toSpliced(targetIdx, 0, entity);
-}
-
-export function applyPickerHistory(rootState, pickerHistory) {
-  return pickerHistory.reduce(
-    (state, historyStep) => state[historyStep.key][historyStep.index],
-    rootState,
-  );
 }
 
 export const searchRecursive = (data, targetStep, currentKey = 'events', searchHistory = []) => {

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -6,22 +6,22 @@ export const ATTEMPT_BASED_EVENTS = ['333fm', '333mbf'];
 
 export const pickerLocalizationConfig = {
   events: {
-    computeEntityName: (evt) => events.byId[evt.id].name,
+    computeEntityName: (id) => events.byId[id].name,
     headerLabel: 'Events',
     dropdownLabel: 'Event',
   },
   rounds: {
-    computeEntityName: (rd) => humanizeActivityCode(rd.id),
+    computeEntityName: (id) => humanizeActivityCode(id),
     headerLabel: 'Rounds',
     dropdownLabel: 'Round',
   },
   scrambleSets: {
-    computeEntityName: (scrSet, idx) => `Group ${idx + 1}`,
+    computeEntityName: (id, idx) => `Group ${idx + 1}`,
     headerLabel: 'Groups',
     dropdownLabel: 'Scramble Set',
   },
   inbox_scrambles: {
-    computeEntityName: (scr, idx) => `Attempt ${idx + 1}`,
+    computeEntityName: (id, idx) => `Attempt ${idx + 1}`,
     headerLabel: 'Scrambles',
     dropdownLabel: 'Scramble',
   },

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -81,6 +81,15 @@ export const matchingDndConfig = {
   },
 };
 
+export function buildHistoryStep(key, entity, index) {
+  return {
+    key,
+    entity,
+    id: entity.id,
+    index,
+  };
+}
+
 export function moveArrayItem(arr, fromIndex, toIndex) {
   const movedItem = arr[fromIndex];
 
@@ -108,12 +117,10 @@ export const searchRecursive = (data, targetStep, currentKey = 'events', searchH
   return data[currentKey]?.reduce((foundPath, item, index) => {
     if (foundPath) return foundPath;
 
-    const nextHistory = [...searchHistory, {
-      key: currentKey,
-      id: item.id,
-      entity: item,
-      index,
-    }];
+    const nextHistory = [
+      ...searchHistory,
+      buildHistoryStep(currentKey, item, index),
+    ];
 
     if (currentKey === targetStep.key && item.id === targetStep.id) {
       return nextHistory;

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -115,6 +115,31 @@ export function applyPickerHistory(rootState, pickerHistory) {
   );
 }
 
+export const searchRecursive = (data, currentKey, targetStep, searchHistory = []) => {
+  const { nestedPicker, matchingConfigKey = nestedPicker } = pickerStepConfig[currentKey] || {};
+
+  return data[currentKey]?.reduce((foundPath, item, index) => {
+    if (foundPath) return foundPath;
+
+    const nextHistory = [...searchHistory, {
+      key: currentKey,
+      id: item.id,
+      entity: item,
+      index,
+    }];
+
+    if (currentKey === targetStep.key && item.id === targetStep.id) {
+      return nextHistory;
+    }
+
+    if (matchingConfigKey) {
+      return searchRecursive(item, matchingConfigKey, targetStep, nextHistory);
+    }
+
+    return null;
+  }, null);
+};
+
 export function groupScrambleSetsIntoWcif(scrambleSets) {
   const groupedMap = _.mapValues(
     _.groupBy(scrambleSets, 'event_id'),

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -113,7 +113,7 @@ export function applyPickerHistory(rootState, pickerHistory) {
   );
 }
 
-export const searchRecursive = (data, currentKey, targetStep, searchHistory = []) => {
+export const searchRecursive = (data, targetStep, currentKey = 'events', searchHistory = []) => {
   const { nestedPicker, matchingConfigKey = nestedPicker } = pickerStepConfig[currentKey] || {};
 
   return data[currentKey]?.reduce((foundPath, item, index) => {
@@ -131,27 +131,11 @@ export const searchRecursive = (data, currentKey, targetStep, searchHistory = []
     }
 
     if (matchingConfigKey) {
-      return searchRecursive(item, matchingConfigKey, targetStep, nextHistory);
+      return searchRecursive(item, targetStep, matchingConfigKey, nextHistory);
     }
 
     return null;
   }, null);
-};
-
-export const flattenToLevel = (data, currentKey, targetKey) => {
-  const items = data[currentKey];
-
-  if (currentKey === targetKey) {
-    return items;
-  }
-
-  const { nestedPicker, matchingConfigKey = nestedPicker } = pickerStepConfig[currentKey] || {};
-
-  if (!matchingConfigKey || !items) {
-    return [];
-  }
-
-  return items?.flatMap((item) => flattenToLevel(item, matchingConfigKey, targetKey));
 };
 
 export function groupScrambleSetsIntoWcif(scrambleSets) {

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -17,8 +17,9 @@ export const pickerLocalizationConfig = {
   },
   scrambleSets: {
     computeEntityName: (id, idx) => `Group ${idx + 1}`,
-    headerLabel: 'Groups',
+    headerLabel: 'Scramble Sets',
     dropdownLabel: 'Scramble Set',
+    pickerLabel: 'Groups',
   },
   inbox_scrambles: {
     computeEntityName: (id, idx) => `Attempt ${idx + 1}`,
@@ -70,14 +71,20 @@ export const matchingDndConfig = {
     computeTableName: scrambleSetToName,
     computeCellDetails: (scrSet) => scrSet.original_filename,
     computeExpectedRowCount: (round) => round.scrambleSetCount,
+    indexAccessKey: 'scramble_set_number',
   },
   inbox_scrambles: {
     computeCellName: scrambleToName,
     computeCellDetails: (scr) => scr.scramble_string,
     cellDetailsAreData: true,
     computeExpectedRowCount: (scrambleSet, history) => inferExpectedSolveCount(history),
+    indexAccessKey: 'scramble_number',
   },
 };
+
+export function buildLightHistory(key, id, index = undefined) {
+  return { key, id, index };
+}
 
 export function moveArrayItem(arr, fromIndex, toIndex) {
   const movedItem = arr[fromIndex];

--- a/app/webpacker/components/ScrambleMatcher/util.js
+++ b/app/webpacker/components/ScrambleMatcher/util.js
@@ -129,8 +129,14 @@ export const searchRecursive = (data, targetStep, currentKey = 'events', searchH
 
 export function groupScrambleSetsIntoWcif(scrambleSets) {
   const groupedMap = _.mapValues(
-    _.groupBy(scrambleSets, 'event_id'),
-    (eventItems) => _.groupBy(eventItems, 'round_number'),
+    _.groupBy(
+      _.sortBy(scrambleSets, (scrSet) => events.byId[scrSet.event_id].rank),
+      'event_id',
+    ),
+    (eventItems) => _.groupBy(
+      _.sortBy(eventItems, (evt) => evt.round_number),
+      'round_number',
+    ),
   );
 
   const wcifEvents = _.map(groupedMap, (roundsMap, eventId) => ({
@@ -141,7 +147,7 @@ export function groupScrambleSetsIntoWcif(scrambleSets) {
     })),
   }));
 
-  return { events: _.sortBy(wcifEvents, (evt) => events.byId[evt.id].rank) };
+  return { events: wcifEvents };
 }
 
 export function computeMatchingProgress(wcifEvents) {

--- a/app/webpacker/packs/global_styles.js
+++ b/app/webpacker/packs/global_styles.js
@@ -3,6 +3,7 @@ import '@cubing/icons';
 
 import 'semantic-css/accordion';
 import 'semantic-css/button';
+import 'semantic-css/breadcrumb';
 import 'semantic-css/card';
 import 'semantic-css/checkbox';
 import 'semantic-css/container';

--- a/db/migrate/20250826042935_add_matched_set_to_inbox_scrambles.rb
+++ b/db/migrate/20250826042935_add_matched_set_to_inbox_scrambles.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddMatchedSetToInboxScrambles < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :inbox_scrambles, :matched_scramble_set, after: :ordered_index, foreign_key: { to_table: :inbox_scramble_sets }
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          UPDATE inbox_scrambles
+          SET matched_scramble_set_id = inbox_scramble_set_id
+          WHERE matched_scramble_set_id IS NULL
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_26_030259) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_26_042935) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -704,11 +704,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_26_030259) do
     t.boolean "is_extra", default: false, null: false
     t.integer "scramble_number", null: false
     t.integer "ordered_index", null: false
+    t.bigint "matched_scramble_set_id"
     t.text "scramble_string", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["inbox_scramble_set_id", "scramble_number", "is_extra"], name: "idx_on_inbox_scramble_set_id_scramble_number_is_ext_bd518aa059", unique: true
     t.index ["inbox_scramble_set_id"], name: "index_inbox_scrambles_on_inbox_scramble_set_id"
+    t.index ["matched_scramble_set_id"], name: "index_inbox_scrambles_on_matched_scramble_set_id"
   end
 
   create_table "incident_competitions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1560,6 +1562,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_26_030259) do
   add_foreign_key "inbox_scramble_sets", "rounds", column: "matched_round_id"
   add_foreign_key "inbox_scramble_sets", "scramble_file_uploads", column: "external_upload_id"
   add_foreign_key "inbox_scrambles", "inbox_scramble_sets"
+  add_foreign_key "inbox_scrambles", "inbox_scramble_sets", column: "matched_scramble_set_id"
   add_foreign_key "live_attempt_history_entries", "live_attempts"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
   add_foreign_key "payment_intents", "users", column: "initiated_by_id"


### PR DESCRIPTION
The basic use-case is that some sets which were generated may not have been used.
<img width="1631" height="783" alt="image" src="https://github.com/user-attachments/assets/b6caf428-a3de-42dc-8395-15c4d8a23f58" />

Unfortunately, this makes the whole matching process **HORRIBLY** complicated.

If you delete a set from the matching, where does it go? I don't think we should wipe the data from the face of the earth. So I came up with an overview table in the "Uploaded Files" accordion dropdowns 
<img width="1618" height="1006" alt="image" src="https://github.com/user-attachments/assets/58cd15c6-e755-472f-ac6a-7ee9f736e036" />

As soon as you delete a scramble, it goes into a "Unused Scramble Sets" panel (which is hidden by default, because all uploaded scrambles are initially marked as 'Used'). You can then auto-assign it to the best-matching round, or you can manually choose where to put it via a modal with dropdowns.
<img width="1652" height="576" alt="image" src="https://github.com/user-attachments/assets/3ccde62d-4e18-47bd-8bfd-9cae4cc35e1e" />

But that is not all! What about the backend? We now need to distinguish between two associations: The scramble set that you're _currently_ matched to, as well as the scramble set you were _originally_ matched to (in order to keep a record of which file upload originally contained which scramble set). The only good news is that it makes validation hooks slightly easier, because we can now skip the "squeeze both bits of information into the same column" hook.