### PR TITLE
Fix inserting attempts before calculating the hash

### DIFF
--- a/app/jobs/update_live_result_job.rb
+++ b/app/jobs/update_live_result_job.rb
@@ -5,15 +5,15 @@ class UpdateLiveResultJob < ApplicationJob
   queue_as EnvConfig.LIVE_QUEUE if Live::Config.sqs_queued?
 
   def perform(live_result, results, entered_by_id)
-    result_upserts = results.map { it.merge(live_result_id: live_result.id) }
-    LiveAttempt.upsert_all(result_upserts)
-
-    attempt_numbers = results.pluck(:attempt_number)
-    live_result.live_attempts.where.not(attempt_number: attempt_numbers).delete_all
-
     round = live_result.round
+    result_upserts = results.map { it.merge(live_result_id: live_result.id) }
 
     Live::DiffHelper.broadcast_changes(round) do
+      LiveAttempt.upsert_all(result_upserts)
+
+      attempt_numbers = results.pluck(:attempt_number)
+      live_result.live_attempts.where.not(attempt_number: attempt_numbers).delete_all
+
       new_attempts = live_result.live_attempts.reload # We did some `upsert_all` and `delete_all` shenanigans above, which bypass Rails memory. Hence reloading...
       average, best = LiveResult.compute_average_and_best(new_attempts, round)
 


### PR DESCRIPTION
If you insert the LiveAttempts before the `broadcast_changes` block the `before_hash` gets calculated incorrectly and will not match with the frontend