### PR TITLE
Fix advancing not being set in the second round of the dual round

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -281,7 +281,7 @@ class Round < ApplicationRecord
     query = <<~SQL.squish
       UPDATE live_results r
       LEFT JOIN
-        (SELECT id,
+        (SELECT registration_id,
                 RANK() OVER (ORDER BY person_best.#{rank_by} <= 0,
                              person_best.#{rank_by} ASC #{", person_best.#{secondary_rank_by} <= 0, person_best.#{secondary_rank_by} ASC" if secondary_rank_by}) AS ranking
          FROM
@@ -294,7 +294,7 @@ class Round < ApplicationRecord
                FROM live_results lr
                WHERE lr.round_id IN (#{round_ids})
                  AND lr.best != 0) x
-            WHERE rownum = 1) AS person_best) ranked ON r.id = ranked.id
+            WHERE rownum = 1) AS person_best) ranked ON r.registration_id = ranked.registration_id
       SET r.global_pos = ranked.ranking
       WHERE r.round_id IN (#{round_ids});
     SQL

--- a/spec/requests/live_recompute_advancing_spec.rb
+++ b/spec/requests/live_recompute_advancing_spec.rb
@@ -273,6 +273,10 @@ RSpec.describe "WCA Live API" do
           # Top 3 = potential + reg[0] + reg[1] → reg[0] and reg[1] are advancing
           advancing_ids = round2.live_results.reload.where(advancing: true).pluck(:registration_id)
           expect(advancing_ids).to contain_exactly(registrations[0].id, registrations[1].id)
+
+          # Also correctly sets it for round 1
+          advancing_ids = round1.live_results.reload.where(advancing: true).pluck(:registration_id)
+          expect(advancing_ids).to contain_exactly(registrations[0].id, registrations[1].id)
         end
       end
 


### PR DESCRIPTION
We were not setting global_pos for both rounds of the dual round, but I was under the impression that we did. The fix is quite easy, we just need to set by `registration_id` and not by the `live_result` id