### PR TITLE
Warn when 333mbf results are submitted to prompt scramble count info

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3031,6 +3031,7 @@ en:
       missing_scrambles_for_competition_error: "Missing scrambles for the competition. Use Scrambles Matcher to add scrambles."
       missing_scrambles_for_group_error: "[%{round_id}] Group %{group_id}: missing scrambles, detected only %{actual} instead of %{expected}."
       missing_scrambles_for_multi_error: "[%{round_id}] While you may have multiple groups in 3x3x3 Multi-Blind, at least one of the groups must contain scrambles for all attempts."
+      mbld_scrambles_warning: "[%{round_id}] This round includes 3x3x3 Multi-Blind results. Please specify in your submission comment how many scrambles from each scramble set were actually used by competitors, so that WRT can remove the unused extra scrambles."
       multiple_fmc_groups_warning: "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
       wrong_number_of_scramble_sets_error: "[%{round_id}] This round has a different number of scramble sets (%{actual}) than specified on the Manage Events tab (%{expected}). Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
   tickets:

--- a/lib/results_validators/scrambles_validator.rb
+++ b/lib/results_validators/scrambles_validator.rb
@@ -8,6 +8,7 @@ module ResultsValidators
     MISSING_SCRAMBLES_FOR_MULTI_ERROR = :missing_scrambles_for_multi_error
     MULTIPLE_FMC_GROUPS_WARNING = :multiple_fmc_groups_warning
     WRONG_NUMBER_OF_SCRAMBLE_SETS_ERROR = :wrong_number_of_scramble_sets_error
+    MBLD_SCRAMBLES_WARNING = :mbld_scrambles_warning
 
     def self.description
       "This validator checks that all results have matching scrambles, and if possible, checks that the scrambles have the correct number of attempts compared to the expected round format."
@@ -85,6 +86,9 @@ module ResultsValidators
                                              :scrambles, competition.id,
                                              round_id: round.human_id)
             end
+            @warnings << ValidationWarning.new(MBLD_SCRAMBLES_WARNING,
+                                               :scrambles, competition.id,
+                                               round_id: round.human_id)
           else
             @errors.concat(errors_for_round)
           end

--- a/spec/lib/results_validators/scrambles_validator_spec.rb
+++ b/spec/lib/results_validators/scrambles_validator_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe SV do
       # MISSING_SCRAMBLES_FOR_ROUND_ERROR
       # MISSING_SCRAMBLES_FOR_COMPETITION_ERROR
       # MISSING_SCRAMBLES_FOR_GROUP_ERROR
+      # MBLD_SCRAMBLES_WARNING
       it "matches Result" do
         [Result, InboxResult].each do |model|
           result_kind = model.model_name.singular.to_sym
@@ -161,10 +162,42 @@ RSpec.describe SV do
                                   round_id: "333mbf-f"),
         ]
 
+        expected_warnings = [
+          RV::ValidationWarning.new(SV::MBLD_SCRAMBLES_WARNING,
+                                    :scrambles, competition1.id,
+                                    round_id: "333mbf-f"),
+          RV::ValidationWarning.new(SV::MBLD_SCRAMBLES_WARNING,
+                                    :scrambles, competition2.id,
+                                    round_id: "333mbf-f"),
+        ]
+
         validator_args.each do |arg|
           sv = SV.new.validate(**arg)
-          expect(sv.warnings).to be_empty
+          expect(sv.warnings).to match_array(expected_warnings)
           expect(sv.errors).to match_array(expected_errors)
+        end
+      end
+
+      it "warns for every 333mbf round" do
+        round_333mbf = create(:round, competition: competition1, event_id: "333mbf", format_id: "3")
+
+        [Result, InboxResult].each do |model|
+          result_kind = model.model_name.singular.to_sym
+          create(result_kind, :mbf, competition: competition1, round: round_333mbf)
+        end
+
+        create_scramble_set(3, round: round_333mbf)
+
+        expected_warnings = [
+          RV::ValidationWarning.new(SV::MBLD_SCRAMBLES_WARNING,
+                                    :scrambles, competition1.id,
+                                    round_id: "333mbf-f"),
+        ]
+
+        validator_args.each do |arg|
+          sv = SV.new.validate(**arg)
+          expect(sv.warnings).to match_array(expected_warnings)
+          expect(sv.errors).to be_empty
         end
       end
     end


### PR DESCRIPTION
## Summary

- Adds a new \`MBLD_SCRAMBLES_WARNING\` in \`ScramblesValidator\` that fires whenever a 333mbf round is present in a results submission.
- The warning asks the Delegate to specify in their submission comment how many scrambles from each scramble set were actually used by competitors, so WRT can remove the unused extra scrambles.
- Updated the existing \`"correctly (in)validates multiple groups for 333mbf"\` spec, which previously asserted \`warnings\` was empty — it now expects the new warning for each 333mbf round.
- Added a new \`"warns for every 333mbf round"\` spec covering the happy path (valid scrambles, no errors, just the new warning).

> [!NOTE]
> This implementation was not locally tested and was co-authored with [Claude Code](https://claude.ai/code).