### PR TITLE
Specify existing Rails inverse relations

### DIFF
--- a/app/models/championship.rb
+++ b/app/models/championship.rb
@@ -15,7 +15,7 @@ class Championship < ApplicationRecord
   ].freeze
 
   belongs_to :competition
-  has_many :eligible_country_iso2s_for_championship, class_name: "EligibleCountryIso2ForChampionship", foreign_key: :championship_type, primary_key: :championship_type
+  has_many :eligible_country_iso2s_for_championship, class_name: "EligibleCountryIso2ForChampionship", foreign_key: :championship_type, primary_key: :championship_type, inverse_of: :championship
   validates :championship_type, uniqueness: { scope: :competition_id, case_sensitive: false },
                                 inclusion: { in: CHAMPIONSHIP_TYPES }
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2,12 +2,12 @@
 
 class Competition < ApplicationRecord
   # We need this default order, tests rely on it.
-  has_many :competition_events, -> { order(:event_id) }, dependent: :destroy
+  has_many :competition_events, -> { order(:event_id) }, dependent: :destroy, inverse_of: :competition
   has_many :events, through: :competition_events
   has_many :rounds, through: :competition_events
   has_many :registrations, dependent: :destroy
   has_many :results
-  has_many :scrambles, -> { order(:group_id, :is_extra, :scramble_num) }
+  has_many :scrambles, -> { order(:group_id, :is_extra, :scramble_num) }, inverse_of: :competition
   has_many :uploaded_jsons, dependent: :destroy
   has_many :competitors, -> { distinct }, through: :results, source: :person
   has_many :competitor_users, -> { distinct }, through: :competitors, source: :user
@@ -16,7 +16,7 @@ class Competition < ApplicationRecord
   has_many :competition_organizers, dependent: :delete_all
   has_many :organizers, through: :competition_organizers
   has_many :media, class_name: "CompetitionMedium", dependent: :delete_all
-  has_many :tabs, -> { order(:display_order) }, dependent: :delete_all, class_name: "CompetitionTab"
+  has_many :tabs, -> { order(:display_order) }, dependent: :delete_all, class_name: "CompetitionTab", inverse_of: :competition
   has_one :delegate_report, dependent: :destroy
   has_one :waiting_list, dependent: :destroy, as: :holder
   has_many :competition_venues, dependent: :destroy
@@ -32,16 +32,16 @@ class Competition < ApplicationRecord
   has_many :series_competitions, -> { readonly }, through: :competition_series, source: :competitions
   has_many :series_registrations, -> { readonly }, through: :series_competitions, source: :registrations
   belongs_to :posting_user, optional: true, foreign_key: 'posting_by', class_name: "User"
-  belongs_to :posted_user, optional: true, foreign_key: 'results_posted_by', class_name: "User"
+  belongs_to :posted_user, optional: true, foreign_key: 'results_posted_by', class_name: "User", inverse_of: :competitions_results_posted
   has_many :inbox_results, dependent: :delete_all
   has_many :inbox_persons, dependent: :delete_all
   has_many :inbox_scramble_sets, dependent: :delete_all
   has_many :matched_scramble_sets, through: :rounds
-  belongs_to :announced_by_user, optional: true, foreign_key: "announced_by", class_name: "User"
+  belongs_to :announced_by_user, optional: true, foreign_key: "announced_by", class_name: "User", inverse_of: :competitions_announced
   belongs_to :cancelled_by_user, optional: true, foreign_key: "cancelled_by", class_name: "User"
   has_many :competition_payment_integrations
   has_many :scramble_file_uploads, dependent: :delete_all
-  has_many :accepted_registrations, -> { accepted }, class_name: "Registration", foreign_key: "competition_id"
+  has_many :accepted_registrations, -> { accepted }, class_name: "Registration", foreign_key: "competition_id", inverse_of: :competition
   has_many :accepted_newcomers, -> { where(wca_id: nil) }, through: :accepted_registrations, source: :user
   has_many :duplicate_checker_job_runs, dependent: :delete_all
   has_one :tickets_competition_result

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -7,7 +7,7 @@ class CompetitionEvent < ApplicationRecord
   has_one :waiting_list, dependent: :destroy, as: :holder
   has_many :registration_competition_events, dependent: :destroy
   has_many :registrations, through: :registration_competition_events
