### PR TITLE
Fixes in ticket comments

### DIFF
--- a/app/models/ticket_comment.rb
+++ b/app/models/ticket_comment.rb
@@ -9,19 +9,19 @@ class TicketComment < ApplicationRecord
     include: %w[acting_user],
   }.freeze
 
-  private def stakeholders_to_email_notify
+  private def stakeholder_emails_to_notify
     stakeholders = ticket.ticket_stakeholders.includes(:stakeholder)
 
     stakeholders = stakeholders.reject { |stakeholder| stakeholder.id == acting_stakeholder_id } if acting_stakeholder.user_stakeholder?
 
-    stakeholders.map(&:stakeholder)
+    stakeholders.flat_map(&:emails)
   end
 
   after_create :notify_stakeholders
   private def notify_stakeholders
-    recipient_emails = stakeholders_to_email_notify.map(&:email)
+    recipient_emails = stakeholder_emails_to_notify
 
-    TicketsMailer.notify_create_ticket_comment(self, recipient_emails).deliver_later
+    TicketsMailer.notify_create_ticket_comment(self, recipient_emails).deliver_now # TODO: Change to deliver_later
   end
 
   def author_text

--- a/app/models/ticket_comment.rb
+++ b/app/models/ticket_comment.rb
@@ -10,18 +10,14 @@ class TicketComment < ApplicationRecord
   }.freeze
 
   private def stakeholder_emails_to_notify
-    stakeholders = ticket.ticket_stakeholders.includes(:stakeholder)
-
-    stakeholders = stakeholders.reject { |stakeholder| stakeholder.id == acting_stakeholder_id } if acting_stakeholder.user_stakeholder?
-
-    stakeholders.flat_map(&:emails)
+    ticket.ticket_stakeholders.includes(:stakeholder).flat_map do |stakeholder|
+      stakeholder.emails unless stakeholder.user_stakeholder? && stakeholder.id == acting_stakeholder_id
+    end.compact
   end
 
   after_create :notify_stakeholders
   private def notify_stakeholders
-    recipient_emails = stakeholder_emails_to_notify
-
-    TicketsMailer.notify_create_ticket_comment(self, recipient_emails).deliver_now # TODO: Change to deliver_later
+    TicketsMailer.notify_create_ticket_comment(self, stakeholder_emails_to_notify).deliver_later
   end
 
   def author_text

--- a/app/models/ticket_stakeholder.rb
+++ b/app/models/ticket_stakeholder.rb
@@ -34,6 +34,18 @@ class TicketStakeholder < ApplicationRecord
     stakeholder_type == "User"
   end
 
+  def competition_stakeholder?
+    stakeholder_type == "Competition"
+  end
+
+  def emails
+    if competition_stakeholder?
+      stakeholder.delegates.map(&:email)
+    else
+      [stakeholder.email]
+    end
+  end
+
   def metadata_actions_allowed
     ticket.metadata.metadata_actions_allowed_for(self)
   end

--- a/app/models/ticket_stakeholder.rb
+++ b/app/models/ticket_stakeholder.rb
@@ -40,7 +40,7 @@ class TicketStakeholder < ApplicationRecord
 
   def emails
     if competition_stakeholder?
-      stakeholder.delegates.map(&:email)
+      stakeholder.delegates.pluck(:email)
     else
       [stakeholder.email]
     end

--- a/app/webpacker/components/Tickets/TicketCommentCreate.jsx
+++ b/app/webpacker/components/Tickets/TicketCommentCreate.jsx
@@ -15,7 +15,7 @@ export default function TicketCommentCreate({
   const queryClient = useQueryClient();
   const {
     mutate: createCommentMutation,
-    isLoading,
+    isPending,
     isError,
   } = useMutation({
     mutationFn: createComment,
@@ -29,7 +29,7 @@ export default function TicketCommentCreate({
     },
   });
 
-  if (isLoading) return <Loading />;
+  if (isPending) return <Loading />;
   if (isError) return <Errored />;
 
   return (


### PR DESCRIPTION
Doing couple of fixes in ticket comments:
1. By the introduction of competition stakeholder, the comments stopped sending email because stakeholder no longer had email object. This is now fixed.
2. When "create comment" button was clicked, it was not going to loading state because we were not using `isPending`. This is also now fixed.