### PR TITLE
Split ApproveWcaIdClaim from AssignWcaIdToUser and show WcaIdClaimCancelWarning

### DIFF
--- a/app/controllers/persons_controller.rb
+++ b/app/controllers/persons_controller.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class PersonsController < ApplicationController
+  before_action :authenticate_user!, only: [:pending_claims]
+  before_action :can_edit_any_user!, only: [:pending_claims]
+
+  private def can_edit_any_user!
+    return if current_user&.can_edit_any_user?
+
+    render status: :unauthorized, json: { error: "You are not allowed to view pending claims." }
+  end
+
   def index
     respond_to do |format|
       format.html
@@ -36,5 +45,12 @@ class PersonsController < ApplicationController
     @results = @person.results.includes(:competition, :event, :format, :round_type, :result_attempts).order("events.rank, competitions.start_date DESC, competitions.id, round_types.rank DESC")
     @championship_podiums = @person.championship_podiums
     params[:event] ||= @results.first.event.id
+  end
+
+  def pending_claims
+    wca_id = params.require(:wca_id)
+    users = User.where(unconfirmed_wca_id: wca_id)
+
+    render status: :ok, json: users.as_json(only: %w[id name], private_attributes: %w[email])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -115,16 +115,32 @@ class UsersController < ApplicationController
     wca_id = params.require(:wcaId)
     person = Person.find_by(wca_id: wca_id)
 
-    return redirect_to edit_user_path(user), flash: { danger: "WCA ID #{wca_id} does not exist." } if person.nil?
-    return redirect_to edit_user_path(user), flash: { danger: "User already has a WCA ID: #{user.wca_id}." } if user.wca_id.present?
-    return redirect_to edit_user_path(user), flash: { danger: "WCA ID #{wca_id} is already assigned to another user." } if person.user.present?
-
-    ActiveRecord::Base.transaction do
-      user.assign_wca_id(wca_id)
-      user.update!(**User::CLEAR_WCA_ID_CLAIM_ATTRIBUTES)
+    error = nil
+    status = nil
+    if person.nil?
+      error = "WCA ID #{wca_id} does not exist."
+      status = :not_found
+    elsif user.wca_id.present?
+      error = "User already has a WCA ID: #{user.wca_id}."
+      status = :bad_request
+    elsif person.user.present?
+      error = "WCA ID #{wca_id} is already assigned to another user."
+      status = :bad_request
     end
 
-    redirect_to edit_user_path(user), flash: { success: "Successfully confirmed WCA ID #{wca_id}." }
+    respond_to do |format|
+      if error
+        format.html { redirect_to edit_user_path(user), flash: { danger: error } }
+        format.json { render status: status, json: { error: error } }
+      else
+        ActiveRecord::Base.transaction do
+          user.assign_wca_id(wca_id)
+          user.update!(**User::CLEAR_WCA_ID_CLAIM_ATTRIBUTES)
+        end
+        format.html { redirect_to edit_user_path(user), flash: { success: "Successfully confirmed WCA ID #{wca_id}." } }
+        format.json { render status: :ok, json: { success: true } }
+      end
+    end
   end
 
   def clear_claim_wca_id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,15 +128,15 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if error.present?
-        format.html { redirect_to edit_user_path(user), flash: { danger: error } }
         format.json { render status: status, json: { error: error } }
+        format.html { redirect_to edit_user_path(user), flash: { danger: error } }
       else
         ActiveRecord::Base.transaction do
           user.assign_wca_id(wca_id)
           user.update!(**User::CLEAR_WCA_ID_CLAIM_ATTRIBUTES)
         end
-        format.html { redirect_to edit_user_path(user), flash: { success: "Successfully confirmed WCA ID #{wca_id}." } }
         format.json { render status: :ok, json: { success: true } }
+        format.html { redirect_to edit_user_path(user), flash: { success: "Successfully confirmed WCA ID #{wca_id}." } }
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -129,7 +129,7 @@ class UsersController < ApplicationController
     end
 
     respond_to do |format|
-      if error
+      if error.present?
         format.html { redirect_to edit_user_path(user), flash: { danger: error } }
         format.json { render status: status, json: { error: error } }
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -115,8 +115,6 @@ class UsersController < ApplicationController
     wca_id = params.require(:wcaId)
     person = Person.find_by(wca_id: wca_id)
 
