### PR TITLE
Change Vault Address in Terraform after upgrade

### DIFF
--- a/infra/wca_on_rails/main.tf
+++ b/infra/wca_on_rails/main.tf
@@ -33,7 +33,7 @@ module "production" {
   name_prefix = "${var.name_prefix}-prod"
   region = var.region
   shared = module.shared
-  VAULT_ADDR = "http://172.31.63.154:8200"
+  VAULT_ADDR = var.VAULT_ADDR
   DATABASE_WRT_USER = var.DATABASE_WRT_USER
   rails_startup_time = local.rails_startup_time
   WRC_WEBHOOK_URL = var.WRC_WEBHOOK_URL
@@ -43,7 +43,7 @@ module "staging" {
   source = "./staging"
   name_prefix = "${var.name_prefix}-staging"
   region = var.region
-  VAULT_ADDR = "http://172.31.63.154:8200"
+  VAULT_ADDR = var.VAULT_ADDR
   DATABASE_WRT_USER = var.DATABASE_WRT_USER
   shared = module.shared
   rails_startup_time = local.rails_startup_time

--- a/infra/wca_on_rails/variables.tf
+++ b/infra/wca_on_rails/variables.tf
@@ -21,7 +21,7 @@ variable "availability_zones" {
 variable "VAULT_ADDR" {
   type = string
   description = "The Address that vault is running at"
-  default = "http://vault.worldcubeassociation.org:8200"
+  default = "http://vault.private.worldcubeassociation.org:8200"
 }
 
 variable "DATABASE_WRT_USER" {


### PR DESCRIPTION
We were hardcoding the address here because the wca-registrations microservice had to connect to vault via the nat gateway so it used a different IP for `vault.worldcubeassociation.org`. Now that we don't have that anymore I created `private.vault.worldcubeassociation.org` to indicate that it's an internal 172 IP and we can fallover for upgrades in the future.

I will run terraform and redeploy after lunch.