### PR TITLE
Allow tests to run on non-main branch

### DIFF
--- a/.github/workflows/ruby-test.yml
+++ b/.github/workflows/ruby-test.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches:
+      - '**'
 
 jobs:
   test:


### PR DESCRIPTION
In cases of sequential PR's, this will let us create PR's that have diffs to their "parent" PR's and still have tests run on them - mostly useful in the context of contributors creating PRs in their own forks