### PR TITLE
Change Scrambles table primary key to bigint

### DIFF
--- a/db/migrate/20260316104129_change_scrambles_id_to_bigint.rb
+++ b/db/migrate/20260316104129_change_scrambles_id_to_bigint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeScramblesIdToBigint < ActiveRecord::Migration[8.1]
+  def up
+    change_column :scrambles, :id, :bigint
+  end
+
+  def down
+    change_column :scrambles, :id, :integer, unsigned: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_10_170809) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_16_104129) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1311,7 +1311,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_10_170809) do
     t.index ["uploaded_by"], name: "index_scramble_file_uploads_on_uploaded_by"
   end
 
-  create_table "scrambles", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "scrambles", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "competition_id", limit: 32, null: false
     t.string "event_id", limit: 6, null: false
     t.string "group_id", limit: 3, null: false


### PR DESCRIPTION
See title. Diff is self-explanatory.

Took 27 seconds on my local machine, so I think this is fair to do without downtime.