### PR TITLE
Don't rotate table for RRL computation

### DIFF
--- a/lib/auxiliary_data_computation.rb
+++ b/lib/auxiliary_data_computation.rb
@@ -2,7 +2,8 @@
 
 module AuxiliaryDataComputation
   def self.compute_everything
-    self.insert_regional_records_lookup
+    CheckRegionalRecords.add_to_lookup_table
+
     self.compute_concise_results
     self.compute_rank_tables
   end
@@ -117,12 +118,6 @@ module AuxiliaryDataComputation
             wr.world_rank
         SQL
       end
-    end
-  end
-
-  def self.insert_regional_records_lookup
-    DbHelper.with_temp_table("regional_records_lookup") do |temp_table_name|
-      CheckRegionalRecords.add_to_lookup_table(table_name: temp_table_name)
     end
   end
 end

--- a/lib/check_regional_records.rb
+++ b/lib/check_regional_records.rb
@@ -4,9 +4,9 @@ module CheckRegionalRecords
   REGION_WORLD = '__World'
   LOOKUP_TABLE_NAME = 'regional_records_lookup'
 
-  def self.add_to_lookup_table(competition_id = nil, table_name: LOOKUP_TABLE_NAME)
+  def self.add_to_lookup_table(competition_id = nil)
     ActiveRecord::Base.connection.execute <<~SQL.squish
-      INSERT INTO #{table_name}
+      INSERT INTO #{LOOKUP_TABLE_NAME}
       (result_id, person_id, country_id, continent_id, event_id, competition_end_date, competition_reg_year, best, average)
       SELECT results.id, results.person_id, results.country_id, countries.continent_id, results.event_id, competitions.end_date, YEAR(competitions.start_date), results.best, results.average
       FROM results


### PR DESCRIPTION
The statement to recompute the `regional_records_lookup` table uses a `INSERT INTO ... ON DUPLICATE KEY UPDATE`, which is atomic in itself. So rotating in the additional table is pretty much useless.

Bonus: This speeds up CAD by factor ~4. A rotated table needs to completely rebuild any and all indexes, while the in-place update is smart about reusing existing indexes.