### PR TITLE
Add option to put ImageBanner image to the right of the text

### DIFF
--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -120,13 +120,15 @@ const BannerImageWithGradient = ({
   mainImage,
   targetColor,
   gradientDirection,
+  boxWidth = "50%",
 }: {
   mainImage: Media;
   targetColor: ComponentProps<typeof Box>["bg"];
   gradientDirection: "left" | "right";
+  boxWidth?: ComponentProps<typeof Box>["width"];
 }) => {
   return (
-    <Box position="relative" width="50%" hideBelow="md">
+    <Box position="relative" width={boxWidth} hideBelow="md">
       <MediaImage
         media={mainImage as Media}
         width="full"
@@ -157,42 +159,46 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
           mainImage={block.mainImage as Media}
           targetColor="colorPalette.1A"
           gradientDirection="right"
+          boxWidth={block.heading ? "50%" : "100%"}
         />
       )}
-      <Card.Body justifyContent="center">
-        <Card.Title
-          colorPalette={block.headingColor}
-          textStyle={{ base: "h3", md: "h2", xl: "h1" }}
-        >
-          {block.heading}
-        </Card.Title>
-        <ChakraMarkdown
-          paragraphAs={Card.Description}
-          textStyle={{ base: "body", md: "s2" }}
-        >
-          {block.bodyMarkdown}
-        </ChakraMarkdown>
-        {block.bgImage && (
-          <Float
-            placement="bottom-end"
-            width={`${block.bgSize}%`}
-            height={`${block.bgSize}%`}
-            offset={28}
+      {block.heading && (
+        <Card.Body justifyContent="center">
+          <Card.Title
+            colorPalette={block.headingColor}
+            textStyle={{ base: "h3", md: "h2", xl: "h1" }}
           >
-            <MediaImage
-              media={block.bgImage as Media}
-              width="auto"
-              height="full"
-              fit="contain"
-            />
-          </Float>
-        )}
-      </Card.Body>
+            {block.heading}
+          </Card.Title>
+          <ChakraMarkdown
+            paragraphAs={Card.Description}
+            textStyle={{ base: "body", md: "s2" }}
+          >
+            {block.bodyMarkdown}
+          </ChakraMarkdown>
+          {block.bgImage && (
+            <Float
+              placement="bottom-end"
+              width={`${block.bgSize}%`}
+              height={`${block.bgSize}%`}
+              offset={28}
+            >
+              <MediaImage
+                media={block.bgImage as Media}
+                width="auto"
+                height="full"
+                fit="contain"
+              />
+            </Float>
+          )}
+        </Card.Body>
+      )}
       {block.imagePosition === "right" && (
         <BannerImageWithGradient
           mainImage={block.mainImage as Media}
           targetColor="colorPalette.1A"
           gradientDirection="left"
+          boxWidth={block.heading ? "50%" : "100%"}
         />
       )}
     </Card.Root>

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import React from "react";
+import React, { ComponentProps } from "react";
 
 export const metadata: Metadata = {
   title: { absolute: "World Cube Association" },
@@ -116,6 +116,32 @@ const AnnouncementsSection = ({
   );
 };
 
+const BannerImageWithGradient = ({
+  mainImage,
+  targetColor,
+  gradientDirection,
+}: {
+  mainImage: Media;
+  targetColor: ComponentProps<typeof Box>["bg"];
+  gradientDirection: "left" | "right";
+}) => {
+  return (
+    <Box position="relative" width="50%" hideBelow="md">
+      <MediaImage
+        media={mainImage as Media}
+        width="full"
+        maxHeight="sm"
+        bg={targetColor}
+      />
+      <AbsoluteCenter
+        width="101%" // weirdly enough, 100% (or "full") creates a tiny gap even though it shouldn't. Shout if you know how to fix this!
+        height="full"
+        bg={`linear-gradient(to ${gradientDirection}, transparent, transparent, {colors.${targetColor}})`}
+      />
+    </Box>
+  );
+};
+
 const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
   return (
     <Card.Root
@@ -126,20 +152,13 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
       maxHeight="sm" // somewhat arbitrary, if you have a better idea please shout
       overflow="hidden"
     >
-      <Box position="relative" width="50%" hideBelow="md">
-        <MediaImage
-          media={block.mainImage as Media}
-          width="full"
-          maxHeight="sm"
-          bg="colorPalette.1A"
+      {block.imagePosition === "left" && (
+        <BannerImageWithGradient
+          mainImage={block.mainImage as Media}
+          targetColor="colorPalette.1A"
+          gradientDirection="right"
         />
-        <AbsoluteCenter
-          width="101%" // weirdly enough, 100% (or "full") creates a tiny gap even though it shouldn't. Shout if you know how to fix this!
-          height="full"
-          bg="linear-gradient(to right, transparent, transparent, {colors.colorPalette.1A})"
-        />
-      </Box>
-
+      )}
       <Card.Body justifyContent="center">
         <Card.Title
           colorPalette={block.headingColor}
@@ -169,6 +188,13 @@ const ImageBanner = ({ block }: { block: ImageBannerBlock }) => {
           </Float>
         )}
       </Card.Body>
+      {block.imagePosition === "right" && (
+        <BannerImageWithGradient
+          mainImage={block.mainImage as Media}
+          targetColor="colorPalette.1A"
+          gradientDirection="left"
+        />
+      )}
     </Card.Root>
   );
 };

