### PR TITLE
Merge Rounds in advancement_conditions_validator.rb

### DIFF
--- a/lib/results_validators/advancement_conditions_validator.rb
+++ b/lib/results_validators/advancement_conditions_validator.rb
@@ -34,6 +34,13 @@ module ResultsValidators
       }
     end
 
+    # Sort key matching Result.merged_dual_rounds: primary score (average or best per format,
+    # with DNF/<=0 ranked worst), then best, then id. Lower sorts first (better).
+    private def dual_round_sort_key(result)
+      primary = result.format.sort_by == "average" ? result.average : result.best
+      [primary <= 0 ? 1 : 0, primary, result.best <= 0 ? 1 : 0, result.best, result.id]
+    end
+
     def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
@@ -79,7 +86,14 @@ module ResultsValidators
             end
 
             if previous_round.present?
-              previous_results = results_by_round_id[previous_round.id]
+              # Linked (dual) rounds are run as a single combined round, so the previous results
+              # are the union of the previous round and any of its colinked rounds, keeping only
+              # each competitor's best result (mirrors Result.merged_dual_rounds).
+              previous_round_ids = [previous_round.id, *previous_round.colinked_rounds.ids]
+              previous_results = previous_round_ids
+                                 .flat_map { |id| results_by_round_id[id] || [] }
+                                 .group_by(&:person_id)
+                                 .map { |_, person_results| person_results.min_by { |r| dual_round_sort_key(r) } }
               number_of_people_in_previous_round = previous_results.size
               condition = previous_round.advancement_condition
 

--- a/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -215,6 +215,27 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
       expect(acv.errors).to be_empty
     end
 
+    it "merges linked (dual) rounds when checking advancement to the next round" do
+      # Dual round (9v5): rounds 1 and 2 are run as a single combined round, then round 3 follows.
+      # 60 competitors in round 1 and 40 (different) in round 2 => 100 combined. 70 advance to
+      # round 3. Checked against round 2 alone (40 people) this would falsely trip 9P1
+      # (max 30 may advance); checked against the merged 100 it is fine (max 75).
+      linked_round = create(:linked_round)
+      round_333_1 = create(:round, competition: competition3, event_id: "333", linked_round: linked_round, total_number_of_rounds: 3, number: 1)
+      round_333_2 = create(:round, competition: competition3, event_id: "333", linked_round: linked_round, total_number_of_rounds: 3, number: 2)
+      round_333_3 = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 3, number: 3)
+
+      results = []
+      results += build_list(:result, 60, competition: competition3, event_id: "333", round_type_id: "1", round: round_333_1)
+      results += build_list(:result, 40, competition: competition3, event_id: "333", round_type_id: "2", round: round_333_2)
+      results += build_list(:result, 70, competition: competition3, event_id: "333", round_type_id: "f", round: round_333_3)
+      Result.import(results, validate: false)
+
+      acv = ACV.new.validate(competition_ids: [competition3.id], model: Result)
+      expect(acv.warnings).to be_empty
+      expect(acv.errors).to be_empty
+    end
+
     # Triggers:
     # REGULATION_9M1_ERROR
     # REGULATION_9M2_ERROR


### PR DESCRIPTION
Fixese #14820. 

The future proof solution is to replace this with a participation_condition_validator, but we want to unblock posting right now