### PR TITLE
Sync Terraform with manual AWS Changes

### DIFF
--- a/infra/wca_on_rails/production/auxiliary_services.tf
+++ b/infra/wca_on_rails/production/auxiliary_services.tf
@@ -125,6 +125,11 @@ resource "aws_ecs_service" "auxiliary" {
     type = "ECS"
   }
 
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   tags = {
     Name = var.name_prefix
   }

--- a/infra/wca_on_rails/shared/elb.tf
+++ b/infra/wca_on_rails/shared/elb.tf
@@ -312,7 +312,7 @@ resource "aws_lb_listener" "http" {
 
 resource "aws_lb_listener_rule" "pma_forward_prod" {
   listener_arn = aws_lb_listener.https.arn
-  priority     = 3
+  priority     = 4
 
   action {
     authenticate_oidc {
@@ -352,7 +352,7 @@ locals {
 
 resource "aws_lb_listener_rule" "next_forward_prod" {
   listener_arn = aws_lb_listener.https.arn
-  priority     = 9
+  priority     = 10
 
   action {
     type             = "forward"
@@ -368,7 +368,7 @@ resource "aws_lb_listener_rule" "next_forward_prod" {
 
 resource "aws_lb_listener_rule" "rails_forward_staging" {
   listener_arn = aws_lb_listener.https.arn
-  priority     = 4
+  priority     = 5
 
   action {
     type             = "forward"
@@ -384,7 +384,7 @@ resource "aws_lb_listener_rule" "rails_forward_staging" {
 
 resource "aws_lb_listener_rule" "rails_forward_staging_api" {
   listener_arn = aws_lb_listener.https.arn
-  priority     = 2
+  priority     = 3
 
   action {
     type             = "forward"


### PR DESCRIPTION
I enabled the `deployment_circuit_breaker` by hand on saturday. The priority changes are a bit weird, they have been there for months (I used them to make room for next), but my linux terraform doesn't seem to pick them up when running terraform plan/apply.