### PR TITLE
Allow linking rounds in WCIF PATCH

### DIFF
--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -124,24 +124,27 @@ class CompetitionEvent < ApplicationRecord
         "Cannot edit rounds for a competition which has qualification rounds or b-finals. Please contact WRT or WST if you need to make change to this competition.",
       )
     end
-    wcif["rounds"].each do |wcif_round|
-      next if (linked_rounds = wcif_round["linkedRounds"]).blank?
+    at_least_v2 = Gem::Version.new(version) >= Gem::Version.new("2.0.0")
+    if at_least_v2
+      wcif["rounds"].each do |wcif_round|
+        next if (linked_rounds = wcif_round["linkedRounds"]).blank?
 
-      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} must contain itself") unless linked_rounds.include?(wcif_round["id"])
-      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} must be longer than one entry") if linked_rounds.length <= 1
+        raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} must contain itself") unless linked_rounds.include?(wcif_round["id"])
+        raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} must be longer than one entry") if linked_rounds.length <= 1
 
-      defined_round_ids = wcif["rounds"].pluck("id")
-      non_existing_round_ids = linked_rounds.reject { defined_round_ids.include?(it) }
+        defined_round_ids = wcif["rounds"].pluck("id")
+        non_existing_round_ids = linked_rounds.reject { defined_round_ids.include?(it) }
 
-      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} references non-existing rounds [#{non_existing_round_ids.join(',')}]") unless non_existing_round_ids.empty?
+        raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} references non-existing rounds [#{non_existing_round_ids.join(',')}]") unless non_existing_round_ids.empty?
 
-      non_matching_siblings = linked_rounds.filter do |sibling_wcif_id|
-        sibling_matching = wcif["rounds"].find { it["id"] == sibling_wcif_id }&.dig("linkedRounds")
+        non_matching_siblings = linked_rounds.filter do |sibling_wcif_id|
+          sibling_matching = wcif["rounds"].find { it["id"] == sibling_wcif_id }&.dig("linkedRounds")
 
-        linked_rounds != sibling_matching
+          linked_rounds != sibling_matching
+        end
+
+        raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} does not match the linking of rounds [#{non_matching_siblings.join(',')}]") unless non_matching_siblings.empty?
       end
-
-      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} does not match the linking of rounds [#{non_matching_siblings.join(',')}]") unless non_matching_siblings.empty?
     end
     model_rounds = wcif["rounds"].map do |round_wcif|
       round = rounds.find { it.wcif_id == round_wcif["id"] } || rounds.build
@@ -153,8 +156,10 @@ class CompetitionEvent < ApplicationRecord
     # Have to do this in a second pass because nested associations (mostly `linked_round` and `participation_source`)
     #   need the record to already exist in the database in order to reference their IDs
     new_rounds = wcif["rounds"].zip(model_rounds).map do |round_wcif, round|
-      # Linked Round already needs to be present for computing the backlinking below
-      round.linked_round = Round.compute_linked_round(round_wcif, round, model_rounds)
+      if at_least_v2
+        # Linked Round already needs to be present for computing the backlinking below
+        round.linked_round = Round.compute_linked_round(round_wcif, round, model_rounds)
+      end
 
       round.update!(**Round.backport_participation_ruleset(round, model_rounds))
       round

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -12,7 +12,7 @@ class CompetitionEvent < ApplicationRecord
   has_many :formats, through: :rounds
   has_many :preferred_formats, through: :event
   has_many :target_rounds, class_name: "Round", as: :participation_source
-  has_many :linked_rounds, -> { distinct }, through: :rounds
+  has_many :linked_rounds, -> { unscope(:order).distinct }, through: :rounds
 
   accepts_nested_attributes_for :rounds, allow_destroy: true
 

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -12,7 +12,6 @@ class CompetitionEvent < ApplicationRecord
   has_many :formats, through: :rounds
   has_many :preferred_formats, through: :event
   has_many :target_rounds, class_name: "Round", as: :participation_source
-  has_many :linked_rounds, -> { unscope(:order).distinct }, through: :rounds
 
   accepts_nested_attributes_for :rounds, allow_destroy: true
 
@@ -31,11 +30,6 @@ class CompetitionEvent < ApplicationRecord
     remaining_rounds = rounds.reject(&:marked_for_destruction?)
     numbers = remaining_rounds.map(&:number).sort
     errors.add(:rounds, "#{numbers} is wrong") if numbers != (1..remaining_rounds.length).to_a
-  end
-
-  after_save :clean_linked_rounds
-  private def clean_linked_rounds
-    linked_rounds.each(&:destroy_if_orphaned)
   end
 
   def advancing_competitor_ids
@@ -130,21 +124,42 @@ class CompetitionEvent < ApplicationRecord
         "Cannot edit rounds for a competition which has qualification rounds or b-finals. Please contact WRT or WST if you need to make change to this competition.",
       )
     end
