### PR TITLE
Add 'aggressive retry' flag to cronjob config

### DIFF
--- a/app/jobs/wca_cronjob.rb
+++ b/app/jobs/wca_cronjob.rb
@@ -10,7 +10,7 @@ class WcaCronjob < ApplicationJob
   before_enqueue do |job|
     statistics = job.class.cronjob_statistics
 
-    if statistics.scheduled? || statistics.in_progress? || statistics.recently_errored?
+    if statistics.scheduled? || statistics.in_progress? || (statistics.recently_errored? && !statistics.is_aggressive_retry?)
       statistics.increment! :recently_rejected
 
       # Make ActiveJob abort and do NOT enqueue the job

--- a/db/migrate/20250901035157_add_aggressive_retry_to_cronjob_statistics.rb
+++ b/db/migrate/20250901035157_add_aggressive_retry_to_cronjob_statistics.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAggressiveRetryToCronjobStatistics < ActiveRecord::Migration[7.2]
+  def change
+    add_column :cronjob_statistics, :is_aggressive_retry, :boolean, default: false, null: false, after: :recently_errored
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_26_042935) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_01_035157) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -551,6 +551,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_26_042935) do
     t.datetime "enqueued_at", precision: nil
     t.integer "recently_rejected", default: 0, null: false
     t.integer "recently_errored", default: 0, null: false
+    t.boolean "is_aggressive_retry", default: false, null: false
     t.integer "times_completed", default: 0, null: false
     t.bigint "average_runtime"
   end


### PR DESCRIPTION
Normally, we don't want cronjobs that errored out to be re-scheduled, because Sidekiq has its own retry mechanism.

However, in the case of the arrogant Google Admin SDK, which enforces draconius rate limits but at the same time does not offer any way of batching requests, we do want to hard-retry upon failure without the exponential backoff of Sidekiq retries. So we override the default mechanism to make sure that our mailing lists stay in sync.