### PR TITLE
Double clean-up of temp tables before CAD

### DIFF
--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -15,6 +15,11 @@ module DbHelper
     temp_table_name = "#{table_name}_temp"
     old_table_name = "#{table_name}_old"
 
+    # Clean up leftover tables from a previous run that was not cleanly terminated.
+    #   In particular, redeployments can hard-kill Sidekiq in a way that skips the `ensure` block below.
+    ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{temp_table_name}")
+    ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{old_table_name}")
+
     ActiveRecord::Base.connection.execute("CREATE TABLE #{temp_table_name} LIKE #{table_name}")
     ActiveRecord::Base.connection.execute("ALTER TABLE #{temp_table_name} AUTO_INCREMENT = 1")
 


### PR DESCRIPTION
We occasionally get crashes from our Sidekiq runner when WRT has to restart CAD. This is because the redeployment kills Sidekiq after 5 minutes so brutally that not even the `ensure` block to clean up tables can run. Quote from the code comment:

> Clean up leftover tables from a previous run that was not cleanly terminated. In particular, redeployments can hard-kill Sidekiq in a way that skips the `ensure` block below.