### PR TITLE
Catch HTML errors in fetchJsonOrError

### DIFF
--- a/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
+++ b/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
@@ -20,5 +20,8 @@ export function fetchJsonOrError(url, fetchOptions = {}) {
           throw new FetchJsonError(`${response.status}: ${response.statusText}\n${json.error}`, response, json);
         }
         return { data: json, headers: response.headers };
+      }).catch((err) => {
+        if (err instanceof FetchJsonError) throw err;
+        throw new FetchJsonError(`${response.status}: ${response.statusText}\nPlease Report this to WST\nRequestId: ${response.headers.get("x-request-id")}`, response, { status: "An unexpected error occurred." });
       }));
 }

--- a/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
+++ b/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
@@ -14,14 +14,16 @@ export function fetchWithAuthenticityToken(url, fetchOptions) {
 
 export function fetchJsonOrError(url, fetchOptions = {}) {
   return fetchWithAuthenticityToken(url, fetchOptions)
-    .then((response) => response.json()
-      .then((json) => {
+    .then((response) => {
+      const contentType = response.headers.get('content-type');
+      if (!contentType || !contentType.includes('application/json')) {
+        throw new FetchJsonError(`${response.status}: ${response.statusText}\nPlease Report this to WST\nRequestId: ${response.headers.get('x-request-id')}`, response, { status: 'An unexpected error occurred.' });
+      }
+      return response.json().then((json) => {
         if (!response.ok) {
           throw new FetchJsonError(`${response.status}: ${response.statusText}\n${json.error}`, response, json);
         }
         return { data: json, headers: response.headers };
-      }).catch((err) => {
-        if (err instanceof FetchJsonError) throw err;
-        throw new FetchJsonError(`${response.status}: ${response.statusText}\nPlease Report this to WST\nRequestId: ${response.headers.get("x-request-id")}`, response, { status: 'An unexpected error occurred.' });
-      }));
+      });
+    });
 }

--- a/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
+++ b/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
@@ -16,7 +16,8 @@ export function fetchJsonOrError(url, fetchOptions = {}) {
   return fetchWithAuthenticityToken(url, fetchOptions)
     .then((response) => {
       const contentType = response.headers.get('content-type');
-      if (!contentType || !contentType.includes('application/json')) {
+      // The content type might include its charset in the header
+      if (!contentType?.startsWith('application/json')) {
         throw new FetchJsonError(`${response.status}: ${response.statusText}\nPlease Report this to WST\nRequestId: ${response.headers.get('x-request-id')}`, response, { status: 'An unexpected error occurred.' });
       }
       return response.json().then((json) => {

--- a/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
+++ b/app/webpacker/lib/requests/fetchWithAuthenticityToken.js
@@ -22,6 +22,6 @@ export function fetchJsonOrError(url, fetchOptions = {}) {
         return { data: json, headers: response.headers };
       }).catch((err) => {
         if (err instanceof FetchJsonError) throw err;
-        throw new FetchJsonError(`${response.status}: ${response.statusText}\nPlease Report this to WST\nRequestId: ${response.headers.get("x-request-id")}`, response, { status: "An unexpected error occurred." });
+        throw new FetchJsonError(`${response.status}: ${response.statusText}\nPlease Report this to WST\nRequestId: ${response.headers.get("x-request-id")}`, response, { status: 'An unexpected error occurred.' });
       }));
 }


### PR DESCRIPTION
I tried to use the `500_contact_html: "<a href=%{contact_url}>Click here</a> to report it."` string, but you can't have URLs in alerts, so this will have to do