### PR TITLE
Expose live_results in wcif v2

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -794,13 +794,15 @@ class Round < ApplicationRecord
   end
 
   def to_wcif(include_results: true, version: Competition::WCIF_STABLE_VERSION)
+    results = Gem::Version.new(version) >= Gem::Version.new("2.0.0") ? live_results : round_results
+
     base_wcif = {
       "id" => wcif_id,
       "format" => self.format_id,
       "timeLimit" => event.can_change_time_limit? ? time_limit&.to_wcif : nil,
       "cutoff" => cutoff&.to_wcif,
       "scrambleSetCount" => self.scramble_set_count,
-      "results" => include_results ? round_results.map(&:to_wcif) : nil,
+      "results" => include_results ? results.map(&:to_wcif) : nil,
       "extensions" => wcif_extensions.map(&:to_wcif),
     }
 

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -794,7 +794,8 @@ class Round < ApplicationRecord
   end
 
   def to_wcif(include_results: true, version: Competition::WCIF_STABLE_VERSION)
-    results = Gem::Version.new(version) >= Gem::Version.new("2.0.0") ? live_results : round_results
+    at_least_v2 = Gem::Version.new(version) >= Gem::Version.new("2.0.0")
+    results = at_least_v2 || competition.scoretaking_software_internal? ? live_results : round_results
 
     base_wcif = {
       "id" => wcif_id,
@@ -806,7 +807,7 @@ class Round < ApplicationRecord
       "extensions" => wcif_extensions.map(&:to_wcif),
     }
 
-    if Gem::Version.new(version) >= Gem::Version.new("2.0.0")
+    if at_least_v2
       base_wcif.merge(
         "linkedRounds" => linked_round&.wcif_ids,
         "participationRuleset" => {


### PR DESCRIPTION
I assume they will pull wcif v2? Or should we check `scoretaking_software_internal?` instead