### PR TITLE
Reduce Container padding from 4 to 3

### DIFF
--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -19,7 +19,6 @@ import {
   AbsoluteCenter,
   Float,
   Carousel,
-  Container,
 } from "@chakra-ui/react";
 import { ChakraMarkdown } from "@/components/Markdown";
 import AnnouncementsCard from "@/components/AnnouncementsCard";
@@ -406,5 +405,9 @@ export default async function Homepage() {
     );
   }
 
-  return <Container asChild>{renderVerticalLayout(homepageEntries)}</Container>;
+  return (
+    <Box p={{ base: "3", md: "8" }} asChild>
+      {renderVerticalLayout(homepageEntries)}
+    </Box>
+  );
 }

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -418,7 +418,7 @@ export default async function Homepage() {
   }
 
   return (
-    <Box p={{ base: "3", md: "8" }} asChild>
+    <Box p={{ base: "3.5", md: "8" }} asChild>
       {renderVerticalLayout(homepageEntries)}
     </Box>
   );

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -19,6 +19,7 @@ import {
   AbsoluteCenter,
   Float,
   Carousel,
+  Container,
 } from "@chakra-ui/react";
 import { ChakraMarkdown } from "@/components/Markdown";
 import AnnouncementsCard from "@/components/AnnouncementsCard";
@@ -405,9 +406,5 @@ export default async function Homepage() {
     );
   }
 
-  return (
-    <Box p={8} asChild>
-      {renderVerticalLayout(homepageEntries)}
-    </Box>
-  );
+  return <Container asChild>{renderVerticalLayout(homepageEntries)}</Container>;
 }

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -418,7 +418,7 @@ export default async function Homepage() {
   }
 
   return (
-    <Box p={{ base: "3.5", md: "8" }} asChild>
+    <Box p={{ base: "3.5", md: "6", lg: "8" }} asChild>
       {renderVerticalLayout(homepageEntries)}
     </Box>
   );

--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -657,7 +657,7 @@ const customConfig = defineConfig({
     recipes: {
       container: {
         base: {
-          px: { base: "3", md: "6", lg: "8" },
+          px: { base: "3.5", md: "6", lg: "8" },
         },
       },
       link: {

--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -655,6 +655,11 @@ const customConfig = defineConfig({
       },
     },
     recipes: {
+      container: {
+        base: {
+          px: { base: "3", md: "6", lg: "8" },
+        },
+      },
       link: {
         base: {
           colorPalette: "link",


### PR DESCRIPTION
The default padding for Containers in Chakra is `px: { base: "4", md: "6", lg: "8" }`, that's equivalent to 1rem on mobile, 1.5rem on tablet, 2rem on desktop. 

This PR drops it from 4 to 3

<img width="578" height="929" alt="image" src="https://github.com/user-attachments/assets/a815b8af-12eb-4294-a67d-29fcb4674351" />

I tried 2, but it looked a little cramped:
<img width="578" height="929" alt="image" src="https://github.com/user-attachments/assets/9aadd026-fb8d-44dd-9129-1c8a17a9db19" />
