### PR TITLE
MPI Backend (clean history)

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -235,28 +235,41 @@ class CompetitionsController < ApplicationController
 
   def connect_payment_integration
     competition = competition_from_params
-    payment_integration = params.require(:payment_integration)
+    payment_integration = params.require(:payment_integration).to_sym
 
     raise ActionController::RoutingError.new('Not Found') unless current_user&.can_manage_competition?(competition)
 
-    if payment_integration == 'paypal' && PaypalInterface.paypal_disabled?
+    if payment_integration == :paypal && PaypalInterface.paypal_disabled?
       flash[:error] = 'PayPal is not yet available in production environments'
-      return redirect_to competitions_payment_setup_path(competition)
+      return redirect_to competition_payment_integration_setup_path(competition)
     end
 
-    connector = CompetitionPaymentIntegration::AVAILABLE_INTEGRATIONS[payment_integration.to_sym].safe_constantize
-    account_reference = connector&.connect_account(params)
+    if CompetitionPaymentIntegration::AVAILABLE_INTEGRATIONS[payment_integration].nil?
+      flash[:error] = "Payment Integration #{payment_integration} not found"
+      return redirect_to competition_payment_integration_setup_path(competition)
+    end
 
-    raise ActionController::RoutingError.new("Payment Integration #{payment_integration} not Found") if account_reference.blank?
+    connector = CompetitionPaymentIntegration::AVAILABLE_INTEGRATIONS[payment_integration].safe_constantize
+    integration_reference = connector&.connect_integration(params)
 
-    competition.competition_payment_integrations.new(connected_account: account_reference)
+    raise ActionController::RoutingError.new("No integration reference submitted") if integration_reference.blank?
+
+    if payment_integration == :manual && competition.manual_payment_details.present?
+      existing_cpi = competition.competition_payment_integrations.first
+
+      # Small hack: We allow de-facto updates by "re-connecting" manual payment in the UI.
+      #   This is done to allow edits to a Manual CPI, but coding a proper `PATCH` form
+      #   would break the mold of the usual OAuth flow with "proper" payment providers.
+      existing_cpi.connected_account.update(**integration_reference.account_details)
+    else
+      competition.competition_payment_integrations.build(connected_account: integration_reference)
+    end
 
     if competition.save
       flash[:success] = t('payments.payment_setup.account_connected', provider: t("payments.payment_providers.#{payment_integration}"))
     else
       flash[:danger] = t('payments.payment_setup.account_not_connected', provider: t("payments.payment_providers.#{payment_integration}"))
     end
-
     redirect_to competition_payment_integration_setup_path(competition)
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -434,7 +434,6 @@ class RegistrationsController < ApplicationController
   end
 
   def payment_completion
-    # Provided by Stripe upon redirect when the "PaymentElement" workflow is completed
     competition_id = params[:competition_id]
     competition = Competition.find(competition_id)
 

--- a/app/models/competition_payment_integration.rb
+++ b/app/models/competition_payment_integration.rb
@@ -9,25 +9,30 @@ class CompetitionPaymentIntegration < ApplicationRecord
   AVAILABLE_INTEGRATIONS = {
     paypal: 'ConnectedPaypalAccount',
     stripe: 'ConnectedStripeAccount',
+    manual: 'ManualPaymentIntegration',
   }.freeze
 
   INTEGRATION_DASHBOARD_URLS = {
     paypal: "https://www.paypal.com/listing/customers",
     stripe: "https://dashboard.stripe.com/account/applications",
+    manual: nil,
   }.freeze
 
   INTEGRATION_CURRENCY_INFORMATION = {
     paypal: "https://developer.paypal.com/docs/reports/reference/paypal-supported-currencies/",
     stripe: "https://docs.stripe.com/currencies#supportedcurrencies",
+    manual: nil,
   }.freeze
 
   INTEGRATION_RECORD_TYPES = {
     paypal: 'PaypalRecord',
     stripe: 'StripeRecord',
+    manual: 'ManualPaymentRecord',
   }.freeze
 
   scope :paypal, -> { where(connected_account_type: AVAILABLE_INTEGRATIONS[:paypal]) }
   scope :stripe, -> { where(connected_account_type: AVAILABLE_INTEGRATIONS[:stripe]) }
+  scope :manual, -> { where(connected_account_type: AVAILABLE_INTEGRATIONS[:manual]) }
 
   def self.validate_integration_name!(integration_name)
     raise ArgumentError.new("Invalid integration name. Allowed values are: #{AVAILABLE_INTEGRATIONS.keys.join(', ')}") unless

