### PR TITLE
Warn when schedule activities fall outside competition dates

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3063,6 +3063,8 @@ en:
       mbld_scrambles_warning: "[%{round_id}] This round includes 3x3x3 Multi-Blind results. Please specify in your submission comment how many scrambles from each scramble set were actually used by competitors, so that WRT can remove the unused extra scrambles."
       multiple_fmc_groups_warning: "[%{round_id}] There are multiple groups of FMC used. If one group of FMC was used, please use the Scrambles Matcher to uncheck the unused scrambles. Otherwise, please include a comment to WRT explaining why multiple groups of FMC were used."
       wrong_number_of_scramble_sets_error: "[%{round_id}] This round has a different number of scramble sets (%{actual}) than specified on the Manage Events tab (%{expected}). Please adjust the number of scramble sets in the Manage Events tab to the number of sets that were used."
+    schedule:
+      activity_outside_competition_dates_warning: "The activity '%{activity_name}' (code: %{activity_code}) is scheduled outside the competition's date range in the venue's local timezone. Please update the competition schedule to reflect the actual competition dates."
   tickets:
     type:
       edit_person: "Edit Person"

--- a/lib/results_validators/schedule_activities_validator.rb
+++ b/lib/results_validators/schedule_activities_validator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module ResultsValidators
+  class ScheduleActivitiesValidator < GenericValidator
+    ACTIVITY_OUTSIDE_COMPETITION_DATES_WARNING = :activity_outside_competition_dates_warning
+
+    def self.description
+      "This validator checks that the competition's schedule is consistent with the competition's remaining data."
+    end
+
+    def self.automatically_fixable?
+      false
+    end
+
+    def competition_associations(check_real_results: false)
+      {
+        competition_venues: {
+          venue_rooms: {
+            schedule_activities: [],
+          },
+        },
+      }
+    end
+
+    def run_validation(validator_data)
+      validator_data.each do |competition_data|
+        competition = competition_data.competition
+
+        competition.competition_venues.each do |venue|
+          timezone = venue.timezone_id
+
+          venue.venue_rooms.each do |room|
+            room.schedule_activities.each do |activity|
+              local_start = activity.start_time.in_time_zone(timezone)
+              local_end   = activity.end_time.in_time_zone(timezone)
+
+              next unless local_start.to_date < competition.start_date ||
+                          local_start.to_date > competition.end_date ||
+                          local_end > (competition.end_date + 1).in_time_zone(timezone)
+
+              @warnings << ValidationWarning.new(
+                ACTIVITY_OUTSIDE_COMPETITION_DATES_WARNING,
+                :schedule,
+                competition.id,
+                activity_name: activity.name,
+                activity_code: activity.activity_code,
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/results_validators/utils.rb
+++ b/lib/results_validators/utils.rb
@@ -9,6 +9,7 @@ module ResultsValidators
       IndividualResultsValidator,
       PersonsValidator,
       PositionsValidator,
+      ScheduleActivitiesValidator,
       ScramblesValidator,
     ].freeze
 

