### PR TITLE
Use different font in development in next webpack config

### DIFF
--- a/next-frontend/next.config.ts
+++ b/next-frontend/next.config.ts
@@ -26,6 +26,13 @@ const nextConfig: NextConfig = {
   },
   output: "standalone",
   productionBrowserSourceMaps: true,
+  webpack(config) {
+    if (!process.env.PROPRIETARY_FONT) {
+      config.resolve.alias["@/styles/fonts"] =
+        require("path").resolve(__dirname, "src/styles/fonts/empty-font.ts");
+    }
+    return config;
+  },
   async rewrites() {
     return [
       {

--- a/next-frontend/src/app/(wca)/layout.tsx
+++ b/next-frontend/src/app/(wca)/layout.tsx
@@ -7,6 +7,7 @@ import Navbar from "./navbar";
 import Footer from "@/components/Footer";
 import RandomBackground from "@/components/RandomBackground";
 import { Rubik } from "next/font/google";
+import { ttNormsPro } from "@/styles/fonts";
 
 export const metadata: Metadata = {
   title: {
@@ -19,8 +20,6 @@ const devFont = Rubik({ subsets: ["latin"] });
 
 const computeFont = async () => {
   if (process.env.PROPRIETARY_FONT === "TTNormsPro") {
-    const { ttNormsPro } = await import("@/styles/fonts");
-
     return ttNormsPro;
   }
 

--- a/next-frontend/src/styles/fonts/empty-font.ts
+++ b/next-frontend/src/styles/fonts/empty-font.ts
@@ -1,0 +1,4 @@
+export const proprietaryFont = {
+  className: "",
+  variable: "",
+};


### PR DESCRIPTION
## Summary

Fix issue with prod fonts trying to be loaded in development.

<img width="1388" height="326" alt="image" src="https://github.com/user-attachments/assets/d0d58469-0ad9-4ce3-b44f-ea06b1c911d8" />

This issue is fixed by loading a different font via the nextjs webpack config.