### PR TITLE
Clean up results dump directory on prod

### DIFF
--- a/lib/db_dump_helper.rb
+++ b/lib/db_dump_helper.rb
@@ -105,6 +105,8 @@ module DbDumpHelper
 
       tsv_zip_contents = [RESULTS_EXPORT_METADATA, RESULTS_EXPORT_README] | tsv_files
       self.zip_and_upload_to_s3(tsv_zip_filename, "#{RESULTS_EXPORT_FOLDER}/#{tsv_zip_filename}", *tsv_zip_contents) unless local
+    ensure
+      FileUtils.remove_entry target_dir unless local
     end
   end
 


### PR DESCRIPTION
See title. We noticed some dump jobs failing because of disk space, and I found out why.

Previously, both the Developer Dump and the Results Dump were running in "block mode", using `FileUtils.mktmpdir do |dir_path| ... end`. This had the advantage that the `FileUtils` stdlib automatically cleaned the tmp dir upon reaching the `end` of the block:
<img width="894" height="543" alt="image" src="https://github.com/user-attachments/assets/e6d7142e-b6dd-4425-8f23-ed1cf879fc7f" />

At some point, we introduced the possiblility of "local dumps", which means that we moved `mktmpdir` into its own separate line. In this case, it creates the folder and returns its location to you, but it does not "clean up" for you.