--- a/app/models/manual_payment_integration.rb
+++ b/app/models/manual_payment_integration.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class ManualPaymentIntegration < ApplicationRecord
+  has_one :competition_payment_integration, as: :connected_account
+
+  def prepare_intent(registration, amount_iso, currency_iso, paying_user)
+    existing_intent = registration.payment_intents.first
+    if existing_intent.present?
+      existing_intent.payment_record.update(amount_iso_denomination: amount_iso, currency_code: currency_iso)
+      return existing_intent
+    end
+
+    self.create_intent(registration, amount_iso, currency_iso, paying_user)
+  end
+
+  private def create_intent(registration, amount_iso, currency_iso, paying_user)
+    manual_record = ManualPaymentRecord.create(amount_iso_denomination: amount_iso, currency_code: currency_iso, manual_status: :created)
+
+    PaymentIntent.create!(
+      holder: registration,
+      payment_record: manual_record,
+      client_secret: manual_record.id,
+      initiated_by: paying_user,
+      wca_status: manual_record.determine_wca_status,
+    )
+  end
+
+  # def find_payment(record_id)
+  #   ManualPaymentRecord.find(record_id)
+  # end
+
+  def find_payment_from_request(params)
+    # The client secret is just the id of the database model, but we override the payment_reference
+    # from the new one, so we can update it in update_status. This is simulating getting an updated version
+    # from a payment provider after paying
+    ManualPaymentRecord.find(params[:client_secret]).tap do |mpr|
+      mpr.payment_reference = params[:payment_reference]
+      mpr.manual_status = ManualPaymentRecord.manual_statuses[:user_submitted]
+    end
+  end
+
+  def retrieve_payments(payment_intent)
+    yield payment_intent.payment_record
+  end
+
+  def self.generate_onboarding_link(competition_id)
+    Rails.application.routes.url_helpers.competition_manual_payment_setup_url(competition_id)
+  end
+
+  # def account_details
+  #   serializable_hash(only: %i[payment_information payment_reference])
+  # end
+
+  def self.connect_integration(form_params)
+    model_attributes = form_params.permit(:payment_information, :payment_reference)
+
+    # We need to pipe the `payment_information` field through Markdown, because otherwise line breaks are lost :(
+    model_attributes[:payment_information] = Base64.decode64(form_params[:payment_information].to_s).force_encoding("UTF-8")
+
+    ManualPaymentIntegration.new(model_attributes)
+  end
+end

--- a/app/models/manual_payment_record.rb
+++ b/app/models/manual_payment_record.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class ManualPaymentRecord < ApplicationRecord
+  WCA_TO_MANUAL_PAYMENT_STATUS_MAP = {
+    created: %w[created],
+    pending: %w[],
+    processing: %w[],
+    requires_capture: %w[user_submitted],
+    partial: %w[],
+    failed: %w[],
+    succeeded: %w[organizer_approved],
+    canceled: %w[],
+  }.freeze
+
+  enum :manual_status, {
+    created: 'created',
+    user_submitted: 'user_submitted',
+    organizer_approved: 'organizer_approved',
+  }
+
+  has_one :registration_payment, as: :receipt
+  has_one :payment_intent, as: :payment_record
+
+  def determine_wca_status
+    WCA_TO_MANUAL_PAYMENT_STATUS_MAP.find { |_key, values| values.include?(self.manual_status) }.first
+  end
+
+  def retrieve_remote
+    self
+  end
+
+  def retrieve_payments
+    self
+  end
+
+  def money_amount
+    Money.new(self.amount_iso_denomination, self.currency_code)
+  end
+
+  def update_status(updated_record)
+    update(payment_reference: updated_record.payment_reference, manual_status: updated_record.manual_status)
+  end
+end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -215,11 +215,13 @@ class Registration < ApplicationRecord
     user_id
   )
     add_history_entry({ payment_status: receipt.determine_wca_status, iso_amount: amount_lowest_denomination }, "user", user_id, 'Payment')
+
     registration_payments.create!(
       amount_lowest_denomination: amount_lowest_denomination,
       currency_code: currency_code,
       receipt: receipt,
       user_id: user_id,
+      is_completed: receipt.try(:manual_status) != 'user_submitted',
     )
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2277,6 +2277,7 @@ en:
     payment_providers:
       paypal: 'PayPal'
       stripe: 'Stripe'
+      manual: 'Manual/External'
     #context: Setting up and making payments
     payment_setup:
       external_dashboard: '%{provider} Dashboard'
@@ -2290,13 +2291,15 @@ en:
       supported_currencies: "%{provider} Supported Currencies"
       provider_heading: "%{provider} Payments"
       accept_payments_header: "Accept Registration Payments"
