### PR TITLE
Fail loudly if Registration validations fail on WCIF patch

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2051,7 +2051,7 @@ class Competition < ApplicationRecord
       # If no registration is found, and the Registration is marked as non-competing, add this person as a non-competing staff member.
       adding_non_competing = wcif_person["registration"].present? && wcif_person["registration"]["isCompeting"] == false
       if adding_non_competing
-        registration ||= registrations.create(
+        registration ||= registrations.create!(
           competition: self,
           user_id: wcif_person["wcaUserId"],
           is_competing: false,


### PR DESCRIPTION
Interesting find that came from an urgent investigation of broken WCIFs for `CFLFinalLodz2025`. The Delegate had mistakenly thought user IDs don't matter for non-competing registrations and submitted the following payload (abridged, this is sufficient to trigger the error behavior)
```json
{
    "id": "CFLFinalLodz2025",
    "persons": [
        {
            "name": "Kacper Rafalski",
            "wcaUserId": -1,
            "wcaId": "",
            "registrantId": 1001,
            "countryIso2": "PL",
            "gender": "m",
            "registration": {
                "wcaRegistrationId": 100000,
                "eventIds": [],
                "status": "accepted",
                "isCompeting": false,
                "guests": 0,
                "comments": "",
                "administrativeNotes": ""
            },
            "avatar": {},
            "roles": [
                "staff-scrambler",
                "staff-judge",
                "staff-runner"
            ],
            "assignments": [],
            "personalBests": [],
            "extensions": [],
            "birthdate": "2000-01-01",
            "email": "test"
        }
    ]
}
```

Note the `wcaUserId: -1` part. We do have validations in place for `registration.rb`, namely `validates :user, presence: true, on: [:create]`. So why the heck was this passing?

Turns out, it wasn't. The line that creates the on-the-fly registration for non-competing peoples (see the diff of this PR) had not persisted the registration, because the `create` failed validations.
However, just below the block that GitHub shows you (expand down a bit...) you will see a `registration.update_attribute(:roles, roles)` call for roles. **This call inserts the whole entity, and skips validations per `update_attribute`'s documentation!!**

TIL: Be really careful with `update_attributes`. The easy solution here is to immediately fail loudly during on-the-fly creation. We do this (loud failing with `save!` instead of `save` etc) in other places of the WCIF patching chain already, so the API handler is prepared for this kind of error.