### PR TITLE
Fix advancing_competitor_ids in competition_event as participation source

### DIFF
--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -33,7 +33,7 @@ class CompetitionEvent < ApplicationRecord
   end
 
   def advancing_competitor_ids
-    registrations.ids
+    registrations.accepted.ids
   end
 
   def next_advancing_without


### PR DESCRIPTION
Accidentally included all registrations not just advancing ones