### PR TITLE
Optimize competitions/competitionId/live/rounds API

### DIFF
--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -39,11 +39,14 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
   def rounds
     competition = Competition.includes(
-      rounds: %i[wcif_extensions live_results],
+      rounds: {
+        wcif_extensions: [],
+        live_results: [],
+        sibling_rounds: [:live_results],
+      },
     ).find(params.require(:competition_id))
 
-    all_rounds = competition.rounds
-    render json: { rounds: all_rounds.map { |r| r.to_live_info_json(all_rounds) } }
+    render json: { rounds: competition.rounds.map(&:to_live_info_json) }
   end
 
   def by_person

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -106,6 +106,10 @@ class LiveResult < ApplicationRecord
     best.zero?
   end
 
+  def not_empty?
+    !empty_result?
+  end
+
   def values_for_sorting
     ranking_columns.map do |column|
       to_solve_time(column)

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -50,6 +50,8 @@ class Round < ApplicationRecord
   has_many :results
   has_many :scrambles
 
+  has_many :sibling_rounds, through: :competition_event, source: :rounds
+
   MAX_NUMBER = 4
   validates :number,
             numericality: { only_integer: true,
@@ -150,13 +152,13 @@ class Round < ApplicationRecord
     live_results.where(global_pos: 1..3)
   end
 
-  def previous_round(all_rounds = nil)
+  def previous_round
     return nil if number == 1
 
-    if all_rounds
-      all_rounds.find { |r| r.competition_event_id == competition_event_id && r.number == number - 1 }
+    if sibling_rounds.loaded?
+      sibling_rounds.find { it.number == self.number - 1 }
     else
-      Round.joins(:competition_event).find_by(competition_event: competition_event, number: number - 1)
+      sibling_rounds.find_by(number: number - 1)
     end
   end
 
@@ -323,7 +325,11 @@ class Round < ApplicationRecord
   end
 
   def competitors_live_results_entered
-    live_results.count { it.best != 0 }
+    if live_results.loaded?
+      live_results.count(&:not_empty?)
+    else
+      live_results.not_empty.count
+    end
   end
 
   def score_taking_done?
@@ -401,10 +407,10 @@ class Round < ApplicationRecord
   STATE_READY = "ready"
   STATE_PENDING = "pending"
 
-  def lifecycle_state(all_rounds = nil)
+  def lifecycle_state
     return STATE_LOCKED if locked?
     return STATE_OPEN if open?
-    return STATE_READY if number == 1 || previous_round(all_rounds).score_taking_done?
+    return STATE_READY if number == 1 || previous_round.score_taking_done?
 
     STATE_PENDING
   end
@@ -523,8 +529,8 @@ class Round < ApplicationRecord
     }
   end
 
-  def to_live_info_json(all_rounds)
-    state = lifecycle_state(all_rounds)
+  def to_live_info_json
+    state = lifecycle_state
     json = {
       **self.to_wcif(include_results: false).compact_blank,
       "state" => state,


### PR DESCRIPTION
Before:
`Completed 200 OK in 677ms (Views: 0.8ms | ActiveRecord: 211.3ms (118 queries, 53 cached) | GC: 0.0ms)`
After:
`Completed 200 OK in 101ms (Views: 0.8ms | ActiveRecord: 8.5ms (22 queries, 10 cached) | GC: 9.4ms)`

This also fixes the bug where the old `round_results` where part of the info endpoint.

Optimizations done:
- Stop previous_round doing a query for each round by giving it all the preloaded rounds
- use live_results in the total_competitors method as it is preloaded (and map registration_id to reduce GC)
- switch competitors_live_results_entered to length to reduce a count query on every round