### PR TITLE
Migrate installed Rust toolchain to Cargo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,13 @@ RUN corepack enable
 # libssl-dev = bindings for the native extensions of Ruby SSL gem
 # libyaml-dev = bindings for the native extensions of Ruby psych gem
 # tzdata = Timezone information for Rails ActiveSupport
+# libclang-dev and cargo = Rust compiler toolchain for Ruby gems that have external Rust bindings
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
       build-essential \
       git \
-      clang \
+      libclang-dev \
+      cargo \
       pkg-config \
       libvips \
       libssl-dev \

--- a/packages.dev.txt
+++ b/packages.dev.txt
@@ -4,4 +4,5 @@ mariadb-client
 libssl-dev
 libyaml-dev
 tzdata
-clang
+libclang-dev
+cargo


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/12936

The `libclang-dev` packge comes from https://github.com/HarlemSquirrel/tzf-rb/blob/main/docker/Dockerfile.
We need to make sure our Ruby monolith can compile Rust code because some very popular Rust bindings will be coming soon :blush: 