### PR TITLE
fix: update nearby competitions text to align with check

### DIFF
--- a/app/webpacker/components/CompetitionForm/Tables/NearbyComps.js
+++ b/app/webpacker/components/CompetitionForm/Tables/NearbyComps.js
@@ -61,7 +61,7 @@ export default function NearbyComps() {
     loading,
   } = useLoadedData(nearbyDataUrl);
 
-  const label = I18n.t('competitions.adjacent_competitions.label', { days: 5, kms: 10 });
+  const label = I18n.t('competitions.adjacent_competitions.label', { days: 5, kms: 30 });
 
   if (loading) {
     return (


### PR DESCRIPTION
As of WCRP 5.5 the minimum distance to check for with regards to proximity policy is 5 days and 30 kilometers. When updating the website I noticed that the check still looked for 5 days and 30 kilometers, hence the PR only updates the text.