### PR TITLE
Fixing newcomer check page related to queryData

### DIFF
--- a/app/webpacker/components/EditUser/index.jsx
+++ b/app/webpacker/components/EditUser/index.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { useQuery } from '@tanstack/react-query';
+import React, { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import getUserDetails from './api/getUserDetails';
 import Loading from '../Requests/Loading';
 import Errored from '../Requests/Errored';
 import EditUserForm from './EditUserForm';
 
 export default function EditUser({ id, onSuccess }) {
+  const queryClient = useQueryClient();
+
   const {
     data: userDetails,
     isPending,
@@ -16,10 +18,15 @@ export default function EditUser({ id, onSuccess }) {
     queryFn: () => getUserDetails(id),
   });
 
+  const handleSuccess = useCallback((updatedUserDetails) => {
+    queryClient.setQueryData(['user-details-for-edit', id], updatedUserDetails);
+    onSuccess(updatedUserDetails);
+  }, [queryClient, id, onSuccess]);
+
   if (isPending) return <Loading />;
   if (isError) return <Errored error={error} />;
 
   return (
-    <EditUserForm userDetails={userDetails} onSuccess={onSuccess} />
+    <EditUserForm userDetails={userDetails} onSuccess={handleSuccess} />
   );
 }

--- a/app/webpacker/components/NewcomerChecks/index.jsx
+++ b/app/webpacker/components/NewcomerChecks/index.jsx
@@ -34,7 +34,7 @@ function NewcomerChecks({ competitionId }) {
       }),
     );
 
-    if (queryClient.getQueryData(['newcomer-name-format-checks', competitionId]).some((check) => check.id === user.id)) {
+    if (queryClient.getQueryData(['newcomer-name-format-checks', competitionId])?.some((check) => check.id === user.id)) {
       queryClient.invalidateQueries(['newcomer-name-format-checks', competitionId]);
     }
   };


### PR DESCRIPTION
There are two fixes here:

1. `newcomer-name-format-checks` is for the other tab, and there are chances that the user have not opened the tab yet in current session, and that was leading to an error. This is now fixed.
2. After editing a user's form, if the form is opened again, it won't have the latest value. This is also now fixed.