### PR TITLE
Cleanup trailing attempts in WCIF results sync

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -470,7 +470,25 @@ class Round < ApplicationRecord
         end
       end
 
-      LiveAttempt.upsert_all(attempts_to_load) if attempts_to_load.any?
+      if attempts_to_load.any?
+        LiveAttempt.upsert_all(attempts_to_load)
+
+        # Count how many attempts were loaded per result_id
+        attempt_counts_by_result = attempts_to_load.map { it[:live_result_id] }.tally
+
+        # Regroup: For each count of results (that determines the maximum `attempt_number`),
+        #   we want to efficiently find all live_result_ids with that attempt number
+        results_with_attempt_count = attempt_counts_by_result.group_by(&:last)
+                                                             .transform_values { it.map(&:first) }
+
+        # Now we can clean up "once per number of attempts", so in reality this generates
+        #   only ~3 extra queries because barely any results have only 1 or only 4 attempts.
+        results_with_attempt_count.each do |valid_count, result_ids|
+          LiveAttempt.where(live_result_id: result_ids)
+                     .where.not(attempt_number: ..valid_count)
+                     .delete_all
+        end
+      end
 
       histories_to_generate = round_results_wcif.filter_map do |round_result_wcif|
         registration_id = person_id_to_registration_id[round_result_wcif["personId"]]

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -1280,6 +1280,25 @@ RSpec.describe "Competition WCIF" do
         expect(competition.to_wcif["events"]).to eq(wcif["events"])
       end
 
+      it "cleans up orphaned attempts upon syncing" do
+        # First, establish five attempts as a baseline
+        competition.set_wcif_events!(wcif["events"], delegate)
+
+        expect(LiveResult.count).to eq(2)
+        expect(LiveAttempt.count).to eq(10) # 5 attempts per result
+
+        # Whoops! That guy accidentally got his scores entered wrong, he actually only did two attempts
+        wcif_333_event["rounds"][0]["results"][1]["attempts"] = [{ "result" => 456, "reconstruction" => nil }] * 2
+
+        # Sync AGAIN, after the original (erroneous) 5 attempts had already been synced
+        competition.set_wcif_events!(wcif["events"], delegate)
+
+        expect(competition.to_wcif["events"]).to eq(wcif["events"])
+
+        expect(LiveResult.count).to eq(2)
+        expect(LiveAttempt.count).to eq(7) # one result now only has 2, so 5+2=7
+      end
+
       it "records histories when something changes" do
         competition.set_wcif_events!(wcif["events"], delegate)
 


### PR DESCRIPTION
Finn's sanity check from #14279 identified the following issue:
- Sometimes (mostly due to human error) a competitor can be synced to us with 5 attempts
- Later (when the human error has been found and corrected) it turns out that same competitor actually only had 2 attempts
- Our `upsert` with SQL `UNIQUE` index correctly updates/overwrites the first two of the 5 old attempts, but otherwise *leaves the dangling 3 attempts intact*

This PR makes sure that the 3 dangling attempts are being deleted.

At first, I thought just deleting plus reinserting all relevant `live_attempts` would work. But unfortunately, this churns through auto-increment IDs _ludicrously_ fast. So with the help of some LLM prompting, I came up with the following approach:
1. Upsert as normal
2. For every `live_result` in the whole sync payload, count how many attempts were just upserted (the line with `tally`)
3. Reverse the hash: Instead of `result_id --> count of attempts` it becomes `count of attempts --> [result_ids]`. Think of it as "which live_results all have 2 attempts?", "which live_results all have 5 attempts?", etc.
4. For each "count of attempts", execute *one* delete_all statement that trims any `attempt_number` bigger than "count of attempts" for those specific results

The uniqueness index which we already have on `(live_result_id, attempt_number)` coincidentally helps this DELETE query a ton and makes it basically instant