### PR TITLE
Add preview functionality for the Homepage

### DIFF
--- a/next-frontend/.env.sample
+++ b/next-frontend/.env.sample
@@ -1,4 +1,5 @@
 AUTH_SECRET="amazing-authjs.secret" # Add by executing `npx auth`. Read more: https://cli.authjs.dev
+PREVIEW_SECRET="amazing-preview.secret"
 OIDC_ISSUER=http://wca_on_rails:3000 # Usually your local (Docker-internal!) Rails root URL
 OIDC_CLIENT_ID=create-your-own-oauth # Create an OAuth application in the monolith with (at least!) `public`, `oidc`, `profile` and `email` scopes
 OIDC_CLIENT_SECRET=create-your-own-oauth # See above

--- a/next-frontend/docker-entrypoint.sh
+++ b/next-frontend/docker-entrypoint.sh
@@ -6,12 +6,14 @@ AUTH_SECRET=$(vault read -field=data -format=json kv/data/"$VAULT_APPLICATION"/A
 OIDC_CLIENT_ID=$(vault read -field=data -format=json kv/data/"$VAULT_APPLICATION"/OIDC_CLIENT_ID | jq -r '.value')
 OIDC_CLIENT_SECRET=$(vault read -field=data -format=json kv/data/"$VAULT_APPLICATION"/OIDC_CLIENT_SECRET | jq -r '.value')
 PAYLOAD_SECRET=$(vault read -field=data -format=json kv/data/"$VAULT_APPLICATION"/PAYLOAD_SECRET | jq -r '.value')
+PREVIEW_SECRET=$(vault read -field=data -format=json kv/data/"$VAULT_APPLICATION"/PREVIEW_SECRET | jq -r '.value')
 NEW_RELIC_LICENSE_KEY=$(vault read -field=data -format=json kv/data/"$VAULT_APPLICATION"/NEW_RELIC_LICENSE_KEY | jq -r '.value')
 
 export AUTH_SECRET
 export OIDC_CLIENT_ID
 export OIDC_CLIENT_SECRET
 export PAYLOAD_SECRET
+export PREVIEW_SECRET
 export NEW_RELIC_LICENSE_KEY
 
 exec node server.js

--- a/next-frontend/src/app/(payload)/api/payload/draft/route.ts
+++ b/next-frontend/src/app/(payload)/api/payload/draft/route.ts
@@ -1,0 +1,74 @@
+import type { CollectionSlug, PayloadRequest } from 'payload'
+import { getPayload } from 'payload'
+
+import { draftMode } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import configPromise from '@payload-config'
+
+export async function GET(
+  req: {
+    cookies: {
+      get: (name: string) => {
+        value: string
+      }
+    }
+  } & Request,
+): Promise<Response> {
+  const payload = await getPayload({ config: configPromise })
+
+  const { searchParams } = new URL(req.url)
+
+  const path = searchParams.get('path')
+  const previewSecret = searchParams.get('previewSecret')
+
+  if (previewSecret !== process.env.PREVIEW_SECRET!) {
+    return new Response('You are not allowed to preview this page', {
+      status: 403,
+    })
+  }
+
+  if (!path) {
+    return new Response('Insufficient search params', { status: 404 })
+  }
+
+  if (!path.startsWith('/')) {
+    return new Response(
+      'This endpoint can only be used for relative previews',
+      { status: 500 },
+    )
+  }
+
+  let user
+
+  try {
+    user = await payload.auth({
+      req: req as unknown as PayloadRequest,
+      headers: req.headers,
+    })
+  } catch (error) {
+    payload.logger.error(
+      { err: error },
+      'Error verifying token for live preview',
+    )
+    return new Response('You are not allowed to preview this page', {
+      status: 403,
+    })
+  }
+
+  const draft = await draftMode()
+
+  if (!user) {
+    draft.disable()
+    return new Response('You are not allowed to preview this page', {
+      status: 403,
+    })
+  }
+
+  // You can add additional checks here to see if the user is allowed to preview this page
+  // We probably don't need to do that because we only allow certain users to use payload?
+
+  draft.enable()
+
+  redirect(path)
+}

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -49,6 +49,7 @@ import type {
 import Link from "next/link";
 import { route } from "nextjs-routes";
 import { getT } from "@/lib/i18n/get18n";
+import { draftMode } from "next/headers";
 
 const TextCard = ({ block }: { block: TextCardBlock }) => {
   return (
@@ -485,7 +486,11 @@ const renderFullBlock = (entry: FullWidthBlock, keyPrefix = "") => {
 
 export default async function Homepage() {
   const payload = await getPayload({ config });
-  const homepage = await payload.findGlobal({ slug: "home" });
+  const { isEnabled: isDraftMode } = await draftMode();
+  const homepage = await payload.findGlobal({
+    slug: "home",
+    draft: isDraftMode,
+  });
 
   const homepageEntries = homepage?.item || [];
 

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -344,9 +344,20 @@ export const Home: GlobalConfig = {
       minRows: 1,
     },
   ],
+  versions: {
+    drafts: {
+      autosave: true,
+    },
+    max: 5,
+  },
   admin: {
-    livePreview: {
-      url: "/",
+    preview: () => {
+      const encodedParams = new URLSearchParams({
+        path: `/`,
+        previewSecret: process.env.PREVIEW_SECRET!,
+      });
+
+      return `/api/payload/draft?${encodedParams.toString()}`;
     },
   },
 };

--- a/next-frontend/src/types/nextjs-routes.d.ts
+++ b/next-frontend/src/types/nextjs-routes.d.ts
@@ -15,6 +15,7 @@ declare module "nextjs-routes" {
     | StaticRoute<"/about">
     | DynamicRoute<"/api/auth/[...nextauth]", { "nextauth": string[] }>
     | DynamicRoute<"/api/payload/[...slug]", { "slug": string[] }>
+    | StaticRoute<"/api/payload/draft">
     | StaticRoute<"/api/payload/graphql">
     | StaticRoute<"/api/payload/graphql-playground">
     | StaticRoute<"/competitions">

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -799,6 +799,7 @@ export interface Nav {
 export interface Home {
   id: number;
   item: (TwoBlocksBlock | FullWidthBlock)[];
+  _status?: ('draft' | 'published') | null;
   updatedAt?: string | null;
   createdAt?: string | null;
 }
@@ -1336,6 +1337,7 @@ export interface HomeSelect<T extends boolean = true> {
         twoBlocks?: T | TwoBlocksBlockSelect<T>;
         fullWidth?: T | FullWidthBlockSelect<T>;
       };
+  _status?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;


### PR DESCRIPTION
While we had
```
livePreview: {
      url: "/",
}
```
set, that actually didn't do anything. It just showed the current Version of the page.

To really introduce Previews, you have to activate [drafts through versioning](https://payloadcms.com/docs/versions/overview#versions-enabled-drafts-disabled) and then set up [draft mode](https://nextjs.org/docs/app/guides/draft-mode) via an API.

I have only activated it for the Home Page so far, but I think every global page could make use of it.

Note: this will most likely break the sqlite database for developers due to changes in the schema (can be reset using `payload migrate:fresh`). I really think we should be switching to mongodb locally and offer a payload import to work with.