### PR TITLE
Correctly link to round id for attempt based events

### DIFF
--- a/next-frontend/src/components/competitions/Schedule/LiveView.tsx
+++ b/next-frontend/src/components/competitions/Schedule/LiveView.tsx
@@ -167,7 +167,7 @@ export default function LiveView({
                                     "/competitions/[competitionId]/live/rounds/[roundId]",
                                   query: {
                                     competitionId,
-                                    roundId: activity.activityCode,
+                                    roundId,
                                   },
                                 })}
                               >


### PR DESCRIPTION
We already fixed this I thought, maybe it got lost in a merge