### PR TITLE
Disable auto-accept when the last CPI is disconnected

### DIFF
--- a/app/models/competition_payment_integration.rb
+++ b/app/models/competition_payment_integration.rb
@@ -6,6 +6,8 @@ class CompetitionPaymentIntegration < ApplicationRecord
 
   belongs_to :competition
 
+  after_destroy :attempt_auto_accept_disable
+
   AVAILABLE_INTEGRATIONS = {
     paypal: 'ConnectedPaypalAccount',
     stripe: 'ConnectedStripeAccount',
@@ -38,4 +40,10 @@ class CompetitionPaymentIntegration < ApplicationRecord
     raise ArgumentError.new("Invalid integration name. Allowed values are: #{AVAILABLE_INTEGRATIONS.keys.join(', ')}") unless
       AVAILABLE_INTEGRATIONS.key?(integration_name)
   end
+
+  private
+
+    def attempt_auto_accept_disable
+      competition.update(auto_accept_preference: :disabled) unless competition.competition_payment_integrations.any?
+    end
 end

--- a/app/models/competition_payment_integration.rb
+++ b/app/models/competition_payment_integration.rb
@@ -44,6 +44,6 @@ class CompetitionPaymentIntegration < ApplicationRecord
   private
 
     def attempt_auto_accept_disable
-      competition.update(auto_accept_preference: :disabled) unless competition.competition_payment_integrations.any?
+      competition.update!(auto_accept_preference: :disabled) unless competition.competition_payment_integrations.reload.any?
     end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2366,7 +2366,7 @@ en:
         manual:  ""
       currently_connected_info: "This competition is set up to accept payments through %{provider}. The Delegate(s) of the competition should contact WCAT to make any changes to connected accounts."
       before_disconnect_warning: "Disconnecting on this page will make our website forget the connection to your %{provider} account. But your %{provider} dashboard (see link below) may still list the WCA website based on the authorization that you previously granted. Note that revoking authorization in the %{provider} dashboard will also affect any other competition linked to accept payments through this account!"
-      before_disconnect_info: "Keep in mind that disconnecting an account should only be done in exceptional situations, such as the current account being unable to receive payments."
+      before_disconnect_info: "This will also disable auto-accept. Keep in mind that disconnecting an account should only be done in exceptional situations, such as the current account being unable to receive payments."
       account_details:
         stripe:
           email: "Email"

--- a/spec/factories/competitions.rb
+++ b/spec/factories/competitions.rb
@@ -109,7 +109,7 @@ FactoryBot.define do
       to_create { |instance| instance.save(validate: false) }
     end
 
-    trait :auto_accept do
+    trait :auto_accept_requirements do
       stripe_connected
       use_wca_registration { true }
       competitor_limit_enabled { true }
@@ -119,12 +119,12 @@ FactoryBot.define do
     end
 
     trait :bulk_auto_accept do
-      auto_accept
+      auto_accept_requirements
       auto_accept_preference { :bulk }
     end
 
     trait :live_auto_accept do
-      auto_accept
+      auto_accept_requirements
       auto_accept_preference { :live }
     end
 

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -1615,6 +1615,20 @@ RSpec.describe Competition do
 
         expect { competition.disconnect_payment_integration(:stripe) }.not_to raise_error
       end
+
+      it 'disables auto accept if it was the only connected payment integration' do
+        competition = create(:competition, :live_auto_accept, :payment_disconnect_delay_elapsed)
+
+        competition.disconnect_payment_integration(:stripe)
+        expect(competition.auto_accept_preference).to eq('disabled')
+      end
+
+      it 'leaves auto accept enabled if there are other connected payment integrations' do
+        competition = create(:competition, :live_auto_accept, :payment_disconnect_delay_elapsed, :paypal_connected)
+
+        competition.disconnect_payment_integration(:stripe)
+        expect(competition.auto_accept_preference).to eq('live')
+      end
     end
 
     describe '#disconnect_all' do

--- a/spec/requests/competitions_spec.rb
+++ b/spec/requests/competitions_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "competitions" do
-  let!(:competition) { create(:competition, :with_delegate, :future, :visible, :auto_accept, :with_valid_schedule) }
+  let!(:competition) { create(:competition, :with_delegate, :future, :visible, :auto_accept_requirements, :with_valid_schedule) }
 
   describe "PATCH #update_competition" do
     context "when signed in as admin" do


### PR DESCRIPTION
We've had a few instances of auto accept being enabled and causing validation errors after a CPI was disconnected. This PR ensures that if a CPI is disconnected and there are no others remaining, auto_accept_preference gets changed to `:disabled`. It also updates the disconnect warning message to indicate this.

I've also changed the Competition factory property `auto_accept` to `auto_accept_requirements`. I wrote those factories, and I forgot that `auto_accept` doesn't _actually enable_ auto accept. So, name change was in order.