### PR TITLE
Change 'Scoretaking Software' from checkbox to dropdown in Competition Form

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2412,8 +2412,8 @@ class Competition < ApplicationRecord
         "generateWebsite" => generate_website,
         "externalWebsite" => external_website,
         "externalRegistrationPage" => external_registration_page,
-        "usesWcaRegistration" => use_wca_registration,
-        "usesWcaLive" => scoretaking_software_wca_live?,
+        "usesWcaRegistration" => use_wca_registration?,
+        "scoretakingSoftware" => scoretaking_software,
       },
       "entryFees" => {
         "currencyCode" => currency_code,
@@ -2521,7 +2521,7 @@ class Competition < ApplicationRecord
         "externalWebsite" => errors[:external_website],
         "externalRegistrationPage" => errors[:external_registration_page],
         "usesWcaRegistration" => errors[:use_wca_registration],
-        "usesWcaLive" => errors[:scoretaking_software],
+        "scoretakingSoftware" => errors[:scoretaking_software],
       },
       "entryFees" => {
         "currencyCode" => errors[:currency_code],
@@ -2729,7 +2729,7 @@ class Competition < ApplicationRecord
       guest_entry_status: form_data.dig('registration', 'guestEntryStatus'),
       allow_registration_edits: form_data.dig('registration', 'allowSelfEdits'),
       competitor_can_cancel: form_data.dig('registration', 'competitorCanCancel'),
-      scoretaking_software: form_data.dig('website', 'usesWcaLive') ? :wca_live : :external,
+      scoretaking_software: form_data.dig('website', 'scoretakingSoftware'),
       allow_registration_without_qualification: form_data.dig('eventRestrictions', 'qualificationResults', 'allowRegistrationWithout'),
       guests_per_registration_limit: form_data.dig('registration', 'guestsPerRegistration'),
       events_per_registration_limit: form_data.dig('eventRestrictions', 'eventLimitation', 'perRegistrationLimit'),
@@ -2888,7 +2888,7 @@ class Competition < ApplicationRecord
             "externalWebsite" => { "type" => %w[string null] },
             "externalRegistrationPage" => { "type" => %w[string null] },
             "usesWcaRegistration" => { "type" => "boolean" },
-            "usesWcaLive" => { "type" => "boolean" },
+            "scoretakingSoftware" => { "type" => "string", "enum" => %w[external wca_live internal] },
           },
         },
         "userSettings" => {
@@ -3018,7 +3018,7 @@ class Competition < ApplicationRecord
           "additionalProperties" => false,
           "properties" => {
             "externalWebsite" => { "type" => %w[string null] },
-            "usesWcaLive" => { "type" => "boolean" },
+            "scoretakingSoftware" => { "type" => "string", "enum" => %w[external wca_live internal] },
           },
         },
         "entryFees" => {

--- a/app/views/competitions/edit_events.html.erb
+++ b/app/views/competitions/edit_events.html.erb
@@ -11,6 +11,7 @@
     canAddAndRemoveEvents: current_user.can_add_and_remove_events?(@competition),
     canUpdateEvents: current_user.can_update_events?(@competition),
     canUpdateQualifications: current_user.can_update_qualifications?(@competition),
+    usesIlr: @competition.scoretaking_software_internal?,
     wcifEvents: @competition.events_wcif(version: '2.1.1')
   }, {
     id: "events-edit-area",

--- a/app/webpacker/components/CompetitionForm/FormSections/Website.js
+++ b/app/webpacker/components/CompetitionForm/FormSections/Website.js
@@ -1,8 +1,18 @@
 import React from 'react';
-import { InputBoolean, InputString } from '../../wca/FormBuilder/input/FormInputs';
+import { InputBoolean, InputSelect, InputString } from '../../wca/FormBuilder/input/FormInputs';
 import ConditionalSection from './ConditionalSection';
 import SubSection from '../../wca/FormBuilder/SubSection';
 import { useFormObject } from '../../wca/FormBuilder/provider/FormObjectProvider';
+import I18n from '../../../lib/i18n';
+
+const ilrChoiceText = I18n.t('competitions.competition_form.choices.website.scoretaking_software.internal');
+const dualRoundsHint = I18n.t('competitions.competition_form.hints.website.scoretaking_software', { choice_ilr: ilrChoiceText });
+
+const scoretakingSoftwareOptions = ['external', 'wca_live', 'internal'].map((software) => ({
+  key: software,
+  value: software,
+  text: I18n.t(`competitions.competition_form.choices.website.scoretaking_software.${software}`),
+}));
 
 export default function Website() {
   const { website: websiteData } = useFormObject();
@@ -20,7 +30,7 @@ export default function Website() {
       <ConditionalSection showIf={usingExternalRegistration}>
         <InputString id="externalRegistrationPage" />
       </ConditionalSection>
-      <InputBoolean id="usesWcaLive" ignoreDisabled />
+      <InputSelect id="scoretakingSoftware" options={scoretakingSoftwareOptions} hint={dualRoundsHint} ignoreDisabled />
     </SubSection>
   );
 }

--- a/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/AdvancementTypeInput.js
+++ b/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/AdvancementTypeInput.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Form, Label } from 'semantic-ui-react';
+import { useStore } from '../../../../lib/providers/StoreProvider';
 
