### PR TITLE
Remove manual AuthJs endpoint rerouting hack

### DIFF
--- a/next-frontend/src/app/(authjs)/api/auth/[...nextauth]/route.ts
+++ b/next-frontend/src/app/(authjs)/api/auth/[...nextauth]/route.ts
@@ -1,25 +1,3 @@
 import { handlers } from "@/auth";
-import { handlers as payloadHandlers } from "@/payload.auth";
-import { NextRequest } from "next/server";
-import { WCA_CMS_PROVIDER_ID } from "@/auth.config";
 
-type HttpVerb = "GET" | "POST";
-
-const wrapRouteHandler =
-  (verb: HttpVerb) =>
-  async (
-    req: NextRequest,
-    { params }: { params: Promise<{ nextauth: string[] }> },
-  ) => {
-    const nextauthParams = await params;
-    const providerId = nextauthParams.nextauth[1];
-
-    if (providerId === WCA_CMS_PROVIDER_ID) {
-      return payloadHandlers[verb](req);
-    }
-
-    return handlers[verb](req);
-  };
-
-export const GET = wrapRouteHandler("GET");
-export const POST = wrapRouteHandler("POST");
+export const { GET, POST } = handlers;

--- a/next-frontend/src/app/(authjs)/api/auth/payload/[...nextauth]/route.ts
+++ b/next-frontend/src/app/(authjs)/api/auth/payload/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/payload.auth";
+
+export const { GET, POST } = handlers;

--- a/next-frontend/src/app/(payload)/payload/importMap.js
+++ b/next-frontend/src/app/(payload)/payload/importMap.js
@@ -23,6 +23,7 @@ import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { AccountRowLabel as AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
 import { SignInButton as SignInButton_06d0cb594d8f6ba2ac35015f930c882e } from 'payload-authjs/components'
+import { SessionProvider as SessionProvider_eb65d9ad4ff5e9757fd28d232b1c2581 } from 'next-auth/react'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 
 export const importMap = {
@@ -51,5 +52,6 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "payload-authjs/components#AccountRowLabel": AccountRowLabel_06d0cb594d8f6ba2ac35015f930c882e,
   "payload-authjs/components#SignInButton": SignInButton_06d0cb594d8f6ba2ac35015f930c882e,
+  "next-auth/react#SessionProvider": SessionProvider_eb65d9ad4ff5e9757fd28d232b1c2581,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24
 }

--- a/next-frontend/src/auth.config.ts
+++ b/next-frontend/src/auth.config.ts
@@ -40,7 +40,7 @@ const cmsWcaProvider: Provider = {
 
 export const authConfig: NextAuthConfig = {
   secret: process.env.AUTH_SECRET,
-  providers: [baseWcaProvider, cmsWcaProvider],
+  providers: [baseWcaProvider],
   callbacks: {
     async jwt({ token, account }) {
       if (account) {
@@ -72,4 +72,16 @@ export const authConfig: NextAuthConfig = {
 export const payloadAuthConfig: NextAuthConfig = {
   ...authConfig,
   providers: [cmsWcaProvider],
+  basePath: "/api/auth/payload",
+  cookies: {
+    sessionToken: {
+      name: "authjs.admin.session-token",
+    },
+    csrfToken: {
+      name: "authjs.admin.csrf-token",
+    },
+    callbackUrl: {
+      name: "authjs.admin.callback-url",
+    },
+  },
 };

--- a/next-frontend/src/payload.auth.ts
+++ b/next-frontend/src/payload.auth.ts
@@ -10,7 +10,7 @@ declare module "@auth/core/types" {
   interface User extends PayloadAuthjsUser<PayloadUser> {}
 }
 
-export const { handlers, signIn, signOut, auth } = NextAuth(
+export const { handlers } = NextAuth(
   withPayload(payloadAuthConfig, {
     payloadConfig,
     events: {

--- a/next-frontend/src/types/nextjs-routes.d.ts
+++ b/next-frontend/src/types/nextjs-routes.d.ts
@@ -14,6 +14,7 @@ declare module "nextjs-routes" {
     | StaticRoute<"/">
     | StaticRoute<"/about">
     | DynamicRoute<"/api/auth/[...nextauth]", { "nextauth": string[] }>
+    | DynamicRoute<"/api/auth/payload/[...nextauth]", { "nextauth": string[] }>
     | DynamicRoute<"/api/payload/[...slug]", { "slug": string[] }>
     | StaticRoute<"/api/payload/graphql">
     | StaticRoute<"/api/payload/graphql-playground">


### PR DESCRIPTION
This gets rid of the manual rerouting that was part of #11781 and "properly" separates the two auth providers into two fully separate auth endpoints with separate cookies and all.

For reference, this would have been the "proper" way to do things all along, but there was a bug/oversight in the AuthJs-Payload bridge that prevented us from using this feature. Now thanks to the 0.8.4 release, we are good to go.