### PR TITLE
Fix AA routine for competitions without waiting list

### DIFF
--- a/app/models/concerns/waitlistable.rb
+++ b/app/models/concerns/waitlistable.rb
@@ -6,7 +6,7 @@ module Waitlistable
   extend ActiveSupport::Concern
 
   included do
-    delegate :empty?, :length, to: :waiting_list, prefix: true
+    delegate :empty?, :blank?, :length, to: :waiting_list, prefix: true
     delegate :present?, :persisted?, to: :waiting_list, prefix: true, allow_nil: true
 
     attr_accessor :tracked_waitlist_position

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -639,7 +639,10 @@ class Registration < ApplicationRecord
     when Registrations::Helper::STATUS_WAITING_LIST
       waiting_list_leader?
     when Registrations::Helper::STATUS_PENDING
-      waiting_list.empty?
+      # The Rails shorthand `blank?` specifically checks "nil or empty". This is exactly what we need because:
+      #   - Either a competition has no waiting list at all, in which case a pending registration can be accepted
+      #   - Or the waiting list exists and is empty, in which case a pending registration can proceed to accepted
+      waiting_list_blank?
     else
       false
     end

--- a/app/models/waiting_list.rb
+++ b/app/models/waiting_list.rb
@@ -3,7 +3,7 @@
 class WaitingList < ApplicationRecord
   belongs_to :holder, polymorphic: true
 
-  delegate :empty?, :length, to: :entries
+  delegate :empty?, :blank?, :length, to: :entries
 
   def remove(entry)
     return unless entries.include?(entry.id)


### PR DESCRIPTION
We got some error reports with stack traces pointing to the `case` of "pending" in `eligible_for_accepted_status?`. Investigation revealed that it checks `waiting_list.empty?` without even considering whether there exists a waiting list in the first place.