### PR TITLE
Fix schedule editor invalid activity warning

### DIFF
--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -334,10 +334,8 @@ export function isActivityTimeValid(activity, wcifVenue, wcifSchedule) {
   const competitionLocalEndTime = DateTime.fromISO(startDate).plus({ days })
     .setZone(wcifVenue?.timezone, { keepLocalTime: true });
 
-  const activityStartTime = DateTime.fromISO(startTime)
-    .setZone(wcifVenue?.timezone);
-  const activityEndTime = DateTime.fromISO(endTime)
-    .setZone(wcifVenue?.timezone);
+  const activityStartTime = DateTime.fromISO(startTime);
+  const activityEndTime = DateTime.fromISO(endTime);
 
   const hasPositiveDuration = activityStartTime < activityEndTime;
   const startsOnOrAfterStartDate = competitionLocalStartTime <= activityStartTime;


### PR DESCRIPTION
The only functional change is adding `{ keepLocalTime: true }` when calling `setZone`. Without this, `setZone` doesn't change the actual point in time, only how it _appears_ (e.g. when querying the hour, which is different in different time zones despite being the same point in time).

I've confirmed this works for a competition one time zone over from me, and another competition on the other side of the world. Still, given that I messed it up originally, please test carefully.