### PR TITLE
Stricter WCIF schema checking upon `PATCH`

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -259,7 +259,14 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     # Only admins can update WCIF (including schedule) after results are submitted
     require_can_admin_competitions! if competition.results_submitted?
 
-    wcif = params.permit!.to_h
+    # We need to clean out some Rails-y stuff.
+    #   Normally, this isn't a problem because you're never supposed to just use `params.permit!`
+    #   without _explicitly_ sanitizing which parameters you *approve*, but WCIF is too big
+    #   for any one developer's mental sanity to control that.
+    # Note that none of the keys that we're "throwing away" here are currently WCIF-compliant,
+    #   nor are we ever likely to introduce any of them in top-level WCIF.
+    wcif = params.permit!.to_h.except(:controller, :action, :competition_id, :competition)
+
     wcif = wcif["_json"] || wcif
     competition.set_wcif!(wcif, require_user!)
     render json: {

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2130,7 +2130,9 @@ class Competition < ApplicationRecord
   def self.wcif_json_schema(version: WCIF_STABLE_VERSION)
     {
       "type" => "object",
-      "required" => %w[formatVersion],
+      # Normally we want to force tools to tell us which version they're patching,
+      #   but as of writing this comment we need more time to tell that to tools.
+      # "required" => %w[formatVersion],
       "properties" => {
         "formatVersion" => { "type" => "string" },
         "id" => { "type" => "string" },

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1946,7 +1946,7 @@ class Competition < ApplicationRecord
     import_version = wcif["formatVersion"]
 
     expected_schema = Competition.wcif_json_schema(version: import_version)
-    JSON::Validator.validate!(expected_schema, wcif)
+    JSON::Validator.validate!(expected_schema, wcif, noAdditionalProperties: true)
 
     ActiveRecord::Base.transaction do
       set_wcif_series!(wcif["series"], current_user) if wcif["series"]

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1942,11 +1942,15 @@ class Competition < ApplicationRecord
     }
   end
 
+  def self.validate_wcif_schema!(wcif, version: WCIF_STABLE_VERSION)
+    expected_schema = Competition.wcif_json_schema(version: version)
+    JSON::Validator.validate!(expected_schema, wcif, noAdditionalProperties: true)
+  end
+
   def set_wcif!(wcif, current_user)
     import_version = wcif["formatVersion"]
 
-    expected_schema = Competition.wcif_json_schema(version: import_version)
-    JSON::Validator.validate!(expected_schema, wcif, noAdditionalProperties: true)
+    Competition.validate_wcif_schema!(wcif, version: import_version)
 
     ActiveRecord::Base.transaction do
       set_wcif_series!(wcif["series"], current_user) if wcif["series"]

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -775,41 +775,31 @@ class Round < ApplicationRecord
           "type" => "object",
           "properties" => {
             "participationSource" => {
-              "allOf" => [
+              "oneOf" => [
                 {
                   "type" => "object",
                   "properties" => {
-                    "type" => { "type" => "string", "enum" => %w[registrations round linkedRounds] },
+                    "type" => { "const" => "registrations" },
                   },
                 },
                 {
-                  "oneOf" => [
-                    {
-                      "type" => "object",
-                      "properties" => {
-                        "type" => { "const" => "registrations" },
-                      },
+                  "type" => "object",
+                  "properties" => {
+                    "type" => { "const" => "round" },
+                    "roundId" => { "type" => "string" },
+                    "resultCondition" => ResultConditions::ResultCondition.wcif_json_schema,
+                  },
+                },
+                {
+                  "type" => "object",
+                  "properties" => {
+                    "type" => { "const" => "linkedRounds" },
+                    "roundIds" => {
+                      "type" => "array",
+                      "items" => { "type" => "string" },
                     },
-                    {
-                      "type" => "object",
-                      "properties" => {
-                        "type" => { "const" => "round" },
-                        "roundId" => { "type" => "string" },
-                        "resultCondition" => ResultConditions::ResultCondition.wcif_json_schema,
-                      },
-                    },
-                    {
-                      "type" => "object",
-                      "properties" => {
-                        "type" => { "const" => "linkedRounds" },
-                        "roundIds" => {
-                          "type" => "array",
-                          "items" => { "type" => "string" },
-                        },
-                        "resultCondition" => ResultConditions::ResultCondition.wcif_json_schema,
-                      },
-                    },
-                  ],
+                    "resultCondition" => ResultConditions::ResultCondition.wcif_json_schema,
+                  },
                 },
               ],
             },

--- a/app/webpacker/components/EditEvents/utils.js
+++ b/app/webpacker/components/EditEvents/utils.js
@@ -20,7 +20,6 @@ export const generateWcifRound = (eventId, roundNumber) => {
     cutoff: null,
     advancementCondition: null,
     results: [],
-    groups: [],
     scrambleSetCount: 1,
   };
 };

--- a/lib/result_conditions/result_condition.rb
+++ b/lib/result_conditions/result_condition.rb
@@ -28,44 +28,34 @@ module ResultConditions
 
     def self.wcif_json_schema
       {
-        "allOf" => [
+        "oneOf" => [
+          # For (very) historic records, we do not have advancement condition data
+          #   even though (from a schema standpoint) we _technically_ should.
+          # Backfilling is too complicated and sometimes even impossible, so just accept NULL.
+          { "type" => "null" },
           {
-            "type" => %w[object null],
+            "type" => "object",
             "properties" => {
-              "type" => { "type" => "string", "enum" => Utils::ALL_RESULT_CONDITIONS.map(&:wcif_type) },
+              "type" => { "const" => "resultAchieved" },
+              "scope" => { "type" => "string", "enum" => %w[single average] },
+              "value" => { "type" => %w[integer null] },
             },
           },
           {
-            "oneOf" => [
-              # For (very) historic records, we do not have advancement condition data
-              #   even though (from a schema standpoint) we _technically_ should.
-              # Backfilling is too complicated and sometimes even impossible, so just accept NULL.
-              { "type" => "null" },
-              {
-                "type" => "object",
-                "properties" => {
-                  "type" => { "const" => "resultAchieved" },
-                  "scope" => { "type" => "string", "enum" => %w[single average] },
-                  "value" => { "type" => %w[integer null] },
-                },
-              },
-              {
-                "type" => "object",
-                "properties" => {
-                  "type" => { "const" => "ranking" },
-                  "scope" => { "type" => "string", "enum" => %w[single average] },
-                  "value" => { "type" => "integer" },
-                },
-              },
-              {
-                "type" => "object",
-                "properties" => {
-                  "type" => { "const" => "percent" },
-                  "scope" => { "type" => "string", "enum" => %w[single average] },
-                  "value" => { "type" => "integer" },
-                },
-              },
-            ],
+            "type" => "object",
+            "properties" => {
+              "type" => { "const" => "ranking" },
+              "scope" => { "type" => "string", "enum" => %w[single average] },
+              "value" => { "type" => "integer" },
+            },
+          },
+          {
+            "type" => "object",
+            "properties" => {
+              "type" => { "const" => "percent" },
+              "scope" => { "type" => "string", "enum" => %w[single average] },
+              "value" => { "type" => "integer" },
+            },
           },
         ],
       }

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -914,17 +914,37 @@ RSpec.describe "Competition WCIF" do
       )
     end
 
-    it "rendered WCIF matches JSON Schema definition" do
-      expect do
-        JSON::Validator.validate!(Competition.wcif_json_schema, competition.to_wcif)
-      end.not_to raise_error
+    context "schema validation" do
+      it "passes on default stable version" do
+        expect do
+          Competition.validate_wcif_schema!(competition.to_wcif)
+        end.not_to raise_error
+      end
 
-      expect do
-        JSON::Validator.validate!(
-          Competition.wcif_json_schema(version: "2.0.0"),
-          competition.to_wcif(version: "2.0.0"),
-        )
-      end.not_to raise_error
+      it "passes on V2" do
+        expect do
+          Competition.validate_wcif_schema!(
+            competition.to_wcif(version: '2.0.0'),
+            version: '2.0.0',
+          )
+        end.not_to raise_error
+      end
+
+      it "does not pass on cross-version schema" do
+        expect do
+          Competition.validate_wcif_schema!(
+            competition.to_wcif(version: '1.0.0'),
+            version: '2.0.0',
+          )
+        end.to raise_error(JSON::Schema::ValidationError)
+
+        expect do
+          Competition.validate_wcif_schema!(
+            competition.to_wcif(version: "2.0.0"),
+            version: '1.0.0',
+          )
+        end.to raise_error(JSON::Schema::ValidationError)
+      end
     end
   end
 

--- a/spec/requests/api_competitions_spec.rb
+++ b/spec/requests/api_competitions_spec.rb
@@ -665,7 +665,7 @@ end
 
 def create_wcif_with_events(event_ids)
   {
-    formatVersion: Competition::WCIF_STABLE_VERSION,
+    formatVersion: '2.1.1',
     events: event_ids.map do |event_id|
       {
         id: event_id,


### PR DESCRIPTION
This PR does three things:
1. Remove the forced check for `formatVersion` (sigh...) and fall back to `STABLE_VERSION` (at the time of this PR: version `1.1`) if not specified
2. Make the schema check on WCIF stricter by not allowing any `additionalProperties` at all
3. Add tests for the corner cases that previously struck us down

If you look at the diff, use "Hide Whitespace" to better understand the changes (with fat airquotes) that I'm doing to the JSON schema. It's actually redundant to check a separate `type`-only object if the nested `oneOf` already implies the `type` fields as `const`.