### PR TITLE
Change "Advancement" data in "Events" page and "Schedule - Table" view from "75%" to "all competitors advance" for the 1st round of a Dual Round

### DIFF
--- a/app/views/competitions/_competition_schedule_tab.html.erb
+++ b/app/views/competitions/_competition_schedule_tab.html.erb
@@ -1,6 +1,6 @@
 <%= react_component("Schedule", {
   wcifSchedule: @competition.schedule_wcif,
-  wcifEvents: @competition.events_wcif(version: Competition::WCIF_VERSION_CATALOGUE[:latest]),
+  wcifEvents: @competition.events_wcif(version: '2.1.1'),
   competitionName: @competition.name,
   calendarLocale: I18n.locale,
   linkedRounds: @competition.rounds.to_h { [it.wcif_id, it.linked_round&.wcif_ids] }.compact_blank,

--- a/app/views/competitions/_competition_schedule_tab.html.erb
+++ b/app/views/competitions/_competition_schedule_tab.html.erb
@@ -1,6 +1,6 @@
 <%= react_component("Schedule", {
   wcifSchedule: @competition.schedule_wcif,
-  wcifEvents: @competition.events_wcif,
+  wcifEvents: @competition.events_wcif(version: Competition::WCIF_VERSION_CATALOGUE[:latest]),
   competitionName: @competition.name,
   calendarLocale: I18n.locale,
   linkedRounds: @competition.rounds.to_h { [it.wcif_id, it.linked_round&.wcif_ids] }.compact_blank,

--- a/app/views/competitions/_events_tab.html.erb
+++ b/app/views/competitions/_events_tab.html.erb
@@ -1,4 +1,4 @@
 <%= react_component("EventsTable", {
-  wcifEvents: @competition.events_wcif,
+  wcifEvents: @competition.events_wcif(version: Competition::WCIF_VERSION_CATALOGUE[:latest]),
   competitionInfo: @competition.to_competition_info
 }) %>

--- a/app/views/competitions/_events_tab.html.erb
+++ b/app/views/competitions/_events_tab.html.erb
@@ -1,4 +1,4 @@
 <%= react_component("EventsTable", {
-  wcifEvents: @competition.events_wcif(version: Competition::WCIF_VERSION_CATALOGUE[:latest]),
+  wcifEvents: @competition.events_wcif(version: '2.1.1'),
   competitionInfo: @competition.to_competition_info
 }) %>

--- a/app/webpacker/components/EventsTable/index.jsx
+++ b/app/webpacker/components/EventsTable/index.jsx
@@ -10,7 +10,7 @@ import {
 import I18n from '../../lib/i18n';
 import { events, formats } from '../../lib/wca-data.js.erb';
 import {
-  advancementConditionToString,
+  roundAdvancementToString,
   cutoffToString,
   eventQualificationToString,
   getRoundTypeId,
@@ -90,8 +90,7 @@ export default function EventsTable({ competitionInfo, wcifEvents }) {
                   </TableCell>
                 )}
                 <TableCell>
-                  {round.advancementCondition
-                    && advancementConditionToString(round)}
+                  {roundAdvancementToString(round, wcifEvents)}
                 </TableCell>
                 {competitionInfo['uses_qualification?'] && (
                   <TableCell>

--- a/app/webpacker/components/Schedule/TableView.jsx
+++ b/app/webpacker/components/Schedule/TableView.jsx
@@ -22,7 +22,7 @@ import { formats } from '../../lib/wca-data.js.erb';
 import {
   parseActivityCode,
   timeLimitToString,
-  advancementConditionToString,
+  roundAdvancementToString,
   cutoffToString,
 } from '../../lib/utils/wcif';
 import '../../stylesheets/schedule_events.scss';
@@ -35,7 +35,6 @@ export default function TableView({
   activeVenueOrNull,
   competitionName,
   wcifEvents,
-  linkedRounds,
 }) {
   const activeRounds = activeEvents.flatMap((event) => event.rounds);
 
@@ -80,7 +79,6 @@ export default function TableView({
             activeVenueOrNull={activeVenueOrNull}
             competitionName={competitionName}
             wcifEvents={wcifEvents}
-            linkedRounds={linkedRounds}
           />
         );
       })}
@@ -98,7 +96,6 @@ function SingleDayTable({
   activeVenueOrNull,
   competitionName,
   wcifEvents,
-  linkedRounds,
 }) {
   const title = I18n.t('competitions.schedule.schedule_for_full_date', { date: date.toLocaleString(DateTime.DATE_HUGE) });
 
@@ -146,7 +143,6 @@ function SingleDayTable({
                 rooms={rooms}
                 timeZone={timeZone}
                 wcifEvents={wcifEvents}
-                isLinked={linkedRounds[activityRound?.id]}
               />
             );
           })
@@ -188,7 +184,6 @@ function ActivityRow({
   rooms,
   timeZone,
   wcifEvents,
-  isLinked,
 }) {
   const representativeActivity = activityGroup[0];
   const { startTime, endTime } = representativeActivity;
@@ -200,8 +195,10 @@ function ActivityRow({
 
   // note: round may be undefined for custom activities like lunch
   const {
-    format, timeLimit, cutoff, advancementCondition,
+    format, timeLimit, cutoff,
   } = round || {};
+
+  const advancement = round && roundAdvancementToString(round, wcifEvents);
 
   const roomsUsed = rooms.filter(
     (room) => room.activities.some((activity) => activityIds.includes(activity.id)),
@@ -243,8 +240,7 @@ function ActivityRow({
             </Grid.Column>
             <Grid.Column width={2}>{cutoff && cutoffToString(round)}</Grid.Column>
             <Grid.Column width={2}>
-              {isLinked && 'Dual Round: '}
-              {advancementCondition && advancementConditionToString(round)}
+              {advancement}
             </Grid.Column>
           </>
         )}
@@ -312,14 +308,13 @@ function ActivityRow({
                 </Grid.Column>
               </>
             )}
-            {advancementCondition && (
+            {advancement && (
               <>
                 <Grid.Column textAlign="left" mobile={6} tablet={4}>
                   {I18n.t('competitions.events.proceed')}
                 </Grid.Column>
                 <Grid.Column textAlign="right" mobile={10} tablet={4}>
-                  {isLinked && 'Dual Round: '}
-                  <b>{advancementConditionToString(round)}</b>
+                  <b>{advancement}</b>
                 </Grid.Column>
               </>
             )}

--- a/app/webpacker/components/Schedule/index.jsx
+++ b/app/webpacker/components/Schedule/index.jsx
@@ -150,7 +150,6 @@ export default function Schedule({
           activeVenueOrNull={activeVenueOrNull}
           competitionName={competitionName}
           wcifEvents={wcifEvents}
-          linkedRounds={linkedRounds}
         />
       )}
     </>

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -308,6 +308,45 @@ export function advancementConditionToString(wcifRound, { short } = {}) {
   }
 }
 
+// WCIF v2 dropped per-round `advancementCondition`: a round's advancement is now
+// derived from the *next* round's participationRuleset. Dual Rounds have no real
+// advancement out of their first round — everyone proceeds to the colinked round.
+export function roundAdvancementToString(wcifRound, wcifEvents, { short } = {}) {
+  const { eventId, roundNumber } = parseActivityCode(wcifRound.id);
+  const allRounds = wcifEvents.find((event) => event.id === eventId).rounds;
+
+  // The final round never advances anywhere.
+  if (roundNumber === allRounds.length) {
+    return null;
+  }
+
+  // First round of a Dual Round: all competitors advance to the colinked round.
+  if (wcifRound.linkedRounds) {
+    const lastLinkedRoundId = wcifRound.linkedRounds
+      .toSorted((a, b) => parseActivityCode(a).roundNumber - parseActivityCode(b).roundNumber)
+      .at(-1);
+
+    if (wcifRound.id !== lastLinkedRoundId) {
+      return I18n.t(`advancement_condition${short ? '.short' : ''}.all_advance`);
+    }
+  }
+
+  // WCIF round numbers are 1-based, so the next round sits at index `roundNumber`.
+  const nextSource = allRounds[roundNumber]?.participationRuleset?.participationSource;
+  const condition = nextSource?.resultCondition;
+  if (!condition) {
+    return null;
+  }
+
+  return advancementConditionToString({
+    ...wcifRound,
+    advancementCondition: {
+      type: condition.type === 'resultAchieved' ? 'attemptResult' : condition.type,
+      level: condition.value,
+    },
+  }, { short });
+}
+
 export function cutoffToString(wcifRound, { short } = {}) {
   const { eventId } = parseActivityCode(wcifRound.id);
   const wcaEvent = events.byId[eventId];

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -320,12 +320,12 @@ export function roundAdvancementToString(wcifRound, wcifEvents, { short } = {}) 
     return null;
   }
 
-  // First round of a Dual Round: all competitors advance to the colinked round.
   if (wcifRound.linkedRounds) {
     const lastLinkedRoundId = wcifRound.linkedRounds
       .toSorted((a, b) => parseActivityCode(a).roundNumber - parseActivityCode(b).roundNumber)
       .at(-1);
 
+    // First round of a Dual Round: all competitors advance to the colinked round.
     if (wcifRound.id !== lastLinkedRoundId) {
       return I18n.t(`advancement_condition${short ? '.short' : ''}.all_advance`);
     }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,10 +161,12 @@ en:
     short:
       ranking: "Top %{ranking}"
       percent: "Top %{percent}%"
+      all_advance: "All advance"
       attempt_result:
         time: "%{round_format} < %{time}"
         moves: "%{round_format} < %{moves}"
         points: "%{round_format} > %{points}"
+    all_advance: "All competitors advance"
     ranking: "Top %{ranking} advance to next round"
     percent: "Top %{percent}% advance to next round"
     attempt_result:

--- a/spec/features/competition_page_spec.rb
+++ b/spec/features/competition_page_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe "competitions/show", :js do
   let(:competition) { create(:competition, :visible, event_ids: %w[333 444]) }
   let(:sixty_second_2_attempt_cutoff) { Cutoff.new(number_of_attempts: 2, attempt_result: 1.minute.in_centiseconds) }
-  let(:top_16_advance) { AdvancementConditions::RankingCondition.new(16) }
-  let!(:round333_1) { create(:round, competition: competition, event_id: "333", number: 1, cutoff: sixty_second_2_attempt_cutoff, advancement_condition: top_16_advance, total_number_of_rounds: 2) }
-  let!(:round333_2) { create(:round, competition: competition, event_id: "333", number: 2, total_number_of_rounds: 2) }
+  let(:top_16_advance) { ResultConditions::Ranking.new(scope: "average", value: 16) }
+  let!(:round333_1) { create(:round, competition: competition, event_id: "333", number: 1, cutoff: sixty_second_2_attempt_cutoff, total_number_of_rounds: 2) }
+  let!(:round333_2) { create(:round, competition: competition, event_id: "333", number: 2, total_number_of_rounds: 2, participation_source: round333_1, participation_condition: top_16_advance) }
   let!(:round444_1) { create(:round, competition: competition, event_id: "444", number: 1) }
 
   before do


### PR DESCRIPTION
Fixes https://github.com/thewca/worldcubeassociation.org/issues/13893