### PR TITLE
Implement custom registration transfer logic while merging

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1575,7 +1575,29 @@ class User < ApplicationRecord
       competitions_results_posted.update_all(results_posted_by: new_user.id)
       competitions_announced.update_all(announced_by: new_user.id)
       roles.update_all(user_id: new_user.id)
-      registrations.update_all(user_id: new_user.id)
+
+      # Handle registrations with custom logic to prioritize accepted ones
+      # 1. Transfer non-conflicting registrations
+      to_user_competition_ids = new_user.registrations.pluck(:competition_id)
+      registrations.where.not(competition_id: to_user_competition_ids).update_all(user_id: new_user.id)
+
+      # 2. Handle conflicting registrations (where both users registered for the same competition)
+      registrations.where(competition_id: to_user_competition_ids).each do |registration|
+        other_registration = new_user.registrations.find_by(competition_id: registration.competition_id)
+        if registration.accepted? && other_registration.accepted?
+          raise "Both users have accepted registrations for #{registration.competition.name} (#{registration.competition_id})"
+        elsif registration.accepted?
+          # The master account has a non-accepted registration, but the old account has an accepted one.
+          # We swap them: the master gets the accepted one, and the old account keeps the unaccepted one.
+          # We use update_columns to bypass validations and avoid intermediate unique index violations.
+          other_registration.update_columns(user_id: nil)
+          registration.update_columns(user_id: new_user.id)
+          other_registration.update_columns(user_id: id)
+        else
+          # Incoming registration is NOT accepted, and master already has one.
+          # In this case, we keep the master's and the other stays in the old account.
+        end
+      end
 
       return if wca_id.blank?
 
@@ -1583,7 +1605,7 @@ class User < ApplicationRecord
       self.update!(wca_id: nil) # Must remove WCA ID before adding it as it is unique in the Users table.
       new_user.update!(wca_id: wca_id_to_be_transferred)
 
-      # After this merge, there won't be any registrations for self as all of
+      # After this merge, there won't be any accepted registrations for self as all of
       # them will be transferred to new_user. So any potential duplicates of
       # self is no longer valid. There might be some potential duplicates for
       # new_user, but they need to be refetched. But refetching here may look

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1581,8 +1581,11 @@ class User < ApplicationRecord
       to_user_competition_ids = new_user.registrations.pluck(:competition_id)
       registrations.where.not(competition_id: to_user_competition_ids).update_all(user_id: new_user.id)
 
-      # 2. Handle conflicting registrations (where both users registered for the same competition)
-      registrations.where(competition_id: to_user_competition_ids).each do |registration|
+      # 2. Handle conflicting registrations (where both users registered for the same competition):
+      #  - If both are accepted: Raise error.
+      #  - If only incoming is accepted: Swap them so the master account gets the accepted one.
+      #  - Otherwise (incoming is not accepted): Keep the master's and the other stays in the old account.
+      registrations.where(competition_id: to_user_competition_ids).find_each do |registration|
         other_registration = new_user.registrations.find_by(competition_id: registration.competition_id)
         if registration.accepted? && other_registration.accepted?
           raise "Both users have accepted registrations for #{registration.competition.name} (#{registration.competition_id})"
@@ -1593,9 +1596,6 @@ class User < ApplicationRecord
           other_registration.update_columns(user_id: nil)
           registration.update_columns(user_id: new_user.id)
           other_registration.update_columns(user_id: id)
-        else
-          # Incoming registration is NOT accepted, and master already has one.
-          # In this case, we keep the master's and the other stays in the old account.
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -268,6 +268,54 @@ RSpec.describe User do
     end
   end
 
+  describe "#transfer_data_to" do
+    let(:from_user) { create(:user) }
+    let(:to_user) { create(:user) }
+    let(:competition) { create(:competition) }
+
+    it "transfers non-conflicting registrations" do
+      registration = create(:registration, user: from_user, competition: competition)
+      from_user.transfer_data_to(to_user)
+      expect(registration.reload.user).to eq to_user
+    end
+
+    it "raises an error if both users have accepted registrations for the same competition" do
+      create(:registration, :accepted, user: from_user, competition: competition)
+      create(:registration, :accepted, user: to_user, competition: competition)
+      expect { from_user.transfer_data_to(to_user) }.to raise_error(RuntimeError, /Both users have accepted registrations/)
+    end
+
+    it "swaps registrations if from_user is accepted and to_user is not" do
+      accepted_reg = create(:registration, :accepted, user: from_user, competition: competition)
+      pending_reg = create(:registration, :pending, user: to_user, competition: competition)
+
+      from_user.transfer_data_to(to_user)
+
+      expect(accepted_reg.reload.user).to eq to_user
+      expect(pending_reg.reload.user).to eq from_user
+    end
+
+    it "keeps to_user's registration and leaves from_user's if to_user is accepted and from_user is not" do
+      pending_reg = create(:registration, :pending, user: from_user, competition: competition)
+      accepted_reg = create(:registration, :accepted, user: to_user, competition: competition)
+
+      from_user.transfer_data_to(to_user)
+
+      expect(accepted_reg.reload.user).to eq to_user
+      expect(pending_reg.reload.user).to eq from_user
+    end
+
+    it "keeps to_user's registration and leaves from_user's if both are unaccepted" do
+      pending_reg_from = create(:registration, :pending, user: from_user, competition: competition)
+      pending_reg_to = create(:registration, :pending, user: to_user, competition: competition)
+
+      from_user.transfer_data_to(to_user)
+
+      expect(pending_reg_to.reload.user).to eq to_user
+      expect(pending_reg_from.reload.user).to eq from_user
+    end
+  end
+
   describe "clearing WCA claims via constant" do
     let(:delegate_role) { create(:delegate_role) }
     let(:person) { create(:person) }


### PR DESCRIPTION
This change is because currently if we try to merge two users having registrations at same competition, it fails.