### PR TITLE
Bugfix/helpful queries permission

### DIFF
--- a/app/controllers/admin/persons_controller.rb
+++ b/app/controllers/admin/persons_controller.rb
@@ -49,52 +49,6 @@ module Admin
       )
     end
 
-    def registrations
-      person_wca_id = params.require(:wcaId)
-
-      person = Person.current.find_by!(wca_id: person_wca_id)
-      registrations = person.user.registrations
-                            .joins(:competition)
-                            .merge(Competition.not_over)
-                            .order(start_date: :asc)
-
-      render json: registrations.as_json(
-        only: %w[competing_status],
-        include: {
-          competition: {
-            only: %w[id name city_name country_id start_date],
-            include: [],
-          },
-        },
-      )
-    end
-
-    def organized_competitions
-      person_wca_id = params.require(:wcaId)
-
-      person = Person.current.find_by!(wca_id: person_wca_id)
-      competitions = person.user.organized_competitions
-                           .over.visible.not_cancelled
-                           .order(start_date: :desc)
-
-      render json: competitions.as_json(
-        only: %w[id name city_name country_id start_date],
-      )
-    end
-
-    def delegated_competitions
-      person_wca_id = params.require(:wcaId)
-
-      person = Person.current.find_by!(wca_id: person_wca_id)
-      competitions = person.user.delegated_competitions
-                           .over.visible.not_cancelled
-                           .order(start_date: :desc)
-
-      render json: competitions.as_json(
-        only: %w[id name city_name country_id start_date],
-      )
-    end
-
     private def new_id_params
       params.permit(:name, :competition_id, :semi_id)
     end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -4,8 +4,8 @@ require 'csv'
 
 class AdminController < ApplicationController
   before_action :authenticate_user!
-  before_action -> { redirect_to_root_unless_user(:can_admin_results?) }, except: %i[all_voters leader_senior_voters regional_voters]
-  before_action -> { redirect_to_root_unless_user(:can_see_eligible_voters?) }, only: %i[all_voters leader_senior_voters regional_voters]
+  before_action -> { redirect_to_root_unless_user(:can_admin_results?) }, except: %i[all_voters leader_senior_voters regional_voters registrations organized_competitions delegated_competitions]
+  before_action -> { redirect_to_root_unless_user(:can_see_eligible_voters?) }, only: %i[all_voters leader_senior_voters regional_voters registrations organized_competitions delegated_competitions]
 
   def index
   end

--- a/app/webpacker/components/Panel/pages/HelpfulQueriesPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/HelpfulQueriesPage/index.jsx
@@ -24,19 +24,19 @@ const statusColor = (s) => {
 
 async function fetchRegistrations(wcaId) {
   if (!hasWcaId(wcaId)) return [];
-  const { data } = await fetchJsonOrError(viewUrls.persons.registrations(wcaId));
+  const { data } = await fetchJsonOrError(viewUrls.helpfulQueries.registrations(wcaId));
   return (data || []);
 }
 
 async function fetchOrganized(wcaId) {
   if (!hasWcaId(wcaId)) return [];
-  const { data } = await fetchJsonOrError(viewUrls.persons.organizedCompetitions(wcaId));
+  const { data } = await fetchJsonOrError(viewUrls.helpfulQueries.organizedCompetitions(wcaId));
   return (data || []);
 }
 
 async function fetchDelegated(wcaId) {
   if (!hasWcaId(wcaId)) return [];
-  const { data } = await fetchJsonOrError(viewUrls.persons.delegatedCompetitions(wcaId));
+  const { data } = await fetchJsonOrError(viewUrls.helpfulQueries.delegatedCompetitions(wcaId));
   return (data || []);
 }
 

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -294,9 +294,6 @@ export const viewUrls = {
   },
   persons: {
     results: (wcaId, competitionId, eventId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.person_results_path) %>?${jsonToQueryString({ wcaId, competitionId, eventId })}`,
-    registrations: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.person_registrations_path) %>?${jsonToQueryString({ wcaId })}`,
-    organizedCompetitions: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.person_organized_competitions_path) %>?${jsonToQueryString({ wcaId })}`,
-    delegatedCompetitions: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.person_delegated_competitions_path) %>?${jsonToQueryString({ wcaId })}`,
   },
   cronjob: {
     details: (cronjobName) => `<%= CGI.unescape(Rails.application.routes.url_helpers.panel_cronjob_details_path(cronjob_name: "${cronjobName}")) %>`,
@@ -305,6 +302,11 @@ export const viewUrls = {
     showForEdit: (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.user_show_for_edit_path(id: "${userId}")) %>`,
     showForMerge: (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.user_show_for_merge_path(id: "${userId}")) %>`,
     rolesEditPage: (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_user_path("${userId}"))%>?${jsonToQueryString({ section: "roles" })}`,
+  },
+  helpfulQueries: {
+    registrations: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.helpful_queries_registrations_path) %>?${jsonToQueryString({ wcaId })}`,
+    organizedCompetitions: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.helpful_queries_organized_competitions_path) %>?${jsonToQueryString({ wcaId })}`,
+    delegatedCompetitions: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.helpful_queries_delegated_competitions_path) %>?${jsonToQueryString({ wcaId })}`,
   },
 }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,9 +198,6 @@ Rails.application.routes.draw do
 
   get 'persons/new_id' => 'admin/persons#generate_ids'
   get '/persons/results' => 'admin/persons#results', as: :person_results
-  get '/persons/registrations' => 'admin/persons#registrations', as: :person_registrations
-  get '/persons/organized-competitions' => 'admin/persons#organized_competitions', as: :person_organized_competitions
-  get '/persons/delegated-competitions' => 'admin/persons#delegated_competitions', as: :person_delegated_competitions
   resources :persons, only: %i[index show]
   post 'persons' => 'admin/persons#create'
 
@@ -335,6 +332,9 @@ Rails.application.routes.draw do
   get '/admin/complete_persons' => 'admin#complete_persons'
   post '/admin/complete_persons' => 'admin#do_complete_persons'
   get '/admin/peek_unfinished_results' => 'admin#peek_unfinished_results'
+  get '/admin/registrations' => 'admin#registrations', as: :helpful_queries_registrations
+  get '/admin/organized-competitions' => 'admin#organized_competitions', as: :helpful_queries_organized_competitions
+  get '/admin/delegated-competitions' => 'admin#delegated_competitions', as: :helpful_queries_delegated_competitions
 
   get '/search' => 'search_results#index'
 


### PR DESCRIPTION
I initially put these functions in the admin/person_controller and it works great when **I** am logged in, but only me. Any other WIC member will not get results on any search. This is because everything in the admin/persons_controller is available to users who `can_admin_results?` giving me access as a WRT member, but not any other WIC members.

Just adding these functions to the AdminController's `before_action` (similar to the voter functions available to WIC) worked, but rubocop complained about them not being defined in the class. So I moved them to the admin_controller and changed the routes accordingly.

I've tested these changes locally with my user and multiple other WIC users and it's working for everyone.