### PR TITLE
Add reject button in edit person ticket

### DIFF
--- a/app/models/tickets_edit_person.rb
+++ b/app/models/tickets_edit_person.rb
@@ -11,6 +11,18 @@ class TicketsEditPerson < ApplicationRecord
   has_one :ticket, as: :metadata
   has_many :tickets_edit_person_fields
 
+  ACTION_TYPE = {
+    reject_edit_person_request: "reject_edit_person_request",
+  }.freeze
+
+  def metadata_actions_allowed_for(ticket_stakeholder)
+    if ticket_stakeholder.stakeholder == UserGroup.teams_committees_group_wrt
+      [ACTION_TYPE[:reject_edit_person_request]]
+    else
+      []
+    end
+  end
+
   def self.create_ticket(wca_id, changes_requested, requester)
     ActiveRecord::Base.transaction do
       ticket_metadata = TicketsEditPerson.create!(

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/RejectView.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/RejectView.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button, Confirm } from 'semantic-ui-react';
+import rejectEditPersonRequest from '../../api/editPerson/rejectEditPersonRequest';
+import Errored from '../../../Requests/Errored';
+import Loading from '../../../Requests/Loading';
+import { ticketStatuses } from '../../../../lib/wca-data.js.erb';
+
+export default function RejectView({ ticketId, currentStakeholder }) {
+  const queryClient = useQueryClient();
+  const [showConfirm, setShowConfirm] = useState();
+
+  const {
+    mutate: rejectEditPersonRequestMutate,
+    isPending,
+    isError,
+    error,
+  } = useMutation({
+    mutationFn: rejectEditPersonRequest,
+    onSuccess: () => {
+      queryClient.setQueryData(
+        ['ticket-details', ticketId],
+        (oldTicketDetails) => ({
+          ...oldTicketDetails,
+          ticket: {
+            ...oldTicketDetails.ticket,
+            metadata: {
+              ...oldTicketDetails.ticket.metadata,
+              status: ticketStatuses.edit_person.closed,
+            },
+          },
+        }),
+      );
+    },
+  });
+
+  if (isPending) return <Loading />;
+  if (isError) return <Errored error={error} />;
+
+  return (
+    <>
+      <Button
+        negative
+        onClick={() => setShowConfirm(true)}
+      >
+        Reject Edit Request
+      </Button>
+      <Confirm
+        open={showConfirm}
+        content="You are about to reject the request. Are you sure?"
+        onCancel={() => setShowConfirm(false)}
+        onConfirm={() => {
+          rejectEditPersonRequestMutate({
+            ticketId,
+            actingStakeholderId: currentStakeholder.id,
+          });
+          setShowConfirm(false);
+        }}
+      />
+    </>
+  );
+}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
@@ -3,9 +3,14 @@ import EditPersonForm from '../../../Panel/pages/EditPersonPage/EditPersonForm';
 import { ticketStatuses } from '../../../../lib/wca-data.js.erb';
 import EditPersonValidations from './EditPersonValidations';
 import EditPersonRequestedChangesList from './EditPersonRequestedChangesList';
+import RejectView from './RejectView';
 
-export default function EditPersonActionerView({ ticketDetails, updateStatus }) {
-  const { ticket } = ticketDetails;
+export default function EditPersonActionerView({
+  ticketDetails,
+  currentStakeholder,
+  updateStatus,
+}) {
+  const { ticket: { id, metadata } } = ticketDetails;
 
   const closeTicket = () => updateStatus(ticketStatuses.edit_person.closed);
 
@@ -19,12 +24,13 @@ export default function EditPersonActionerView({ ticketDetails, updateStatus }) 
         ticketDetails={ticketDetails}
       />
       <EditPersonRequestedChangesList
-        requestedChanges={ticket.metadata?.tickets_edit_person_fields}
+        requestedChanges={metadata.tickets_edit_person_fields}
       />
       <EditPersonForm
-        wcaId={ticket.metadata.wca_id}
+        wcaId={metadata.wca_id}
         onSuccess={closeTicket}
       />
+      <RejectView ticketId={id} currentStakeholder={currentStakeholder} />
     </>
   );
 }

--- a/app/webpacker/components/Tickets/api/editPerson/rejectEditPersonRequest.js
+++ b/app/webpacker/components/Tickets/api/editPerson/rejectEditPersonRequest.js
@@ -1,0 +1,18 @@
+import { fetchJsonOrError } from '../../../../lib/requests/fetchWithAuthenticityToken';
+import { actionUrls } from '../../../../lib/requests/routes.js.erb';
+
+export default async function rejectEditPersonRequest({ ticketId, actingStakeholderId }) {
+  const { data } = await fetchJsonOrError(
+    actionUrls.tickets.rejectEditPersonRequest(ticketId),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        acting_stakeholder_id: actingStakeholderId,
+      }),
+    },
+  );
+  return data || {};
+}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -316,6 +316,7 @@ export const actionUrls = {
     mergeInboxResults: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_merge_inbox_results_path("${ticketId}")) %>`,
     deleteInboxPersons: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_delete_inbox_persons_path("${ticketId}")) %>`,
     postResults: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_post_results_path("${ticketId}")) %>`,
+    rejectEditPersonRequest: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_reject_edit_person_request_path("${ticketId}")) %>`,
   },
   validators: {
     forCompetitionList: (competitionIds, selectedValidators, applyFixWhenPossible, checkRealResults) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_validators_for_competition_list_path) %>?${jsonToQueryString({ competitionIds, selectedValidators, applyFixWhenPossible, checkRealResults })}`,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,6 +239,7 @@ Rails.application.routes.draw do
     get 'inbox_person_summary' => 'tickets#inbox_person_summary', as: :inbox_person_summary
     post 'delete_inbox_persons' => 'tickets#delete_inbox_persons', as: :delete_inbox_persons
     get 'events_merged_data' => 'tickets#events_merged_data', as: :events_merged_data
+    post 'reject_edit_person_request' => 'tickets#reject_edit_person_request', as: :reject_edit_person_request
     resources :ticket_comments, only: %i[index create], as: :comments
     resources :ticket_logs, only: [:index], as: :logs
   end


### PR DESCRIPTION
In edit person ticket, added a 'reject' button. This button allows WRT to explicitly consider the request as rejected, and hence won't need to update status manually to mark it as rejected.

This also helps to avoid directly updating the status. Ideally `update_status` shouldn't be an action, instead it should be a `change` of an action.