### PR TITLE
Improve WEAT's monthly digest draft email

### DIFF
--- a/app/mailers/wca_monthly_digest_mailer.rb
+++ b/app/mailers/wca_monthly_digest_mailer.rb
@@ -4,10 +4,12 @@ class WcaMonthlyDigestMailer < ApplicationMailer
   include MailersHelper
 
   def send_weat_digest_content
+    @delegate_milestones = User.delegate_milestones_for_digest
+    last_month = Time.now.beginning_of_month - 1.month
     mail(
       to: ["assistants@worldcubeassociation.org"],
       reply_to: ["assistants@worldcubeassociation.org"],
-      subject: "WCA Monthly Digest Draft",
+      subject: "WCA Monthly Digest Draft - #{last_month.strftime('%B %Y')}",
     )
   end
 end

--- a/app/mailers/wca_monthly_digest_mailer.rb
+++ b/app/mailers/wca_monthly_digest_mailer.rb
@@ -4,8 +4,7 @@ class WcaMonthlyDigestMailer < ApplicationMailer
   include MailersHelper
 
   def send_weat_digest_content
-    @delegate_milestones = User.delegate_milestones_for_digest
-    last_month = Time.now.beginning_of_month - 1.month
+    last_month = 1.month.ago.beginning_of_month
     mail(
       to: ["assistants@worldcubeassociation.org"],
       reply_to: ["assistants@worldcubeassociation.org"],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1234,14 +1234,14 @@ class User < ApplicationRecord
     base_scope = User.joins(:actually_delegated_competitions).where(id: active_delegate_ids)
 
     before_counts = base_scope
-      .where("competitions.end_date < ?", last_month_start)
-      .group("users.id")
-      .count
+                    .where(competitions: { end_date: ...last_month_start })
+                    .group("users.id")
+                    .count
 
     through_counts = base_scope
-      .where("competitions.end_date <= ?", last_month_end)
-      .group("users.id")
-      .count
+                     .where(competitions: { end_date: ..last_month_end })
+                     .group("users.id")
+                     .count
 
     milestone_achievers = Hash.new { |h, k| h[k] = [] }
 
@@ -1261,9 +1261,8 @@ class User < ApplicationRecord
       next if milestone_achievers[milestone].empty?
 
       result[milestone] = milestone_achievers[milestone]
-        .map { |id| users_by_id[id] }
-        .compact
-        .sort_by(&:name)
+                          .filter_map { |id| users_by_id[id] }
+                          .sort_by(&:name)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1218,6 +1218,55 @@ class User < ApplicationRecord
       .map(&:user_id)
   end
 
+  DELEGATE_MILESTONES = [50, 100, 200, 300].freeze
+
+  def self.delegate_milestones_for_digest
+    last_month_start = (Time.now.beginning_of_month - 1.month).to_date
+    last_month_end = (Time.now.beginning_of_month - 1.day).to_date
+
+    active_delegate_ids = UserRole.active
+                                  .where(group: UserGroup.delegate_regions)
+                                  .pluck(:user_id)
+                                  .uniq
+
+    return {} if active_delegate_ids.empty?
+
+    base_scope = User.joins(:actually_delegated_competitions).where(id: active_delegate_ids)
+
+    before_counts = base_scope
+      .where("competitions.end_date < ?", last_month_start)
+      .group("users.id")
+      .count
+
+    through_counts = base_scope
+      .where("competitions.end_date <= ?", last_month_end)
+      .group("users.id")
+      .count
+
+    milestone_achievers = Hash.new { |h, k| h[k] = [] }
+
+    through_counts.each do |user_id, through_count|
+      before_count = before_counts[user_id] || 0
+      DELEGATE_MILESTONES.each do |milestone|
+        milestone_achievers[milestone] << user_id if before_count < milestone && through_count >= milestone
+      end
+    end
+
+    all_ids = milestone_achievers.values.flatten.uniq
+    return {} if all_ids.empty?
+
+    users_by_id = User.where(id: all_ids).index_by(&:id)
+
+    DELEGATE_MILESTONES.each_with_object({}) do |milestone, result|
+      next if milestone_achievers[milestone].empty?
+
+      result[milestone] = milestone_achievers[milestone]
+        .map { |id| users_by_id[id] }
+        .compact
+        .sort_by(&:name)
+    end
+  end
+
   def self.search(query, params: {})
     search_by_email = ActiveRecord::Type::Boolean.new.cast(params[:email])
     admin_search = ActiveRecord::Type::Boolean.new.cast(params[:adminSearch])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1221,8 +1221,8 @@ class User < ApplicationRecord
   DELEGATE_MILESTONES = [50, 100, 200, 300].freeze
 
   def self.delegate_milestones_for_digest
-    last_month_start = (Time.now.beginning_of_month - 1.month).to_date
-    last_month_end = (Time.now.beginning_of_month - 1.day).to_date
+    last_month_start = 1.month.ago.beginning_of_month.to_date
+    last_month_end = 1.month.ago.end_of_month.to_date
 
     active_delegate_ids = UserRole.active
                                   .where(group: UserGroup.delegate_regions)
@@ -1243,26 +1243,21 @@ class User < ApplicationRecord
                      .group("users.id")
                      .count
 
-    milestone_achievers = Hash.new { |h, k| h[k] = [] }
-
-    through_counts.each do |user_id, through_count|
-      before_count = before_counts[user_id] || 0
-      DELEGATE_MILESTONES.each do |milestone|
-        milestone_achievers[milestone] << user_id if before_count < milestone && through_count >= milestone
+    milestone_achievers = DELEGATE_MILESTONES.index_with do |milestone|
+      through_counts.filter_map do |user_id, through_count|
+        before_count = before_counts.fetch(user_id, 0)
+        user_id if before_count < milestone && through_count >= milestone
       end
     end
 
+    milestone_achievers.select! { |_milestone, user_ids| user_ids.any? }
     all_ids = milestone_achievers.values.flatten.uniq
     return {} if all_ids.empty?
 
     users_by_id = User.where(id: all_ids).index_by(&:id)
 
-    DELEGATE_MILESTONES.each_with_object({}) do |milestone, result|
-      next if milestone_achievers[milestone].empty?
-
-      result[milestone] = milestone_achievers[milestone]
-                          .filter_map { |id| users_by_id[id] }
-                          .sort_by(&:name)
+    milestone_achievers.transform_values do |user_ids|
+      user_ids.filter_map { |id| users_by_id[id] }.sort_by(&:name)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1248,9 +1248,8 @@ class User < ApplicationRecord
         before_count = before_counts.fetch(user_id, 0)
         user_id if before_count < milestone && through_count >= milestone
       end
-    end
+    end.select { |_milestone, user_ids| user_ids.any? }
 
-    milestone_achievers.select! { |_milestone, user_ids| user_ids.any? }
     all_ids = milestone_achievers.values.flatten.uniq
     return {} if all_ids.empty?
 

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -201,6 +201,7 @@ class UserGroup < ApplicationRecord
   # rubocop:disable Metrics/PerceivedComplexity
   def changes_in_group_for_digest
     duration_start_date = Time.now.beginning_of_month - 1.month
+    duration_end_date = Time.now.beginning_of_month
     sorted_users = []
     team_member_changes = {}
 
@@ -214,7 +215,7 @@ class UserGroup < ApplicationRecord
     no_more_members = []
 
     roles
-      .select { |role| role.updated_at >= duration_start_date } # Filters members who have change in the duration.
+      .select { |role| role.updated_at >= duration_start_date && role.updated_at < duration_end_date }
       .sort_by { |role| [role.user.name, role.updated_at] } # Sorts the members alphabetically.
       .each do |role|
         user = role.user

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -200,8 +200,9 @@ class UserGroup < ApplicationRecord
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def changes_in_group_for_digest
-    duration_end_date = Time.current.beginning_of_month
-    duration_start_date = duration_end_date - 1.month
+    last_month = 1.month.ago
+    duration_start_date = last_month.beginning_of_month
+    duration_end_date = last_month.end_of_month
     sorted_users = []
     team_member_changes = {}
 
@@ -215,7 +216,7 @@ class UserGroup < ApplicationRecord
     no_more_members = []
 
     roles
-      .select { |role| role.updated_at >= duration_start_date && role.updated_at < duration_end_date }
+      .select { |role| role.updated_at.between?(duration_start_date, duration_end_date) }
       .sort_by { |role| [role.user.name, role.updated_at] } # Sorts the members alphabetically.
       .each do |role|
         user = role.user

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -200,8 +200,8 @@ class UserGroup < ApplicationRecord
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def changes_in_group_for_digest
-    duration_start_date = Time.now.beginning_of_month - 1.month
-    duration_end_date = Time.now.beginning_of_month
+    duration_end_date = Time.current.beginning_of_month
+    duration_start_date = duration_end_date - 1.month
     sorted_users = []
     team_member_changes = {}
 

--- a/app/views/wca_monthly_digest_mailer/send_weat_digest_content.html.erb
+++ b/app/views/wca_monthly_digest_mailer/send_weat_digest_content.html.erb
@@ -2,6 +2,19 @@
 
 <p>Here's the draft for this month digest (Please verify whether all the changes were informed to the WCA Board):</p>
 
-<div><b>Changes in Teams/Committees/Councils</b></div>
+<div><b>Changes in Teams/Committees</b></div>
 
 <p><%= sanitize UserGroup.changes_in_groups_for_digest %></p>
+
+<div><b>Delegate Milestones</b></div>
+
+<% if @delegate_milestones.empty? %>
+  <p>There are no delegate milestones to show.</p>
+<% else %>
+  <p>
+    <% @delegate_milestones.each do |milestone, delegates| %>
+      <br><b><%= milestone %> competitions</b><br>
+      <%= delegates.map(&:name).join("<br>").html_safe %>
+    <% end %>
+  </p>
+<% end %>

--- a/app/views/wca_monthly_digest_mailer/send_weat_digest_content.html.erb
+++ b/app/views/wca_monthly_digest_mailer/send_weat_digest_content.html.erb
@@ -15,7 +15,7 @@
   <p>
     <% delegate_milestones.each do |milestone, delegates| %>
       <br><b><%= milestone %> competitions</b><br>
-      <%= delegates.map(&:name).join("<br>").html_safe %>
+      <%= safe_join(delegates.map(&:name), tag.br) %>
     <% end %>
   </p>
 <% end %>

--- a/app/views/wca_monthly_digest_mailer/send_weat_digest_content.html.erb
+++ b/app/views/wca_monthly_digest_mailer/send_weat_digest_content.html.erb
@@ -8,11 +8,12 @@
 
 <div><b>Delegate Milestones</b></div>
 
-<% if @delegate_milestones.empty? %>
+<% delegate_milestones = User.delegate_milestones_for_digest %>
+<% if delegate_milestones.empty? %>
   <p>There are no delegate milestones to show.</p>
 <% else %>
   <p>
-    <% @delegate_milestones.each do |milestone, delegates| %>
+    <% delegate_milestones.each do |milestone, delegates| %>
       <br><b><%= milestone %> competitions</b><br>
       <%= delegates.map(&:name).join("<br>").html_safe %>
     <% end %>

--- a/spec/mailers/wca_monthly_digest_mailer_spec.rb
+++ b/spec/mailers/wca_monthly_digest_mailer_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe WcaMonthlyDigestMailer do
     let(:mail) { WcaMonthlyDigestMailer.send_weat_digest_content }
 
     it "renders the headers" do
+      last_month = Time.now.beginning_of_month - 1.month
       expect(mail.to).to eq(["assistants@worldcubeassociation.org"])
       expect(mail.reply_to).to eq(["assistants@worldcubeassociation.org"])
-      expect(mail.subject).to eq("WCA Monthly Digest Draft")
+      expect(mail.subject).to eq("WCA Monthly Digest Draft - #{last_month.strftime('%B %Y')}")
+    end
+
+    it "renders the changes in teams/committees section" do
+      expect(mail.body.encoded).to include("Changes in Teams/Committees")
+    end
+
+    it "renders the delegate milestones section" do
+      expect(mail.body.encoded).to include("Delegate Milestones")
     end
   end
 end

--- a/spec/mailers/wca_monthly_digest_mailer_spec.rb
+++ b/spec/mailers/wca_monthly_digest_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe WcaMonthlyDigestMailer do
     let(:mail) { WcaMonthlyDigestMailer.send_weat_digest_content }
 
     it "renders the headers" do
-      last_month = Time.now.beginning_of_month - 1.month
+      last_month = 1.month.ago.beginning_of_month
       expect(mail.to).to eq(["assistants@worldcubeassociation.org"])
       expect(mail.reply_to).to eq(["assistants@worldcubeassociation.org"])
       expect(mail.subject).to eq("WCA Monthly Digest Draft - #{last_month.strftime('%B %Y')}")

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -152,9 +152,13 @@ RSpec.describe UserGroup do
   end
 
   context "Monthly digest changes" do
+    let(:last_month) { 1.month.ago }
+
     it "Added 2 new members" do
-      create(:wrc_member_role, user_id: users[6].id, start_date: Time.now - 4.days)
-      create(:wrc_member_role, user_id: users[7].id, start_date: Time.now - 4.days)
+      role6 = create(:wrc_member_role, user_id: users[6].id, start_date: last_month)
+      role7 = create(:wrc_member_role, user_id: users[7].id, start_date: last_month)
+      role6.update_columns(updated_at: last_month)
+      role7.update_columns(updated_at: last_month)
 
       expected_output = [
         "<br><b>Changes in WCA Regulations Committee</b>",
@@ -168,8 +172,9 @@ RSpec.describe UserGroup do
     it "Promoted 1 member" do
       wrc_group = UserGroup.teams_committees_group_wrc
       team_member = wrc_group.roles[3]
-      team_member.update_columns(end_date: Time.now - 5.days, updated_at: Time.now - 5.days)
-      create(:wrc_senior_member_role, user_id: team_member.user.id, start_date: Time.now - 5.days)
+      team_member.update_columns(end_date: last_month, updated_at: last_month)
+      role = create(:wrc_senior_member_role, user_id: team_member.user.id, start_date: last_month)
+      role.update_columns(updated_at: last_month)
 
       expected_output = [
         "<br><b>Changes in WCA Regulations Committee</b>",
@@ -180,14 +185,30 @@ RSpec.describe UserGroup do
       expect(UserGroup.teams_committees_group_wrc.changes_in_group_for_digest).to eq expected_output
     end
 
+    it "does not include changes from the current month" do
+      role6 = create(:wrc_member_role, user_id: users[6].id, start_date: last_month)
+      role6.update_columns(updated_at: last_month)
+      create(:wrc_member_role, user_id: users[7].id, start_date: Time.now)
+
+      expected_output = [
+        "<br><b>Changes in WCA Regulations Committee</b>",
+        "",
+        "<b>New Members</b>",
+        users[6].name,
+      ].join("<br>")
+      expect(UserGroup.teams_committees_group_wrc.changes_in_group_for_digest).to eq expected_output
+    end
+
     it "Leader resigned and another person became leader" do
       wrc_group = UserGroup.teams_committees_group_wrc
       cur_leader = wrc_group.roles[0]
       new_leader = wrc_group.roles[1]
-      cur_leader.update_columns(end_date: Time.now - 10.days, updated_at: Time.now - 10.days)
-      new_leader.update_columns(end_date: Time.now - 10.days, updated_at: Time.now - 10.days)
-      create(:wrc_senior_member_role, user_id: users[0].id, start_date: Time.now - 10.days)
-      create(:wrc_leader_role, user_id: new_leader.user.id, start_date: Time.now - 10.days)
+      cur_leader.update_columns(end_date: last_month, updated_at: last_month)
+      new_leader.update_columns(end_date: last_month, updated_at: last_month)
+      role_senior = create(:wrc_senior_member_role, user_id: users[0].id, start_date: last_month)
+      role_senior.update_columns(updated_at: last_month)
+      role_leader = create(:wrc_leader_role, user_id: new_leader.user.id, start_date: last_month)
+      role_leader.update_columns(updated_at: last_month)
 
       expected_output = [
         "<br><b>Changes in WCA Regulations Committee</b>",

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe UserGroup do
     it "does not include changes from the current month" do
       role6 = create(:wrc_member_role, user_id: users[6].id, start_date: last_month)
       role6.update_columns(updated_at: last_month)
-      create(:wrc_member_role, user_id: users[7].id, start_date: Time.now)
+      create(:wrc_member_role, user_id: users[7].id, start_date: Time.current)
 
       expected_output = [
         "<br><b>Changes in WCA Regulations Committee</b>",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -374,6 +374,51 @@ RSpec.describe User do
     expect(avatar.private_image.attached?).to be true
   end
 
+  describe ".delegate_milestones_for_digest" do
+    let(:delegate) { create(:delegate) }
+    let(:last_month_end) { (Time.now.beginning_of_month - 1.day).to_date }
+    let(:two_years_ago) { 2.years.ago.to_date }
+
+    def bulk_insert_competitions(count, end_date, cancelled: false)
+      now = Time.now
+      ids = Array.new(count) { |i| "BulkComp#{SecureRandom.hex(4)}#{i}" }
+      Competition.insert_all(
+        ids.map { |id| { id: id[0..31], name: id[0..49], cell_name: id[0..44], show_at_all: true, end_date: end_date, cancelled_at: (now if cancelled), created_at: now, updated_at: now } },
+      )
+      CompetitionDelegate.insert_all(
+        ids.map { |id| { competition_id: id[0..31], delegate_id: delegate.id, created_at: now, updated_at: now } },
+      )
+    end
+
+    it "returns empty hash when no delegate crosses a milestone" do
+      bulk_insert_competitions(49, two_years_ago)
+      expect(User.delegate_milestones_for_digest).to eq({})
+    end
+
+    it "returns delegate who reaches the 50 milestone during last month" do
+      bulk_insert_competitions(49, two_years_ago)
+      bulk_insert_competitions(1, last_month_end)
+      expect(User.delegate_milestones_for_digest).to eq({ 50 => [delegate] })
+    end
+
+    it "does not include a delegate who reached the milestone before last month" do
+      bulk_insert_competitions(50, two_years_ago)
+      expect(User.delegate_milestones_for_digest).to eq({})
+    end
+
+    it "does not count cancelled competitions toward milestones" do
+      bulk_insert_competitions(49, two_years_ago)
+      bulk_insert_competitions(1, last_month_end, cancelled: true)
+      expect(User.delegate_milestones_for_digest).to eq({})
+    end
+
+    it "does not count competitions from future months" do
+      bulk_insert_competitions(49, two_years_ago)
+      bulk_insert_competitions(1, 1.month.from_now.to_date)
+      expect(User.delegate_milestones_for_digest).to eq({})
+    end
+  end
+
   describe "#delegated_competitions" do
     let(:delegate) { create(:delegate) }
     let(:other_delegate) { create(:delegate) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -386,8 +386,9 @@ RSpec.describe User do
         starts: end_date,
         ends: end_date,
         delegates: [delegate],
+        organizers: [delegate],
         show_at_all: true,
-        cancelled_at: (Time.now if cancelled),
+        cancelled_at: (Time.current if cancelled),
       )
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -376,46 +376,47 @@ RSpec.describe User do
 
   describe ".delegate_milestones_for_digest" do
     let(:delegate) { create(:delegate) }
-    let(:last_month_end) { (Time.now.beginning_of_month - 1.day).to_date }
+    let(:last_month_end) { 1.month.ago.end_of_month.to_date }
     let(:two_years_ago) { 2.years.ago.to_date }
 
-    def bulk_insert_competitions(count, end_date, cancelled: false)
-      now = Time.now
-      ids = Array.new(count) { |i| "BulkComp#{SecureRandom.hex(4)}#{i}" }
-      Competition.insert_all(
-        ids.map { |id| { id: id[0..31], name: id[0..49], cell_name: id[0..44], show_at_all: true, end_date: end_date, cancelled_at: (now if cancelled), created_at: now, updated_at: now } },
-      )
-      CompetitionDelegate.insert_all(
-        ids.map { |id| { competition_id: id[0..31], delegate_id: delegate.id, created_at: now, updated_at: now } },
+    def create_delegated_competitions(count, end_date, cancelled: false)
+      create_list(
+        :competition,
+        count,
+        starts: end_date,
+        ends: end_date,
+        delegates: [delegate],
+        show_at_all: true,
+        cancelled_at: (Time.now if cancelled),
       )
     end
 
     it "returns empty hash when no delegate crosses a milestone" do
-      bulk_insert_competitions(49, two_years_ago)
-      expect(User.delegate_milestones_for_digest).to eq({})
+      create_delegated_competitions(49, two_years_ago)
+      expect(User.delegate_milestones_for_digest).to be_empty
     end
 
     it "returns delegate who reaches the 50 milestone during last month" do
-      bulk_insert_competitions(49, two_years_ago)
-      bulk_insert_competitions(1, last_month_end)
+      create_delegated_competitions(49, two_years_ago)
+      create_delegated_competitions(1, last_month_end)
       expect(User.delegate_milestones_for_digest).to eq({ 50 => [delegate] })
     end
 
     it "does not include a delegate who reached the milestone before last month" do
-      bulk_insert_competitions(50, two_years_ago)
-      expect(User.delegate_milestones_for_digest).to eq({})
+      create_delegated_competitions(50, two_years_ago)
+      expect(User.delegate_milestones_for_digest).to be_empty
     end
 
     it "does not count cancelled competitions toward milestones" do
-      bulk_insert_competitions(49, two_years_ago)
-      bulk_insert_competitions(1, last_month_end, cancelled: true)
-      expect(User.delegate_milestones_for_digest).to eq({})
+      create_delegated_competitions(49, two_years_ago)
+      create_delegated_competitions(1, last_month_end, cancelled: true)
+      expect(User.delegate_milestones_for_digest).to be_empty
     end
 
     it "does not count competitions from future months" do
-      bulk_insert_competitions(49, two_years_ago)
-      bulk_insert_competitions(1, 1.month.from_now.to_date)
-      expect(User.delegate_milestones_for_digest).to eq({})
+      create_delegated_competitions(49, two_years_ago)
+      create_delegated_competitions(1, 1.month.from_now.to_date)
+      expect(User.delegate_milestones_for_digest).to be_empty
     end
   end
 


### PR DESCRIPTION
This PR introduces four changes related to WEAT's monthly digest draft email:

- Lists all delegate milestones. Previously, WEAT had to manually check all milestones, so this change significantly simplifies the workflow
- Adds the month name to the email subject
- Remove "Councils" from the email, since we don't have councils anymore
- Fixes a bug where changes from the current month could be included in the email. If the email is sent after the 1st of the month, it may include changes from the current month, whereas we only want changes that were actioned during the digest's month

I've also added a few more tests to cover these changes
