### PR TITLE
[Concise 2/3] Turn result_id into the primary key for RRL

### DIFF
--- a/db/migrate/20260202173059_change_rrl_primary_key_to_result_id.rb
+++ b/db/migrate/20260202173059_change_rrl_primary_key_to_result_id.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ChangeRrlPrimaryKeyToResultId < ActiveRecord::Migration[8.1]
+  # rubocop:disable Rails/BulkChangeTable, Rails/DangerousColumnNames
+  def up
+    remove_column :regional_records_lookup, :id
+
+    execute "ALTER TABLE `regional_records_lookup` ADD PRIMARY KEY (result_id)"
+
+    remove_index :regional_records_lookup, :result_id
+  end
+
+  def down
+    execute "ALTER TABLE `regional_records_lookup` DROP PRIMARY KEY"
+
+    add_column :regional_records_lookup, :id, :primary_key, first: true
+    add_index :regional_records_lookup, :result_id
+  end
+  # rubocop:enable all
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_28_194213) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_02_173059) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1055,16 +1055,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_28_194213) do
     t.index ["name"], name: "index_regional_organizations_on_name"
   end
 
-  create_table "regional_records_lookup", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "regional_records_lookup", primary_key: "result_id", id: :integer, default: nil, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "average", default: 0, null: false
     t.integer "best", default: 0, null: false
     t.date "competition_end_date", null: false
     t.string "country_id", null: false
     t.string "event_id", null: false
-    t.integer "result_id", null: false
     t.index ["event_id", "country_id", "average", "competition_end_date"], name: "idx_on_eventId_countryId_average_competitionEndDate_b424c59953"
     t.index ["event_id", "country_id", "best", "competition_end_date"], name: "idx_on_eventId_countryId_best_competitionEndDate_4e01b1ae38"
-    t.index ["result_id"], name: "index_regional_records_lookup_on_resultId"
   end
 
   create_table "registration_competition_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Extracted from https://github.com/thewca/worldcubeassociation.org/pull/13331 to reduce DB load during deployments. The goal is to run the migrations separately.

We had an auto-increment primary on this lookup table, which is silly because it's just CAD data. Using hte result ID foreign key as primary key also means that we get the blazing fast `PRIMARY` index "for free" and we can discard the existing, separate index on `result_id`