### PR TITLE
Make CMS homepage buttons solid blue by default

### DIFF
--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -88,19 +88,25 @@ const TextCard = ({ block }: { block: TextCardBlock }) => {
       {block.buttons && block.buttons.length > 0 && (
         <Card.Footer asChild>
           <HStack>
-            {block.buttons.map((btn) => (
+            {block.buttons.map((button) => (
               <Button
-                key={btn.id}
+                key={button.id}
                 asChild
-                variant="outline"
-                _hover={{ bg: "colorPalette.emphasized" }}
+                colorPalette={button.inheritColorScheme ? undefined : "blue"}
+                variant={button.inheritColorScheme ? "outline" : "solid"}
+                bg={button.inheritColorScheme ? undefined : "colorPalette.1A"}
+                _hover={{
+                  bg: button.inheritColorScheme
+                    ? "colorPalette.emphasized"
+                    : undefined,
+                }}
               >
                 <ChakraLink
                   color="colorPalette.pastelContrast"
                   textStyle={undefined}
-                  href={btn.hyperlink}
+                  href={button.hyperlink}
                 >
-                  {btn.displayText}
+                  {button.displayText}
                 </ChakraLink>
               </Button>
             ))}

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -85,21 +85,26 @@ const TextCard = ({ block }: { block: TextCardBlock }) => {
           {block.bodyMarkdown}
         </ChakraMarkdown>
       </Card.Body>
-      {block.buttonText?.trim() && (
-        <Card.Footer>
-          <Button
-            asChild
-            variant="outline"
-            _hover={{ bg: "colorPalette.emphasized" }}
-          >
-            <ChakraLink
-              color="colorPalette.pastelContrast"
-              textStyle={undefined}
-              href={block.buttonLink!}
-            >
-              {block.buttonText}
-            </ChakraLink>
-          </Button>
+      {block.buttons && block.buttons.length > 0 && (
+        <Card.Footer asChild>
+          <HStack>
+            {block.buttons.map((btn) => (
+              <Button
+                key={btn.id}
+                asChild
+                variant="outline"
+                _hover={{ bg: "colorPalette.emphasized" }}
+              >
+                <ChakraLink
+                  color="colorPalette.pastelContrast"
+                  textStyle={undefined}
+                  href={btn.hyperlink}
+                >
+                  {btn.displayText}
+                </ChakraLink>
+              </Button>
+            ))}
+          </HStack>
         </Card.Footer>
       )}
     </Card.Root>

--- a/next-frontend/src/blocks/text/textCard.ts
+++ b/next-frontend/src/blocks/text/textCard.ts
@@ -21,6 +21,10 @@ const actionButtonBlock: Block = {
       type: "checkbox",
       required: true,
       defaultValue: false,
+      admin: {
+        description:
+          "Buttons are solid blue by default. If you click this checkbox, their color will follow the original text box instead",
+      },
     },
   ],
 };

--- a/next-frontend/src/blocks/text/textCard.ts
+++ b/next-frontend/src/blocks/text/textCard.ts
@@ -2,6 +2,29 @@ import { Block } from "payload";
 import { markdownConvertedField } from "@/collections/helpers";
 import { colorPaletteSelect } from "@/blocks/utils";
 
+const actionButtonBlock: Block = {
+  slug: "actionButton",
+  interfaceName: "BentoActionButton",
+  fields: [
+    {
+      name: "displayText",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "hyperlink",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "inheritColorScheme",
+      type: "checkbox",
+      required: true,
+      defaultValue: false,
+    },
+  ],
+};
+
 export const TextCardBlock: Block = {
   slug: "TextCard",
   interfaceName: "TextCardBlock",
@@ -25,14 +48,11 @@ export const TextCardBlock: Block = {
       defaultValue: false,
     },
     {
-      name: "buttonText",
-      type: "text",
-      required: false,
-    },
-    {
-      name: "buttonLink",
-      type: "text",
-      required: false,
+      name: "buttons",
+      type: "blocks",
+      blocks: [actionButtonBlock],
+      minRows: 0,
+      maxRows: 1,
     },
     {
       name: "headerImage",

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -1161,13 +1161,24 @@ export interface TextCardBlock {
   };
   bodyMarkdown?: string | null;
   separatorAfterHeading: boolean;
-  buttonText?: string | null;
-  buttonLink?: string | null;
+  buttons?: BentoActionButton[] | null;
   headerImage?: (string | null) | Media;
   colorPalette: ColorPaletteSelect;
   id?: string | null;
   blockName?: string | null;
   blockType: 'TextCard';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "BentoActionButton".
+ */
+export interface BentoActionButton {
+  displayText: string;
+  hyperlink: string;
+  inheritColorScheme: boolean;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'actionButton';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1890,10 +1901,24 @@ export interface TextCardBlockSelect<T extends boolean = true> {
   body?: T;
   bodyMarkdown?: T;
   separatorAfterHeading?: T;
-  buttonText?: T;
-  buttonLink?: T;
+  buttons?:
+    | T
+    | {
+        actionButton?: T | BentoActionButtonSelect<T>;
+      };
   headerImage?: T;
   colorPalette?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "BentoActionButton_select".
+ */
+export interface BentoActionButtonSelect<T extends boolean = true> {
+  displayText?: T;
+  hyperlink?: T;
+  inheritColorScheme?: T;
   id?: T;
   blockName?: T;
 }


### PR DESCRIPTION
This makes all buttons blue by default, like in the Slate mockups.
<img width="638" height="223" alt="image" src="https://github.com/user-attachments/assets/d55486b7-c1a9-494a-a3b7-b4ca223c767c" />

There is also an additional checkbox in the Payload CMS config, if you tick it (ie you *actively* turn it on) then you're actively saying "I do NOT want blue, I want it to follow the color scheme of the parent box instead". This essentially lets you keep the "outline color buttons" from the previous iteration, if you want.
<img width="742" height="364" alt="image" src="https://github.com/user-attachments/assets/14017a2e-635c-477b-9524-0ff7f1e21d7a" />
<img width="628" height="236" alt="image" src="https://github.com/user-attachments/assets/a26096d9-4715-4852-a485-555ddb4fc09d" />
 
Note how the button in the yellow example is also yellow, because I clicked the box. The checkbox is unselected by default, so you will get blue buttons by default everywhere.