### PR TITLE
Fix flaky February factory

### DIFF
--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -310,7 +310,7 @@ FactoryBot.define do
 
     trait :registration_not_opened do
       registration_open { 1.week.from_now.change(usec: 0) }
-      registration_close { 4.weeks.from_now.change(usec: 0) }
+      registration_close { 3.weeks.from_now.change(usec: 0) }
       starts { 1.month.from_now }
       ends { starts }
     end


### PR DESCRIPTION
In the first days of February, particularly in non-leap-years, the specification "4 weeks from now" can actually come *after* "1 month from now" (because in Feb, 1 month can be shorter than 4 weeks).

This makes our CI randomly fail in the first days of Feb, so I hope this slightly tighter window fixes it without breaking anything els