### PR TITLE
Add features to edit the requested changes in edit person ticket

### DIFF
--- a/app/controllers/tickets_edit_person_fields_controller.rb
+++ b/app/controllers/tickets_edit_person_fields_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class TicketsEditPersonFieldsController < ApplicationController
+  before_action :authenticate_user!
+  before_action -> { check_ticket_errors(TicketLog.action_types[:metadata_action], TicketsEditPerson::ACTION_TYPE[:create_edit_person_change]) }, only: [:create]
+  before_action -> { check_ticket_errors(TicketLog.action_types[:metadata_action], TicketsEditPerson::ACTION_TYPE[:update_edit_person_change]) }, only: [:update]
+  before_action -> { check_ticket_errors(TicketLog.action_types[:metadata_action], TicketsEditPerson::ACTION_TYPE[:delete_edit_person_change]) }, only: [:destroy]
+
+  private def check_ticket_errors(action_type, metadata_action = nil)
+    @action_type = action_type
+    @metadata_action = metadata_action
+    @ticket = Ticket.find(params.require(:ticket_id))
+    @acting_stakeholder = TicketStakeholder.find(params.require(:acting_stakeholder_id))
+
+    render status: :bad_request, json: { error: "You are not a stakeholder for this ticket." } unless @ticket.user_stakeholders(current_user).include?(@acting_stakeholder)
+
+    # Actions which are not metadata-actions are allowed for all stakeholders currently.
+    return if metadata_action.nil?
+
+    render status: :unauthorized, json: { error: "You are not allowed to perform this metadata action." } unless @acting_stakeholder.metadata_actions_allowed.include?(@metadata_action)
+  end
+
+  def create
+    field_name = params.require(:field_name)
+    old_value = params.require(:old_value)
+    new_value = params.require(:new_value)
+
+    ActiveRecord::Base.transaction do
+      @created_field = @ticket.metadata.tickets_edit_person_fields.create!(
+        field_name: TicketsEditPersonField.field_names[field_name],
+        old_value: old_value,
+        new_value: new_value,
+      )
+      @ticket.ticket_logs.create!(
+        action_type: @action_type,
+        acting_user_id: current_user.id,
+        acting_stakeholder_id: @acting_stakeholder.id,
+        metadata_action: @metadata_action,
+      )
+    end
+
+    render status: :ok, json: @created_field
+  end
+
+  def update
+    edit_person_field_id = params.require(:id)
+    edit_person_field = TicketsEditPersonField.find(edit_person_field_id)
+    new_value = params.require(:new_value)
+
+    ActiveRecord::Base.transaction do
+      edit_person_field.update!(new_value: new_value)
+      @ticket.ticket_logs.create!(
+        action_type: @action_type,
+        acting_user_id: current_user.id,
+        acting_stakeholder_id: @acting_stakeholder.id,
+        metadata_action: @metadata_action,
+      )
+    end
+
+    render status: :ok, json: { success: true }
+  end
+
+  def destroy
+    edit_person_field_id = params.require(:id)
+    edit_person_field = TicketsEditPersonField.find(edit_person_field_id)
+
+    ActiveRecord::Base.transaction do
+      edit_person_field.destroy!
+      @ticket.ticket_logs.create!(
+        action_type: @action_type,
+        acting_user_id: current_user.id,
+        acting_stakeholder_id: @acting_stakeholder.id,
+        metadata_action: @metadata_action,
+      )
+    end
+
+    render status: :ok, json: { success: true }
+  end
+end

--- a/app/models/tickets_edit_person.rb
+++ b/app/models/tickets_edit_person.rb
@@ -10,14 +10,23 @@ class TicketsEditPerson < ApplicationRecord
 
   has_one :ticket, as: :metadata
   has_many :tickets_edit_person_fields
