### PR TITLE
Fix stale data issues in attempts form after submitting

### DIFF
--- a/next-frontend/src/components/live/AttemptsForm.tsx
+++ b/next-frontend/src/components/live/AttemptsForm.tsx
@@ -10,12 +10,16 @@ import AttemptResultField from "@/app/(wca)/dashboard/AttemptResultField";
 import _ from "lodash";
 import { useResultsAdmin } from "@/providers/LiveResultAdminProvider";
 import { useLiveResults } from "@/providers/LiveResultProvider";
+import { LiveCompetitor } from "@/types/live";
 
 interface AttemptsFormProps {
   solveCount: number;
   header: string;
   eventId: string;
 }
+
+const toCompetitorString = (competitor: LiveCompetitor) =>
+  `${competitor.name} (${competitor.registrant_id})`;
 
 export default function AttemptsForm({
   solveCount,
@@ -30,6 +34,7 @@ export default function AttemptsForm({
     attempts,
     handleAttemptChange,
     isPending,
+    registrationId,
   } = useResultsAdmin();
 
   const { competitors } = useLiveResults();
@@ -37,12 +42,18 @@ export default function AttemptsForm({
   const { collection, filter } = useListCollection({
     initialItems: Array.from(competitors.values()),
     itemToValue: (competitor) => competitor.id.toString(),
-    itemToString: (competitor) =>
-      `${competitor.name} (${competitor.registrant_id})`,
+    itemToString: (competitor) => toCompetitorString(competitor),
     filter: (itemText, filterText, item) =>
       itemText.includes(filterText) ||
       parseInt(filterText, 10) === item.registrant_id,
   });
+
+  const selectedCompetitor = registrationId
+    ? competitors.get(registrationId)
+    : undefined;
+  const inputDisplayValue = selectedCompetitor
+    ? toCompetitorString(selectedCompetitor)
+    : "";
 
   return (
     <form>
@@ -51,9 +62,13 @@ export default function AttemptsForm({
       <Combobox.Root
         collection={collection}
         onInputValueChange={(e) => filter(e.inputValue)}
-        onValueChange={(e) =>
-          handleRegistrationIdChange(parseInt(e.value[0], 10))
-        }
+        inputValue={inputDisplayValue}
+        onValueChange={(e) => {
+          if (e.value.length > 0) {
+            handleRegistrationIdChange(parseInt(e.value[0], 10));
+          }
+        }}
+        value={registrationId ? [registrationId.toString()] : []}
       >
         <Combobox.Label>
           <Heading size="2xl">{header}</Heading>
@@ -71,7 +86,7 @@ export default function AttemptsForm({
               <Combobox.Empty>No items found</Combobox.Empty>
               {collection.items.map((item) => (
                 <Combobox.Item item={item} key={item.id}>
-                  `${item.name} (${item.registrant_id})`
+                  {toCompetitorString(item)}
                   <Combobox.ItemIndicator />
                 </Combobox.Item>
               ))}

--- a/next-frontend/src/providers/LiveResultAdminProvider.tsx
+++ b/next-frontend/src/providers/LiveResultAdminProvider.tsx
@@ -60,7 +60,7 @@ export function LiveResultAdminProvider({
       setRegistrationId(value);
       // Even for Dual Rounds we only fetch one round in the admin view
       const alreadyEnteredResults = liveResultsByRegistrationId[value][0];
-      if (alreadyEnteredResults) {
+      if (alreadyEnteredResults.attempts.length > 0) {
         setAttempts(alreadyEnteredResults.attempts.map((a) => a.value));
       } else {
         setAttempts(zeroedArrayOfSize(solveCount));


### PR DESCRIPTION
Fixes two issues:
- The Registration id + Competitor not being correctly reset when submitting a result (this is taken from the double check PR, where I noticed it first)
- The Attempts not being correctly reset after submitting a result (setting them to an empty array instead of a zeroed array doesn't clear the state of the AttemptResultFields)