### PR TITLE
Make round clickable after opening it

### DIFF
--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/live/admin/RoundActions.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/live/admin/RoundActions.tsx
@@ -23,7 +23,7 @@ export default function RoundActions({
 
   const [state, setState] = useState<LiveRoundState>(round.state);
 
-  const isOpen = ["open", "locked"].includes(round.state);
+  const isOpen = ["open", "locked"].includes(state);
 
   const roundName = getRoundName(round.id, t, rounds);
 


### PR DESCRIPTION
Most annoying thing about #13844 because you need to refresh currently. Not the true solution yet, which requires a RoundInfo Context that can be refetched per round like we do for live Results. That is a good idea anyway because why currently do so much extra fetching, but for this weekend this will solve the most annoying issue