### PR TITLE
Show message on closed edit person ticket for WRT

### DIFF
--- a/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/EditPersonActionerView/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import EditPersonForm from '../../../Panel/pages/EditPersonPage/EditPersonForm';
-import { ticketStatuses } from '../../../../lib/wca-data.js.erb';
+import { ticketStatuses, PANEL_PAGES } from '../../../../lib/wca-data.js.erb';
+import { panelPageUrl } from '../../../../lib/requests/routes.js.erb';
 import EditPersonValidations from './EditPersonValidations';
 import EditPersonRequestedChanges from './EditPersonRequestedChanges';
 import RejectView from './RejectView';
@@ -15,7 +16,17 @@ export default function EditPersonActionerView({
   const closeTicket = () => updateStatus(ticketStatuses.edit_person.closed);
 
   if (ticketDetails.ticket.metadata.status === ticketStatuses.edit_person.closed) {
-    return null;
+    return (
+      <>
+        You cannot edit this person through ticket anymore as the ticket is closed.
+        But you can do it through
+        {' '}
+        <a href={panelPageUrl(PANEL_PAGES.editPerson, { wcaId: metadata.wca_id })}>
+          Edit Person form
+        </a>
+        .
+      </>
+    );
   }
 
   return (


### PR DESCRIPTION
This info is shown just to inform WRT that they need to execute the change manually if the ticket is closed.