### PR TITLE
Consider not meeting cutoff attempts in competitors_live_results_entered

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -318,15 +318,17 @@ class Round < ApplicationRecord
     if live_results.loaded?
       live_results.count(&:complete?)
     else
-      cutoff_done = if cutoff.blank?
-                      0
-                    else
-                      live_results
-                        .where(live_attempts_count: cutoff.number_of_attempts)
-                        .where("best >= ? OR best < 0", cutoff.attempt_result)
-                        .count
-                    end
-      live_results.where(live_attempts_count: format.expected_solve_count).count + cutoff_done
+      fully_done = live_results.where(live_attempts_count: format.expected_solve_count)
+
+      if cutoff.present?
+        only_done_cutoff_attempts = live_results
+                                    .where(live_attempts_count: cutoff.number_of_attempts)
+        didnt_meet_cutoff = only_done_cutoff_attempts.where(best: cutoff.attempt_result..)
+                                                     .or(only_done_cutoff_attempts.where(best: ...0))
+        return fully_done.or(didnt_meet_cutoff).count
+      end
+
+      fully_done.count
     end
   end
 

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -318,7 +318,15 @@ class Round < ApplicationRecord
     if live_results.loaded?
       live_results.count(&:complete?)
     else
-      live_results.where(live_attempts_count: format.expected_solve_count).count
+      cutoff_done = if cutoff.blank?
+                      0
+                    else
+                      live_results
+                        .where(live_attempts_count: cutoff.number_of_attempts)
+                        .where("best >= ? OR best < 0", cutoff.attempt_result)
+                        .count
+                    end
+      live_results.where(live_attempts_count: format.expected_solve_count).count + cutoff_done
     end
   end
 


### PR DESCRIPTION
This bug hasn't surfaced before because we were incorrectly storing 0s in live_attempts. I guess two wrongs did make a right 🙃 