### PR TITLE
Dual Rounds terminology (pluralize)

### DIFF
--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/live/rounds/[roundId]/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/live/rounds/[roundId]/page.tsx
@@ -62,7 +62,7 @@ export default async function ResultPage({
               formatId={format}
               roundWcifId={roundId}
               competitionId={competitionId}
-              title="Combined Dual Round"
+              title="Combined Dual Rounds"
               isLinkedRound
               canManage={canManage}
             />


### PR DESCRIPTION
"Duals Rounds" should be plural. See all references in the [WCA Regulations](https://www.worldcubeassociation.org/regulations/). In particular, [9v](https://www.worldcubeassociation.org/regulations/#9v) specifies that Dual Rounds applies to a combination of two rounds and [9o2](https://www.worldcubeassociation.org/regulations/#9o2) considers Dual Rounds to be two rounds.  