### PR TITLE
Use simple grid in delegates page

### DIFF
--- a/next-frontend/src/app/(wca)/delegates/page.tsx
+++ b/next-frontend/src/app/(wca)/delegates/page.tsx
@@ -1,5 +1,4 @@
 import {
-  Center,
   Container,
   Heading,
   Link,


### PR DESCRIPTION
I don't know what I was trying to do with the first version of this, but this is so much cleaner
<img width="1433" height="855" alt="Screenshot 2025-12-04 at 20 38 05" src="https://github.com/user-attachments/assets/d53bff56-f6b2-4f92-abd4-34990abef29e" />

There is definitely still a backend issue regarding which groups contain delegates.
Even on prod, trying to get all African Delegates with
https://www.worldcubeassociation.org/api/v0/user_roles?parentGroupId=8&isActive=true&sort=location%2Cname
does not lead to any results.