### PR TITLE
Fill in competition coordinates as default in EditVenue panel

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1035,6 +1035,10 @@ class Competition < ApplicationRecord
     ["Europe/London"]
   end
 
+  def coordinates
+    { latitude: self.latitude_microdegrees, longitude: self.longitude_microdegrees }
+  end
+
   private def compute_coordinates
     self.latitude_microdegrees = @latitude_degrees * 1e6 unless @latitude_degrees.nil?
     self.longitude_microdegrees = @longitude_degrees * 1e6 unless @longitude_degrees.nil?

--- a/app/views/competitions/edit_schedule.html.erb
+++ b/app/views/competitions/edit_schedule.html.erb
@@ -21,6 +21,7 @@
       wcifSchedule: @competition.schedule_wcif,
       countryZones: @competition.country_zones,
       referenceTime: @competition.start_date.to_fs,
+      competitionCoordinates: @competition.coordinates,
       calendarLocale: I18n.locale,
     }, {
       id: 'edit-schedule-area'

--- a/app/webpacker/components/EditSchedule/EditVenues/index.js
+++ b/app/webpacker/components/EditSchedule/EditVenues/index.js
@@ -13,13 +13,14 @@ import { addVenue } from '../store/actions';
 function EditVenues({
   countryZones,
   referenceTime,
+  competitionCoordinates,
 }) {
   const { wcifSchedule } = useStore();
 
   const dispatch = useDispatch();
 
   const handleAddVenue = () => {
-    dispatch(addVenue());
+    dispatch(addVenue(competitionCoordinates));
   };
 
   return (

--- a/app/webpacker/components/EditSchedule/index.js
+++ b/app/webpacker/components/EditSchedule/index.js
@@ -23,6 +23,7 @@ function EditSchedule({
   wcifEvents,
   countryZones,
   referenceTime,
+  competitionCoordinates,
   calendarLocale,
 }) {
   const {
@@ -114,6 +115,7 @@ function EditSchedule({
               <EditVenues
                 countryZones={countryZones}
                 referenceTime={referenceTime}
+                competitionCoordinates={competitionCoordinates}
               />
             )}
           </Accordion.Content>
@@ -148,6 +150,7 @@ export default function Wrapper({
   wcifSchedule,
   countryZones,
   referenceTime,
+  competitionCoordinates,
   calendarLocale,
 }) {
   return (
@@ -165,6 +168,7 @@ export default function Wrapper({
             wcifEvents={wcifEvents}
             countryZones={countryZones}
             referenceTime={referenceTime}
+            competitionCoordinates={competitionCoordinates}
             calendarLocale={calendarLocale}
           />
         </WCAQueryClientProvider>

--- a/app/webpacker/components/EditSchedule/store/actions.js
+++ b/app/webpacker/components/EditSchedule/store/actions.js
@@ -178,9 +178,11 @@ export const removeRoom = (roomId) => ({
  * Action creator for adding a blank venue.
  * @returns {Action}
  */
-export const addVenue = () => ({
+export const addVenue = (compCoordinates) => ({
   type: AddVenue,
-  payload: {},
+  payload: {
+    coordinates: compCoordinates,
+  },
 });
 
 /**

--- a/app/webpacker/components/EditSchedule/store/reducer.js
+++ b/app/webpacker/components/EditSchedule/store/reducer.js
@@ -232,7 +232,7 @@ const reducers = {
     },
   }),
 
-  [AddVenue]: (state) => ({
+  [AddVenue]: (state, { payload }) => ({
     ...state,
     wcifSchedule: {
       ...state.wcifSchedule,
@@ -240,8 +240,8 @@ const reducers = {
         ...state.wcifSchedule.venues,
         {
           id: nextVenueId(state.wcifSchedule),
-          latitudeMicrodegrees: 0,
-          longitudeMicrodegrees: 0,
+          latitudeMicrodegrees: payload.coordinates?.latitude ?? 0,
+          longitudeMicrodegrees: payload.coordinates?.longitude ?? 0,
           rooms: [],
           extensions: [],
         },


### PR DESCRIPTION
Somewhat related to #13970. Not sure if it's fair to call this a "fix", but I saw the following remark:

> The reason why this is also so error prone is that the delegates must manually do this twice. In the past the venue location was auto populated.

So I changed it back to pre-fill new venues with the competition's coordinates :)