### PR TITLE
Try out test CI speed up by removing query logging in test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -72,4 +72,11 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Don't log queries in tests
+  config.active_record.verbose_query_logs = false
+  config.active_record.query_log_tags_enabled = false
+
+  # Raise the log level to reduce i/o
+  config.log_level = :fatal
 end


### PR DESCRIPTION
Just read this https://evilmartians.com/chronicles/the-whop-chop-how-we-cut-a-rails-test-suite-and-ci-time-in-half and got curious if we get the same speed up. Will close if it doesn't work