### PR TITLE
Always use results_submitted_at in competitions admin view

### DIFF
--- a/app/webpacker/lib/utils/competition-table.js
+++ b/app/webpacker/lib/utils/competition-table.js
@@ -117,9 +117,8 @@ export function reportAdminCellContent(comp) {
 }
 
 export function resultsSubmittedAtAdminCellContent(comp) {
-  if (comp.results_posted_at) {
-    const date = comp.results_submitted_at ? comp.results_submitted_at : comp.results_posted_at;
-    return timeDifferenceAfter(comp, date);
+  if (comp.results_submitted_at) {
+    return timeDifferenceAfter(comp, comp.results_submitted_at);
   }
 
   if (isProbablyOver(comp)) {


### PR DESCRIPTION
As discussed with @danieljames-dj on Slack, there are no competitions which does not have `results_submitted_at` and have `results_posted_at`, so this if statement was unnecessary. 
<img width="1724" height="186" alt="image" src="https://github.com/user-attachments/assets/4d1fd404-f269-41b6-b52b-9375f437f6f4" />
