### PR TITLE
Person Search: Split wca_id search and name search to use fulltext index

### DIFF
--- a/app/controllers/persons_controller.rb
+++ b/app/controllers/persons_controller.rb
@@ -16,7 +16,10 @@ class PersonsController < ApplicationController
       format.json do
         persons = Person.in_region(params[:region]).order(:name)
         params[:search]&.split&.each do |part|
-          persons = persons.where("MATCH(persons.name) AGAINST (:name_match IN BOOLEAN MODE) OR wca_id LIKE :wca_id_part", name_match: "#{part}*", wca_id_part: "#{part}%")
+          # Quoted phrase against the ngram FULLTEXT index does substring matching
+          # (see Person.search); strip embedded quotes so input can't break out.
+          name_match = %("#{part.delete('"')}")
+          persons = persons.where("MATCH(persons.name) AGAINST (:name_match IN BOOLEAN MODE) OR wca_id LIKE :wca_id_part", name_match: name_match, wca_id_part: "#{part}%")
         end
 
         render json: {

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -268,16 +268,17 @@ class Person < ApplicationRecord
         # is a WCA ID lookup. A prefix match (no leading wildcard) uses the wca_id index.
         persons = persons.where("wca_id LIKE :part", part: "#{part}%")
       else
-        # Match on the FULLTEXT index on `name`. A leading-wildcard `LIKE '%part%'`
-        # can't use any index and forces a full table scan (~500ms on ~290k rows);
-        # boolean-mode fulltext with a prefix wildcard uses the index (~3ms).
-        # Strip boolean-mode operators (e.g. the `-` in "Al-Sayed") so user input
-        # can't be interpreted as query syntax, and require every resulting token.
-        tokens = part.gsub(/[-+~<>()*"@]/, " ").split
-        next if tokens.empty?
+        # Match on the ngram FULLTEXT index on `name` (see the
+        # UseNgramFulltextIndexOnPersonsName migration). A leading-wildcard `LIKE
+        # '%part%'` can't use any index and forces a full table scan (~500ms on
+        # ~290k rows); the ngram index does substring matching via the index (~ms),
+        # so e.g. "koy" still finds "Akoy". A double-quoted phrase makes boolean
+        # mode require the part's n-grams in sequence (i.e. a real substring match);
+        # strip embedded quotes so the input can't break out of the phrase.
+        token = part.delete('"')
+        next if token.empty?
 
-        against = tokens.map { |token| "+#{token}*" }.join(" ")
-        persons = persons.where("MATCH(name) AGAINST(:against IN BOOLEAN MODE)", against: against)
+        persons = persons.where("MATCH(name) AGAINST(:phrase IN BOOLEAN MODE)", phrase: %("#{token}"))
       end
     end
     persons.order(:name)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -263,7 +263,22 @@ class Person < ApplicationRecord
     # `User#serializable_hash` touches to avoid an N+1 per person.
     persons = Person.current.includes(user: User::SERIALIZATION_INCLUDES)
     query.split.each do |part|
-      persons = persons.where("name LIKE :part OR wca_id LIKE :part", part: "%#{part}%")
+      if part.match?(/\d/)
+        # WCA IDs always contain digits and names never do, so a part with a digit
+        # is a WCA ID lookup. A prefix match (no leading wildcard) uses the wca_id index.
+        persons = persons.where("wca_id LIKE :part", part: "#{part}%")
+      else
+        # Match on the FULLTEXT index on `name`. A leading-wildcard `LIKE '%part%'`
+        # can't use any index and forces a full table scan (~500ms on ~290k rows);
+        # boolean-mode fulltext with a prefix wildcard uses the index (~3ms).
+        # Strip boolean-mode operators (e.g. the `-` in "Al-Sayed") so user input
+        # can't be interpreted as query syntax, and require every resulting token.
+        tokens = part.gsub(/[-+~<>()*"@]/, " ").split
+        next if tokens.empty?
+
+        against = tokens.map { |token| "+#{token}*" }.join(" ")
+        persons = persons.where("MATCH(name) AGAINST(:against IN BOOLEAN MODE)", against: against)
+      end
     end
     persons.order(:name)
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,6 +4,11 @@ class Person < ApplicationRecord
   # for some reason, the ActiveRecord plural for "Person" is "people"…
   self.table_name = 'persons'
 
+  # Matches the MySQL `ngram_token_size` used by the ngram FULLTEXT index on `name`
+  # (see the UseNgramFulltextIndexOnPersonsName migration). Search tokens shorter
+  # than this can't be matched by the index.
+  NGRAM_TOKEN_SIZE = 2
+
   has_one :user, primary_key: "wca_id", foreign_key: "wca_id", inverse_of: :person
   has_one :unconfirmed_user, primary_key: "wca_id", foreign_key: "unconfirmed_wca_id", class_name: "User", inverse_of: :unconfirmed_person
   has_many :results, primary_key: "wca_id"
@@ -276,7 +281,10 @@ class Person < ApplicationRecord
         # mode require the part's n-grams in sequence (i.e. a real substring match);
         # strip embedded quotes so the input can't break out of the phrase.
         token = part.delete('"')
-        next if token.empty?
+        # Tokens shorter than the ngram token size can't be matched by the index
+        # (and a 1-char fragment is meaningless as a search term), so skip them
+        # rather than AND-ing in a clause that can never match.
+        next if token.length < NGRAM_TOKEN_SIZE
 
         persons = persons.where("MATCH(name) AGAINST(:phrase IN BOOLEAN MODE)", phrase: %("#{token}"))
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1225,18 +1225,18 @@ class User < ApplicationRecord
 
     return User.where(email: query) if admin_search && search_by_email
 
-    if searching_persons_table
-      users = Person.includes(user: SERIALIZATION_INCLUDES).current
-      search_by_email = false # We can't search by email on the 'Person' table
-    else
-      users = User.confirmed_email.not_dummy_account.includes(SERIALIZATION_INCLUDES)
+    # Searching the 'persons' table is identical to Person.search (same includes and
+    # ordering), which uses the FULLTEXT index on persons.name. The 'users' table has
+    # no such index, so it keeps the (slower) LIKE search below.
+    return Person.search(query) if searching_persons_table
 
-      users = users.where(id: self.staff_delegate_ids) if ActiveRecord::Type::Boolean.new.cast(params[:only_staff_delegates])
+    users = User.confirmed_email.not_dummy_account.includes(SERIALIZATION_INCLUDES)
 
-      users = users.where(id: self.trainee_delegate_ids) if ActiveRecord::Type::Boolean.new.cast(params[:only_trainee_delegates])
+    users = users.where(id: self.staff_delegate_ids) if ActiveRecord::Type::Boolean.new.cast(params[:only_staff_delegates])
 
-      users = users.where.not(wca_id: nil) if ActiveRecord::Type::Boolean.new.cast(params[:only_with_wca_ids])
-    end
+    users = users.where(id: self.trainee_delegate_ids) if ActiveRecord::Type::Boolean.new.cast(params[:only_trainee_delegates])
+
+    users = users.where.not(wca_id: nil) if ActiveRecord::Type::Boolean.new.cast(params[:only_with_wca_ids])
 
     query.split.each do |part|
       users = users.where("name LIKE :part OR wca_id LIKE :part #{'OR email LIKE :part' if search_by_email}", part: "%#{part}%")

--- a/db/migrate/20260612120000_use_ngram_fulltext_index_on_persons_name.rb
+++ b/db/migrate/20260612120000_use_ngram_fulltext_index_on_persons_name.rb
@@ -21,7 +21,7 @@ class UseNgramFulltextIndexOnPersonsName < ActiveRecord::Migration[8.1]
   end
 
   def down
-    remove_index :persons, name: "index_persons_on_name"
+    remove_index :persons, name: "index_persons_on_name" # rubocop:disable Rails/BulkChangeTable
     add_index :persons, :name, type: :fulltext, name: "index_persons_on_name"
   end
 end

--- a/db/migrate/20260612120000_use_ngram_fulltext_index_on_persons_name.rb
+++ b/db/migrate/20260612120000_use_ngram_fulltext_index_on_persons_name.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UseNgramFulltextIndexOnPersonsName < ActiveRecord::Migration[8.1]
+  # Replace the word-prefix FULLTEXT index on persons.name with one that uses the
+  # ngram parser, so person search can match substrings mid-word (e.g. "koy" finds
+  # "Akoy Gregory") while still being index-backed instead of a `LIKE '%...%'` scan.
+  def up
+    remove_index :persons, name: "index_persons_on_name"
+    execute <<~SQL.squish
+      CREATE FULLTEXT INDEX index_persons_on_name ON persons (name) WITH PARSER ngram
+    SQL
+  end
+
+  def down
+    remove_index :persons, name: "index_persons_on_name"
+    add_index :persons, :name, type: :fulltext, name: "index_persons_on_name"
+  end
+end

--- a/db/migrate/20260612120000_use_ngram_fulltext_index_on_persons_name.rb
+++ b/db/migrate/20260612120000_use_ngram_fulltext_index_on_persons_name.rb
@@ -4,11 +4,20 @@ class UseNgramFulltextIndexOnPersonsName < ActiveRecord::Migration[8.1]
   # Replace the word-prefix FULLTEXT index on persons.name with one that uses the
   # ngram parser, so person search can match substrings mid-word (e.g. "koy" finds
   # "Akoy Gregory") while still being index-backed instead of a `LIKE '%...%'` scan.
+  #
+  # Stopwords are disabled for this index: InnoDB's default stopword list contains
+  # common bigrams ("la", "en", "de", "on", ...), and the ngram parser would drop
+  # those tokens, breaking searches like "Law" (la + aw). The stopword setting is
+  # read at index-build time and baked into the index, so this needs no query-time
+  # changes. Toggling it is safe because it only affects FULLTEXT index builds.
   def up
     remove_index :persons, name: "index_persons_on_name"
+    execute "SET SESSION innodb_ft_enable_stopword = OFF"
     execute <<~SQL.squish
       CREATE FULLTEXT INDEX index_persons_on_name ON persons (name) WITH PARSER ngram
     SQL
+  ensure
+    execute "SET SESSION innodb_ft_enable_stopword = ON"
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_110117) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_120000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false

--- a/spec/controllers/persons_controller_spec.rb
+++ b/spec/controllers/persons_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PersonsController do
     # on https://dev.mysql.com/doc/refman/5.7/en/innodb-fulltext-index.html.
     # "a FULLTEXT search can only see committed data", which means that
     # we cannot run these tests inside of a transaction (as is the default).
-    context "Ajax request", :clean_db_with_truncation do
+    context "Ajax request", :clean_db_with_truncation, :ngram_person_index do
       let!(:person1) { create(:person, name: "Jennifer Lawrence", country_id: "USA", wca_id: "2016LAWR01") }
       let!(:person2) { create(:person, name: "Benedict Cumberbatch", country_id: "United Kingdom", wca_id: "2016CUMB01") }
       let!(:competition) { create(:competition) }

--- a/spec/requests/api_persons_spec.rb
+++ b/spec/requests/api_persons_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe "API Persons" do
       end
     end
 
-    context "when a query is given" do
+    # A FULLTEXT search can only see committed data, so this cannot run inside the
+    # default transaction. See PersonsController spec for the same handling.
+    context "when a query is given", :clean_db_with_truncation do
       it "renders only people matching the query parameter" do
         get api_v0_persons_path, params: { q: "#{person.wca_id.first(4)} #{person.name[1..]}" }
         expect(response).to be_successful

--- a/spec/requests/api_persons_spec.rb
+++ b/spec/requests/api_persons_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe "API Persons" do
 
     # A FULLTEXT search can only see committed data, so this cannot run inside the
     # default transaction. See PersonsController spec for the same handling.
-    context "when a query is given", :clean_db_with_truncation do
+    # `:ngram_person_index` rebuilds the ngram index so substring search works here.
+    context "when a query is given", :clean_db_with_truncation, :ngram_person_index do
       it "renders only people matching the query parameter" do
         get api_v0_persons_path, params: { q: "#{person.wca_id.first(4)} #{person.name[1..]}" }
         expect(response).to be_successful

--- a/spec/support/ngram_person_index.rb
+++ b/spec/support/ngram_person_index.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# The `WITH PARSER ngram` clause on the persons.name FULLTEXT index (added by the
+# UseNgramFulltextIndexOnPersonsName migration) cannot be represented in Rails'
+# Ruby schema dumper, so the schema-loaded test DB gets a plain word index instead.
+# That makes substring person search (e.g. "koy" -> "Akoy") behave differently in
+# tests than in production. Tag a context with `:ngram_person_index` to rebuild the
+# real ngram index before those examples run.
+module NgramPersonIndex
+  module_function
+
+  def recreate!
+    conn = ActiveRecord::Base.connection
+    # Stopwords OFF so ngram bigrams like "la"/"en" are not dropped; see the
+    # UseNgramFulltextIndexOnPersonsName migration for the full rationale. We leave
+    # the session setting OFF (rather than resetting it) on purpose: DatabaseCleaner
+    # truncates persons between examples, and TRUNCATE rebuilds the FULLTEXT index
+    # re-reading this setting -- if it were ON again the index would revert to
+    # stopword behavior and substring searches like "Law" would start failing.
+    conn.execute("SET SESSION innodb_ft_enable_stopword = OFF")
+    conn.execute("ALTER TABLE persons DROP INDEX index_persons_on_name")
+    conn.execute("CREATE FULLTEXT INDEX index_persons_on_name ON persons (name) WITH PARSER ngram")
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:context, :ngram_person_index) do
+    NgramPersonIndex.recreate!
+  end
+end

--- a/spec/support/ngram_person_index.rb
+++ b/spec/support/ngram_person_index.rb
@@ -12,11 +12,8 @@ module NgramPersonIndex
   def recreate!
     conn = ActiveRecord::Base.connection
     # Stopwords OFF so ngram bigrams like "la"/"en" are not dropped; see the
-    # UseNgramFulltextIndexOnPersonsName migration for the full rationale. We leave
-    # the session setting OFF (rather than resetting it) on purpose: DatabaseCleaner
-    # truncates persons between examples, and TRUNCATE rebuilds the FULLTEXT index
-    # re-reading this setting -- if it were ON again the index would revert to
-    # stopword behavior and substring searches like "Law" would start failing.
+    # UseNgramFulltextIndexOnPersonsName migration for the full rationale. The
+    # setting is read (and baked into the index) at CREATE time on this connection.
     conn.execute("SET SESSION innodb_ft_enable_stopword = OFF")
     conn.execute("ALTER TABLE persons DROP INDEX index_persons_on_name")
     conn.execute("CREATE FULLTEXT INDEX index_persons_on_name ON persons (name) WITH PARSER ngram")
@@ -24,7 +21,12 @@ module NgramPersonIndex
 end
 
 RSpec.configure do |config|
-  config.before(:context, :ngram_person_index) do
+  # Rebuild per example, not per context: DatabaseCleaner truncates persons between
+  # examples and TRUNCATE rebuilds the FULLTEXT index (reverting it to a stopword
+  # word index), so a once-per-context rebuild would go stale after the first
+  # truncation. This hook runs after DatabaseCleaner.start, so the table is clean;
+  # rows created afterwards by `let!` are indexed by the freshly-built ngram index.
+  config.before(:each, :ngram_person_index) do
     NgramPersonIndex.recreate!
   end
 end


### PR DESCRIPTION
This has been on my todo list for quite a while and I finally found out why our search fulltext index wasn't used. The problem was the OR query killed the index.

Before:
```
rails        | [user:15073]   ↳ app/controllers/api/v0/api_controller.rb:146:in 'Array#each'
rails        | [user:15073]   Person Load (899.1ms)  SELECT `persons`.* FROM `persons` WHERE `persons`.`sub_id` = 1 AND (name LIKE '%2012ICKL%' OR wca_id LIKE '%2012ICKL%' ) ORDER BY `persons`.`name` ASC LIMIT 20
```
after wca_id:
```
rails        | [user:15073]   ↳ app/controllers/api/v0/api_controller.rb:146:in 'Array#each'
rails        | [user:15073]   Person Load (1.8ms)  SELECT `persons`.* FROM `persons` WHERE `persons`.`sub_id` = 1 AND (wca_id LIKE '2012ICKL01%') ORDER BY `persons`.`name` ASC LIMIT 2
```
after text search
```
rails        | [user:15073]   ↳ app/controllers/api/v0/api_controller.rb:146:in 'Array#each'
rails        | [user:15073]   Person Load (6.3ms)  SELECT `persons`.* FROM `persons` WHERE `persons`.`sub_id` = 1 AND (MATCH(name) AGAINST('+Finn*' IN BOOLEAN MODE)) AND (MATCH(name) AGAINST('+Ickler*' IN BOOLEAN MODE)) ORDER BY `persons`.`name` ASC LIMIT 20
```

This is like a 500x speed up for wca id and 100x speed up for text search