### PR TITLE
Privacy Statement Clerical Changes

### DIFF
--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -75,7 +75,7 @@
   </ul>
   <p>We explicitly do not buy and/or use information on you from other parties, like social media, web trackers, or marketing companies.</p>
   <h2><%= anchorable "What is your data used for?" %></h2>
-  <p>We use your data to provide services to you, to the Registered Speedcubers, to other users of our services, and for internal use of the WCA. For each service we only use relevant data. We use this data in compliance with the GDPR policy and applicable other legislations and regulations.</p>
+  <p>We use your data to provide services to you, to the Registered Speedcubers, to other users of our services, and for internal use of the WCA. For each service we only use relevant data. We use this data in compliance with the GDPR policy and applicable other legislation and regulations.</p>
   <ul>
     <li>
       Participate at WCA Competitions:<br>In order to participate at WCA competitions we collect data from you during the registration process and during the competition.<br>With this information we:
@@ -129,7 +129,7 @@
   <h2><%= anchorable "How is your data used internationally?" %></h2>
   <p>The WCA is based in the United States of America. But since the WCA is a worldwide organization, your data may also be processed by the WCA in other countries.</p>
   <ul>
-    <li>The WCA may transfer your personal data from one country to another country<br>to provide the services of the WCA. In all cases we will follow the GDPR policy and applicable local legislation and regulations.</li>
+    <li>The WCA may transfer your personal data from one country to another country to provide the services of the WCA. In all cases we will follow the GDPR policy and applicable local legislation and regulations.</li>
   </ul>
   <h2><%= anchorable "What are your rights?" %></h2>
   <p>The WCA has a Data Protection Officer that will monitor if the WCA is following the data protection laws, and take action where necessary. You may contact our Data Protection Officer to exercise any of the rights you are granted under applicable data protection laws. Some of your rights you may directly exercise on our website through functions available in your account.</p>


### PR DESCRIPTION
See email "Question about the owner of the WCA website's Privacy section". The following changes were requested by the OP, and approved by Callum on behalf of WRT: 

> The clerical errors that I believe that there are, are the following:
> 1.- After the text "The WCA may transfer your personal data from one country to another country" there is a <br> that I don't think should be there.
> 2.- After the text "The WCA has a Data Protection Officer that will monitor if the WCA is following the data protection laws" there is a period that should be a comma.
> 3.- The text "applicable other legislations and regulations" should use the word legislation in singular.

No action taken on item 2 because I couldn't see the issue in the code.