### PR TITLE
Switch to S3::TransferManager to upload Dump files

### DIFF
--- a/lib/db_dump_helper.rb
+++ b/lib/db_dump_helper.rb
@@ -120,10 +120,8 @@ module DbDumpHelper
     end
 
     LogTask.log_task "Moving zipped file to 's3://#{s3_path}'" do
-      bucket = Aws::S3::Resource.new(
-        credentials: Aws::ECSCredentials.new,
-      ).bucket(BUCKET_NAME)
-      bucket.object(s3_path).upload_file(zip_filename)
+      tm = Aws::S3::TransferManager.new
+      tm.upload_file(zip_filename, bucket: BUCKET_NAME, key: s3_path)
 
       # Delete the zipfile now that it's uploaded
       FileUtils.rm zip_filename


### PR DESCRIPTION
calling `.upload_file(zip_filename)` on an object directly is deprecated. 
Where did the credentials go? According to the [Credential Chain ](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/credential-providers.html) it should pick it up automatically now.

I confirmed by uploading a dummy file on the container
<img width="1200" height="90" alt="Screenshot 2025-10-06 at 14 31 54" src="https://github.com/user-attachments/assets/9184167c-dd92-4742-87b0-58d37eed8fd1" />
<img width="1200" height="103" alt="Screenshot 2025-10-06 at 14 31 40" src="https://github.com/user-attachments/assets/777421ba-7bfc-464a-af7e-2234d782496f" />
