### PR TITLE
Remove redundant key packing in schema.rb

### DIFF
--- a/db/migrate/20251217122230_remove_redundant_key_packing.rb
+++ b/db/migrate/20251217122230_remove_redundant_key_packing.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveRedundantKeyPacking < ActiveRecord::Migration[8.1]
+  def up
+    execute "ALTER TABLE events PACK_KEYS=DEFAULT"
+    execute "ALTER TABLE inbox_results PACK_KEYS=DEFAULT"
+    execute "ALTER TABLE results PACK_KEYS=DEFAULT"
+  end
+
+  def down
+    execute "ALTER TABLE events PACK_KEYS=0"
+    execute "ALTER TABLE inbox_results PACK_KEYS=0"
+    execute "ALTER TABLE results PACK_KEYS=1"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_01_115143) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_17_122230) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -596,7 +596,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_01_115143) do
     t.index ["championship_type", "eligible_country_iso2"], name: "index_eligible_iso2s_for_championship_on_type_and_country_iso2", unique: true
   end
 
-  create_table "events", id: { type: :string, limit: 6, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB PACK_KEYS=0", force: :cascade do |t|
+  create_table "events", id: { type: :string, limit: 6, default: "" }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "format", limit: 10, default: "", null: false
     t.string "name", limit: 54, default: "", null: false
     t.integer "rank", default: 0, null: false
@@ -659,7 +659,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_01_115143) do
     t.index ["wca_id"], name: "InboxPersons_id"
   end
 
-  create_table "inbox_results", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB PACK_KEYS=0", force: :cascade do |t|
+  create_table "inbox_results", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "average", default: 0, null: false
     t.integer "best", default: 0, null: false
     t.string "competition_id", limit: 32, default: "", null: false
@@ -1101,7 +1101,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_01_115143) do
     t.index ["result_id"], name: "index_result_attempts_on_result_id"
   end
 
-  create_table "results", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB PACK_KEYS=1", force: :cascade do |t|
+  create_table "results", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "average", default: 0, null: false
     t.integer "best", default: 0, null: false
     t.string "competition_id", limit: 32, default: "", null: false


### PR DESCRIPTION
This cleanup came up while working on the Results Export v2.

The option `PACK_KEYS` is ignored in InnoDB. It was only relevant for old MyISAM tables.
The most likely explanation is that this "leaked" into our DB schema based on the fact that the tables which are affected are all very old core parts of our results system. It is possible that they were created at a time when this option still had an effect.