### PR TITLE
Fix typos in TimeLimit class documentation comment

### DIFF
--- a/lib/time_limit.rb
+++ b/lib/time_limit.rb
@@ -6,7 +6,7 @@ class TimeLimit
   # ActiveRecord's serialization uses a "default value" which is stored as
   # 'NULL' in the db. In order to keep the db information readable for humans,
   # we want to keep this 'NULL' value for cases where the time limit is undefined.
-  # This can happens in the following cases:
+  # This can happen in the following cases:
   #   - Until 2013, specifying a time limit beforehand was not mandatory.
   #   Sometimes we could retrieve the information, sometimes not, therefore we
   #   use an undefined time limit when we don't have the data.
@@ -17,7 +17,7 @@ class TimeLimit
   # 0 seconds (see the UNDEF_TL value below).
   # When trying to serialize a time limit, ActiveRecord will compare this value
   # to the value created from TimeLimit.load(nil). If they match then 'NULL' is
-  # stored, otherwise it is serialize to json according to the WCIF spec.
+  # stored, otherwise it is serialized to JSON according to the WCIF spec.
   # You can read more about the motivations behind this here:
   # https://github.com/thewca/worldcubeassociation.org/issues/5460
   include ActiveModel::Validations


### PR DESCRIPTION
What:
Fixed two small grammatical typos in the documentation comment at the top of `time_limit.rb`.

Why:
The comment explains a non-obvious design decision about how TimeLimit objects are serialized. Small typos made the explanation harder to read and could confuse contributors new to this part of the codebase.

Changes:
- Corrected: 'This can happens' -> 'This can happen'
- Corrected: 'it is serialize to json' -> 'it is serialized to JSON'

No logic was changed, this is a comment-only fix.