### PR TITLE
Use new Staging DB

### DIFF
--- a/infra/wca_on_rails/staging/rails.tf
+++ b/infra/wca_on_rails/staging/rails.tf
@@ -22,7 +22,7 @@ locals {
     },
     {
       name = "DATABASE_HOST"
-      value = "staging-worldcubeassociation-dot-org.comp2du1hpno.us-west-2.rds.amazonaws.com"
+      value = "staging-v2-worldcubeassociation-dot-org.comp2du1hpno.us-west-2.rds.amazonaws.com"
     },
     {
       name = "WCA_REGISTRATIONS_POLL_URL"
@@ -42,11 +42,11 @@ locals {
     },
     {
       name = "READ_REPLICA_HOST"
-      value = "readonly-staging-worldcubeassociation-dot-org.comp2du1hpno.us-west-2.rds.amazonaws.com"
+      value = "staging-v2-worldcubeassociation-dot-org.comp2du1hpno.us-west-2.rds.amazonaws.com"
     },
     {
       name = "DEV_DUMP_HOST"
-      value = "readonly-staging-worldcubeassociation-dot-org.comp2du1hpno.us-west-2.rds.amazonaws.com"
+      value = "staging-v2-worldcubeassociation-dot-org.comp2du1hpno.us-west-2.rds.amazonaws.com"
     },
     {
       name = "CACHE_REDIS_URL"


### PR DESCRIPTION
I recreated the staging DB to have way more IOPS and also bumped it up an instance size. Too offset the cost I didn't a create read only replica. I can recreate a read only replica and bump down the size next week if needed.

Imports are down to 1h on this setup though.