### PR TITLE
Copy whole new relic folder in docker build

### DIFF
--- a/next-frontend/Dockerfile
+++ b/next-frontend/Dockerfile
@@ -76,6 +76,8 @@ ENV PORT=3000
 ENV NEW_RELIC_APP_NAME='next-js-production'
 ENV NEW_RELIC_LOG='stdout'
 
+# Even following the official new relic example not all the submodules are copied over
+# See https://github.com/newrelic/newrelic-node-examples/issues/307#issuecomment-3665368688
 COPY --from=builder /app/node_modules/newrelic /app/node_modules/newrelic
 
 # server.js is created by next build from the standalone output


### PR DESCRIPTION
For some reason only some parts of the new relic folder is copied during the build. This is the sledgehammer solution until we hear back from new relic or find out a better solution ourselves.