### PR TITLE
Make sure to include all new relic transitive deps

### DIFF
--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -37,3 +37,15 @@ jobs:
         run: yarn run lint
       - name: Run build
         run: yarn run build
+      - name: Verify newrelic loads from standalone output
+        # Simulates the production container startup: NODE_OPTIONS='-r newrelic'.
+        # If any transitive dep is missing from the standalone node_modules
+        # (e.g. meriyah via @apm-js-collab/code-transformer), this step fails
+        # before the image is built or deployed.
+        working-directory: next-frontend/.next/standalone
+        env:
+          NODE_ENV: production
+          NEW_RELIC_LICENSE_KEY: ci-test-not-real
+          NEW_RELIC_APP_NAME: ci-test
+          NEW_RELIC_LOG_LEVEL: error
+        run: node -e "require('./node_modules/newrelic')"

--- a/next-frontend/Dockerfile
+++ b/next-frontend/Dockerfile
@@ -84,10 +84,6 @@ EXPOSE 3000
 ENV PORT=3000
 ENV NEW_RELIC_LOG='stdout'
 
-# Even following the official new relic example not all the submodules are copied over
-# See https://github.com/newrelic/newrelic-node-examples/issues/307#issuecomment-3665368688
-COPY --from=builder /app/node_modules/newrelic /app/node_modules/newrelic
-
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
 ENV HOSTNAME="0.0.0.0"

--- a/next-frontend/next.config.ts
+++ b/next-frontend/next.config.ts
@@ -1,4 +1,5 @@
 import { withPayload } from "@payloadcms/next/withPayload";
+import { existsSync, readFileSync } from "fs";
 import type { NextConfig } from "next";
 import nextRoutes from "nextjs-routes/config";
 import path from "path";
@@ -6,6 +7,41 @@ import path from "path";
 // New Relic is CommonJS
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const nrExternals = require("newrelic/load-externals");
+
+// Recursively collect the transitive dependencies of a package so that
+// outputFileTracingIncludes can ensure they all land in the standalone output.
+// Without this, Next.js's file tracer misses packages that are loaded via
+// dynamic ESM imports (e.g. meriyah, loaded by @apm-js-collab/code-transformer
+// which is pulled in by @newrelic/security-agent).
+function getTransitiveDeps(
+  pkgName: string,
+  visited = new Set<string>(),
+): string[] {
+  if (visited.has(pkgName)) return [];
+  visited.add(pkgName);
+  const pkgJsonPath = path.join(
+    __dirname,
+    "node_modules",
+    pkgName,
+    "package.json",
+  );
+  if (!existsSync(pkgJsonPath)) return [];
+  try {
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+    const result = [pkgName];
+    for (const dep of Object.keys({
+      ...pkg.dependencies,
+      ...pkg.optionalDependencies,
+    })) {
+      result.push(...getTransitiveDeps(dep, visited));
+    }
+    return result;
+  } catch {
+    return [pkgName];
+  }
+}
+
+const newrelicDeps = getTransitiveDeps("newrelic");
 
 const withRoutes = nextRoutes({ outDir: "src/types" });
 
@@ -48,6 +84,14 @@ const nextConfig: NextConfig = {
     ],
   },
   output: "standalone",
+  // Explicitly include newrelic and every transitive dependency in the
+  // standalone output. Next.js's file tracer misses packages loaded via
+  // dynamic ESM imports (e.g. meriyah via @apm-js-collab/code-transformer).
+  // getTransitiveDeps() walks the full dep tree at build time so this list
+  // stays accurate automatically when newrelic updates its dependencies.
+  outputFileTracingIncludes: {
+    "**": newrelicDeps.map((dep) => `./node_modules/${dep}/**/*`),
+  },
   productionBrowserSourceMaps: true,
   async rewrites() {
     return [


### PR DESCRIPTION
LLM Suggestion to the failing build. It's a little sledgehammer as only dynamic transitive imports break the build, but that is impossible to detect. I also added a test to make sure we notice this issue not on deploy but before