### PR TITLE
Reuse User Serializer includes in competition info

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -51,7 +51,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def show
-    competition = competition_from_params
+    competition = competition_from_params(associations: Competition::INFO_SERIALIZATION_INCLUDES)
 
     render json: competition.to_competition_info if stale?(competition)
   end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1863,6 +1863,17 @@ class Competition < ApplicationRecord
     }
   end
 
+  # Associations that `to_competition_info` touches: delegates and organizers are serialized
+  # via `User#serializable_hash` (see `User::SERIALIZATION_INCLUDES`), `event_ids` reads the
+  # events association, and `uses_cutoff?`/`uses_qualification?` iterate over every round of
+  # every competition event. Eager load them all to avoid an N+1 explosion.
+  INFO_SERIALIZATION_INCLUDES = [
+    :events,
+    { competition_events: :rounds },
+    { delegates: User::SERIALIZATION_INCLUDES },
+    { organizers: User::SERIALIZATION_INCLUDES },
+  ].freeze
+
   def to_competition_info
     options = {
       only: %w[id name website start_date registration_open registration_close announced_at cancelled_at end_date competitor_limit


### PR DESCRIPTION
Before
`Completed 200 OK in 1041ms (Views: 0.5ms | ActiveRecord: 119.6ms (328 queries, 87 cached) | GC: 148.6ms)`
After
`Completed 200 OK in 287ms (ActiveRecord: 31.8ms (34 queries, 2 cached) | GC: 68.1ms)`