### PR TITLE
[redesign] set cursor: pointer on menuitem

### DIFF
--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -434,6 +434,9 @@ const customConfig = defineConfig({
           },
         },
       },
+      cursor: {
+        menuitem: { value: "pointer" },
+      },
     },
     semanticTokens: {
       colors: {


### PR DESCRIPTION
For some reason, by default Chakra uses `cursor: default` on `MenuItem`s. A `MenuItem` is a link, so it should follow `cursor: pointer` styling to indicate as such.

# Test plan:

See demo video testing on MenuItems in navbar (not in video but it works the same on the Avatar menu, for example)

https://github.com/user-attachments/assets/ffe74bc3-6c8a-4ae4-ad45-0399751d38f1

