### PR TITLE
Don't use useBreakPointValue for UI elements

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/competitors/[registrationId]/ByPersonByRoundTable.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/competitors/[registrationId]/ByPersonByRoundTable.tsx
@@ -29,11 +29,7 @@ export default function ByPersonByRoundTable({
 
   return (
     <Table.Root mb="10" size="sm">
-      <LiveTableHeader
-        format={formats.byId[rounds[0].format]}
-        byPerson
-        t={t}
-      />
+      <LiveTableHeader format={formats.byId[rounds[0].format]} byPerson t={t} />
       <Table.Body>
         {eventResults.map((result) => {
           const {

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/competitors/[registrationId]/ByPersonByRoundTable.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/competitors/[registrationId]/ByPersonByRoundTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Link, Table, useBreakpointValue } from "@chakra-ui/react";
+import { Link, Table } from "@chakra-ui/react";
 import {
   LiveAttemptsCells,
   LivePositionCell,
@@ -25,16 +25,12 @@ export default function ByPersonByRoundTable({
   rounds: LiveRoundAdmin[];
 }) {
   const { t } = useT();
-  const isMobile = useBreakpointValue({ base: true, md: false });
-  const showFull = !isMobile;
-
   const roundsByWcifId = _.keyBy(rounds, "id");
 
   return (
     <Table.Root mb="10" size="sm">
       <LiveTableHeader
         format={formats.byId[rounds[0].format]}
-        showFull={showFull}
         byPerson
         t={t}
       />
@@ -68,14 +64,12 @@ export default function ByPersonByRoundTable({
                 position={global_pos}
                 advancingParams={result}
               />
-              {showFull && (
-                <LiveAttemptsCells
-                  format={format}
-                  attempts={attempts}
-                  eventId={eventId}
-                  competitorId={registration_id}
-                />
-              )}
+              <LiveAttemptsCells
+                format={format}
+                attempts={attempts}
+                eventId={eventId}
+                competitorId={registration_id}
+              />
               <LiveStatCells
                 stats={stats}
                 eventId={eventId}

--- a/next-frontend/src/components/live/Cells.tsx
+++ b/next-frontend/src/components/live/Cells.tsx
@@ -50,7 +50,9 @@ export function LiveTableHeader({
         )}
         {isLinked && (
           <Table.ColumnHeader>
-            {t("competitions.results_table.round")}
+            <Box as="span" hideBelow="md">
+              {t("competitions.results_table.round")}
+            </Box>
           </Table.ColumnHeader>
         )}
         {attemptIndexes.map((num) => (

--- a/next-frontend/src/components/live/Cells.tsx
+++ b/next-frontend/src/components/live/Cells.tsx
@@ -1,5 +1,5 @@
 import { Format } from "@/lib/wca/data/formats";
-import { Link, Table } from "@chakra-ui/react";
+import { Box, Link, Table } from "@chakra-ui/react";
 import { Stat, statColumnsForFormat } from "@/lib/live/statColumnsForFormat";
 import { rankingCellColorPalette } from "@/lib/live/rankingCellColorPalette";
 import { padSkipped } from "@/lib/live/padSkipped";
@@ -11,13 +11,11 @@ import { TFunction } from "i18next";
 export function LiveTableHeader({
   isLinked = false,
   format,
-  showFull = true,
   byPerson = false,
   isAdmin = false,
   t,
 }: {
   isLinked?: boolean;
-  showFull?: boolean;
   byPerson?: boolean;
   isAdmin?: boolean;
   format: Format;
@@ -45,22 +43,21 @@ export function LiveTableHeader({
             {t("competitions.live.results.competitor")}
           </Table.ColumnHeader>
         )}
-        {showFull && !byPerson && (
-          <Table.ColumnHeader>
+        {!byPerson && (
+          <Table.ColumnHeader hideBelow="md">
             {t("results.table_elements.region")}
           </Table.ColumnHeader>
         )}
         {isLinked && (
           <Table.ColumnHeader>
-            {showFull && t("competitions.results_table.round")}
+            {t("competitions.results_table.round")}
           </Table.ColumnHeader>
         )}
-        {showFull &&
-          attemptIndexes.map((num) => (
-            <Table.ColumnHeader key={num} textAlign="right">
-              {num + 1}
-            </Table.ColumnHeader>
-          ))}
+        {attemptIndexes.map((num) => (
+          <Table.ColumnHeader key={num} textAlign="right" hideBelow="md">
+            {num + 1}
+          </Table.ColumnHeader>
+        ))}
         {stats.map((stat) => (
           <Table.ColumnHeader textAlign="right" key={stat.field}>
             {t(stat.i18nKey)}
@@ -99,32 +96,30 @@ export function LivePositionCell({
 
 export function LiveCompetitorCell({
   isAdmin = false,
-  link = true,
   rowSpan,
   competitionId,
   competitor,
 }: {
   isAdmin?: boolean;
-  link?: boolean;
   rowSpan?: number;
   competitionId: string;
   competitor: Pick<LiveCompetitor, "id" | "name">;
 }) {
   return (
     <Table.Cell rowSpan={rowSpan}>
-      {link ? (
-        <Link
-          href={
-            isAdmin
-              ? `/registrations/${competitor.id}/edit`
-              : `/competitions/${competitionId}/live/competitors/${competitor.id}`
-          }
-        >
-          {competitor.name}
-        </Link>
-      ) : (
-        competitor.name
-      )}
+      <Link
+        href={
+          isAdmin
+            ? `/registrations/${competitor.id}/edit`
+            : `/competitions/${competitionId}/live/competitors/${competitor.id}`
+        }
+        hideBelow="md"
+      >
+        {competitor.name}
+      </Link>
+      <Box as="span" hideFrom="md">
+        {competitor.name}
+      </Box>
     </Table.Cell>
   );
 }
@@ -144,6 +139,7 @@ export function LiveAttemptsCells({
     <Table.Cell
       textAlign="right"
       key={`attempts-${competitorId}-${attempt.attempt_number}`}
+      hideBelow="md"
     >
       {formatAttemptResult(attempt.value, eventId)}
     </Table.Cell>

--- a/next-frontend/src/components/live/LiveResultsTable.tsx
+++ b/next-frontend/src/components/live/LiveResultsTable.tsx
@@ -69,8 +69,10 @@ export default function LiveResultsTable({
 
   const stats = statColumnsForFormat(format);
 
-  const isMobile = useBreakpointValue({ base: true, md: false });
-  const showFull = !isMobile;
+  const isMobile = useBreakpointValue(
+    { base: true, md: false },
+    { fallback: "md" },
+  );
 
   return (
     <>
@@ -78,7 +80,6 @@ export default function LiveResultsTable({
         <LiveTableHeader
           format={format}
           isLinked={showLinkedRoundsView}
-          showFull={showFull}
           t={t}
           isAdmin={isAdmin}
         />
@@ -161,13 +162,13 @@ export default function LiveResultsTable({
                       competitor={competitorAndTheirResults}
                       rowSpan={rowSpan}
                       isAdmin={isAdmin}
-                      link={showFull}
                     />
                   )}
-                  {showText && showFull && (
+                  {showText && (
                     <CountryCell
                       countryIso2={competitorAndTheirResults.country_iso2}
                       rowSpan={rowSpan}
+                      hideBelow="md"
                     />
                   )}
                   {showLinkedRoundsView && (
@@ -175,14 +176,12 @@ export default function LiveResultsTable({
                       {parseActivityCode(result.round_wcif_id).roundNumber}
                     </Table.Cell>
                   )}
-                  {showFull && (
-                    <LiveAttemptsCells
-                      format={format}
-                      attempts={result.attempts}
-                      eventId={eventId}
-                      competitorId={competitorAndTheirResults.id}
-                    />
-                  )}
+                  <LiveAttemptsCells
+                    format={format}
+                    attempts={result.attempts}
+                    eventId={eventId}
+                    competitorId={competitorAndTheirResults.id}
+                  />
                   <LiveStatCells
                     stats={stats}
                     competitorId={competitorAndTheirResults.id}

--- a/next-frontend/src/components/results/ResultTableCells.tsx
+++ b/next-frontend/src/components/results/ResultTableCells.tsx
@@ -15,12 +15,14 @@ type CountryCellProps = (
     }
 ) & {
   rowSpan?: number;
+  hideBelow?: string;
 };
 
 export function CountryCell({
   countryId,
   countryIso2,
   rowSpan,
+  hideBelow,
 }: CountryCellProps) {
   const country =
     // Explicitly check for undefined so TypeScript knows which branch it is
@@ -28,7 +30,7 @@ export function CountryCell({
       ? countries.byId[countryId]
       : countries.byIso2[countryIso2];
   return (
-    <Table.Cell rowSpan={rowSpan}>
+    <Table.Cell rowSpan={rowSpan} hideBelow={hideBelow}>
       {country && (
         <Icon asChild size="sm">
           <WcaFlag code={country.iso2} />

--- a/next-frontend/src/providers/WCAQueryClientProvider.tsx
+++ b/next-frontend/src/providers/WCAQueryClientProvider.tsx
@@ -8,8 +8,7 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
-      staleTime: Infinity,
-      refetchOnMount: "always",
+      staleTime: 60 * 1000,
       retry: false,
     },
   },

--- a/next-frontend/src/providers/WCAQueryClientProvider.tsx
+++ b/next-frontend/src/providers/WCAQueryClientProvider.tsx
@@ -8,7 +8,8 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
-      staleTime: 60 * 1000,
+      staleTime: Infinity,
+      refetchOnMount: "always",
       retry: false,
     },
   },


### PR DESCRIPTION
The issue is twofold: 
- One is the fundamental error we made using `useBreakPointValue` for UX elements. This causes the UI to jump when loaded, as it defaults to `base` when first rendering. You can set a default (which I did), but then it would be jumpy in mobile. So instead you should only use the `useBreakPointValue` for setting interactivity or something similar, not UI elements.
- The second one is a bit more subtle and I am not 100% sure if we should change this everywhere or just for ILR. Basically because we have `stale time: inifinity` and `refetch: on mount` together, we keep the stale data in the browser even on navigation which can cause jumpy UI from the stale data. This wasn't an issue in rails as the js is refetched on every page.