### PR TITLE
Fix couple of bugs in newcomers page

### DIFF
--- a/app/models/potential_duplicate_person.rb
+++ b/app/models/potential_duplicate_person.rb
@@ -18,7 +18,7 @@ class PotentialDuplicatePerson < ApplicationRecord
       },
       duplicate_person: {
         private_attributes: %w[dob],
-        methods: %w[country country_iso2 user_id],
+        methods: %w[country user_id],
       },
     },
   }.freeze

--- a/app/webpacker/components/NewcomerChecks/SimilarPersonTable.jsx
+++ b/app/webpacker/components/NewcomerChecks/SimilarPersonTable.jsx
@@ -43,7 +43,7 @@ export default function SimilarPersonTable({
           const exactSameDetails = (
             originalUser.name === duplicatePerson.name
                   && originalUser.dob === duplicatePerson.dob
-                  && originalUser.country_iso2 === duplicatePerson.country_iso2
+                  && originalUser.country.iso2 === duplicatePerson.country.iso2
                   && originalUser.gender === duplicatePerson.gender
           );
           return (


### PR DESCRIPTION
Following two fixes are applied in this PR:
1. Duplicate person was not parsing `country_iso2`, hence it was taking the same from corresponding `user`. If there is no `user`, then this person will have `null` `country_iso2` and it impacts the newcomers page for some cases.
2. `exactSameDetails` was not considering same ~~DOB~~ gender.