### PR TITLE
Change "Slovensko" to "Slovenščina"

### DIFF
--- a/config/locales/available.json
+++ b/config/locales/available.json
@@ -106,7 +106,7 @@
   },
   "sl": {
     "flag_id": "si",
-    "name": "Slovensko"
+    "name": "Slovenščina"
   },
   "sv": {
     "flag_id": "se",


### PR DESCRIPTION
Per "WCA Website Translation" email thread, from our new verified translator: 
> It's "Slovensko". Maybe a better word to use would actually be "Slovenščina" (this is the noun for "Slovenian", "Slovensko" is the adjective) as it provides a clearer separation from Slovakian (which is "Slovensky" :) ).

