### PR TITLE
Add button to clear WCA ID claim

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   before_action :set_recent_authentication!, only: %i[edit update enable_2fa disable_2fa]
   before_action :redirect_if_cannot_edit_user, only: %i[edit update]
   before_action -> { redirect_to_root_unless_user(:can_admin_results?) }, only: %i[admin_search]
-  before_action -> { redirect_to_root_unless_user(:can_edit_any_user?) }, only: %i[assign_wca_id confirm_wca_id merge]
+  before_action -> { redirect_to_root_unless_user(:can_edit_any_user?) }, only: %i[assign_wca_id confirm_wca_id merge clear_claim_wca_id]
   before_action -> { check_edit_access }, only: %i[show_for_edit update_user_data]
 
   RECENT_AUTHENTICATION_DURATION = 10.minutes.freeze
@@ -125,6 +125,15 @@ class UsersController < ApplicationController
     end
 
     redirect_to edit_user_path(user), flash: { success: "Successfully confirmed WCA ID #{wca_id}." }
+  end
+
+  def clear_claim_wca_id
+    user = User.find(params.require(:userId))
+    wca_id = user.unconfirmed_wca_id
+
+    user.update!(**User::CLEAR_WCA_ID_CLAIM_ATTRIBUTES)
+
+    redirect_to edit_user_path(user), flash: { success: "Successfully cleared claim for WCA ID #{wca_id}." }
   end
 
   def assign_wca_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1126,12 +1126,7 @@ class User < ApplicationRecord
     fields += %i[name dob gender country_iso2] unless cannot_edit_data_reason_html(user)
     fields += CLAIM_WCA_ID_PARAMS if user == self || can_edit_any_user?
     fields << :name if user.wca_id.blank? && organizer_for?(user)
-    if can_edit_any_user?
-      fields += %i[
-        unconfirmed_wca_id
-      ]
-      fields += %i[wca_id] unless user.special_account?
-    end
+    fields << :wca_id if can_edit_any_user? && !user.special_account?
     fields
   end
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -83,6 +83,7 @@
                       </a>
                     </span>
                     <div class="input-group-btn">
+                      <%= link_to t('.clear_claim'), clear_claim_wca_id_path(userId: @user.id), method: :post, data: { confirm: t('.clear_claim_confirm', wca_id: @user.unconfirmed_wca_id) }, class: "btn btn-danger", id: "clear-claim-wca-id" %>
                       <%= link_to t('.approve'), confirm_wca_id_path(userId: @user.id, wcaId: @user.unconfirmed_wca_id), method: :post, data: { confirm: t('.approve_confirm', wca_id: @user.unconfirmed_wca_id) }, class: "btn btn-default", id: "approve-wca-id" %>
                     </div>
                   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -83,8 +83,8 @@
                       </a>
                     </span>
                     <div class="input-group-btn">
-                      <%= link_to t('.clear_claim'), clear_claim_wca_id_path(userId: @user.id), method: :post, data: { confirm: t('.clear_claim_confirm', wca_id: @user.unconfirmed_wca_id) }, class: "btn btn-danger", id: "clear-claim-wca-id" %>
                       <%= link_to t('.approve'), confirm_wca_id_path(userId: @user.id, wcaId: @user.unconfirmed_wca_id), method: :post, data: { confirm: t('.approve_confirm', wca_id: @user.unconfirmed_wca_id) }, class: "btn btn-default", id: "approve-wca-id" %>
+                      <%= link_to t('.clear_claim'), clear_claim_wca_id_path(userId: @user.id), method: :post, data: { confirm: t('.clear_claim_confirm', wca_id: @user.unconfirmed_wca_id) }, class: "btn btn-danger", id: "clear-claim-wca-id" %>
                     </div>
                   </div>
                 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1050,6 +1050,8 @@ en:
       profile: "Profile"
       approve: "Approve"
       approve_confirm: "Are you sure you want to approve WCA ID %{wca_id}?"
+      clear_claim: "Clear claim"
+      clear_claim_confirm: "Are you sure you want to clear the claim for WCA ID %{wca_id}?"
       unconfirmed_email: "This account's email address (%{email}) is not confirmed."
       confirm_new_email: "Changing your email will require confirming the new email before being effective."
       pending_mail_confirmation: "This account is pending confirmation of the new email address %{email}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
   post 'users/merge' => 'users#merge'
   post 'users/assign_wca_id' => 'users#assign_wca_id'
   post 'users/confirm_wca_id' => 'users#confirm_wca_id', as: :confirm_wca_id
+  post 'users/clear_claim_wca_id' => 'users#clear_claim_wca_id', as: :clear_claim_wca_id
   get '/users/registrations' => 'users#registrations', as: :helpful_queries_registrations
   get '/users/organized-competitions' => 'users#organized_competitions', as: :helpful_queries_organized_competitions
   get '/users/delegated-competitions' => 'users#delegated_competitions', as: :helpful_queries_delegated_competitions


### PR DESCRIPTION
This was missed in earlier PR where the WCA ID claim approve button was added.

Also, realized that in `editable_fields`, `unconfirmed_wca_id` need not be there anymore. So removed it as well in the same PR.