### PR TITLE
Fix recording remote payment stamps in Stripe Webhook

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -216,7 +216,8 @@ class Registration < ApplicationRecord
     amount_lowest_denomination,
     currency_code,
     receipt,
-    user_id
+    user_id,
+    paid_at: nil
   )
     add_history_entry({ payment_status: receipt.determine_wca_status, iso_amount: amount_lowest_denomination }, "user", user_id, 'Payment')
     registration_payments.create!(
@@ -224,6 +225,7 @@ class Registration < ApplicationRecord
       currency_code: currency_code,
       receipt: receipt,
       user_id: user_id,
+      paid_at: paid_at,
     )
   end
 


### PR DESCRIPTION
We had previously used `created_at` as the "paid on" source in the UI, but already months ago we updated the model to include a dedicated `paid_at` timestamp separate from the lifecycle creation. The webhook endpoint unfortunately didn't follow suit.

This is a small outcome of the Euros registration yesterday. It does not affect registration fairness for that competition (and in particular, it is unrelated to the registration(s) that the organizers mailed us about with payment timestamp discrepancies) because these discrepancies were so big that the "Bulk Auto Accept" had already well-filled the approved list before this issue even became relevant.
Or in other words: Even if we had correctly populated the `paid_at` timestamp already yesterday, the timing discrepancy between the organizers hitting Bulk Accept and the Stripe webhook reaching us was still too big.