### PR TITLE
Add option to grow horizontal splitter heights if desired

### DIFF
--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -248,13 +248,20 @@ const ImageOnlyCardImage = ({ block }: { block: ImageOnlyCardBlock }) => {
   );
 };
 
-const ImageOnlyCard = ({ block }: { block: ImageOnlyCardBlock }) => {
+const ImageOnlyCard = ({
+  block,
+  grow = false,
+}: {
+  block: ImageOnlyCardBlock;
+  grow?: boolean;
+}) => {
   return (
     <Card.Root
       overflow="hidden"
       colorPalette={block.colorPalette}
       colorVariant="slatePastel"
       width="full"
+      flexGrow={grow ? "1" : undefined}
     >
       {block.textPosition === "bottom" && <ImageOnlyCardImage block={block} />}
       {block.heading && (
@@ -460,7 +467,7 @@ const renderBlock = (
     case "ImageBanner":
       return <ImageBanner block={entry} />;
     case "ImageOnlyCard":
-      return <ImageOnlyCard block={entry} />;
+      return <ImageOnlyCard block={entry} grow={grow} />;
     case "FeaturedComps":
       return <FeaturedCompetitions block={entry} />;
     case "TestimonialsSpinner":

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -390,7 +390,7 @@ const renderVerticalLayout = (
       {verticalLayout.map((entry) => {
         return (
           <Box key={entry.id} asChild flexGrow={grow ? "1" : undefined}>
-            {renderBlock(entry, level)}
+            {renderBlock(entry, level, grow)}
           </Box>
         );
       })}
@@ -398,7 +398,11 @@ const renderVerticalLayout = (
   );
 };
 
-const renderHorizontalSplit = (entry: TwoBlocksUnion, level: number) => {
+const renderHorizontalSplit = (
+  entry: TwoBlocksUnion,
+  level: number,
+  grow: boolean = false,
+) => {
   const { left: leftCols, right: rightCols } = RATIO_GRID_MAP[entry.ratio];
 
   const totalCols = leftCols + rightCols;
@@ -414,13 +418,13 @@ const renderHorizontalSplit = (entry: TwoBlocksUnion, level: number) => {
         colSpan={{ base: 1, md: foldMd ? 1 : leftCols, lg: leftCols }}
         asChild
       >
-        {renderVerticalLayout(entry.left, level, !!entry.fillHeight)}
+        {renderVerticalLayout(entry.left, level, grow || !!entry.fillHeight)}
       </GridItem>
       <GridItem
         colSpan={{ base: 1, md: foldMd ? 1 : rightCols, lg: rightCols }}
         asChild
       >
-        {renderVerticalLayout(entry.right, level, !!entry.fillHeight)}
+        {renderVerticalLayout(entry.right, level, grow || !!entry.fillHeight)}
       </GridItem>
     </SimpleGrid>
   );
@@ -428,12 +432,16 @@ const renderHorizontalSplit = (entry: TwoBlocksUnion, level: number) => {
 
 type LayoutBlock = VerticalLayout[number];
 
-const renderBlock = (entry: LayoutBlock, level: number) => {
+const renderBlock = (
+  entry: LayoutBlock,
+  level: number,
+  grow: boolean = false,
+) => {
   switch (entry.blockType) {
     case "twoBlocksLevel0":
     case "twoBlocksLevel1":
     case "twoBlocksLevel2":
-      return renderHorizontalSplit(entry, level + 1);
+      return renderHorizontalSplit(entry, level + 1, grow);
     case "TextCard":
       return <TextCard block={entry} />;
     case "AnnouncementsSection":

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -66,12 +66,19 @@ const RATIO_GRID_MAP: Record<TwoBlocksRatio, TwoBlocksSpanConfig> = {
   "3/4 & 1/4": { left: 3, right: 1 },
 };
 
-const TextCard = ({ block }: { block: TextCardBlock }) => {
+const TextCard = ({
+  block,
+  grow = false,
+}: {
+  block: TextCardBlock;
+  grow?: boolean;
+}) => {
   return (
     <Card.Root
       colorPalette={block.colorPalette}
       colorVariant="slatePastel"
       width="full"
+      flexGrow={grow ? "1" : undefined}
     >
       {block.headerImage && (
         <MediaImage media={block.headerImage as Media} aspectRatio="3/1" />
@@ -444,7 +451,7 @@ const renderBlock = (
     case "twoBlocksLevel2":
       return renderHorizontalSplit(entry, level + 1, grow);
     case "TextCard":
-      return <TextCard block={entry} />;
+      return <TextCard block={entry} grow={grow} />;
     case "AnnouncementsSection":
       return <AnnouncementsSection block={entry} />;
     case "ImageBanner":

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -383,13 +383,14 @@ type VerticalLayout =
 const renderVerticalLayout = (
   verticalLayout: VerticalLayout,
   level: number = 0,
+  grow: boolean = false,
 ) => {
   return (
     <VStack gap={8}>
       {verticalLayout.map((entry) => {
         return (
           <React.Fragment key={entry.id}>
-            {renderBlock(entry, level)}
+            {renderBlock(entry, level, grow)}
           </React.Fragment>
         );
       })}
@@ -397,7 +398,11 @@ const renderVerticalLayout = (
   );
 };
 
-const renderHorizontalSplit = (entry: TwoBlocksUnion, level: number) => {
+const renderHorizontalSplit = (
+  entry: TwoBlocksUnion,
+  level: number,
+  grow: boolean = false,
+) => {
   const { left: leftCols, right: rightCols } = RATIO_GRID_MAP[entry.ratio];
 
   const totalCols = leftCols + rightCols;
@@ -408,18 +413,19 @@ const renderHorizontalSplit = (entry: TwoBlocksUnion, level: number) => {
       columns={{ base: 1, md: foldMd ? 1 : totalCols, lg: totalCols }}
       gap={8}
       width="full"
+      flexGrow={grow ? "1" : undefined}
     >
       <GridItem
         colSpan={{ base: 1, md: foldMd ? 1 : leftCols, lg: leftCols }}
         asChild
       >
-        {renderVerticalLayout(entry.left, level)}
+        {renderVerticalLayout(entry.left, level, !!entry.fillHeight)}
       </GridItem>
       <GridItem
         colSpan={{ base: 1, md: foldMd ? 1 : rightCols, lg: rightCols }}
         asChild
       >
-        {renderVerticalLayout(entry.right, level)}
+        {renderVerticalLayout(entry.right, level, !!entry.fillHeight)}
       </GridItem>
     </SimpleGrid>
   );
@@ -427,12 +433,16 @@ const renderHorizontalSplit = (entry: TwoBlocksUnion, level: number) => {
 
 type LayoutBlock = VerticalLayout[number];
 
-const renderBlock = (entry: LayoutBlock, level: number) => {
+const renderBlock = (
+  entry: LayoutBlock,
+  level: number,
+  grow: boolean = false,
+) => {
   switch (entry.blockType) {
     case "twoBlocksLevel0":
     case "twoBlocksLevel1":
     case "twoBlocksLevel2":
-      return renderHorizontalSplit(entry, level + 1);
+      return renderHorizontalSplit(entry, level + 1, grow);
     case "TextCard":
       return <TextCard block={entry} />;
     case "AnnouncementsSection":

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -126,8 +126,10 @@ const TextCard = ({
 
 const AnnouncementsSection = ({
   block,
+  grow = false,
 }: {
   block: AnnouncementsSectionBlock;
+  grow?: boolean;
 }) => {
   const mainAnnouncement = block.mainAnnouncement as Announcement;
   const furtherAnnouncements =
@@ -141,6 +143,7 @@ const AnnouncementsSection = ({
       others={furtherAnnouncements}
       colorPalette={block.colorPalette}
       showSeeAll={block.showSeeAll}
+      grow={grow}
     />
   );
 };
@@ -453,7 +456,7 @@ const renderBlock = (
     case "TextCard":
       return <TextCard block={entry} grow={grow} />;
     case "AnnouncementsSection":
-      return <AnnouncementsSection block={entry} />;
+      return <AnnouncementsSection block={entry} grow={grow} />;
     case "ImageBanner":
       return <ImageBanner block={entry} />;
     case "ImageOnlyCard":

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -40,6 +40,7 @@ import type {
   Announcement,
   ColorPaletteSelect,
   Home,
+  GrowthStrategy,
 } from "@/types/payload";
 import Link from "next/link";
 import { route } from "nextjs-routes";
@@ -383,14 +384,23 @@ type VerticalLayout =
 const renderVerticalLayout = (
   verticalLayout: VerticalLayout,
   level: number = 0,
-  grow: boolean = false,
+  growthStrategy?: GrowthStrategy,
 ) => {
   return (
-    <VStack gap={8}>
+    <VStack
+      gap={8}
+      justifyContent={
+        growthStrategy === "justify" ? "space-between" : undefined
+      }
+    >
       {verticalLayout.map((entry) => {
         return (
-          <Box key={entry.id} asChild flexGrow={grow ? "1" : undefined}>
-            {renderBlock(entry, level, grow)}
+          <Box
+            key={entry.id}
+            asChild
+            flexGrow={growthStrategy === "grow" ? "1" : undefined}
+          >
+            {renderBlock(entry, level, growthStrategy)}
           </Box>
         );
       })}
@@ -401,12 +411,15 @@ const renderVerticalLayout = (
 const renderHorizontalSplit = (
   entry: TwoBlocksUnion,
   level: number,
-  grow: boolean = false,
+  growthStrategy?: GrowthStrategy,
 ) => {
   const { left: leftCols, right: rightCols } = RATIO_GRID_MAP[entry.ratio];
 
   const totalCols = leftCols + rightCols;
   const foldMd = level <= 1;
+
+  const fallbackGrowthStrategy =
+    growthStrategy === "grow" ? "justify" : undefined;
 
   return (
     <SimpleGrid
@@ -418,13 +431,21 @@ const renderHorizontalSplit = (
         colSpan={{ base: 1, md: foldMd ? 1 : leftCols, lg: leftCols }}
         asChild
       >
-        {renderVerticalLayout(entry.left, level, grow || !!entry.fillHeight)}
+        {renderVerticalLayout(
+          entry.left,
+          level,
+          entry.growthStrategy || fallbackGrowthStrategy,
+        )}
       </GridItem>
       <GridItem
         colSpan={{ base: 1, md: foldMd ? 1 : rightCols, lg: rightCols }}
         asChild
       >
-        {renderVerticalLayout(entry.right, level, grow || !!entry.fillHeight)}
+        {renderVerticalLayout(
+          entry.right,
+          level,
+          entry.growthStrategy || fallbackGrowthStrategy,
+        )}
       </GridItem>
     </SimpleGrid>
   );
@@ -435,13 +456,13 @@ type LayoutBlock = VerticalLayout[number];
 const renderBlock = (
   entry: LayoutBlock,
   level: number,
-  grow: boolean = false,
+  growthStrategy?: GrowthStrategy,
 ) => {
   switch (entry.blockType) {
     case "twoBlocksLevel0":
     case "twoBlocksLevel1":
     case "twoBlocksLevel2":
-      return renderHorizontalSplit(entry, level + 1, grow);
+      return renderHorizontalSplit(entry, level + 1, growthStrategy);
     case "TextCard":
       return <TextCard block={entry} />;
     case "AnnouncementsSection":

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -66,19 +66,12 @@ const RATIO_GRID_MAP: Record<TwoBlocksRatio, TwoBlocksSpanConfig> = {
   "3/4 & 1/4": { left: 3, right: 1 },
 };
 
-const TextCard = ({
-  block,
-  grow = false,
-}: {
-  block: TextCardBlock;
-  grow?: boolean;
-}) => {
+const TextCard = ({ block }: { block: TextCardBlock }) => {
   return (
     <Card.Root
       colorPalette={block.colorPalette}
       colorVariant="slatePastel"
       width="full"
-      flexGrow={grow ? "1" : undefined}
     >
       {block.headerImage && (
         <MediaImage media={block.headerImage as Media} aspectRatio="3/1" />
@@ -126,10 +119,8 @@ const TextCard = ({
 
 const AnnouncementsSection = ({
   block,
-  grow = false,
 }: {
   block: AnnouncementsSectionBlock;
-  grow?: boolean;
 }) => {
   const mainAnnouncement = block.mainAnnouncement as Announcement;
   const furtherAnnouncements =
@@ -143,7 +134,6 @@ const AnnouncementsSection = ({
       others={furtherAnnouncements}
       colorPalette={block.colorPalette}
       showSeeAll={block.showSeeAll}
-      grow={grow}
     />
   );
 };
@@ -248,20 +238,13 @@ const ImageOnlyCardImage = ({ block }: { block: ImageOnlyCardBlock }) => {
   );
 };
 
-const ImageOnlyCard = ({
-  block,
-  grow = false,
-}: {
-  block: ImageOnlyCardBlock;
-  grow?: boolean;
-}) => {
+const ImageOnlyCard = ({ block }: { block: ImageOnlyCardBlock }) => {
   return (
     <Card.Root
       overflow="hidden"
       colorPalette={block.colorPalette}
       colorVariant="slatePastel"
       width="full"
-      flexGrow={grow ? "1" : undefined}
     >
       {block.textPosition === "bottom" && <ImageOnlyCardImage block={block} />}
       {block.heading && (
@@ -406,20 +389,16 @@ const renderVerticalLayout = (
     <VStack gap={8}>
       {verticalLayout.map((entry) => {
         return (
-          <React.Fragment key={entry.id}>
-            {renderBlock(entry, level, grow)}
-          </React.Fragment>
+          <Box key={entry.id} asChild flexGrow={grow ? "1" : undefined}>
+            {renderBlock(entry, level)}
+          </Box>
         );
       })}
     </VStack>
   );
 };
 
-const renderHorizontalSplit = (
-  entry: TwoBlocksUnion,
-  level: number,
-  grow: boolean = false,
-) => {
+const renderHorizontalSplit = (entry: TwoBlocksUnion, level: number) => {
   const { left: leftCols, right: rightCols } = RATIO_GRID_MAP[entry.ratio];
 
   const totalCols = leftCols + rightCols;
@@ -430,7 +409,6 @@ const renderHorizontalSplit = (
       columns={{ base: 1, md: foldMd ? 1 : totalCols, lg: totalCols }}
       gap={8}
       width="full"
-      flexGrow={grow ? "1" : undefined}
     >
       <GridItem
         colSpan={{ base: 1, md: foldMd ? 1 : leftCols, lg: leftCols }}
@@ -450,24 +428,20 @@ const renderHorizontalSplit = (
 
 type LayoutBlock = VerticalLayout[number];
 
-const renderBlock = (
-  entry: LayoutBlock,
-  level: number,
-  grow: boolean = false,
-) => {
+const renderBlock = (entry: LayoutBlock, level: number) => {
   switch (entry.blockType) {
     case "twoBlocksLevel0":
     case "twoBlocksLevel1":
     case "twoBlocksLevel2":
-      return renderHorizontalSplit(entry, level + 1, grow);
+      return renderHorizontalSplit(entry, level + 1);
     case "TextCard":
-      return <TextCard block={entry} grow={grow} />;
+      return <TextCard block={entry} />;
     case "AnnouncementsSection":
-      return <AnnouncementsSection block={entry} grow={grow} />;
+      return <AnnouncementsSection block={entry} />;
     case "ImageBanner":
       return <ImageBanner block={entry} />;
     case "ImageOnlyCard":
-      return <ImageOnlyCard block={entry} grow={grow} />;
+      return <ImageOnlyCard block={entry} />;
     case "FeaturedComps":
       return <FeaturedCompetitions block={entry} />;
     case "TestimonialsSpinner":

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -423,6 +423,9 @@ const renderHorizontalSplit = (
   const totalCols = leftCols + rightCols;
   const foldMd = level <= 1;
 
+  // If a parent horizontal splitter has a `grow` strategy,
+  //   it will look weird if children in either half of the splitter don't grow.
+  // So make sure that any `grow` splitter passes down "at least" `justify` as a base strategy.
   const fallbackGrowthStrategy =
     growthStrategy === "grow" ? "justify" : undefined;
 

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -399,6 +399,11 @@ const renderVerticalLayout = (
             key={entry.id}
             asChild
             flexGrow={growthStrategy === "grow" ? "1" : undefined}
+            // In case of justifying the space, a stack with one single child (CSS :only-child)
+            //   cannot push it towards the beginning and end simultaneously. So in that case,
+            //   also grow if the selected strategy is `justify`, to simulate the visual impression
+            //   of "filling" the container like it would be if there was more than one item.
+            _only={{ flexGrow: growthStrategy === "justify" ? "1" : undefined }}
           >
             {renderBlock(entry, level, growthStrategy)}
           </Box>

--- a/next-frontend/src/components/AnnouncementsCard.tsx
+++ b/next-frontend/src/components/AnnouncementsCard.tsx
@@ -31,20 +31,17 @@ export default function AnnouncementsCard({
   others = [],
   colorPalette,
   showSeeAll = true,
-  grow = false,
 }: {
   hero: Announcement;
   others: Announcement[];
   colorPalette: string;
   showSeeAll?: boolean;
-  grow?: boolean;
 }) {
   return (
     <Accordion.Root
       variant="card"
       defaultValue={[hero.id]}
       colorPalette={colorPalette}
-      flexGrow={grow ? "1" : undefined}
       display="flex"
       flexDirection="column"
       justifyContent="space-between"

--- a/next-frontend/src/components/AnnouncementsCard.tsx
+++ b/next-frontend/src/components/AnnouncementsCard.tsx
@@ -31,17 +31,23 @@ export default function AnnouncementsCard({
   others = [],
   colorPalette,
   showSeeAll = true,
+  grow = false,
 }: {
   hero: Announcement;
   others: Announcement[];
   colorPalette: string;
   showSeeAll?: boolean;
+  grow?: boolean;
 }) {
   return (
     <Accordion.Root
       variant="card"
       defaultValue={[hero.id]}
       colorPalette={colorPalette}
+      flexGrow={grow ? "1" : undefined}
+      display="flex"
+      flexDirection="column"
+      justifyContent="space-between"
     >
       <AnnouncementItem announcement={hero} />
 

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -132,9 +132,20 @@ const createTwoBlocks = (depth: number = 1): Block => {
         ],
       },
       {
-        type: "checkbox",
-        name: "fillHeight",
-        defaultValue: false,
+        type: "select",
+        name: "growthStrategy",
+        interfaceName: "GrowthStrategy",
+        options: [
+          {
+            label: "Grow the height of the bento boxes to fill space",
+            value: "grow",
+          },
+          {
+            label:
+              "Redistribute vertical space between the bento boxes (may introduce gaps)",
+            value: "justify",
+          },
+        ],
       },
     ],
   };

--- a/next-frontend/src/globals/Home.ts
+++ b/next-frontend/src/globals/Home.ts
@@ -131,6 +131,11 @@ const createTwoBlocks = (depth: number = 1): Block => {
           },
         ],
       },
+      {
+        type: "checkbox",
+        name: "fillHeight",
+        defaultValue: false,
+      },
     ],
   };
 };

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -1300,6 +1300,7 @@ export interface TwoBlocksLevel2Block {
     | FeaturedCompetitionsBlock
     | TwoBlocksLevel1Block
   )[];
+  fillHeight?: boolean | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twoBlocksLevel2';
@@ -1328,6 +1329,7 @@ export interface TwoBlocksLevel1Block {
     | FeaturedCompetitionsBlock
     | TwoBlocksLevel0Block
   )[];
+  fillHeight?: boolean | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twoBlocksLevel1';
@@ -1354,6 +1356,7 @@ export interface TwoBlocksLevel0Block {
     | TestimonialsBlock
     | FeaturedCompetitionsBlock
   )[];
+  fillHeight?: boolean | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twoBlocksLevel0';
@@ -2023,6 +2026,7 @@ export interface TwoBlocksLevel2BlockSelect<T extends boolean = true> {
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
         twoBlocksLevel1?: T | TwoBlocksLevel1BlockSelect<T>;
       };
+  fillHeight?: T;
   id?: T;
   blockName?: T;
 }
@@ -2054,6 +2058,7 @@ export interface TwoBlocksLevel1BlockSelect<T extends boolean = true> {
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
         twoBlocksLevel0?: T | TwoBlocksLevel0BlockSelect<T>;
       };
+  fillHeight?: T;
   id?: T;
   blockName?: T;
 }
@@ -2083,6 +2088,7 @@ export interface TwoBlocksLevel0BlockSelect<T extends boolean = true> {
         TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
       };
+  fillHeight?: T;
   id?: T;
   blockName?: T;
 }

--- a/next-frontend/src/types/payload.ts
+++ b/next-frontend/src/types/payload.ts
@@ -150,6 +150,11 @@ export type StaticTargetLink =
   | '/teams-committees'
   | '/translators';
 /**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "GrowthStrategy".
+ */
+export type GrowthStrategy = ('grow' | 'justify') | null;
+/**
  * Supported timezones in IANA format.
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1300,7 +1305,7 @@ export interface TwoBlocksLevel2Block {
     | FeaturedCompetitionsBlock
     | TwoBlocksLevel1Block
   )[];
-  fillHeight?: boolean | null;
+  growthStrategy?: GrowthStrategy;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twoBlocksLevel2';
@@ -1329,7 +1334,7 @@ export interface TwoBlocksLevel1Block {
     | FeaturedCompetitionsBlock
     | TwoBlocksLevel0Block
   )[];
-  fillHeight?: boolean | null;
+  growthStrategy?: GrowthStrategy;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twoBlocksLevel1';
@@ -1356,7 +1361,7 @@ export interface TwoBlocksLevel0Block {
     | TestimonialsBlock
     | FeaturedCompetitionsBlock
   )[];
-  fillHeight?: boolean | null;
+  growthStrategy?: GrowthStrategy;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twoBlocksLevel0';
@@ -2026,7 +2031,7 @@ export interface TwoBlocksLevel2BlockSelect<T extends boolean = true> {
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
         twoBlocksLevel1?: T | TwoBlocksLevel1BlockSelect<T>;
       };
-  fillHeight?: T;
+  growthStrategy?: T;
   id?: T;
   blockName?: T;
 }
@@ -2058,7 +2063,7 @@ export interface TwoBlocksLevel1BlockSelect<T extends boolean = true> {
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
         twoBlocksLevel0?: T | TwoBlocksLevel0BlockSelect<T>;
       };
-  fillHeight?: T;
+  growthStrategy?: T;
   id?: T;
   blockName?: T;
 }
@@ -2088,7 +2093,7 @@ export interface TwoBlocksLevel0BlockSelect<T extends boolean = true> {
         TestimonialsSpinner?: T | TestimonialsBlockSelect<T>;
         FeaturedComps?: T | FeaturedCompetitionsBlockSelect<T>;
       };
-  fillHeight?: T;
+  growthStrategy?: T;
   id?: T;
   blockName?: T;
 }


### PR DESCRIPTION
Successor in spirit of #14584. This retains the idea of passing around a `grow` variable, but instead of setting the value of this variable based on a whole new component, it just adds a checkbox to the existing splitter component.