--- a/next-frontend/src/blocks/image/bannerImage.ts
+++ b/next-frontend/src/blocks/image/bannerImage.ts
@@ -10,12 +10,10 @@ export const BannerImageBlock: Block = {
     {
       name: "heading",
       type: "text",
-      required: true,
     },
     {
       name: "body",
       type: "richText",
-      required: true,
     },
     markdownConvertedField("body"),
     {

--- a/next-frontend/src/blocks/image/bannerImage.ts
+++ b/next-frontend/src/blocks/image/bannerImage.ts
@@ -24,6 +24,16 @@ export const BannerImageBlock: Block = {
       relationTo: "media",
       required: true,
     },
+    {
+      name: "imagePosition",
+      type: "radio",
+      options: ["left", "right"],
+      defaultValue: "left",
+      required: true,
+      admin: {
+        layout: "horizontal",
+      },
+    },
     colorPaletteSelect,
     colorPaletteToneToggle,
     {

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -1204,6 +1204,7 @@ export interface ImageBannerBlock {
   };
   bodyMarkdown?: string | null;
   mainImage: string | Media;
+  imagePosition: 'left' | 'right';
   colorPalette: ColorPaletteSelect;
   /**
    * Use a slightly darker nuance of the color palette
@@ -1914,6 +1915,7 @@ export interface ImageBannerBlockSelect<T extends boolean = true> {
   body?: T;
   bodyMarkdown?: T;
   mainImage?: T;
+  imagePosition?: T;
   colorPalette?: T;
   colorPaletteDarker?: T;
   headingColor?: T;

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -1186,8 +1186,8 @@ export interface AnnouncementsSectionBlock {
  * via the `definition` "ImageBannerBlock".
  */
 export interface ImageBannerBlock {
-  heading: string;
-  body: {
+  heading?: string | null;
+  body?: {
     root: {
       type: string;
       children: {
@@ -1201,7 +1201,7 @@ export interface ImageBannerBlock {
       version: number;
     };
     [k: string]: unknown;
-  };
+  } | null;
   bodyMarkdown?: string | null;
   mainImage: string | Media;
   imagePosition: 'left' | 'right';


### PR DESCRIPTION
<img width="2520" height="837" alt="image" src="https://github.com/user-attachments/assets/dd138999-bf12-4b93-baae-9fe0681e33d5" />

This is selectable in Payload. You can now also drop the `heading` and `body` text, to get a pure "image with gradient" experience