### PR TITLE
Don't keep binlog in dev mysql

### DIFF
--- a/docker/my.cnf
+++ b/docker/my.cnf
@@ -5,6 +5,7 @@ default-character-set          = utf8mb4
 default-character-set          = utf8mb4
 
 [mysqld]
+skip-log-bin
 collation-server = utf8mb4_unicode_ci
 character-set-server = utf8mb4
 log-error-verbosity=1


### PR DESCRIPTION
This will stop our mysql docker volume to balloon locally, especially rake tasks and loading dumps cause very big binlogs which are not useful locally as we don't do any replication.

I have tested it locally and this turns it off
```
SHOW VARIABLES LIKE 'log_bin';
+---------------+-------+
| Variable_name | Value |
+---------------+-------+
| log_bin       | OFF   |
+---------------+-------+

```