### PR TITLE
Dont throw 9m1 warning if dual rounds are being used 

### DIFF
--- a/lib/results_validators/advancement_conditions_validator.rb
+++ b/lib/results_validators/advancement_conditions_validator.rb
@@ -54,8 +54,16 @@ module ResultsValidators
 
           rounds_without_deprecated_types.each do |round|
             results = results_by_round_id[round.id]
-            number_of_people_in_round = results.size
-            remaining_number_of_rounds = round.total_number_of_rounds - round.number
+            number_of_people_in_round = if round.linked_round.present?
+                                          round.linked_round.combine_results.count
+                                        else
+                                          results.size
+                                        end
+            remaining_number_of_rounds =  if round.linked_round.present?
+                                            round.total_number_of_rounds - 2
+                                          else
+                                            round.total_number_of_rounds - round.number
+                                          end
 
             if number_of_people_in_round <= 7 && remaining_number_of_rounds.positive?
               # https://www.worldcubeassociation.org/regulations/#9m3: Rounds with 7 or fewer competitors must not have subsequent rounds.
@@ -71,7 +79,7 @@ module ResultsValidators
                                              round_id: round.human_id)
             end
 
-            if number_of_people_in_round <= 99 && remaining_number_of_rounds > 2 && round.linked_round.nil?
+            if number_of_people_in_round <= 99 && remaining_number_of_rounds > 2
               # https://www.worldcubeassociation.org/regulations/#9m1: Rounds with 99 or fewer competitors must have at most two subsequent rounds.
               @errors << ValidationError.new(REGULATION_9M1_ERROR,
                                              :rounds, competition.id,

--- a/lib/results_validators/advancement_conditions_validator.rb
+++ b/lib/results_validators/advancement_conditions_validator.rb
@@ -59,11 +59,11 @@ module ResultsValidators
                                         else
                                           results.size
                                         end
-            remaining_number_of_rounds =  if round.linked_round.present?
-                                            round.total_number_of_rounds - 2
-                                          else
-                                            round.total_number_of_rounds - round.number
-                                          end
+            remaining_number_of_rounds = if round.linked_round.present?
+                                           round.total_number_of_rounds - 2
+                                         else
+                                           round.total_number_of_rounds - round.number
+                                         end
 
             if number_of_people_in_round <= 7 && remaining_number_of_rounds.positive?
               # https://www.worldcubeassociation.org/regulations/#9m3: Rounds with 7 or fewer competitors must not have subsequent rounds.

--- a/lib/results_validators/advancement_conditions_validator.rb
+++ b/lib/results_validators/advancement_conditions_validator.rb
@@ -71,7 +71,7 @@ module ResultsValidators
                                              round_id: round.human_id)
             end
 
-            if number_of_people_in_round <= 99 && remaining_number_of_rounds > 2
+            if number_of_people_in_round <= 99 && remaining_number_of_rounds > 2 && round.linked_round.nil?
               # https://www.worldcubeassociation.org/regulations/#9m1: Rounds with 99 or fewer competitors must have at most two subsequent rounds.
               @errors << ValidationError.new(REGULATION_9M1_ERROR,
                                              :rounds, competition.id,


### PR DESCRIPTION
I thought this would be a 1-liner when I started - if it requires follow-ups, it might be better to let you or Finn hijack it. 

The problem is that 9m1 fires on Dual Rounds when it shouldn't - the solution here is to 
- define number of competitors using the combined results of the LinkedRound, and
- determine remaining rounds in a Dual Rounds aware way (there's a more generic implementation of this which would allow an arbitrary number of LinkedRounds in arbitrary places - but I want to keep this simple)