### PR TITLE
Paginate Banned Competitors

### DIFF
--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitors.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/BannedCompetitors.jsx
@@ -2,19 +2,15 @@ import React from 'react';
 import { Icon, Table, Segment } from 'semantic-ui-react';
 import UserBadge from '../../../UserBadge';
 import PaginationFooter from '../../../PaginationFooter';
-import usePagination from '../../../../lib/hooks/usePagination';
 
 export default function BannedCompetitors({
   bannedCompetitorRoles,
   canEditBannedCompetitors,
   editBannedCompetitor,
+  pagination,
+  totalPages,
+  toatlEntries,
 }) {
-  const pagination = usePagination(50);
-  const { entriesPerPage, activePage } = pagination;
-  const paginatedRoles = bannedCompetitorRoles.slice(
-    (activePage - 1) * entriesPerPage,
-    activePage * entriesPerPage,
-  );
   return bannedCompetitorRoles.length > 0 ? (
     <>
       <Table>
@@ -32,7 +28,7 @@ export default function BannedCompetitors({
         </Table.Header>
 
         <Table.Body>
-          {paginatedRoles.map((role) => (
+          {bannedCompetitorRoles.map((role) => (
             <Table.Row key={role.id}>
               <Table.Cell>
                 <UserBadge
@@ -62,8 +58,9 @@ export default function BannedCompetitors({
 
       <PaginationFooter
         pagination={pagination}
-        totalPages={Math.ceil(bannedCompetitorRoles.length / entriesPerPage)}
-        totalEntries={bannedCompetitorRoles.length}
+        totalPages={totalPages}
+        totalEntries={toatlEntries}
+        allowChangingEntriesPerPage
       />
     </>
   ) : (

--- a/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
+++ b/app/webpacker/components/Panel/pages/BannedCompetitorsPage/index.jsx
@@ -8,26 +8,33 @@ import Errored from '../../../Requests/Errored';
 import BannedCompetitors from './BannedCompetitors';
 import useLoggedInUserPermissions from '../../../../lib/hooks/useLoggedInUserPermissions';
 import BannedCompetitorForm from './BannedCompetitorForm';
+import usePagination from '../../../../lib/hooks/usePagination';
 
 export default function BannedCompetitorsPage() {
+  const bannedPagination = usePagination(50);
+  const pastBannedPagination = usePagination(50);
   const {
     data: bannedCompetitorRoles,
+    headers: bannedCompetitorHeaders,
     loading: bannedCompetitorRolesLoading,
     error: bannedCompetitorRolesError,
     sync: syncBannedCompetitorRoles,
   } = useLoadedData(apiV0Urls.userRoles.list({
     isActive: true,
     groupType: groupTypes.banned_competitors,
-  }, 'startDate', 500));
+    page: bannedPagination.activePage,
+  }, 'startDate', bannedPagination.entriesPerPage));
   const {
     data: pastBannedCompetitorRoles,
+    headers: pastBannedCompetitorHeaders,
     loading: pastBannedCompetitorRolesLoading,
     error: pastBannedCompetitorRolesError,
     sync: syncPastBannedCompetitorRoles,
   } = useLoadedData(apiV0Urls.userRoles.list({
     isActive: false,
     groupType: groupTypes.banned_competitors,
-  }, 'startDate:desc', 500));
+    page: pastBannedPagination.activePage,
+  }, 'startDate:desc', pastBannedPagination.entriesPerPage));
   const {
     data: bannedGroups,
     loading: bannedGroupLoading,
@@ -56,6 +63,13 @@ export default function BannedCompetitorsPage() {
   const canEditBannedCompetitors = bannedGroups
     .some((bannedGroup) => loggedInUserPermissions.canEditGroup(bannedGroup.id));
 
+  const bannedTotalEntries = parseInt(bannedCompetitorHeaders.get('total'), 10);
+  const bannedEntriesPerPage = parseInt(bannedCompetitorHeaders.get('per-page'), 10);
+  const bannedTotalPages = Math.ceil(bannedTotalEntries / bannedEntriesPerPage);
+
+  const pastTotalEntries = parseInt(pastBannedCompetitorHeaders.get('total'), 10);
+  const pastEntriesPerPage = parseInt(pastBannedCompetitorHeaders.get('per-page'), 10);
+  const pastTotalPages = Math.ceil(pastTotalEntries / pastEntriesPerPage);
   return (
     <>
       <>
@@ -69,6 +83,9 @@ export default function BannedCompetitorsPage() {
           bannedCompetitorRoles={bannedCompetitorRoles}
           canEditBannedCompetitors={canEditBannedCompetitors}
           editBannedCompetitor={setBanModalParams}
+          pagination={bannedPagination}
+          totalPages={bannedTotalPages}
+          toatlEntries={bannedTotalEntries}
         />
       </>
       <>
@@ -77,6 +94,9 @@ export default function BannedCompetitorsPage() {
           bannedCompetitorRoles={pastBannedCompetitorRoles}
           canEditBannedCompetitors={canEditBannedCompetitors}
           editBannedCompetitor={setBanModalParams}
+          pagination={pastBannedPagination}
+          totalPages={pastTotalPages}
+          toatlEntries={pastTotalEntries}
         />
       </>
       <Modal open={!!banModalParams} onClose={() => setBanModalParams(null)}>

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -237,7 +237,7 @@ export const apiV0Urls = {
     resetClaimCount: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_wrt_person_reset_claim_count_path("${wcaId}"))%>`,
   },
   userRoles: {
-    list: ({isActive, isGroupHidden, userId, groupId, status, groupType, isLead} = {}, sort, perPage = 100) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId, groupId, status, groupType, isLead, per_page: perPage })}`,
+    list: ({isActive, isGroupHidden, userId, groupId, status, groupType, isLead, page} = {}, sort, perPage = 100) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>?${jsonToQueryString({ sort, isActive, isGroupHidden, userId, groupId, status, groupType, isLead, page, per_page: perPage })}`,
     create: () => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_roles_path) %>`,
     update: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,
     delete: (roleId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.api_v0_user_role_path("${roleId}")) %>`,


### PR DESCRIPTION
fixes: https://github.com/thewca/worldcubeassociation.org/issues/11710

The hard part was getting over 100 users banned in my local database :sweat_smile: 

I mostly just copied what Parnav did in https://github.com/thewca/worldcubeassociation.org/pull/11711. However, as discussed in that PR, the api call is only returning 100 rows and the front end is only paginating over that. Daniel mentioned that you can pass the page number like `/api/v0/user_roles?page=3` which works, however the total number of rows there could be is unknown and page options can not be accurately displayed on the front end.

This endpoint seems to be used all over the application so I did not want to modify the return structure by adding the total number of results to `users_roles_controller@index`

The simplest solution seems to be increasing the perPage limit on these specific calls, which are defaulted to 100.
This is what I did by simply adding 500 to the banned competitor requests...
```
apiV0Urls.userRoles.list({
    isActive: true,
    groupType: groupTypes.banned_competitors,
}, 'startDate', 500)
```
This seems like a band-aid solution as the problem could arise again if this limit is passed, but the only other solution I can think of is creating a separate endpoint for banned competitors that would include the total result count and can be properly paginated. Otherwise, 500 should _hopefully_ be sufficient enough for a while.

Please let me know if this is not an acceptable solution for this and if you have a different suggestion.
