### PR TITLE
Return early in compute_best_and_worse_possible_average

### DIFF
--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -140,15 +140,10 @@ class LiveResult < ApplicationRecord
 
   def forecast_statistics
     # use .length on purpose here as otherwise we would use one query per row
-    LiveResult.compute_best_and_worse_possible_average(live_attempts.as_json, round) if live_attempts.length < round.format.expected_solve_count
+    LiveResult.compute_best_and_worse_possible_average(live_attempts.as_json, round) if live_attempts.length == round.format.expected_solve_count - 1
   end
 
   def self.compute_best_and_worse_possible_average(live_attempts, round)
-    return {
-      "best_possible_average" => BEST_POSSIBLE_SCORE,
-      "worst_possible_average" => WORST_POSSIBLE_SCORE,
-    } if live_attempts.length == 0
-
     missing_count = round.format.expected_solve_count - live_attempts.length
 
     {


### PR DESCRIPTION
This drops the `round_result` route back from like 800ms to 200ms for a round with 100 results. 

Before:
`Completed 200 OK in 770ms (Views: 582.6ms | ActiveRecord: 11.4ms (7 queries, 0 cached) | GC: 47.7ms)`
After:
`Completed 200 OK in 193ms (Views: 30.6ms | ActiveRecord: 8.0ms (8 queries, 0 cached) | GC: 33.7ms)`