+    wcif["rounds"].each do |wcif_round|
+      next if (linked_rounds = wcif_round["linkedRounds"]).blank?
+
+      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} must contain itself") unless linked_rounds.include?(wcif_round["id"])
+      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} must be longer than one entry") if linked_rounds.length <= 1
+
+      defined_round_ids = wcif["rounds"].pluck("id")
+      non_existing_round_ids = linked_rounds.reject { defined_round_ids.include?(it) }
+
+      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} references non-existing rounds [#{non_existing_round_ids.join(',')}]") unless non_existing_round_ids.empty?
+
+      non_matching_siblings = linked_rounds.filter do |sibling_wcif_id|
+        sibling_matching = wcif["rounds"].find { it["id"] == sibling_wcif_id }&.dig("linkedRounds")
+
+        linked_rounds != sibling_matching
+      end
+
+      raise WcaExceptions::BadApiParameter.new("The linking for round #{wcif_round['id']} does not match the linking of rounds [#{non_matching_siblings.join(',')}]") unless non_matching_siblings.empty?
+    end
     model_rounds = wcif["rounds"].map do |round_wcif|
       round = rounds.find { it.wcif_id == round_wcif["id"] } || rounds.build
       round.update!(**Round.wcif_to_round_attributes(self.event, round_wcif, wcif["rounds"], version: version))
       WcifExtension.update_wcif_extensions!(round, round_wcif["extensions"]) if round_wcif["extensions"]
       round
     end
+    previously_linked_rounds = model_rounds.filter_map(&:linked_round)
     # Have to do this in a second pass because nested associations (mostly `linked_round` and `participation_source`)
     #   need the record to already exist in the database in order to reference their IDs
     new_rounds = wcif["rounds"].zip(model_rounds).map do |round_wcif, round|
-      round.update!(
-        **Round.backport_participation_ruleset(round, model_rounds),
-        linked_round: Round.compute_linked_round(round_wcif, round, model_rounds),
-      )
+      # Linked Round already needs to be present for computing the backlinking below
+      round.linked_round = Round.compute_linked_round(round_wcif, round, model_rounds)
+
+      round.update!(**Round.backport_participation_ruleset(round, model_rounds))
       round
     end
+    previously_linked_rounds.each(&:destroy_if_orphaned)
     # This is not techincally a third pass, because we're not updating the round itself.
     #   But for the advancement through rounds, the whole CE already needs to be fully linked up
     new_rounds.zip(wcif["rounds"]).each do |round, round_wcif|

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -12,6 +12,7 @@ class CompetitionEvent < ApplicationRecord
   has_many :formats, through: :rounds
   has_many :preferred_formats, through: :event
   has_many :target_rounds, class_name: "Round", as: :participation_source
+  has_many :linked_rounds, -> { distinct }, through: :rounds
 
   accepts_nested_attributes_for :rounds, allow_destroy: true
 
@@ -30,6 +31,11 @@ class CompetitionEvent < ApplicationRecord
     remaining_rounds = rounds.reject(&:marked_for_destruction?)
     numbers = remaining_rounds.map(&:number).sort
     errors.add(:rounds, "#{numbers} is wrong") if numbers != (1..remaining_rounds.length).to_a
+  end
+
+  after_save :clean_linked_rounds
+  private def clean_linked_rounds
+    linked_rounds.each(&:destroy_if_orphaned)
   end
 
   def advancing_competitor_ids

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -132,8 +132,11 @@ class CompetitionEvent < ApplicationRecord
     end
     # Have to do this in a second pass because nested associations (mostly `linked_round` and `participation_source`)
     #   need the record to already exist in the database in order to reference their IDs
-    new_rounds = model_rounds.map do |round|
-      round.update!(**Round.wcif_backlinking(round, model_rounds))
+    new_rounds = wcif["rounds"].zip(model_rounds).map do |round_wcif, round|
+      round.update!(
+        **Round.backport_participation_ruleset(round, model_rounds),
+        linked_round: Round.compute_linked_round(round_wcif, round, model_rounds),
+      )
       round
     end
     # This is not techincally a third pass, because we're not updating the round itself.

--- a/app/models/linked_round.rb
+++ b/app/models/linked_round.rb
@@ -11,7 +11,7 @@ class LinkedRound < ApplicationRecord
   validates :competition_event_ids, length: { maximum: 1, message: "must all belong to the same competition event" }
 
   # see https://www.worldcubeassociation.org/regulations/#9v1
-  validates :first_round_number, comparison: { less_than_or_equal_to: 2, message: "can only include the first two rounds of a competition" }
+  validates :first_round_number, comparison: { less_than_or_equal_to: 2, message: "can only include the first two rounds of a competition", allow_nil: true }
   validates :round_ids, length: { maximum: 2, message: "can only include up to 2 rounds in a Dual Round" }
 
   # see https://www.worldcubeassociation.org/regulations/#9v2
@@ -30,10 +30,10 @@ class LinkedRound < ApplicationRecord
     rounds.map(&:time_limit).uniq
   end
 
-  delegate :number, to: :first_round_in_link, prefix: :first_round
+  delegate :number, to: :first_round_in_link, prefix: :first_round, allow_nil: true
 
   def final_round_of_championship?
-    last_round_in_link.final_round? && last_round_in_link.competition.any_championship?
+    last_round_in_link&.final_round? && last_round_in_link.competition.any_championship?
   end
 
   def merged_live_results

--- a/app/models/linked_round.rb
+++ b/app/models/linked_round.rb
@@ -97,7 +97,7 @@ class LinkedRound < ApplicationRecord
 
   # The _removed_round argument is passed by Rails
   # as part of the `has_many :rounds, after_remove: :destroy_if_orphaned` callback chain
-  def destroy_if_orphaned(_removed_round)
+  def destroy_if_orphaned(_removed_round = nil)
     return unless persisted? && rounds.size <= 1
 
     self.destroy # NULL is handled by has_many#dependent set to :nullify above

--- a/app/models/linked_round.rb
+++ b/app/models/linked_round.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LinkedRound < ApplicationRecord
-  has_many :rounds, -> { ordered }, inverse_of: :linked_round
+  has_many :rounds, -> { ordered }, inverse_of: :linked_round, dependent: :nullify, after_remove: :destroy_if_orphaned
   has_many :results, through: :rounds
   has_many :live_results, through: :rounds
   has_many :formats, -> { distinct }, through: :rounds
@@ -80,5 +80,13 @@ class LinkedRound < ApplicationRecord
       "roundIds" => self.wcif_ids,
       "resultCondition" => target_round.participation_condition&.to_wcif,
     }
