### PR TITLE
Show Mean instead of average in LiveHeader and don't show average for Bo1/2

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,7 +238,6 @@ en:
     best: "Best"
     single: "Single"
     average: "Average"
-    mean: "Mean"
     solves: "Solves"
     #context: Used as an introduction in emails
     hello: "Hello %{name},"
@@ -1436,6 +1435,7 @@ en:
           failed_to_fetch: "Failed to fetch next advancing competitor"
       results:
         competitor: "Competitor"
+        mean: "Mean"
       errors:
         round_closed: "The Round is not open yet"
     #context: on the "My competitions" page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,7 @@ en:
     best: "Best"
     single: "Single"
     average: "Average"
+    mean: "Mean"
     solves: "Solves"
     #context: Used as an introduction in emails
     hello: "Hello %{name},"

--- a/next-frontend/src/components/live/Cells.tsx
+++ b/next-frontend/src/components/live/Cells.tsx
@@ -61,7 +61,7 @@ export function LiveTableHeader({
           ))}
         {stats.map((stat) => (
           <Table.ColumnHeader textAlign="right" key={stat.field}>
-            {t(`common.${stat.name}`)}
+            {t(stat.i18nKey)}
           </Table.ColumnHeader>
         ))}
       </Table.Row>
@@ -172,7 +172,7 @@ export function LiveStatCells({
 
   return stats.map((stat, statIndex) => (
     <Table.Cell
-      key={`${competitorId}-${stat.name}`}
+      key={`${competitorId}-${stat.i18nKey}`}
       textAlign="right"
       position="relative"
       fontWeight={shouldHighlight(statIndex) ? "bold" : "normal"}

--- a/next-frontend/src/components/live/LiveResultsMobileModal.tsx
+++ b/next-frontend/src/components/live/LiveResultsMobileModal.tsx
@@ -14,6 +14,7 @@ import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
 import { recordTagBadge } from "@/components/results/TableCells";
 import { CompetitorWithResults } from "@/lib/live/mergeAndOrderResults";
 import { Stat } from "@/lib/live/statColumnsForFormat";
+import { TFunction } from "i18next";
 
 export default function LiveResultsMobileModal({
   selectedRow,
@@ -21,12 +22,14 @@ export default function LiveResultsMobileModal({
   competitionId,
   eventId,
   stats,
+  t,
 }: {
   selectedRow: CompetitorWithResults | null;
   setSelectedRow: (selectedRow: CompetitorWithResults | null) => void;
   competitionId: string;
   eventId: string;
   stats: Stat[];
+  t: TFunction;
 }) {
   const onOpenChange = ({ open }: { open: boolean }) => {
     if (!open) setSelectedRow(null);
@@ -87,8 +90,10 @@ export default function LiveResultsMobileModal({
                       </DataList.ItemValue>
                     </DataList.Item>
                     {stats.map((stat) => (
-                      <DataList.Item key={stat.name}>
-                        <DataList.ItemLabel>{stat.name}</DataList.ItemLabel>
+                      <DataList.Item key={stat.i18nKey}>
+                        <DataList.ItemLabel>
+                          {t(stat.i18nKey)}
+                        </DataList.ItemLabel>
                         <DataList.ItemValue>
                           {formatAttemptResult(r[stat.field], eventId)}{" "}
                           {recordTagBadge(r[stat.recordTagField])}

--- a/next-frontend/src/components/live/LiveResultsTable.tsx
+++ b/next-frontend/src/components/live/LiveResultsTable.tsx
@@ -177,6 +177,7 @@ export default function LiveResultsTable({
           competitionId={competitionId}
           eventId={eventId}
           stats={stats}
+          t={t}
         />
       )}
     </>

--- a/next-frontend/src/lib/live/statColumnsForFormat.ts
+++ b/next-frontend/src/lib/live/statColumnsForFormat.ts
@@ -22,7 +22,8 @@ type StatKey = keyof typeof statMap;
 export type Stat = (typeof statMap)[StatKey];
 
 export const statColumnsForFormat = (format: Format) =>
-  [format.sort_by, format.sort_by_second]
+  // Why do Bo1 and Bo2 even return a format.sort_by_second?
+  [format.sort_by, format.expected_solve_count > 2 && format.sort_by_second]
     .filter(Boolean)
     .map((s) =>
       s === "average" && format.id === "m"

--- a/next-frontend/src/lib/live/statColumnsForFormat.ts
+++ b/next-frontend/src/lib/live/statColumnsForFormat.ts
@@ -2,17 +2,17 @@ import { Format } from "@/lib/wca/data/formats";
 
 const statMap = {
   average: {
-    name: "average",
+    i18nKey: "common.average",
     recordTagField: "average_record_tag",
     field: "average",
   },
   mean: {
-    name: "mean",
+    i18nKey: "competitions.live.results.mean",
     recordTagField: "average_record_tag",
     field: "average",
   },
   single: {
-    name: "single",
+    i18nKey: "common.single",
     recordTagField: "single_record_tag",
     field: "best",
   },

--- a/next-frontend/src/lib/live/statColumnsForFormat.ts
+++ b/next-frontend/src/lib/live/statColumnsForFormat.ts
@@ -6,6 +6,11 @@ const statMap = {
     recordTagField: "average_record_tag",
     field: "average",
   },
+  mean: {
+    name: "mean",
+    recordTagField: "average_record_tag",
+    field: "average",
+  },
   single: {
     name: "single",
     recordTagField: "single_record_tag",
@@ -19,4 +24,8 @@ export type Stat = (typeof statMap)[StatKey];
 export const statColumnsForFormat = (format: Format) =>
   [format.sort_by, format.sort_by_second]
     .filter(Boolean)
-    .map((s) => statMap[s as StatKey]);
+    .map((s) =>
+      s === "average" && format.id === "m"
+        ? statMap.mean
+        : statMap[s as StatKey],
+    );


### PR DESCRIPTION
fixes #14006, but I feel like we need to change formats.json (and the db I guess?) to not have sort_by_second for Bo1 and Bo2?