### PR TITLE
Schedule editor: handle invalid events

### DIFF
--- a/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -39,6 +39,7 @@ import {
   addActivity,
   editActivity,
   moveActivity,
+  removeActivities,
   removeActivity,
   scaleActivity,
 } from '../store/actions';
@@ -165,10 +166,7 @@ function EditActivities({
   ) ?? [];
 
   const deleteInvalidActivities = () => {
-    activitiesWithInvalidTimes.forEach((activity) => {
-      // do not remove matching activities; they may be valid in their time zone
-      dispatch(removeActivity(activity.id, false));
-    });
+    dispatch(removeActivities(activitiesWithInvalidTimes.map((a) => a.id), false));
   };
 
   // we 'fake' our own ref due to quirks in useRef + useEffect combinations.

--- a/app/webpacker/components/EditSchedule/EditActivities/index.js
+++ b/app/webpacker/components/EditSchedule/EditActivities/index.js
@@ -166,7 +166,13 @@ function EditActivities({
   ) ?? [];
 
   const deleteInvalidActivities = () => {
-    dispatch(removeActivities(activitiesWithInvalidTimes.map((a) => a.id), false));
+    confirm({
+      content: `Are you sure you want to delete the following event(s): ${
+        activitiesWithInvalidTimes.map((a) => a.name).join(', ')
+      }? THIS ACTION CANNOT BE UNDONE!`,
+    }).then(() => {
+      dispatch(removeActivities(activitiesWithInvalidTimes.map((a) => a.id), false));
+    });
   };
 
   // we 'fake' our own ref due to quirks in useRef + useEffect combinations.

--- a/app/webpacker/components/EditSchedule/store/actions.js
+++ b/app/webpacker/components/EditSchedule/store/actions.js
@@ -2,6 +2,7 @@ export const ChangesSaved = 'saving_started';
 export const AddActivity = 'ADD_ACTIVITY';
 export const EditActivity = 'EDIT_ACTIVITY';
 export const RemoveActivity = 'REMOVE_ACTIVITY';
+export const RemoveActivities = 'REMOVE_ACTIVITIES';
 export const MoveActivity = 'MOVE_ACTIVITY';
 export const ScaleActivity = 'SCALE_ACTIVITY';
 export const EditVenue = 'EDIT_VENUE';
@@ -64,6 +65,20 @@ export const removeActivity = (activityId, updateMatches) => ({
   type: RemoveActivity,
   payload: {
     activityId,
+    updateMatches,
+  },
+});
+
+/**
+ * Action creator for removing activities.
+ * @param {int[]} activityIds
+ * @param {boolean} updateMatches
+ * @returns {Action}
+ */
+export const removeActivities = (activityIds, updateMatches) => ({
+  type: RemoveActivities,
+  payload: {
+    activityIds,
     updateMatches,
   },
 });

--- a/app/webpacker/components/EditSchedule/store/reducer.js
+++ b/app/webpacker/components/EditSchedule/store/reducer.js
@@ -10,6 +10,7 @@ import {
   EditRoom,
   EditVenue,
   MoveActivity,
+  RemoveActivities,
   RemoveActivity,
   RemoveRoom,
   RemoveVenue,
@@ -93,6 +94,32 @@ const reducers = {
             activities: room.activities.filter((activity) => (
               activity.id !== payload.activityId && (
                 !payload.updateMatches || !doActivitiesMatch(activity, selectedActivity)
+              )
+            )),
+          })),
+        })),
+      },
+    };
+  },
+
+  [RemoveActivities]: (state, { payload }) => {
+    const selectedActivities = payload.activityIds.map(
+      (activityId) => activityWcifFromId(state.wcifSchedule, activityId),
+    );
+
+    return {
+      ...state,
+      wcifSchedule: {
+        ...state.wcifSchedule,
+        venues: state.wcifSchedule.venues.map((venue) => ({
+          ...venue,
+          rooms: venue.rooms.map((room) => ({
+            ...room,
+            activities: room.activities.filter((activity) => (
+              !payload.activityIds.includes(activity.id) && (
+                !payload.updateMatches || !selectedActivities.some(
+                  (selectedActivity) => doActivitiesMatch(activity, selectedActivity),
+                )
               )
             )),
           })),

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -324,3 +324,17 @@ export function cutoffToString(wcifRound, { short } = {}) {
 
   return null;
 }
+
+export function isActivityTimeValid(activity, wcifVenue, wcifSchedule) {
+  const { startDate, numberOfDays: days } = wcifSchedule;
+  const { startTime, endTime } = activity;
+
+  const luxonStartDate = DateTime.fromISO(startDate).setZone(wcifVenue?.timezone);
+  const luxonEndDate = DateTime.fromISO(startDate).plus({ days }).setZone(wcifVenue?.timezone);
+
+  const hasPositiveDuration = DateTime.fromISO(startTime) < DateTime.fromISO(endTime);
+  const startsOnOrAfterStartDate = luxonStartDate <= DateTime.fromISO(startTime);
+  const endsOnOrBeforeEndDate = DateTime.fromISO(endTime) <= luxonEndDate;
+
+  return hasPositiveDuration && startsOnOrAfterStartDate && endsOnOrBeforeEndDate;
+}


### PR DESCRIPTION
Hopefully the code is self-explanatory. Activities are not allowed to happen outside the competition date.

[Screencast from 2025-08-26 06:54:35 PM.webm](https://github.com/user-attachments/assets/32fba198-e2c0-49d9-abb1-ce04231be9f8)

(note: after recording video below, added a pop-up confirmation, see 3rd video)

[Screencast from 2025-08-26 07:01:01 PM.webm](https://github.com/user-attachments/assets/1396b8e3-f312-4230-b66a-2b95a7dfa899)

Update: with a pop-up confirmation for deletion:

[Screencast from 2025-08-26 07:17:29 PM.webm](https://github.com/user-attachments/assets/a5d9f172-a7fd-4370-8d96-0211169886f6)

Instead of deleting activities, you could try moving them into the valid competition days. But this gets complicated quickly (you can't just bump them by 24-hour increments if they cross midnight and the competition is 1 day; what if they are longer than the competition; etc.). Seeing as this _shouldn't_ ever be happening, and hopefully won't after the back-end bug is fixed, it's not worth the effort.

Replaces #12014