### PR TITLE
Remove outdated information from scrambles page

### DIFF
--- a/app/views/regulations/scrambles.html.erb
+++ b/app/views/regulations/scrambles.html.erb
@@ -42,6 +42,8 @@
   <h3>Notes</h3>
   <ul>
     <li>4x4x4 scramble sequences <strong>may take a few minutes</strong> to initialize and generate. If you are generating 4x4x4 scramble sequences, be patient while the loading bar may appear to be stuck.</li>
+    <li>In old versions, TNoodle creates a <code>tnoodle_resources</code> folder with a few MB of files (mostly cached tables) in the same folder it is run.<br />
+      Keep this folder if you want to generate more 4x4x4 scramble sequences more quickly in the future, but feel free to delete it if you need to reclaim disk space.</li>
     <li>TNoodle performs scramble filtering according to <a href="https://www.worldcubeassociation.org/regulations/#4b3">Regulation 4b3</a>.</li>
   </ul>
   <h2>About TNoodle</h2>


### PR DESCRIPTION
Correct me if  I am wrong here but I have been generating scrambles since years now and I have never seen this folder in my directory