### PR TITLE
Don't write to round_results when score taking is set to internal and delete cleared results

### DIFF
--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -152,7 +152,12 @@ class CompetitionEvent < ApplicationRecord
     end
     model_rounds = wcif["rounds"].map do |round_wcif|
       round = rounds.find { it.wcif_id == round_wcif["id"] } || rounds.build
-      round.update!(**Round.wcif_to_round_attributes(self.event, round_wcif, wcif["rounds"], version: version))
+      round_attributes = Round.wcif_to_round_attributes(self.event, round_wcif, wcif["rounds"], version: version)
+      # For internal-scoretaking comps `live_results` is the source of truth and `round_results`
+      #   is never read back (see `Round#to_wcif`). Persisting the WCIF snapshot just creates
+      #   stale data that drifts from `live_results`, so we don't store it (and clear any leftovers).
+      round_attributes[:round_results] = [] if self.competition.scoretaking_software_internal?
+      round.update!(**round_attributes)
       WcifExtension.update_wcif_extensions!(round, round_wcif["extensions"]) if round_wcif["extensions"]
       round
     end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -483,24 +483,25 @@ class Round < ApplicationRecord
         end
       end
 
-      if attempts_to_load.any?
-        LiveAttempt.upsert_all(attempts_to_load)
+      LiveAttempt.upsert_all(attempts_to_load) if attempts_to_load.any?
 
-        # Count how many attempts were loaded per result_id
-        attempt_counts_by_result = attempts_to_load.map { it[:live_result_id] }.tally
+      # Every synced result needs its stale attempts pruned down to the incoming count.
+      #   This MUST be driven by all incoming results, not just `attempts_to_load`, so that
+      #   results whose attempts were cleared (count 0) also get pruned. Otherwise their
+      #   previously-synced attempts get orphaned and `live_results` diverges from `round_results`.
+      attempt_count_by_result_id = round_results_wcif.to_h do |round_result_wcif|
+        registration_id = person_id_to_registration_id[round_result_wcif["personId"]]
+        live_result = results_by_registration_id[registration_id]
 
-        # Regroup: For each count of results (that determines the maximum `attempt_number`),
-        #   we want to efficiently find all live_result_ids with that attempt number
-        results_with_attempt_count = attempt_counts_by_result.group_by(&:last)
-                                                             .transform_values { it.map(&:first) }
+        [live_result.id, round_result_wcif["attempts"]&.length || 0]
+      end
 
-        # Now we can clean up "once per number of attempts", so in reality this generates
-        #   only ~3 extra queries because barely any results have only 1 or only 4 attempts.
-        results_with_attempt_count.each do |valid_count, result_ids|
-          LiveAttempt.where(live_result_id: result_ids)
-                     .where.not(attempt_number: ..valid_count)
-                     .delete_all
-        end
+      # Group by count so we clean up "once per number of attempts", which in reality is
+      #   only a handful of queries because barely any results have an unusual attempt count.
+      attempt_count_by_result_id.group_by(&:last).each do |valid_count, pairs|
+        LiveAttempt.where(live_result_id: pairs.map(&:first))
+                   .where.not(attempt_number: ..valid_count)
+                   .delete_all
       end
 
       histories_to_generate = round_results_wcif.filter_map do |round_result_wcif|

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -470,13 +470,15 @@ class Round < ApplicationRecord
                                        .includes(:live_attempts)
                                        .index_by(&:registration_id)
 
-      attempts_to_load = round_results_wcif.flat_map do |round_result_wcif|
+      result_wcif_by_id = round_results_wcif.index_by do |round_result_wcif|
         registration_id = person_id_to_registration_id[round_result_wcif["personId"]]
-        live_result = results_by_registration_id[registration_id]
+        results_by_registration_id[registration_id].id
+      end
 
+      attempts_to_load = result_wcif_by_id.flat_map do |live_result_id, round_result_wcif|
         round_result_wcif["attempts"].map.with_index(1) do |attempt, attempt_number|
           {
-            live_result_id: live_result.id,
+            live_result_id: live_result_id,
             attempt_number: attempt_number,
             value: attempt["result"],
           }
