### PR TITLE
Approve WCA ID claims via proper function

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -6,22 +6,6 @@ onPage('users#edit, users#update', function() {
     $('.form-group.user_avatar').toggle(!toDelete);
   }).trigger("change");
 
-  var $approve_wca_id = $('#approve-wca-id');
-  var $unconfirmed_wca_id = $("#user_unconfirmed_wca_id");
-  var $unconfirmed_wca_id_profile_link = $("a#unconfirmed-wca-id-profile");
-  $approve_wca_id.on("click", function(e) {
-    $("#user_wca_id").val($unconfirmed_wca_id.val());
-    $unconfirmed_wca_id.val('');
-    $unconfirmed_wca_id.trigger('input');
-  });
-  $unconfirmed_wca_id.on("input", function(e) {
-    var unconfirmed_wca_id = $unconfirmed_wca_id.val();
-    $approve_wca_id.prop("disabled", !unconfirmed_wca_id);
-    $unconfirmed_wca_id_profile_link.parent().toggle(!!unconfirmed_wca_id);
-    $unconfirmed_wca_id_profile_link.attr('href', "/persons/" + unconfirmed_wca_id);
-  });
-  $unconfirmed_wca_id.trigger('input');
-
   // Change the 'section' parameter when a tab is switched.
   $('a[data-toggle="tab"]').on('show.bs.tab', function() {
     var section = $(this).attr('href').slice(1);

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -76,16 +76,14 @@
                     <%= t 'activerecord.attributes.user.unconfirmed_wca_id' %>
                   </label>
                   <div class="input-group">
-                    <%= f.input_field :unconfirmed_wca_id, as: :wca_id, disabled: !editable_fields.include?(:unconfirmed_wca_id), class: "form-control" %>
+                    <%= f.input_field :unconfirmed_wca_id, as: :wca_id, disabled: true, class: "form-control" %>
                     <span class="input-group-addon">
-                      <a href="#" id="unconfirmed-wca-id-profile" target="_blank">
+                      <a href="<%= person_path(@user.unconfirmed_wca_id) %>" id="unconfirmed-wca-id-profile" target="_blank">
                         <%= t '.profile' %>
                       </a>
                     </span>
                     <div class="input-group-btn">
-                      <button type="button" class="btn btn-default" id="approve-wca-id">
-                        <%= t '.approve' %>
-                      </button>
+                      <%= link_to t('.approve'), confirm_wca_id_path(userId: @user.id, wcaId: @user.unconfirmed_wca_id), method: :post, data: { confirm: t('.approve_confirm', wca_id: @user.unconfirmed_wca_id) }, class: "btn btn-default", id: "approve-wca-id" %>
                     </div>
                   </div>
                 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1042,6 +1042,7 @@ en:
       please_fix_profile: "In order to register for competitions, you need to fix the following problems:"
       profile: "Profile"
       approve: "Approve"
+      approve_confirm: "Are you sure you want to approve WCA ID %{wca_id}?"
       unconfirmed_email: "This account's email address (%{email}) is not confirmed."
       confirm_new_email: "Changing your email will require confirming the new email before being effective."
       pending_mail_confirmation: "This account is pending confirmation of the new email address %{email}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
   post 'users/update_user_data' => 'users#update_user_data'
   post 'users/merge' => 'users#merge'
   post 'users/assign_wca_id' => 'users#assign_wca_id'
+  post 'users/confirm_wca_id' => 'users#confirm_wca_id', as: :confirm_wca_id
   get '/users/registrations' => 'users#registrations', as: :helpful_queries_registrations
   get '/users/organized-competitions' => 'users#organized_competitions', as: :helpful_queries_organized_competitions
   get '/users/delegated-competitions' => 'users#delegated_competitions', as: :helpful_queries_delegated_competitions


### PR DESCRIPTION
Currently to approve a WCA ID claim, the steps are as follows:
1. Click 'approve', and the WCA ID will go to the WCA ID box.
2. Click 'save', and it gets saved.

New flow is as follows:
1. Click 'approve' button which asks for a confirmation box
2. Confirm it and completed

In the new flow, I've made one extra change - make the `unconfirmed_wca_id` as disabled - this is to avoid changing the unconfirmed WCA ID by the user. Ideally they should not have any way to edit unconfirmed WCA ID.

This change is necessary for "Ticket for WCA ID claims" task. If this change is in, then during all the claims, old claims will get cleared. And once we are done with the cleanup of stale claims, then we will be left with only genuine claims, and it will allow to create only those tickets which are necessary.