### PR TITLE
Implement various changes related to Lead Delegate

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -42,7 +42,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     serial_includes = {}
 
     serial_includes["delegates"] = { only: %w[id name], methods: [], include: ["avatar"] } if admin_mode
-    serial_methods |= %w[results_submitted_at results_posted_at report_posted_at report_posted_by_user] if admin_mode
+    serial_methods |= %w[results_submitted_at results_posted_at report_posted_at report_posted_by_user lead_delegate_id] if admin_mode
 
     paginate json: competitions,
              only: %w[id name start_date end_date registration_open registration_close venue competitor_limit main_event_id],

--- a/app/views/competitions_mailer/submit_report_nag.html.erb
+++ b/app/views/competitions_mailer/submit_report_nag.html.erb
@@ -1,33 +1,40 @@
 <p>
-  Dear <%= "Delegate".pluralize(@competition.delegates.count) %> of <%= @competition.name %>,
+    Dear <%= "Delegate".pluralize(@competition.delegates.count) %> of <%= @competition.name %>,
 </p>
 
 <p>
-  This is an automated reminder. <%= @competition.name %> took place <%= (DateTime.now.utc.to_date - @competition.end_date).to_i %> days ago and
-  the Delegate report must have been submitted
-  within one week of the end of the competition according to the <a href="https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf">WCA Competition Requirements Policy</a>.
-  Irrespective of if you are available to send in your report any time soon,
-  <span style="text-decoration: underline; font-weight: bold; font-size: larger;">please reply to
-  this email to update your Senior Delegate on the situation of this missing report</span>. Then submit the report as fast
-  as possible <%= link_to "here", delegate_report_url(@competition) %>.
+    This is an automated reminder. <%= @competition.name %> took place <%= (DateTime.now.utc.to_date - @competition.end_date).to_i %> days ago and
+    the Delegate report must have been submitted
+    within one week of the end of the competition according to the <a href="https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf">WCA Competition Requirements Policy</a>.
+    Irrespective of if you are available to send in your report any time soon,
+    <span style="text-decoration: underline; font-weight: bold; font-size: larger;">please reply to
+        this email to update your Senior Delegate on the situation of this missing report</span>. Then submit the report as fast
+    as possible <%= link_to "here", delegate_report_url(@competition) %>.
 </p>
-
+<% if @competition.lead_delegate.present? %>
 <p>
-  <b>
-    As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, Delegates who are listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation.
-  </b>
+    <b>
+        As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, a Lead Delegate who is listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation. The Lead Delegate of this competition is <%= @competition.lead_delegate.name %>.
+    </b>
 </p>
-
 <p>
-  @Senior Delegate: You can view the <%= "history".pluralize(@competition.delegates.count) %> of the <%= "Delegate".pluralize(@competition.delegates.count) %> here:
-  <ul>
+    <% else %>
+<p>
+    <b>
+        As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, Delegates who are listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation.
+    </b>
+</p>
+<% end %>
+<p>
+    @Senior Delegate: You can view the <%= "history".pluralize(@competition.delegates.count) %> of the <%= "Delegate".pluralize(@competition.delegates.count) %> here:
+<ul>
     <% @competition.delegates.each do |delegate| %>
-      <li><%= link_to "#{delegate.name}", competitions_url(display: "admin", years: "all", state: "past", delegate: delegate.id), target: "_blank" %></li>
+    <li><%= link_to "#{delegate.name}", competitions_url(display: "admin", years: "all", state: "past", delegate: delegate.id), target: "_blank" %></li>
     <% end %>
-  </ul>
+</ul>
 </p>
 
 <p>
-  Regards,
-  The WCA Executive Assistants Team.
+    Regards,
+    The WCA Executive Assistants Team.
 </p>

--- a/app/views/competitions_mailer/submit_report_reminder.html.erb
+++ b/app/views/competitions_mailer/submit_report_reminder.html.erb
@@ -8,11 +8,20 @@
   within one week of the end of the competition according to the <a href="https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf">WCA Competition Requirements Policy</a>. The report can be submitted <%= link_to("here", delegate_report_url(@competition)) %>.
 </p>
 
+<% if @competition.lead_delegate.present? %>
 <p>
-  <b>
-    As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, Delegates who are listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation.
-  </b>
+    <b>
+        As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, a Lead Delegate who is listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation. The Lead Delegate of this competition is <%= @competition.lead_delegate.name %>.
+    </b>
 </p>
+<p>
+    <% else %>
+<p>
+    <b>
+        As a reminder, according to the <a href="https://documents.worldcubeassociation.org/documents/policies/internal/Delegate%20Probationary%20Status.pdf">WCA Delegate Probationary Status Policy</a>, Delegates who are listed on late reports for two consecutive competitions without an approved exception prior to the report due date will be put on probation.
+    </b>
+</p>
+<% end %>
 
 <p>
   Regards,

--- a/app/views/competitions_mailer/submit_results_nag.html.erb
+++ b/app/views/competitions_mailer/submit_results_nag.html.erb
@@ -21,6 +21,9 @@
       <li><%= link_to "#{delegate.name}", competitions_url(display: "admin", years: "all", state: "past", delegate: delegate.id), target: "_blank" %></li>
     <% end %>
   </ul>
+  <% if @competition.lead_delegate.present? %>
+    Lead Delegate for this competition is <%= @competition.lead_delegate.name %>.
+  <% end %>
 </p>
 
 <p>

--- a/app/views/delegate_reports/_delegate_report.html.erb
+++ b/app/views/delegate_reports/_delegate_report.html.erb
@@ -54,7 +54,12 @@
     (<%= competition.events.count %>)
     <%= competition.events.map(&:name).join(", ") %>
   </div>
-
+  <% if competition.lead_delegate.present? %>
+    <div>
+      <strong>Lead Delegate</strong>
+      <%= competition.lead_delegate.name %>
+    </div>
+  <% end %>
   <div>
     <strong>Delegates</strong>
     <%= competition.staff_delegates.pluck(:name).to_sentence %>

--- a/app/webpacker/components/CompetitionsOverview/ListViewSection.js
+++ b/app/webpacker/components/CompetitionsOverview/ListViewSection.js
@@ -358,6 +358,7 @@ function AdminCompetitionsTable({
                       <List.Item
                         key={delegate.id}
                         active={!selectedDelegate || delegate.id === selectedDelegate}
+                        style={{ fontWeight: delegate.id === comp.lead_delegate_id ? 'bold' : 'normal' }}
                         disabled
                       >
                         <Image avatar src={delegate.avatar.thumb_url} />


### PR DESCRIPTION
All changes here have been discussed with @lmkucala. Quick summary:

### Mark Lead Delegate in bold in admin competitions view
<img width="1242" height="129" alt="image" src="https://github.com/user-attachments/assets/ce4dd444-c0bd-4c1f-91bf-6f264be8bda4" />

### Update delegate report on the website & email to include who was the Lead Delegate
<img width="791" height="352" alt="image" src="https://github.com/user-attachments/assets/139ff4c3-2661-42b2-9fed-b98e82ae4cc7" />

### Update report automated reminder
<img width="959" height="393" alt="image" src="https://github.com/user-attachments/assets/01afba2f-cd3a-42bb-bfba-df3cac384eb4" />

### Update late results/report emails for competitions with Lead Delegate selected
<img width="959" height="218" alt="image" src="https://github.com/user-attachments/assets/48703466-5488-4772-9b65-12825fb16912" />
<img width="1908" height="451" alt="image" src="https://github.com/user-attachments/assets/2b556e2a-f8ea-4005-9769-703a9347afe5" />


@gregorbg do I need to write tests for any of these changes?