### PR TITLE
Fix Multi Line Items being misaligned in LiveMenu

### DIFF
--- a/next-frontend/src/components/competitions/TabMenu.tsx
+++ b/next-frontend/src/components/competitions/TabMenu.tsx
@@ -65,7 +65,7 @@ export default function TabMenu({
         position="sticky"
         width="fit-content"
         min-width="3xs"
-        textAlign="center"
+        textAlign="start"
         hideBelow="md"
         gap="3"
       >
@@ -206,7 +206,7 @@ function CollapsibleTabGroup({
         _hover={{ bg: "bg.subtle" }}
         cursor="pointer"
       >
-        <Text textStyle="bodyEmphasis">
+        <Text textStyle="bodyEmphasis" textAlign="start">
           <IconComponent /> {t(i18nKey)}
         </Text>
       </Collapsible.Trigger>

--- a/next-frontend/src/components/competitions/TabMenu.tsx
+++ b/next-frontend/src/components/competitions/TabMenu.tsx
@@ -199,14 +199,14 @@ function CollapsibleTabGroup({
       <Collapsible.Trigger
         width="full"
         display="flex"
-        justifyContent="space-between"
+        textAlign="start"
         px="3"
         py="2"
         borderRadius="md"
         _hover={{ bg: "bg.subtle" }}
         cursor="pointer"
       >
-        <Text textStyle="bodyEmphasis" textAlign="start">
+        <Text textStyle="bodyEmphasis">
           <IconComponent /> {t(i18nKey)}
         </Text>
       </Collapsible.Trigger>


### PR DESCRIPTION
<img width="1426" height="696" alt="Screenshot 2026-06-26 at 23 12 07" src="https://github.com/user-attachments/assets/45205b13-dd2b-451e-9db3-a9c8b6040dd6" />
That was surprisingly hard to track down. Fixes #14758