+  end
+
+  # The _removed_round argument is passed by Rails
+  # as part of the `has_many :rounds, after_remove: :destroy_if_orphaned` callback chain
+  def destroy_if_orphaned(_removed_round)
+    return unless persisted? && rounds.size <= 1
+
+    self.destroy # NULL is handled by has_many#dependent set to :nullify above
   end
 end

--- a/app/models/linked_round.rb
+++ b/app/models/linked_round.rb
@@ -22,6 +22,16 @@ class LinkedRound < ApplicationRecord
   validates :round_cutoffs, length: { maximum: 1, message: "all rounds must have the same cutoff" }
   validates :round_time_limits, length: { maximum: 1, message: "all rounds must have the same time limit" }
 
+  after_touch :reset_round_information
+  def reset_round_information
+    self.rounds.reset
+
+    # Even associations that define `through` have their own cache
+    #   which needs to be reset individually
+    self.formats.reset
+    self.competition_events.reset
+  end
+
   def round_cutoffs
     rounds.filter_map(&:cutoff).uniq(&:to_wcif)
   end

--- a/app/models/linked_round.rb
+++ b/app/models/linked_round.rb
@@ -10,6 +10,13 @@ class LinkedRound < ApplicationRecord
 
   validates :competition_event_ids, length: { maximum: 1, message: "must all belong to the same competition event" }
 
+  # see https://www.worldcubeassociation.org/regulations/#9v1
+  validates :first_round_number, comparison: { less_than_or_equal_to: 2, message: "can only include the first two rounds of a competition" }
+  validates :round_ids, length: { maximum: 2, message: "can only include up to 2 rounds in a Dual Round" }
+
+  # see https://www.worldcubeassociation.org/regulations/#9v2
+  validates :final_round_of_championship?, absence: true
+
   # see https://www.worldcubeassociation.org/regulations/#9v3
   validates :format_ids, length: { maximum: 1, message: "all rounds must have the same format" }
   validates :round_cutoffs, length: { maximum: 1, message: "all rounds must have the same cutoff" }
