### PR TITLE
Bump Yarn to 4.17.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
       versions:
         - ">= 7"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 1
 - package-ecosystem: npm
   directory: "/next-frontend"
   schedule:
@@ -52,6 +54,8 @@ updates:
         - "next"
         - "eslint-config-next"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 1
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,12 @@ updates:
   open-pull-requests-limit: 10
   cooldown:
     default-days: 1
+    exclude:
+      - "react"
+      - "react-dom"
+      - "next"
+      - "payload"
+      - "@payloadcms/*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,4 +5,4 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 0
+npmMinimalAgeGate: 1d

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,3 +4,5 @@ approvedGitRepositories:
 enableScripts: false
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 0

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,3 +6,10 @@ enableScripts: false
 nodeLinker: node-modules
 
 npmMinimalAgeGate: 1d
+
+npmPreapprovedPackages:
+  - "react"
+  - "react-dom"
+  - "next"
+  - "payload"
+  - "@payloadcms/*"

--- a/next-frontend/package.json
+++ b/next-frontend/package.json
@@ -120,5 +120,5 @@
   "scarfSettings": {
     "enabled": false
   },
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.17.0"
 }

--- a/next-frontend/yarn.lock
+++ b/next-frontend/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@adobe/css-tools@npm:^4.4.0":

--- a/package.json
+++ b/package.json
@@ -131,5 +131,5 @@
     "lint": "eslint -c .eslintrc.json app/webpacker/components/**/*.js app/webpacker/components/**/*.jsx app/webpacker/lib/**/*.js",
     "webpack:analyze": "mkdir -p public/packs && RACK_ENV=test NODE_ENV=production webpack --config config/webpack/webpack.config.js --profile --json > public/packs/stats.json && webpack-bundle-analyzer public/packs/stats.json"
   },
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.17.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@aashutoshrathi/word-wrap@npm:^1.2.3":


### PR DESCRIPTION
See title.

This introduced the new option `npmMinimalAgeGate` by default, and I went with 1 day as a reasonable starting point. If there are strong opinions about other values, please shout.