### PR TITLE
Remove duplicate payment records via Rake task

### DIFF
--- a/lib/tasks/remove_duplicate_payments.rake
+++ b/lib/tasks/remove_duplicate_payments.rake
@@ -4,10 +4,10 @@ namespace :duplicate_payments do
   desc "Remove duplicate payment records from database"
   task destroy: :environment do
     duplicate_refund_stripe_ids = StripeRecord
-                                    .group(:stripe_id)
-                                    .having("COUNT(*) > 1")
-                                    .count
-                                    .keys
+                                  .group(:stripe_id)
+                                  .having("COUNT(*) > 1")
+                                  .count
+                                  .keys
 
     puts "About to process #{duplicate_refund_stripe_ids}. Continue? [y/N]"
     proceed = $stdin.gets.chomp.downcase
@@ -39,7 +39,7 @@ namespace :duplicate_payments do
         break
       end
 
-      unless non_wh_record.registration_payment.present?
+      if non_wh_record.registration_payment.blank?
         puts "No registration_payment present for non_wh_record: #{non_wh_record} - aborting."
         break
       end


### PR DESCRIPTION
StripeRecords should be unique on the basis of stripe_id. However, due to some crazy race condition being addressed here, there have been limited instances of duplicate stripe_records being recorded for the same refund, and in most cases those also created duplicate registration_payments.

This rake task dedupes by:

-     Identifying the webhook/non-webhook generated records
-     Pointing any saved stripe_webhook_events at the non-webhook records[1^]
-     Remove any registration payments associated with webhook-generated duplicate StripeRecords
-     Remove the webhook-generated duplicate StripeRecords themselves

PR has been tested locally and works as expected. Testing data not committed as it mimics production data. Spec file accessible in second footnote[^2]

**Note: ** In production, there is one instance of a registration payment being created for a webhook-generated StripeRecord, where the non-wh-generated StripeRecord has no corresponding registration_payment. To fix this, reg_pmt 616407 should be manually edited to point at stripe_record 883736 - once that's done, this script will run as expected.

[^1] the registration payments associated with the non-webhook records have the correct user_id for the user who initiated the refund, so we want to keep those

[^2] 

```ruby
# frozen_string_literal: true

require 'rails_helper'
require 'rake'

# return unless Rails.env.development?

RSpec.describe "remove duplicate payments", type: :task do
  before(:all) do
    Rake.application.rake_require "tasks/duplicate_payments"
    Rake::Task.define_task(:environment)
  end

  before do
    sql = File.read(Rails.root.join("sql_import.sql"))
    statements = sql.split(/;[ \t]*\n/)
    statements.each do |statement|
      next if statement.strip.empty?
      ActiveRecord::Base.connection.execute(statement)
    end

    Rake::Task["duplicate_payments:destroy"].reenable

  end

  it 'removes duplicates as expected' do
    Rake::Task["duplicate_payments:destroy"].invoke

    # Leaves no duplicate records
    duplicate_records = StripeRecord
                          .group(:stripe_id)
                          .having("COUNT(*) > 1")
                          .count
    expect(duplicate_records).to be_empty

    # Removes the following stripe_records (webhook-generated)
    removed_records = [redacted]
    expect(StripeRecord.where(id: removed_records)).to be_empty

    # Keeps the following stripe_records (non-webhook-generated)
    kept_records = [redacted]
    expect(StripeRecord.where(id: kept_records).count).to be(38)

    # Removes the following registration_payments (linked to wh-generated StripeRecords)
    removed_registration_payments = [redacted]
    expect(RegistrationPayment.where(id: removed_registration_payments)).to be_empty

    # Keeps the following registration_payments (linked to non-webhook-generated StripeRecords)
    kept_registration_payments = [redacted]
    expect(RegistrationPayment.where(id: kept_registration_payments).count).to be(38)
  end
end
```