-  has_many :rounds, -> { order(:number) }, dependent: :destroy
+  has_many :rounds, -> { order(:number) }, dependent: :destroy, inverse_of: :competition_event
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
   has_many :formats, through: :rounds
   has_many :preferred_formats, through: :event

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -67,7 +67,7 @@ class Country < ApplicationRecord
 
   belongs_to :continent
   has_many :competitions
-  has_one :band, foreign_key: :iso2, primary_key: :iso2, class_name: "CountryBand"
+  has_one :band, foreign_key: :iso2, primary_key: :iso2, class_name: "CountryBand", inverse_of: :country
 
   def continent
     Continent.c_find(self.continent_id)

--- a/app/models/country_band.rb
+++ b/app/models/country_band.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CountryBand < ApplicationRecord
-  belongs_to :country, foreign_key: :iso2, primary_key: :iso2
+  belongs_to :country, foreign_key: :iso2, primary_key: :iso2, inverse_of: :band
   has_many :country_band_details, foreign_key: :number, primary_key: :number
   validates :iso2, inclusion: { in: Country::WCA_COUNTRY_ISO_CODES }
   validates :number, numericality: {

--- a/app/models/eligible_country_iso2_for_championship.rb
+++ b/app/models/eligible_country_iso2_for_championship.rb
@@ -5,7 +5,7 @@ class EligibleCountryIso2ForChampionship < ApplicationRecord
 
   self.table_name = "eligible_country_iso2s_for_championship"
 
-  belongs_to :championship, foreign_key: :championship_type, primary_key: :championship_type, optional: true
+  belongs_to :championship, foreign_key: :championship_type, primary_key: :championship_type, optional: true, inverse_of: :eligible_country_iso2s_for_championship
 
   validates :eligible_country_iso2, uniqueness: { scope: :championship_type, case_sensitive: false },
                                     inclusion: { in: Country::WCA_COUNTRY_ISO_CODES }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,7 +4,7 @@ class Person < ApplicationRecord
   # for some reason, the ActiveRecord plural for "Person" is "people"…
   self.table_name = 'persons'
 
-  has_one :user, primary_key: "wca_id", foreign_key: "wca_id"
+  has_one :user, primary_key: "wca_id", foreign_key: "wca_id", inverse_of: :person
   has_many :results, primary_key: "wca_id"
   has_many :result_attempts, through: :results
   has_many :competitions, -> { distinct }, through: :results

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -24,7 +24,7 @@ class Registration < ApplicationRecord
   belongs_to :competition
   belongs_to :user, optional: true # A user may be deleted later. We only enforce validation directly on creation further down below.
 
-  has_many :registration_history_entries, -> { order(:created_at) }, dependent: :destroy
+  has_many :registration_history_entries, -> { order(:created_at) }, dependent: :destroy, inverse_of: :registration
   has_many :registration_competition_events
   has_many :registration_payments
   has_many :competition_events, through: :registration_competition_events

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -3,7 +3,7 @@
 class Result < ApplicationRecord
   include Resultable
 
-  belongs_to :person, -> { current }, primary_key: :wca_id, optional: true
+  belongs_to :person, -> { current }, primary_key: :wca_id, optional: true, inverse_of: :results
   validates :person_name, presence: true
   belongs_to :country
   has_one :continent, through: :country

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -41,11 +41,11 @@ class Round < ApplicationRecord
   serialize :round_results, coder: RoundResults
   validates_associated :round_results
 
-  has_many :schedule_activities, -> { root_activities }, dependent: :destroy
+  has_many :schedule_activities, -> { root_activities }, dependent: :destroy, inverse_of: :round
 
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
 
-  has_many :live_results, -> { order(:global_pos) }
+  has_many :live_results, -> { order(:global_pos) }, inverse_of: :round
   has_many :live_competitors, through: :live_results, source: :registration
   has_many :results
   has_many :scrambles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,25 +4,25 @@ require "uri"
 require "fileutils"
 
 class User < ApplicationRecord
-  has_many :competition_delegates, foreign_key: "delegate_id"
+  has_many :competition_delegates, foreign_key: "delegate_id", inverse_of: :delegate
   # This gives all the competitions where the user is marked as a Delegate,
   # regardless of the competition's status.
   has_many :delegated_competitions, through: :competition_delegates, source: "competition"
   # This gives all the competitions which actually happened and where the user
   # was a Delegate.
   has_many :actually_delegated_competitions, -> { over.visible.not_cancelled }, through: :competition_delegates, source: "competition"
-  has_many :competition_organizers, foreign_key: "organizer_id"
+  has_many :competition_organizers, foreign_key: "organizer_id", inverse_of: :organizer
   has_many :organized_competitions, through: :competition_organizers, source: "competition"
   has_many :votes
   has_many :registrations
   has_many :competitions_registered_for, through: :registrations, source: "competition"
-  belongs_to :person, -> { current }, primary_key: "wca_id", foreign_key: "wca_id", optional: true
+  belongs_to :person, -> { current }, primary_key: "wca_id", foreign_key: "wca_id", optional: true, inverse_of: :user
   belongs_to :unconfirmed_person, -> { current }, primary_key: "wca_id", foreign_key: "unconfirmed_wca_id", class_name: "Person", optional: true
-  belongs_to :delegate_to_handle_wca_id_claim, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User", optional: true
+  belongs_to :delegate_to_handle_wca_id_claim, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User", optional: true, inverse_of: :users_claiming_wca_id
   belongs_to :region, class_name: "UserGroup", optional: true
   has_many :roles, class_name: "UserRole"
-  has_many :active_roles, -> { active }, class_name: "UserRole"
-  has_many :past_roles, -> { inactive }, class_name: "UserRole"
+  has_many :active_roles, -> { active }, class_name: "UserRole", inverse_of: :user
+  has_many :past_roles, -> { inactive }, class_name: "UserRole", inverse_of: :user
   has_many :delegate_role_metadata, through: :active_roles, source: :metadata, source_type: "RolesMetadataDelegateRegions"
   has_many :delegate_roles, -> { includes(:group, :metadata) }, through: :delegate_role_metadata, source: :user_role, class_name: "UserRole"
   has_many :delegate_region_groups, through: :delegate_roles, source: :group, class_name: "UserGroup"
@@ -41,16 +41,16 @@ class User < ApplicationRecord
   has_many :active_bans, through: :active_bans_metadata, source: :user_role, class_name: "UserRole"
   has_many :active_groups, through: :active_roles, source: :group, class_name: "UserGroup"
   has_many :board_metadata, through: :active_groups, source: :metadata, source_type: "GroupsMetadataBoard"
-  has_many :users_claiming_wca_id, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
-  has_many :confirmed_users_claiming_wca_id, -> { confirmed_email }, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User"
+  has_many :users_claiming_wca_id, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User", inverse_of: :delegate_to_handle_wca_id_claim
+  has_many :confirmed_users_claiming_wca_id, -> { confirmed_email }, foreign_key: "delegate_id_to_handle_wca_id_claim", class_name: "User", inverse_of: :delegate_to_handle_wca_id_claim
   has_many :oauth_applications, class_name: 'Doorkeeper::Application', as: :owner
-  has_many :oauth_access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id
+  has_many :oauth_access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id, inverse_of: false
   has_many :user_preferred_events, dependent: :destroy
   has_many :preferred_events, through: :user_preferred_events, source: :event
   has_many :bookmarked_competitions, dependent: :destroy
   has_many :competitions_bookmarked, through: :bookmarked_competitions, source: :competition
-  has_many :competitions_announced, foreign_key: "announced_by", class_name: "Competition"
-  has_many :competitions_results_posted, foreign_key: "results_posted_by", class_name: "Competition"
+  has_many :competitions_announced, foreign_key: "announced_by", class_name: "Competition", inverse_of: :announced_by_user
+  has_many :competitions_results_posted, foreign_key: "results_posted_by", class_name: "Competition", inverse_of: :posted_user
   has_many :confirmed_payment_intents, class_name: "PaymentIntent", as: :confirmation_source
   has_many :canceled_payment_intents, class_name: "PaymentIntent", as: :cancellation_source
   has_many :ranks_single, through: :person
@@ -60,7 +60,7 @@ class User < ApplicationRecord
   belongs_to :current_avatar, class_name: "UserAvatar", inverse_of: :current_user, optional: true
   belongs_to :pending_avatar, class_name: "UserAvatar", inverse_of: :pending_user, optional: true
   has_many :user_avatars, dependent: :destroy, inverse_of: :user
-  has_many :potential_duplicate_persons, dependent: :destroy, foreign_key: :original_user_id, class_name: "PotentialDuplicatePerson"
+  has_many :potential_duplicate_persons, dependent: :destroy, foreign_key: :original_user_id, class_name: "PotentialDuplicatePerson", inverse_of: :original_user
 
   scope :confirmed_email, -> { where.not(confirmed_at: nil) }
   scope :newcomers, -> { where(wca_id: nil) }

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -20,8 +20,8 @@ class UserGroup < ApplicationRecord
   # There are few associations/methods here that are used only for testing. They are to make sure
   # the connections between group and roles are as expected. It's recommended not to remove them.
   has_many :direct_child_groups, class_name: "UserGroup", inverse_of: :parent_group, foreign_key: "parent_group_id"
-  has_many :roles, foreign_key: "group_id", class_name: "UserRole"
-  has_many :active_roles, -> { active }, foreign_key: "group_id", class_name: "UserRole"
+  has_many :roles, foreign_key: "group_id", class_name: "UserRole", inverse_of: :group
+  has_many :active_roles, -> { active }, foreign_key: "group_id", class_name: "UserRole", inverse_of: :group
   has_many :direct_child_roles, through: :direct_child_groups, source: :roles
   has_many :active_direct_child_roles, -> { active }, through: :direct_child_groups, source: :roles
   has_many :users, through: :roles

--- a/app/models/venue_room.rb
+++ b/app/models/venue_room.rb
@@ -6,7 +6,7 @@ class VenueRoom < ApplicationRecord
   belongs_to :competition_venue
   has_one :competition, through: :competition_venue
   delegate :start_time, :end_time, to: :competition, prefix: true
-  has_many :schedule_activities, -> { root_activities }, dependent: :destroy
+  has_many :schedule_activities, -> { root_activities }, dependent: :destroy, inverse_of: :venue_room
   has_many :wcif_extensions, as: :extendable, dependent: :delete_all
 
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: "Please input a valid hexadecimal color code" }