-    error = nil
-    status = nil
     if person.nil?
       error = "WCA ID #{wca_id} does not exist."
       status = :not_found

--- a/app/models/potential_duplicate_person.rb
+++ b/app/models/potential_duplicate_person.rb
@@ -16,6 +16,7 @@ class PotentialDuplicatePerson < ApplicationRecord
     include: {
       original_user: {
         private_attributes: %w[dob],
+        only: User::DEFAULT_SERIALIZE_OPTIONS[:only] + %w[unconfirmed_wca_id],
       },
       duplicate_person: {
         private_attributes: %w[dob],

--- a/app/models/potential_duplicate_person.rb
+++ b/app/models/potential_duplicate_person.rb
@@ -16,7 +16,7 @@ class PotentialDuplicatePerson < ApplicationRecord
     include: {
       original_user: {
         private_attributes: %w[dob],
-        only: User::DEFAULT_SERIALIZE_OPTIONS[:only] + %w[unconfirmed_wca_id],
+        only: User::DEFAULT_SERIALIZE_OPTIONS[:only] | %w[unconfirmed_wca_id],
       },
       duplicate_person: {
         private_attributes: %w[dob],

--- a/app/webpacker/components/NewcomerChecks/MergeModal.jsx
+++ b/app/webpacker/components/NewcomerChecks/MergeModal.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { Message } from 'semantic-ui-react';
 import MergeUsers from '../Panel/pages/MergeUsersPage/MergeUsers';
 import AssignWcaIdToUser from '../Panel/views/AssignWcaIdToUser';
+import ApproveWcaIdClaim from '../Panel/views/ApproveWcaIdClaim';
+import { editPersonUrl } from '../../lib/requests/routes.js.erb';
 
 export default function MergeModal({
   potentialDuplicatePerson, competitionId, onMergeSuccess,
@@ -11,8 +14,6 @@ export default function MergeModal({
     original_user: originalUser,
     duplicate_person: duplicatePerson,
   } = potentialDuplicatePerson;
-
-  const action = duplicatePerson.user_id ? 'merge' : 'assign_wca_id';
 
   const clearUserIdsFromDuplicates = (ids) => {
     queryClient.setQueryData(
@@ -36,18 +37,7 @@ export default function MergeModal({
     onMergeSuccess();
   };
 
-  if (action === 'assign_wca_id') {
-    return (
-      <AssignWcaIdToUser
-        user={originalUser}
-        prefilledWcaId={duplicatePerson.wca_id}
-        onSuccess={onAssignSuccess}
-        requireConfirmation
-      />
-    );
-  }
-
-  if (action === 'merge') {
+  if (duplicatePerson.user_id) {
     return (
       <MergeUsers
         firstUserId={originalUser.id}
@@ -58,5 +48,42 @@ export default function MergeModal({
     );
   }
 
-  return null;
+  if (originalUser.unconfirmed_wca_id) {
+    if (originalUser.unconfirmed_wca_id !== duplicatePerson.wca_id) {
+      return (
+        <Message error>
+          The user has claimed for a different WCA ID (
+          {originalUser.unconfirmed_wca_id}
+          ), and first cancel that claim request if you want to assign another WCA ID.
+          {' '}
+          You can do this on the
+          {' '}
+          <a
+            href={editPersonUrl(originalUser.id)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            user edit page
+          </a>
+          .
+        </Message>
+      );
+    }
+    return (
+      <ApproveWcaIdClaim
+        user={originalUser}
+        onSuccess={onAssignSuccess}
+        requireConfirmation
+      />
+    );
+  }
+
+  return (
+    <AssignWcaIdToUser
+      user={originalUser}
+      prefilledWcaId={duplicatePerson.wca_id}
+      onSuccess={onAssignSuccess}
+      requireConfirmation
+    />
+  );
 }

--- a/app/webpacker/components/NewcomerChecks/MergeModal.jsx
+++ b/app/webpacker/components/NewcomerChecks/MergeModal.jsx
@@ -54,7 +54,7 @@ export default function MergeModal({
         <Message error>
           The user has claimed for a different WCA ID (
           {originalUser.unconfirmed_wca_id}
-          ), and first cancel that claim request if you want to assign another WCA ID.
+          ), so please first cancel that claim request if you want to assign another WCA ID.
           {' '}
           You can do this on the
           {' '}

--- a/app/webpacker/components/NewcomerChecks/WcaIdClaimCancelWarning.jsx
+++ b/app/webpacker/components/NewcomerChecks/WcaIdClaimCancelWarning.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { List, Message } from 'semantic-ui-react';
+import getPendingClaims from './api/getPendingClaims';
+import Loading from '../Requests/Loading';
+import Errored from '../Requests/Errored';
+import { viewUrls } from '../../lib/requests/routes.js.erb';
+
+export default function WcaIdClaimCancelWarning({ wcaId, userId }) {
+  const {
+    data: users = [], isFetching, isError, error,
+  } = useQuery({
+    queryKey: ['pending-claims', wcaId],
+    queryFn: () => getPendingClaims({ wcaId }),
+  });
+
+  if (isFetching) return <Loading />;
+  if (isError) return <Errored error={error} />;
+
+  const otherUsers = users.filter((u) => u.id !== userId);
+  const claimCount = otherUsers.length;
+
+  if (claimCount === 0) return null;
+
+  return (
+    <Message warning>
+      <Message.Header>Conflicting claims</Message.Header>
+      <Message.Content>
+        <p>
+          Note: When the WCA ID is assigned to this account, the pending claims for
+          this WCA ID from the following
+          {' '}
+          {claimCount}
+          {' '}
+          account(s) will be automatically declined, and those users will be notified:
+        </p>
+        <List bulleted>
+          {otherUsers.map((u) => (
+            <List.Item key={u.id}>
+              <a
+                href={viewUrls.users.showForEdit(u.id)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {u.name}
+              </a>
+              {' '}
+              (
+              {u.email}
+              )
+            </List.Item>
+          ))}
+        </List>
+      </Message.Content>
+    </Message>
+  );
+}

--- a/app/webpacker/components/NewcomerChecks/api/confirmWcaId.js
+++ b/app/webpacker/components/NewcomerChecks/api/confirmWcaId.js
@@ -1,0 +1,16 @@
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+import { actionUrls } from '../../../lib/requests/routes.js.erb';
+
+export default async function confirmWcaId({ userId, wcaId }) {
+  const { data } = await fetchJsonOrError(
+    actionUrls.users.confirmWcaId,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userId, wcaId }),
+    },
+  );
+  return data;
+}

--- a/app/webpacker/components/NewcomerChecks/api/getPendingClaims.js
+++ b/app/webpacker/components/NewcomerChecks/api/getPendingClaims.js
@@ -1,0 +1,9 @@
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+import { viewUrls } from '../../../lib/requests/routes.js.erb';
+
+export default async function getPendingClaims({ wcaId }) {
+  const { data } = await fetchJsonOrError(
+    viewUrls.users.pendingClaims(wcaId),
+  );
+  return data || [];
+}

--- a/app/webpacker/components/Panel/views/ApproveWcaIdClaim/index.jsx
+++ b/app/webpacker/components/Panel/views/ApproveWcaIdClaim/index.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useMutation } from '@tanstack/react-query';
+import {
+  Button, Header,
+} from 'semantic-ui-react';
+import Loading from '../../../Requests/Loading';
+import Errored from '../../../Requests/Errored';
+import { useConfirm } from '../../../../lib/providers/ConfirmProvider';
+import confirmWcaId from '../../../NewcomerChecks/api/confirmWcaId';
+import WcaIdClaimCancelWarning from '../../../NewcomerChecks/WcaIdClaimCancelWarning';
+
+export default function ApproveWcaIdClaim({
+  user, onSuccess, requireConfirmation,
+}) {
+  const confirm = useConfirm();
+
+  const {
+    mutate: approveWcaIdMutation,
+    isPending,
+    isError,
+    error,
+  } = useMutation({
+    mutationFn: confirmWcaId,
+    onSuccess,
+  });
+
+  const approveHandler = () => {
+    if (requireConfirmation) {
+      confirm({
+        content: `Are you sure you want to approve WCA ID ${user.unconfirmed_wca_id} to ${user.name}?`,
+        confirmButton: 'Approve',
+        requireInput: 'APPROVE WCA ID CLAIM',
+      })
+        .then(() => approveWcaIdMutation({ userId: user.id, wcaId: user.unconfirmed_wca_id }))
+        .catch(() => {});
+    } else {
+      approveWcaIdMutation({ userId: user.id, wcaId: user.unconfirmed_wca_id });
+    }
+  };
+
+  if (isPending) return <Loading />;
+  if (isError) return <Errored error={error} />;
+
+  return (
+    <>
+      <Header as="h3">
+        Approve WCA ID Claim
+        <Header.Subheader>
+          User
+          {' '}
+          {user.name}
+          {' '}
+          has already claimed for this WCA ID (
+          {user.unconfirmed_wca_id}
+          ) earlier.
+        </Header.Subheader>
+      </Header>
+      <Button primary onClick={approveHandler}>Approve</Button>
+      <WcaIdClaimCancelWarning wcaId={user.unconfirmed_wca_id} userId={user.id} />
+    </>
+  );
+}

--- a/app/webpacker/components/Panel/views/AssignWcaIdToUser/index.jsx
+++ b/app/webpacker/components/Panel/views/AssignWcaIdToUser/index.jsx
@@ -10,6 +10,7 @@ import assignWcaIdToUser from '../../../NewcomerChecks/api/assignWcaIdToUser';
 import useInputState from '../../../../lib/hooks/useInputState';
 import { IdWcaSearch } from '../../../SearchWidget/WcaSearch';
 import SEARCH_MODELS from '../../../SearchWidget/SearchModel';
+import WcaIdClaimCancelWarning from '../../../NewcomerChecks/WcaIdClaimCancelWarning';
 
 export default function AssignWcaIdToUser({
   user, prefilledWcaId, onSuccess, requireConfirmation,
@@ -72,6 +73,7 @@ export default function AssignWcaIdToUser({
         />
         <Button primary onClick={assignHandler}>Assign</Button>
       </Form>
+      <WcaIdClaimCancelWarning wcaId={wcaId} userId={user.id} />
     </>
   );
 }

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -308,6 +308,7 @@ export const viewUrls = {
     showForEdit: (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.user_show_for_edit_path(id: "${userId}")) %>`,
     showForMerge: (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.user_show_for_merge_path(id: "${userId}")) %>`,
     rolesEditPage: (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.edit_user_path("${userId}"))%>?${jsonToQueryString({ section: "roles" })}`,
+    pendingClaims: (wcaId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.person_pending_claims_path(wca_id: "${wcaId}")) %>`,
   },
   helpfulQueries: {
     registrations: (userId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.helpful_queries_registrations_path) %>?${jsonToQueryString({ userId })}`,
@@ -357,6 +358,7 @@ export const actionUrls = {
     updateUserData: `<%= CGI.unescape(Rails.application.routes.url_helpers.users_update_user_data_path) %>`,
     merge: `<%= CGI.unescape(Rails.application.routes.url_helpers.users_merge_path) %>`,
     assignWcaId: `<%= CGI.unescape(Rails.application.routes.url_helpers.users_assign_wca_id_path) %>`,
+    confirmWcaId: `<%= CGI.unescape(Rails.application.routes.url_helpers.confirm_wca_id_path) %>`,
   },
 }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ Rails.application.routes.draw do
 
   get 'persons/new_id' => 'admin/persons#generate_ids'
   get '/persons/results' => 'admin/persons#results', as: :person_results
+  get '/persons/:wca_id/pending_claims' => "persons#pending_claims", as: :person_pending_claims
   resources :persons, only: %i[index show]
   post 'persons' => 'admin/persons#create'
 


### PR DESCRIPTION
Within newcomers page, when we click merge button, there were two actions earlier: 1. Merge users, 2. Assign WCA ID to user

Let's say I have an account and I registered a competition as a newcomer even though I have an account-less WCA ID "2012JAME04". Within newcomer page, the delegate will click "Assign WCA ID", and it will assign the WCA ID to me.

Now, if I had already claimed the WCA ID and if it was in pending state, this action will trigger me an email saying "your claim has been cancelled" but the actual action is it got approved in a different way.

To avoid this, I've split AssignWcaIdToUser to have another view to directly approve the claim.

I also took this opportunity to have a new component WcaIdClaimCancelWarning, which will show the pending claims for a WCA ID which is going to get cancelled because of the assigning that Delegate is going to do.