### PR TITLE
Optimize attempt backfill

### DIFF
--- a/lib/tasks/move_results_to_attempt_tables.rake
+++ b/lib/tasks/move_results_to_attempt_tables.rake
@@ -3,7 +3,18 @@
 namespace :results do
   desc "Migrates all results to attempts"
   task migrate_attempts: [:environment] do
-    Result.find_each(&:create_or_update_attempts)
+    ActiveRecord::Base.connection.execute <<-SQL.squish
+    INSERT IGNORE INTO result_attempts (value, attempt_number, result_id)
+    SELECT value1, 1, id FROM results WHERE value1 != 0
+    UNION ALL
+    SELECT value2, 2, id FROM results WHERE value2 != 0
+    UNION ALL
+    SELECT value3, 3, id FROM results WHERE value3 != 0
+    UNION ALL
+    SELECT value4, 4, id FROM results WHERE value4 != 0
+    UNION ALL
+    SELECT value5, 5, id FROM results WHERE value5 != 0
+    SQL
   end
 
   desc "Migrates results from one competition to attempts"

--- a/lib/tasks/move_results_to_attempt_tables.rake
+++ b/lib/tasks/move_results_to_attempt_tables.rake
@@ -17,6 +17,25 @@ namespace :results do
     SQL
   end
 
+  task check_attempts: :environment do
+    total = Result.count
+    i = 0
+
+    Result.find_each do |result|
+      result.result_attempts.each do |attempt|
+        expected = result.public_send("value#{attempt.attempt_number}")
+        if attempt.value != expected
+          abort "Result #{result.id} does not match attempt #{attempt.attempt_number} (attempt id #{attempt.id})"
+        end
+      end
+
+      i += 1
+      puts "Checked #{i}/#{total} results" if i % 1000 == 0
+    end
+
+    puts "All result_attempts match their results"
+  end
+
   desc "Migrates results from one competition to attempts"
   task :migrate_competition_results, [:competition_id] => [:environment] do |_, args|
     competition_id = args[:competition_id]

--- a/lib/tasks/move_results_to_attempt_tables.rake
+++ b/lib/tasks/move_results_to_attempt_tables.rake
@@ -17,6 +17,7 @@ namespace :results do
     SQL
   end
 
+  desc "Check if the attempts table is correct"
   task check_attempts: :environment do
     sql = <<-SQL.squish
     SELECT ra.id, ra.result_id, ra.attempt_number, ra.value,


### PR DESCRIPTION
Query performance: `Query OK, 26155354 rows affected (3 min 26.72 sec)`
I ran the integrity check and found two missmatches:
Result Id 7253786 and 7096277 which both had attempts that were deleted (set to 0) later. Which caused the
```
def create_or_update_attempts
    attempts = (1..5).filter_map do |n|
      value = public_send(:"value#{n}")

      { value: value, attempt_number: n, result_id: id } unless value.zero?
    end
    ResultAttempt.upsert_all(attempts)
  end
```
not to work because it doesn't deal with deleted attempts.
Running the integrity check just takes a couple seconds so just deleting those attempts and rerunning the `create_or_update_attempts` method for those is easy