### PR TITLE
Prevent Thai Names from triggering Special Character Validator

### DIFF
--- a/lib/results_validators/persons_validator.rb
+++ b/lib/results_validators/persons_validator.rb
@@ -76,7 +76,7 @@ module ResultsValidators
       validation_issues << ValidationError.new(WRONG_PARENTHESIS_TYPE_ERROR, :persons, competition_id, name: name) if /[（）]/.match?(name)
 
       # Check for special characters in name.
-      # Regex [^\p{L}\s\-'.()] uses negated character class - matches anything NOT allowed
+      # Regex [^\p{L}\p{M}\s\-'.()] uses negated character class - matches anything NOT allowed
       # : ^\p{L} (Unicode letters), \p{M} (combining/accent marks) \s (whitespace), \- (hyphen), ' (apostrophe), . (period), () (parentheses), /u (enables unicode mode)
       # Triggers warning for: digits, @, #, and other special symbols
       validation_issues << ValidationWarning.new( SPECIAL_CHARACTERS_IN_NAME_WARNING, :persons, competition_id, name: name) if /[^\p{L}\p{M}\s\-'.()]/u.match?(name)


### PR DESCRIPTION
Note: Regex generated by ChatGPT - I don't know regex or unicode well enough to come up with this myself. 

We have an issue with the newly-added Person Name validator where Thai characters were getting flagged as special characters. For example, this name triggered a warning: "Meechok Torpattananan (มีโชค ต่อพัฒนนันท์)".

The new regex appears to work without this false-positive. I have tested locally with:
- the Rails console, as a first step
- the same Results JSON on the same competition as the one that triggered that error in the first place, 