@@ -21,6 +28,12 @@ class LinkedRound < ApplicationRecord
 
   def round_time_limits
     rounds.map(&:time_limit).uniq
+  end
+
+  delegate :number, to: :first_round_in_link, prefix: :first_round
+
+  def final_round_of_championship?
+    last_round_in_link.final_round? && last_round_in_link.competition.any_championship?
   end
 
   def merged_live_results

--- a/app/models/linked_round.rb
+++ b/app/models/linked_round.rb
@@ -8,7 +8,20 @@ class LinkedRound < ApplicationRecord
   has_many :competition_events, -> { distinct }, through: :rounds
   has_many :target_rounds, class_name: "Round", as: :participation_source
 
-  validates :competition_event_ids, length: { maximum: 1, message: "must all belong to the same competition" }
+  validates :competition_event_ids, length: { maximum: 1, message: "must all belong to the same competition event" }
+
+  # see https://www.worldcubeassociation.org/regulations/#9v3
+  validates :format_ids, length: { maximum: 1, message: "all rounds must have the same format" }
+  validates :round_cutoffs, length: { maximum: 1, message: "all rounds must have the same cutoff" }
+  validates :round_time_limits, length: { maximum: 1, message: "all rounds must have the same time limit" }
+
+  def round_cutoffs
+    rounds.map(&:cutoff).uniq
+  end
+
+  def round_time_limits
+    rounds.map(&:time_limit).uniq
+  end
 
   def merged_live_results
     LinkedRound.combine_results(self.live_results)

--- a/app/models/linked_round.rb
+++ b/app/models/linked_round.rb
@@ -4,18 +4,18 @@ class LinkedRound < ApplicationRecord
   has_many :rounds, -> { ordered }, inverse_of: :linked_round, dependent: :nullify, after_remove: :destroy_if_orphaned
   has_many :results, through: :rounds
   has_many :live_results, through: :rounds
-  has_many :formats, -> { distinct }, through: :rounds
-  has_many :competition_events, -> { distinct }, through: :rounds
+  has_many :formats, -> { unscope(:order).distinct }, through: :rounds
+  has_many :competition_events, -> { unscope(:order).distinct }, through: :rounds
   has_many :target_rounds, class_name: "Round", as: :participation_source
 
   validates :competition_event_ids, length: { maximum: 1, message: "must all belong to the same competition event" }
 
   # see https://www.worldcubeassociation.org/regulations/#9v1
-  validates :first_round_number, comparison: { less_than_or_equal_to: 2, message: "can only include the first two rounds of a competition", allow_nil: true }
+  validates :first_round_number, comparison: { equal_to: 1, message: "can only include the first two rounds of a competition", allow_nil: true }
   validates :round_ids, length: { maximum: 2, message: "can only include up to 2 rounds in a Dual Round" }
 
   # see https://www.worldcubeassociation.org/regulations/#9v2
-  validates :final_round_of_championship?, absence: true
+  validates :final_round_of_championship?, absence: { message: "cannot include the final round of any championship" }
 
   # see https://www.worldcubeassociation.org/regulations/#9v3
   validates :format_ids, length: { maximum: 1, message: "all rounds must have the same format" }
@@ -23,11 +23,11 @@ class LinkedRound < ApplicationRecord
   validates :round_time_limits, length: { maximum: 1, message: "all rounds must have the same time limit" }
 
   def round_cutoffs
-    rounds.map(&:cutoff).uniq
+    rounds.filter_map(&:cutoff).uniq(&:to_wcif)
   end
 
   def round_time_limits
-    rounds.map(&:time_limit).uniq
+    rounds.filter_map(&:time_limit).uniq(&:to_wcif)
   end
 
   delegate :number, to: :first_round_in_link, prefix: :first_round, allow_nil: true

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -600,6 +600,7 @@ class Round < ApplicationRecord
     existing_linked_round = all_rounds_model.filter { linked_round_ids.include? it.wcif_id }
                                             .filter { it.number < round_model.number } # always start building links in-order
                                             .filter_map(&:linked_round)
+                                            .first
 
     existing_linked_round || round_model.build_linked_round
   end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -85,6 +85,8 @@ class Round < ApplicationRecord
   after_save :reset_linked_rounds, if: :linked_round_previously_changed?
   private def reset_linked_rounds
     self.linked_round&.rounds&.reset
