### PR TITLE
Add helpful queries to WRT panel

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -702,6 +702,7 @@ class User < ApplicationRecord
           panel_pages[:fixResults],
           panel_pages[:mergeProfiles],
           panel_pages[:mergeUsers],
+          panel_pages[:helpfulQueries],
         ],
       },
       wst: {


### PR DESCRIPTION
This PR adds helpful queries page introduced in #12299 to WRT panel. Competitor registrations will be useful for WRT, since we are often waiting for responses from competitors, and it would be easier to ask those questions through delegates of their upcoming competitions. A delegated competitions page would also be helpful for promotions. Other pages available in the panel may be useful as well, though I don’t have specific use cases in mind yet