### PR TITLE
Restructure Markdown rendering component

### DIFF
--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/register/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/register/page.tsx
@@ -5,7 +5,7 @@ import { serverClientWithToken } from "@/lib/wca/wcaAPI";
 import StepPanel from "@/app/(wca)/competitions/[competitionId]/register/StepPanel";
 import { getCompetitionInfo } from "@/lib/wca/competitions/getCompetitionInfo";
 import RegistrationRequirementsCard from "@/app/(wca)/competitions/[competitionId]/register/RegistrationRequirementsCard";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 
 const fetchConfig = cache(async (authToken: string, competitionId: string) => {
   const client = serverClientWithToken(authToken);
@@ -57,10 +57,11 @@ export default async function RegisterPage({
       </Box>
       {competitionInfo.extra_registration_requirements && (
         <Card.Root width="full">
-          <MarkdownProse
-            as={Card.Body}
-            content={competitionInfo.extra_registration_requirements}
-          />
+          <Card.Body>
+            <ChakraMarkdown>
+              {competitionInfo.extra_registration_requirements}
+            </ChakraMarkdown>
+          </Card.Body>
         </Card.Root>
       )}
       <Card.Root width="full">

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/register/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/register/page.tsx
@@ -58,7 +58,10 @@ export default async function RegisterPage({
       {competitionInfo.extra_registration_requirements && (
         <Card.Root width="full">
           <Card.Body>
-            <ChakraMarkdown>
+            <ChakraMarkdown
+              headingAs={Card.Title}
+              paragraphAs={Card.Description}
+            >
               {competitionInfo.extra_registration_requirements}
             </ChakraMarkdown>
           </Card.Body>

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/tabs/[tabName]/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/tabs/[tabName]/page.tsx
@@ -2,7 +2,7 @@ import { Card, Text } from "@chakra-ui/react";
 
 import { getTabs } from "@/lib/wca/competitions/getTabs";
 import React from "react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import OpenapiError from "@/components/ui/openapiError";
 import { getT } from "@/lib/i18n/get18n";
 
@@ -31,7 +31,7 @@ export default async function Tab({
   return (
     <Card.Root>
       <Card.Body>
-        <MarkdownProse content={tab.content} />
+        <ChakraMarkdown>{tab.content}</ChakraMarkdown>
       </Card.Body>
     </Card.Root>
   );

--- a/next-frontend/src/app/(wca)/competitions/[competitionId]/tabs/[tabName]/page.tsx
+++ b/next-frontend/src/app/(wca)/competitions/[competitionId]/tabs/[tabName]/page.tsx
@@ -31,7 +31,9 @@ export default async function Tab({
   return (
     <Card.Root>
       <Card.Body>
-        <ChakraMarkdown>{tab.content}</ChakraMarkdown>
+        <ChakraMarkdown headingAs={Card.Title} paragraphAs={Card.Description}>
+          {tab.content}
+        </ChakraMarkdown>
       </Card.Body>
     </Card.Root>
   );

--- a/next-frontend/src/app/(wca)/disclaimer/page.tsx
+++ b/next-frontend/src/app/(wca)/disclaimer/page.tsx
@@ -1,7 +1,7 @@
 import { getPayload } from "payload";
 import config from "@payload-config";
 import { Container, Heading, VStack, Box } from "@chakra-ui/react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import { Metadata } from "next";
 import { getT } from "@/lib/i18n/get18n";
 
@@ -32,7 +32,7 @@ export default async function Disclaimer() {
         {disclaimerItems.map((item) => (
           <Box key={item.id}>
             {item.title && <Heading size="xl">{item.title}</Heading>}
-            <MarkdownProse content={item.contentMarkdown!} />
+            <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
           </Box>
         ))}
       </VStack>

--- a/next-frontend/src/app/(wca)/disclaimer/page.tsx
+++ b/next-frontend/src/app/(wca)/disclaimer/page.tsx
@@ -32,7 +32,7 @@ export default async function Disclaimer() {
         {disclaimerItems.map((item) => (
           <Box key={item.id}>
             {item.title && <Heading size="xl">{item.title}</Heading>}
-            <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
+            <ChakraMarkdown>{item.contentMarkdown}</ChakraMarkdown>
           </Box>
         ))}
       </VStack>

--- a/next-frontend/src/app/(wca)/faq/page.tsx
+++ b/next-frontend/src/app/(wca)/faq/page.tsx
@@ -51,7 +51,13 @@ export default async function FAQ() {
           <Card.Body>
             <Card.Title textStyle="h1">Frequently Asked Questions</Card.Title>
             {faqPage.introTextMarkdown ? (
-              <ChakraMarkdown>{faqPage.introTextMarkdown}</ChakraMarkdown>
+              <ChakraMarkdown
+                headingAs={Card.Title}
+                paragraphAs={Card.Description}
+                textStyle="body"
+              >
+                {faqPage.introTextMarkdown}
+              </ChakraMarkdown>
             ) : (
               <Card.Description>No Intro text, add it!</Card.Description>
             )}

--- a/next-frontend/src/app/(wca)/faq/page.tsx
+++ b/next-frontend/src/app/(wca)/faq/page.tsx
@@ -7,12 +7,11 @@ import {
   Heading,
   Tabs,
   Accordion,
-  Text,
 } from "@chakra-ui/react";
 import { getPayload } from "payload";
 import config from "@payload-config";
 import { FaqCategory, FaqQuestion } from "@/types/payload";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import { uniqBy } from "lodash";
 import { Metadata } from "next";
 import { getT } from "@/lib/i18n/get18n";
@@ -52,12 +51,9 @@ export default async function FAQ() {
           <Card.Body>
             <Card.Title textStyle="h1">Frequently Asked Questions</Card.Title>
             {faqPage.introTextMarkdown ? (
-              <MarkdownProse
-                content={faqPage.introTextMarkdown}
-                textStyle="body"
-              />
+              <ChakraMarkdown>{faqPage.introTextMarkdown}</ChakraMarkdown>
             ) : (
-              <Text>No Intro text, add it!</Text>
+              <Card.Description>No Intro text, add it!</Card.Description>
             )}
           </Card.Body>
         </Card.Root>

--- a/next-frontend/src/app/(wca)/logo/page.tsx
+++ b/next-frontend/src/app/(wca)/logo/page.tsx
@@ -9,7 +9,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import { Media } from "@/types/payload";
 import LogoDownload from "@/app/(wca)/logo/download";
 import { Fragment } from "react";
@@ -48,11 +48,7 @@ export default async function LogoPage() {
               return (
                 <Fragment key={item.id}>
                   <Heading size="2xl">{item.title}</Heading>
-                  <MarkdownProse
-                    key={item.id}
-                    content={item.contentMarkdown!}
-                    as={Text}
-                  />
+                  <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
                 </Fragment>
               );
             }

--- a/next-frontend/src/app/(wca)/logo/page.tsx
+++ b/next-frontend/src/app/(wca)/logo/page.tsx
@@ -48,7 +48,7 @@ export default async function LogoPage() {
               return (
                 <Fragment key={item.id}>
                   <Heading size="2xl">{item.title}</Heading>
-                  <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
+                  <ChakraMarkdown>{item.contentMarkdown}</ChakraMarkdown>
                 </Fragment>
               );
             }

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -81,7 +81,9 @@ const TextCard = ({ block }: { block: TextCardBlock }) => {
           {block.heading}
         </Card.Title>
         {block.separatorAfterHeading && <Separator size="md" />}
-        <ChakraMarkdown>{block.bodyMarkdown!}</ChakraMarkdown>
+        <ChakraMarkdown paragraphAs={Card.Description} textStyle="body">
+          {block.bodyMarkdown}
+        </ChakraMarkdown>
       </Card.Body>
       {block.buttonText?.trim() && (
         <Card.Footer>
@@ -145,7 +147,12 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
         >
           {block.heading}
         </Card.Title>
-        <ChakraMarkdown>{block.bodyMarkdown!}</ChakraMarkdown>
+        <ChakraMarkdown
+          paragraphAs={Card.Description}
+          textStyle={{ base: "body", md: "s2" }}
+        >
+          {block.bodyMarkdown}
+        </ChakraMarkdown>
         {block.bgImage && (
           <Float
             placement="bottom-end"
@@ -276,7 +283,10 @@ const TestimonialsSpinner = ({ block }: { block: TestimonialsBlock }) => {
                     {testimonial.punchline}
                   </Card.Title>
                   <Separator size="md" />
-                  <ChakraMarkdown>
+                  <ChakraMarkdown
+                    paragraphAs={Card.Description}
+                    textStyle="quote"
+                  >
                     {testimonial.fullTestimonialMarkdown!}
                   </ChakraMarkdown>
                   <Text>{testimonial.whoDunnit}</Text>

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -20,7 +20,7 @@ import {
   Float,
   Carousel,
 } from "@chakra-ui/react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import AnnouncementsCard from "@/components/AnnouncementsCard";
 import { getPayload } from "payload";
 import config from "@payload-config";
@@ -81,11 +81,7 @@ const TextCard = ({ block }: { block: TextCardBlock }) => {
           {block.heading}
         </Card.Title>
         {block.separatorAfterHeading && <Separator size="md" />}
-        <MarkdownProse
-          as={Card.Description}
-          content={block.bodyMarkdown!}
-          textStyle="body"
-        />
+        <ChakraMarkdown>{block.bodyMarkdown!}</ChakraMarkdown>
       </Card.Body>
       {block.buttonText?.trim() && (
         <Card.Footer>
@@ -149,11 +145,7 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
         >
           {block.heading}
         </Card.Title>
-        <MarkdownProse
-          as={Card.Description}
-          content={block.bodyMarkdown!}
-          textStyle={{ base: "body", md: "s2" }}
-        />
+        <ChakraMarkdown>{block.bodyMarkdown!}</ChakraMarkdown>
         {block.bgImage && (
           <Float
             placement="bottom-end"
@@ -284,11 +276,9 @@ const TestimonialsSpinner = ({ block }: { block: TestimonialsBlock }) => {
                     {testimonial.punchline}
                   </Card.Title>
                   <Separator size="md" />
-                  <MarkdownProse
-                    as={Card.Description}
-                    content={testimonial.fullTestimonialMarkdown!}
-                    textStyle="quote"
-                  />
+                  <ChakraMarkdown>
+                    {testimonial.fullTestimonialMarkdown!}
+                  </ChakraMarkdown>
                   <Text>{testimonial.whoDunnit}</Text>
                 </Card.Body>
               </Card.Root>

--- a/next-frontend/src/app/(wca)/privacy/page.tsx
+++ b/next-frontend/src/app/(wca)/privacy/page.tsx
@@ -30,11 +30,11 @@ export default async function Privacy() {
     <Container bg="bg">
       <VStack gap="8" width="full" pt="8" alignItems="left">
         <Heading size="5xl">WCA Privacy Statement</Heading>
-        <ChakraMarkdown>{privacyPage.preambleMarkdown!}</ChakraMarkdown>
+        <ChakraMarkdown>{privacyPage.preambleMarkdown}</ChakraMarkdown>
         {privacyItems.map((item) => (
           <Box key={item.id}>
             <Heading size="xl">{item.title}</Heading>
-            <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
+            <ChakraMarkdown>{item.contentMarkdown}</ChakraMarkdown>
           </Box>
         ))}
       </VStack>

--- a/next-frontend/src/app/(wca)/privacy/page.tsx
+++ b/next-frontend/src/app/(wca)/privacy/page.tsx
@@ -1,7 +1,7 @@
 import { getPayload } from "payload";
 import config from "@payload-config";
 import { Container, Heading, VStack, Box } from "@chakra-ui/react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import { Metadata } from "next";
 import { getT } from "@/lib/i18n/get18n";
 
@@ -30,11 +30,11 @@ export default async function Privacy() {
     <Container bg="bg">
       <VStack gap="8" width="full" pt="8" alignItems="left">
         <Heading size="5xl">WCA Privacy Statement</Heading>
-        <MarkdownProse content={privacyPage.preambleMarkdown!} />
+        <ChakraMarkdown>{privacyPage.preambleMarkdown!}</ChakraMarkdown>
         {privacyItems.map((item) => (
           <Box key={item.id}>
             <Heading size="xl">{item.title}</Heading>
-            <MarkdownProse content={item.contentMarkdown!} />
+            <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
           </Box>
         ))}
       </VStack>

--- a/next-frontend/src/app/(wca)/regulations/about/page.tsx
+++ b/next-frontend/src/app/(wca)/regulations/about/page.tsx
@@ -38,7 +38,9 @@ export default async function AboutTheRegulations() {
           <Card.Root key={item.id}>
             <Card.Body>
               <Card.Title>{item.title}</Card.Title>
-              <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
+              <ChakraMarkdown paragraphAs={Card.Description}>
+                {item.contentMarkdown}
+              </ChakraMarkdown>
             </Card.Body>
           </Card.Root>
         ))}

--- a/next-frontend/src/app/(wca)/regulations/about/page.tsx
+++ b/next-frontend/src/app/(wca)/regulations/about/page.tsx
@@ -1,9 +1,9 @@
 "use server";
 
-import { Container, Heading, VStack, Card, Text } from "@chakra-ui/react";
+import { Container, Heading, VStack, Card } from "@chakra-ui/react";
 import { getPayload } from "payload";
 import config from "@payload-config";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import { getT } from "@/lib/i18n/get18n";
 import { Metadata } from "next";
 
@@ -38,13 +38,7 @@ export default async function AboutTheRegulations() {
           <Card.Root key={item.id}>
             <Card.Body>
               <Card.Title>{item.title}</Card.Title>
-              <Card.Description>
-                <MarkdownProse
-                  key={item.id}
-                  content={item.contentMarkdown!}
-                  as={Text}
-                />
-              </Card.Description>
+              <ChakraMarkdown>{item.contentMarkdown!}</ChakraMarkdown>
             </Card.Body>
           </Card.Root>
         ))}

--- a/next-frontend/src/app/(wca)/speedcubing-history/page.tsx
+++ b/next-frontend/src/app/(wca)/speedcubing-history/page.tsx
@@ -13,7 +13,7 @@ import Quote from "@/components/Quote";
 import { getPayload } from "payload";
 import config from "@payload-config";
 import { Media } from "@/types/payload";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import { getT } from "@/lib/i18n/get18n";
 import { Metadata } from "next";
 
@@ -57,11 +57,9 @@ export default async function SpeedcubingHistory() {
             }
             case "paragraph": {
               return (
-                <MarkdownProse
-                  key={item.id}
-                  content={item.contentMarkdown!}
-                  as={Text}
-                />
+                <ChakraMarkdown key={item.id}>
+                  {item.contentMarkdown!}
+                </ChakraMarkdown>
               );
             }
             case "captionedImage": {

--- a/next-frontend/src/components/AnnouncementsCard.tsx
+++ b/next-frontend/src/components/AnnouncementsCard.tsx
@@ -1,5 +1,5 @@
-import { Text, Accordion } from "@chakra-ui/react";
-import { MarkdownProse } from "@/components/Markdown";
+import { Accordion } from "@chakra-ui/react";
+import { ChakraMarkdown } from "@/components/Markdown";
 import { Announcement, User } from "@/types/payload";
 
 function AnnouncementItem({ announcement }: { announcement: Announcement }) {
@@ -12,14 +12,10 @@ function AnnouncementItem({ announcement }: { announcement: Announcement }) {
         {announcement.title}
       </Accordion.ItemTrigger>
       <Accordion.ItemContent>
-        <Text textStyle="s2">
+        <Accordion.ItemBody textStyle="s2">
           Posted by {publishedByUser.name} · {announcement.publishedAt}
-        </Text>
-        <MarkdownProse
-          as={Accordion.ItemBody}
-          content={announcement.contentMarkdown!}
-          textStyle="body"
-        />
+        </Accordion.ItemBody>
+        <ChakraMarkdown>{announcement.contentMarkdown!}</ChakraMarkdown>
       </Accordion.ItemContent>
     </Accordion.Item>
   );

--- a/next-frontend/src/components/AnnouncementsCard.tsx
+++ b/next-frontend/src/components/AnnouncementsCard.tsx
@@ -15,7 +15,9 @@ function AnnouncementItem({ announcement }: { announcement: Announcement }) {
         <Accordion.ItemBody textStyle="s2">
           Posted by {publishedByUser.name} · {announcement.publishedAt}
         </Accordion.ItemBody>
-        <ChakraMarkdown>{announcement.contentMarkdown!}</ChakraMarkdown>
+        <ChakraMarkdown paragraphAs={Accordion.ItemBody} textStyle="body">
+          {announcement.contentMarkdown}
+        </ChakraMarkdown>
       </Accordion.ItemContent>
     </Accordion.Item>
   );

--- a/next-frontend/src/components/Markdown.tsx
+++ b/next-frontend/src/components/Markdown.tsx
@@ -1,14 +1,25 @@
 import { Prose } from "@/components/ui/prose";
 import Markdown from "react-markdown";
-import { Link as ChakraLink, Image as ChakraImage } from "@chakra-ui/react";
+import {
+  Link as ChakraLink,
+  Image as ChakraImage,
+  Em,
+  Separator,
+  Code,
+  List,
+  Blockquote,
+  Text,
+  Heading,
+} from "@chakra-ui/react";
 
 import type { PolymorphicComponent } from "@/lib/types/components";
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, ComponentType } from "react";
 
 type MarkdownProseOwnProps = {
   content: string;
   linkProps?: ComponentPropsWithoutRef<typeof ChakraLink>;
   imageProps?: ComponentPropsWithoutRef<typeof ChakraImage>;
+  headingAs?: ComponentType;
 };
 
 export const MarkdownProse: PolymorphicComponent<
@@ -18,6 +29,7 @@ export const MarkdownProse: PolymorphicComponent<
   content,
   linkProps = {},
   imageProps = {},
+  headingAs: HeadingRenderAs = Heading,
   as: RenderAs = Prose,
   ...restProps
 }) => {
@@ -36,6 +48,24 @@ export const MarkdownProse: PolymorphicComponent<
             </ChakraLink>
           ),
           img: (imgTag) => <ChakraImage {...imgTag} {...imageProps} />,
+          h1: (h1Tag) => <HeadingRenderAs {...h1Tag} as="h1" />,
+          h2: (h2Tag) => <HeadingRenderAs {...h2Tag} as="h2" />,
+          h3: (h3Tag) => <HeadingRenderAs {...h3Tag} as="h3" />,
+          h4: (h4Tag) => <HeadingRenderAs {...h4Tag} as="h4" />,
+          h5: (h5Tag) => <HeadingRenderAs {...h5Tag} as="h5" />,
+          h6: (h6Tag) => <HeadingRenderAs {...h6Tag} as="h6" />,
+          p: Text,
+          em: Em,
+          hr: Separator,
+          code: Code,
+          ul: (ulTag) => <List.Root {...ulTag} as="ul" />,
+          ol: (olTag) => <List.Root {...olTag} as="ol" />,
+          li: List.Item,
+          blockquote: (blockquoteTag) => (
+            <Blockquote.Root>
+              <Blockquote.Content {...blockquoteTag} />
+            </Blockquote.Root>
+          ),
         }}
       >
         {content}

--- a/next-frontend/src/components/Markdown.tsx
+++ b/next-frontend/src/components/Markdown.tsx
@@ -1,4 +1,3 @@
-import { Prose } from "@/components/ui/prose";
 import Markdown from "react-markdown";
 import {
   Link as ChakraLink,
@@ -12,64 +11,60 @@ import {
   Heading,
 } from "@chakra-ui/react";
 
-import type { PolymorphicComponent } from "@/lib/types/components";
-import type { ComponentPropsWithoutRef, ComponentType } from "react";
+import type {
+  ComponentPropsWithoutRef,
+  ComponentType,
+  ElementType,
+} from "react";
 
 type MarkdownProseOwnProps = {
-  content: string;
+  children: string;
   linkProps?: ComponentPropsWithoutRef<typeof ChakraLink>;
   imageProps?: ComponentPropsWithoutRef<typeof ChakraImage>;
-  headingAs?: ComponentType;
+  headingAs?: ComponentType<{ as: ElementType | undefined }>;
 };
 
-export const MarkdownProse: PolymorphicComponent<
-  MarkdownProseOwnProps,
-  typeof Prose
-> = ({
-  content,
+export const ChakraMarkdown = ({
+  children,
   linkProps = {},
   imageProps = {},
   headingAs: HeadingRenderAs = Heading,
-  as: RenderAs = Prose,
-  ...restProps
-}) => {
+}: MarkdownProseOwnProps) => {
   return (
-    <RenderAs {...restProps}>
-      <Markdown
-        components={{
-          a: ({ children, ...aTag }) => (
-            <ChakraLink
-              {...aTag}
-              {...linkProps}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {children}
-            </ChakraLink>
-          ),
-          img: (imgTag) => <ChakraImage {...imgTag} {...imageProps} />,
-          h1: (h1Tag) => <HeadingRenderAs {...h1Tag} as="h1" />,
-          h2: (h2Tag) => <HeadingRenderAs {...h2Tag} as="h2" />,
-          h3: (h3Tag) => <HeadingRenderAs {...h3Tag} as="h3" />,
-          h4: (h4Tag) => <HeadingRenderAs {...h4Tag} as="h4" />,
-          h5: (h5Tag) => <HeadingRenderAs {...h5Tag} as="h5" />,
-          h6: (h6Tag) => <HeadingRenderAs {...h6Tag} as="h6" />,
-          p: Text,
-          em: Em,
-          hr: Separator,
-          code: Code,
-          ul: (ulTag) => <List.Root {...ulTag} as="ul" />,
-          ol: (olTag) => <List.Root {...olTag} as="ol" />,
-          li: List.Item,
-          blockquote: (blockquoteTag) => (
-            <Blockquote.Root>
-              <Blockquote.Content {...blockquoteTag} />
-            </Blockquote.Root>
-          ),
-        }}
-      >
-        {content}
-      </Markdown>
-    </RenderAs>
+    <Markdown
+      components={{
+        a: ({ children, ...aTag }) => (
+          <ChakraLink
+            {...aTag}
+            {...linkProps}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {children}
+          </ChakraLink>
+        ),
+        img: (imgTag) => <ChakraImage {...imgTag} {...imageProps} />,
+        h1: (h1Tag) => <HeadingRenderAs {...h1Tag} as="h1" />,
+        h2: (h2Tag) => <HeadingRenderAs {...h2Tag} as="h2" />,
+        h3: (h3Tag) => <HeadingRenderAs {...h3Tag} as="h3" />,
+        h4: (h4Tag) => <HeadingRenderAs {...h4Tag} as="h4" />,
+        h5: (h5Tag) => <HeadingRenderAs {...h5Tag} as="h5" />,
+        h6: (h6Tag) => <HeadingRenderAs {...h6Tag} as="h6" />,
+        p: Text,
+        em: Em,
+        hr: Separator,
+        code: Code,
+        ul: (ulTag) => <List.Root {...ulTag} as="ul" />,
+        ol: (olTag) => <List.Root {...olTag} as="ol" />,
+        li: List.Item,
+        blockquote: (blockquoteTag) => (
+          <Blockquote.Root>
+            <Blockquote.Content {...blockquoteTag} />
+          </Blockquote.Root>
+        ),
+      }}
+    >
+      {children}
+    </Markdown>
   );
 };

--- a/next-frontend/src/components/Markdown.tsx
+++ b/next-frontend/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import Markdown, { Options } from "react-markdown";
 import {
   Link as ChakraLink,
   Image as ChakraImage,
@@ -12,24 +12,41 @@ import {
 } from "@chakra-ui/react";
 
 import type {
+  ComponentProps,
   ComponentPropsWithoutRef,
   ComponentType,
   ElementType,
 } from "react";
 
-type MarkdownProseOwnProps = {
-  children: string;
+type DefaultParagraph = typeof Text;
+type ParagraphElement = ElementType<ComponentProps<"p">>;
+
+type MarkdownBaseProps = {
+  children: Options["children"];
   linkProps?: ComponentPropsWithoutRef<typeof ChakraLink>;
   imageProps?: ComponentPropsWithoutRef<typeof ChakraImage>;
-  headingAs?: ComponentType<{ as: ElementType | undefined }>;
+  headingAs?: ComponentType<{ as?: ElementType }>;
 };
 
-export const ChakraMarkdown = ({
+type MarkdownDynamicProps<T extends ElementType> = MarkdownBaseProps & {
+  paragraphAs?: T;
+} & Omit<ComponentPropsWithoutRef<T>, keyof MarkdownBaseProps | "paragraphAs">;
+
+export type ChakraMarkdownComponent = <
+  E extends ParagraphElement = ParagraphElement,
+  T extends E = DefaultParagraph extends E ? DefaultParagraph : E,
+>(
+  props: MarkdownDynamicProps<T>,
+) => ReturnType<typeof Markdown>;
+
+export const ChakraMarkdown: ChakraMarkdownComponent = ({
   children,
   linkProps = {},
   imageProps = {},
   headingAs: HeadingRenderAs = Heading,
-}: MarkdownProseOwnProps) => {
+  paragraphAs: ParagraphRenderAs = Text,
+  ...paragraphProps
+}) => {
   return (
     <Markdown
       components={{
@@ -50,7 +67,7 @@ export const ChakraMarkdown = ({
         h4: (h4Tag) => <HeadingRenderAs {...h4Tag} as="h4" />,
         h5: (h5Tag) => <HeadingRenderAs {...h5Tag} as="h5" />,
         h6: (h6Tag) => <HeadingRenderAs {...h6Tag} as="h6" />,
-        p: Text,
+        p: (pTag) => <ParagraphRenderAs {...pTag} {...paragraphProps} />,
         em: Em,
         hr: Separator,
         code: Code,

--- a/next-frontend/src/components/Quote.tsx
+++ b/next-frontend/src/components/Quote.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Blockquote } from "@chakra-ui/react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 
 export default function Quote({
   content,
@@ -13,7 +13,7 @@ export default function Quote({
   return (
     <Blockquote.Root>
       <Blockquote.Content cite={author}>
-        <MarkdownProse content={content} />
+        <ChakraMarkdown>{content}</ChakraMarkdown>
       </Blockquote.Content>
       <Blockquote.Caption>
         — <cite>{author}</cite>

--- a/next-frontend/src/components/about/AboutUsItem.tsx
+++ b/next-frontend/src/components/about/AboutUsItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Image as ChakraImage, Stack } from "@chakra-ui/react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import type { Media } from "@/types/payload";
 import Image from "next/image";
 
@@ -22,7 +22,7 @@ export default function AboutUsItem({
     >
       <Stack direction="column">
         <Heading size="lg">{title}</Heading>
-        <MarkdownProse content={contentMarkdown} />
+        <ChakraMarkdown>{contentMarkdown}</ChakraMarkdown>
       </Stack>
 
       {image?.url && (

--- a/next-frontend/src/components/about/CallToAction.tsx
+++ b/next-frontend/src/components/about/CallToAction.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
 } from "@chakra-ui/react";
 import React from "react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 
 type CallToActionBlockProps = {
   content: string;
@@ -33,7 +33,7 @@ export function CallToActionBlock({
     >
       <Stack direction="column">
         <Box color="gray.700" fontSize="lg">
-          <MarkdownProse content={content} />
+          <ChakraMarkdown>{content}</ChakraMarkdown>
         </Box>
 
         <Stack direction={{ base: "column", sm: "row" }}>

--- a/next-frontend/src/components/competitions/Cards.tsx
+++ b/next-frontend/src/components/competitions/Cards.tsx
@@ -23,7 +23,7 @@ import SpectatorsIcon from "@/components/icons/SpectatorsIcon";
 import OnTheSpotRegistrationIcon from "@/components/icons/OnTheSpotRegistrationIcon";
 import CompRegoCloseDateIcon from "@/components/icons/CompRegoCloseDateIcon";
 import EventIcon from "@/components/EventIcon";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import VenueIcon from "@/components/icons/VenueIcon";
 import MapIcon from "@/components/icons/MapIcon";
 import DetailsIcon from "@/components/icons/DetailsIcon";
@@ -87,10 +87,9 @@ export function VenueDetailsCard({
               <VenueIcon />
               Venue
             </Stat.Label>
-            <MarkdownProse
-              as={Stat.ValueText}
-              content={competitionInfo.venue}
-            />
+            <Stat.ValueText>
+              <ChakraMarkdown>{competitionInfo.venue}</ChakraMarkdown>
+            </Stat.ValueText>
           </Stat.Root>
 
           <Stat.Root variant="competition">
@@ -107,10 +106,9 @@ export function VenueDetailsCard({
                 <DetailsIcon />
                 Details
               </Stat.Label>
-              <MarkdownProse
-                as={Stat.ValueText}
-                content={competitionInfo.venue_details}
-              />
+              <Stat.ValueText>
+                <ChakraMarkdown>{competitionInfo.venue_details}</ChakraMarkdown>
+              </Stat.ValueText>
             </Stat.Root>
           )}
         </SimpleGrid>
@@ -128,12 +126,11 @@ export function AdditionalInformationCard({
     <Card.Root>
       <Card.Body>
         <Card.Title textStyle="s4">Information</Card.Title>
-        <MarkdownProse
-          as={Card.Description}
-          content={competitionInfo.information}
-          imageProps={{ maxW: "sm" }}
-          textStyle="body"
-        />
+        <Card.Description>
+          <ChakraMarkdown imageProps={{ maxW: "sm" }}>
+            {competitionInfo.information}
+          </ChakraMarkdown>
+        </Card.Description>
       </Card.Body>
     </Card.Root>
   );

--- a/next-frontend/src/components/competitions/Cards.tsx
+++ b/next-frontend/src/components/competitions/Cards.tsx
@@ -87,9 +87,9 @@ export function VenueDetailsCard({
               <VenueIcon />
               Venue
             </Stat.Label>
-            <Stat.ValueText>
-              <ChakraMarkdown>{competitionInfo.venue}</ChakraMarkdown>
-            </Stat.ValueText>
+            <ChakraMarkdown paragraphAs={Stat.ValueText}>
+              {competitionInfo.venue}
+            </ChakraMarkdown>
           </Stat.Root>
 
           <Stat.Root variant="competition">
@@ -106,9 +106,9 @@ export function VenueDetailsCard({
                 <DetailsIcon />
                 Details
               </Stat.Label>
-              <Stat.ValueText>
-                <ChakraMarkdown>{competitionInfo.venue_details}</ChakraMarkdown>
-              </Stat.ValueText>
+              <ChakraMarkdown paragraphAs={Stat.ValueText}>
+                {competitionInfo.venue_details}
+              </ChakraMarkdown>
             </Stat.Root>
           )}
         </SimpleGrid>
@@ -126,11 +126,13 @@ export function AdditionalInformationCard({
     <Card.Root>
       <Card.Body>
         <Card.Title textStyle="s4">Information</Card.Title>
-        <Card.Description>
-          <ChakraMarkdown imageProps={{ maxW: "sm" }}>
-            {competitionInfo.information}
-          </ChakraMarkdown>
-        </Card.Description>
+        <ChakraMarkdown
+          paragraphAs={Card.Description}
+          imageProps={{ maxW: "sm" }}
+          textStyle="body"
+        >
+          {competitionInfo.information}
+        </ChakraMarkdown>
       </Card.Body>
     </Card.Root>
   );

--- a/next-frontend/src/components/competitions/OrganizerCard.tsx
+++ b/next-frontend/src/components/competitions/OrganizerCard.tsx
@@ -11,7 +11,7 @@ import {
   Stat,
 } from "@chakra-ui/react";
 import { Link as ChakraLink } from "@chakra-ui/react";
-import { MarkdownProse } from "@/components/Markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
 import WcaDocsIcon from "@/components/icons/WcaDocsIcon";
 import { LuChevronLeft, LuChevronRight } from "react-icons/lu";
 
@@ -89,10 +89,9 @@ export default function OrganizationTeamCard({
         {competitionInfo.contact && (
           <Stat.Root variant="competition">
             <Stat.Label>Contact</Stat.Label>
-            <MarkdownProse
-              as={Stat.ValueText}
-              content={competitionInfo.contact}
-            />
+            <Stat.ValueText>
+              <ChakraMarkdown>{competitionInfo.contact}</ChakraMarkdown>
+            </Stat.ValueText>
           </Stat.Root>
         )}
 

--- a/next-frontend/src/components/competitions/OrganizerCard.tsx
+++ b/next-frontend/src/components/competitions/OrganizerCard.tsx
@@ -89,9 +89,9 @@ export default function OrganizationTeamCard({
         {competitionInfo.contact && (
           <Stat.Root variant="competition">
             <Stat.Label>Contact</Stat.Label>
-            <Stat.ValueText>
-              <ChakraMarkdown>{competitionInfo.contact}</ChakraMarkdown>
-            </Stat.ValueText>
+            <ChakraMarkdown paragraphAs={Stat.ValueText}>
+              {competitionInfo.contact}
+            </ChakraMarkdown>
           </Stat.Root>
         )}
 


### PR DESCRIPTION
The previous implementation used Chakra `Prose` to basically "fake" styling of native HTML components to look like Chakra.

The main innovation of this PR lives at `src/components/Markdown.tsx`. As you will see, it now maps relevant Markdown tags to actual, properly styled Chakra components.

It also gives the opportunity to override some of the components if you want. For example, when rendering Markdown in the body of a Chakra `Card`, you may want to render the main text as `Card.Description`.

The previous implementation had a conceptual flaw, because it was built on the assumption that a rendered Markdown always resolves to **exactly one** DOM node, so it wrapped the rendering result _into_ `Card.Description`. However, this assumption is wrong: Add two line breaks to start a new paragraph in your Markdown, and the rendered result will be **two** `p` nodes.
Wrapping these two `p` nodes inside a `Card.Description` (which is in itself a `p` node) also caused a lot of warnings in the NextJS console. These should now be fixed, as the new PR makes it so that every respective `p` of the Markdown is rendered as its own `Card.Description` now.

Before: (technically invalid / non-compliant HTML)
```jsx
<Card.Root>
  <Card.Title>This is the title of the post that WCT entered in Payload</Card.Title>
  <Card.Description>{/* <--- This will turn out to be a `<p>` tag in itself!*/}
    <p>Here is a paragraph of the rendered Markdown</p>
    <p>Oh wait, but there's more! WCT decided to add another paragraph in Markdown</p>
  <Card.Description>
</Card.Root>
```

After:
```jsx
<Card.Root>
  <Card.Title>This is the title of the post that WCT entered in Payload</Card.Title>
  <Card.Description>Here is a paragraph of the rendered Markdown</Card.Description>
  <Card.Description>Oh wait, but there's more! WCT decided to add another paragraph in Markdown</Card.Description>
</Card.Root>
```

Sidenote: Yes, it is valid for Chakra cards to have multiple `Description`s. It will simply be rendered as two visually distinct paragraphs in the same card body.