### PR TITLE
Replace mission statement with purpose statement

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2485,8 +2485,8 @@ en:
   #context: About the WCA
   about:
     title: "About the WCA"
-    mission_statement: Our mission is to have more competitions in more countries with more people and more fun, under fair and equal conditions.
-    mission_footer: WCA Mission Statement
+    mission_statement: Our Purpose is to empower the global speedcubing community and uphold a fun and fair competitive environment for all.
+    mission_footer: WCA Purpose Statement
     who_we_are_title: Who we are
     who_we_are_content_html: <p>The World Cube Association governs competitions for mechanical puzzles that are operated by twisting groups of pieces, commonly known as 'twisty puzzles'. The most famous of these puzzles is the Rubik's Cube, invented by professor Rubik from Hungary. A selection of these puzzles are chosen as official events of the WCA.</p>
       <p>As the WCA has evolved over the past decade, over 245,000 people have competed in our competitions. Despite this growth, we remain an organization that is almost entirely run by volunteers, from local organizers to WCA Delegates to even the WCA Board. We are very grateful to everyone who takes time out of their lives to allow the WCA to function. With more financial support, we hope to bring an even greater level of professionalism to our competitions as we continue to sanction more events across the globe.</p>


### PR DESCRIPTION
This PR replaces the WCA mission statement on the About page with the WCA Purpose Statement that was adopted by WCA voting members in October 2025.

This PR does not replace the path of the locale string `mission_statement` or `mission_footer`. Let me know if it is preferred to change that as well.