### PR TITLE
Simplify event rankings queries

### DIFF
--- a/app/controllers/api/v0/results/rankings_controller.rb
+++ b/app/controllers/api/v0/results/rankings_controller.rb
@@ -39,7 +39,7 @@ class Api::V0::Results::RankingsController < Api::V0::Results::ResultsController
                   SELECT MIN(value_and_id) value_and_id
                   FROM concise_#{type_param}_results results
                   #{'JOIN persons ON results.person_id = persons.wca_id and persons.sub_id = 1' if @gender_condition.present?}
-                  WHERE #{value} > 0
+                  WHERE 1
                     #{@event_condition}
                     #{@region_condition}
                     #{@gender_condition}

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -71,7 +71,7 @@ class ResultsController < ApplicationController
           SELECT MIN(value_and_id) value_and_id
           FROM concise_#{type_param}_results results
           #{'JOIN persons ON results.person_id = persons.wca_id and persons.sub_id = 1' if @gender_condition.present?}
-          WHERE #{value} > 0
+          WHERE 1
             #{@event_condition}
             #{@years_condition_result}
             #{@region_condition}

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -63,8 +63,7 @@ class ComputeAuxiliaryData < WcaCronjob
       FROM (
         SELECT MIN(value_and_id) value_and_id
         FROM concise_#{type}_results results
-        WHERE #{column} > 0
-          AND event_id = '#{event_id}'
+        WHERE event_id = '#{event_id}'
         GROUP BY person_id
         ORDER BY value_and_id
         LIMIT 100


### PR DESCRIPTION
Extracted from https://github.com/thewca/worldcubeassociation.org/pull/13266

This is a low-hanging fruit, because the `concise_*` tables are generated using...
```sql
SELECT MIN(best * 1000000000 + result_id) value_and_id
FROM regional_records_lookup
WHERE best > 0
GROUP BY person_id, country_id, event_id, competition_reg_year
```
...in the first place, meaning they only contain results that were GT 0 in the first place. So it does not make sense to filter for `> 0` within the concise tables again.