### PR TITLE
Add user_roles_id to sanity check 72 output

### DIFF
--- a/lib/sanity_check_sql/8 - user_data_irregularities/72 - user_role_short_lived.sql
+++ b/lib/sanity_check_sql/8 - user_data_irregularities/72 - user_role_short_lived.sql
@@ -5,6 +5,7 @@ SELECT
   ug.group_type,
   ur.start_date,
   ur.end_date,
+  ur.id AS user_roles_id,
   ur.metadata_id,
   ur.metadata_type,
   ur.created_at,
@@ -15,4 +16,4 @@ ON ur.group_id = ug.id
 INNER JOIN users AS u
 ON ur.user_id = u.id
 WHERE end_date - start_date <= 1
-ORDER BY ur.created_at, ur.user_id;
+ORDER BY user_name, created_at;


### PR DESCRIPTION
Small follow-up to #14583: adds `ur.id AS user_roles_id` to the output of sanity check 72 to make it easier to look up the specific role entry, and adjusts `ORDER BY` to `user_name, created_at`.