### PR TITLE
Set @typescript-eslint/no-unused-vars to error

### DIFF
--- a/next-frontend/eslint.config.mjs
+++ b/next-frontend/eslint.config.mjs
@@ -30,6 +30,11 @@ const eslintConfig = [
   stylistic.configs.recommended,
   eslintConfigPrettier,
   globalIgnores(["src/types"]),
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": "error",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/next-frontend/src/app/(wca)/results/records/filteredRecords.tsx
+++ b/next-frontend/src/app/(wca)/results/records/filteredRecords.tsx
@@ -10,13 +10,6 @@ import { components } from "@/types/openapi";
 import { useRouter } from "next/navigation";
 import { route } from "nextjs-routes";
 
-type ValidActions =
-  | "SET_EVENT"
-  | "SET_REGION"
-  | "SET_RANKING_TYPE"
-  | "SET_GENDER"
-  | "SET_SHOW";
-
 type FilterParams = {
   event: EventId | "all events";
   region: string;


### PR DESCRIPTION
This keeps on slipping through the cracks so let's set it to error so it gets flagged in IDEs that support linting