### PR TITLE
Update Lambda runtime to Ruby 3.4

### DIFF
--- a/infra/wca_on_rails/lambda/Gemfile
+++ b/infra/wca_on_rails/lambda/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '3.3.7'
+ruby '3.4.6'
 
 gem 'aws-sdk-sqs'
 gem 'superconfig'

--- a/infra/wca_on_rails/main.tf
+++ b/infra/wca_on_rails/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.72.1"
+      version = ">= 6.14.1"
     }
   }
 

--- a/infra/wca_on_rails/production/lambda.tf
+++ b/infra/wca_on_rails/production/lambda.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "registration_status_lambda" {
   function_name    = "${var.name_prefix}-poller-lambda"
   role             = aws_iam_role.lambda_role.arn
   handler          = "processing_status.lambda_handler"
-  runtime          = "ruby3.3"
+  runtime          = "ruby3.4"
   source_code_hash = filebase64sha256("./lambda/processing_status.zip")
   vpc_config {
     security_group_ids = [var.shared.cluster_security.id]

--- a/infra/wca_on_rails/staging/lambda.tf
+++ b/infra/wca_on_rails/staging/lambda.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "registration_status_lambda" {
   function_name    = "${var.name_prefix}-poller-lambda"
   role             = aws_iam_role.lambda_role.arn
   handler          = "processing_status.lambda_handler"
-  runtime          = "ruby3.3"
+  runtime          = "ruby3.4"
   source_code_hash = filebase64sha256("./lambda/processing_status.zip")
   vpc_config {
     security_group_ids = [var.shared.cluster_security.id]


### PR DESCRIPTION
Now officially supported by AWS!

(Kinda depends on https://github.com/thewca/worldcubeassociation.org/pull/12487. Not technically, but at least conceptually)