### PR TITLE
Allow Delegates to edit Series competitions in Organizer View

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2678,12 +2678,12 @@ class Competition < ApplicationRecord
   end
 
   def set_form_data_series(form_data_series, current_user)
-    raise WcaExceptions::BadApiParameter.new("Cannot change Competition Series") unless current_user.can_update_competition_series?(self)
-
     raise WcaExceptions::BadApiParameter.new("The Series must include the competition you're currently editing.") unless form_data_series["competitionIds"].include?(self.id)
 
-    competition_series = form_data_series["id"].present? ? CompetitionSeries.find(form_data_series["id"]) : CompetitionSeries.new
+    competition_series = form_data_series["id"].present? ? CompetitionSeries.find(form_data_series["id"]) : self.build_competition_series
     competition_series.set_form_data(form_data_series)
+
+    raise WcaExceptions::BadApiParameter.new("Cannot change Competition Series") if competition_series.changed? && !current_user.can_update_competition_series?(self)
 
     self.competition_series = competition_series
   end


### PR DESCRIPTION
We had a check that locked out even _trying_ to change Competition Series details for non-admins.

The problem is that the React frontend always sends a full "Carbon Copy" of the whole competition (including the series) and relies on ActiveRecord to only store the stuff that actually changed.

So, we also relax the error to only throw if ActiveRecord tells us that something actually changed.

The diff about `build_competition_series` is _technically_ unrelated, but since I was touching this part of the code anyways I thought I might as well clean it up.