### PR TITLE
Change `body` font weight to normal

### DIFF
--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -582,7 +582,7 @@ const customConfig = defineConfig({
         value: {
           fontSize: "0.875rem",
           lineHeight: "1.5",
-          fontWeight: "light",
+          fontWeight: "normal",
         },
       },
       bodyEmphasis: {


### PR DESCRIPTION
Requested by Nick in this Slack message: https://worldcubeassociation.slack.com/archives/C0B80BQKUAF/p1781599385434109?thread_ts=1781585769.695009&cid=C0B80BQKUAF

I think it looks waaay better