### PR TITLE
add back instrumentation.ts

### DIFF
--- a/next-frontend/src/instrumentation.ts
+++ b/next-frontend/src/instrumentation.ts
@@ -1,0 +1,8 @@
+export async function register() {
+  if (
+    process.env.NEXT_RUNTIME === "nodejs" &&
+    process.env.NODE_ENV === "production"
+  ) {
+    await import("newrelic");
+  }
+}


### PR DESCRIPTION
We actually still need this because otherwise nextjs will optimize the newrelic import away because it's not used anywhere