### PR TITLE
Use result_attempts instead of value{v} when seeding

### DIFF
--- a/db/seeds/development/competitions.seeds.rb
+++ b/db/seeds/development/competitions.seeds.rb
@@ -94,7 +94,10 @@ after "development:users", "development:user_roles" do
             regional_average_record: k.zero? ? "WR" : nil,
           )
           round_format.expected_solve_count.times do |v|
-            result.send(:"value#{v + 1}=", random_wca_value)
+            result.result_attempts.build(
+              attempt_number: v + 1,
+              value: random_wca_value,
+            )
           end
           result.average = result.compute_correct_average
           result.best = result.compute_correct_best


### PR DESCRIPTION
Results have switched to a normalized table with individual results rather than have a value{N} column for each attempt. When this change was made, the seeding scripts were not updated to match the new schema. This updates the format by building the result_attempts rows instead of the now-missing value{N} columns.

# Testing

Running `docker exec -it rails bash -c "bin/rake db:reset"` now works to seed the database:

Before:

```
➜  worldcubeassociation.org git:(master) docker exec -it rails bash -c "bin/rake db:reset"
Running via Spring preloader in process 578
Dropped database 'wca_development'
Dropped database 'wca_test'
Created database 'wca_development'
Created database 'wca_test'
rake aborted!
NoMethodError: undefined method 'value1=' for an instance of Result (NoMethodError)
Did you mean?  id_value=
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/activemodel-8.1.3/lib/active_model/attribute_methods.rb:512:in 'ActiveModel::AttributeMethods#method_missing'
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/activerecord-8.1.3/lib/active_record/attribute_methods.rb:495:in 'ActiveRecord::AttributeMethods#method_missing'
/app/db/seeds/development/competitions.seeds.rb:97:in 'block (6 levels) in Seedbank::Runner#evaluate'
/app/db/seeds/development/competitions.seeds.rb:96:in 'block (5 levels) in Seedbank::Runner#evaluate'
/app/db/seeds/development/competitions.seeds.rb:81:in 'Array#each'
/app/db/seeds/development/competitions.seeds.rb:81:in 'Enumerable#each_with_index'
/app/db/seeds/development/competitions.seeds.rb:81:in 'block (4 levels) in Seedbank::Runner#evaluate'
/app/db/seeds/development/competitions.seeds.rb:66:in 'Array#each'
/app/db/seeds/development/competitions.seeds.rb:66:in 'Enumerable#each_with_index'
/app/db/seeds/development/competitions.seeds.rb:66:in 'block (3 levels) in Seedbank::Runner#evaluate'
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/activerecord-8.1.3/lib/active_record/relation/delegation.rb:100:in 'Array#each'
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/activerecord-8.1.3/lib/active_record/relation/delegation.rb:100:in 'ActiveRecord::Delegation#each'
/app/db/seeds/development/competitions.seeds.rb:62:in 'block (2 levels) in Seedbank::Runner#evaluate'
/app/db/seeds/development/competitions.seeds.rb:33:in 'block in Seedbank::Runner#evaluate'
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/seedbank-0.5.0/lib/seedbank/runner.rb:31:in 'Seedbank::Runner#after'
/app/db/seeds/development/competitions.seeds.rb:3:in 'Seedbank::Runner#evaluate'
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/seedbank-0.5.0/lib/seedbank/runner.rb:51:in 'BasicObject#instance_eval'
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/seedbank-0.5.0/lib/seedbank/runner.rb:51:in 'Seedbank::Runner#evaluate'
/usr/local/bundle/3.4.6/ruby/3.4.0/gems/seedbank-0.5.0/lib/seedbank/dsl.rb:32:in 'block in define_seed_task'
<internal:/usr/local/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
<internal:/usr/local/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
-e:1:in '<main>'
Tasks: TOP => db:seed:development:competitions:body
(See full trace by running task with --trace) 
```

After:

```bash
➜  worldcubeassociation.org git:(master) ✗ docker exec -it rails bash -c "bin/rake db:reset" 
Running via Spring preloader in process 87
Dropped database 'wca_development'
Dropped database 'wca_test'
Created database 'wca_development'
Created database 'wca_test'

What's next:
    Try Docker Debug for seamless, persistent debugging tools in any container or image → docker debug rails
    Learn more at https://docs.docker.com/go/debug-cli/
➜  worldcubeassociation.org git:(master) ✗ 
```
