### PR TITLE
Add sanity check 72: suspiciously short-lived user roles

### DIFF
--- a/lib/sanity_check_sql/8 - user_data_irregularities/72 - user_role_short_lived.sql
+++ b/lib/sanity_check_sql/8 - user_data_irregularities/72 - user_role_short_lived.sql
@@ -1,0 +1,18 @@
+SELECT
+  ur.user_id,
+  u.name AS user_name,
+  ug.name AS group_name,
+  ug.group_type,
+  ur.start_date,
+  ur.end_date,
+  ur.metadata_id,
+  ur.metadata_type,
+  ur.created_at,
+  ur.updated_at
+FROM user_roles AS ur
+INNER JOIN user_groups AS ug
+ON ur.group_id = ug.id
+INNER JOIN users AS u
+ON ur.user_id = u.id
+WHERE end_date - start_date <= 1
+ORDER BY ur.created_at, ur.user_id;

--- a/lib/static_data/sanity_checks.json
+++ b/lib/static_data/sanity_checks.json
@@ -481,5 +481,12 @@
     "topic": "Invalid Cumulative Time Limit",
     "comments": null,
     "query_file": "invalid_cumulative_limit.sql"
+  },
+  {
+    "id": "72",
+    "sanity_check_category_id": "8",
+    "topic": "Suspiciously short-lived user role (same or consecutive day start/end)",
+    "comments": null,
+    "query_file": "user_role_short_lived.sql"
   }
 ]


### PR DESCRIPTION
## Summary

- Adds sanity check 72 in category 8 (User Data Irregularities)
- Detects `user_roles` rows where `end_date - start_date <= 1`, i.e. a role that was ended the same day or the day after it was assigned
- Intended to catch misclick-caused role changes that were immediately corrected
- Returns 27 results on production to be investigated by WRT (resolve or add exclusions)