### PR TITLE
Add includes for search

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1754,7 +1754,15 @@ class Competition < ApplicationRecord
     # Respect other `includes` associations that might have been specified ahead of time
     previous_includes = competitions.includes_values
 
-    competitions.includes(:delegates, :organizers, *previous_includes).order(**order)
+    # The delegates and organizers get run through `User#serializable_hash`, so eager load the
+    # associations it touches to avoid an N+1 explosion (one set of queries per delegate/organizer
+    # per competition). See `User::SERIALIZATION_INCLUDES`.
+    competitions.includes(
+      :events, # serialized via the `event_ids` method, one query per competition otherwise
+      { delegates: User::SERIALIZATION_INCLUDES },
+      { organizers: User::SERIALIZATION_INCLUDES },
+      *previous_includes,
+    ).order(**order)
   end
 
   def competing_step_parameters(current_user)

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -19,7 +19,9 @@ module Taggable
     attr_writer :tags
 
     def tags
-      @tags ||= item_tags.pluck(:tag).join(",")
+      # Reuse the loaded association when the caller eager loaded the tags (e.g. when
+      # serializing many records); `pluck` would otherwise issue a query per record.
+      @tags ||= (item_tags.loaded? ? item_tags.map(&:tag) : item_tags.pluck(:tag)).join(",")
     end
 
     def tags_array

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -40,7 +40,9 @@ class Incident < ApplicationRecord
   end
 
   def self.search(query, params: {})
-    incidents = Incident
+    # `serializable_hash` walks `incident_competitions` (and their `competition`) and the
+    # incident tags, so eager load them to avoid an N+1 per incident during serialization.
+    incidents = Incident.includes(:incident_tags, incident_competitions: :competition)
     query&.split&.each do |part|
       like_query = %w[public_summary title].map { |col| "#{col} LIKE :part" }.join(" OR ")
       incidents = incidents.where(like_query, part: "%#{part}%")

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -259,7 +259,9 @@ class Person < ApplicationRecord
   end
 
   def self.search(query, params: {})
-    persons = Person.current.includes(:user)
+    # `serializable_hash` serializes the associated user, so eager load the associations
+    # `User#serializable_hash` touches to avoid an N+1 per person.
+    persons = Person.current.includes(user: User::SERIALIZATION_INCLUDES)
     query.split.each do |part|
       persons = persons.where("name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1226,10 +1226,10 @@ class User < ApplicationRecord
     return User.where(email: query) if admin_search && search_by_email
 
     if searching_persons_table
-      users = Person.includes(:user).current
+      users = Person.includes(user: SERIALIZATION_INCLUDES).current
       search_by_email = false # We can't search by email on the 'Person' table
     else
-      users = User.confirmed_email.not_dummy_account
+      users = User.confirmed_email.not_dummy_account.includes(SERIALIZATION_INCLUDES)
 
       users = users.where(id: self.staff_delegate_ids) if ActiveRecord::Type::Boolean.new.cast(params[:only_staff_delegates])
 
@@ -1254,8 +1254,12 @@ class User < ApplicationRecord
   end
 
   private def deprecated_team_roles
-    active_roles
-      .includes(:metadata, group: [:metadata])
+    # Reuse the already-loaded association (with its metadata/group preloaded) when the
+    # caller eager loaded it; otherwise build the query with the includes we need. Calling
+    # `.includes` unconditionally would discard any preloaded `active_roles` and re-query.
+    roles = active_roles.loaded? ? active_roles : active_roles.includes(:metadata, group: [:metadata])
+
+    roles
       .select do |role|
         [
           UserGroup.group_types[:teams_committees],
@@ -1273,6 +1277,16 @@ class User < ApplicationRecord
     methods: %w[url country],
     include: %w[avatar],
   }.freeze
+
+  # Associations that `serializable_hash` touches: `staff_delegate?` (delegate role metadata),
+  # `deprecated_team_roles` (active roles + their metadata/group) and `avatar` (current_avatar).
+  # Eager load these whenever many users are serialized to avoid an N+1 explosion.
+  SERIALIZATION_INCLUDES = [
+    :current_avatar,
+    :delegate_role_metadata,
+    :delegate_roles,
+    { active_roles: [:metadata, { group: :metadata }] },
+  ].freeze
 
   def serializable_hash(options = nil)
     # NOTE: doing deep_dup is necessary here to avoid changing the inner values


### PR DESCRIPTION
Takes the queries down from 
`Completed 200 OK in 10321ms (Views: 3.1ms | ActiveRecord: 1814.6ms (1808 queries, 676 cached) | GC: 599.2ms)`
to 
`Completed 200 OK in 2027ms (Views: 1.9ms | ActiveRecord: 1190.3ms (46 queries, 2 cached) | GC: 194.2ms)`

And gives a 8x speedup on my machine.