-      connect_button: "Connect with %{provider}"
+      connect_button: "Set up %{provider}"
       connect_account_info:
         stripe: "In order to accept payments for this competition, you need to connect your own Stripe account with the WCA Stripe account by clicking the button below. If you don't already have your own Stripe account you can still click on the button below and it will guide you through the process."
         paypal: "A PayPal Business account is required to accept PayPal payments via the competition page. If you don't already have a PayPal business account, you can still click on the button below and it will guide you through the process."
+        manual: "Define payment instructions for competitors. Competitors will be able to indicate when they have paid, and provide a payment reference for you to check against your records in the external payment service you use."
       connect_account_warning:
         stripe: "Connecting your Stripe account gives the WCA website the ability to create charges, and issue refunds directly on your Stripe account."
         paypal: "Connecting your PayPal account gives the WCA website the ability to route payments to you, and issue refunds directly on your PayPal account."
+        manual:  ""
       currently_connected_info: "This competition is set up to accept payments through %{provider}. The Delegate(s) of the competition should contact WCAT to make any changes to connected accounts."
       before_disconnect_warning: "Disconnecting on this page will make our website forget the connection to your %{provider} account. But your %{provider} dashboard (see link below) may still list the WCA website based on the authorization that you previously granted. Note that revoking authorization in the %{provider} dashboard will also affect any other competition linked to accept payments through this account!"
       before_disconnect_info: "Keep in mind that disconnecting an account should only be done in exceptional situations, such as the current account being unable to receive payments."
@@ -2308,6 +2311,9 @@ en:
         paypal:
           display_name: "Name"
           primary_email: "Email"
+        manual:
+          payment_info: "Payment instructions (will be displayed on Competition Page)"
+          payment_reference: "What information should the user provide for you to identify their payment? (eg, payment reference number / account ID / etc)"
         fallback_not_applicable: "N/A"
   persons:
     #context: Person search page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,7 @@ Rails.application.routes.draw do
     get '/admin/scrambles/:round_id/new' => 'admin/scrambles#new', as: :new_scramble
 
     get '/payment_integration/setup' => 'competitions#payment_integration_setup', as: :payment_integration_setup
+    get '/payment_integration/setup/manual' => 'competitions#payment_integration_manual_setup', as: :manual_payment_setup
     get '/payment_integration/:payment_integration/connect' => 'competitions#connect_payment_integration', as: :connect_payment_integration
     post '/payment_integration/:payment_integration/disconnect' => 'competitions#disconnect_payment_integration', as: :disconnect_payment_integration
   end

--- a/db/migrate/20250804070122_add_manual_cpi_tables.rb
+++ b/db/migrate/20250804070122_add_manual_cpi_tables.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddManualCpiTables < ActiveRecord::Migration[7.2]
+  def change
+    create_table :manual_payment_integrations do |t|
+      t.string :payment_reference, null: false
+      t.text :payment_information, null: false
+      t.timestamps
+    end
+
+    create_table :manual_payment_records do |t|
+      t.string :payment_reference
+      t.string :manual_status, null: false
+      t.integer :amount_iso_denomination, null: false
+      t.string :currency_code, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -793,6 +793,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_075341) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "manual_payment_integrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "payment_reference", null: false
+    t.text "payment_information", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "manual_payment_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "payment_reference"
+    t.string "manual_status", null: false
+    t.integer "amount_iso_denomination", null: false
+    t.string "currency_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "oauth_access_grants", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
@@ -1215,7 +1231,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_075341) do
   end
 
   create_table "schedule_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "venue_room_id", null: false
+    t.bigint "venue_room_id"
     t.bigint "parent_activity_id"
     t.integer "wcif_id", null: false
     t.string "name", null: false

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -175,6 +175,7 @@ module DatabaseDumper
     }.freeze,
     "connected_paypal_accounts" => :skip_all_rows,
     "connected_stripe_accounts" => :skip_all_rows,
+    "manual_payment_integrations" => :skip_all_rows,
     "continents" => {
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w[
@@ -856,6 +857,7 @@ module DatabaseDumper
     }.freeze,
     "paypal_records" => :skip_all_rows,
     "stripe_records" => :skip_all_rows,
+    "manual_payment_records" => :skip_all_rows,
     "payment_intents" => :skip_all_rows,
     "stripe_webhook_events" => :skip_all_rows,
     "uploaded_jsons" => :skip_all_rows,

--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -293,6 +293,7 @@ FactoryBot.define do
     end
 
     trait :registration_open do
+      # visible
       starts { 1.month.from_now }
       ends { starts }
       registration_open { 2.weeks.ago.change(usec: 0) }
@@ -370,6 +371,12 @@ FactoryBot.define do
     trait :paypal_connected do
       transient do
         paypal_merchant_id { '95XC2UKUP2CFW' }
+      end
+    end
+
+    trait :manual_payments do
+      transient do
+        manual_payment_reference { 'Manual payment instructions' }
       end
     end
 
@@ -579,6 +586,14 @@ FactoryBot.define do
           consent_status: "test",
         )
         competition.competition_payment_integrations.new(connected_account: paypal_account)
