### PR TITLE
Don't share WCAQueryClientProvider on server

### DIFF
--- a/next-frontend/src/providers/WCAQueryClientProvider.tsx
+++ b/next-frontend/src/providers/WCAQueryClientProvider.tsx
@@ -1,25 +1,44 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  environmentManager,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import React from "react";
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      staleTime: Infinity,
-      refetchOnMount: "always",
-      retry: false,
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: Infinity,
+        refetchOnMount: "always",
+        retry: false,
+      },
     },
-  },
-});
+  });
+}
+
+let browserQueryClient: QueryClient | undefined;
+
+function getQueryClient() {
+  // On the server, the module scope is shared across requests, so a
+  // module-level client would serve every request stale data from the
+  // first render (and leak data between users). Always make a fresh one.
+  if (environmentManager.isServer()) return makeQueryClient();
+
+  return (browserQueryClient ??= makeQueryClient());
+}
 
 export default function WCAQueryClientProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const queryClient = getQueryClient();
+
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/next-frontend/src/providers/WCAQueryClientProvider.tsx
+++ b/next-frontend/src/providers/WCAQueryClientProvider.tsx
@@ -21,6 +21,9 @@ function makeQueryClient() {
   });
 }
 
+// Lazily initialized: this module is also evaluated on the server during SSR,
+// and an eager `const` would construct a throwaway client on every server render.
+// The `??=` defers construction until we're actually in the browser.
 let browserQueryClient: QueryClient | undefined;
 
 function getQueryClient() {


### PR DESCRIPTION
Finally found the real culprit of the stale data. We were sharing the client provider on the server. Lucky for us that we do not have any pages yet where this could have been a pii issue. 

This is the solution recommended here https://tanstack.com/query/v5/docs/framework/react/guides/advanced-ssr#initial-setup