@@ -489,17 +491,18 @@ class Round < ApplicationRecord
       #   This MUST be driven by all incoming results, not just `attempts_to_load`, so that
       #   results whose attempts were cleared (count 0) also get pruned. Otherwise their
       #   previously-synced attempts get orphaned and `live_results` diverges from `round_results`.
-      attempt_count_by_result_id = round_results_wcif.to_h do |round_result_wcif|
-        registration_id = person_id_to_registration_id[round_result_wcif["personId"]]
-        live_result = results_by_registration_id[registration_id]
-
-        [live_result.id, round_result_wcif["attempts"]&.length || 0]
+      attempt_count_by_result_id = result_wcif_by_id.transform_values do |round_result_wcif|
+        round_result_wcif["attempts"]&.length || 0
       end
 
       # Group by count so we clean up "once per number of attempts", which in reality is
       #   only a handful of queries because barely any results have an unusual attempt count.
-      attempt_count_by_result_id.group_by(&:last).each do |valid_count, pairs|
-        LiveAttempt.where(live_result_id: pairs.map(&:first))
+      results_grouped_by_attempt_count = attempt_count_by_result_id.group_by { |_result_id, count| count }
+
+      results_grouped_by_attempt_count.each do |valid_count, results|
+        result_ids = results.map { |result_id, _count| result_id }
+
+        LiveAttempt.where(live_result_id: result_ids)
                    .where.not(attempt_number: ..valid_count)
                    .delete_all
       end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -507,37 +507,11 @@ class Round < ApplicationRecord
       histories_to_generate = round_results_wcif.filter_map do |round_result_wcif|
         registration_id = person_id_to_registration_id[round_result_wcif["personId"]]
         live_result = results_by_registration_id[registration_id]
+        result_already_existed = recorded_registration_ids.include?(registration_id)
 
-        recorded_attempts = live_result.live_attempts.pluck(:value)
-        imported_attempts = round_result_wcif["attempts"].pluck("result")
-
-        result_already_existed = recorded_registration_ids.include?(person_id_to_registration_id[round_result_wcif["personId"]])
-
-        result_has_attempts = !imported_attempts.empty?
-        attempts_have_changed = recorded_attempts != imported_attempts
-
-        next if result_has_attempts && !attempts_have_changed
-
-        action_type = if result_has_attempts
-                        :scoretaking
-                      elsif result_already_existed
-                        :cleared
-                      elsif round_already_had_results
-                        :advanced_next
-                      else
-                        :opened
-                      end
-
-        attempts = imported_attempts if action_type == :scoretaking
-
-        {
-          live_result_id: live_result.id,
-          entered_by_id: current_user.id,
-          entered_at: database_now,
-          attempt_details: attempts,
-          action_type: action_type,
-          action_source: :api_sync,
-        }
+        build_history_entry(round_result_wcif, live_result, current_user, database_now,
+                            result_already_existed: result_already_existed,
+                            round_already_had_results: round_already_had_results)
       end
 
       LiveResultHistoryEntry.insert_all!(histories_to_generate) if histories_to_generate.any?
@@ -549,6 +523,38 @@ class Round < ApplicationRecord
     # Sync up all internal results columns not covered by the sync payload
     #   This also resets the corresponding `live_results` associations
     self.recompute_live_columns
+  end
+
+  private def build_history_entry(round_result_wcif, live_result, current_user, database_now,
+                                  result_already_existed:, round_already_had_results:)
+    recorded_attempts = live_result.live_attempts.pluck(:value)
+    imported_attempts = round_result_wcif["attempts"].pluck("result")
+
+    result_has_attempts = !imported_attempts.empty?
+    attempts_have_changed = recorded_attempts != imported_attempts
+
+    return if result_has_attempts && !attempts_have_changed
+
+    action_type = if result_has_attempts
+                    :scoretaking
+                  elsif result_already_existed
+                    :cleared
+                  elsif round_already_had_results
+                    :advanced_next
+                  else
+                    :opened
+                  end
+
+    attempts = imported_attempts if action_type == :scoretaking
+
+    {
+      live_result_id: live_result.id,
+      entered_by_id: current_user.id,
+      entered_at: database_now,
+      attempt_details: attempts,
+      action_type: action_type,
+      action_source: :api_sync,
+    }
   end
 
   def self.load_wcif_advancement_condition(wcif_round, all_wcif_rounds, version: Competition::WCIF_STABLE_VERSION)