-const advancementTypeOptions = (roundNumber) => [
+const advancementTypeOptions = (roundNumber, usesIlr) => [
   { key: 0, value: 0, text: 'To be Announced' },
   {
     key: -1, value: -1, text: '────────', disabled: true,
   },
   {
-    key: -2, value: 'dual', text: 'Dual Round', disabled: roundNumber !== 1,
+    key: -2, value: 'dual', text: 'Dual Round', disabled: roundNumber !== 1 || !usesIlr,
   },
   { key: 1, value: 'ranking', text: 'Ranking' },
   { key: 2, value: 'percent', text: 'Percent' },
@@ -15,9 +16,9 @@ const advancementTypeOptions = (roundNumber) => [
 ];
 
 export function AdvancementTypeInput({
-  advancementType, onChange, roundNumber,
+  advancementType, onChange, roundNumber, usesIlr,
 }) {
-  const options = advancementTypeOptions(roundNumber);
+  const options = advancementTypeOptions(roundNumber, usesIlr);
 
   return (
     <Form.Select
@@ -33,8 +34,10 @@ export function AdvancementTypeInput({
 export default function AdvancementTypeField({
   advancementType, onChange, roundNumber,
 }) {
+  const { usesIlr } = useStore();
+
   return (
-    <Form.Field inline>
+    <Form.Field>
       <Label>
         Type
       </Label>
@@ -43,6 +46,7 @@ export default function AdvancementTypeField({
         advancementType={advancementType}
         onChange={onChange}
         roundNumber={roundNumber}
+        usesIlr={usesIlr}
       />
     </Form.Field>
   );

--- a/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/index.js
+++ b/app/webpacker/components/EditEvents/Modals/EditAdvancementConditionModal/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import _ from 'lodash';
-import { Label } from 'semantic-ui-react';
+import { Form, Label } from 'semantic-ui-react';
 import useInputState from '../../../../lib/hooks/useInputState';
 import { roundIdToString } from '../../../../lib/utils/wcif';
 import ButtonActivatedModal from '../ButtonActivatedModal';
@@ -173,18 +173,21 @@ export default function EditAdvancementConditionModal({
         onChange={setType}
         roundNumber={roundNumber}
       />
+      <p>
+        If you would like to use Dual Rounds, please make sure that
+        the scoretaking software is configured as &apos;Internal Live Results&apos;
+      </p>
       {!!type && (
         <>
           {type !== 'dual' && (
-            <>
+            <Form.Field>
               <AdvancementInput
                 eventId={wcifEvent.id}
                 type={type}
                 level={level}
                 onChange={setLevel}
               />
-              <br />
-            </>
+            </Form.Field>
           )}
           <p>
             {advanceReqToExplanationText(wcifEvent, roundNumber, { type, level })}

--- a/app/webpacker/components/EditEvents/index.js
+++ b/app/webpacker/components/EditEvents/index.js
@@ -89,6 +89,7 @@ export default function Wrapper({
   canAddAndRemoveEvents,
   canUpdateEvents,
   canUpdateQualifications,
+  usesIlr,
   wcifEvents,
 }) {
   const normalizedEvents = normalizeWcifEvents(wcifEvents);
@@ -101,6 +102,7 @@ export default function Wrapper({
         canAddAndRemoveEvents,
         canUpdateEvents,
         canUpdateQualifications,
+        usesIlr,
         wcifEvents: normalizedEvents,
         initialWcifEvents: normalizedEvents,
         unsavedChanges: false,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1742,7 +1742,7 @@ en:
           external_website: "Website"
           external_registration_page: "Registration page"
           uses_wca_registration: "I would like to use the WCA website for registration"
-          uses_wca_live: "I will be using WCA Live for scoretaking"
+          scoretaking_software: "Software used for scoretaking"
         entry_fees:
           currency_code: "Currency code"
           base_entry_fee: "Base registration fee"
@@ -1830,7 +1830,7 @@ en:
           external_website: "The website of the competition. Must be a valid http(s) url."
           external_registration_page: "The page where the competitors have to register for the competition. Must be a valid http(s) url."
           uses_wca_registration: ""
-          uses_wca_live: ""
+          scoretaking_software: "Select '%{choice_ilr}' if you want to use Dual Rounds"
         user_settings:
           receive_registration_emails: ""
         entry_fees:
@@ -1886,6 +1886,11 @@ en:
             "disabled": "Disable 'Bulk Auto Accept' button"
             "bulk": "Enable 'Bulk Auto Accept' button in Registrations menu"
             "live": "Automatically accept registrations when payment is made"
+        website:
+          scoretaking_software:
+            external: "An external tool, not maintained by the WCA"
+            wca_live: "WCA Live, hosted on live.worldcubeassociation.org"
+            internal: "Integrated Live Results"
         registration:
           allow_on_the_spot:
             "true": "On the spot registrations will be accepted"


### PR DESCRIPTION
Currently, the competition form still has a checkbox which effectively (under the hood) is a toggle between WCA Live and "External". With Dual Rounds generally available, we need to allow Delegates to select ILR by themselves.

I have also configured "Edit Events" to grey out Dual Rounds if ILR is *not* selected.

Delegates can still create an inconsistent state by setting ILR, adding some Dual Rounds, and then going back to set scoretaking to WCA Live again. The Dual Rounds which were previously configured will persist in that case. Do we want to care about this? It would be non-trivial to implement, and TBH it kinda sounds like "Meh your fault" if somebody does that despite several clear hints and explainer texts on the website