### PR TITLE
H2H: Ignore `h2h` finals in Results JSON

### DIFF
--- a/app/models/upload_json.rb
+++ b/app/models/upload_json.rb
@@ -53,6 +53,9 @@ class UploadJson
     parsed_json["events"].each do |event|
       competition_event = competition.competition_events.find { |ce| ce.event_id == event["eventId"] }
       event["rounds"].each do |round|
+        # H2H results are skipped, as they get imported via a manual import process. See #13200 for more information
+        next if round['formatId'] == "h"
+
         # Find the corresponding competition round and get the actual round_type_id
         # (in case the incoming one doesn't correspond to cutoff presence).
         incoming_round_type_id = round["roundId"]


### PR DESCRIPTION
Currently, our process for importing H2H results includes manually removing any H2H finals from the Results JSON. This is error-prone and introduces lag time (as the delegate has to submit the modified Results JSON we send them). 

If we upload the file _without_ changing anything, it triggers validation errors on the finals round. 

This PR simply modifies the Results JSON importer to skip any rounds with `format_id == "h"`. 

I also tried to remove the exception to `events_rounds_validator` that I added in #13200, but it turns out that remains necessary even when skipping the H2H round on import - which makes sense, as it is rightly raising the error that results for the H2H finals rounds appear to be missing.