### PR TITLE
Support USD to USD conversion in Money::Bank::CurrencylayerBank

### DIFF
--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -162,20 +162,4 @@ Rails.configuration.to_prepare do
       end
     end
   end
-
-  # Temporary fix until https://github.com/phlegx/money-currencylayer-bank/pull/20
-  # to allow exchanging from a currency to itself
-  Money::Bank::CurrencylayerBank.class_eval do
-    # 1. Create an alias for the original method so we don't lose it
-    alias_method :original_get_rate, :get_rate
-
-    # 2. Redefine get_rate to handle the "same currency" check
-    def get_rate(from_currency, to_currency, opts = {})
-      # If source and destination are the same, return 1.0
-      return 1.0 if from_currency == to_currency
-
-      # Otherwise, call the original method (which calls the API/Cache)
-      original_get_rate(from_currency, to_currency, opts)
-    end
-  end
 end

--- a/lib/dues_calculator.rb
+++ b/lib/dues_calculator.rb
@@ -31,7 +31,7 @@ module DuesCalculator
       "Country band detail not found for #{country_band.iso2}."
     elsif !Money::Currency.table.key?(currency_code.downcase.to_sym)
       "Currency #{currency_code} is not supported."
-    elsif Money.default_bank.get_rate(currency_code, 'USD').nil?
+    elsif currency_code != 'USD' && Money.default_bank.get_rate(currency_code, 'USD').nil?
       "Currency #{currency_code} cannot be converted to USD."
     end
     # Money.default_bank.get_rate will return CurrencyUnavailable if the currency cannot be


### PR DESCRIPTION
Currently the dues calculation is failing for USD, because the library is not allowing to convert USD to USD as the exchange rate is not available.

Added the patch fix for the same.

Alternative considered: Modify dues_calculator.rb to check if currency code is USD, but it will make the code more complicated. Also I feel converting from USD to USD should be allowed by the library ideally.