### PR TITLE
Also run build as part of nextjs test

### DIFF
--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -28,14 +28,12 @@ jobs:
         run: yarn run check:types
       - name: Run Lint
         run: yarn run lint
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-access-key-id: ${{ secrets.CI_CD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_CD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Download proprietary assets from protected bucket for build
+      - name: Create dummy fonts
         shell: bash
-        run: aws s3 cp s3://wca-fonts ./next-frontend/src/styles/fonts/ --recursive
+        run: |
+          mkdir ./src/styles/fonts/TTNormsPro
+          for style in Light Light_Italic Regular Medium Bold Condensed_ExtraBold; do
+            touch "./src/styles/fonts/TTNormsPro/TT_Norms_Pro_${style}.woff2"
+          done
       - name: Run build
         run: yarn run build


### PR DESCRIPTION
There are some issues that we only discover when the build fails so we can just run a build as part of the test suite. 
I am keeping the lint step separate as `next lint` is deprecated so I am not sure what the plan is around running lint automatically on each build.

For the real build we do set a couple ENV variables, but I think this should still just work without them?