### PR TITLE
Added volunteer panel on homepage

### DIFF
--- a/app/views/posts/homepage.html.erb
+++ b/app/views/posts/homepage.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <div class="ui container cover-segments">
-      <div class="ui five column stackable cards">
+      <div class="ui six column stackable cards">
         <%= render "box", title: t('homepage.about_us.title'), path: about_path do %>
           <%= t('homepage.about_us.text') %>
         <% end %>
@@ -27,6 +27,9 @@
         <% end %>
         <%= render "box", title: t('homepage.records.title'), path: records_path do %>
           <%= t('homepage.records.text') %>
+        <% end %>
+        <%= render "box", title: t('homepage.volunteer.title'), path: '/volunteer' do %>
+          <%= t('homepage.volunteer.text') %>
         <% end %>
         <%= render "box", title: t('homepage.faq.title'), path: faq_path do %>
           <%= t('homepage.faq.text') %>

--- a/app/views/posts/homepage.html.erb
+++ b/app/views/posts/homepage.html.erb
@@ -28,7 +28,7 @@
         <%= render "box", title: t('homepage.records.title'), path: records_path do %>
           <%= t('homepage.records.text') %>
         <% end %>
-        <%= render "box", title: t('homepage.volunteer.title'), path: '/volunteer' do %>
+        <%= render "box", title: t('homepage.volunteer.title'), path: volunteer_positions_path do %>
           <%= t('homepage.volunteer.text') %>
         <% end %>
         <%= render "box", title: t('homepage.faq.title'), path: faq_path do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -917,26 +917,24 @@ en:
     latest_news: "Latest news"
     announcements: "Announcements"
     see_all_announcements: "See all announcements"
-    #context: "About us" box
     about_us:
       title: "About us"
       text: "The World Cube Association governs competitions for mechanical puzzles that are operated by twisting groups of pieces, commonly known as 'twisty puzzles'."
-    #context: "Competitions" box
     competitions:
       title: "Competitions"
       text_html: "Find out about competitions near you or competition results. At a competition now and want to see the results? Check out %{wca_live_link}!"
-    #context: "Merchandise" box
     merchandise:
       title: "Merchandise"
       #context: Indicate that the feature is new (like an advertisement)
       ad_new: "New"
       text_html: "Check out our newly launched official merchandise which includes a selection of apparels ranging from T-shirts to Hoodies."
       link_title: "Link to shop"
-    #context: "Records" box
     records:
       title: "Records"
       text: "Check out the current and past records of all official WCA events."
-    #context: "FAQ" box
+    volunteer:
+      title: "Volunteer"
+      text: "Get involved! The WCA has volunteer positions open across different teams. You do not have to be a speedcuber to be a volunteer."
     faq:
       title: "FAQ"
       text: "Take a look at our list of Frequently Asked Questions if you need help with anything. Many questions you have might have an answer there."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,6 +274,7 @@ Rails.application.routes.draw do
   get 'teams-committees' => 'static_pages#teams_committees'
   get 'tutorial' => redirect('/education', status: 302)
   get 'translators' => 'static_pages#translators'
+  get 'volunteer', to: redirect('https://docs.google.com/spreadsheets/d/13JhGJWDfJR96MYgPpxkSaV2E3bMIdIWjWLuYO83vOls/edit?gid=0#gid=0')
   get 'officers-and-board' => 'static_pages#officers_and_board'
 
   resources :regional_organizations, only: %i[new create update edit destroy], path: '/regional-organizations'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,7 +274,7 @@ Rails.application.routes.draw do
   get 'teams-committees' => 'static_pages#teams_committees'
   get 'tutorial' => redirect('/education', status: 302)
   get 'translators' => 'static_pages#translators'
-  get 'volunteer', to: redirect('https://docs.google.com/spreadsheets/d/13JhGJWDfJR96MYgPpxkSaV2E3bMIdIWjWLuYO83vOls/edit?gid=0#gid=0')
+  get 'volunteer-positions', to: redirect('https://docs.google.com/spreadsheets/d/13JhGJWDfJR96MYgPpxkSaV2E3bMIdIWjWLuYO83vOls/edit?gid=0#gid=0')
   get 'officers-and-board' => 'static_pages#officers_and_board'
 
   resources :regional_organizations, only: %i[new create update edit destroy], path: '/regional-organizations'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,7 +274,7 @@ Rails.application.routes.draw do
   get 'teams-committees' => 'static_pages#teams_committees'
   get 'tutorial' => redirect('/education', status: 302)
   get 'translators' => 'static_pages#translators'
-  get 'volunteer-positions', to: redirect('https://docs.google.com/spreadsheets/d/13JhGJWDfJR96MYgPpxkSaV2E3bMIdIWjWLuYO83vOls/edit?gid=0#gid=0')
+  get 'volunteer-positions', to: redirect('https://docs.google.com/spreadsheets/d/13JhGJWDfJR96MYgPpxkSaV2E3bMIdIWjWLuYO83vOls/edit?gid=0#gid=0', status: 302)
   get 'officers-and-board' => 'static_pages#officers_and_board'
 
   resources :regional_organizations, only: %i[new create update edit destroy], path: '/regional-organizations'


### PR DESCRIPTION
Dan asked us to include a link to the [Volunteer Positions](https://docs.google.com/spreadsheets/d/13JhGJWDfJR96MYgPpxkSaV2E3bMIdIWjWLuYO83vOls/edit?gid=0#gid=0) doc on the homepage - adding a sixth card seems the easiest way to go about this. 

I dislike the thinner cards - spent a few minutes trying to set the width to 1300px instead, but wasn't able to and didn't want to play too much with custom CSS as I know we aren't the biggest fans of it. I sent a screenshot and Dan is happy with the box sizing. 

Wording was provided by WCT. 