### PR TITLE
increase AWS service connect request timeout to 60 seconds

### DIFF
--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -291,6 +291,7 @@ resource "aws_ecs_task_definition" "this" {
           hostPort = 3000
           containerPort = 3000
           protocol      = "tcp"
+          appProtocol = "http"
         },
       ]
       logConfiguration = {
@@ -385,6 +386,9 @@ resource "aws_ecs_service" "this" {
     service {
       port_name = "rails-port"
       discovery_name = "rails-cluster"
+      timeout {
+        per_request_timeout_seconds = 60
+      }
       client_alias {
         port = 3000
         dns_name = local.rails_internal_dns


### PR DESCRIPTION
The default aws service connect time out is 15 seconds, this increases it to 60 so long running wcif syncs don't die. Increasing it to more than 60 seconds doesn't make sense because we have 60 seconds timeout at the Rails and Load Balancer level