### PR TITLE
Add RO Management Permissions for WEAT

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -866,7 +866,7 @@ class User < ApplicationRecord
   end
 
   def can_manage_regional_organizations?
-    admin? || board_member?
+    admin? || board_member? || weat_team?
   end
 
   def can_create_competitions?


### PR DESCRIPTION
Per Nick's request in slack: https://worldcubeassociation.slack.com/archives/C0GHEEJ3S/p1761705048142389

I've tested and:
- edit/create updates are going through
- RO management items are appearing in the menu

So that seems to be everything necessary