+        competition.save
+      end
+
+      if defined?(evaluator.manual_payment_reference)
+        manual_payment_account = ManualPaymentIntegration.new(
+          payment_information: evaluator.manual_payment_reference, payment_reference: "test reference",
+        )
+        competition.competition_payment_integrations.new(connected_account: manual_payment_account)
         competition.save
       end
     end

--- a/spec/factories/manual_payment_records.rb
+++ b/spec/factories/manual_payment_records.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :manual_payment_record do
+    payment_reference { nil }
+    manual_status { 'created' }
+    amount_iso_denomination { 1000 }
+    currency_code { 'USD' }
+  end
+end

--- a/spec/factories/payment_intents.rb
+++ b/spec/factories/payment_intents.rb
@@ -7,6 +7,11 @@ FactoryBot.define do
     initiated_by { association(:user) }
     wca_status { 'pending' }
 
+    trait :manual do
+      payment_record { association(:manual_payment_record) }
+      wca_status { 'created' }
+    end
+
     trait :canceled do
       canceled_at { DateTime.now }
       wca_status { 'canceled' }

--- a/spec/models/manual_payment_integration_spec.rb
+++ b/spec/models/manual_payment_integration_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManualPaymentIntegration do
+  describe '#prepare_intent' do
+    let(:competition) { create(:competition, :manual_payments) }
+    let(:registration) { create(:registration, competition: competition) }
+    let(:payment_account) { competition.payment_account_for(:manual) }
+
+    before do
+      payment_account.prepare_intent(registration, 1000, "USD", registration.user)
+      @payment_intent = PaymentIntent.first
+      @payment_record = @payment_intent.payment_record
+    end
+
+    it 'creates a PaymentIntent' do
+      expect(@payment_intent.initiated_by).to eq(registration.user)
+    end
+
+    it 'creates a ManualPaymentRecord' do
+      expect(@payment_record).to be_present
+    end
+  end
+end

--- a/spec/models/manual_payment_record_spec.rb
+++ b/spec/models/manual_payment_record_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManualPaymentRecord do
+  describe 'status mappings' do
+    it 'contains all wca_statuses' do
+      expect(ManualPaymentRecord::WCA_TO_MANUAL_PAYMENT_STATUS_MAP.keys.sort.map(&:to_s)).to eq(PaymentIntent.wca_statuses.values.sort)
+    end
+
+    it 'contains all manual_statuses' do
+      expect(ManualPaymentRecord.manual_statuses.keys.sort).to eq(ManualPaymentRecord::WCA_TO_MANUAL_PAYMENT_STATUS_MAP.values.flatten.sort)
+    end
+  end
+end

--- a/spec/requests/competitions_spec.rb
+++ b/spec/requests/competitions_spec.rb
@@ -463,6 +463,42 @@ RSpec.describe "competitions" do
         end
       end
     end
+
+    describe "GET #connect_payment_integration" do
+      before do
+        sign_in competition.delegates.first
+      end
+
+      it 'rejects an invalid payment integration type' do
+        get competition_connect_payment_integration_path(competition, 'invalid')
+        expect(response).not_to be_successful
+      end
+
+      context 'connecting a manual integration' do
+        let(:unencoded_payment_information) { 'example instructions' }
+        let(:manual_payment_reference) { 'test ref' }
+
+        before do
+          get competition_connect_payment_integration_path(competition, 'manual'), params: {
+            payment_information: "ZXhhbXBsZSBpbnN0cnVjdGlvbnM", payment_reference: "test ref"
+          }
+        end
+
+        it 'returns redirects to confirmation page response' do
+          expect(response).to redirect_to(competition_payment_integration_setup_path(competition))
+        end
+
+        it 'creates a connected_payment_integration record' do
+          expect(ManualPaymentIntegration.count).to eq(1)
+        end
+
+        it 'populates the integration with the submitted data' do
+          integration = ManualPaymentIntegration.first
+          expect(integration.payment_information).to eq(unencoded_payment_information)
+          expect(integration.payment_reference).to eq(manual_payment_reference)
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This PR is a replacement for #12159 - due to merging instead of rebasing, the commit history there is beyond redemption in a reasonable timeframe, but if any specific commits are needed they can be accessed there. 