### PR TITLE
Fix Event Table Qualifications

### DIFF
--- a/app/webpacker/components/EventsTable/index.jsx
+++ b/app/webpacker/components/EventsTable/index.jsx
@@ -95,7 +95,7 @@ export default function EventsTable({ competitionInfo, wcifEvents }) {
                 {competitionInfo['uses_qualification?'] && (
                   <TableCell>
                     { i === 0
-                    && eventQualificationToString(event, event.qualification)}
+                    && eventQualificationToString(event, event.qualification, { isV2: true })}
                   </TableCell>
                 )}
               </TableRow>


### PR DESCRIPTION
When I switched the events page to wcif v2 this got broken