### PR TITLE
Upload asset files to s3 with cache control immutable

### DIFF
--- a/.github/actions/build-environment/action.yaml
+++ b/.github/actions/build-environment/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: | # We do this once the first image is build so it will be definitely available
         id=$(docker create ${{ steps.build.outputs.imageid }})
         docker cp $id:/rails/public/ ./assets
-        aws s3 sync ./assets s3://${{ env.ASSET_BUCKET }}/assets/${{ inputs.build_tag }}
+        aws s3 sync ./assets s3://${{ env.ASSET_BUCKET }}/assets/${{ inputs.build_tag }} --cache-control "public, max-age=31536000, immutable"
     - name: Build and push API Image
       uses: ./.github/actions/build-ruby-image
       with:


### PR DESCRIPTION
One piece of the puzzle to stop serving 304 request for our assets. The other is just a setting on Cloudfront so no code changes needed.