### PR TITLE
Add lifecycle_state to Round model

### DIFF
--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -78,11 +78,9 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
     # TODO: Move these to actual error codes at one point
     require_manage!(competition)
 
-    state = round.lifecycle_state
+    return render json: { status: "round is locked" }, status: :bad_request if round.lifecycle_state_locked?
 
-    return render json: { status: "round is locked" }, status: :bad_request if state == Round::STATE_LOCKED
-
-    return render json: { status: "round is not open" }, status: :bad_request if [Round::STATE_READY, Round::STATE_PENDING].include?(state)
+    return render json: { status: "round is not open" }, status: :bad_request unless round.lifecycle_state_open?
 
     recreated_rows = round.clear_round!(@current_user)
 
@@ -121,11 +119,9 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
     # TODO: Move these to actual error codes at one point
     require_manage!(competition)
 
-    state = round.lifecycle_state
+    return render json: { status: "round already open" }, status: :bad_request if round.lifecycle_state_open? || round.lifecycle_state_locked?
 
-    return render json: { status: "score taking is not finished in the previous round" }, status: :bad_request if state == Round::STATE_PENDING
-
-    return render json: { status: "round already open" }, status: :bad_request if [Round::STATE_OPEN, Round::STATE_LOCKED].include?(state)
+    return render json: { status: "score taking is not finished in the previous round" }, status: :bad_request unless round.participation_source.score_taking_done?
 
     created_rows, locked_rows = round.open_and_lock_previous(@current_user)
 

--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -18,10 +18,12 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
     live_result = round.live_results.find_by(registration_id: registration_id)
 
     if live_result.blank?
-      return render json: { status: "round is not open" }, status: :unprocessable_content unless round.live_results.any?
+      return render json: { status: "round is not open" }, status: :unprocessable_content unless round.lifecycle_state_open?
 
       return render json: { status: "user is not part of this round" }, status: :unprocessable_content
     end
+
+    return render json: { status: "results have already been submitted and cannot be changed" }, status: :unprocessable_content if round.lifecycle_state_done?
 
     UpdateLiveResultJob.perform_later(live_result, results, @current_user.id)
 
@@ -82,6 +84,8 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "round is not open" }, status: :bad_request unless round.lifecycle_state_open?
 
+    return render json: { status: "results have already been submitted and cannot be changed" }, status: :unprocessable_content if round.lifecycle_state_done?
+
     recreated_rows = round.clear_round!(@current_user)
 
     render json: { status: "ok", recreated_rows: recreated_rows }
@@ -95,6 +99,8 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
     round = Round.find_by_wcif_id!(wcif_id, competition.id)
 
     require_manage!(competition)
+
+    return render json: { status: "results have already been submitted and cannot be changed" }, status: :unprocessable_content if round.lifecycle_state_done?
 
     result = round.live_results.find_by!(registration_id: registration_id)
 

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -593,7 +593,7 @@ class Round < ApplicationRecord
   end
 
   def lock_results(locking_user)
-    update!(:lifecycle_state => :locked)
+    update!(lifecycle_state: :locked)
     self.bulk_insert_history(live_results.ids, locking_user, action_type: :locked)
     count
   end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -601,7 +601,7 @@ class Round < ApplicationRecord
   validate :lifecycle_state_matches_inferred, if: :lifecycle_state_changed?
 
   private def lifecycle_state_matches_inferred
