### PR TITLE
Add lock to recompute_live_columns to fix quitting concurrency issues

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -213,9 +213,11 @@ class Round < ApplicationRecord
   end
 
   def recompute_live_columns(skip_advancing: false)
-    recompute_local_pos
-    recompute_global_pos
-    recompute_advancing unless skip_advancing
+    with_lock do
+      recompute_local_pos
+      recompute_global_pos
+      recompute_advancing unless skip_advancing
+    end
 
     # We need to reset because live results are changed directly on SQL level for more optimized queries
     live_results.reset


### PR DESCRIPTION
We have this tricky situation:
Quitting is synchronous, while adding results and computing advancing is asynchronous. 

Consider this common scenario:
1. Add the last results
2. Quit the no shows

Because Quitting is synchronous, the last result and the quitting will try to compute advancing at the same time which will lead to wrong results.

This is one solution to the problem. The benefit here is that it also allows us to run more than one results worker again if we want to (because of the lock this only makes sense when running multiple competitions anyway). 

Another solution would be to make everything asynchronous. That is a little harder to do UX wise and a little bit less intuitive for the client though.