### PR TITLE
Submit synced results from ILR

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -120,7 +120,7 @@ class ResultsSubmissionController < ApplicationController
       }
     end
 
-    results_to_import = competition.rounds.flat_map { it.live_results.map(&:to_inbox_result) }
+    results_to_import = competition.rounds.flat_map { it.live_results.includes(:live_attempts, :registration).map(&:to_inbox_result) }
 
     person_with_results = results_to_import.map(&:person_id).uniq
 

--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -120,7 +120,16 @@ class ResultsSubmissionController < ApplicationController
       }
     end
 
-    results_to_import = competition.rounds.flat_map { it.live_results.includes(:live_attempts, :registration).map(&:to_inbox_result) }
+    results_to_import = competition.rounds.flat_map do |round|
+      round.live_results
+           .includes(:live_attempts, :registration)
+           .map(&:to_inbox_result)
+    end.map do |ibr|
+      # This is _technically_ useless because the IBR already knows its competition ID,
+      #   but not its actual competition memory object.
+      # Redundantly assigning here saves a ton of "does this competition exist?" validation checks later.
+      ibr.tap { it.competition = competition }
+    end
 
     person_with_results = results_to_import.map(&:person_id).uniq
 

--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -120,26 +120,7 @@ class ResultsSubmissionController < ApplicationController
       }
     end
 
-    results_to_import = competition.rounds.flat_map do |round|
-      round.round_results.map do |result|
-        InboxResult.new({
-                          competition: competition,
-                          person_id: result.person_id,
-                          pos: result.ranking,
-                          event_id: round.event_id,
-                          round_type_id: round.round_type_id,
-                          round_id: round.id,
-                          format_id: round.format_id,
-                          best: result.best,
-                          average: result.average,
-                          value1: result.attempts[0].result,
-                          value2: result.attempts[1]&.result || 0,
-                          value3: result.attempts[2]&.result || 0,
-                          value4: result.attempts[3]&.result || 0,
-                          value5: result.attempts[4]&.result || 0,
-                        })
-      end
-    end
+    results_to_import = competition.rounds.flat_map { it.live_results.map(&:to_inbox_result) }
 
     person_with_results = results_to_import.map(&:person_id).uniq
 

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -33,6 +33,7 @@ class LiveResult < ApplicationRecord
 
   has_one :event, through: :round
   has_one :format, through: :round
+  has_one :competition, through: :round
 
   validates :best,
             presence: true,
@@ -53,6 +54,9 @@ class LiveResult < ApplicationRecord
   end
 
   delegate :id, to: :event, prefix: true
+  delegate :id, to: :format, prefix: true
+  delegate :round_type_id, to: :round
+  delegate :registrant_id, to: :registration
 
   def to_solve_time(field)
     SolveTime.new(event_id, field, send(field))
@@ -116,17 +120,18 @@ class LiveResult < ApplicationRecord
   end
 
   def to_inbox_result
-    attempt_values = result.attempts.map(&:value)
+    attempt_values = live_attempts.pluck(:value)
+
     InboxResult.new({
-                      competition: competition,
-                      person_id: result.person_id,
-                      pos: result.ranking,
-                      event_id: round.event_id,
-                      round_type_id: round.round_type_id,
-                      round_id: round.id,
-                      format_id: round.format_id,
-                      best: result.best,
-                      average: result.average,
+                      competition: self.competition,
+                      round: self.round,
+                      person_id: self.registrant_id,
+                      pos: self.local_pos,
+                      event_id: self.event_id,
+                      format_id: self.format_id,
+                      round_type_id: self.round_type_id,
+                      best: self.best,
+                      average: self.average,
                       value1: attempt_values[0],
                       value2: attempt_values[1] || 0,
                       value3: attempt_values[2] || 0,

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -122,22 +122,22 @@ class LiveResult < ApplicationRecord
   def to_inbox_result
     attempt_values = live_attempts.pluck(:value)
 
-    InboxResult.new({
-                      competition: self.competition,
-                      round: self.round,
-                      person_id: self.registrant_id,
-                      pos: self.local_pos,
-                      event_id: self.event_id,
-                      format_id: self.format_id,
-                      round_type_id: self.round_type_id,
-                      best: self.best,
-                      average: self.average,
-                      value1: attempt_values[0],
-                      value2: attempt_values[1] || 0,
-                      value3: attempt_values[2] || 0,
-                      value4: attempt_values[3] || 0,
-                      value5: attempt_values[4] || 0,
-                    })
+    InboxResult.new(
+      competition: self.competition,
+      round: self.round,
+      person_id: self.registrant_id,
+      pos: self.local_pos,
+      event_id: self.event_id,
+      format_id: self.format_id,
+      round_type_id: self.round_type_id,
+      best: self.best,
+      average: self.average,
+      value1: attempt_values[0],
+      value2: attempt_values[1] || 0,
+      value3: attempt_values[2] || 0,
+      value4: attempt_values[3] || 0,
+      value5: attempt_values[4] || 0,
+    )
   end
 
   LIVE_STATE_SERIALIZE_OPTIONS = {

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -33,7 +33,6 @@ class LiveResult < ApplicationRecord
 
   has_one :event, through: :round
   has_one :format, through: :round
-  has_one :competition, through: :round
 
   validates :best,
             presence: true,
@@ -53,9 +52,7 @@ class LiveResult < ApplicationRecord
     super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
   end
 
-  delegate :id, to: :event, prefix: true
-  delegate :id, to: :format, prefix: true
-  delegate :round_type_id, to: :round
+  delegate :event_id, :format_id, :round_type_id, :competition_id, to: :round
   delegate :registrant_id, to: :registration
 
   def to_solve_time(field)
@@ -123,8 +120,8 @@ class LiveResult < ApplicationRecord
     attempt_values = live_attempts.pluck(:value)
 
     InboxResult.new(
-      competition: self.competition,
       round: self.round,
+      competition_id: self.competition_id,
       person_id: self.registrant_id,
       pos: self.local_pos,
       event_id: self.event_id,

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -115,6 +115,26 @@ class LiveResult < ApplicationRecord
     end
   end
 
+  def to_inbox_result
+    attempt_values = result.attempts.map(&:value)
+    InboxResult.new({
+                      competition: competition,
+                      person_id: result.person_id,
+                      pos: result.ranking,
+                      event_id: round.event_id,
+                      round_type_id: round.round_type_id,
+                      round_id: round.id,
+                      format_id: round.format_id,
+                      best: result.best,
+                      average: result.average,
+                      value1: attempt_values[0],
+                      value2: attempt_values[1] || 0,
+                      value3: attempt_values[2] || 0,
+                      value4: attempt_values[3] || 0,
+                      value5: attempt_values[4] || 0,
+                    })
+  end
+
   LIVE_STATE_SERIALIZE_OPTIONS = {
     only: %w[advancing advancing_questionable average average_record_tag best registration_id last_attempt_entered_at single_record_tag],
     methods: %w[],


### PR DESCRIPTION
Extracted from #13261

This means that "classic" WCA Live competitions currently cannot use the "Post from synced results" feature.

The easiest alternative would be to use the `scoretaking_software` enum to detect _which_ type of synced results to compare. But #13261 is basically complete (probably won't be merged today only because it's Friday) and once done, all WCA Live competitions will "accidentally" also post to ILR. So in literally 3 days it won't make a difference anymore.