### PR TITLE
Use global Pos to determine true dual round podium

### DIFF
--- a/app/helpers/competitions_helper.rb
+++ b/app/helpers/competitions_helper.rb
@@ -58,9 +58,9 @@ module CompetitionsHelper
   end
 
   def winners(competition, main_event)
-    top_three = competition.results.where(event: main_event).podium.order(:pos)
+    top_three = competition.results.where(event: main_event).podium.order(:global_pos)
     h2h_finals = top_three.first.format_id == "h"
-    results_by_place = top_three.group_by(&:pos)
+    results_by_place = top_three.group_by(&:global_pos)
 
     return t('competitions.competition_info.no_winner', event_name: main_event.name) if results_by_place.blank?
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1451,7 +1451,7 @@ class Competition < ApplicationRecord
   end
 
   def events_with_podium_results
-    results.includes(:result_attempts).podium.order(:pos).group_by(&:event)
+    results.includes(:result_attempts).podium.order(:global_pos).group_by(&:event)
            .sort_by { |event, _results| event.rank }
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -231,7 +231,7 @@ class Person < ApplicationRecord
   end
 
   def medals
-    positions = results.podium.pluck(:pos)
+    positions = results.podium.pluck(:global_pos)
     {
       gold: positions.count(1),
       silver: positions.count(2),

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -27,11 +27,25 @@ class Result < ApplicationRecord
 
   validates :person_id, uniqueness: { scope: :round_id, message: "this WCA ID already has a result for that round" }
 
-  scope :final, -> { where(round_type_id: RoundType.final_rounds.select(:id)) }
+  scope :final, -> { joins(:round).merge(Round.final) }
   scope :succeeded, -> { where("best > 0") }
   scope :average_succeeded, -> { where("average > 0") }
-  scope :podium, -> { final.succeeded.where(pos: [1..3]) }
-  scope :winners, -> { final.succeeded.where(pos: 1).joins(:event).order("events.rank") }
+  # A dual (linked) round stores one result row per round, so a competitor who took part in
+  # both rounds appears twice with the same global_pos. Keep only their better solve so each
+  # competitor shows up once. No-op for normal rounds (already one row per competitor).
+  scope :merged_dual_rounds, lambda {
+    best_per_person = select(:id).joins(:format).select(Arel.sql(<<~SQL.squish))
+      ROW_NUMBER() OVER (
+        PARTITION BY results.competition_id, results.event_id, results.person_id
+        ORDER BY (CASE WHEN formats.sort_by = 'average' THEN results.average ELSE results.best END) <= 0,
+                 (CASE WHEN formats.sort_by = 'average' THEN results.average ELSE results.best END) ASC,
+                 results.best <= 0, results.best ASC, results.id ASC
+      ) AS rn
+    SQL
+    where("results.id IN (SELECT id FROM (#{best_per_person.to_sql}) ranked WHERE rn = 1)")
+  }
+  scope :podium, -> { final.succeeded.where(global_pos: [1..3]).merged_dual_rounds }
+  scope :winners, -> { final.succeeded.where(global_pos: 1).merged_dual_rounds.joins(:event).order("events.rank") }
   scope :before, ->(date) { joins(:competition).where(competition: { end_date: ...date }) }
   scope :on_or_before, ->(date) { joins(:competition).where(competition: { end_date: ..date }) }
   scope :single_better_than, ->(time) { where("best < ? AND best > 0", time) }

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -28,6 +28,12 @@ class Round < ApplicationRecord
 
   scope :ordered, -> { order(:number) }
   scope :h2h, -> { where(is_h2h_mock: true) }
+  # A round is final when it's the last round (mirrors #final_round?), or when it's
+  # co-linked with the final round (a linked round marks both rounds as final).
+  scope :final, lambda {
+    finals = where("number = total_number_of_rounds")
+    finals.or(where(linked_round_id: finals.where.not(linked_round_id: nil).select(:linked_round_id)))
+  }
 
   serialize :time_limit, coder: TimeLimit
   validates_associated :time_limit

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
 
     competition_id { competition.id }
     pos { 1 }
-    global_pos { 1 }
+    global_pos { pos }
     event_id { "333oh" }
     round_type_id { "f" }
     format_id { "a" }


### PR DESCRIPTION
`global_pos` now allows us to implement it without any actual changes to the methods, just a new deduplication scope and changing a bunch of `pos` to `global_pos`