### PR TITLE
Sign out user on failed Double Refresh

### DIFF
--- a/next-frontend/src/lib/wca/useAPI.ts
+++ b/next-frontend/src/lib/wca/useAPI.ts
@@ -1,4 +1,4 @@
-import { useSession } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import { useMemo } from "react";
 import { authenticatedClient, unauthenticatedClient } from "@/lib/wca/wcaAPI";
 import createQueryClient from "openapi-react-query";
@@ -8,7 +8,22 @@ export function useAPIClient() {
 
   return useMemo(() => {
     if (session) {
-      return authenticatedClient(session.accessToken);
+      const client = authenticatedClient(session.accessToken);
+
+      // If the backend rejects our access_token (revoked, expired, etc.),
+      // the session is no longer usable —
+      // drop it so the user is forced through a fresh login rather than
+      // continuing to fire requests that 401.
+      client.use({
+        onResponse({ response }) {
+          if (response.status === 401) {
+            signOut();
+          }
+          return response;
+        },
+      });
+
+      return client;
     } else {
       return unauthenticatedClient;
     }

--- a/next-frontend/src/sessionOrSignIn.ts
+++ b/next-frontend/src/sessionOrSignIn.ts
@@ -1,9 +1,11 @@
-import { auth, signIn } from "@/auth";
+import { auth, signOut } from "@/auth";
 
 export async function sessionOrSignIn() {
   const session = await auth();
   if (session?.error === "RefreshTokenError") {
-    await signIn(); // Force sign in to get a new set of access and refresh tokens
+    // Refresh failed Drop the session so the user is forced through a fresh login
+    // rather than continuing with a stale access_token.
+    await signOut();
   }
   return session;
 }


### PR DESCRIPTION
The original id to just sign in again never worked so I am doing the opposite now.
Part of https://github.com/thewca/worldcubeassociation.org/pull/14532