### PR TITLE
Add global_pos to results

### DIFF
--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -136,6 +136,7 @@ class LiveResult < ApplicationRecord
       competition_id: self.competition_id,
       person_id: self.registrant_id,
       pos: self.local_pos,
+      global_pos: self.global_pos,
       event_id: self.event_id,
       format_id: self.format_id,
       round_type_id: self.round_type_id,

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -257,33 +257,7 @@ class Round < ApplicationRecord
     # For non-linked rounds, global_pos was already set equal to local_pos in recompute_local_pos
     return if linked_round.blank?
 
-    rank_by = format.rank_by_column
-    secondary_rank_by = format.secondary_rank_by_column
-    round_ids = linked_round.round_ids.join(",")
-
-    # Similar to the query that recomputes local_pos, but
-    # at first it computes the best result of a person over all linked rounds
-    # by using the same ORDER BY <=0 trick
-    query = <<~SQL.squish
-      UPDATE live_results r
-      LEFT JOIN
-        (SELECT registration_id,
-                RANK() OVER (ORDER BY person_best.#{rank_by} <= 0,
-                             person_best.#{rank_by} ASC #{", person_best.#{secondary_rank_by} <= 0, person_best.#{secondary_rank_by} ASC" if secondary_rank_by}) AS ranking
-         FROM
-           (SELECT *
-            FROM
-              (SELECT lr.*,
-                      ROW_NUMBER() OVER (PARTITION BY lr.registration_id
-                                         ORDER BY (lr.#{rank_by} <= 0) ASC,
-                                         lr.#{rank_by} ASC #{", lr.#{secondary_rank_by} <= 0, lr.#{secondary_rank_by} ASC" if secondary_rank_by}) AS rownum
-               FROM live_results lr
-               WHERE lr.round_id IN (#{round_ids})
-                 AND lr.best != 0) x
-            WHERE rownum = 1) AS person_best) ranked ON r.registration_id = ranked.registration_id
-      SET r.global_pos = ranked.ranking
-      WHERE r.round_id IN (#{round_ids});
-    SQL
+    query = Live::Advancing.recompute_global_pos_query(format, linked_round, "registration_id", "live_results")
 
     ActiveRecord::Base.connection.exec_query query
   end
@@ -292,30 +266,16 @@ class Round < ApplicationRecord
     return if format_id == "h"
     return if linked_round.blank?
 
-    rank_by = format.rank_by_column
-    secondary_rank_by = format.secondary_rank_by_column
-    round_ids = linked_round.round_ids.join(",")
+    query = Live::Advancing.recompute_global_pos_query(format, linked_round, "person_id", "results")
 
-    query = <<~SQL.squish
-      UPDATE results r
-      LEFT JOIN
-        (SELECT person_id,
-                RANK() OVER (ORDER BY person_best.#{rank_by} <= 0,
-                             person_best.#{rank_by} ASC #{", person_best.#{secondary_rank_by} <= 0, person_best.#{secondary_rank_by} ASC" if secondary_rank_by}) AS ranking
-         FROM
-           (SELECT *
-            FROM
-              (SELECT r2.*,
-                      ROW_NUMBER() OVER (PARTITION BY r2.person_id
-                                         ORDER BY (r2.#{rank_by} <= 0) ASC,
-                                         r2.#{rank_by} ASC #{", r2.#{secondary_rank_by} <= 0, r2.#{secondary_rank_by} ASC" if secondary_rank_by}) AS rownum
-               FROM results r2
-               WHERE r2.round_id IN (#{round_ids})
-                 AND r2.best != 0) x
-            WHERE rownum = 1) AS person_best) ranked ON r.person_id = ranked.person_id
-      SET r.global_pos = ranked.ranking
-      WHERE r.round_id IN (#{round_ids});
-    SQL
+    ActiveRecord::Base.connection.exec_query query
+  end
+
+  def recompute_inbox_results_global_pos
+    return if format_id == "h"
+    return if linked_round.blank?
+
+    query = Live::Advancing.recompute_global_pos_query(format, linked_round, "person_id", "inbox_results")
 
     ActiveRecord::Base.connection.exec_query query
   end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -288,6 +288,38 @@ class Round < ApplicationRecord
     ActiveRecord::Base.connection.exec_query query
   end
 
+  def recompute_results_global_pos
+    return if format_id == "h"
+    return if linked_round.blank?
+
+    rank_by = format.rank_by_column
+    secondary_rank_by = format.secondary_rank_by_column
+    round_ids = linked_round.round_ids.join(",")
+
+    query = <<~SQL.squish
+      UPDATE results r
+      LEFT JOIN
+        (SELECT person_id,
+                RANK() OVER (ORDER BY person_best.#{rank_by} <= 0,
+                             person_best.#{rank_by} ASC #{", person_best.#{secondary_rank_by} <= 0, person_best.#{secondary_rank_by} ASC" if secondary_rank_by}) AS ranking
+         FROM
+           (SELECT *
+            FROM
+              (SELECT r2.*,
+                      ROW_NUMBER() OVER (PARTITION BY r2.person_id
+                                         ORDER BY (r2.#{rank_by} <= 0) ASC,
+                                         r2.#{rank_by} ASC #{", r2.#{secondary_rank_by} <= 0, r2.#{secondary_rank_by} ASC" if secondary_rank_by}) AS rownum
+               FROM results r2
+               WHERE r2.round_id IN (#{round_ids})
+                 AND r2.best != 0) x
+            WHERE rownum = 1) AS person_best) ranked ON r.person_id = ranked.person_id
+      SET r.global_pos = ranked.ranking
+      WHERE r.round_id IN (#{round_ids});
+    SQL
+
+    ActiveRecord::Base.connection.exec_query query
+  end
+
   def recompute_local_pos
     return if format_id == "h"
 

--- a/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
+++ b/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
@@ -2,8 +2,8 @@
 
 class RenamePosToGlobalPosAndAddLocalPosOnResults < ActiveRecord::Migration[8.1]
   def up
-    add_column :results, :global_pos, :integer, limit: 2, default: 0, null: false
-    add_column :inbox_results, :global_pos, :integer, limit: 2, default: 0, null: false
+    add_column :results, :global_pos, :integer, limit: 2, default: 0, null: false, after: :pos
+    add_column :inbox_results, :global_pos, :integer, limit: 2, default: 0, null: false, after: :pos
     execute "UPDATE results SET global_pos = pos"
     execute "UPDATE inbox_results SET global_pos = pos"
   end

--- a/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
+++ b/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
@@ -2,13 +2,11 @@
 
 class RenamePosToGlobalPosAndAddLocalPosOnResults < ActiveRecord::Migration[8.1]
   def up
-    rename_column :results, :pos, :local_pos
     add_column :results, :global_pos, :integer, limit: 2, default: 0, null: false
-    execute "UPDATE results SET global_pos = local_pos"
+    execute "UPDATE results SET global_pos = pos"
   end
 
   def down
     remove_column :results, :global_pos
-    rename_column :results, :local_pos, :pos
   end
 end

--- a/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
+++ b/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RenamePosToGlobalPosAndAddLocalPosOnResults < ActiveRecord::Migration[8.1]
+  def up
+    rename_column :results, :pos, :local_pos
+    add_column :results, :global_pos, :integer, limit: 2, default: 0, null: false
+    execute "UPDATE results SET global_pos = local_pos"
+  end
+
+  def down
+    remove_column :results, :global_pos
+    rename_column :results, :local_pos, :pos
+  end
+end

--- a/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
+++ b/db/migrate/20260528000001_rename_pos_to_global_pos_and_add_local_pos_on_results.rb
@@ -3,7 +3,9 @@
 class RenamePosToGlobalPosAndAddLocalPosOnResults < ActiveRecord::Migration[8.1]
   def up
     add_column :results, :global_pos, :integer, limit: 2, default: 0, null: false
+    add_column :inbox_results, :global_pos, :integer, limit: 2, default: 0, null: false
     execute "UPDATE results SET global_pos = pos"
+    execute "UPDATE inbox_results SET global_pos = pos"
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_110117) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_000001) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1186,6 +1186,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_110117) do
     t.string "country_id", limit: 50, default: "", null: false
     t.string "event_id", limit: 6, default: "", null: false
     t.string "format_id", limit: 1, default: "", null: false
+    t.integer "global_pos", limit: 2, default: 0, null: false
     t.string "person_id", limit: 10, default: "", null: false
     t.string "person_name", limit: 80, default: "", null: false
     t.integer "pos", limit: 2, default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -736,9 +736,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_000001) do
     t.string "competition_id", limit: 32, default: "", null: false
     t.string "event_id", limit: 6, default: "", null: false
     t.string "format_id", limit: 1, default: "", null: false
-    t.integer "global_pos", limit: 2, default: 0, null: false
     t.string "person_id", limit: 20, null: false
     t.integer "pos", limit: 2, default: 0, null: false
+    t.integer "global_pos", limit: 2, default: 0, null: false
     t.bigint "round_id", null: false
     t.string "round_type_id", limit: 1, default: "", null: false
     t.integer "value1", default: 0, null: false
@@ -1187,10 +1187,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_000001) do
     t.string "country_id", limit: 50, default: "", null: false
     t.string "event_id", limit: 6, default: "", null: false
     t.string "format_id", limit: 1, default: "", null: false
-    t.integer "global_pos", limit: 2, default: 0, null: false
     t.string "person_id", limit: 10, default: "", null: false
     t.string "person_name", limit: 80, default: "", null: false
     t.integer "pos", limit: 2, default: 0, null: false
+    t.integer "global_pos", limit: 2, default: 0, null: false
     t.string "regional_average_record", limit: 3
     t.string "regional_single_record", limit: 3
     t.bigint "round_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -736,6 +736,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_000001) do
     t.string "competition_id", limit: 32, default: "", null: false
     t.string "event_id", limit: 6, default: "", null: false
     t.string "format_id", limit: 1, default: "", null: false
+    t.integer "global_pos", limit: 2, default: 0, null: false
     t.string "person_id", limit: 20, null: false
     t.integer "pos", limit: 2, default: 0, null: false
     t.bigint "round_id", null: false

--- a/lib/competition_results_import.rb
+++ b/lib/competition_results_import.rb
@@ -22,6 +22,8 @@ module CompetitionResultsImport
       Scramble.where(competition_id: competition.id).delete_all
       InboxPerson.import!(persons_to_import)
       InboxResult.import!(results_to_import)
+      # Compute global_pos for inbox results with linked_rounds
+      competition.rounds.includes(:linked_round).where.not(linked_round_id: nil).find_each(&:recompute_inbox_results_global_pos)
 
       if import_matched_scrambles
         # Foreign Key handles transitive deletion of individual scrambles
@@ -105,7 +107,7 @@ module CompetitionResultsImport
 
                                  {
                                    pos: inbox_res.pos,
-                                   global_pos: inbox_res.pos,
+                                   global_pos: inbox_res.global_pos,
                                    person_id: person_id,
                                    person_name: inbox_res.person_name,
                                    country_id: person_country.id,
@@ -130,9 +132,6 @@ module CompetitionResultsImport
       #   But the properties round_id and person_id are still the same as before, so we use them as a lookup.
       attempt_rows = competition.reload.results.flat_map { Result.unpack_attempt_attributes(result_attempts_index.fetch([it.round_id, it.person_id]), result_id: it.id) }
       ResultAttempt.insert_all!(attempt_rows)
-
-      # Compute global_pos for linked rounds
-      competition.rounds.includes(:linked_round).where.not(linked_round_id: nil).find_each(&:recompute_results_global_pos)
 
       competition.inbox_results.destroy_all
     end

--- a/lib/competition_results_import.rb
+++ b/lib/competition_results_import.rb
@@ -105,6 +105,7 @@ module CompetitionResultsImport
 
                                  {
                                    pos: inbox_res.pos,
+                                   global_pos: inbox_res.pos,
                                    person_id: person_id,
                                    person_name: inbox_res.person_name,
                                    country_id: person_country.id,
@@ -129,6 +130,9 @@ module CompetitionResultsImport
       #   But the properties round_id and person_id are still the same as before, so we use them as a lookup.
       attempt_rows = competition.reload.results.flat_map { Result.unpack_attempt_attributes(result_attempts_index.fetch([it.round_id, it.person_id]), result_id: it.id) }
       ResultAttempt.insert_all!(attempt_rows)
+
+      # Compute global_pos for linked rounds
+      competition.rounds.includes(:linked_round).where.not(linked_round_id: nil).find_each(&:recompute_results_global_pos)
 
       competition.inbox_results.destroy_all
     end

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -277,6 +277,7 @@ module DatabaseDumper
           person_id
           person_name
           pos
+          global_pos
           regional_average_record
           regional_single_record
           round_type_id

--- a/lib/live/advancing.rb
+++ b/lib/live/advancing.rb
@@ -39,25 +39,25 @@ module Live
       # at first it computes the best result of a person over all linked rounds
       # by using the same ORDER BY <=0 trick
       <<~SQL.squish
-      UPDATE #{table} r
-      LEFT JOIN
-        (SELECT #{person_key},
-                RANK() OVER (ORDER BY person_best.#{rank_by} <= 0,
-                             person_best.#{rank_by} ASC #{secondary_rank_sql}) AS ranking
-         FROM
-           (SELECT *
-            FROM
-              (SELECT t.*,
-                      ROW_NUMBER() OVER (PARTITION BY t.#{person_key}
-                                         ORDER BY (t.#{rank_by} <= 0) ASC,
-                                         t.#{rank_by} ASC #{secondary_rank_inner_sql}) AS rownum
-               FROM #{table} t
-               WHERE t.round_id IN (#{round_ids})
-                 AND t.best != 0) x
-            WHERE rownum = 1) AS person_best) ranked ON r.#{person_key} = ranked.#{person_key}
-      SET r.global_pos = ranked.ranking
-      WHERE r.round_id IN (#{round_ids});
-    SQL
+        UPDATE #{table} r
+        LEFT JOIN
+          (SELECT #{person_key},
+                  RANK() OVER (ORDER BY person_best.#{rank_by} <= 0,
+                               person_best.#{rank_by} ASC #{secondary_rank_sql}) AS ranking
+           FROM
+             (SELECT *
+              FROM
+                (SELECT t.*,
+                        ROW_NUMBER() OVER (PARTITION BY t.#{person_key}
+                                           ORDER BY (t.#{rank_by} <= 0) ASC,
+                                           t.#{rank_by} ASC #{secondary_rank_inner_sql}) AS rownum
+                 FROM #{table} t
+                 WHERE t.round_id IN (#{round_ids})
+                   AND t.best != 0) x
+              WHERE rownum = 1) AS person_best) ranked ON r.#{person_key} = ranked.#{person_key}
+        SET r.global_pos = ranked.ranking
+        WHERE r.round_id IN (#{round_ids});
+      SQL
     end
 
     def self.podium_condition(format)

--- a/lib/live/advancing.rb
+++ b/lib/live/advancing.rb
@@ -27,6 +27,39 @@ module Live
       end
     end
 
+    def self.recompute_global_pos_query(format, linked_round, person_key, table)
+      rank_by = format.rank_by_column
+      secondary_rank_by = format.secondary_rank_by_column
+      round_ids = linked_round.round_ids.join(",")
+
+      secondary_rank_sql = secondary_rank_by ? ", person_best.#{secondary_rank_by} <= 0, person_best.#{secondary_rank_by} ASC" : ""
+      secondary_rank_inner_sql = secondary_rank_by ? ", t.#{secondary_rank_by} <= 0, t.#{secondary_rank_by} ASC" : ""
+
+      # Similar to the query that recomputes local_pos, but
+      # at first it computes the best result of a person over all linked rounds
+      # by using the same ORDER BY <=0 trick
+      <<~SQL.squish
+      UPDATE #{table} r
+      LEFT JOIN
+        (SELECT #{person_key},
+                RANK() OVER (ORDER BY person_best.#{rank_by} <= 0,
+                             person_best.#{rank_by} ASC #{secondary_rank_sql}) AS ranking
+         FROM
+           (SELECT *
+            FROM
+              (SELECT t.*,
+                      ROW_NUMBER() OVER (PARTITION BY t.#{person_key}
+                                         ORDER BY (t.#{rank_by} <= 0) ASC,
+                                         t.#{rank_by} ASC #{secondary_rank_inner_sql}) AS rownum
+               FROM #{table} t
+               WHERE t.round_id IN (#{round_ids})
+                 AND t.best != 0) x
+            WHERE rownum = 1) AS person_best) ranked ON r.#{person_key} = ranked.#{person_key}
+      SET r.global_pos = ranked.ranking
+      WHERE r.round_id IN (#{round_ids});
+    SQL
+    end
+
     def self.podium_condition(format)
       ResultConditions::Ranking.new(scope: format.sort_by, value: 3)
     end

--- a/lib/tasks/backfill_results_global_pos.rake
+++ b/lib/tasks/backfill_results_global_pos.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :results do
+  desc "Backfill global_pos for all results belonging to linked (dual) rounds"
+  task backfill_linked_round_global_pos: :environment do
+    Round.includes(:linked_round).where.not(linked_round_id: nil).find_each(&:recompute_results_global_pos)
+  end
+end

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
 
     competition_id { competition.id }
     pos { 1 }
+    global_pos { 1 }
     event_id { "333oh" }
     round_type_id { "f" }
     format_id { "a" }
@@ -154,7 +155,6 @@ FactoryBot.define do
     country_id { person.country_id }
     regional_single_record { nil }
     regional_average_record { nil }
-    global_pos { 1 }
 
     after(:build) do |result, builder|
       legacy_attempts = (1..5).map { builder.public_send(:"value#{it}") }

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
 
     competition_id { competition.id }
     pos { 1 }
+    global_pos { 1 }
     event_id { "333oh" }
     round_type_id { "f" }
     format_id { "a" }

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
 
     competition_id { competition.id }
     pos { 1 }
-    global_pos { 1 }
     event_id { "333oh" }
     round_type_id { "f" }
     format_id { "a" }
@@ -155,6 +154,7 @@ FactoryBot.define do
     country_id { person.country_id }
     regional_single_record { nil }
     regional_average_record { nil }
+    global_pos { 1 }
 
     after(:build) do |result, builder|
       legacy_attempts = (1..5).map { builder.public_send(:"value#{it}") }


### PR DESCRIPTION
This is part 1 of the `local_pos` and `global_pos` transition. As we use `pos` in a million places, this just adds `global_pos` separately, introduces a backfill and computes `global_pos` for linked rounds after results are uploaded.

This allows us to implement #14410 for almost free.