### PR TITLE
Show in edit person ticket if old value is in sync with person

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -7,6 +7,7 @@ class TicketsController < ApplicationController
   before_action -> { check_ticket_errors(TicketLog.action_types[:update_status]) }, only: [:update_status]
   before_action -> { check_ticket_errors(TicketLog.action_types[:metadata_action], TicketsCompetitionResult::ACTION_TYPE[:merge_inbox_results]) }, only: [:merge_inbox_results]
   before_action -> { check_ticket_errors(TicketLog.action_types[:metadata_action], TicketsEditPerson::ACTION_TYPE[:reject_edit_person_request]) }, only: [:reject_edit_person_request]
+  before_action -> { check_ticket_errors(TicketLog.action_types[:metadata_action], TicketsEditPerson::ACTION_TYPE[:sync_edit_person_request]) }, only: [:sync_edit_person_request]
   before_action -> { redirect_to_root_unless_user(:can_admin_results?) }, only: %i[delete_inbox_persons]
 
   SORT_WEIGHT_LAMBDAS = {
@@ -279,14 +280,45 @@ class TicketsController < ApplicationController
       ticket_status = TicketsEditPerson.statuses[:closed]
       @ticket.metadata.update!(status: ticket_status)
       ticket_log = @ticket.ticket_logs.create!(
-        action_type: @action_type,
-        acting_user_id: current_user.id,
-        acting_stakeholder_id: @acting_stakeholder.id,
-        metadata_action: @metadata_action,
+        @ticket.ticket_logs.create!(
+          action_type: @action_type,
+          acting_user_id: current_user.id,
+          acting_stakeholder_id: @acting_stakeholder.id,
+          metadata_action: @metadata_action,
+        ),
       )
       ticket_log.ticket_log_changes.create!(
         field_name: TicketLogChange.field_names[:status],
         field_value: ticket_status,
+      )
+    end
+  end
+
+  def sync_edit_person_request
+    person = @ticket.metadata.person
+    any_request_still_valid = @ticket.metadata.tickets_edit_person_fields.any? do |edit_person_field|
+      person.send(edit_person_field.field_name).to_s != edit_person_field.new_value
+    end
+
+    unless any_request_still_valid
+      return render status: :unprocessable_entity, json: {
+        error: "All requested changes have already been applied. If you think this is correct, please reject the request.",
+      }
+    end
+
+    ActiveRecord::Base.transaction do
+      @ticket.metadata.tickets_edit_person_fields.each do |edit_person_field|
+        if person.send(edit_person_field.field_name).to_s == edit_person_field.new_value
+          edit_person_field.delete
+        else
+          edit_person_field.update!(old_value: person.send(edit_person_field.field_name).to_s)
+        end
+      end
+      @ticket.ticket_logs.create!(
+        action_type: @action_type,
+        acting_user_id: current_user.id,
+        acting_stakeholder_id: @acting_stakeholder.id,
+        metadata_action: @metadata_action,
       )
     end
 

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -280,18 +280,17 @@ class TicketsController < ApplicationController
       ticket_status = TicketsEditPerson.statuses[:closed]
       @ticket.metadata.update!(status: ticket_status)
       ticket_log = @ticket.ticket_logs.create!(
-        @ticket.ticket_logs.create!(
-          action_type: @action_type,
-          acting_user_id: current_user.id,
-          acting_stakeholder_id: @acting_stakeholder.id,
-          metadata_action: @metadata_action,
-        ),
+        action_type: @action_type,
+        acting_user_id: current_user.id,
+        acting_stakeholder_id: @acting_stakeholder.id,
+        metadata_action: @metadata_action,
       )
       ticket_log.ticket_log_changes.create!(
         field_name: TicketLogChange.field_names[:status],
         field_value: ticket_status,
       )
     end
+    render status: :ok, json: { success: true }
   end
 
   def sync_edit_person_request
@@ -322,6 +321,6 @@ class TicketsController < ApplicationController
       )
     end
 
-    render status: :ok, json: { success: true }
+    render status: :ok, json: @ticket
   end
 end

--- a/app/models/tickets_edit_person.rb
+++ b/app/models/tickets_edit_person.rb
@@ -17,6 +17,7 @@ class TicketsEditPerson < ApplicationRecord
     create_edit_person_change: "create_edit_person_change",
     update_edit_person_change: "update_edit_person_change",
     delete_edit_person_change: "delete_edit_person_change",
+    sync_edit_person_request: "sync_edit_person_request",
   }.freeze
 
   def metadata_actions_allowed_for(ticket_stakeholder)
@@ -26,6 +27,7 @@ class TicketsEditPerson < ApplicationRecord
         ACTION_TYPE[:create_edit_person_change],
         ACTION_TYPE[:update_edit_person_change],
         ACTION_TYPE[:delete_edit_person_change],
