### PR TITLE
Fixes related to post results page of tickets

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -269,7 +269,7 @@ class TicketsController < ApplicationController
 
     CompetitionResultsImport.post_results(competition, current_user)
 
-    render status: :ok, json: { success: true }
+    render status: :ok, json: ticket
   end
 
   def events_merged_data

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/FinalSteps.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/FinalSteps.jsx
@@ -4,7 +4,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Loading from '../../../Requests/Loading';
 import Errored from '../../../Requests/Errored';
 import postResults from '../../api/competitionResult/postResults';
-import { ticketsCompetitionResultStatuses } from '../../../../lib/wca-data.js.erb';
 import { viewUrls, competitionAllResultsUrl } from '../../../../lib/requests/routes.js.erb';
 
 export default function FinalSteps({ ticketDetails }) {
@@ -19,21 +18,10 @@ export default function FinalSteps({ ticketDetails }) {
     error,
   } = useMutation({
     mutationFn: postResults,
-    onSuccess: () => {
-      queryClient.setQueryData(
-        ['ticket-details', id],
-        (oldTicketDetails) => ({
-          ...oldTicketDetails,
-          ticket: {
-            ...oldTicketDetails.ticket,
-            metadata: {
-              ...oldTicketDetails.ticket.metadata,
-              status: ticketsCompetitionResultStatuses.posted,
-            },
-          },
-        }),
-      );
-    },
+    onSuccess: (ticket) => queryClient.setQueryData(
+      ['ticket-details', id],
+      (oldTicketDetails) => ({ ...oldTicketDetails, ticket }),
+    ),
   });
 
   if (isPending) return <Loading />;

--- a/lib/competition_results_import.rb
+++ b/lib/competition_results_import.rb
@@ -72,13 +72,13 @@ module CompetitionResultsImport
   end
 
   def self.post_results_error(comp)
-    return t('competitions.messages.computing_auxiliary_data') if ComputeAuxiliaryData.in_progress?
+    I18n.t('competitions.messages.computing_auxiliary_data') if ComputeAuxiliaryData.in_progress?
 
-    return t('competitions.messages.no_results') unless comp.results.any?
+    return I18n.t('competitions.messages.no_results') unless comp.results.any?
 
-    return t('competitions.messages.no_main_event_results', event_name: comp.main_event.name) if comp.main_event && comp.results.where(event_id: comp.main_event_id).empty?
+    return I18n.t('competitions.messages.no_main_event_results', event_name: comp.main_event.name) if comp.main_event && comp.results.where(event_id: comp.main_event_id).empty?
 
-    t('competitions.messages.results_already_posted') if comp.results_posted?
+    I18n.t('competitions.messages.results_already_posted') if comp.results_posted?
   end
 
   def self.post_results(comp, current_user)


### PR DESCRIPTION
Fixing basically two errors:
1. Ticket page going blank on posting - reason is that frontend expects `posted_user` and `results_posted_at`, which was not available. So sending the ticket as response now, so that frontend gets the latest data.
2. During error, there was no `I18n.t`, because of which we wouldn't have known if errors have come (we will know there are some errors, but won't know exact errors, and luckily these are rare errors so this wasn't impacted so far).