### PR TITLE
Set the max width of tables to 100% of container in competition tabs

### DIFF
--- a/next-frontend/src/components/competitions/TabCompetitors.tsx
+++ b/next-frontend/src/components/competitions/TabCompetitors.tsx
@@ -76,7 +76,7 @@ const TabCompetitors: React.FC<CompetitorData> = ({ id }) => {
             onClearClick={() => setPsychSheetEvent(null)}
           />
         </Card.Title>
-        <Table.ScrollArea borderWidth="1px" maxW="100%">
+        <Table.ScrollArea borderWidth="1px" maxW="full">
           {psychSheetEvent && (
             <PsychsheetTable
               pychsheet={psychSheetQuery!}

--- a/next-frontend/src/components/competitions/TabEvents.tsx
+++ b/next-frontend/src/components/competitions/TabEvents.tsx
@@ -42,7 +42,7 @@ export default async function TabEvents({
   return (
     <Card.Root>
       <Card.Body>
-        <Table.ScrollArea borderWidth="1px" maxW="100%">
+        <Table.ScrollArea borderWidth="1px" maxW="full">
           <Table.Root striped interactive>
             <Table.Header>
               <Table.Row>


### PR DESCRIPTION
This fixes the tables in the tabs not taking the full width. For the competitor tab, this happens only if there are enough events/long competitor names to fill that space. This is a separate issue which I will fix separately 