### PR TITLE
Don't add competitor to both rounds of a dual round if one is not open yet

### DIFF
--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -219,6 +219,8 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
     rounds = round.linked_round.present? ? round.linked_round.rounds : round.rounds
 
     rounds.each do |r|
+      next unless r.lifecycle_state == Round::STATE_OPEN
+
       Live::DiffHelper.broadcast_changes(r) do
         r.create_empty_live_result(registration.id)
       end

--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -218,9 +218,9 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     rounds = round.linked_round.present? ? round.linked_round.rounds : round.rounds
 
-    rounds.each do |r|
-      next unless r.lifecycle_state == Round::STATE_OPEN
+    open_rounds = rounds.select { |r| r.lifecycle_state == Round::STATE_OPEN }
 
+    open_rounds.each do |r|
       Live::DiffHelper.broadcast_changes(r) do
         r.create_empty_live_result(registration.id)
       end


### PR DESCRIPTION
Fixes the issue where it accidentally "opens" the second round with only one competitor in it.