### PR TITLE
Fix Ranking For Incomplete results in Best of X/Mo3 events when there are complete results present

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -295,13 +295,24 @@ class Round < ApplicationRecord
     #
     # For non-linked rounds global_pos equals local_pos, so we set both here to avoid
     # a second UPDATE in recompute_global_pos.
+
+    # For average-ranked formats, within the invalid-average group we further separate results
+    # by whether their best single is also invalid (all DNF/DNS), pushing those to the very bottom.
+    # Then sort by best single so e.g. incomplete (average=0, best=39) ranks above DNF mean
+    # (average=-1, best=40), and both rank above all-DNF (average=-1, best=-1).
+    order_clause = if secondary_rank_by
+                     primary_sort = "CASE WHEN #{rank_by} > 0 THEN #{rank_by} ELSE #{secondary_rank_by} END"
+                     "#{rank_by} <= 0, #{secondary_rank_by} <= 0, #{primary_sort} ASC, #{secondary_rank_by} ASC"
+                   else
+                     "#{rank_by} <= 0, #{rank_by} ASC"
+                   end
+
     ActiveRecord::Base.connection.exec_query <<~SQL.squish
       UPDATE live_results r
       LEFT JOIN (
           SELECT id,
                  RANK() OVER (
-                     ORDER BY #{rank_by} <= 0, #{rank_by} ASC
-                       #{", #{secondary_rank_by} <= 0, #{secondary_rank_by} ASC" if secondary_rank_by}
+                     ORDER BY #{order_clause}
                  ) AS `rank`
           FROM live_results
           WHERE round_id = #{id} AND best != 0

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -301,7 +301,7 @@ class Round < ApplicationRecord
     # Then sort by best single so e.g. incomplete (average=0, best=39) ranks above DNF mean
     # (average=-1, best=40), and both rank above all-DNF (average=-1, best=-1).
     order_clause = if secondary_rank_by
-                     primary_sort = "CASE WHEN #{rank_by} > 0 THEN #{rank_by} ELSE #{secondary_rank_by} END"
+                     primary_sort = "IF(#{rank_by} > 0, #{rank_by}, #{secondary_rank_by})"
                      "#{rank_by} <= 0, #{secondary_rank_by} <= 0, #{primary_sort} ASC, #{secondary_rank_by} ASC"
                    else
                      "#{rank_by} <= 0, #{rank_by} ASC"

--- a/next-frontend/src/lib/live/mergeAndOrderResults.test.ts
+++ b/next-frontend/src/lib/live/mergeAndOrderResults.test.ts
@@ -492,6 +492,32 @@ const testResults = {
 };
 // 333bf-r1 uses Ao5 format (sort by average, then single)
 const ao5Format = formats.byId["a"];
+// FMC uses Mean of 3 (sort by average/mean, then single)
+const mo3Format = formats.byId["m"];
+
+const makeFmcResult = (
+  registrationId: number,
+  best: number,
+  average: number,
+): LiveResultsByRegistrationId => ({
+  [String(registrationId)]: [
+    {
+      global_pos: 0,
+      local_pos: 0,
+      registration_id: registrationId,
+      best,
+      average,
+      single_record_tag: "",
+      average_record_tag: "",
+      advancing: false,
+      last_attempt_entered_at: "2026-05-01T10:00:00.000Z",
+      advancing_questionable: false,
+      event_id: "333fm",
+      attempts: [],
+      round_wcif_id: "333fm-r1",
+    },
+  ],
+});
 
 describe("mergeAndOrderResults", () => {
   it("ranks valid competitors above DNF and empty competitors", () => {
@@ -578,5 +604,61 @@ describe("mergeAndOrderResults", () => {
     for (const id of emptyIds) {
       expect(posById[id], `expected ${id} to have global_pos 5`).toBe(5);
     }
+  });
+});
+
+describe("mergeAndOrderResults for FMC (Mean of 3)", () => {
+  it("ranks incomplete result (best=39) above DNF mean result (best=40)", () => {
+    // Both have invalid means; they should rank only by best single.
+    // incomplete: average=0, best=39 (only one attempt entered)
+    // DNF mean:   average=-1, best=40 (two valid + one DNF)
+    const fmcResults: LiveResultsByRegistrationId = {
+      ...makeFmcResult(1, 20, 2500), // complete mean of 25 moves → rank 1
+      ...makeFmcResult(2, 25, 3000), // complete mean of 30 moves → rank 2
+      ...makeFmcResult(3, 30, 3500), // complete mean of 35 moves → rank 3
+      ...makeFmcResult(4, 39, 0), // incomplete (one attempt only) → rank 4
+      ...makeFmcResult(5, 40, -1), // DNF mean (40, 50, DNF)      → rank 5
+    };
+
+    const result = mergeAndOrderResults(
+      fmcResults,
+      makeCompetitorsMap(fmcResults),
+      mo3Format,
+    );
+    const posById = Object.fromEntries(result.map((r) => [r.id, r.global_pos]));
+
+    expect(posById[1]).toBe(1);
+    expect(posById[2]).toBe(2);
+    expect(posById[3]).toBe(3);
+    expect(posById[4]).toBe(4); // incomplete with best=39 ranks above DNF mean with best=40
+    expect(posById[5]).toBe(5);
+  });
+
+  it("ranks all-DNF result (best=-1) at the very bottom, below incomplete and DNF mean", () => {
+    // Tier 1: valid means
+    // Tier 2: invalid mean but valid single (incomplete or partial DNF) — ranked by best single
+    // Tier 3: invalid mean AND invalid single (all DNF/DNS) — ranked last
+    const fmcResults: LiveResultsByRegistrationId = {
+      ...makeFmcResult(1, 20, 2500), // complete mean of 25 moves → rank 1
+      ...makeFmcResult(2, 25, 3000), // complete mean of 30 moves → rank 2
+      ...makeFmcResult(3, 30, 3500), // complete mean of 35 moves → rank 3
+      ...makeFmcResult(4, 39, 0), // incomplete (one attempt only, best=39)  → rank 4
+      ...makeFmcResult(5, 40, -1), // DNF mean, best single=40               → rank 5
+      ...makeFmcResult(6, -1, -1), // all DNF (best=-1, mean=-1)              → rank 6
+    };
+
+    const result = mergeAndOrderResults(
+      fmcResults,
+      makeCompetitorsMap(fmcResults),
+      mo3Format,
+    );
+    const posById = Object.fromEntries(result.map((r) => [r.id, r.global_pos]));
+
+    expect(posById[1]).toBe(1);
+    expect(posById[2]).toBe(2);
+    expect(posById[3]).toBe(3);
+    expect(posById[4]).toBe(4);
+    expect(posById[5]).toBe(5);
+    expect(posById[6]).toBe(6); // all-DNF ranks below everyone with a valid single
   });
 });

--- a/next-frontend/src/lib/live/orderResults.ts
+++ b/next-frontend/src/lib/live/orderResults.ts
@@ -8,6 +8,14 @@ export const orderResults = (results: LiveResult[], format: Format) => {
   const rankBy = stats[0].field;
   const secondaryRankBy = stats[1]?.field;
 
+  // When rankBy is invalid (≤ 0) and a secondaryRankBy exists, fall back to
+  // secondaryRankBy so e.g. incomplete (average=0, best=39) ranks above DNF mean
+  // (average=-1, best=40) — both have invalid averages so rank only by best single.
+  const effectiveSortKey = (result: LiveResult) => {
+    if (result[rankBy] <= 0 && secondaryRankBy) return result[secondaryRankBy];
+    return result[rankBy];
+  };
+
   const sortedResults = results.toSorted((a, b) => {
     const aInvalid = a[rankBy] <= 0;
     const bInvalid = b[rankBy] <= 0;
@@ -16,8 +24,21 @@ export const orderResults = (results: LiveResult[], format: Format) => {
       return aInvalid ? 1 : -1;
     }
 
-    if (a[rankBy] !== b[rankBy]) {
-      return a[rankBy] - b[rankBy];
+    // Both have invalid primary. Results where the secondary is also invalid
+    // (all DNF/DNS, no valid single) rank after those with a valid secondary.
+    if (aInvalid && secondaryRankBy) {
+      const aSecondaryInvalid = a[secondaryRankBy] <= 0;
+      const bSecondaryInvalid = b[secondaryRankBy] <= 0;
+      if (aSecondaryInvalid !== bSecondaryInvalid) {
+        return aSecondaryInvalid ? 1 : -1;
+      }
+    }
+
+    const aPrimary = effectiveSortKey(a);
+    const bPrimary = effectiveSortKey(b);
+
+    if (aPrimary !== bPrimary) {
+      return aPrimary - bPrimary;
     }
 
     if (secondaryRankBy) {
@@ -43,7 +64,7 @@ export const orderResults = (results: LiveResult[], format: Format) => {
       const prev = acc[index - 1];
 
       const isTied =
-        result[rankBy] === prev[rankBy] &&
+        effectiveSortKey(result) === effectiveSortKey(prev) &&
         (!secondaryRankBy || result[secondaryRankBy] === prev[secondaryRankBy]);
 
       return [

--- a/spec/requests/live_recompute_ranking_spec.rb
+++ b/spec/requests/live_recompute_ranking_spec.rb
@@ -113,20 +113,38 @@ RSpec.describe "WCA Live API" do
       expect(round.live_results.sort_by(&:best).pluck(:local_pos)).to eq [4, 1, 2, 3]
     end
 
-    it "Ranks results correctly by single even with incomplete results present" do
-      competition = create(:competition, event_ids: ["333bf"], delegates: [delegate])
-      round = create(:round, competition: competition, event_id: "333bf", format_id: "5")
+    it "Ranks results correctly for FMC with incomplete and DNF mean results present" do
+      competition = create(:competition, event_ids: ["333fm"], delegates: [delegate])
+      round = create(:round, competition: competition, event_id: "333fm", format_id: "m")
 
-      3.times do |i|
-        registration = create(:registration, :accepted, competition: competition, event_ids: ["333bf"])
-
-        create(:live_result, round: round, registration: registration, best: (i + 1) * 100)
+      # Three complete results with valid means (25, 30, 35 moves)
+      [[20, 25, 30], [25, 30, 35], [30, 35, 40]].each do |moves|
+        registration = create(:registration, :accepted, competition: competition, event_ids: ["333fm"])
+        live_result = LiveResult.create!(LiveResult.empty_result_attributes(registration.id, round.id))
+        attempts = moves.each_with_index.map { |v, i| { attempt_number: i + 1, value: v } }
+        UpdateLiveResultJob.perform_now(live_result, attempts, delegate.id)
       end
 
-      registration = create(:registration, :accepted, competition: competition, event_ids: ["333bf"])
-      create(:live_result, round: round, registration: registration, best: 0)
+      # One result with only the first attempt entered (39 moves) — still competing, no mean yet
+      registration = create(:registration, :accepted, competition: competition, event_ids: ["333fm"])
+      live_result = LiveResult.create!(LiveResult.empty_result_attributes(registration.id, round.id))
+      UpdateLiveResultJob.perform_now(live_result, [{ attempt_number: 1, value: 39 }], delegate.id)
 
-      expect(round.live_results.sort_by(&:best).pluck(:local_pos)).to eq [nil, 1, 2, 3]
+      # One result with two valid attempts (40, 50) and one DNF — mean is DNF, best single is 40
+      registration = create(:registration, :accepted, competition: competition, event_ids: ["333fm"])
+      live_result = LiveResult.create!(LiveResult.empty_result_attributes(registration.id, round.id))
+      UpdateLiveResultJob.perform_now(live_result, [
+        { attempt_number: 1, value: 40 },
+        { attempt_number: 2, value: 50 },
+        { attempt_number: 3, value: -1 },
+      ], delegate.id)
+
+      # Expected ranking (sorted by best single, all positive in this test):
+      # 1-3: the three people with complete means (best singles: 20, 25, 30)
+      # 4: person with only one attempt entered (best=39) — ranks above DNF because 39 < 40
+      # 5: person with DNF mean (best=40)
+      # Both incomplete and DNF results have invalid means so they rank only by best single.
+      expect(round.live_results.reload.sort_by(&:best).map(&:local_pos)).to eq [1, 2, 3, 4, 5]
     end
   end
 

--- a/spec/requests/live_recompute_ranking_spec.rb
+++ b/spec/requests/live_recompute_ranking_spec.rb
@@ -134,10 +134,10 @@ RSpec.describe "WCA Live API" do
       registration = create(:registration, :accepted, competition: competition, event_ids: ["333fm"])
       live_result = LiveResult.create!(LiveResult.empty_result_attributes(registration.id, round.id))
       UpdateLiveResultJob.perform_now(live_result, [
-        { attempt_number: 1, value: 40 },
-        { attempt_number: 2, value: 50 },
-        { attempt_number: 3, value: -1 },
-      ], delegate.id)
+                                        { attempt_number: 1, value: 40 },
+                                        { attempt_number: 2, value: 50 },
+                                        { attempt_number: 3, value: -1 },
+                                      ], delegate.id)
 
       # Expected ranking (sorted by best single, all positive in this test):
       # 1-3: the three people with complete means (best singles: 20, 25, 30)


### PR DESCRIPTION
Currently these cause Results to be ranked incorrectly like this:

<img width="1186" height="387" alt="image" src="https://github.com/user-attachments/assets/8cc47fa8-0f9b-4275-a14f-533958d98dc7" />

This fixes it, but it's also an interesting case because those results are technically 'wrong' as they are missing the DNSes. 

This code produces the same outcome as WCA Live (see https://live.worldcubeassociation.org/competitions/10450/rounds/138042), @jonatanklosko any particular reason you came up with this behaviour? I assume because this is fairly common for FMC and it's hard to distinguish between 'missing' attempts and 'hasn't competed yet'?