### PR TITLE
De-duplication of potential duplicates of newcomers

### DIFF
--- a/app/jobs/compute_potential_duplicates.rb
+++ b/app/jobs/compute_potential_duplicates.rb
@@ -8,23 +8,19 @@ class ComputePotentialDuplicates < ApplicationJob
     job.update!(run_status: DuplicateCheckerJobRun.run_statuses[:in_progress])
 
     job.competition.accepted_newcomers.each do |user|
-      matches = PotentialDuplicatePerson.name_matching_algorithms.keys.flat_map do |algorithm|
-        find_duplicates(algorithm, user, persons_cache).map do |person_id, score|
-          {
+      PotentialDuplicatePerson.name_matching_algorithms.each_key do |algorithm|
+        duplicates = find_duplicates(algorithm, user, persons_cache)
+
+        duplicates.each do |person_id, score|
+          PotentialDuplicatePerson.create!(
             duplicate_checker_job_run_id: job.id,
             original_user_id: user.id,
             duplicate_person_id: person_id,
             name_matching_algorithm: PotentialDuplicatePerson.name_matching_algorithms[algorithm],
             score: score,
-          }
+          )
         end
       end
-
-      best_matches = matches
-                     .group_by { |match| match[:duplicate_person_id] }
-                     .map { |_, person_matches| person_matches.max_by { |m| m[:score] } }
-
-      PotentialDuplicatePerson.create!(best_matches) if best_matches.any?
     end
 
     job.touch(:end_time)

--- a/app/webpacker/components/NewcomerChecks/SimilarPersonTable.jsx
+++ b/app/webpacker/components/NewcomerChecks/SimilarPersonTable.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import _ from 'lodash';
 import {
-  Button, Icon, Popup, Table,
+  Button, Icon, List, Popup, Table,
 } from 'semantic-ui-react';
 import { personUrl } from '../../lib/requests/routes.js.erb';
 
@@ -8,6 +9,20 @@ export default function SimilarPersonTable({
   potentialDuplicates, editUser, mergePotentialDuplicate,
 }) {
   const originalUser = potentialDuplicates[0].original_user;
+
+  const displayDuplicates = _.chain(potentialDuplicates)
+    .groupBy('duplicate_person.id')
+    .map((group) => {
+      const highestScoreItem = _.maxBy(group, 'score');
+      return {
+        ...highestScoreItem,
+        allScores: group.map((item) => ({
+          score: item.score,
+          algorithm: item.name_matching_algorithm,
+        })),
+      };
+    })
+    .value();
 
   return (
     <Table celled>
@@ -34,11 +49,12 @@ export default function SimilarPersonTable({
             </Button>
           </Table.Cell>
         </Table.Row>
-        {potentialDuplicates.map((potentialDuplicatePerson) => {
+        {displayDuplicates.map((potentialDuplicatePerson) => {
           const {
             duplicate_person: duplicatePerson,
             score,
             name_matching_algorithm: nameMatchingAlgorithm,
+            allScores,
           } = potentialDuplicatePerson;
           const exactSameDetails = (
             originalUser.name === duplicatePerson.name
@@ -47,7 +63,7 @@ export default function SimilarPersonTable({
                   && originalUser.gender === duplicatePerson.gender
           );
           return (
-            <Table.Row negative={exactSameDetails}>
+            <Table.Row key={duplicatePerson.id} negative={exactSameDetails}>
               <Table.Cell>{duplicatePerson.name}</Table.Cell>
               <Table.Cell>{duplicatePerson.country.name}</Table.Cell>
               <Table.Cell>{duplicatePerson.dob}</Table.Cell>
@@ -61,7 +77,21 @@ export default function SimilarPersonTable({
                 {' '}
                 <Popup
                   trigger={<Icon name="info circle" />}
-                  content={`Computed using ${nameMatchingAlgorithm} algorithm`}
+                  header={allScores.length > 1 ? 'Scores from Multiple Algorithms' : 'Matching Algorithm'}
+                  content={allScores.length > 1 ? (
+                    <List bulleted>
+                      {allScores.map((s) => (
+                        <List.Item key={s.algorithm}>
+                          <strong>{s.algorithm}</strong>
+                          :
+                          {' '}
+                          {s.score}
+                        </List.Item>
+                      ))}
+                    </List>
+                  ) : (
+                    `Computed using ${nameMatchingAlgorithm} algorithm.`
+                  )}
                 />
               </Table.Cell>
               <Table.Cell>


### PR DESCRIPTION
Currently if a duplicate is found for a newcomer in multiple accounts, it will be shown multiple times creating confusion for the delegates. Here's an example:

<img width="4304" height="1704" alt="image" src="https://github.com/user-attachments/assets/2290596b-d9e6-459d-bcb8-6bbd55a46e51" />

If there are more than one duplicate duplicate-matches, only the best needs to be shown.