### PR TITLE
Add Country translations to translation.jsons using third party library

### DIFF
--- a/next-frontend/build-translations.js
+++ b/next-frontend/build-translations.js
@@ -30,11 +30,6 @@ function addCountryNames(translation, lang) {
   }
   const iso3166CountryCodes = Object.keys(countries.getAlpha2Codes());
 
-  // Load the language file for the country names
-  countries.registerLocale(
-    require(`i18n-iso-countries/langs/${iso639LanguageCode}.json`),
-  );
-
   iso3166CountryCodes.forEach((iso3166CountryCode) => {
     const languageKey = `countries.${iso3166CountryCode}`;
     if (!translation[languageKey]) {

--- a/next-frontend/build-translations.js
+++ b/next-frontend/build-translations.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const yaml = require("js-yaml");
 const languages = Object.keys(require("./src/lib/i18n/locales/available.json"));
+const countries = require("i18n-iso-countries");
 
 // Recursively flatten a nested object using dot notation
 function flattenObject(obj, prefix = "") {
@@ -17,6 +18,26 @@ function flattenObject(obj, prefix = "") {
     }
     return acc;
   }, {});
+}
+
+// Add Country Names if not translated already
+function addCountryNames(translation, lang) {
+  const supportedLanguages = countries.getSupportedLanguages();
+  if (supportedLanguages.indexOf(lang) === -1) {
+    return translation;
+  }
+  const languageCode = lang.slice(0, 2);
+  const codes = Object.keys(countries.getAlpha2Codes());
+  countries.registerLocale(
+    require(`i18n-iso-countries/langs/${languageCode}.json`),
+  );
+  codes.forEach((code) => {
+    const languageKey = `countries.${code}`;
+    if (!translation[languageKey]) {
+      translation[languageKey] = countries.getName(code, languageCode);
+    }
+  });
+  return translation;
 }
 
 const localeDir = process.env.LOCALE_DIR || "../config/locales/";
@@ -35,8 +56,9 @@ languages.forEach((lang) => {
 
   Object.entries(parsed).forEach(([topLevelKey, content]) => {
     const flattened = flattenObject(content);
+    const withCountries = addCountryNames(flattened, lang);
     const outputPath = path.join(outputDir, `${topLevelKey}.json`);
-    fs.writeFileSync(outputPath, JSON.stringify(flattened, null, 2));
+    fs.writeFileSync(outputPath, JSON.stringify(withCountries, null, 2));
     console.log(`✔ Wrote ${outputPath}`);
   });
 });

--- a/next-frontend/build-translations.js
+++ b/next-frontend/build-translations.js
@@ -23,20 +23,28 @@ function flattenObject(obj, prefix = "") {
 // Add Country Names if not translated already
 function addCountryNames(translation, lang) {
   const supportedLanguages = countries.getSupportedLanguages();
-  if (supportedLanguages.indexOf(lang) === -1) {
+  const iso639LanguageCode = lang.slice(0, 2);
+
+  if (!supportedLanguages.includes(iso639LanguageCode)) {
     return translation;
   }
-  const languageCode = lang.slice(0, 2);
-  const codes = Object.keys(countries.getAlpha2Codes());
+  const iso3166CountryCodes = Object.keys(countries.getAlpha2Codes());
+
+  // Load the language file for the country names
   countries.registerLocale(
-    require(`i18n-iso-countries/langs/${languageCode}.json`),
+    require(`i18n-iso-countries/langs/${iso639LanguageCode}.json`),
   );
-  codes.forEach((code) => {
-    const languageKey = `countries.${code}`;
+
+  iso3166CountryCodes.forEach((iso3166CountryCode) => {
+    const languageKey = `countries.${iso3166CountryCode}`;
     if (!translation[languageKey]) {
-      translation[languageKey] = countries.getName(code, languageCode);
+      translation[languageKey] = countries.getName(
+        iso3166CountryCode,
+        iso639LanguageCode,
+      );
     }
   });
+
   return translation;
 }
 

--- a/next-frontend/package.json
+++ b/next-frontend/package.json
@@ -83,6 +83,7 @@
     "eslint-config-next": "15.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "i18n-iso-countries": "^7.14.0",
     "jsdom": "^26.1.0",
     "openapi-typescript": "^7.9.1",
     "prettier": "^3.6.2",

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/page.tsx
@@ -148,7 +148,11 @@ async function GeneralPage({ competitionId }: { competitionId: string }) {
                   </Card.Header>
                   <Card.Body>
                     <Text>{competitionInfo.city}, </Text>
-                    <CountryMap code={competitionInfo.country_iso2} bold />
+                    <CountryMap
+                      code={competitionInfo.country_iso2}
+                      t={t}
+                      bold
+                    />
                   </Card.Body>
                 </Card.Root>
 

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -48,6 +48,7 @@ import type {
 } from "@/types/payload";
 import Link from "next/link";
 import { route } from "nextjs-routes";
+import { getT } from "@/lib/i18n/get18n";
 
 const TextCard = ({ block }: { block: TextCardBlock }) => {
   return (
@@ -203,11 +204,12 @@ const ImageOnlyCard = ({ block }: { block: ImageOnlyCardBlock }) => {
   );
 };
 
-const FeaturedCompetitions = ({
+const FeaturedCompetitions = async ({
   block,
 }: {
   block: FeaturedCompetitionsBlock;
 }) => {
+  const { t } = await getT();
   return (
     <Card.Root variant="info" colorPalette="grey" width="full">
       <Card.Body justifyContent="space-around">
@@ -230,7 +232,7 @@ const FeaturedCompetitions = ({
                     colorPalette={featuredComp.colorPalette}
                   >
                     <Flag code="US" fallback="US" />
-                    <CountryMap code="US" bold /> Seattle
+                    <CountryMap code="US" bold t={t} /> Seattle
                   </Badge>
                   <Badge
                     variant="information"

--- a/next-frontend/src/components/CompetitionTableEntry.tsx
+++ b/next-frontend/src/components/CompetitionTableEntry.tsx
@@ -33,6 +33,7 @@ import CountryMap from "@/components/CountryMap";
 import type { components } from "@/types/openapi";
 import Link from "next/link";
 import { route } from "nextjs-routes";
+import { useT } from "@/lib/i18n/useI18n";
 
 // Raw competition type from WCA API
 type CompetitionIndex = components["schemas"]["CompetitionIndex"];
@@ -102,6 +103,8 @@ function formatDateRange(start: string, end: string): string {
 const CompetitionTableEntry: React.FC<Props> = ({ comp }) => {
   const [open, setOpen] = useState(false);
   const regoStatus = getRegistrationStatus(comp);
+
+  const { t } = useT();
   return (
     <Table.Row bg="bg.inverted" onClick={() => setOpen(true)} key={comp.id}>
       <Table.Cell>{registrationStatusIcons[regoStatus] || null}</Table.Cell>
@@ -128,7 +131,7 @@ const CompetitionTableEntry: React.FC<Props> = ({ comp }) => {
       </Table.Cell>
 
       <Table.Cell textAlign="right">
-        <CountryMap code={comp.country_iso2} bold />
+        <CountryMap code={comp.country_iso2} bold t={t} />
       </Table.Cell>
 
       <Table.Cell minWidth="4em">
@@ -165,7 +168,8 @@ const CompetitionTableEntry: React.FC<Props> = ({ comp }) => {
                       code={comp.country_iso2}
                       fallback={comp.country_iso2}
                     />
-                    <CountryMap code={comp.country_iso2} bold /> {comp.city}
+                    <CountryMap code={comp.country_iso2} bold t={t} />{" "}
+                    {comp.city}
                   </Badge>
                   <Badge variant="information" colorPalette="grey">
                     <CompRegoCloseDateIcon />

--- a/next-frontend/src/components/CountryMap.tsx
+++ b/next-frontend/src/components/CountryMap.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Text } from "@chakra-ui/react";
-import countries from "@/lib/wca/data/countries";
+import WCACountries from "@/lib/wca/data/countries";
+import { useT } from "@/lib/i18n/useI18n";
 
 type CountryMapProps = {
   code: string;
@@ -9,8 +10,13 @@ type CountryMapProps = {
 };
 
 const CountryMap = ({ code, bold = false }: CountryMapProps) => {
-  const country = countries.byIso2[code.toUpperCase()].id || "Unknown";
-  return <Text fontWeight={bold ? "bold" : "normal"}>{country}</Text>;
+  const { t } = useT();
+  const translatedCountryName = t(`countries.${code}`);
+  const countryName =
+    translatedCountryName ||
+    WCACountries.byIso2[code.toUpperCase()].id ||
+    "Unknown";
+  return <Text fontWeight={bold ? "bold" : "normal"}>{countryName}</Text>;
 };
 
 export default CountryMap;

--- a/next-frontend/src/components/CountryMap.tsx
+++ b/next-frontend/src/components/CountryMap.tsx
@@ -1,16 +1,14 @@
-"use client";
-
 import { Text } from "@chakra-ui/react";
 import WCACountries from "@/lib/wca/data/countries";
-import { useT } from "@/lib/i18n/useI18n";
+import { TFunction } from "i18next";
 
 type CountryMapProps = {
   code: string;
+  t: TFunction;
   bold?: boolean;
 };
 
-const CountryMap = ({ code, bold = false }: CountryMapProps) => {
-  const { t } = useT();
+const CountryMap = ({ code, t, bold = false }: CountryMapProps) => {
   const translatedCountryName = t(`countries.${code}`);
   const countryName =
     translatedCountryName ||

--- a/next-frontend/src/components/competitions/TabCompetitors.tsx
+++ b/next-frontend/src/components/competitions/TabCompetitors.tsx
@@ -67,7 +67,7 @@ const TabCompetitors: React.FC<CompetitorData> = ({ id }) => {
                   <Text fontWeight="medium">{registration.user_id}</Text>
                 </Table.Cell>
                 <Table.Cell>
-                  <CountryMap code="AU" bold />
+                  <CountryMap code="AU" bold t={t} />
                 </Table.Cell>
 
                 {eventIds.map((eventId) => (

--- a/next-frontend/yarn.lock
+++ b/next-frontend/yarn.lock
@@ -8693,6 +8693,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diacritics@npm:1.3.0":
+  version: 1.3.0
+  resolution: "diacritics@npm:1.3.0"
+  checksum: 10c0/bc99c3d2e64315b1830f1573eafe1f7b06fd5dbc9687f35ea8e2e25ce8618d1444d0a2c8313b98467b0aff1d0ee35b8f9f67ef214e56e810b37da3cdb29785ac
+  languageName: node
+  linkType: hard
+
 "doctrine@npm:^2.1.0":
   version: 2.1.0
   resolution: "doctrine@npm:2.1.0"
@@ -10785,6 +10792,15 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
+"i18n-iso-countries@npm:^7.14.0":
+  version: 7.14.0
+  resolution: "i18n-iso-countries@npm:7.14.0"
+  dependencies:
+    diacritics: "npm:1.3.0"
+  checksum: 10c0/048efe0c95feb6666a72cb0918d6edcb6a392787b2998eefe7e42d19bf35ac27a02ad61efd64857399d7938dcf3e4c7710f622f7e6c8de9628cb4e4dd5534830
   languageName: node
   linkType: hard
 
@@ -12977,6 +12993,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-prettier: "npm:^5.5.4"
     graphql: "npm:^16.11.0"
+    i18n-iso-countries: "npm:^7.14.0"
     i18next: "npm:^25.4.2"
     i18next-browser-languagedetector: "npm:^8.2.0"
     i18next-resources-to-backend: "npm:^1.2.1"


### PR DESCRIPTION
I decided to this route (adding it to the json) instead of using the library directly in the code for the following reasons (I started with using it in the code directly):

- Much easier to overwrite language names
- saves a bunch of space not shipping the country json (which has so much more data in it)
- The library already [anticipates](https://github.com/michaelwittig/node-i18n-iso-countries?tab=readme-ov-file#installing) the space issue so we would need to have a file that calls `countries.registerLocale(...));` 20 times. We can't do this dynamically because dynamic importing would need async components.
- Much cleaner implementation by using the t function
- This is basically how we do it in rails (library injects something into the translations)