+  belongs_to :person, -> { current }, primary_key: :wca_id, foreign_key: :wca_id
 
   ACTION_TYPE = {
     reject_edit_person_request: "reject_edit_person_request",
+    create_edit_person_change: "create_edit_person_change",
+    update_edit_person_change: "update_edit_person_change",
+    delete_edit_person_change: "delete_edit_person_change",
   }.freeze
 
   def metadata_actions_allowed_for(ticket_stakeholder)
     if ticket_stakeholder.stakeholder == UserGroup.teams_committees_group_wrt
-      [ACTION_TYPE[:reject_edit_person_request]]
+      [
+        ACTION_TYPE[:reject_edit_person_request],
+        ACTION_TYPE[:create_edit_person_change],
+        ACTION_TYPE[:update_edit_person_change],
+        ACTION_TYPE[:delete_edit_person_change],
+      ]
     else
       []
     end
@@ -68,7 +77,14 @@ class TicketsEditPerson < ApplicationRecord
   end
 
   DEFAULT_SERIALIZE_OPTIONS = {
-    include: %w[tickets_edit_person_fields],
+    include: {
+      tickets_edit_person_fields: {},
+      person: {
+        only: %w[name gender],
+        methods: %w[country_iso2],
+        private_attributes: %w[dob],
+      },
+    },
   }.freeze
 
   def serializable_hash(options = nil)

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonFieldEditor.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonFieldEditor.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Form } from 'semantic-ui-react';
 import useInputState from '../../../../lib/hooks/useInputState';
 import I18n from '../../../../lib/i18n';