-    return unless Round.lifecycle_state != inferred_lifecycle_state
+    return unless lifecycle_state != inferred_lifecycle_state
 
     errors.add(:lifecycle_state, "does not match inferred state (#{inferred_lifecycle_state})")
   end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -728,6 +728,7 @@ class Round < ApplicationRecord
     json = {
       **self.to_wcif(include_results: false).compact_blank,
       "state" => lifecycle_state,
+      "ready" => lifecycle_state_pending? && participation_source.score_taking_done?
     }
     if lifecycle_state_open? || lifecycle_state_locked?
       json = json.merge({

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -194,7 +194,7 @@ class Round < ApplicationRecord
       LiveResult.empty_result_attributes(reg_id, self.id)
     end
     LiveResult.insert_all!(empty_results)
-    update!(:lifecycle_state => :open)
+    update!(lifecycle_state: :open)
 
     inserted_ids = self.live_results.where(registration_id: advancing_reg_ids).ids
     self.bulk_insert_history(inserted_ids, opening_user, action_type: :opened)

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -736,7 +736,7 @@ class Round < ApplicationRecord
     json = {
       **self.to_wcif(include_results: false).compact_blank,
       "state" => lifecycle_state,
-      "ready" => lifecycle_state_pending? && participation_source.score_taking_done?
+      "ready" => lifecycle_state_pending? && participation_source.score_taking_done?,
     }
     if lifecycle_state_open? || lifecycle_state_locked?
       json = json.merge({

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -728,7 +728,7 @@ class Round < ApplicationRecord
   def to_live_info_json
     json = {
       **self.to_wcif(include_results: false).compact_blank,
-      "state" => STATE_INTEGERS.key(lifecycle_state),
+      "state" => lifecycle_state,
       "ready" => lifecycle_state_pending? && participation_source.score_taking_done?
     }
     if lifecycle_state_open? || lifecycle_state_locked?

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -60,7 +60,8 @@ class Round < ApplicationRecord
 
   has_many :sibling_rounds, through: :competition_event, source: :rounds
 
-  enum :lifecycle_state, { pending: "pending", open: "open", locked: "locked", done: "done" }, prefix: true
+  STATE_INTEGERS = { "pending" => 0, "open" => 1, "locked" => 2, "done" => 3 }.freeze
+  enum :lifecycle_state, %i[pending open locked done], prefix: true
 
   MAX_NUMBER = 4
   validates :number,
@@ -599,11 +600,11 @@ class Round < ApplicationRecord
   end
 
   def inferred_lifecycle_state
-    return "done" if competition.results_submitted?
-    return "locked" if locked?
-    return "open" if open?
+    return STATE_INTEGERS["done"] if competition.results_submitted?
+    return STATE_INTEGERS["locked"] if locked?
+    return STATE_INTEGERS["open"] if open?
 
-    "pending"
+    STATE_INTEGERS["pending"]
   end
 
   def open?
@@ -727,7 +728,7 @@ class Round < ApplicationRecord
   def to_live_info_json
     json = {
       **self.to_wcif(include_results: false).compact_blank,
-      "state" => lifecycle_state,
+      "state" => STATE_INTEGERS.key(lifecycle_state),
       "ready" => lifecycle_state_pending? && participation_source.score_taking_done?
     }
     if lifecycle_state_open? || lifecycle_state_locked?

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -60,6 +60,8 @@ class Round < ApplicationRecord
 
   has_many :sibling_rounds, through: :competition_event, source: :rounds
 
+  enum :lifecycle_state, { pending: "pending", open: "open", locked: "locked", done: "done" }, prefix: true
+
   MAX_NUMBER = 4
   validates :number,
             numericality: { only_integer: true,
@@ -192,6 +194,7 @@ class Round < ApplicationRecord
       LiveResult.empty_result_attributes(reg_id, self.id)
     end
     LiveResult.insert_all!(empty_results)
+    update!(:lifecycle_state => :open)
 
     inserted_ids = self.live_results.where(registration_id: advancing_reg_ids).ids
     self.bulk_insert_history(inserted_ids, opening_user, action_type: :opened)
@@ -590,18 +593,15 @@ class Round < ApplicationRecord
   end
 
   def lock_results(locking_user)
-    count = live_results.update_all(locked_by_id: locking_user.id)
+    update!(:lifecycle_state => :locked)
     self.bulk_insert_history(live_results.ids, locking_user, action_type: :locked)
     count
   end
-
-  enum :lifecycle_state, { pending: "pending", ready: "ready", open: "open", locked: "locked", done: "done" }, prefix: true
 
   def inferred_lifecycle_state
     return "done" if competition.results_submitted?
     return "locked" if locked?
     return "open" if open?
-    return "ready" if participation_source.score_taking_done?
 
     "pending"
   end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -60,7 +60,6 @@ class Round < ApplicationRecord
 
   has_many :sibling_rounds, through: :competition_event, source: :rounds
 
-  STATE_INTEGERS = { "pending" => 0, "open" => 1, "locked" => 2, "done" => 3 }.freeze
   enum :lifecycle_state, %i[pending open locked done], prefix: true
 
   MAX_NUMBER = 4
@@ -599,12 +598,20 @@ class Round < ApplicationRecord
     count
   end
 
-  def inferred_lifecycle_state
-    return STATE_INTEGERS["done"] if competition.results_submitted?
-    return STATE_INTEGERS["locked"] if locked?
-    return STATE_INTEGERS["open"] if open?
+  validate :lifecycle_state_matches_inferred, if: :lifecycle_state_changed?
 
-    STATE_INTEGERS["pending"]
+  private def lifecycle_state_matches_inferred
+    return unless Round.lifecycle_state != inferred_lifecycle_state
+
+    errors.add(:lifecycle_state, "does not match inferred state (#{inferred_lifecycle_state})")
+  end
+
+  def inferred_lifecycle_state
+    return "done" if competition.results_submitted?
+    return "locked" if locked?
+    return "open" if open?
+
+    "pending"
   end
 
   def open?

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -595,23 +595,22 @@ class Round < ApplicationRecord
     count
   end
 
-  STATE_LOCKED = "locked"
-  STATE_OPEN = "open"
-  STATE_READY = "ready"
-  STATE_PENDING = "pending"
+  enum :lifecycle_state, { pending: "pending", ready: "ready", open: "open", locked: "locked", done: "done" }, prefix: true
 
-  def lifecycle_state
-    return STATE_LOCKED if locked?
-    return STATE_OPEN if open?
-    return STATE_READY if participation_source.score_taking_done?
+  def inferred_lifecycle_state
+    return "done" if competition.results_submitted?
+    return "locked" if locked?
+    return "open" if open?
+    return "ready" if participation_source.score_taking_done?
 
-    STATE_PENDING
+    "pending"
   end
 
   def open?
     live_results.any?
   end
 
+  # TODO: Remove after Migration has ran
   def locked?
     return false unless score_taking_done?
 
@@ -726,18 +725,17 @@ class Round < ApplicationRecord
   end
 
   def to_live_info_json
-    state = lifecycle_state
     json = {
       **self.to_wcif(include_results: false).compact_blank,
-      "state" => state,
+      "state" => lifecycle_state,
     }
-    if [STATE_OPEN, STATE_LOCKED].include?(state)
+    if lifecycle_state_open? || lifecycle_state_locked?
       json = json.merge({
                           "total_competitors" => total_competitors,
                         })
     end
 
-    if state == STATE_OPEN
+    if lifecycle_state_open?
       json = json.merge({
                           "competitors_live_results_entered" => competitors_live_results_entered,
                         })

--- a/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
+++ b/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
@@ -1,9 +1,10 @@
-class AddLifecycleStateToRounds < ActiveRecord::Migration[7.2]
+class AddLifecycleStateToRounds < ActiveRecord::Migration[8.1]
   def up
     add_column :rounds, :lifecycle_state, :string, limit: 10, null: false, default: "pending"
 
-    Round.reset_column_information
-    Round.find_each do |round|
+    Round.joins(:competition).where.not(competitions: { results_submitted_at: nil }).update_all(lifecycle_state: "done")
+
+    Round.joins(:competition).where(competitions: { results_submitted_at: nil }).find_each do |round|
       round.update_columns(lifecycle_state: round.inferred_lifecycle_state)
     end
   end

--- a/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
+++ b/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
@@ -1,8 +1,8 @@
 class AddLifecycleStateToRounds < ActiveRecord::Migration[8.1]
   def up
-    add_column :rounds, :lifecycle_state, :string, limit: 10, null: false, default: "pending"
+    add_column :rounds, :lifecycle_state, :integer, null: false, default: 0
 
-    Round.joins(:competition).where.not(competitions: { results_submitted_at: nil }).update_all(lifecycle_state: "done")
+    Round.joins(:competition).where.not(competitions: { results_submitted_at: nil }).update_all(lifecycle_state: Round::STATE_INTEGERS["done"])
 
     Round.joins(:competition).where(competitions: { results_submitted_at: nil }).find_each do |round|
       round.update_columns(lifecycle_state: round.inferred_lifecycle_state)

--- a/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
+++ b/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLifecycleStateToRounds < ActiveRecord::Migration[8.1]
   def up
     add_column :rounds, :lifecycle_state, :integer, null: false, default: 0

--- a/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
+++ b/db/migrate/20260427120000_add_lifecycle_state_to_rounds.rb
@@ -1,0 +1,14 @@
+class AddLifecycleStateToRounds < ActiveRecord::Migration[7.2]
+  def up
+    add_column :rounds, :lifecycle_state, :string, limit: 10, null: false, default: "pending"
+
+    Round.reset_column_information
+    Round.find_each do |round|
+      round.update_columns(lifecycle_state: round.inferred_lifecycle_state)
+    end
+  end
+
+  def down
+    remove_column :rounds, :lifecycle_state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1261,7 +1261,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_120000) do
     t.text "cutoff"
     t.string "format_id", limit: 255, null: false
     t.boolean "is_h2h_mock", default: false, null: false
-    t.string "lifecycle_state", limit: 10, default: "pending", null: false
+    t.integer "lifecycle_state", default: 0, null: false
     t.bigint "linked_round_id"
     t.integer "number", null: false
     t.string "old_type", limit: 1

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_120000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1261,6 +1261,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
     t.text "cutoff"
     t.string "format_id", limit: 255, null: false
     t.boolean "is_h2h_mock", default: false, null: false
+    t.string "lifecycle_state", limit: 10, default: "pending", null: false
     t.bigint "linked_round_id"
     t.integer "number", null: false
     t.string "old_type", limit: 1

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -306,6 +306,7 @@ module DatabaseDumper
           old_type
           linked_round_id
           is_h2h_mock
+          lifecycle_state
         ],
         db_default: %w[
           round_results

--- a/next-frontend/openapi/schemas/live/AdminRounds/BaseAdminRound.yaml
+++ b/next-frontend/openapi/schemas/live/AdminRounds/BaseAdminRound.yaml
@@ -3,6 +3,9 @@ allOf:
   - type: object
     required:
       - state
+      - ready
     properties:
       state:
         type: string
+      ready:
+        type: boolean

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/live/admin/ActionButtons.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/live/admin/ActionButtons.tsx
@@ -9,11 +9,13 @@ import { useT } from "@/lib/i18n/useI18n";
 export default function ActionButtons({
   state,
   setState,
+  ready,
   roundId,
   competitionId,
 }: {
   state: LiveRoundState;
   setState: (state: LiveRoundState) => void;
+  ready: boolean;
   roundId: string;
   competitionId: string;
 }) {
@@ -60,7 +62,7 @@ export default function ActionButtons({
 
   const { t } = useT();
 
-  if (state == "ready") {
+  if (state == "pending" && ready) {
     return (
       <Button
         variant="outline"

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/live/admin/RoundActions.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/live/admin/RoundActions.tsx
@@ -35,7 +35,7 @@ export default function RoundActions({
         flex="1"
         justifyContent="flex-start"
         textAlign="left"
-        disabled={["ready", "pending"].includes(state)}
+        disabled={!["open", "locked"].includes(state)}
       >
         {isOpen ? (
           <Link asChild>
@@ -69,6 +69,7 @@ export default function RoundActions({
       <ActionButtons
         state={state}
         setState={setState}
+        ready={round.ready}
         roundId={round.id}
         competitionId={competitionId}
       />

--- a/next-frontend/src/lib/wca/competitions/tabs.ts
+++ b/next-frontend/src/lib/wca/competitions/tabs.ts
@@ -131,7 +131,7 @@ export const duringCompetitionTabs = (
           i18nKey: `rounds.${roundTypeId}.name`,
           menuKey: round.id,
           badge: round.state === "locked" ? "Done" : "live",
-          disabled: round.state === "pending" || round.state === "ready",
+          disabled: round.state === "pending",
           href: route({
             pathname: "/competitions/[competitionId]/live/rounds/[roundId]",
             query: { competitionId: competitionInfo.id, roundId: round.id },

--- a/next-frontend/src/types/openapi.ts
+++ b/next-frontend/src/types/openapi.ts
@@ -919,6 +919,7 @@ export interface components {
         };
         BaseAdminRound: components["schemas"]["WcifRound"] & {
             state: string;
+            ready: boolean;
         };
         OpenRound: components["schemas"]["BaseAdminRound"] & {
             total_competitors: number;
@@ -946,14 +947,7 @@ export interface components {
              */
             state: "pending";
         };
-        ReadyRound: components["schemas"]["BaseAdminRound"] & {
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            state: "ready";
-        };
-        LiveRoundAdmin: components["schemas"]["OpenRound"] | components["schemas"]["LockedRound"] | components["schemas"]["PendingRound"] | components["schemas"]["ReadyRound"];
+        LiveRoundAdmin: components["schemas"]["OpenRound"] | components["schemas"]["LockedRound"] | components["schemas"]["PendingRound"];
         LiveAttempt: {
             value: number;
             attempt_number: number;

--- a/spec/requests/live_info_spec.rb
+++ b/spec/requests/live_info_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "WCA Live API - rounds" do
+  describe "GET #rounds" do
+    let!(:delegate) { create(:delegate) }
+
+    it "returns a pending state for a freshly created round" do
+      sign_in delegate
+
+      competition = create(:competition, event_ids: ["333"], delegates: [delegate])
+      create(:round, competition: competition, event_id: "333", number: 1)
+
+      get api_v1_competition_live_live_admin_path(competition.id)
+
+      expect(response).to be_successful
+      round_info = response.parsed_body["rounds"].first
+      expect(round_info["state"]).to eq "pending"
+      expect(round_info["ready"]).to be true
+    end
+
+    it "returns a ready flag when the participation source is done with score taking" do
+      sign_in delegate
+
+      competition = create(:competition, event_ids: ["333"], delegates: [delegate])
+      create(:registration, :accepted, competition: competition)
+      round1 = create(:round, competition: competition, event_id: "333", number: 1, total_number_of_rounds: 2)
+      round2 = create(:round, competition: competition, event_id: "333", number: 2, total_number_of_rounds: 2, participation_source: round1)
+
+      round1.open_round!(delegate)
+      expected_solve_count = round1.format.expected_solve_count
+      round1.live_results.update_all(live_attempts_count: expected_solve_count, advancing: true)
+
+      get api_v1_competition_live_live_admin_path(competition.id)
+
+      expect(response).to be_successful
+      round2_info = response.parsed_body["rounds"].find { |r| r["id"] == round2.wcif_id }
+      expect(round2_info["state"]).to eq "pending"
+      expect(round2_info["ready"]).to be true
+    end
+
+    it "returns an open state with competitor counts after opening a round" do
+      sign_in delegate
+
+      competition = create(:competition, event_ids: ["333"], delegates: [delegate])
+      create(:registration, :accepted, competition: competition)
+      round = create(:round, competition: competition, event_id: "333", number: 1)
+
+      round.open_round!(delegate)
+
+      get api_v1_competition_live_live_admin_path(competition.id)
+
+      expect(response).to be_successful
+      round_info = response.parsed_body["rounds"].first
+      expect(round_info["state"]).to eq "open"
+      expect(round_info["ready"]).to be false
+      expect(round_info["total_competitors"]).to eq 1
+      expect(round_info["competitors_live_results_entered"]).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
Does not remove `locked_by_id` yet because that is required by the backfilling. The migration is also crazy inefficient right now as 99.99% of rounds will be just "done" as a state (it actually has not finished running on my laptop yet).

Maybe we just say every round with results submitted is done and otherwise pending? Should cover our bases if every competition using ILR is either done or submitted right now