### PR TITLE
Give The Live SQS queue a concurrency of 1 in Shoryuken

### DIFF
--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,10 +1,10 @@
 groups:
-  group1:
+  registrations:
     concurrency: 2
     delay: 1
     queues:
       - <%= EnvConfig.REGISTRATION_QUEUE %>
-  group2:
+  live_results:
     concurrency: 1
     queues:
       - <%= EnvConfig.LIVE_QUEUE %>

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,5 +1,10 @@
-queues:
-  - <%= EnvConfig.REGISTRATION_QUEUE %>
-  - <%= EnvConfig.LIVE_QUEUE %>
-delay: 1
-concurrency: 2
+groups:
+  group1:
+    concurrency: 2
+    delay: 1
+    queues:
+      - <%= EnvConfig.REGISTRATION_QUEUE %>
+  group2:
+    concurrency: 1
+    queues:
+      - <%= EnvConfig.LIVE_QUEUE %>


### PR DESCRIPTION
Much easier change on a friday before the next comps than splitting up the actual containers. 
Fixes #14229 and hopefully also gets the processing time down because of no delay