### PR TITLE
Add Validation for round after linked rounds having participation source as the linked round

### DIFF
--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -80,21 +80,7 @@ class Round < ApplicationRecord
   validates :advancement_condition, presence: { if: :advancement_condition_changed?, unless: :final_round?, message: "cannot be un-set on a non-final round" }, on: :update
   validates :advancement_condition, absence: { if: :final_round?, message: "cannot be set on a final round" }
 
-  validate :participation_source_respects_linked_rounds
-  private def participation_source_respects_linked_rounds
-    return if number == 1
-    return if linked_round.present?
-    return if participation_source.blank?
-
-    previous_round = competition_event.rounds.find_by(number: number - 1)
-
-    prev_linked_round = previous_round.linked_round
-    return if prev_linked_round.blank?
-
-    return if participation_source == prev_linked_round
-
-    errors.add(:participation_source, "must be the linked round group when the previous rounds are linked")
-  end
+  validates :participation_source_type, comparison: { equal_to: LinkedRound.model_name, if: :participation_source_linked? }
 
   after_save :reset_linked_round_information, if: :linked_round_previously_changed?
   private def reset_linked_round_information
@@ -158,6 +144,14 @@ class Round < ApplicationRecord
 
   def final_round?
     number == total_number_of_rounds
+  end
+
+  def linked_round?
+    self.linked_round.present?
+  end
+
+  def participation_source_linked?
+    self.participation_source&.try(:linked_round?)
   end
 
   def name

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -80,7 +80,7 @@ class Round < ApplicationRecord
   validates :advancement_condition, presence: { if: :advancement_condition_changed?, unless: :final_round?, message: "cannot be un-set on a non-final round" }, on: :update
   validates :advancement_condition, absence: { if: :final_round?, message: "cannot be set on a final round" }
 
-  validates :participation_source_type, comparison: { equal_to: LinkedRound.model_name, if: :participation_source_linked? }
+  validates :participation_source_type, comparison: { equal_to: LinkedRound.model_name, if: :participation_source_linked?, message: "must be the linked round group when the previous rounds are linked" }
 
   after_save :reset_linked_round_information, if: :linked_round_previously_changed?
   private def reset_linked_round_information

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -80,6 +80,22 @@ class Round < ApplicationRecord
   validates :advancement_condition, presence: { if: :advancement_condition_changed?, unless: :final_round?, message: "cannot be un-set on a non-final round" }, on: :update
   validates :advancement_condition, absence: { if: :final_round?, message: "cannot be set on a final round" }
 
+  validate :participation_source_respects_linked_rounds
+  private def participation_source_respects_linked_rounds
+    return if number == 1
+    return if linked_round.present?
+    return if participation_source.blank?
+
+    previous_round = competition_event.rounds.find_by(number: number - 1)
+
+    prev_linked_round = previous_round.linked_round
+    return if prev_linked_round.blank?
+
+    return if participation_source == prev_linked_round
+
+    errors.add(:participation_source, "must be the linked round group when the previous rounds are linked")
+  end
+
   after_save :reset_linked_round_information, if: :linked_round_previously_changed?
   private def reset_linked_round_information
     self.linked_round&.reset_round_information

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -1180,7 +1180,10 @@ RSpec.describe "Competition WCIF" do
         linked_round = create(:linked_round)
 
         round333_1.update!(linked_round: linked_round)
-        round333_2.update!(linked_round: linked_round)
+        # Previously, 333 used to be a "classic" R1 -> R2 -> R3 setup. Now that R1 and R2 are getting linked,
+        # R2 cannot point to "only" R1 anymore. Instead, it has to source from the same place as R1,
+        # to keep Linked Rounds state consistent.
+        round333_2.update!(linked_round: linked_round, participation_source: round333_1.participation_source)
 
         expect(competition.to_wcif(version: wcif_version)["events"]).not_to eq(wcif_unlinked)
 

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Round do
 
     it "is invalid when referencing a plain round instead of the linked round group" do
       round3.participation_source = round2
-      expect(round3).to be_invalid_with_errors(participation_source_type: ["must be equal to LinkedRound"])
+      expect(round3).to be_invalid_with_errors(participation_source_type: ["must be the linked round group when the previous rounds are linked"])
     end
 
     it "is valid when the previous rounds are not linked" do

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -165,6 +165,30 @@ RSpec.describe Round do
       end
     end
   end
+
+  context "participation_source with previous rounds linked" do
+    let(:competition) { create(:competition, event_ids: %w[333]) }
+    let!(:linked) { create(:linked_round) }
+    let!(:round1) { create(:round, number: 1, total_number_of_rounds: 3, competition: competition, linked_round: linked) }
+    let!(:round2) { create(:round, number: 2, total_number_of_rounds: 3, competition: competition, linked_round: linked, participation_source: round1.competition_event) }
+    let!(:round3) { create(:round, number: 3, total_number_of_rounds: 3, competition: competition, participation_source: linked) }
+
+    it "is valid when referencing the linked round group" do
+      expect(round3).to be_valid
+    end
+
+    it "is invalid when referencing a plain round instead of the linked round group" do
+      round3.participation_source = round2
+      expect(round3).to be_invalid_with_errors(participation_source: ["must be the linked round group when the previous rounds are linked"])
+    end
+
+    it "is valid when the previous rounds are not linked" do
+      round1.update!(linked_round: nil)
+      round2.update!(linked_round: nil)
+      round3.participation_source = round2
+      expect(round3).to be_valid
+    end
+  end
 end
 
 def create_rounds(event_id, count:, format_id: 'a')

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Round do
 
     it "is invalid when referencing a plain round instead of the linked round group" do
       round3.participation_source = round2
-      expect(round3).to be_invalid_with_errors(participation_source: ["must be the linked round group when the previous rounds are linked"])
+      expect(round3).to be_invalid_with_errors(participation_source_type: ["must be equal to LinkedRound"])
     end
 
     it "is valid when the previous rounds are not linked" do


### PR DESCRIPTION
I haven't 100% figured out why this happened for that Utah competition though.

LLM thinks it is here in competition_event.rb line 159
```
    new_rounds = wcif["rounds"].zip(model_rounds).map do |round_wcif, round|
      if at_least_v2
        # Linked Round already needs to be present for computing the backlinking below
        round.linked_round = Round.compute_linked_round(round_wcif, round, model_rounds)
      end

      round.update!(**Round.backport_participation_ruleset(round, model_rounds))
      round
    end
```
which should be
```
if at_least_v2
  # Linked Round already needs to be present for computing the backlinking below.
  # Crucially, we must persist the LinkedRound *before* assigning it: assigning an unsaved
  # record to a belongs_to sets the FK to nil (the new record has no ID yet), which then
  # gets persisted by the update! call below (save! writes all dirty attributes, not just
  # the ones in the hash), silently clearing any existing linked_round relationship.
  linked_round = Round.compute_linked_round(round_wcif, round, model_rounds)
  linked_round.save! if linked_round&.new_record?
  round.linked_round = linked_round
end
```

I am a bit more skeptical though as I am not sure if that would cause the bug we saw