### PR TITLE
Don't join users for number_of_bookmarks

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -511,7 +511,7 @@ class Competition < ApplicationRecord
   end
 
   def number_of_bookmarks
-    bookmarked_users.count
+    bookmarked_competitions.count
   end
 
   def country


### PR DESCRIPTION
Just noticed this

Before:
`User Count (100.8ms)  SELECT COUNT(*) FROM `users` INNER JOIN `bookmarked_competitions` ON `users`.`id` = `bookmarked_competitions`.`user_id` WHERE `bookmarked_competitions`.`competition_id` = 'SAC2026'`
After:
`BookmarkedCompetition Count (0.5ms)  SELECT COUNT(*) FROM `bookmarked_competitions` WHERE `bookmarked_competitions`.`competition_id` = 'SAC2026'`