### PR TITLE
Fix registration table paid on column in refunded case

### DIFF
--- a/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
+++ b/app/webpacker/components/RegistrationsV2/RegistrationAdministration/AdministrationTableRow.jsx
@@ -40,6 +40,7 @@ function RegisteredOn({
 function PaidOn({
   withFullDate, registeredOn, paymentStatus, hasPaid, updatedAt,
 }) {
+  // trigger must be wrapped in a span, literal text causes a crash
   const trigger = (() => {
     if (hasPaid) {
       return (


### PR DESCRIPTION
Follow-up to #12785 because refunded registrations aren't showing up as expected (they're indistinguishable from registrations which never paid). The problem was happening because if `paymentStatus === 'refund'` is true then (typically) `hasPaid` is false; the `wasRefunded ? '*' : ''` was always never even reached what the registration had been refunded.

As before, I don't have a competition with payments locally, so will need someone else to run this and carefully check that (partial/full) refunds show up as expected in the table (at `.../edit/registrations`).

_Edit: test failure seems unrelated?_