### PR TITLE
Combobox fixes for AddPerson and AddResults

### DIFF
--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/live/rounds/[roundId]/admin/AddPerson.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/live/rounds/[roundId]/admin/AddPerson.tsx
@@ -114,7 +114,9 @@ function AddPersonCombobox({
   registrations: RegistrationData[];
 }) {
   const { collection, filter } = useListCollection({
-    initialItems: registrations,
+    initialItems: registrations.toSorted(
+      (a, b) => a.registrant_id - b.registrant_id,
+    ),
     itemToValue: (competitor) => competitor.id.toString(),
     itemToString: (competitor) => competitor.user.name,
     filter: (itemText, filterText, item) =>
@@ -126,6 +128,7 @@ function AddPersonCombobox({
     <VStack>
       <Combobox.Root
         collection={collection}
+        inputBehavior="autohighlight"
         onInputValueChange={(e) => filter(e.inputValue)}
         onValueChange={(e) => setSelectedCompetitor(parseInt(e.value[0], 10))}
       >

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/live/rounds/[roundId]/admin/AddPerson.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/live/rounds/[roundId]/admin/AddPerson.tsx
@@ -120,7 +120,7 @@ function AddPersonCombobox({
     itemToValue: (competitor) => competitor.id.toString(),
     itemToString: (competitor) => competitor.user.name,
     filter: (itemText, filterText, item) =>
-      itemText.includes(filterText) ||
+      itemText.toLowerCase().includes(filterText.toLowerCase()) ||
       parseInt(filterText, 10) === item.registrant_id,
   });
 

--- a/next-frontend/src/components/live/AttemptsForm.tsx
+++ b/next-frontend/src/components/live/AttemptsForm.tsx
@@ -51,7 +51,7 @@ export default function AttemptsForm({
     itemToValue: (competitor) => competitor.id.toString(),
     itemToString: toCompetitorString,
     filter: (itemText, filterText, item) =>
-      itemText.includes(filterText) ||
+      itemText.toLowerCase().includes(filterText.toLowerCase()) ||
       parseInt(filterText, 10) === item.registrant_id,
   });
 

--- a/next-frontend/src/components/live/AttemptsForm.tsx
+++ b/next-frontend/src/components/live/AttemptsForm.tsx
@@ -88,6 +88,7 @@ export default function AttemptsForm({
             }
           }}
           value={registrationId ? [registrationId.toString()] : []}
+          inputBehavior="autohighlight"
         >
           <Combobox.Label>
             <Heading size="2xl">{header}</Heading>


### PR DESCRIPTION
fixes https://github.com/thewca/worldcubeassociation.org/issues/13783 which includes:
- Listing the matched registrant_id on the top
- Being able to press enter to select using autohighlight
- ignoring case when searching.

I also ported those fixes to the AddResults combobox