### PR TITLE
add mobile specific footer

### DIFF
--- a/next-frontend/src/app/(wca)/footer.tsx
+++ b/next-frontend/src/app/(wca)/footer.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import {
+  Box,
   Center,
+  Grid,
   HStack,
   IconButton,
   Link as ChakraLink,
-  Stack,
 } from "@chakra-ui/react";
 import { getPayload } from "payload";
 import config from "@payload-config";
@@ -35,6 +36,7 @@ function FooterLink({ item }: { item: FooterNavItem | FooterSocialItem }) {
           aria-label={item.displayText}
         >
           <IconDisplay name={item.displayIcon as IconName} />
+          <Box>{item.displayText}</Box>
         </ChakraLink>
       </IconButton>
     );
@@ -58,26 +60,75 @@ export default async function Footer() {
   const legalLinks = footer.legalLinks ?? [];
 
   return (
-    <Center borderTop="md" borderColor="border" padding={3} mt={5} bg="bg">
-      <Stack align="center" gap={5} direction={{ base: "column", lg: "row" }}>
+    <Box borderTop="md" borderColor="border" mt={5} bg="bg">
+      {/* Mobile layout */}
+      <Box hideFrom="lg">
         {navigationLinks.map((item) => (
-          <FooterLink key={item.id} item={item} />
+          <Center
+            key={item.id}
+            bg="bg.subtle"
+            py={3}
+            borderBottom="1px solid"
+            borderColor="border"
+          >
+            <FooterLink item={item} />
+          </Center>
         ))}
+        {socialLinks.map((item) => (
+          <Center
+            key={item.id}
+            bg="bg.subtle"
+            py={3}
+            borderBottom="1px solid"
+            borderColor="border"
+          >
+            <FooterLink item={item} />
+          </Center>
+        ))}
+        <Center bg="bg.subtle" py={4} flexDir="column" gap={2}>
+          <WCALogo />
+          <HStack>
+            {legalLinks.map((item) => (
+              <FooterLink key={item.id} item={item} />
+            ))}
+          </HStack>
+        </Center>
+      </Box>
 
-        <WCALogo />
+      {/* Desktop layout */}
+      <Box hideBelow="lg" padding={3}>
+        <Grid
+          templateColumns="1fr auto 1fr"
+          alignItems="center"
+          gap={5}
+          maxW="breakpoint-xl"
+          mx="auto"
+        >
+          <HStack justify="flex-end" wrap="wrap" gap={5}>
+            {navigationLinks.map((item) => (
+              <FooterLink key={item.id} item={item} />
+            ))}
+          </HStack>
 
-        <HStack wrap="wrap">
-          {socialLinks.map((item) => (
-            <FooterLink key={item.id} item={item} />
-          ))}
-        </HStack>
+          <Center>
+            <WCALogo />
+          </Center>
 
-        <HStack>
-          {legalLinks.map((item) => (
-            <FooterLink key={item.id} item={item} />
-          ))}
-        </HStack>
-      </Stack>
-    </Center>
+          <HStack justify="flex-start">
+            {socialLinks.map((item) => (
+              <FooterLink key={item.id} item={item} />
+            ))}
+          </HStack>
+        </Grid>
+
+        <Center mt={3}>
+          <HStack>
+            {legalLinks.map((item) => (
+              <FooterLink key={item.id} item={item} />
+            ))}
+          </HStack>
+        </Center>
+      </Box>
+    </Box>
   );
 }


### PR DESCRIPTION
Fixes #14444, but I need to look into the mock ups again tomorrow to see when to include the social links. Currently:
<img width="543" height="736" alt="image" src="https://github.com/user-attachments/assets/f50383f9-1c51-413f-a255-a4dbecfa3a36" />
<img width="1015" height="734" alt="image" src="https://github.com/user-attachments/assets/df5e2ea7-c8db-438b-babb-eb6f65076bdf" />
I also made the WCA Logo always in the middle, but now it looks a little silly with it being so weighted on the right with the social media links? 
<img width="1791" height="182" alt="image" src="https://github.com/user-attachments/assets/642dddb6-3eed-45ae-9558-6df387f443a7" />
