### PR TITLE
Task to cleanup stale WCA ID claims

### DIFF
--- a/app/mailers/wca_id_claim_mailer.rb
+++ b/app/mailers/wca_id_claim_mailer.rb
@@ -11,9 +11,10 @@ class WcaIdClaimMailer < ApplicationMailer
     )
   end
 
-  def notify_user_of_claim_cancelled(user, unconfirmed_wca_id)
+  def notify_user_of_claim_cancelled(user, unconfirmed_wca_id, cleanup: false)
     @user = user
     @unconfirmed_wca_id = unconfirmed_wca_id
+    @cleanup = cleanup
     mail(
       to: user.email,
       subject: "Your WCA ID claim for #{unconfirmed_wca_id} has been cancelled",

--- a/app/views/wca_id_claim_mailer/notify_user_of_claim_cancelled.html.erb
+++ b/app/views/wca_id_claim_mailer/notify_user_of_claim_cancelled.html.erb
@@ -2,7 +2,11 @@
 
 <p>You have previously requested to claim the WCA ID <%= @unconfirmed_wca_id %> for your account.</p>
 
+<% if @cleanup %>
 <p>We are currently cleaning up our records and reviewing these requests. We found that the WCA ID you asked for, was already taken by another account (<%= wca_id_link @unconfirmed_wca_id %>) before we could process your request.</p>
+<% else %>
+<p>The WCA ID you asked for (<%= wca_id_link @unconfirmed_wca_id %>), is now taken by another account before we could process your request.</p>
+<% end %>
 
 <p>It means that this WCA ID is no longer available, so we have cancelled your claim.</p>
 

--- a/lib/tasks/cleanup_unclaimed_wca_ids.rake
+++ b/lib/tasks/cleanup_unclaimed_wca_ids.rake
@@ -14,7 +14,7 @@ namespace :cleanup do
     stale_claims.limit(limit).each do |user|
       wca_id = user.unconfirmed_wca_id
       if user.update_columns(unconfirmed_wca_id: nil, delegate_id_to_handle_wca_id_claim: nil)
-        WcaIdClaimMailer.notify_user_of_claim_cancelled(user, wca_id).deliver_later
+        WcaIdClaimMailer.notify_user_of_claim_cancelled(user, wca_id, cleanup: true).deliver_later
         puts "Cleared stale claim for user #{user.id} (#{user.email}) - WCA ID #{wca_id}"
       else
         puts "Failed to clear stale claim for user #{user.id} (#{user.email}) - WCA ID #{wca_id}: #{user.errors.full_messages.join(', ')}"


### PR DESCRIPTION
Currently we have so many claims which are stale because the WCA ID is already assigned to another user. This task is to cleanup those cases.

I'm also working on moving WCA ID claims to tickets (https://github.com/thewca/worldcubeassociation.org/pull/13151). Once that PR is completed, this task won't be needed anymore.

My plan is to run this script before getting that PR merged, so that we won't have stale tickets.

This task cannot be run as part of migration because we need to send email notifications for each claim cancelling.