+        ACTION_TYPE[:sync_edit_person_request],
       ]
     else
       []

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/OldDataSyncInfo.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/OldDataSyncInfo.jsx
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import React, { useMemo } from 'react';
+import { Button, Message } from 'semantic-ui-react';
+import syncEditPersonRequest from '../../api/editPerson/syncEditPersonRequest';
+import Loading from '../../../Requests/Loading';
+import Errored from '../../../Requests/Errored';
+
+export default function OldDataSyncInfo({ ticketDetails, currentStakeholder }) {
+  const {
+    ticket: {
+      id,
+      metadata: {
+        tickets_edit_person_fields: ticketsEditPersonFields,
+        person,
+      },
+    },
+  } = ticketDetails;
+
+  const queryClient = useQueryClient();
+  const {
+    mutate: syncEditPersonRequestMutate,
+    isPending,
+    isError,
+    error,
+  } = useMutation({
+    mutationFn: syncEditPersonRequest,
+    onSuccess: () => {
+      // We've invalidated the ticket details because we can't confirm that the updated value
+      // matches the current person's data. To be safe, we're refetching the information, as
+      // the person's details may have changed since the last time they were accessed.
+      queryClient.invalidateQueries(['ticket-details', id]);
+    },
+  });
+
+  const personsDataSynced = useMemo(() => ticketsEditPersonFields.every(
+    (field) => field.old_value === person[field.field_name],
+  ), [person, ticketsEditPersonFields]);
+
+  if (isPending) return <Loading />;
+  if (isError) return <Errored error={error} />;
+  if (personsDataSynced) return null;
+
+  return (
+    <Message error>
+      The old data provided here is not in sync with actual person data.
+      <Button
+        onClick={() => syncEditPersonRequestMutate({
+          ticketId: id,
+          actingStakeholderId: currentStakeholder.id,
+        })}
+      >
+        Sync Now
+      </Button>
+    </Message>
+  );
+}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/OldDataSyncInfo.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/OldDataSyncInfo.jsx
@@ -24,11 +24,11 @@ export default function OldDataSyncInfo({ ticketDetails, currentStakeholder }) {
     error,
   } = useMutation({
     mutationFn: syncEditPersonRequest,
-    onSuccess: () => {
-      // We've invalidated the ticket details because we can't confirm that the updated value
-      // matches the current person's data. To be safe, we're refetching the information, as
-      // the person's details may have changed since the last time they were accessed.
-      queryClient.invalidateQueries(['ticket-details', id]);
+    onSuccess: (syncedTicketDetails) => {
+      queryClient.setQueryData(
+        ['ticket-details', id],
+        (oldTicketDetails) => ({ ...oldTicketDetails, ticket: syncedTicketDetails }),
+      );
     },
   });
 

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
@@ -4,6 +4,7 @@ import { ticketStatuses } from '../../../../lib/wca-data.js.erb';
 import EditPersonValidations from './EditPersonValidations';
 import EditPersonRequestedChanges from './EditPersonRequestedChanges';
 import RejectView from './RejectView';
+import OldDataSyncInfo from './OldDataSyncInfo';
 
 export default function EditPersonActionerView({
   ticketDetails,
@@ -22,6 +23,10 @@ export default function EditPersonActionerView({
     <>
       <EditPersonValidations
         ticketDetails={ticketDetails}
+      />
+      <OldDataSyncInfo
+        ticketDetails={ticketDetails}
+        currentStakeholder={currentStakeholder}
       />
       <EditPersonRequestedChanges
         ticketId={id}

--- a/app/webpacker/components/Tickets/api/editPerson/syncEditPersonRequest.js
+++ b/app/webpacker/components/Tickets/api/editPerson/syncEditPersonRequest.js
@@ -1,0 +1,18 @@
+import { fetchJsonOrError } from '../../../../lib/requests/fetchWithAuthenticityToken';
+import { actionUrls } from '../../../../lib/requests/routes.js.erb';
+
+export default async function syncEditPersonRequest({ ticketId, actingStakeholderId }) {
+  const { data } = await fetchJsonOrError(
+    actionUrls.tickets.syncEditPersonRequest(ticketId),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        acting_stakeholder_id: actingStakeholderId,
+      }),
+    },
+  );
+  return data;
+}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -319,6 +319,7 @@ export const actionUrls = {
     rejectEditPersonRequest: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_reject_edit_person_request_path("${ticketId}")) %>`,
     editPersonFields: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_edit_person_fields_path("${ticketId}")) %>`,
     editPersonField: (ticketId, editPersonFieldId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_edit_person_field_path("${ticketId}", "${editPersonFieldId}")) %>`,
+    syncEditPersonRequest: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_sync_edit_person_request_path("${ticketId}")) %>`,
   },
   validators: {
     forCompetitionList: (competitionIds, selectedValidators, applyFixWhenPossible, checkRealResults) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_validators_for_competition_list_path) %>?${jsonToQueryString({ competitionIds, selectedValidators, applyFixWhenPossible, checkRealResults })}`,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,7 @@ Rails.application.routes.draw do
     post 'delete_inbox_persons' => 'tickets#delete_inbox_persons', as: :delete_inbox_persons
     get 'events_merged_data' => 'tickets#events_merged_data', as: :events_merged_data
     post 'reject_edit_person_request' => 'tickets#reject_edit_person_request', as: :reject_edit_person_request
+    post 'sync_edit_person_request' => 'tickets#sync_edit_person_request', as: :sync_edit_person_request
     resources :ticket_comments, only: %i[index create], as: :comments
     resources :ticket_logs, only: [:index], as: :logs
     resources :tickets_edit_person_fields, only: %i[create update destroy], as: :edit_person_fields


### PR DESCRIPTION
This is because there are chances that `old_value` can be different from the current person data - especially when the person details got updated through some other way - like direct PMA edit, or through edit person form.

If WRT is informed about the out-of-sync, it will help them to understand that something has changed since the request initially happened.