--- a/spec/lib/results_validators/schedule_activities_validator_spec.rb
+++ b/spec/lib/results_validators/schedule_activities_validator_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RV = ResultsValidators
+SAV = RV::ScheduleActivitiesValidator
+
+RSpec.describe SAV do
+  context "on InboxResult and Result" do
+    let!(:competition) { create(:competition, :past, :with_valid_schedule, event_ids: %w[333]) }
+
+    before do
+      round = competition.rounds.first
+      [Result, InboxResult].each do |model|
+        create(model.model_name.singular.to_sym, competition: competition, event_id: "333", round: round)
+      end
+    end
+
+    let(:validator_args) do
+      [InboxResult, Result].flat_map do |model|
+        [
+          { competition_ids: [competition.id], model: model },
+          { results: model.where(competition_id: competition.id), model: model },
+        ]
+      end
+    end
+
+    it "produces no warnings for a valid schedule" do
+      validator_args.each do |arg|
+        sav = SAV.new.validate(**arg)
+        expect(sav.warnings).to be_empty
+        expect(sav.errors).to be_empty
+      end
+    end
+
+    context "with an activity outside competition dates" do
+      before do
+        room = competition.competition_venues.first.venue_rooms.first
+        # The factory creates venues in "Europe/Paris" (UTC+1 in winter, UTC+2 in summer).
+        # Picking 03:00 UTC means the local time is 04:00 (CET) or 05:00 (CEST) on end_date+1,
+        # so the activity is always after midnight locally regardless of DST, and the warning fires.
+        # 03:00 UTC also stays below noon UTC on end_date+1, which is the ceiling enforced by
+        # ScheduleActivity#included_in_competition_dates (Competition#end_time uses UTC-12 = noon UTC),
+        # so the record saves without bypassing that validation.
+        next_day = competition.end_date + 1
+        out_of_range_start = Time.utc(next_day.year, next_day.month, next_day.day, 3, 0, 0)
+        room.schedule_activities.create!(
+          wcif_id: 999,
+          name: "Late closing ceremony",
+          activity_code: "other-misc",
+          start_time: out_of_range_start,
+          end_time: out_of_range_start + 1.hour,
+        )
+      end
+
+      it "warns about the out-of-range activity" do
+        expected_warnings = [
+          RV::ValidationWarning.new(
+            SAV::ACTIVITY_OUTSIDE_COMPETITION_DATES_WARNING,
+            :schedule,
+            competition.id,
+            activity_name: "Late closing ceremony",
+            activity_code: "other-misc",
+          ),
+        ]
+
+        validator_args.each do |arg|
+          sav = SAV.new.validate(**arg)
+          expect(sav.warnings).to match_array(expected_warnings)
+          expect(sav.errors).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/results_validators/schedule_activities_validator_spec.rb
+++ b/spec/lib/results_validators/schedule_activities_validator_spec.rb
@@ -8,20 +8,19 @@ SAV = RV::ScheduleActivitiesValidator
 RSpec.describe SAV do
   context "on InboxResult and Result" do
     let!(:competition) { create(:competition, :past, :with_valid_schedule, event_ids: %w[333]) }
-
-    before do
-      round = competition.rounds.first
-      [Result, InboxResult].each do |model|
-        create(model.model_name.singular.to_sym, competition: competition, event_id: "333", round: round)
-      end
-    end
-
     let(:validator_args) do
       [InboxResult, Result].flat_map do |model|
         [
           { competition_ids: [competition.id], model: model },
           { results: model.where(competition_id: competition.id), model: model },
         ]
+      end
+    end
+
+    before do
+      round = competition.rounds.first
+      [Result, InboxResult].each do |model|
+        create(model.model_name.singular.to_sym, competition: competition, event_id: "333", round: round)
       end
     end
 


### PR DESCRIPTION
## Summary

- Adds `ScheduleActivitiesValidator`, a new result submission validator that checks whether any top-level schedule activity falls outside the competition's date range when converted to the venue's local timezone
- Registers the validator in `ALL_VALIDATORS` so it runs automatically as part of the full result submission validation
- Adds the corresponding locale string under `validators.schedule`

## Motivation

Sanity check 73 already detects this issue retroactively on posted results. This validator catches it earlier — at result submission time — so delegates can correct the schedule before WRT sees it.

The check mirrors the sanity check logic exactly: activity start/end times are converted from UTC to the venue's `timezone_id`, then compared against `competition.start_date` and `competition.end_date`. The end-time condition uses a strict `>` against midnight of `end_date + 1` in local time, matching the SQL's `local_end_datetime > TIMESTAMP(DATE_ADD(end_date, INTERVAL 1 DAY))` — so an activity ending exactly at midnight is not flagged.

The existing `ScheduleActivity#included_in_competition_dates` model validation is intentionally permissive (it uses UTC±12/14 extremes rather than the actual venue timezone), which is why issues can slip through to sanity check 73 in the first place.

> [!NOTE]
> This implementation was not locally tested and was co-authored with [Claude Code](https://claude.ai/code).

## Test plan

- [ ] Happy path: competition with a valid schedule produces no warnings
- [ ] Out-of-range activity produces exactly one `ACTIVITY_OUTSIDE_COMPETITION_DATES_WARNING`
- [ ] Both cases verified against `InboxResult` and `Result` models, via both `competition_ids:` and `results:` entry points