### PR TITLE
Update venue setup instructions for clarity in the Delegate Reports template on the Website

### DIFF
--- a/app/views/delegate_reports/working_group_2024/_venue_default.md
+++ b/app/views/delegate_reports/working_group_2024/_venue_default.md
@@ -9,4 +9,4 @@ QiYi Displays:
 
 * **Venue notes:** [Type of venue used, were any complaints made about aspects of the venue such as lighting or temperature, was there anything noteworthy or unique about the venue?]
 
-* **Setup:** [Please write a brief description of the competition set up. You **MUST** include at least 2 images which illustrate the scrambling and competition areas (other images are also welcome). Such images are to be uploaded using the upload button below.]
+* **Setup:** [You MUST include at least 2 images which illustrate the scrambling and competition areas from this current competition, prefferably during the competition (other images are also welcome). You can select multiple files at once. You can delete images only when enough other images have been uploaded (if you want to replace an image, you need to upload the new one first, and then delete the old one). If you do not have current pictures of the competition area and/or the scrambling area while in use, please explain why below.]


### PR DESCRIPTION
Clarified instructions for image uploads and added context about the competition setup. Included that venue photos must be from the current competition and preferably from the competition. Asks delegates to explain why they may not have current photos.