### PR TITLE
Improve registration event diff

### DIFF
--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -59,6 +59,17 @@ const potentialWarnings = (competitionInfo) => {
   return warnings;
 };
 
+function getUpdateMessage(
+  hasCommentChanged,
+  comment,
+  hasEventsChanged,
+  selectedEventIds,
+  hasGuestsChanged,
+  guests,
+) {
+  return `\n${hasCommentChanged ? `Comment: ${comment}\n` : ''}${hasEventsChanged ? `Events: ${selectedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''}${hasGuestsChanged ? `Guests: ${guests}\n` : ''}`;
+}
+
 export default function CompetingStep({
   competitionInfo,
   user,
@@ -218,7 +229,14 @@ export default function CompetingStep({
           },
         });
       } else {
-        const updateMessage = getUpdateMessage(hasCommentChanged, comment, hasEventsChanged, selectedEventIds, hasGuestsChanged, guests);
+        const updateMessage = getUpdateMessage(
+          hasCommentChanged,
+          comment,
+          hasEventsChanged,
+          selectedEventIds.asArray,
+          hasGuestsChanged,
+          guests,
+        );
         window.location = contactCompetitionUrl(competitionInfo.id, encodeURIComponent(I18n.t('competitions.registration_v2.update.update_contact_message', { update_params: updateMessage })));
       }
     }).catch(() => {
@@ -458,8 +476,4 @@ export default function CompetingStep({
       </Form>
     </Segment>
   );
-}
-
-const getUpdateMessage = (hasCommentChanged, comment, hasEventsChanged, selectedEventIds, hasGuestsChanged, guests) => {
-  return `\n${hasCommentChanged ? `Comment: ${comment}\n` : ''}${hasEventsChanged ? `Events: ${selectedEventIds.asArray.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''}${hasGuestsChanged ? `Guests: ${guests}\n` : ''}`
 }

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -218,7 +218,7 @@ export default function CompetingStep({
           },
         });
       } else {
-        const updateMessage = `\n${hasCommentChanged ? `Comment: ${comment}\n` : ''}${hasEventsChanged ? `Events: ${selectedEventIds.asArray.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''}${hasGuestsChanged ? `Guests: ${guests}\n` : ''}`;
+        const updateMessage = getUpdateMessage(hasCommentChanged, comment, hasEventsChanged, selectedEventIds, hasGuestsChanged, guests);
         window.location = contactCompetitionUrl(competitionInfo.id, encodeURIComponent(I18n.t('competitions.registration_v2.update.update_contact_message', { update_params: updateMessage })));
       }
     }).catch(() => {
@@ -458,4 +458,8 @@ export default function CompetingStep({
       </Form>
     </Segment>
   );
+}
+
+const getUpdateMessage = (hasCommentChanged, comment, hasEventsChanged, selectedEventIds, hasGuestsChanged, guests) => {
+  return `\n${hasCommentChanged ? `Comment: ${comment}\n` : ''}${hasEventsChanged ? `Events: ${selectedEventIds.asArray.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''}${hasGuestsChanged ? `Guests: ${guests}\n` : ''}`
 }

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -67,7 +67,13 @@ function getUpdateMessage(
   hasGuestsChanged,
   guests,
 ) {
-  return `\n${hasCommentChanged ? `Comment: ${comment}\n` : ''}${hasEventsChanged ? `Events: ${selectedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''}${hasGuestsChanged ? `Guests: ${guests}\n` : ''}`;
+  return `\n${
+    hasCommentChanged ? `Comment: ${comment}\n` : ''
+  }${
+    hasEventsChanged ? `Events: ${selectedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
+  }${
+    hasGuestsChanged ? `Guests: ${guests}\n` : ''
+  }`;
 }
 
 export default function CompetingStep({

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -62,17 +62,25 @@ const potentialWarnings = (competitionInfo) => {
 function getUpdateMessage(
   hasCommentChanged,
   comment,
-  hasEventsChanged,
+  originalEventIds,
   selectedEventIds,
   hasGuestsChanged,
   guests,
 ) {
+  const addedEventIds = selectedEventIds.filter((id) => !originalEventIds.includes(id));
+  const removedEventIds = originalEventIds.filter((id) => !selectedEventIds.includes(id));
+  const hasEventsChanged = (addedEventIds.length + removedEventIds.length) > 0;
+
   return `\n${
-    hasCommentChanged ? `Comment: ${comment}\n` : ''
+    hasCommentChanged ? `Updated Comment: ${comment}\n` : ''
   }${
-    hasEventsChanged ? `Events: ${selectedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
+    addedEventIds.length ? `Added Events: ${addedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
   }${
-    hasGuestsChanged ? `Guests: ${guests}\n` : ''
+    removedEventIds.length ? `Removed Events: ${removedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
+  }${
+    hasEventsChanged ? `Updated Event List: ${selectedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
+  }${
+    hasGuestsChanged ? `Updated Guests: ${guests}\n` : ''
   }`;
 }
 
@@ -90,7 +98,7 @@ export default function CompetingStep({
 
   const {
     isRegistered, isPolling, isProcessing, startPolling, refetchRegistration,
-    isPending, isWaitingList, registrationId,
+    isPending, isWaitingList, registration, registrationId,
   } = useRegistration();
 
   const dispatch = useDispatch();
@@ -238,7 +246,7 @@ export default function CompetingStep({
         const updateMessage = getUpdateMessage(
           hasCommentChanged,
           comment,
-          hasEventsChanged,
+          registration.competing.event_ids,
           selectedEventIds.asArray,
           hasGuestsChanged,
           guests,
@@ -257,6 +265,7 @@ export default function CompetingStep({
     hasCommentChanged,
     comment,
     hasEventsChanged,
+    registration.competing.event_ids,
     selectedEventIds.asArray,
     hasGuestsChanged,
     guests,

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -248,7 +248,7 @@ export default function CompetingStep({
         const updateMessage = getUpdateMessage(
           hasCommentChanged,
           comment,
-          registration.competing.event_ids,
+          registration?.competing?.event_ids ?? [],
           selectedEventIds.asArray,
           hasGuestsChanged,
           guests,
@@ -267,7 +267,7 @@ export default function CompetingStep({
     hasCommentChanged,
     comment,
     hasEventsChanged,
-    registration.competing.event_ids,
+    registration?.competing?.event_ids,
     selectedEventIds.asArray,
     hasGuestsChanged,
     guests,

--- a/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
+++ b/app/webpacker/components/RegistrationsV2/Register/CompetingStep.jsx
@@ -59,6 +59,8 @@ const potentialWarnings = (competitionInfo) => {
   return warnings;
 };
 
+const getName = (eventId) => events.byId[eventId].name;
+
 function getUpdateMessage(
   hasCommentChanged,
   comment,
@@ -74,11 +76,11 @@ function getUpdateMessage(
   return `\n${
     hasCommentChanged ? `Updated Comment: ${comment}\n` : ''
   }${
-    addedEventIds.length ? `Added Events: ${addedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
+    addedEventIds.length ? `Added Events: ${addedEventIds.map(getName).join(', ')}\n` : ''
   }${
-    removedEventIds.length ? `Removed Events: ${removedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
+    removedEventIds.length ? `Removed Events: ${removedEventIds.map(getName).join(', ')}\n` : ''
   }${
-    hasEventsChanged ? `Updated Event List: ${selectedEventIds.map((eventId) => events.byId[eventId].name).join(', ')}\n` : ''
+    hasEventsChanged ? `Updated Event List: ${selectedEventIds.map(getName).join(', ')}\n` : ''
   }${
     hasGuestsChanged ? `Updated Guests: ${guests}\n` : ''
   }`;

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -62,15 +62,15 @@ export default function RegistrationHistory({ registrationId }) {
               <Table.Cell>
                 {Object.entries(entry.changed_attributes).map(
                   ([k, v]) => (
-                    <>
+                    <React.Fragment key={k}>
                       {k === 'event_ids' ? (
-                        <span key={k}>
+                        <span>
                           Toggled events
                           {' '}
                           <EventIcons ids={v} />
                         </span>
                       ) : (
-                        <span key={k}>
+                        <span>
                           Changed
                           {' '}
                           {k}
@@ -81,7 +81,7 @@ export default function RegistrationHistory({ registrationId }) {
                         </span>
                       )}
                       <br />
-                    </>
+                    </React.Fragment>
                   ),
                 )}
               </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -69,17 +69,26 @@ export default function RegistrationHistory({ registrationId }) {
               <Table.Cell>
                 {Object.entries(entry.changed_attributes).map(
                   ([k, v]) => (
-                    <span key={k}>
-                      Changed
-                      {' '}
-                      {k}
-                      {' '}
-                      to
-                      {' '}
-                      {formatHistoryColumn(k, v)}
-                      {' '}
+                    <>
+                      {k === 'event_ids' ? (
+                        <span key={k}>
+                          Toggled events
+                          {' '}
+                          {formatHistoryColumn(k, v)}
+                        </span>
+                      ) : (
+                        <span key={k}>
+                          Changed
+                          {' '}
+                          {k}
+                          {' '}
+                          to
+                          {' '}
+                          {formatHistoryColumn(k, v)}
+                        </span>
+                      )}
                       <br />
-                    </span>
+                    </>
                   ),
                 )}
               </Table.Cell>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -102,5 +102,5 @@ export default function RegistrationHistory({ registrationId }) {
 }
 
 const renderEventIcons = (ids) => {
-  return events.official.flatMap((e) => (ids.includes(e.id) ? <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} /> : []));
+  return events.official.map((e) => ids.includes(e.id) && <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} />);
 };

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -12,10 +12,6 @@ import getUsersInfo from '../api/user/post/getUserInfo';
 import Loading from '../../Requests/Loading';
 import { getRegistrationHistory } from '../api/registration/get/get_registrations';
 
-const renderEventIcons = (ids) => {
-  return events.official.flatMap((e) => (ids.includes(e.id) ? <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} /> : []));
-};
-
 export default function RegistrationHistory({ registrationId }) {
   const {
     isLoading: historyLoading,
@@ -104,3 +100,7 @@ export default function RegistrationHistory({ registrationId }) {
     </>
   );
 }
+
+const renderEventIcons = (ids) => {
+  return events.official.flatMap((e) => (ids.includes(e.id) ? <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} /> : []));
+};

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -67,7 +67,7 @@ export default function RegistrationHistory({ registrationId }) {
                         <span key={k}>
                           Toggled events
                           {' '}
-                          {renderEventIcons(v)}
+                          <EventIcons ids={v} />
                         </span>
                       ) : (
                         <span key={k}>
@@ -101,6 +101,6 @@ export default function RegistrationHistory({ registrationId }) {
   );
 }
 
-const renderEventIcons = (ids) => {
+function EventIcons({ ids }) {
   return events.official.map((e) => ids.includes(e.id) && <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} />);
-};
+}

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -12,11 +12,8 @@ import getUsersInfo from '../api/user/post/getUserInfo';
 import Loading from '../../Requests/Loading';
 import { getRegistrationHistory } from '../api/registration/get/get_registrations';
 
-const formatHistoryColumn = (key, value) => {
-  if (key === 'event_ids') {
-    return events.official.flatMap((e) => (value.includes(e.id) ? <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} /> : []));
-  }
-  return value;
+const renderEventIcons = (ids) => {
+  return events.official.flatMap((e) => (ids.includes(e.id) ? <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} /> : []));
 };
 
 export default function RegistrationHistory({ registrationId }) {
@@ -74,7 +71,7 @@ export default function RegistrationHistory({ registrationId }) {
                         <span key={k}>
                           Toggled events
                           {' '}
-                          {formatHistoryColumn(k, v)}
+                          {renderEventIcons(v)}
                         </span>
                       ) : (
                         <span key={k}>

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -102,5 +102,7 @@ export default function RegistrationHistory({ registrationId }) {
 }
 
 function EventIcons({ ids }) {
-  return events.official.map((e) => ids.includes(e.id) && <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} />);
+  return events.official.map((e) => (
+    ids.includes(e.id) && <EventIcon key={e.id} id={e.id} style={{ cursor: 'unset' }} />
+  ));
 }

--- a/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationEdit/RegistrationHistory.jsx
@@ -84,7 +84,7 @@ export default function RegistrationHistory({ registrationId }) {
                           {' '}
                           to
                           {' '}
-                          {formatHistoryColumn(k, v)}
+                          {v}
                         </span>
                       )}
                       <br />


### PR DESCRIPTION
Mostly resolves #12252. The backend is only sending the toggled events for the registration history view, so this is the best I can do on the frontend alone. If someone wants to update the backend to alter the data being sent, I could build on that to show the added and removed events separately. Additionally, here seems to be a bug where the backend is only sending the added events and ignoring the removed events. This behaviour is happening on main, so not related to my changes.

[Screencast from 2025-09-30 06:43:33 PM.webm](https://github.com/user-attachments/assets/3c08c969-4fca-4bff-8878-43d74c123cc5)

Requesting to change events via contact form:

[Screencast from 2025-09-30 06:05:25 PM.webm](https://github.com/user-attachments/assets/a285fe52-a7b8-4640-95d0-e0162ac7e024)

I'm not sure whether `registration.competing.event_ids` is the appropriate way to get the originally selected events.