### PR DESCRIPTION
While working on https://github.com/thewca/worldcubeassociation.org/pull/13261, I noticed that seemingly cases like the following:

```ruby
some_competition.competition_events.each { it.load_wcif(foo_wcif) }

# competition_event.rb
def load_wcif(wcif)
  self.competition.foo_bar
end
```

...fired an SQL call for `self.competition` within `competition_event`, even though that competition event was instantiated through its parent competition in the first place.

This is because some relations in our code (like `has_many :competition_events` in `competition.rb` for example) use either
1. scopes like `-> { order(:something) }`, like in `has_many :competition_events, -> { order(:event_id) }, dependent: :destroy`
2. foreign keys like `foreign_key: :something_non_trivial`, like `belongs_to :posted_user, optional: true, foreign_key: 'results_posted_by', class_name: "User"`

...and in both cases, Rails' auto-detection of inverse relations breaks. This is the reason why Rails is not able to infer that `some_competition.competition_events.first.competition` can stay purely in-memory without needing to fire another `SELECT` for the last `.competition` part.

This PR specifies all `inverse_of` options in cases where it's trivial, ie in cases where we already had all relations fully defined and we just needed to tell Rails about it. There will be a second follow-up PR that adds extra relations for cases where they don't exist yet, and then we can also enforce RuboCop. 