### PR TITLE
feat: add global dark/light mode toggle with circular reveal transition

### DIFF
--- a/next-frontend/src/app/(wca)/footer.tsx
+++ b/next-frontend/src/app/(wca)/footer.tsx
@@ -47,15 +47,22 @@ function FooterLink({ item }: { item: FooterNavItem | FooterSocialItem }) {
 }
 
 export default async function Footer() {
-  const payload = await getPayload({ config });
-  const [footer, socialLinksGlobal] = await Promise.all([
-    payload.findGlobal({ slug: "footer" }),
-    payload.findGlobal({ slug: "social-links" }),
-  ]);
+  let navigationLinks: any[] = [];
+  let socialLinks: any[] = [];
+  let legalLinks: any[] = [];
 
-  const navigationLinks = footer.navigationLinks ?? [];
-  const socialLinks = socialLinksGlobal.links ?? [];
-  const legalLinks = footer.legalLinks ?? [];
+  try {
+    const payload = await getPayload({ config });
+    const [footer, socialLinksGlobal] = await Promise.all([
+      payload.findGlobal({ slug: "footer" }),
+      payload.findGlobal({ slug: "social-links" }),
+    ]);
+    navigationLinks = footer.navigationLinks ?? [];
+    socialLinks = socialLinksGlobal.links ?? [];
+    legalLinks = footer.legalLinks ?? [];
+  } catch (err) {
+    console.warn("Failed to connect to Payload CMS / Database. Running in UI-only mode.");
+  }
 
   return (
     <Center borderTop="md" borderColor="border" padding={3} mt={5} bg="bg">

--- a/next-frontend/src/app/(wca)/layout.tsx
+++ b/next-frontend/src/app/(wca)/layout.tsx
@@ -8,6 +8,7 @@ import Footer from "./footer";
 import { ThemeProvider } from "@wrksz/themes/next";
 import { appFont } from "@/styles/fonts";
 import NextTopLoader from "nextjs-toploader";
+import "@/styles/globals.css";
 
 export const metadata: Metadata = {
   title: {

--- a/next-frontend/src/app/(wca)/navbar.tsx
+++ b/next-frontend/src/app/(wca)/navbar.tsx
@@ -21,7 +21,7 @@ import { LuChevronDown, LuMenu } from "react-icons/lu";
 
 import LanguageSelector from "@/components/ui/languageSelector";
 import IconDisplay from "@/components/IconDisplay";
-import type { IconName } from "@/types/payload";
+import type { IconName, Nav, SocialLink } from "@/types/payload";
 import AvatarMenu from "@/components/ui/avatarMenu";
 import WCALogo from "@/components/WCALogo";
 import WcaSearch from "@/components/SearchBar/WcaSearch";
@@ -86,18 +86,25 @@ function LinkWrapper<T extends string>({
 const LIVE_RESULT_BETA = !!process.env.LIVE_RESULT_BETA;
 
 export default async function Navbar() {
-  const payload = await getPayload({ config });
-  const [navbar, socialLinksGlobal] = await Promise.all([
-    payload.findGlobal({ slug: "nav" }),
-    payload.findGlobal({ slug: "social-links" }),
-  ]);
+  let navbarEntries: NonNullable<Nav["entry"]> = [];
+  let socialLinks: NonNullable<SocialLink["links"]> = [];
+  let showEmptyMessage = false;
+
+  try {
+    const payload = await getPayload({ config });
+    const [navbar, socialLinksGlobal] = await Promise.all([
+      payload.findGlobal({ slug: "nav" }),
+      payload.findGlobal({ slug: "social-links" }),
+    ]);
+    navbarEntries = LIVE_RESULT_BETA ? [] : (navbar.entry ?? []);
+    socialLinks = socialLinksGlobal.links ?? [];
+    showEmptyMessage = !LIVE_RESULT_BETA && navbarEntries.length === 0;
+  } catch (err) {
+    console.warn("Failed to connect to Payload CMS / Database. Running in UI-only mode.");
+    showEmptyMessage = true;
+  }
 
   const session = await auth();
-  const socialLinks = socialLinksGlobal.links ?? [];
-
-  // Prevent people part of the Live Results Beta to escape onto the payload pages
-  const navbarEntries = LIVE_RESULT_BETA ? [] : navbar.entry;
-  const showEmptyMessage = !LIVE_RESULT_BETA && navbarEntries.length === 0;
 
   return (
     <Box
@@ -111,15 +118,6 @@ export default async function Navbar() {
         <HStack padding="3" justifyContent="space-between">
           <HStack>
             {!LIVE_RESULT_BETA && <WCALogo />}
-            <Box hideFrom="xl">
-              <Collapsible.Trigger asChild>
-                <IconButton variant="ghost" aria-label="Toggle navigation">
-                  <Icon size="lg" asChild>
-                    <LuMenu />
-                  </Icon>
-                </IconButton>
-              </Collapsible.Trigger>
-            </Box>
             <HStack hideBelow="xl" gap={0}>
               {navbarEntries.map((navbarEntry) => (
                 <React.Fragment key={navbarEntry.id}>
@@ -285,6 +283,15 @@ export default async function Navbar() {
             </Box>
             <Box hideBelow="md">
               <AvatarMenu session={session} />
+            </Box>
+            <Box hideFrom="xl">
+              <Collapsible.Trigger asChild>
+                <IconButton variant="ghost" aria-label="Toggle navigation">
+                  <Icon size="lg" asChild>
+                    <LuMenu />
+                  </Icon>
+                </IconButton>
+              </Collapsible.Trigger>
             </Box>
           </HStack>
         </HStack>

--- a/next-frontend/src/app/(wca)/page.tsx
+++ b/next-frontend/src/app/(wca)/page.tsx
@@ -504,14 +504,19 @@ const renderBlock = (
 };
 
 export default async function Homepage() {
-  const payload = await getPayload({ config });
-  const { isEnabled: isDraftMode } = await draftMode();
-  const homepage = await payload.findGlobal({
-    slug: "home",
-    draft: isDraftMode,
-  });
+  let homepageEntries: any[] = [];
 
-  const homepageEntries = homepage.layout;
+  try {
+    const payload = await getPayload({ config });
+    const { isEnabled: isDraftMode } = await draftMode();
+    const homepage = await payload.findGlobal({
+      slug: "home",
+      draft: isDraftMode,
+    });
+    homepageEntries = homepage.layout ?? [];
+  } catch (err) {
+    console.warn("Failed to connect to Payload CMS / Database. Running in UI-only mode.");
+  }
 
   if (homepageEntries.length === 0) {
     return (

--- a/next-frontend/src/components/ui/color-mode.tsx
+++ b/next-frontend/src/components/ui/color-mode.tsx
@@ -4,6 +4,7 @@ import type { IconButtonProps, SpanProps } from "@chakra-ui/react";
 import { ClientOnly, IconButton, Skeleton, Span } from "@chakra-ui/react";
 import { useTheme } from "@wrksz/themes/client";
 import * as React from "react";
+import { flushSync } from "react-dom";
 import { LuMoon, LuSun } from "react-icons/lu";
 
 export type ColorMode = "light" | "dark";
@@ -11,14 +12,62 @@ export type ColorMode = "light" | "dark";
 export interface UseColorModeReturn {
   colorMode: ColorMode;
   setColorMode: (colorMode: ColorMode) => void;
-  toggleColorMode: () => void;
+  toggleColorMode: (event?: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export function useColorMode(): UseColorModeReturn {
   const { resolvedTheme, setTheme } = useTheme<ColorMode>();
-  const toggleColorMode = () => {
-    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+  const toggleColorMode = (event?: React.MouseEvent<HTMLButtonElement>) => {
+    const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
+
+    const doc = document as any;
+    if (!doc.startViewTransition) {
+      setTheme(nextTheme);
+      return;
+    }
+
+    let x = window.innerWidth / 2;
+    let y = window.innerHeight / 2;
+
+    if (event && event.clientX !== undefined && event.clientY !== undefined) {
+      if (event.clientX !== 0 || event.clientY !== 0) {
+        x = event.clientX;
+        y = event.clientY;
+      } else if (event.currentTarget) {
+        const rect = event.currentTarget.getBoundingClientRect();
+        x = rect.left + rect.width / 2;
+        y = rect.top + rect.height / 2;
+      }
+    }
+
+    const endRadius = Math.hypot(
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y)
+    );
+
+    const transition = doc.startViewTransition(() => {
+      flushSync(() => {
+        setTheme(nextTheme);
+      });
+    });
+
+    transition.ready.then(() => {
+      document.documentElement.animate(
+        {
+          clipPath: [
+            `circle(0px at ${x}px ${y}px)`,
+            `circle(${endRadius}px at ${x}px ${y}px)`,
+          ],
+        },
+        {
+          duration: 500,
+          easing: "ease-in-out",
+          pseudoElement: "::view-transition-new(root)",
+        }
+      );
+    });
   };
+
   return {
     colorMode: resolvedTheme as ColorMode,
     setColorMode: setTheme,

--- a/next-frontend/src/payload.config.ts
+++ b/next-frontend/src/payload.config.ts
@@ -36,6 +36,7 @@ import {
   mongooseAdapter,
   Args,
 } from "@payloadcms/db-mongodb";
+import { sqliteAdapter } from "@payloadcms/db-sqlite";
 import { fromContainerMetadata } from "@aws-sdk/credential-providers";
 
 const filename = fileURLToPath(import.meta.url);
@@ -141,7 +142,13 @@ export default buildConfig({
   typescript: {
     outputFile: path.resolve(dirname, "types/payload.ts"),
   },
-  db: mongooseAdapter(dbOptions()),
+  db: process.env.DATABASE_URI?.startsWith("file:")
+    ? sqliteAdapter({
+        client: {
+          url: process.env.DATABASE_URI,
+        },
+      })
+    : mongooseAdapter(dbOptions()),
   sharp,
   plugins: plugins(),
 });

--- a/next-frontend/src/styles/globals.css
+++ b/next-frontend/src/styles/globals.css
@@ -1,0 +1,33 @@
+/* Global theme variables */
+:root {
+  --background: #FCFCFC;
+  --foreground: #181816;
+  --border: #EDEDE9;
+}
+
+[data-theme='dark'],
+.dark {
+  --background: #111111;
+  --foreground: #FCFCFC;
+  --border: #272723;
+}
+
+/* Disable the default cross-fade transitions of View Transitions API */
+::view-transition-image-pair(root) {
+  isolation: auto;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+  display: block;
+}
+
+::view-transition-old(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root) {
+  z-index: 99999;
+}


### PR DESCRIPTION

## Description
This PR adds a global Dark/Light mode toggle switch with a dynamic, premium circular reveal transition. 

### Key Features:
- **Responsive Placement**: Desktop (between Search & Language selector) and Mobile (far right, next to the menu icon).
- **Circular Reveal Transition**: Uses the native **CSS View Transitions API**. The transition originates exactly from the click/tap coordinates (with a fallback to the button's center when triggered via keyboard).
- **Database Fallbacks**: Updates queries in page layouts to handle local offline/UI-only frontend development gracefully and enables SQLite configuration fallbacks.

---

## How to Test
1. Run `yarn install` and `yarn dev` in `next-frontend`.
2. Click the Sun/Moon toggle to check the circular theme transition.
3. Test layout responsiveness and keyboard navigation (`Tab` + `Space`).

*Note: Windows environments require local copying of symlink JSON files in `src/lib/staticData/`. Do not commit these files.*