@@ -15,16 +15,18 @@ export default function EditPersonFieldEditor({
   actionMutate,
 }) {
   const [newValue, setNewValue] = useInputState(oldValue);
+
+  const formSubmitHandler = useCallback(() => actionMutate({
+    ticketId,
+    actingStakeholderId,
+    fieldName,
+    oldValue,
+    newValue,
+    editPersonFieldId: id,
+  }), [actingStakeholderId, actionMutate, fieldName, id, newValue, oldValue, ticketId]);
+
   return (
-    <Form onSubmit={() => actionMutate({
-      ticketId,
-      actingStakeholderId,
-      fieldName,
-      oldValue,
-      newValue,
-      editPersonFieldId: id,
-    })}
-    >
+    <Form onSubmit={formSubmitHandler}>
       <FormInput
         fieldName={fieldName}
         newValue={newValue}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonFieldEditor.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonFieldEditor.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Form } from 'semantic-ui-react';
+import useInputState from '../../../../lib/hooks/useInputState';
+import I18n from '../../../../lib/i18n';
+import RegionSelector from '../../../wca/RegionSelector';
+import GenderSelector from '../../../wca/GenderSelector';
+import UtcDatePicker from '../../../wca/UtcDatePicker';
+
+export default function EditPersonFieldEditor({
+  id,
+  ticketId,
+  actingStakeholderId,
+  fieldName,
+  oldValue,
+  actionMutate,
+}) {
+  const [newValue, setNewValue] = useInputState(oldValue);
+  return (
+    <Form onSubmit={() => actionMutate({
+      ticketId,
+      actingStakeholderId,
+      fieldName,
+      oldValue,
+      newValue,
+      editPersonFieldId: id,
+    })}
+    >
+      <FormInput
+        fieldName={fieldName}
+        newValue={newValue}
+        setNewValue={setNewValue}
+      />
+      <Form.Button>Submit</Form.Button>
+    </Form>
+  );
+}
+
+function FormInput({ fieldName, newValue, setNewValue }) {
+  switch (fieldName) {
+    case 'name': return (
+      <Form.Input
+        label={I18n.t('activerecord.attributes.user.name')}
+        name="name"
+        value={newValue}
+        onChange={setNewValue}
+        required
+      />
+    );
+    case 'country_iso2': return (
+      <RegionSelector
+        label={I18n.t('activerecord.attributes.user.country_iso2')}
+        name="country_iso2"
+        onlyCountries
+        region={newValue}
+        onRegionChange={setNewValue}
+      />
+    );
+    case 'gender': return (
+      <GenderSelector
+        name="gender"
+        gender={newValue}
+        onChange={setNewValue}
+      />
+    );
+    case 'dob': return (
+      <Form.Field
+        label={I18n.t('activerecord.attributes.user.dob')}
+        name="dob"
+        control={UtcDatePicker}
+        showYearDropdown
+        dateFormatOverride="yyyy-MM-dd"
+        dropdownMode="select"
+        isoDate={newValue}
+        onChange={setNewValue}
+        required
+      />
+    );
+    default: return <>Unknown field</>;
+  }
+}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonRequestedChanges.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonRequestedChanges.jsx
@@ -1,0 +1,178 @@
+import React, { useState } from 'react';
+import { Confirm, Modal } from 'semantic-ui-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import EditPersonRequestedChangesList from './EditPersonRequestedChangesList';
+import Loading from '../../../Requests/Loading';
+import Errored from '../../../Requests/Errored';
+import createEditPersonField from '../../api/competitionResult/createEditPersonField';
+import updateEditPersonField from '../../api/competitionResult/updateEditPersonField';
+import deleteEditPersonField from '../../api/competitionResult/deleteEditPersonField';
+import EditPersonFieldEditor from './EditPersonFieldEditor';
+
+export default function EditPersonRequestedChanges({
+  ticketId,
+  currentStakeholder,
+  requestedChanges,
+  person,
+}) {
+  const [editPersonFieldActionDetails, setEditPersonFieldActionDetails] = useState();
+
+  const queryClient = useQueryClient();
+  const {
+    mutate: createEditPersonFieldMutate,
+    isPending: isCreatePending,
+    isError: isCreateError,
+    error: createError,
+  } = useMutation({
+    mutationFn: createEditPersonField,
+    onSuccess: (newEditField) => {
+      setEditPersonFieldActionDetails(null);
+      queryClient.setQueryData(
+        ['ticket-details', ticketId],
+        (oldTicketDetails) => ({
+          ...oldTicketDetails,
+          ticket: {
+            ...oldTicketDetails.ticket,
+            metadata: {
+              ...oldTicketDetails.ticket.metadata,
+              tickets_edit_person_fields: [
+                ...oldTicketDetails.ticket.metadata.tickets_edit_person_fields,
+                newEditField,
+              ],
+            },
+          },
+        }),
+      );
+    },
+  });
+
+  const {
+    mutate: updateEditPersonFieldMutate,
+    isPending: isUpdatePending,
+    isError: isUpdateError,
+    error: updateError,
+  } = useMutation({
+    mutationFn: updateEditPersonField,
+    onSuccess: (_, { editPersonFieldId, newValue }) => {
+      setEditPersonFieldActionDetails(null);
+      queryClient.setQueryData(
+        ['ticket-details', ticketId],
+        (oldTicketDetails) => ({
+          ...oldTicketDetails,
+          ticket: {
+            ...oldTicketDetails.ticket,
+            metadata: {
+              ...oldTicketDetails.ticket.metadata,
+              tickets_edit_person_fields: (
+                oldTicketDetails.ticket.metadata.tickets_edit_person_fields.map(
+                  (editPersonField) => {
+                    if (editPersonField.id === editPersonFieldId) {
+                      return { ...editPersonField, new_value: newValue };
+                    }
+                    return editPersonField;
+                  },
+                )
+              ),
+            },
+          },
+        }),
+      );
+    },
+  });
+
+  const {
+    mutate: deleteEditPersonFieldMutate,
+    isPending: isDeletePending,
+    isError: isDeleteError,
+    error: deleteError,
+  } = useMutation({
+    mutationFn: deleteEditPersonField,
+    onSuccess: (_, { editPersonFieldId }) => {
+      setEditPersonFieldActionDetails(null);
+      queryClient.setQueryData(
+        ['ticket-details', ticketId],
+        (oldTicketDetails) => ({
+          ...oldTicketDetails,
+          ticket: {
+            ...oldTicketDetails.ticket,
+            metadata: {
+              ...oldTicketDetails.ticket.metadata,
+              tickets_edit_person_fields: (
+                oldTicketDetails.ticket.metadata.tickets_edit_person_fields.filter(
+                  (editPersonField) => editPersonField.id !== editPersonFieldId,
+                )
+              ),
+            },
+          },
+        }),
+      );
+    },
+  });
+
+  const actionMutateMap = {
+    create: createEditPersonFieldMutate,
+    update: updateEditPersonFieldMutate,
+  };
+
+  if (isCreatePending || isUpdatePending || isDeletePending) return <Loading />;
+  if (isCreateError) return <Errored error={createError} />;
+  if (isUpdateError) return <Errored error={updateError} />;
+  if (isDeleteError) return <Errored error={deleteError} />;
+
+  return (
+    <>
+      <EditPersonRequestedChangesList
+        requestedChanges={requestedChanges}
+        createChange={({ fieldName, oldValue }) => setEditPersonFieldActionDetails({
+          action: 'create',
+          fieldName,
+          oldValue,
+        })}
+        updateChange={({
+          id,
+          field_name: fieldName,
+          old_value: oldValue,
+        }) => setEditPersonFieldActionDetails({
+          action: 'update',
+          id,
+          fieldName,
+          oldValue,
+        })}
+        deleteChange={(editPersonFieldId) => setEditPersonFieldActionDetails({
+          action: 'delete',
+          editPersonFieldId,
+        })}
+      />
+      <Confirm
+        open={editPersonFieldActionDetails?.action === 'delete'}
+        content="Are you sure you want to delete this change?"
+        onCancel={() => setEditPersonFieldActionDetails(null)}
+        onConfirm={() => deleteEditPersonFieldMutate({
+          ticketId,
+          editPersonFieldId: editPersonFieldActionDetails?.editPersonFieldId,
+          actingStakeholderId: currentStakeholder.id,
+        })}
+      />
+      <Modal
+        open={['create', 'update'].includes(editPersonFieldActionDetails?.action)}
+        onClose={() => setEditPersonFieldActionDetails(null)}
+        closeIcon
+      >
+        <Modal.Header>Edit Person Field Editor</Modal.Header>
+        <Modal.Content>
+          <EditPersonFieldEditor
+            id={editPersonFieldActionDetails?.id}
+            ticketId={ticketId}
+            actingStakeholderId={currentStakeholder.id}
+            fieldName={editPersonFieldActionDetails?.fieldName}
+            oldValue={
+              editPersonFieldActionDetails?.oldValue
+              || person[editPersonFieldActionDetails?.fieldName]
+            }
+            actionMutate={actionMutateMap[editPersonFieldActionDetails?.action]}
+          />
+        </Modal.Content>
+      </Modal>
+    </>
+  );
+}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonRequestedChangesList.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/EditPersonRequestedChangesList.jsx
@@ -1,12 +1,24 @@
 import React from 'react';
-import { Header, Table } from 'semantic-ui-react';
+import { Button, Header, Table } from 'semantic-ui-react';
+import _ from 'lodash';
 import I18n from '../../../../lib/i18n';
+import { countries } from '../../../../lib/wca-data.js.erb';
 
 function formatField(field, value) {
-  return field === 'name' ? value.replaceAll(' ', '#') : value;
+  switch (field) {
+    case 'name': return value.replaceAll(' ', '#');
+    case 'country_iso2': return countries.byIso2[value].name;
+    default: return value;
+  }
 }
 
-export default function EditPersonRequestedChangesList({ requestedChanges }) {
+const FIELDS = ['name', 'country_iso2', 'gender', 'dob'];
+
+export default function EditPersonRequestedChangesList({
+  requestedChanges, createChange, updateChange, deleteChange,
+}) {
+  const requestedChangesMapped = _.mapKeys(requestedChanges, 'field_name');
+
   return (
     <>
       <Header as="h3">Requested changes</Header>
@@ -14,20 +26,52 @@ export default function EditPersonRequestedChangesList({ requestedChanges }) {
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Field</Table.HeaderCell>
-            <Table.HeaderCell>Old value</Table.HeaderCell>
-            <Table.HeaderCell>New value</Table.HeaderCell>
+            <Table.HeaderCell>Change</Table.HeaderCell>
+            <Table.HeaderCell>Action</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {requestedChanges?.map((change) => (
-            <Table.Row>
-              <Table.Cell>{I18n.t(`activerecord.attributes.user.${change.field_name}`)}</Table.Cell>
-              <Table.Cell>{formatField(change.field_name, change.old_value)}</Table.Cell>
-              <Table.Cell>{formatField(change.field_name, change.new_value)}</Table.Cell>
-            </Table.Row>
+          {FIELDS.map((fieldName) => (
+            <EditFieldRow
+              fieldName={fieldName}
+              requestedChange={requestedChangesMapped[fieldName]}
+              createChange={createChange}
+              updateChange={updateChange}
+              deleteChange={deleteChange}
+            />
           ))}
         </Table.Body>
       </Table>
     </>
+  );
+}
+
+function EditFieldRow({
+  fieldName, requestedChange, createChange, updateChange, deleteChange,
+}) {
+  if (requestedChange) {
+    return (
+      <Table.Row>
+        <Table.Cell>{I18n.t(`activerecord.attributes.user.${fieldName}`)}</Table.Cell>
+        <Table.Cell>
+          {formatField(requestedChange.field_name, requestedChange.old_value)}
+          {' -> '}
+          {formatField(requestedChange.field_name, requestedChange.new_value)}
+        </Table.Cell>
+        <Table.Cell>
+          <Button onClick={() => updateChange(requestedChange)}>Edit</Button>
+          <Button onClick={() => deleteChange(requestedChange.id)}>Delete</Button>
+        </Table.Cell>
+      </Table.Row>
+    );
+  }
+  return (
+    <Table.Row>
+      <Table.Cell>{I18n.t(`activerecord.attributes.user.${fieldName}`)}</Table.Cell>
+      <Table.Cell>NO CHANGE</Table.Cell>
+      <Table.Cell>
+        <Button onClick={() => createChange({ fieldName })}>Add</Button>
+      </Table.Cell>
+    </Table.Row>
   );
 }

--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import EditPersonForm from '../../../Panel/pages/EditPersonPage/EditPersonForm';
 import { ticketStatuses } from '../../../../lib/wca-data.js.erb';
 import EditPersonValidations from './EditPersonValidations';
-import EditPersonRequestedChangesList from './EditPersonRequestedChangesList';
+import EditPersonRequestedChanges from './EditPersonRequestedChanges';
 import RejectView from './RejectView';
 
 export default function EditPersonActionerView({
@@ -23,8 +23,11 @@ export default function EditPersonActionerView({
       <EditPersonValidations
         ticketDetails={ticketDetails}
       />
-      <EditPersonRequestedChangesList
+      <EditPersonRequestedChanges
+        ticketId={id}
+        currentStakeholder={currentStakeholder}
         requestedChanges={metadata.tickets_edit_person_fields}
+        person={metadata.person}
       />
       <EditPersonForm
         wcaId={metadata.wca_id}

--- a/app/webpacker/components/Tickets/api/competitionResult/createEditPersonField.js
+++ b/app/webpacker/components/Tickets/api/competitionResult/createEditPersonField.js
@@ -1,0 +1,27 @@
+import { fetchJsonOrError } from '../../../../lib/requests/fetchWithAuthenticityToken';
+import { actionUrls } from '../../../../lib/requests/routes.js.erb';
+
+export default async function createEditPersonField({
+  ticketId,
+  actingStakeholderId,
+  fieldName,
+  oldValue,
+  newValue,
+}) {
+  const { data } = await fetchJsonOrError(
+    actionUrls.tickets.editPersonFields(ticketId),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        acting_stakeholder_id: actingStakeholderId,
+        field_name: fieldName,
+        old_value: oldValue,
+        new_value: newValue,
+      }),
+    },
+  );
+  return data;
+}

--- a/app/webpacker/components/Tickets/api/competitionResult/deleteEditPersonField.js
+++ b/app/webpacker/components/Tickets/api/competitionResult/deleteEditPersonField.js
@@ -1,0 +1,22 @@
+import { fetchJsonOrError } from '../../../../lib/requests/fetchWithAuthenticityToken';
+import { actionUrls } from '../../../../lib/requests/routes.js.erb';
+
+export default async function deleteEditPersonField({
+  ticketId,
+  editPersonFieldId,
+  actingStakeholderId,
+}) {
+  const { data } = await fetchJsonOrError(
+    actionUrls.tickets.editPersonField(ticketId, editPersonFieldId),
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        acting_stakeholder_id: actingStakeholderId,
+      }),
+    },
+  );
+  return data;
+}

--- a/app/webpacker/components/Tickets/api/competitionResult/updateEditPersonField.js
+++ b/app/webpacker/components/Tickets/api/competitionResult/updateEditPersonField.js
@@ -1,0 +1,24 @@
+import { fetchJsonOrError } from '../../../../lib/requests/fetchWithAuthenticityToken';
+import { actionUrls } from '../../../../lib/requests/routes.js.erb';
+
+export default async function updateEditPersonField({
+  ticketId,
+  actingStakeholderId,
+  newValue,
+  editPersonFieldId,
+}) {
+  const { data } = await fetchJsonOrError(
+    actionUrls.tickets.editPersonField(ticketId, editPersonFieldId),
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        acting_stakeholder_id: actingStakeholderId,
+        new_value: newValue,
+      }),
+    },
+  );
+  return data;
+}

--- a/app/webpacker/lib/helpers/update-ticket-query-data.js
+++ b/app/webpacker/lib/helpers/update-ticket-query-data.js
@@ -1,0 +1,11 @@
+// eslint-disable-next-line import/prefer-default-export
+export const updateTicketMetadata = (oldTicketDetails, fieldName, newData) => ({
+  ...oldTicketDetails,
+  ticket: {
+    ...oldTicketDetails.ticket,
+    metadata: {
+      ...oldTicketDetails.ticket.metadata,
+      [fieldName]: newData,
+    },
+  },
+});

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -317,6 +317,8 @@ export const actionUrls = {
     deleteInboxPersons: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_delete_inbox_persons_path("${ticketId}")) %>`,
     postResults: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_post_results_path("${ticketId}")) %>`,
     rejectEditPersonRequest: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_reject_edit_person_request_path("${ticketId}")) %>`,
+    editPersonFields: (ticketId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_edit_person_fields_path("${ticketId}")) %>`,
+    editPersonField: (ticketId, editPersonFieldId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.ticket_edit_person_field_path("${ticketId}", "${editPersonFieldId}")) %>`,
   },
   validators: {
     forCompetitionList: (competitionIds, selectedValidators, applyFixWhenPossible, checkRealResults) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_validators_for_competition_list_path) %>?${jsonToQueryString({ competitionIds, selectedValidators, applyFixWhenPossible, checkRealResults })}`,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,6 +242,7 @@ Rails.application.routes.draw do
     post 'reject_edit_person_request' => 'tickets#reject_edit_person_request', as: :reject_edit_person_request
     resources :ticket_comments, only: %i[index create], as: :comments
     resources :ticket_logs, only: [:index], as: :logs
+    resources :tickets_edit_person_fields, only: %i[create update destroy], as: :edit_person_fields
   end
   resources :notifications, only: [:index]
 


### PR DESCRIPTION
There can be cases where WRT needs to modify the request a bit instead of rejecting it. For example, if the user accidentally gives the name as "Jonh" instead of "John", and if ID clearly mentioned that the name is "John", then it will be good if WRT is allowed to edit the change field.

Currently the advantage of this changing will be that the ticket will be updated with what exactly is going to happen. In future, we will have action buttons like "Execute as fix" and "Execute as update". Once we have that buttons, then we will be using this value in database to perform the action.