### PR TITLE
Simplify layout engine for frontpage

### DIFF
--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -23,18 +23,18 @@ import config from "@payload-config";
 import type {
   TextCardBlock,
   FeaturedCompetitionsBlock,
-  FullWidthBlock,
   ImageBannerBlock,
   ImageOnlyCardBlock,
   Media,
   TestimonialsBlock,
-  TwoBlocksBlock,
-  TwoBlocksBranchBlock,
-  TwoBlocksLeafBlock,
+  TwoBlocksLevel0Block,
+  TwoBlocksLevel1Block,
+  TwoBlocksLevel2Block,
   Testimonial,
   AnnouncementsSectionBlock,
   Announcement,
   ColorPaletteSelect,
+  Home,
 } from "@/types/payload";
 import Link from "next/link";
 import { route } from "nextjs-routes";
@@ -44,6 +44,22 @@ import { MediaImage } from "@/components/MediaImage";
 import { getCompetitionInfo } from "@/lib/wca/competitions/getCompetitionInfo";
 import CompetitionShortlist from "@/components/competitions/CompetitionShortlist";
 import OpenapiError from "@/components/ui/openapiError";
+
+type TwoBlocksUnion =
+  | TwoBlocksLevel0Block
+  | TwoBlocksLevel1Block
+  | TwoBlocksLevel2Block;
+
+type TwoBlocksRatio = TwoBlocksUnion["ratio"];
+type TwoBlocksSpanConfig = { left: number; right: number };
+
+const RATIO_GRID_MAP: Record<TwoBlocksRatio, TwoBlocksSpanConfig> = {
+  "1/3 & 2/3": { left: 1, right: 2 },
+  "2/3 & 1/3": { left: 2, right: 1 },
+  "1/2 & 1/2": { left: 1, right: 1 },
+  "1/4 & 3/4": { left: 1, right: 3 },
+  "3/4 & 1/4": { left: 3, right: 1 },
+};
 
 const TextCard = ({ block }: { block: TextCardBlock }) => {
   return (
@@ -83,9 +99,10 @@ const AnnouncementsSection = ({
   block: AnnouncementsSectionBlock;
 }) => {
   const mainAnnouncement = block.mainAnnouncement as Announcement;
-  const furtherAnnouncements = block.furtherAnnouncements!.map(
-    (announcement) => announcement as Announcement,
-  );
+  const furtherAnnouncements =
+    block.furtherAnnouncements?.map(
+      (announcement) => announcement as Announcement,
+    ) || [];
 
   return (
     <AnnouncementsCard
@@ -283,178 +300,68 @@ const TestimonialsSpinner = ({ block }: { block: TestimonialsBlock }) => {
   );
 };
 
-type TwoBlocksUnion =
-  | TwoBlocksBlock
-  | TwoBlocksBranchBlock
-  | TwoBlocksLeafBlock;
+type VerticalLayout =
+  | Home["layout"]
+  | TwoBlocksUnion["left"]
+  | TwoBlocksUnion["right"];
 
-const renderBlockGroup = (entry: TwoBlocksUnion, keyPrefix = "") => {
-  let columnCount = 2;
-  let col1 = 1;
-  let col2 = 1;
-
-  switch (entry.type) {
-    case "1/3 & 2/3":
-      columnCount = 3;
-      col2 = 2;
-      break;
-    case "2/3 & 1/3":
-      columnCount = 3;
-      col1 = 2;
-      break;
-    case "1/2 & 1/2":
-      columnCount = 2;
-      break;
-    case "1/4 & 3/4":
-      columnCount = 4;
-      col2 = 3;
-      break;
-    case "3/4 & 1/4":
-      columnCount = 4;
-      col1 = 3;
-      break;
-    default:
-      columnCount = 2;
-  }
-
-  const columns = [col1, col2];
-
-  const isHorizontal = entry.alignment === "horizontal";
-  const RenderAs = isHorizontal ? SimpleGrid : VStack;
-
+const renderVerticalLayout = (verticalLayout: VerticalLayout) => {
   return (
-    <RenderAs
-      key={keyPrefix}
-      columns={{ base: 1, md: columnCount }}
-      gap={8}
-      width="full"
-    >
-      {entry.blocks.map((subEntry, i) => {
-        const key = `${keyPrefix}-${i}`;
-
-        switch (subEntry.blockType) {
-          case "TextCard":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                <TextCard block={subEntry} />
-              </GridItem>
-            );
-          case "AnnouncementsSection":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                <AnnouncementsSection block={subEntry} />
-              </GridItem>
-            );
-          case "twoBlocksBranch":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                {renderBlockGroup(subEntry, key)}
-              </GridItem>
-            );
-          case "twoBlocksLeaf":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                {renderBlockGroup(subEntry, key)}
-              </GridItem>
-            );
-          case "ImageBanner":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                <ImageBanner block={subEntry} />
-              </GridItem>
-            );
-          case "ImageOnlyCard":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                <ImageOnlyCard block={subEntry} />
-              </GridItem>
-            );
-          case "FeaturedComps":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                <FeaturedCompetitions block={subEntry} />
-              </GridItem>
-            );
-          case "TestimonialsSpinner":
-            return (
-              <GridItem
-                key={key}
-                colSpan={{ base: 1, md: columns[i] || 1 }}
-                display="flex"
-                width="full"
-              >
-                <TestimonialsSpinner block={subEntry} />
-              </GridItem>
-            );
+    <VStack gap={8}>
+      {verticalLayout.map((entry, index) => {
+        switch (entry.blockType) {
+          case "twoBlocksLevel0":
+          case "twoBlocksLevel1":
+          case "twoBlocksLevel2":
+            return renderHorizontalSplit(entry, `entry-${index}`);
           default:
-            return null;
+            return renderFullBlock(entry, `entry-${index}`);
         }
       })}
-    </RenderAs>
+    </VStack>
   );
 };
 
-const renderFullBlock = (entry: FullWidthBlock, keyPrefix = "") => {
+const renderHorizontalSplit = (entry: TwoBlocksUnion, keyPrefix = "") => {
+  const { left, right } = RATIO_GRID_MAP[entry.ratio];
+
   return (
-    <Box key={keyPrefix} width="full">
-      {entry.blocks.map((subEntry, i) => {
-        const key = `${keyPrefix}-${i}`;
-
-        switch (subEntry.blockType) {
-          case "TextCard":
-            return <TextCard key={key} block={subEntry} />;
-          case "AnnouncementsSection":
-            return <AnnouncementsSection key={key} block={subEntry} />;
-          case "ImageBanner":
-            return <ImageBanner key={key} block={subEntry} />;
-          case "ImageOnlyCard":
-            return <ImageOnlyCard key={key} block={subEntry} />;
-          case "FeaturedComps":
-            return <FeaturedCompetitions key={key} block={subEntry} />;
-          case "TestimonialsSpinner":
-            return <TestimonialsSpinner key={key} block={subEntry} />;
-
-          default:
-            return null;
-        }
-      })}
-    </Box>
+    <SimpleGrid
+      key={keyPrefix}
+      columns={{ base: 1, md: left + right }}
+      gap={8}
+      width="full"
+    >
+      <GridItem colSpan={{ base: 1, md: left }} asChild>
+        {renderVerticalLayout(entry.left)}
+      </GridItem>
+      <GridItem colSpan={{ base: 1, md: right }} asChild>
+        {renderVerticalLayout(entry.right)}
+      </GridItem>
+    </SimpleGrid>
   );
+};
+
+type LayoutBlock = VerticalLayout[number];
+
+const renderFullBlock = (entry: LayoutBlock, key = "") => {
+  switch (entry.blockType) {
+    case "TextCard":
+      return <TextCard key={key} block={entry} />;
+    case "AnnouncementsSection":
+      return <AnnouncementsSection key={key} block={entry} />;
+    case "ImageBanner":
+      return <ImageBanner key={key} block={entry} />;
+    case "ImageOnlyCard":
+      return <ImageOnlyCard key={key} block={entry} />;
+    case "FeaturedComps":
+      return <FeaturedCompetitions key={key} block={entry} />;
+    case "TestimonialsSpinner":
+      return <TestimonialsSpinner key={key} block={entry} />;
+
+    default:
+      return null;
+  }
 };
 
 export default async function Homepage() {
@@ -465,7 +372,7 @@ export default async function Homepage() {
     draft: isDraftMode,
   });
 
-  const homepageEntries = homepage?.item || [];
+  const homepageEntries = homepage.layout;
 
   if (homepageEntries.length === 0) {
     return (
@@ -485,21 +392,8 @@ export default async function Homepage() {
   }
 
   return (
-    <SimpleGrid columns={1} gap={8} p={8}>
-      {homepageEntries.map((entry, index) => {
-        // Handle `twoBlocks` layout
-        if (entry.blockType === "twoBlocks") {
-          return renderBlockGroup(entry, `entry-${index}`);
-        }
-
-        // Handle `fullWidth` layout
-        if (entry.blockType === "fullWidth") {
-          return renderFullBlock(entry, `entry-${index}`);
-        }
-
-        // Handle unknown blockType
-        return null;
-      })}
-    </SimpleGrid>
+    <Box p={8} asChild>
+      {renderVerticalLayout(homepageEntries)}
+    </Box>
   );
 }

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -81,128 +81,62 @@ const coreBlocks = [
   FeaturedCompetitions,
 ];
 
-const twoBlocksLeaf: Block = {
-  slug: "twoBlocksLeaf",
-  interfaceName: "TwoBlocksLeafBlock",
-  fields: [
-    {
-      name: "type",
-      type: "select",
-      required: true,
-      options: [
-        "1/3 & 2/3",
-        "2/3 & 1/3",
-        "1/2 & 1/2",
-        "1/4 & 3/4",
-        "3/4 & 1/4",
-      ],
-    },
-    {
-      name: "alignment",
-      type: "select",
-      required: true,
-      options: ["horizontal", "vertical"],
-    },
-    {
-      name: "blocks",
-      type: "blocks",
-      blocks: coreBlocks,
-      required: true,
-      minRows: 2,
-      maxRows: 2,
-    },
-  ],
-};
+const createTwoBlocks = (depth: number = 1): Block => {
+  const allowedBlocks =
+    depth === 0 ? coreBlocks : [...coreBlocks, createTwoBlocks(depth - 1)];
 
-const twoBlocksBranch: Block = {
-  slug: "twoBlocksBranch",
-  interfaceName: "TwoBlocksBranchBlock",
-  fields: [
-    {
-      name: "type",
-      type: "select",
-      required: true,
-      options: [
-        "1/3 & 2/3",
-        "2/3 & 1/3",
-        "1/2 & 1/2",
-        "1/4 & 3/4",
-        "3/4 & 1/4",
-      ],
+  return {
+    slug: `twoBlocksLevel${depth}`,
+    interfaceName: `TwoBlocksLevel${depth}Block`,
+    labels: {
+      singular: "Two Blocks",
+      plural: "Two Blocks",
     },
-    {
-      name: "alignment",
-      type: "select",
-      required: true,
-      options: ["horizontal", "vertical"],
-    },
-    {
-      name: "blocks",
-      type: "blocks",
-      blocks: [...coreBlocks, twoBlocksLeaf],
-      required: true,
-      minRows: 2,
-      maxRows: 2,
-    },
-  ],
-};
-
-const twoBlocks: Block = {
-  slug: "twoBlocks",
-  interfaceName: "TwoBlocksBlock",
-  fields: [
-    {
-      name: "type",
-      type: "select",
-      required: true,
-      options: [
-        "1/3 & 2/3",
-        "2/3 & 1/3",
-        "1/2 & 1/2",
-        "1/4 & 3/4",
-        "3/4 & 1/4",
-      ],
-    },
-    {
-      name: "alignment",
-      type: "select",
-      required: true,
-      options: ["horizontal", "vertical"],
-    },
-    {
-      name: "blocks",
-      type: "blocks",
-      blocks: [...coreBlocks, twoBlocksBranch],
-      required: true,
-      minRows: 2,
-      maxRows: 2,
-    },
-  ],
-};
-
-const fullWidth: Block = {
-  slug: "fullWidth",
-  interfaceName: "FullWidthBlock",
-  fields: [
-    {
-      name: "blocks",
-      type: "blocks",
-      blocks: coreBlocks,
-      required: true,
-      maxRows: 1,
-    },
-  ],
+    fields: [
+      {
+        name: "ratio",
+        type: "select",
+        required: true,
+        defaultValue: "1/2 & 1/2",
+        options: [
+          "1/3 & 2/3",
+          "2/3 & 1/3",
+          "1/2 & 1/2",
+          "1/4 & 3/4",
+          "3/4 & 1/4",
+        ],
+      },
+      {
+        type: "row",
+        fields: [
+          {
+            name: "left",
+            type: "blocks",
+            blocks: allowedBlocks,
+            required: true,
+            minRows: 1,
+          },
+          {
+            name: "right",
+            type: "blocks",
+            blocks: allowedBlocks,
+            required: true,
+            minRows: 1,
+          },
+        ],
+      },
+    ],
+  };
 };
 
 export const Home: GlobalConfig = {
   slug: "home",
   fields: [
     {
-      name: "item",
+      name: "layout",
       type: "blocks",
-      blocks: [twoBlocks, fullWidth],
+      blocks: [...coreBlocks, createTwoBlocks(2)],
       required: true,
-      minRows: 1,
     },
   ],
   versions: {

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -958,30 +958,18 @@ export interface Nav {
  */
 export interface Home {
   id: string;
-  item: (TwoBlocksBlock | FullWidthBlock)[];
-  _status?: ('draft' | 'published') | null;
-  updatedAt?: string | null;
-  createdAt?: string | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TwoBlocksBlock".
- */
-export interface TwoBlocksBlock {
-  type: '1/3 & 2/3' | '2/3 & 1/3' | '1/2 & 1/2' | '1/4 & 3/4' | '3/4 & 1/4';
-  alignment: 'horizontal' | 'vertical';
-  blocks: (
+  layout: (
     | TextCardBlock
     | AnnouncementsSectionBlock
     | ImageBannerBlock
     | ImageOnlyCardBlock
     | TestimonialsBlock
     | FeaturedCompetitionsBlock
-    | TwoBlocksBranchBlock
+    | TwoBlocksLevel2Block
   )[];
-  id?: string | null;
-  blockName?: string | null;
-  blockType: 'twoBlocks';
+  _status?: ('draft' | 'published') | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1109,49 +1097,75 @@ export interface FeaturedCompetitionsBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TwoBlocksBranchBlock".
+ * via the `definition` "TwoBlocksLevel2Block".
  */
-export interface TwoBlocksBranchBlock {
-  type: '1/3 & 2/3' | '2/3 & 1/3' | '1/2 & 1/2' | '1/4 & 3/4' | '3/4 & 1/4';
-  alignment: 'horizontal' | 'vertical';
-  blocks: (
+export interface TwoBlocksLevel2Block {
+  ratio: '1/3 & 2/3' | '2/3 & 1/3' | '1/2 & 1/2' | '1/4 & 3/4' | '3/4 & 1/4';
+  left: (
     | TextCardBlock
     | AnnouncementsSectionBlock
     | ImageBannerBlock
     | ImageOnlyCardBlock
     | TestimonialsBlock
     | FeaturedCompetitionsBlock
-    | TwoBlocksLeafBlock
+    | TwoBlocksLevel1Block
+  )[];
+  right: (
+    | TextCardBlock
+    | AnnouncementsSectionBlock
+    | ImageBannerBlock
+    | ImageOnlyCardBlock
+    | TestimonialsBlock
+    | FeaturedCompetitionsBlock
+    | TwoBlocksLevel1Block
   )[];
   id?: string | null;
   blockName?: string | null;
-  blockType: 'twoBlocksBranch';
+  blockType: 'twoBlocksLevel2';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TwoBlocksLeafBlock".
+ * via the `definition` "TwoBlocksLevel1Block".
  */
-export interface TwoBlocksLeafBlock {
-  type: '1/3 & 2/3' | '2/3 & 1/3' | '1/2 & 1/2' | '1/4 & 3/4' | '3/4 & 1/4';
-  alignment: 'horizontal' | 'vertical';
-  blocks: (
+export interface TwoBlocksLevel1Block {
+  ratio: '1/3 & 2/3' | '2/3 & 1/3' | '1/2 & 1/2' | '1/4 & 3/4' | '3/4 & 1/4';
+  left: (
     | TextCardBlock
     | AnnouncementsSectionBlock
     | ImageBannerBlock
     | ImageOnlyCardBlock
     | TestimonialsBlock
     | FeaturedCompetitionsBlock
+    | TwoBlocksLevel0Block
+  )[];
+  right: (
+    | TextCardBlock
+    | AnnouncementsSectionBlock
+    | ImageBannerBlock
+    | ImageOnlyCardBlock
+    | TestimonialsBlock
+    | FeaturedCompetitionsBlock
+    | TwoBlocksLevel0Block
   )[];
   id?: string | null;
   blockName?: string | null;
-  blockType: 'twoBlocksLeaf';
+  blockType: 'twoBlocksLevel1';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "FullWidthBlock".
+ * via the `definition` "TwoBlocksLevel0Block".
  */
-export interface FullWidthBlock {
-  blocks: (
+export interface TwoBlocksLevel0Block {
+  ratio: '1/3 & 2/3' | '2/3 & 1/3' | '1/2 & 1/2' | '1/4 & 3/4' | '3/4 & 1/4';
+  left: (
+    | TextCardBlock
+    | AnnouncementsSectionBlock
+    | ImageBannerBlock
+    | ImageOnlyCardBlock
+    | TestimonialsBlock
+    | FeaturedCompetitionsBlock
+  )[];
+  right: (
     | TextCardBlock
     | AnnouncementsSectionBlock
     | ImageBannerBlock
@@ -1161,7 +1175,7 @@ export interface FullWidthBlock {
   )[];
   id?: string | null;
   blockName?: string | null;
-  blockType: 'fullWidth';
+  blockType: 'twoBlocksLevel0';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1611,25 +1625,7 @@ export interface NavSelect<T extends boolean = true> {
  * via the `definition` "home_select".
  */
 export interface HomeSelect<T extends boolean = true> {
-  item?:
-    | T
-    | {
-        twoBlocks?: T | TwoBlocksBlockSelect<T>;
-        fullWidth?: T | FullWidthBlockSelect<T>;
-      };
-  _status?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  globalType?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TwoBlocksBlock_select".
- */
-export interface TwoBlocksBlockSelect<T extends boolean = true> {
-  type?: T;
-  alignment?: T;
-  blocks?:
+  layout?:
     | T
     | {
         TextCard?: T | TextCardBlockSelect<T>;
@@ -1638,10 +1634,12 @@ export interface TwoBlocksBlockSelect<T extends boolean = true> {
         ImageOnlyCard?: T | ImageOnlyCardBlockSelect<T>;
         TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
-        twoBlocksBranch?: T | TwoBlocksBranchBlockSelect<T>;
+        twoBlocksLevel2?: T | TwoBlocksLevel2BlockSelect<T>;
       };
-  id?: T;
-  blockName?: T;
+  _status?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1731,12 +1729,11 @@ export interface FeaturedCompetitionsBlockSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TwoBlocksBranchBlock_select".
+ * via the `definition` "TwoBlocksLevel2Block_select".
  */
-export interface TwoBlocksBranchBlockSelect<T extends boolean = true> {
-  type?: T;
-  alignment?: T;
-  blocks?:
+export interface TwoBlocksLevel2BlockSelect<T extends boolean = true> {
+  ratio?: T;
+  left?:
     | T
     | {
         TextCard?: T | TextCardBlockSelect<T>;
@@ -1745,19 +1742,60 @@ export interface TwoBlocksBranchBlockSelect<T extends boolean = true> {
         ImageOnlyCard?: T | ImageOnlyCardBlockSelect<T>;
         TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
-        twoBlocksLeaf?: T | TwoBlocksLeafBlockSelect<T>;
+        twoBlocksLevel1?: T | TwoBlocksLevel1BlockSelect<T>;
+      };
+  right?:
+    | T
+    | {
+        TextCard?: T | TextCardBlockSelect<T>;
+        AnnouncementsSection?: T | AnnouncementsSectionBlockSelect<T>;
+        ImageBanner?: T | ImageBannerBlockSelect<T>;
+        ImageOnlyCard?: T | ImageOnlyCardBlockSelect<T>;
+        TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
+        FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
+        twoBlocksLevel1?: T | TwoBlocksLevel1BlockSelect<T>;
       };
   id?: T;
   blockName?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "TwoBlocksLeafBlock_select".
+ * via the `definition` "TwoBlocksLevel1Block_select".
  */
-export interface TwoBlocksLeafBlockSelect<T extends boolean = true> {
-  type?: T;
-  alignment?: T;
-  blocks?:
+export interface TwoBlocksLevel1BlockSelect<T extends boolean = true> {
+  ratio?: T;
+  left?:
+    | T
+    | {
+        TextCard?: T | TextCardBlockSelect<T>;
+        AnnouncementsSection?: T | AnnouncementsSectionBlockSelect<T>;
+        ImageBanner?: T | ImageBannerBlockSelect<T>;
+        ImageOnlyCard?: T | ImageOnlyCardBlockSelect<T>;
+        TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
+        FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
+        twoBlocksLevel0?: T | TwoBlocksLevel0BlockSelect<T>;
+      };
+  right?:
+    | T
+    | {
+        TextCard?: T | TextCardBlockSelect<T>;
+        AnnouncementsSection?: T | AnnouncementsSectionBlockSelect<T>;
+        ImageBanner?: T | ImageBannerBlockSelect<T>;
+        ImageOnlyCard?: T | ImageOnlyCardBlockSelect<T>;
+        TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
+        FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
+        twoBlocksLevel0?: T | TwoBlocksLevel0BlockSelect<T>;
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TwoBlocksLevel0Block_select".
+ */
+export interface TwoBlocksLevel0BlockSelect<T extends boolean = true> {
+  ratio?: T;
+  left?:
     | T
     | {
         TextCard?: T | TextCardBlockSelect<T>;
@@ -1767,15 +1805,7 @@ export interface TwoBlocksLeafBlockSelect<T extends boolean = true> {
         TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
       };
-  id?: T;
-  blockName?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "FullWidthBlock_select".
- */
-export interface FullWidthBlockSelect<T extends boolean = true> {
-  blocks?:
+  right?:
     | T
     | {
         TextCard?: T | TextCardBlockSelect<T>;


### PR DESCRIPTION
This boils down the frontpage layout to one central axis: Vertical.

You can add boxes to the vertical layout, and one of the boxes that you can add just "happens to be" a horizontal splitter. This splitter now contains `left` and `right` blocks, which are in themselves also vertical layouts.

Payload does not allow recursive schema definitions (aka it is hard to say "The block which I am currently defining is a valid child block"), but in our case I think this is somewhat helpful: We do NOT want content managers to nest horizontal splitters infinitely deeply. By manually nesting only to a certain depth (currently: 2), we forbid them to introduce too much horizontal splitting.