### PR TITLE
Fix statistics display in all delegates table

### DIFF
--- a/app/webpacker/react_on_rails_components/Delegates/DelegatesOfAllRegion.jsx
+++ b/app/webpacker/react_on_rails_components/Delegates/DelegatesOfAllRegion.jsx
@@ -76,7 +76,7 @@ export default function DelegatesOfAllRegion() {
       <DelegatesTable
         delegates={otherDelegatesWithExtraData}
         isAdminMode
-        isAllSeniorAndRegionalDelegates
+        isAllNonSeniorAndRegionalDelegates
       />
     </>
   );


### PR DESCRIPTION
In #14053 I made a mistake while renaming variables, which caused statistics to be hidden. 
<img width="500" height="72" alt="image" src="https://github.com/user-attachments/assets/7ca03d60-f871-4603-b146-d2a0699fe77f" />

This PR fixes that.