### PR TITLE
Add uniqueness key per competitor per event per year to concise_* tables

### DIFF
--- a/db/migrate/20260501101433_concise_table_uniqueness_key.rb
+++ b/db/migrate/20260501101433_concise_table_uniqueness_key.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ConciseTableUniquenessKey < ActiveRecord::Migration[8.1]
+  def change
+    add_index :concise_single_results, %i[person_id country_id event_id reg_year], unique: true, name: 'unique_per_competitor_per_event_per_year'
+    add_index :concise_average_results, %i[person_id country_id event_id reg_year], unique: true, name: 'unique_per_competitor_per_event_per_year'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_101433) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -481,6 +481,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
     t.bigint "value_and_id"
     t.index ["event_id", "average"], name: "mixed_records_speedup"
     t.index ["event_id", "country_id", "average"], name: "regional_records_speedup"
+    t.index ["person_id", "country_id", "event_id", "reg_year"], name: "unique_per_competitor_per_event_per_year", unique: true
     t.index ["person_id", "event_id", "continent_id", "country_id", "average"], name: "average_ranks_speedup"
   end
 
@@ -494,6 +495,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_101712) do
     t.bigint "value_and_id"
     t.index ["event_id", "best"], name: "mixed_records_speedup"
     t.index ["event_id", "country_id", "best"], name: "regional_records_speedup"
+    t.index ["person_id", "country_id", "event_id", "reg_year"], name: "unique_per_competitor_per_event_per_year", unique: true
     t.index ["person_id", "event_id", "continent_id", "country_id", "best"], name: "single_ranks_speedup"
   end
 

--- a/lib/auxiliary_data_computation.rb
+++ b/lib/auxiliary_data_computation.rb
@@ -34,6 +34,7 @@ module AuxiliaryDataComputation
         FROM concise_agg
           INNER JOIN regional_records_lookup rrl ON rrl.result_id = (concise_agg.value_and_id % 1000000000)
         ON DUPLICATE KEY UPDATE
+          result_id = rrl.result_id,
           #{field} = rrl.#{field},
           value_and_id = concise_agg.value_and_id,
           person_id = rrl.person_id,


### PR DESCRIPTION
This allows us to react via `ON DUPLICATE KEY UPDATE` to a certain edge case:

When a competitor previously had a fast solve from one result in one specific round, it is inserted into concise_* for that year.

If that solve is later found to be a typo, or a penalty is applied, and the new best time now actually comes from a _different_ result in a _different_ round, then the existing (status quo) `result_id` will not clash, meaning the old row will stick around.

This uniqueness key also makes a lot of sense in terms of "what this table actually means and what its reason for existing is".