### PR TITLE
Fix WMCT name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -798,7 +798,7 @@ en:
         weat: "WCA Executive Assistants Team"
         wfc: "WCA Financial Committee"
         wmt: "WCA Marketing Team"
-        wmct: "WCA Major Championships Team"
+        wmct: "WCA Major Championship Team"
         wqac: "WCA Quality Assurance Committee"
         wrc: "WCA Regulations Committee"
         wrt: "WCA Results Team"


### PR DESCRIPTION
The correct name is in singular as defined in the [relevant motion](https://documents.worldcubeassociation.org/documents/motions/10.2024.14%20-%20Major%20Championship%20Team.pdf).