### PR TITLE
Log errors when connecting Stripe fails

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -286,6 +286,7 @@ class CompetitionsController < ApplicationController
     if competition.save
       flash[:success] = t('payments.payment_setup.account_connected', provider: t("payments.payment_providers.#{payment_integration}"))
     else
+      Rails.logger.error "Failed to save competition #{competition.id}: #{competition.errors.full_messages.join(', ')}"
       flash[:danger] = t('payments.payment_setup.account_not_connected', provider: t("payments.payment_providers.#{payment_integration}"))
     end
 


### PR DESCRIPTION
Currently, we have no insight on why a competition didn't save in the below `else` block. This makes it impossible to troubleshoot payment connection issues when they get reported to us. I'm adding logging, so that we get insight into what validations are causing the competition to fail to save. 

This is in response to email thread "Re: CuboMática Cuiabá 2026 is confirmed".

```ruby
    if competition.save
      flash[:success] = t('payments.payment_setup.account_connected', provider: t("payments.payment_providers.#{payment_integration}"))
    else
      flash[:danger] = t('payments.payment_setup.account_not_connected', provider: t("payments.payment_providers.#{payment_integration}"))
```