### PR TITLE
Change strategic plan link in th.yml

### DIFF
--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -4908,7 +4908,7 @@ th:
       สร้างโอกาสการเติบโตสำหรับคนหนุ่มสาวที่เกี่ยวข้องและการแนะนำกิจกรรมนี้ให้กับกลุ่มคนใหม่
       ๆ ทำให้ชุมชนโดยรวมของเราแข็งแกร่งขึ้น
       เอกสารที่มีแผนเชิงกลยุทธ์ของคณะกรรมการสำหรับ WCA สามารถอ่านได้<a
-      href="https://documents.worldcubeassociation.org/documents/WCA_Vision_and_Strategy.pdf">
+      href="https://documents.worldcubeassociation.org/documents/WCA_Strategic_Plan.pdf">
       ที่นี่ </a></p>
     #original_hash: f64ccc7
     whats_next_title: ก้าวต่อไปของ WCA


### PR DESCRIPTION
This was missed in #12697 - we need all links in the translation files to be updated to avoid deadlinking