### PR TITLE
Migrate and uplink registration ID to bigint

### DIFF
--- a/db/migrate/20260408124442_add_foreign_key_from_rce_to_registrations.rb
+++ b/db/migrate/20260408124442_add_foreign_key_from_rce_to_registrations.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddForeignKeyFromRceToRegistrations < ActiveRecord::Migration[8.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute "DELETE FROM registration_competition_events WHERE registration_id NOT IN (SELECT id FROM registrations)"
+
+        change_column :registrations, :id, :bigint
+
+        change_column :registration_payments, :registration_id, :bigint
+        change_column :registration_competition_events, :registration_id, :bigint
+      end
+
+      dir.down do
+        change_column :registration_competition_events, :registration_id, :integer
+        change_column :registration_payments, :registration_id, :integer
+
+        change_column :registrations, :id, :integer, unsigned: true
+      end
+    end
+
+    add_foreign_key :registration_competition_events, :registrations, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1097,7 +1097,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
 
   create_table "registration_competition_events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "competition_event_id"
-    t.integer "registration_id"
+    t.bigint "registration_id"
     t.index ["competition_event_id"], name: "index_registration_competition_events_on_competition_event_id"
     t.index ["registration_id", "competition_event_id"], name: "idx_registration_competition_events_on_reg_id_and_comp_event_id", unique: true
     t.index ["registration_id"], name: "index_registration_competition_events_on_registration_id"
@@ -1131,7 +1131,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
     t.bigint "receipt_id"
     t.string "receipt_type"
     t.integer "refunded_registration_payment_id"
-    t.integer "registration_id"
+    t.bigint "registration_id"
     t.string "stripe_charge_id"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
@@ -1141,7 +1141,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
     t.index ["stripe_charge_id"], name: "index_registration_payments_on_stripe_charge_id"
   end
 
-  create_table "registrations", id: { type: :integer, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "accepted_at", precision: nil
     t.integer "accepted_by"
     t.text "administrative_notes"
@@ -1671,6 +1671,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
   add_foreign_key "potential_duplicate_persons", "users", column: "original_user_id"
   add_foreign_key "regional_records_lookup", "results", on_update: :cascade, on_delete: :cascade
   add_foreign_key "registration_competition_events", "competition_events", on_delete: :cascade
+  add_foreign_key "registration_competition_events", "registrations", on_delete: :cascade
   add_foreign_key "registration_history_changes", "registration_history_entries"
   add_foreign_key "result_attempts", "results", on_delete: :cascade
   add_foreign_key "results", "rounds"


### PR DESCRIPTION
The original idea was to "just" add a foreign key from RCE to registrations. Then I discovered two problems:
- `registrations` has a (very) non-standard ID type
- There are ~370K orphaned rows in RCE which need to be cleaned before the FK can be added