### PR TITLE
Fix inconsistent text style and alignment in comp navbar

### DIFF
--- a/next-frontend/src/components/competitions/TabMenu.tsx
+++ b/next-frontend/src/components/competitions/TabMenu.tsx
@@ -54,27 +54,32 @@ export default function TabMenu({
         height="fit-content"
         position="sticky"
         minWidth="fit-content"
+        textAlign="center"
         gap="3"
       >
         {tabs.map((tab) => (
           <Tabs.Trigger key={tab.i18nKey} value={tab.menuKey} asChild>
-            <Link href={tab.href}>{t(tab.i18nKey)}</Link>
+            <Text textStyle="bodyEmphasis" asChild maxW="44">
+              <Link href={tab.href}>{t(tab.i18nKey)}</Link>
+            </Text>
           </Tabs.Trigger>
         ))}
         <Separator />
         {competitionInfo.tab_names.map((tabName) => (
           <Tabs.Trigger key={tabName} value={tabName} asChild>
-            <Link
-              href={route({
-                pathname: "/competitions/[competitionId]/tabs/[tabName]",
-                query: {
-                  competitionId: competitionInfo.id,
-                  tabName: encodeURIComponent(tabName),
-                },
-              })}
-            >
-              <Text maxW="44">{tabName}</Text>
-            </Link>
+            <Text textStyle="bodyEmphasis" asChild maxW="44">
+              <Link
+                href={route({
+                  pathname: "/competitions/[competitionId]/tabs/[tabName]",
+                  query: {
+                    competitionId: competitionInfo.id,
+                    tabName: encodeURIComponent(tabName),
+                  },
+                })}
+              >
+                {tabName}
+              </Link>
+            </Text>
           </Tabs.Trigger>
         ))}
       </Tabs.List>


### PR DESCRIPTION
## Before
<img width="508" height="590" alt="image" src="https://github.com/user-attachments/assets/0d7128ac-e26b-4daf-a2d3-6fe417dbdf11" />

Note how the font style is inconsistent between "main tabs" and "custom tabs". This is interesting but definitely unintended and an accidental happenstance. If we want this to be styled differently on purpose, then this PR gives us the power to style it on purpose in a follow-up changeset.

The text also became unaligned when there were line-breaks. I introduced `textAlign: center` on the container to fix that.

## After
<img width="508" height="590" alt="image" src="https://github.com/user-attachments/assets/4957c56f-52a0-4316-a212-8839f9b88f47" />
