### PR TITLE
Replace venue name with events list in competition list

### DIFF
--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -20,7 +20,7 @@ import {
   startYear,
   timeDifferenceBefore,
 } from '../../lib/utils/competition-table';
-import { countries } from '../../lib/wca-data.js.erb';
+import { countries, events } from '../../lib/wca-data.js.erb';
 import { adminCompetitionUrl, competitionUrl } from '../../lib/requests/routes.js.erb';
 import { dateRange, toRelativeOptions } from '../../lib/utils/dates';
 import RegionFlag from '../wca/RegionFlag';
@@ -135,7 +135,7 @@ export function CompetitionsTable({
           <Table.HeaderCell textAlign="right">{I18n.t('competitions.competition_info.date')}</Table.HeaderCell>
           <Table.HeaderCell>{I18n.t('competitions.competition_info.name')}</Table.HeaderCell>
           <Table.HeaderCell>{I18n.t('competitions.competition_info.location')}</Table.HeaderCell>
-          <Table.HeaderCell>{I18n.t('competitions.competition_info.venue')}</Table.HeaderCell>
+          <Table.HeaderCell>{I18n.t('competitions.competition_info.events')}</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>
@@ -169,7 +169,19 @@ export function CompetitionsTable({
                 {`, ${comp.city}`}
               </Table.Cell>
               <Table.Cell width={5}>
-                <PseudoLinkMarkdown text={comp.venue} />
+                {comp.event_ids?.map((eventId) => (
+                  <Popup
+                    key={eventId}
+                    position="bottom center"
+                    size="tiny"
+                    content={events.byId[eventId].name}
+                    trigger={(
+                      <i
+                        className={`cubing-icon icon event-${eventId}`}
+                      />
+                    )}
+                  />
+                ))}
               </Table.Cell>
             </Table.Row>
           </React.Fragment>


### PR DESCRIPTION
fixes: https://github.com/thewca/worldcubeassociation.org/issues/8156

<img width="1636" height="791" alt="image" src="https://github.com/user-attachments/assets/c42df47a-d764-438e-8fe5-fa165aae597d" />

No changes done for tablet and mobile view yet 

<img width="883" height="782" alt="image" src="https://github.com/user-attachments/assets/5d34c6e0-fcfa-46e1-828c-d6113473157b" />

<img width="468" height="722" alt="image" src="https://github.com/user-attachments/assets/b6b51b74-a57c-414c-827c-2014c6a41f02" />


- Suggest if i should remove venue from tablet view and add events there ?
- Also what can be done for mobile view ? 