+    self.linked_round&.formats&.reset
+    self.linked_round&.competition_events&.reset
   end
 
   def initialize(attributes = nil)

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -82,6 +82,11 @@ class Round < ApplicationRecord
   validates :advancement_condition, presence: { if: :advancement_condition_changed?, unless: :final_round?, message: "cannot be un-set on a non-final round" }, on: :update
   validates :advancement_condition, absence: { if: :final_round?, message: "cannot be set on a final round" }
 
+  after_save :reset_linked_rounds, if: :linked_round_previously_changed?
+  private def reset_linked_rounds
+    self.linked_round&.rounds&.reset
+  end
+
   def initialize(attributes = nil)
     # Overrides the default constructor to setup the default time limit if not
     # set explicitly.

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -2,7 +2,7 @@
 
 class Round < ApplicationRecord
   belongs_to :competition_event
-  belongs_to :linked_round, optional: true
+  belongs_to :linked_round, optional: true, validate: true
 
   has_one :competition, through: :competition_event
   delegate :competition_id, to: :competition_event

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -585,7 +585,19 @@ class Round < ApplicationRecord
     end
   end
 
-  def self.wcif_backlinking(round_model, all_rounds_model)
+  def self.compute_linked_round(round_wcif, round_model, all_rounds_model)
+    linked_round_ids = round_wcif["linkedRounds"]&.sort_by { self.parse_wcif_id(it)[:round_number] }
+
+    return nil if linked_round_ids.blank?
+
+    existing_linked_round = all_rounds_model.filter { linked_round_ids.include? it.wcif_id }
+                                            .filter { it.number < round_model.number } # always start building links in-order
+                                            .filter_map(&:linked_round)
+
+    existing_linked_round || round_model.build_linked_round
+  end
+
+  def self.backport_participation_ruleset(round_model, all_rounds_model)
     participation_source = self.backport_participation_source(round_model, all_rounds_model)
 
     {

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -522,6 +522,10 @@ class Round < ApplicationRecord
       next_wcif_round = all_wcif_rounds[round_number] # WCIF numbers are 1-based, so no +1 necessary
       next_participation_condition = next_wcif_round.dig("participationRuleset", "participationSource", "resultCondition")
 
+      # We know that `next_wcif_round` definitely exists, but historical records (cf. Worlds 2003)
+      #   may not have any advancement data present in our records.
+      return nil if next_participation_condition.nil?
+
       backported_wcif_v1 = {
         "type" => next_participation_condition["type"].gsub('resultAchieved', 'attemptResult'),
         "level" => next_participation_condition["value"],

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -2,7 +2,7 @@
 
 class Round < ApplicationRecord
   belongs_to :competition_event
-  belongs_to :linked_round, optional: true, validate: true
+  belongs_to :linked_round, optional: true, validate: true, touch: true
 
   has_one :competition, through: :competition_event
   delegate :competition_id, to: :competition_event
@@ -82,11 +82,9 @@ class Round < ApplicationRecord
   validates :advancement_condition, presence: { if: :advancement_condition_changed?, unless: :final_round?, message: "cannot be un-set on a non-final round" }, on: :update
   validates :advancement_condition, absence: { if: :final_round?, message: "cannot be set on a final round" }
 
-  after_save :reset_linked_rounds, if: :linked_round_previously_changed?
-  private def reset_linked_rounds
-    self.linked_round&.rounds&.reset
-    self.linked_round&.formats&.reset
-    self.linked_round&.competition_events&.reset
+  after_save :reset_linked_round_information, if: :linked_round_previously_changed?
+  private def reset_linked_round_information
+    self.linked_round&.reset_round_information
   end
 
   def initialize(attributes = nil)

--- a/db/migrate/20260506110117_remove_wcif_id_from_linked_rounds.rb
+++ b/db/migrate/20260506110117_remove_wcif_id_from_linked_rounds.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveWcifIdFromLinkedRounds < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :linked_rounds, :wcif_id, type: :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_01_101433) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_110117) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -783,7 +783,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_01_101433) do
   create_table "linked_rounds", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "wcif_id"
   end
 
   create_table "live_attempts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -316,7 +316,6 @@ module DatabaseDumper
       column_sanitizers: actions_to_column_sanitizers(
         copy: %w[
           id
-          wcif_id
           created_at
           updated_at
         ],

--- a/lib/tasks/result_conditions.rake
+++ b/lib/tasks/result_conditions.rake
@@ -10,7 +10,7 @@ namespace :result_conditions do
         all_ce_rounds = competition_event.rounds
 
         all_ce_rounds.each do |round|
-          round.assign_attributes(**Round.wcif_backlinking(round, all_ce_rounds))
+          round.assign_attributes(**Round.backport_participation_ruleset(round, all_ce_rounds))
           # Circumventing validations here on purpose to bypass validations,
           #   because we have a LOT of rounds which were historically valid
           #   but are not valid any longer (think 333ft or switching from 333bf Mo3 to Ao5)

--- a/spec/factories/linked_rounds.rb
+++ b/spec/factories/linked_rounds.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :linked_round do
-    wcif_id { "TestLinkedRound2026" }
-  end
+  factory :linked_round
 end

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -1003,7 +1003,8 @@ RSpec.describe "Competition WCIF" do
   end
 
   describe "#set_wcif_events!" do
-    let(:wcif) { competition.to_wcif }
+    let(:wcif_version) { Competition::WCIF_STABLE_VERSION }
+    let(:wcif) { competition.to_wcif(version: wcif_version) }
 
     it "does not remove competition event when wcif rounds are empty" do
       wcif_444_event = wcif["events"].find { |e| e["id"] == "444" }
@@ -1144,6 +1145,110 @@ RSpec.describe "Competition WCIF" do
       competition.set_wcif_events!(wcif["events"], delegate)
 
       expect(competition.to_wcif["events"]).to eq(wcif["events"])
+    end
+
+    context "linked rounds" do
+      let(:wcif_version) { '2.1.1' }
+
+      it "links rounds that were previously not linked" do
+        wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
+
+        wcif_333_event["rounds"][0]["linkedRounds"] = %w[333-r1 333-r2]
+        wcif_333_event["rounds"][1]["linkedRounds"] = %w[333-r1 333-r2]
+        wcif_333_event["rounds"][1]["participationRuleset"] = wcif_333_event["rounds"][0]["participationRuleset"]
+
+        competition.set_wcif_events!(wcif["events"], delegate, version: wcif_version)
+
+        expect(competition.to_wcif(version: wcif_version)["events"]).to eq(wcif["events"])
+
+        expect(LinkedRound.count).to be 1
+
+        expect(round333_1.reload.linked_round).not_to be_nil
+        expect(round333_2.reload.linked_round).not_to be_nil
+
+        # already reloaded everything above
+        expect(round333_1.linked_round).to eq(round333_2.linked_round)
+      end
+
+      it "unlinks rounds that had previously been linked" do
+        # Synchronize cutoff to allow linking further down
+        round333_2.update!(cutoff: sixty_second_2_attempt_cutoff)
+
+        # store a copy of the WCIF before making any changes, so the rounds are NOT linked
+        wcif_unlinked = wcif["events"].deep_dup
+
+        linked_round = create(:linked_round)
+
+        round333_1.update!(linked_round: linked_round)
+        round333_2.update!(linked_round: linked_round)
+
+        expect(competition.to_wcif(version: wcif_version)["events"]).not_to eq(wcif_unlinked)
+
+        competition.set_wcif_events!(wcif_unlinked, delegate, version: wcif_version)
+        expect(competition.to_wcif(version: wcif_version)["events"]).to eq(wcif_unlinked)
+
+        # Our cleanup code picks up orphaned rounds, see the model spec for linked_round.rb
+        expect(LinkedRound.count).to be 0
+      end
+
+      context "malformed linked_rounds entries" do
+        let(:round333_3) { build(:round, number: 3, total_number_of_rounds: 3, participation_source: round333_2, participation_condition: top_16_average_condition) }
+
+        before :each do
+          round333_1.update!(total_number_of_rounds: 3)
+          round333_2.update!(total_number_of_rounds: 3)
+
+          event_333.update!(rounds: [round333_1, round333_2, round333_3])
+        end
+
+        it "throws when rounds are giving inconsistent information" do
+          wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
+
+          # Explicitly ONLY setting R1 here, which is inconsistent. R2 _should_ also know about the linking
+          wcif_333_event["rounds"][0]["linkedRounds"] = %w[333-r1 333-r2]
+
+          expect { competition.set_wcif_events!(wcif["events"], delegate, version: wcif_version) }.to raise_error(WcaExceptions::BadApiParameter) do |ex|
+            expect(ex.message).to eq("The linking for round 333-r1 does not match the linking of rounds [333-r2]")
+          end
+        end
+
+        it "throws when rounds are giving individually valid but different linking information" do
+          wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
+
+          # Each linking is theoretically valid, but they do not match with each other
+          wcif_333_event["rounds"][0]["linkedRounds"] = %w[333-r1 333-r2]
+          wcif_333_event["rounds"][1]["linkedRounds"] = %w[333-r2 333-r3]
+
+          expect { competition.set_wcif_events!(wcif["events"], delegate, version: wcif_version) }.to raise_error(WcaExceptions::BadApiParameter) do |ex|
+            expect(ex.message).to eq("The linking for round 333-r1 does not match the linking of rounds [333-r2]")
+          end
+        end
+
+        it "throws when rounds are giving obviously bogus information" do
+          wcif_333_event = wcif["events"].find { |e| e["id"] == "333" }
+
+          # The linking is not valid because it is not self-contained
+          wcif_333_event["rounds"][0]["linkedRounds"] = %w[333-r2 333-r3]
+
+          expect { competition.set_wcif_events!(wcif["events"], delegate, version: wcif_version) }.to raise_error(WcaExceptions::BadApiParameter) do |ex|
+            expect(ex.message).to eq("The linking for round 333-r1 must contain itself")
+          end
+
+          # The linking is not valid because it references a round that does not exist
+          wcif_333_event["rounds"][0]["linkedRounds"] = %w[333-r1 333-r4]
+
+          expect { competition.set_wcif_events!(wcif["events"], delegate, version: wcif_version) }.to raise_error(WcaExceptions::BadApiParameter) do |ex|
+            expect(ex.message).to eq("The linking for round 333-r1 references non-existing rounds [333-r4]")
+          end
+
+          # The linking is not valid because it is of length 1
+          wcif_333_event["rounds"][0]["linkedRounds"] = %w[333-r1]
+
+          expect { competition.set_wcif_events!(wcif["events"], delegate, version: wcif_version) }.to raise_error(WcaExceptions::BadApiParameter) do |ex|
+            expect(ex.message).to eq("The linking for round 333-r1 must be longer than one entry")
+          end
+        end
+      end
     end
 
     context "round results" do

--- a/spec/models/linked_round_spec.rb
+++ b/spec/models/linked_round_spec.rb
@@ -101,4 +101,37 @@ RSpec.describe LinkedRound do
       end
     end
   end
+
+  context "cleaning up orphans via after_destroy hook" do
+    it "does not clean up a perfectly valid Dual Round" do
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+
+      expect(linked_round.reload).not_to be_nil
+    end
+
+    it "cleans up a valid Dual Round after deleting one round" do
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+      r2 = create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+
+      expect(linked_round.reload).not_to be_nil
+
+      linked_round.rounds.delete(r2)
+
+      expect(r2.reload.linked_round_id).to be_nil
+      expect { linked_round.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "does not clean up while building a perfectly valid Dual Round" do
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+
+      # Intentionally create it without a linked_round first
+      r2 = create(:round, event_id: "333", competition: competition, total_number_of_rounds: 3, number: 2)
+
+      expect(linked_round.reload).not_to be_nil
+
+      linked_round.rounds << r2
+      expect(linked_round.reload).not_to be_nil
+    end
+  end
 end

--- a/spec/models/linked_round_spec.rb
+++ b/spec/models/linked_round_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe LinkedRound do
-  context "final_round?" do
-    let(:competition) { create(:competition) }
-    let(:linked_round) { create(:linked_round) }
+  let(:competition) { create(:competition) }
+  let(:linked_round) { create(:linked_round) }
 
+  context "final_round?" do
     it "returns true for Dual Rounds with round 1 + 2 of 2" do
       create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 2, number: 1)
       create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 2, number: 2)
