### PR TITLE
Add feature flag for WCA Live data submission

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -9,7 +9,9 @@ class ResultsSubmissionController < ApplicationController
 
   def new
     @competition = competition_from_params
-    @show_wca_live_beta = params[:wcaLiveBeta] == "0xCaliforniaRoll"
+
+    expected_feature_flag = ServerSetting.find_by(name: ServerSetting::WCA_LIVE_BETA_FEATURE_FLAG)
+    @show_wca_live_beta = expected_feature_flag.present? && params[:wcaLiveBeta] == expected_feature_flag.value
   end
 
   def newcomer_checks

--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -9,6 +9,7 @@ class ResultsSubmissionController < ApplicationController
 
   def new
     @competition = competition_from_params
+    @show_wca_live_beta = params[:wcaLiveBeta] == "0xCaliforniaRoll"
   end
 
   def newcomer_checks

--- a/app/models/server_setting.rb
+++ b/app/models/server_setting.rb
@@ -6,6 +6,13 @@ class ServerSetting < ApplicationRecord
   BASE_LOCALE_HASH = 'en_translation_modification'
   TEST_VIDEO_ID_NAME = 'TEST_wc2025_video_url'
   LIVE_VIDEO_ID_NAME = 'wc2025_video_url'
+  WCA_LIVE_BETA_FEATURE_FLAG = 'wca_live_beta_feature_flag'
+
+  # These are settings which should not appear in the public exports.
+  # They are filtered out directly in `database_dumper` via a WHERE clause
+  HIDDEN_SETTINGS = [
+    WCA_LIVE_BETA_FEATURE_FLAG,
+  ].freeze
 
   def as_datetime
     Time.at(self.value.to_i).to_datetime

--- a/app/views/results_submission/new.html.erb
+++ b/app/views/results_submission/new.html.erb
@@ -8,6 +8,7 @@
     resultsSubmitted: @competition.results_submitted?,
     hasTemporaryResults: @competition.inbox_results.present?,
     uploadedScrambleFilesCount: @competition.scramble_file_uploads.count,
+    showWcaLiveBeta: @show_wca_live_beta,
     canSubmitResults: @current_user.can_submit_competition_results?(@competition),
   }) %>
 <% end %>

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
@@ -29,6 +29,7 @@ export function ImportResultsData({
   hasTemporaryResults,
   isAdminView = false,
   uploadedScrambleFilesCount = 0,
+  showWcaLiveBeta = false,
 }) {
   const [activeAccordion, setActiveAccordion] = useState(!hasTemporaryResults);
 
@@ -52,7 +53,7 @@ export function ImportResultsData({
         </Tab.Pane>
       ),
     },
-    ...(isAdminView ? [{
+    ...((isAdminView || showWcaLiveBeta) ? [{
       menuItem: '[BETA] Use WCA Live Results',
       render: () => (
         <Tab.Pane>

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -9,6 +9,7 @@ export default function Wrapper({
   resultsSubmitted,
   hasTemporaryResults,
   uploadedScrambleFilesCount,
+  showWcaLiveBeta,
   canSubmitResults,
 }) {
   return (
@@ -18,6 +19,7 @@ export default function Wrapper({
         resultsSubmitted={resultsSubmitted}
         hasTemporaryResults={hasTemporaryResults}
         uploadedScrambleFilesCount={uploadedScrambleFilesCount}
+        showWcaLiveBeta={showWcaLiveBeta}
         canSubmitResults={canSubmitResults}
       />
     </WCAQueryClientProvider>
@@ -29,6 +31,7 @@ function CompetitionResultSubmission({
   resultsSubmitted,
   hasTemporaryResults,
   uploadedScrambleFilesCount,
+  showWcaLiveBeta,
   canSubmitResults,
 }) {
   if (resultsSubmitted) {
@@ -45,14 +48,13 @@ function CompetitionResultSubmission({
       The result submission process has two steps:
       <List ordered>
         <List.Item>
-          Providing valid results data to the website. This can be done in one of two ways:
+          Providing valid results data to the website.
+          This can be done in one of the following ways:
           <List.List>
-            <List.Item value="a">
-              Uploading a Results JSON file
-              {' '}
-              <b>OR</b>
-            </List.Item>
-            <List.Item value="b">Importing results directly from WCA Live</List.Item>
+            <List.Item value="a">Uploading a Results JSON file</List.Item>
+            {showWcaLiveBeta && (
+              <List.Item value="b">Importing results directly from WCA Live</List.Item>
+            )}
           </List.List>
         </List.Item>
         <List.Item>
@@ -63,6 +65,7 @@ function CompetitionResultSubmission({
         competitionId={competitionId}
         uploadedScrambleFilesCount={uploadedScrambleFilesCount}
         hasTemporaryResults={hasTemporaryResults}
+        showWcaLiveBeta={showWcaLiveBeta}
       />
       {hasTemporaryResults && (
         <FormToWrt competitionId={competitionId} canSubmitResults={canSubmitResults} />

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -812,6 +812,7 @@ module DatabaseDumper
     "vote_options" => :skip_all_rows,
     "votes" => :skip_all_rows,
     "server_settings" => {
+      where_clause: "WHERE name NOT IN (#{ServerSetting::HIDDEN_SETTINGS.map { "'#{it}'" }.join(',')})",
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w[
           name

--- a/next-frontend/src/types/nextjs-routes.d.ts
+++ b/next-frontend/src/types/nextjs-routes.d.ts
@@ -27,7 +27,6 @@ declare module "nextjs-routes" {
     | DynamicRoute<"/competitions/[competitionId]/schedule", { "competitionId": string }>
     | StaticRoute<"/dashboard">
     | StaticRoute<"/delegates">
-    | StaticRoute<"/disciplinary">
     | StaticRoute<"/disclaimer">
     | StaticRoute<"/documents">
     | StaticRoute<"/export/developer">


### PR DESCRIPTION
I admit this is a kind of power abuse, but I have a competition this upcoming weekend where I know the Delegates well and we can test this feature in production under my supervision. So this flag is just there to make sure that we can actually see the button in production if required.