### PR TITLE
[redesign] Set borderColor="border" on header and footer

### DIFF
--- a/next-frontend/src/app/(wca)/footer.tsx
+++ b/next-frontend/src/app/(wca)/footer.tsx
@@ -58,7 +58,7 @@ export default async function Footer() {
   const legalLinks = footer.legalLinks ?? [];
 
   return (
-    <Center borderTop="md" padding={3} mt={5} bg="bg">
+    <Center borderTop="md" borderColor="border" padding={3} mt={5} bg="bg">
       <Stack align="center" gap={5} direction={{ base: "column", lg: "row" }}>
         {navigationLinks.map((item) => (
           <FooterLink key={item.id} item={item} />

--- a/next-frontend/src/app/(wca)/navbar.tsx
+++ b/next-frontend/src/app/(wca)/navbar.tsx
@@ -68,7 +68,12 @@ export default async function Navbar() {
   const showEmptyMessage = !LIVE_RESULT_BETA && navbarEntries.length === 0;
 
   return (
-    <Box borderBottom="md" bg="bg" data-testid="header-navbar">
+    <Box
+      borderBottom="md"
+      borderColor="border"
+      bg="bg"
+      data-testid="header-navbar"
+    >
       <RefreshRouteOnSave />
       <Collapsible.Root>
         <HStack padding="3" justifyContent="space-between">


### PR DESCRIPTION
Sets `borderColor="border"` on the bottom border of the nav and the top border of the footer to the `border` color, which is a much lighter and less intrusive that also matches our brand guidelines better.

# Comparison

(ignore font differences; I don't have the correct font installed on my local)

## Header before/after:

<img width="1229" height="150" alt="image" src="https://github.com/user-attachments/assets/e21c7d62-c5c1-46ac-b15a-8455946b4f05" />

<img width="1238" height="287" alt="image" src="https://github.com/user-attachments/assets/432a2fb2-7922-440e-bac8-081b4a5a08c2" />


## Footer before/after

(for some reason my local doesn't have footer content?)

<img width="1874" height="203" alt="image" src="https://github.com/user-attachments/assets/b4afef54-d6b9-4ee9-b850-a4dd720d54d9" />

<img width="1213" height="130" alt="image" src="https://github.com/user-attachments/assets/58e66988-e36e-41cb-a43a-b8ef6dc6c521" />

