### PR TITLE
Fix `signed_id` issue in Delegate Reports

### DIFF
--- a/app/views/delegate_reports/edit.html.erb
+++ b/app/views/delegate_reports/edit.html.erb
@@ -28,13 +28,15 @@
         <% if @delegate_report.setup_images.attached? %>
           <div class="row">
             <% @delegate_report.setup_images.each do |image| %>
-              <div class="col-sm-1 thumb">
-                <%= image_tag image.variant(:preview).processed %>
+              <% if image.blob.persisted? %>
+                <div class="col-sm-1 thumb">
+                  <%= image_tag image.variant(:preview).processed %>
 
-                <% if @delegate_report.setup_images.count > @delegate_report.required_setup_images_count %>
-                  <%= link_to 'Delete', delegate_report_delete_image_path(competition_id: @delegate_report.competition_id, image_id: image.id), method: :delete %>
-                <% end %>
-              </div>
+                  <% if @delegate_report.setup_images.count > @delegate_report.required_setup_images_count %>
+                    <%= link_to 'Delete', delegate_report_delete_image_path(competition_id: @delegate_report.competition_id, image_id: image.id), method: :delete %>
+                  <% end %>
+                </div>
+              <% end %>
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
Sometimes users will experience the following error when trying to work with a Delegate Report: 
```bash 
ActionView::Template::Error (Cannot get a signed_id for a new record):
```

Gregor explains the cause in detail [here](https://github.com/rails/rails/issues/50234) - in brief, a user uploading a valid image on a delegate report that fails validations causes an image to be attached but not persisted, yielding the error. 

The easy fix suggested in that issue discussion is to check `.persisted?` before trying to render the image, which is what this PR does. 