### PR TITLE
Make newcomers page duplicate persons null safe

### DIFF
--- a/app/webpacker/components/NewcomerChecks/DuplicateChecker.jsx
+++ b/app/webpacker/components/NewcomerChecks/DuplicateChecker.jsx
@@ -43,7 +43,7 @@ export default function DuplicateChecker({ competitionId, setUserIdToEdit }) {
         run={() => computePotentialDuplicatesMutate({ competitionId })}
         refetch={refetch}
       />
-      {lastDuplicateCheckerJobRun.potential_duplicate_persons.length === 0 && (
+      {lastDuplicateCheckerJobRun?.potential_duplicate_persons?.length === 0 && (
         <Segment>No newcomers to show</Segment>
       )}
       {lastDuplicateCheckerJobRun.run_status === duplicateCheckerJobRunStatuses.success


### PR DESCRIPTION
I missed to consider the case where newcomer check is not yet ran for a competition