### PR TITLE
Only group schedule table activities if names match

### DIFF
--- a/app/webpacker/lib/utils/activities.js
+++ b/app/webpacker/lib/utils/activities.js
@@ -28,6 +28,7 @@ const areGroupable = (a, b) => (
   a.startTime === b.startTime
   && a.endTime === b.endTime
   && a.activityCode === b.activityCode
+  && a.name === b.name
 );
 
 // assumes they are sorted


### PR DESCRIPTION
Resolves #13538 for the legacy page (but not necessarily the next page, I'm not sure how to access that locally yet).