### PR TITLE
Remove redundant database indices

### DIFF
--- a/db/migrate/20260218192349_remove_value_n_indices.rb
+++ b/db/migrate/20260218192349_remove_value_n_indices.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveValueNIndices < ActiveRecord::Migration[8.1]
+  def change
+    change_table :results, bulk: true do |t|
+      t.remove_index %i[event_id value1]
+      t.remove_index %i[event_id value2]
+      t.remove_index %i[event_id value3]
+      t.remove_index %i[event_id value4]
+      t.remove_index %i[event_id value5]
+    end
+  end
+end

--- a/db/migrate/20260218192442_remove_duplicate_index_on_rce.rb
+++ b/db/migrate/20260218192442_remove_duplicate_index_on_rce.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveDuplicateIndexOnRce < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :registration_competition_events, %i[registration_id competition_event_id], name: "index_reg_events_reg_id_comp_event_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_02_173059) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_18_192442) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1066,7 +1066,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_02_173059) do
     t.integer "registration_id"
     t.index ["competition_event_id"], name: "index_registration_competition_events_on_competition_event_id"
     t.index ["registration_id", "competition_event_id"], name: "idx_registration_competition_events_on_reg_id_and_comp_event_id", unique: true
-    t.index ["registration_id", "competition_event_id"], name: "index_reg_events_reg_id_comp_event_id"
     t.index ["registration_id"], name: "index_registration_competition_events_on_registration_id"
   end
 
@@ -1174,11 +1173,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_02_173059) do
     t.index ["event_id", "best"], name: "Results_eventAndBest"
     t.index ["event_id", "competition_id", "round_type_id", "country_id", "average"], name: "Results_regionalAverageRecordCheckSpeedup"
     t.index ["event_id", "competition_id", "round_type_id", "country_id", "best"], name: "Results_regionalSingleRecordCheckSpeedup"
-    t.index ["event_id", "value1"], name: "index_Results_on_eventId_and_value1"
-    t.index ["event_id", "value2"], name: "index_Results_on_eventId_and_value2"
-    t.index ["event_id", "value3"], name: "index_Results_on_eventId_and_value3"
-    t.index ["event_id", "value4"], name: "index_Results_on_eventId_and_value4"
-    t.index ["event_id", "value5"], name: "index_Results_on_eventId_and_value5"
     t.index ["event_id"], name: "Results_fk_event"
     t.index ["format_id"], name: "Results_fk_format"
     t.index ["person_id"], name: "Results_fk_competitor"


### PR DESCRIPTION
The first one is stolen from #12696. It came from a time when we still displayed rankings using a `UNION ALL` with 5 subqueries, but luckily that's history now.

The second one is just removing an index which actually was a duplicate (you can see in the diff we have the exact same index definition one line above with `unique: true`)