### PR TITLE
Fix live results not meeting cutoff being seen as incomplete

### DIFF
--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -100,7 +100,11 @@ class LiveResult < ApplicationRecord
   end
 
   def complete?
-    live_attempts_count == round.format.expected_solve_count
+    live_attempts_count == round.format.expected_solve_count || didnt_meet_cutoff?
+  end
+
+  def didnt_meet_cutoff?
+    best != 0 && round.cutoff.present? && !round.cutoff.apply(live_attempts)
   end
 
   def empty_result?

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -104,7 +104,7 @@ class LiveResult < ApplicationRecord
   end
 
   def didnt_meet_cutoff?
-    best != 0 && round.cutoff.present? && !round.cutoff.apply(live_attempts)
+    live_attempts.any? && round.cutoff.present? && round.cutoff.exceeds?(live_attempts)
   end
 
   def empty_result?

--- a/lib/cutoff.rb
+++ b/lib/cutoff.rb
@@ -14,8 +14,12 @@ class Cutoff
     self.event = event
   end
 
-  def apply(attempts)
+  def meets?(attempts)
     attempts[0..(number_of_attempts - 1)].any? { it.value.positive? && it.value < attempt_result }
+  end
+
+  def exceeds?(attempts)
+    !meets?(attempts)
   end
 
   def to_wcif

--- a/lib/cutoff.rb
+++ b/lib/cutoff.rb
@@ -14,6 +14,10 @@ class Cutoff
     self.event = event
   end
 
+  def apply(attempts)
+    attempts[0..(number_of_attempts - 1)].any? { it.value.positive? && it.value < attempt_result }
+  end
+
   def to_wcif
     { "numberOfAttempts" => self.number_of_attempts, "attemptResult" => self.attempt_result }
   end

--- a/spec/requests/live_recompute_advancing_spec.rb
+++ b/spec/requests/live_recompute_advancing_spec.rb
@@ -101,6 +101,80 @@ RSpec.describe "WCA Live API" do
       end
     end
 
+    context 'with a cutoff' do
+      it 'does not mark as advancing competitors who did not meet the cutoff' do
+        cutoff = Cutoff.new(number_of_attempts: 2, attempt_result: 5000)
+        round = create(:round, number: 1, total_number_of_rounds: 2, event_id: "333", competition: competition, cutoff: cutoff)
+        create(:round, number: 2, total_number_of_rounds: 2, event_id: "333", competition: competition, participation_condition: ranking_condition, participation_source: round)
+
+        registrations # ensure registrations are created before opening the round
+        round.open_round!(User.first)
+        live_results = round.live_results
+
+        # 3 competitors met the cutoff (at least one attempt < 5000 in first 2)
+        3.times do |i|
+          result = live_results.find_by!(registration_id: registrations[i].id)
+          UpdateLiveResultJob.perform_now(result, Array.new(5) { |j| { value: (i + 1) * 1000, attempt_number: j + 1 } }, User.first.id)
+        end
+
+        # 2 competitors did NOT meet the cutoff (both first 2 attempts >= 5000)
+        2.times do |i|
+          result = live_results.find_by!(registration_id: registrations[3 + i].id)
+          UpdateLiveResultJob.perform_now(result, [{ value: 6000, attempt_number: 1 }, { value: 7000, attempt_number: 2 }], User.first.id)
+        end
+
+        no_cutoff_ids = [registrations[3].id, registrations[4].id]
+        expect(round.live_results.reload.where(registration_id: no_cutoff_ids).pluck(:advancing)).to all(be false)
+        expect(round.live_results.reload.where.not(registration_id: no_cutoff_ids).pluck(:advancing)).to all(be true)
+      end
+
+      it 'does not mark as advancing competitors who did not meet the cutoff when they have a dnf' do
+        cutoff = Cutoff.new(number_of_attempts: 2, attempt_result: 5000)
+        round = create(:round, number: 1, total_number_of_rounds: 2, event_id: "333", competition: competition, cutoff: cutoff)
+        create(:round, number: 2, total_number_of_rounds: 2, event_id: "333", competition: competition, participation_condition: ranking_condition, participation_source: round)
+
+        registrations # ensure registrations are created before opening the round
+        round.open_round!(User.first)
+        live_results = round.live_results
+
+        # 3 competitors met the cutoff (at least one attempt < 5000 in first 2)
+        3.times do |i|
+          result = live_results.find_by!(registration_id: registrations[i].id)
+          UpdateLiveResultJob.perform_now(result, Array.new(5) { |j| { value: (i + 1) * 1000, attempt_number: j + 1 } }, User.first.id)
+        end
+
+        # 2 competitors did NOT meet the cutoff (both first 2 attempts >= 5000)
+        2.times do |i|
+          result = live_results.find_by!(registration_id: registrations[3 + i].id)
+          UpdateLiveResultJob.perform_now(result, [{ value: 6000, attempt_number: 1 }, { value: -1, attempt_number: 2 }], User.first.id)
+        end
+
+        no_cutoff_ids = [registrations[3].id, registrations[4].id]
+        expect(round.live_results.reload.where(registration_id: no_cutoff_ids).pluck(:advancing)).to all(be false)
+        expect(round.live_results.reload.where.not(registration_id: no_cutoff_ids).pluck(:advancing)).to all(be true)
+      end
+
+      it 'with missing results' do
+        cutoff = Cutoff.new(number_of_attempts: 2, attempt_result: 5000)
+        round = create(:round, number: 1, total_number_of_rounds: 2, event_id: "333", competition: competition, cutoff: cutoff)
+        create(:round, number: 2, total_number_of_rounds: 2, event_id: "333", competition: competition, participation_condition: ranking_condition, participation_source: round)
+
+        registrations # ensure registrations are created before opening the round
+        round.open_round!(User.first)
+        live_results = round.live_results
+
+        # 3 competitors met the cutoff (at least one attempt < 5000 in first 2)
+        3.times do |i|
+          result = live_results.find_by!(registration_id: registrations[i].id)
+          UpdateLiveResultJob.perform_now(result, Array.new(5) { |j| { value: (i + 1) * 1000, attempt_number: j + 1 } }, User.first.id)
+        end
+
+        # We are still missing two results so only the first result should be marked as advancing
+        expect(round.live_results.reload.where(registration_id: [registrations.first]).pluck(:advancing)).to all(be true)
+        expect(round.live_results.reload.where.not(registration_id: [registrations.first]).pluck(:advancing)).to all(be false)
+      end
+    end
+
     context 'with an attempt_result advancement condition' do
       it 'returns results with ranking better or equal to the given level' do
         round = create(:round, number: 1, total_number_of_rounds: 2, event_id: "333", competition: competition)


### PR DESCRIPTION
The `best != 0 && round.cutoff.present? && !round.cutoff.apply(live_attempts)` got a little clunky but I think it's the only way to figure out if someone didn't meet the cutoff but definitely has competed already. 

Added 3 new tests to cover all the bases (cutoff, cutoff with DNF and with incomplete)