### PR TITLE
Correctly detect NextJS traffic from internal LB

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -22,14 +22,14 @@ class Api::V0::ApiController < ApplicationController
   # See the bottom of https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect-concepts-deploy.html#service-connect-considerations
   INTERNAL_LOOPBACK_IP = IPAddr.new('127.0.0.1')
 
-  INTERNAL_RANGES = [
+  INTERNAL_IP_RANGES = [
     IPAddr.new('172.16.0.0/12'),
     IPAddr.new('10.0.0.0/8'),
     IPAddr.new('192.168.0.0/16'),
   ].freeze
 
   def internal_ip?(remote_ip)
-    remote_ip == INTERNAL_LOOPBACK_IP || INTERNAL_RANGES.any? { |range| range.include?(remote_ip) }
+    remote_ip == INTERNAL_LOOPBACK_IP || INTERNAL_IP_RANGES.any? { it.include?(remote_ip) }
   end
 
   def me


### PR DESCRIPTION
See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect-concepts-deploy.html#service-connect-considerations for an explanation of the loopback IP address. I've also added this link to the code directly in a comment.