### PR TITLE
Reg Admin: Add conditional footer cell for DOB

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/RegistrationAdministrationTableFooter.jsx
@@ -19,7 +19,9 @@ export default function RegistrationAdministrationTableFooter({
   competitionInfo,
   withPosition = false,
 }) {
-  const { events: eventsAreExpanded, comments: commentsAreShown } = columnsExpanded;
+  const {
+    dob: dobIsShown, events: eventsAreExpanded, comments: commentsAreShown,
+  } = columnsExpanded;
 
   const newcomerCount = registrations.filter(
     (reg) => !reg.user.wca_id,
@@ -62,6 +64,7 @@ export default function RegistrationAdministrationTableFooter({
           }`
         }
       </Table.Cell>
+      {dobIsShown && <Table.Cell key="dob" />}
       <Table.Cell>
         {`${I18n.t('registrations.list.country_plural', { count: countryCount })}`}
       </Table.Cell>


### PR DESCRIPTION
I wasted some time today reading the event column totals offset by 1 without realizing it...

Most of the footer cells have unnecessary keys to make it easier to figure out which is which.

<img width="1619" height="565" alt="image" src="https://github.com/user-attachments/assets/7f7ce5a0-3d36-43d4-aff6-ca6d09eeacd7" />

<img width="1619" height="565" alt="image" src="https://github.com/user-attachments/assets/806528a2-4c32-466c-b5a8-e30e5a98f011" />

To anyone randomly stumbling across this PR, that is not my birthdate.