### PR TITLE
Don't send 0 as a value for empty fields

### DIFF
--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -23,6 +23,8 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       return render json: { status: "user is not part of this round" }, status: :unprocessable_content
     end
 
+    return render json: { status: "Values cannot be 0, please omit them instead" }, status: :unprocessable_content if results.any? { it[:value].zero? }
+
     UpdateLiveResultJob.perform_later(live_result, results, @current_user.id)
 
     render json: { status: "ok" }

--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       return render json: { status: "user is not part of this round" }, status: :unprocessable_content
     end
 
-    return render json: { status: "Values cannot be 0, please omit them instead" }, status: :unprocessable_content if results.any? { it[:value].zero? }
+    return render json: { status: "Values cannot be 0, please omit them instead" }, status: :unprocessable_content if results.any? { it[:value].to_i.zero? }
 
     UpdateLiveResultJob.perform_later(live_result, results, @current_user.id)
 

--- a/next-frontend/src/components/live/AttemptsForm.tsx
+++ b/next-frontend/src/components/live/AttemptsForm.tsx
@@ -136,7 +136,11 @@ export default function AttemptsForm({
           </AttemptFieldsNav>
           <Button
             onClick={confirmSubmission}
-            disabled={isPending || attempts.length === 0}
+            disabled={
+              isPending ||
+              attempts.length === 0 ||
+              attempts.some((v) => v === 0)
+            }
           >
             Submit Results
           </Button>

--- a/next-frontend/src/components/live/AttemptsForm.tsx
+++ b/next-frontend/src/components/live/AttemptsForm.tsx
@@ -136,11 +136,7 @@ export default function AttemptsForm({
           </AttemptFieldsNav>
           <Button
             onClick={confirmSubmission}
-            disabled={
-              isPending ||
-              attempts.length === 0 ||
-              attempts.some((v) => v === 0)
-            }
+            disabled={isPending || attempts.length === 0}
           >
             Submit Results
           </Button>

--- a/next-frontend/src/providers/LiveResultAdminProvider.tsx
+++ b/next-frontend/src/providers/LiveResultAdminProvider.tsx
@@ -213,10 +213,12 @@ export function LiveResultAdminProvider({
           path: { competitionId, roundId },
         },
         body: {
-          attempts: attempts.map((attempt, index) => ({
-            value: attempt,
-            attempt_number: index + 1,
-          })),
+          attempts: attempts
+            .map((attempt, index) => ({
+              value: attempt,
+              attempt_number: index + 1,
+            }))
+            .filter((a) => a.value !== 0),
           registration_id: registrationId,
         },
       },

--- a/next-frontend/src/providers/LiveResultAdminProvider.tsx
+++ b/next-frontend/src/providers/LiveResultAdminProvider.tsx
@@ -218,6 +218,7 @@ export function LiveResultAdminProvider({
               value: attempt,
               attempt_number: index + 1,
             }))
+            // Preserve the original attempt_numbers even when there were gaps in the attempts
             .filter((a) => a.value !== 0),
           registration_id: registrationId,
         },


### PR DESCRIPTION
Just noticed that this happened for the cutoff results in https://www.worldcubeassociation.org/api/v1/competitions/WaggaAutumn2026/live/rounds/333oh-r1 which caused advancement not to calculate correctly as live_attempt values cannot be 0. 

This does show a challenge for any future "live" scoretaking though. Live scoretaking often leaves 'holes' in competitors results when a scoretaker didn't get the result down. These holes would currently not be displayed and it would show incorrectly. 