### PR TITLE
add helpful queries to WQAC panel

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -762,6 +762,12 @@ class User < ApplicationRecord
           panel_pages[:delegateProbations],
         ],
       },
+      wqac: {
+        name: 'WQAC panel',
+        pages: [
+          panel_pages[:helpfulQueries],
+        ],
+      },
     }
   end
 
@@ -1444,6 +1450,8 @@ class User < ApplicationRecord
       wic_team?
     when :weat
       weat_team?
+    when :wqac
+      quality_assurance_committee?
     else
       false
     end


### PR DESCRIPTION
WQAC requested to have access to the helpful queries panel page.

There was no WQAC panel, so that also had to be added.