@@ -19,6 +19,86 @@ RSpec.describe LinkedRound do
       create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
 
       expect(linked_round).not_to be_final_round
+    end
+  end
+
+  context "validations" do
+    it "considers a standard Dual Round as valid" do
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+
+      expect(linked_round).to be_valid
+    end
+
+    it "does not allow linking more than 2 rounds" do
+      r1 = create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+      r2 = create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+
+      # Create it as standalone round initially
+      r3 = create(:round, event_id: "333", competition: competition, total_number_of_rounds: 3, number: 3)
+
+      # Technically valid but our Regulations forbid it
+      linked_round.rounds = [r1, r2, r3]
+
+      expect(linked_round).to be_invalid_with_errors(round_ids: ["can only include up to 2 rounds in a Dual Round"])
+    end
+
+    it "does not allow linking rounds other than first round" do
+      create(:round, event_id: "333", competition: competition, total_number_of_rounds: 3, number: 1)
+
+      r2 = create(:round, event_id: "333", competition: competition, total_number_of_rounds: 3, number: 2)
+      r3 = create(:round, event_id: "333", competition: competition, total_number_of_rounds: 3, number: 3)
+
+      # Technically valid but our Regulations forbid it
+      linked_round.rounds = [r2, r3]
+
+      expect(linked_round).to be_invalid_with_errors(first_round_number: ["can only include the first two rounds of a competition"])
+    end
+
+    context "does not allow linking 2 rounds" do
+      it "that have different formats" do
+        create(:round, event_id: "333fm", format_id: "2", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+        create(:round, event_id: "333fm", format_id: "1", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+
+        expect(linked_round).to be_invalid_with_errors(format_ids: ["all rounds must have the same format"])
+      end
+
+      it "that have different cutoffs" do
+        create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1, cutoff: Cutoff.new(number_of_attempts: 2, attempt_result: 2000))
+        create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2, cutoff: Cutoff.new(number_of_attempts: 2, attempt_result: 3000))
+
+        expect(linked_round).to be_invalid_with_errors(round_cutoffs: ["all rounds must have the same cutoff"])
+      end
+
+      it "that have different time limits" do
+        create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+        create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2, time_limit: TimeLimit.new(centiseconds: 5.minutes.in_centiseconds))
+
+        expect(linked_round).to be_invalid_with_errors(round_time_limits: ["all rounds must have the same time limit"])
+      end
+    end
+
+    context "when linking rounds of a championship" do
+      let(:competition) { create(:competition, :world_championship) }
+
+      it "allows linking non-final rounds" do
+        create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+        create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+
+        expect(linked_round).to be_valid
+      end
+
+      it "does not allow linking final rounds" do
+        # These are rounds with the same format, cutoff and time limit, so basically they could be linked.
+        #   However, there are only two rounds overall, so the "first two rounds" stipulated by 9v1
+        #   also accidentally implies that the second round is the final, which in turn violates 9v2.
+        r1 = create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 2, number: 1)
+        r2 = build(:round, event_id: "333", competition: competition, total_number_of_rounds: 2, number: 2)
+
+        linked_round.rounds = [r1, r2]
+
+        expect(linked_round).to be_invalid_with_errors(final_round_of_championship?: ["cannot include the final round of any championship"])
+      end
     end
   end
 end

