### PR TITLE
Add more indexes to CAD tables

### DIFF
--- a/db/migrate/20260125194535_add_event_rankings_index_to_concise_results.rb
+++ b/db/migrate/20260125194535_add_event_rankings_index_to_concise_results.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEventRankingsIndexToConciseResults < ActiveRecord::Migration[8.1]
+  def change
+    add_index :concise_single_results, %i[event_id person_id value_and_id], name: :event_rankings_speedup
+    add_index :concise_average_results, %i[event_id person_id value_and_id], name: :event_rankings_speedup
+  end
+end

--- a/db/migrate/20260319154657_add_unique_key_to_ranks_tables.rb
+++ b/db/migrate/20260319154657_add_unique_key_to_ranks_tables.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUniqueKeyToRanksTables < ActiveRecord::Migration[8.1]
+  def change
+    add_index :ranks_single, %i[person_id event_id], unique: true
+    add_index :ranks_average, %i[person_id event_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1051,6 +1051,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_101433) do
     t.string "person_id", limit: 10, default: "", null: false
     t.integer "world_rank", default: 0, null: false
     t.index ["event_id"], name: "fk_events"
+    t.index ["person_id", "event_id"], name: "index_ranks_average_on_person_id_and_event_id", unique: true
     t.index ["person_id"], name: "fk_persons"
   end
 
@@ -1062,6 +1063,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_101433) do
     t.string "person_id", limit: 10, default: "", null: false
     t.integer "world_rank", default: 0, null: false
     t.index ["event_id"], name: "fk_events"
+    t.index ["person_id", "event_id"], name: "index_ranks_single_on_person_id_and_event_id", unique: true
     t.index ["person_id"], name: "fk_persons"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -483,6 +483,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_101433) do
     t.index ["event_id", "country_id", "average"], name: "regional_records_speedup"
     t.index ["person_id", "country_id", "event_id", "reg_year"], name: "unique_per_competitor_per_event_per_year", unique: true
     t.index ["person_id", "event_id", "continent_id", "country_id", "average"], name: "average_ranks_speedup"
+    t.index ["event_id", "person_id", "value_and_id"], name: "event_rankings_speedup"
   end
 
   create_table "concise_single_results", primary_key: "result_id", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -497,6 +498,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_101433) do
     t.index ["event_id", "country_id", "best"], name: "regional_records_speedup"
     t.index ["person_id", "country_id", "event_id", "reg_year"], name: "unique_per_competitor_per_event_per_year", unique: true
     t.index ["person_id", "event_id", "continent_id", "country_id", "best"], name: "single_ranks_speedup"
+    t.index ["event_id", "person_id", "value_and_id"], name: "event_rankings_speedup"
   end
 
   create_table "connected_paypal_accounts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/helpers/persons_helper_spec.rb
+++ b/spec/helpers/persons_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PersonsHelper do
 
       it "when country rank is greater than continent rank" do
         rank_single = create(:ranks_single, continent_rank: 10, country_rank: 1)
-        rank_average = create(:ranks_single, continent_rank: 10, country_rank: 50)
+        rank_average = create(:ranks_average, continent_rank: 10, country_rank: 50)
         expect(odd_rank_reason_needed?(rank_single, rank_average)).to be true
       end
     end


### PR DESCRIPTION
1. An index on `concise_*` tables, to speed up the "Event rankings" view (for example https://www.worldcubeassociation.org/results/rankings/333/single, which is the default page that you end up on when you just click "Rankings" in the menu bar). This is stolen from https://github.com/thewca/worldcubeassociation.org/pull/13266 but ignoring the part that actually stops pre-computing the tables
2. An `UNIQUE` index on `ranks_*` tables. No practical purposes in terms of database efficiency, but helpful for ensuring semantic correctness of our tables. This is stolen from https://github.com/thewca/worldcubeassociation.org/pull/13682.