--- a/lib/tasks/sanity_check_live_results.rake
+++ b/lib/tasks/sanity_check_live_results.rake
@@ -8,12 +8,17 @@ namespace :live_results do
 
     rounds = Round.joins(:live_results)
                   .where("round_results IS NOT NULL AND round_results != '[]'")
-                  .includes(:competition_event)
+                  .includes(:competition_event, :competition)
                   .distinct
 
     puts "Checking #{rounds.count} rounds with both round_results and live_results..."
 
     rounds.find_each do |round|
+      # For internal-scoretaking competitions `round_results` is dead data: `Round#to_wcif`
+      #   always serves `live_results` for them, never `round_results`. The latter is only ever
+      #   a stale WCIF-PATCH snapshot, so comparing the two just produces noise.
+      next if round.competition.scoretaking_software_internal?
+
       round_wcif = round.round_results.map(&:to_wcif).index_by { it["personId"] }
       live_wcif = round.live_results.includes(:live_attempts, :registration).map(&:to_wcif).index_by { it["personId"] }
 

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -1302,6 +1302,28 @@ RSpec.describe "Competition WCIF" do
         expect(LiveAttempt.count).to eq(7) # one result now only has 2, so 5+2=7
       end
 
+      it "cleans up attempts when a result is cleared back to zero" do
+        # Establish five attempts for both competitors
+        competition.set_wcif_events!(wcif["events"], delegate)
+
+        expect(LiveResult.count).to eq(2)
+        expect(LiveAttempt.count).to eq(10)
+
+        # One competitor's attempts are cleared entirely, while the other keeps theirs.
+        #   The non-empty other result keeps `attempts_to_load` non-empty, which used to
+        #   make the cleanup skip the cleared result and orphan its attempts.
+        wcif_333_event["rounds"][0]["results"][0]["attempts"] = []
+        wcif_333_event["rounds"][0]["results"][0]["best"] = 0
+        wcif_333_event["rounds"][0]["results"][0]["average"] = 0
+
+        competition.set_wcif_events!(wcif["events"], delegate)
+
+        expect(competition.to_wcif["events"]).to eq(wcif["events"])
+
+        expect(LiveResult.count).to eq(2)
+        expect(LiveAttempt.count).to eq(5) # cleared result drops to 0, other keeps 5
+      end
+
       it "records histories when something changes" do
         competition.set_wcif_events!(wcif["events"], delegate)
 

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -1283,7 +1283,7 @@ RSpec.describe "Competition WCIF" do
         expect(competition.to_wcif["events"]).to eq(wcif["events"])
       end
 
-       it "does not persist round_results for internal-scoretaking competitions" do
+      it "does not persist round_results for internal-scoretaking competitions" do
         competition.update!(scoretaking_software: :internal)
 
         competition.set_wcif_events!(wcif["events"], delegate)

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -1283,6 +1283,27 @@ RSpec.describe "Competition WCIF" do
         expect(competition.to_wcif["events"]).to eq(wcif["events"])
       end
 
+       it "does not persist round_results for internal-scoretaking competitions" do
+        competition.update!(scoretaking_software: :internal)
+
+        competition.set_wcif_events!(wcif["events"], delegate)
+
+        # live_results are still populated from the sync, but round_results stays empty
+        #   since live_results is the source of truth for internal scoretaking.
+        expect(LiveResult.count).to eq(2)
+        expect(competition.rounds.flat_map(&:round_results)).to be_empty
+      end
+
+      it "clears previously-stored round_results once a comp switches to internal scoretaking" do
+        competition.set_wcif_events!(wcif["events"], delegate)
+        expect(competition.rounds.flat_map(&:round_results)).not_to be_empty
+
+        competition.update!(scoretaking_software: :internal)
+        competition.set_wcif_events!(wcif["events"], delegate)
+
+        expect(competition.rounds.reload.flat_map(&:round_results)).to be_empty
+      end
+
       it "cleans up orphaned attempts upon syncing" do
         # First, establish five attempts as a baseline
         competition.set_wcif_events!(wcif["events"], delegate)


### PR DESCRIPTION
When all attempts where cleared they were not deleted as `attempts_to_load` had a guard clause.

I also stopped writing to round_results for internal competitions and ignored it in the sanity check