### PR TITLE
Slightly Reduce RAM usage for Rails

### DIFF
--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -253,14 +253,14 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn      = aws_iam_role.task_role.arn
 
   cpu = "1024"
-  memory = "3910"
+  memory = "3900"
 
   container_definitions = jsonencode([
     {
       name              = "rails-production"
       image             = "${var.shared.ecr_repository.repository_url}:latest"
       cpu    = 1024
-      memory = 3910
+      memory = 3900
       portMappings = [
         {
           # The hostPort is automatically set for awsvpc network mode,


### PR DESCRIPTION
Seems like the base RAM for our ECS Orchestrated machine has dropped by a few MB due to an update of the ECS Agent. 
10MB shouldn't really have any performance impact