### PR TITLE
Deprecate TNoodle versions older than 1.2.3

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -71,10 +71,6 @@ class Api::V0::ApiController < ApplicationController
         "download" => "https://github.com/thewca/tnoodle/releases/download/v1.2.3/TNoodle-WCA-1.2.3.jar",
       },
       "allowed" => [
-        "TNoodle-WCA-1.1.3.1",
-        "TNoodle-WCA-1.2.0",
-        "TNoodle-WCA-1.2.1",
-        "TNoodle-WCA-1.2.2",
         "TNoodle-WCA-1.2.3",
       ],
       "publicKeyBytes" => public_key,

--- a/app/views/regulations/scrambles.html.erb
+++ b/app/views/regulations/scrambles.html.erb
@@ -10,7 +10,7 @@
       <strong><%= link_to latest_version, latest_jarfilename %></strong>
     </span>
     <br/>
-    Last official change: December 17th, 2025
+    Last official change: January 1st, 2026
   </center>
   <h2>Important Notes for Delegates</h2>
   <ul>

--- a/next-frontend/src/app/(wca)/regulations/scrambles/page.tsx
+++ b/next-frontend/src/app/(wca)/regulations/scrambles/page.tsx
@@ -40,7 +40,7 @@ export default async function ScramblesPage() {
           <VStack>
             <Text>Download the official scramble program:</Text>
             <Link href={LATEST_JARFILE}>{LATEST_VERSION}</Link>
-            <Text>Last official change: December 17th, 2025</Text>
+            <Text>Last official change: January 1st, 2026</Text>
           </VStack>
         </Center>
         <Heading size="2xl">Important Notes for Delegates</Heading>


### PR DESCRIPTION
See title. TNoodle versions older than 1.2.3 do not support 3BLD Bo5, so with the 2026 Regs now in effect this seems like a sensible change.