### PR TITLE
Add validator warning for suspicious newcomer last names

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2932,6 +2932,7 @@ en:
       multiple_newcomers_with_same_name_warning: "There are multiple new competitors with the exact same name: %{name}. Please ensure that all results are correct for these competitors and that all results are correctly separated by their corresponding id."
       wrong_parenthesis_type_error: "The parenthesis character used in '%{name}' is an irregular character, please replace it with a regular parenthesis '(' or ')' and with appropriate spacing."
       special_characters_in_name_warning: "The name '%{name}' contains invalid special characters (such as numbers, quotes, or other symbols). Names should only contain letters, spaces, hyphens, apostrophes, periods, and regular parentheses."
+      suspicious_last_name_warning: "'%{name}' has '%{suffix}' as their last name, which may not be an actual last name (e.g. a generational suffix written in full). Please confirm it is their legal last name, or replace/remove it accordingly."
       successive_uppercase_name_warning: "'%{name}' has successive uppercase letters in their name. Please confirm that this is indeed the correct spelling or fix the name."
       lowercase_name_warning: "'%{name}' has a lowercase name. Please confirm that this is indeed the correct spelling or fix the name."
       missing_period_in_single_letter_middle_name_warning: "'%{name}' has a single letter middle name without an abbreviation period. Please confirm that this is indeed the correct spelling or fix the name."

--- a/lib/results_validators/persons_validator.rb
+++ b/lib/results_validators/persons_validator.rb
@@ -25,6 +25,7 @@ module ResultsValidators
     SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING = :single_letter_first_or_last_name_warning
     SINGLE_NAME_WARNING = :single_name_warning
     SPECIAL_CHARACTERS_IN_NAME_WARNING = :special_characters_in_name_warning
+    SUSPICIOUS_LAST_NAME_WARNING = :suspicious_last_name_warning
     REGISTRATION_DETAILS_MISMATCH_WARNING = :registration_details_mismatch_warning
     MISSING_MATCHING_REGISTRATION_WARNING = :missing_matching_registration_warning
     UNACCEPTED_REGISTRATION_WITH_RESULTS_WARNING = :unaccepted_registration_with_results_warning
@@ -102,6 +103,9 @@ module ResultsValidators
 
       # Check if the name is a single name.
       validation_issues << ValidationWarning.new(SINGLE_NAME_WARNING, :persons, competition_id, name: name) if split_name.length == 1
+
+      # Check if the last name token is a word that may not be an actual last name (e.g. a generational suffix written in full).
+      validation_issues << ValidationWarning.new(SUSPICIOUS_LAST_NAME_WARNING, :persons, competition_id, name: name, suffix: split_name.last) if %w[junior senior].include?(split_name.last.downcase)
 
       # Check for missing period in single letter middle name.
       validation_issues << ValidationWarning.new(MISSING_PERIOD_WARNING, :persons, competition_id, name: name) if split_name.length > 2 && split_name[1, split_name.length - 2].any? { |n| n.length == 1 }

--- a/spec/lib/results_validators/persons_validator_spec.rb
+++ b/spec/lib/results_validators/persons_validator_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe PV do
       # LETTER_AFTER_PERIOD_WARNING
       # SINGLE_LETTER_FIRST_OR_LAST_NAME_WARNING
       # SINGLE_NAME_WARNING
+      # SUSPICIOUS_LAST_NAME_WARNING
       it "validates person data" do
         round_222 = create(:round, event_id: "222", competition: competition2)
         create(:inbox_result, competition: competition2, event_id: "222", round: round_222)
@@ -226,6 +227,16 @@ RSpec.describe PV do
                                   event_id: "333oh",
                                   round: round_333_oh)
         res_wrong_wca_id.person.update(wca_id: "ERR")
+        res_suspicious_junior = create(:inbox_result,
+                                       competition: competition1,
+                                       event_id: "333oh",
+                                       round: round_333_oh)
+        res_suspicious_junior.person.update(name: "John Junior")
+        res_suspicious_senior = create(:inbox_result,
+                                       competition: competition1,
+                                       event_id: "333oh",
+                                       round: round_333_oh)
+        res_suspicious_senior.person.update(name: "Maria Senior")
 
         expected_errors = [
           RV::ValidationError.new(PV::PERSON_WITHOUT_RESULTS_ERROR,
@@ -298,6 +309,14 @@ RSpec.describe PV do
           RV::ValidationWarning.new(PV::SINGLE_NAME_WARNING,
                                     :persons, competition1.id,
                                     name: res_same_name2.person.name),
+          RV::ValidationWarning.new(PV::SUSPICIOUS_LAST_NAME_WARNING,
+                                    :persons, competition1.id,
+                                    name: res_suspicious_junior.person.name,
+                                    suffix: "Junior"),
+          RV::ValidationWarning.new(PV::SUSPICIOUS_LAST_NAME_WARNING,
+                                    :persons, competition1.id,
+                                    name: res_suspicious_senior.person.name,
+                                    suffix: "Senior"),
         ]
         validator_args = [
           { competition_ids: [competition1.id, competition2.id], model: InboxResult },


### PR DESCRIPTION
In a recent result submission, posting was delayed because a last name was "Junior" and we wanted clarification from the Delegate first before proceeding.

This new warning, which can be extended with further name sin the future, requires delegated to clarify suspicious last names.