### PR TITLE
Rerun payload:types after switching to local mongo

### DIFF
--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -238,7 +238,7 @@ export interface Config {
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
   };
   db: {
-    defaultIDType: number;
+    defaultIDType: string;
   };
   globals: {
     nav: Nav;
@@ -323,7 +323,7 @@ export interface UserAuthOperations {
  * via the `definition` "media".
  */
 export interface Media {
-  id: number;
+  id: string;
   alt: string;
   customLink?: string | null;
   updatedAt: string;
@@ -343,8 +343,8 @@ export interface Media {
  * via the `definition` "testimonials".
  */
 export interface Testimonial {
-  id: number;
-  image?: (number | null) | Media;
+  id: string;
+  image?: (string | null) | Media;
   punchline: string;
   fullTestimonial: {
     root: {
@@ -371,8 +371,8 @@ export interface Testimonial {
  * via the `definition` "announcements".
  */
 export interface Announcement {
-  id: number;
-  image?: (number | null) | Media;
+  id: string;
+  image?: (string | null) | Media;
   title: string;
   content: {
     root: {
@@ -422,11 +422,11 @@ export interface User {
  * via the `definition` "faqCategories".
  */
 export interface FaqCategory {
-  id: number;
+  id: string;
   title: string;
   colorPalette: ColorPaletteSelect;
   relatedQuestions?: {
-    docs?: (number | FaqQuestion)[];
+    docs?: (string | FaqQuestion)[];
     hasNextPage?: boolean;
     totalDocs?: number;
   };
@@ -438,8 +438,8 @@ export interface FaqCategory {
  * via the `definition` "faqQuestions".
  */
 export interface FaqQuestion {
-  id: number;
-  category: number | FaqCategory;
+  id: string;
+  category: string | FaqCategory;
   question: string;
   answer: string;
   updatedAt: string;
@@ -450,7 +450,7 @@ export interface FaqQuestion {
  * via the `definition` "documents".
  */
 export interface Document {
-  id: number;
+  id: string;
   title: string;
   icon: IconName;
   link: string;
@@ -466,7 +466,7 @@ export interface Document {
  * via the `definition` "regulationsHistoryItem".
  */
 export interface RegulationsHistoryItem {
-  id: number;
+  id: string;
   version: string;
   url: string;
   changesUrl?: string | null;
@@ -479,7 +479,7 @@ export interface RegulationsHistoryItem {
  * via the `definition` "tools".
  */
 export interface Tool {
-  id: number;
+  id: string;
   name: string;
   description: string;
   homepageLink: string;
@@ -496,27 +496,27 @@ export interface Tool {
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
-  id: number;
+  id: string;
   document?:
     | ({
         relationTo: 'media';
-        value: number | Media;
+        value: string | Media;
       } | null)
     | ({
         relationTo: 'testimonials';
-        value: number | Testimonial;
+        value: string | Testimonial;
       } | null)
     | ({
         relationTo: 'announcements';
-        value: number | Announcement;
+        value: string | Announcement;
       } | null)
     | ({
         relationTo: 'faqCategories';
-        value: number | FaqCategory;
+        value: string | FaqCategory;
       } | null)
     | ({
         relationTo: 'faqQuestions';
-        value: number | FaqQuestion;
+        value: string | FaqQuestion;
       } | null)
     | ({
         relationTo: 'users';
@@ -524,15 +524,15 @@ export interface PayloadLockedDocument {
       } | null)
     | ({
         relationTo: 'documents';
-        value: number | Document;
+        value: string | Document;
       } | null)
     | ({
         relationTo: 'regulationsHistoryItem';
-        value: number | RegulationsHistoryItem;
+        value: string | RegulationsHistoryItem;
       } | null)
     | ({
         relationTo: 'tools';
-        value: number | Tool;
+        value: string | Tool;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -547,7 +547,7 @@ export interface PayloadLockedDocument {
  * via the `definition` "payload-preferences".
  */
 export interface PayloadPreference {
-  id: number;
+  id: string;
   user: {
     relationTo: 'users';
     value: string | User;
@@ -570,7 +570,7 @@ export interface PayloadPreference {
  * via the `definition` "payload-migrations".
  */
 export interface PayloadMigration {
-  id: number;
+  id: string;
   name?: string | null;
   batch?: number | null;
   updatedAt: string;
@@ -743,7 +743,7 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
  * via the `definition` "nav".
  */
 export interface Nav {
-  id: number;
+  id: string;
   entry: (
     | {
         title: string;
@@ -799,7 +799,7 @@ export interface Nav {
  * via the `definition` "home".
  */
 export interface Home {
-  id: number;
+  id: string;
   item: (TwoBlocksBlock | FullWidthBlock)[];
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -850,7 +850,7 @@ export interface TextCardBlock {
   separatorAfterHeading: boolean;
   buttonText?: string | null;
   buttonLink?: string | null;
-  headerImage?: (number | null) | Media;
+  headerImage?: (string | null) | Media;
   colorPalette: ColorPaletteSelect;
   id?: string | null;
   blockName?: string | null;
@@ -861,8 +861,8 @@ export interface TextCardBlock {
  * via the `definition` "AnnouncementsSectionBlock".
  */
 export interface AnnouncementsSectionBlock {
-  mainAnnouncement: number | Announcement;
-  furtherAnnouncements?: (number | Announcement)[] | null;
+  mainAnnouncement: string | Announcement;
+  furtherAnnouncements?: (string | Announcement)[] | null;
   colorPalette: ColorPaletteSelect;
   id?: string | null;
   blockName?: string | null;
@@ -890,14 +890,14 @@ export interface ImageBannerBlock {
     [k: string]: unknown;
   };
   bodyMarkdown?: string | null;
-  mainImage: number | Media;
+  mainImage: string | Media;
   colorPalette: ColorPaletteSelect;
   /**
    * Use a slightly darker nuance of the color palette
    */
   colorPaletteDarker?: boolean | null;
   headingColor?: ColorPaletteSelect;
-  bgImage?: (number | null) | Media;
+  bgImage?: (string | null) | Media;
   /**
    * The size of the background image in percent (%)
    */
@@ -912,7 +912,7 @@ export interface ImageBannerBlock {
  * via the `definition` "ImageOnlyCardBlock".
  */
 export interface ImageOnlyCardBlock {
-  mainImage: number | Media;
+  mainImage: string | Media;
   heading?: string | null;
   colorPalette: ColorPaletteSelect;
   id?: string | null;
@@ -925,7 +925,7 @@ export interface ImageOnlyCardBlock {
  */
 export interface TestimonialsBlock {
   slides: {
-    testimonial: number | Testimonial;
+    testimonial: string | Testimonial;
     colorPalette: ColorPaletteSelect;
     id?: string | null;
   }[];
@@ -1010,7 +1010,7 @@ export interface FullWidthBlock {
  * via the `definition` "about-us-page".
  */
 export interface AboutUsPage {
-  id: number;
+  id: string;
   blocks: (
     | {
         content: {
@@ -1040,7 +1040,7 @@ export interface AboutUsPage {
       }
     | {
         title: string;
-        image?: (number | null) | Media;
+        image?: (string | null) | Media;
         content: {
           root: {
             type: string;
@@ -1092,7 +1092,7 @@ export interface AboutUsPage {
  * via the `definition` "privacy-page".
  */
 export interface PrivacyPage {
-  id: number;
+  id: string;
   preamble: {
     root: {
       type: string;
@@ -1139,7 +1139,7 @@ export interface PrivacyPage {
  * via the `definition` "disclaimer-page".
  */
 export interface DisclaimerPage {
-  id: number;
+  id: string;
   blocks: {
     title?: string | null;
     content: {
@@ -1170,7 +1170,7 @@ export interface DisclaimerPage {
  * via the `definition` "speedcubing-history-page".
  */
 export interface SpeedcubingHistoryPage {
-  id: number;
+  id: string;
   blocks: (
     | {
         content: {
@@ -1195,7 +1195,7 @@ export interface SpeedcubingHistoryPage {
       }
     | {
         caption: string;
-        image: number | Media;
+        image: string | Media;
         id?: string | null;
         blockName?: string | null;
         blockType: 'captionedImage';
@@ -1231,7 +1231,7 @@ export interface SpeedcubingHistoryPage {
  * via the `definition` "about-regulations-page".
  */
 export interface AboutRegulationsPage {
-  id: number;
+  id: string;
   blocks: {
     title: string;
     content: {


### PR DESCRIPTION
Seems to be that mongo uses string ids and not numbers. Good that we haven't used that field yet, would have been a pain to debug in prod