--- a/spec/models/linked_round_spec.rb
+++ b/spec/models/linked_round_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe LinkedRound do
       create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 2, number: 1)
       create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 2, number: 2)
 
-      expect(linked_round.reload).to be_final_round
+      expect(linked_round).to be_final_round
     end
 
     it "returns false for Dual Rounds with round 1 + 2 of 3" do
       create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
       create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
 
-      expect(linked_round.reload).not_to be_final_round
+      expect(linked_round).not_to be_final_round
     end
   end
 end

--- a/spec/models/linked_round_spec.rb
+++ b/spec/models/linked_round_spec.rb
@@ -3,21 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe LinkedRound do
-  it "final_round? returns true for Dual Rounds with round 1 + 2 of 2" do
-    c = create(:competition)
-    l = create(:linked_round)
-    create(:round, event_id: "333", competition: c, linked_round_id: l.id, total_number_of_rounds: 2, number: 1)
-    create(:round, event_id: "333", competition: c, linked_round_id: l.id, total_number_of_rounds: 2, number: 2)
+  context "final_round?" do
+    let(:competition) { create(:competition) }
+    let(:linked_round) { create(:linked_round) }
 
-    expect(l.reload).to be_final_round
-  end
+    it "returns true for Dual Rounds with round 1 + 2 of 2" do
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 2, number: 1)
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 2, number: 2)
 
-  it "final_round? returns false for Dual Rounds with round 1 + 2 of 3" do
-    c = create(:competition)
-    l = create(:linked_round)
-    create(:round, event_id: "333", competition: c, linked_round_id: l.id, total_number_of_rounds: 3, number: 1)
-    create(:round, event_id: "333", competition: c, linked_round_id: l.id, total_number_of_rounds: 3, number: 2)
+      expect(linked_round.reload).to be_final_round
+    end
 
-    expect(l.reload).not_to be_final_round
+    it "returns false for Dual Rounds with round 1 + 2 of 3" do
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+      create(:round, event_id: "333", competition: competition, linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+
+      expect(linked_round.reload).not_to be_final_round
+    end
   end
 end


### PR DESCRIPTION
Inspired by https://github.com/thewca/worldcubeassociation.org/pull/14222 but ultimately pulled out the backend part into this separate PR.

The gist of this PR is that when you now `PATCH` a V2 payload that has `linkedRounds` set, the endpoint actually respects it.