### PR TITLE
Always run Dependabot on Monday morning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+    day: monday
+    time: 06:00
   ignore:
     # Ignore all dependencies that (currently) point to GitHub forks that we ourselves maintain
     #   (in order for updates to be available, we ourselves would need to trigger a fork sync.)
@@ -16,6 +18,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+    day: monday
+    time: 06:00
   ignore:
     # Version 7 automatically activates React Compiler strict rules that we won't implement in the old ecosystem
     - dependency-name: eslint-plugin-react-hooks
@@ -26,6 +30,8 @@ updates:
   directory: "/next-frontend"
   schedule:
     interval: weekly
+    day: monday
+    time: 06:00
   groups:
     react:
       patterns:


### PR DESCRIPTION
The [documentation](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#interval) claims that it runs on Monday by default, but over the last at least ~6 weeks, our Dependabot slipped to Tuesday.

Maybe this setting will incentivize him to fall back to the good old Monday routine. The rationale here is that if we have the update PRs readily laying around by Monday morning start of business, then we have the most possible time to address migrations, breaking changes, etc.