### PR TITLE
Switch ECS base AMI to Amazon linux 2023

### DIFF
--- a/infra/wca_on_rails/main.tf
+++ b/infra/wca_on_rails/main.tf
@@ -28,24 +28,6 @@ provider "aws" {
   }
 }
 
-# Amazon Linux 2023 ECS-optimized AMI. To migrate a pool to AL2023, set the
-# matching *_ami_id below to data.aws_ami.ecs_al2023.id (one pool at a time).
-data "aws_ami" "ecs_al2023" {
-  most_recent = true
-
-  owners = ["amazon"]
-
-  filter {
-    name   = "owner-alias"
-    values = ["amazon"]
-  }
-
-  filter {
-    name   = "name"
-    values = ["al2023-ami-ecs-hvm-*-x86_64"]
-  }
-}
-
 module "production" {
   source                   = "./production"
   name_prefix              = "${var.name_prefix}-prod"
@@ -80,6 +62,4 @@ module "shared" {
   rails_startup_time = local.rails_startup_time
   pma_auth_secret    = var.pma_auth_secret
   anycable_path      = var.anycable_path
-  t3_ami_id          = data.aws_ami.ecs_al2023.id
-  m6i_ami_id         = data.aws_ami.ecs_al2023.id
 }

--- a/infra/wca_on_rails/main.tf
+++ b/infra/wca_on_rails/main.tf
@@ -80,6 +80,6 @@ module "shared" {
   rails_startup_time = local.rails_startup_time
   pma_auth_secret    = var.pma_auth_secret
   anycable_path      = var.anycable_path
-  t3_ami_id          = var.t3_ami_id
-  m6i_ami_id         = var.m6i_ami_id
+  t3_ami_id          = data.aws_ami.ecs_al2023.id
+  m6i_ami_id         = data.aws_ami.ecs_al2023.id
 }

--- a/infra/wca_on_rails/main.tf
+++ b/infra/wca_on_rails/main.tf
@@ -28,38 +28,58 @@ provider "aws" {
   }
 }
 
+# Amazon Linux 2023 ECS-optimized AMI. To migrate a pool to AL2023, set the
+# matching *_ami_id below to data.aws_ami.ecs_al2023.id (one pool at a time).
+data "aws_ami" "ecs_al2023" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-ecs-hvm-*-x86_64"]
+  }
+}
+
 module "production" {
-  source = "./production"
-  name_prefix = "${var.name_prefix}-prod"
-  region = var.region
-  shared = module.shared
-  VAULT_ADDR = var.VAULT_ADDR
-  DATABASE_WRT_USER = var.DATABASE_WRT_USER
+  source                   = "./production"
+  name_prefix              = "${var.name_prefix}-prod"
+  region                   = var.region
+  shared                   = module.shared
+  VAULT_ADDR               = var.VAULT_ADDR
+  DATABASE_WRT_USER        = var.DATABASE_WRT_USER
   DATABASE_WRT_SENIOR_USER = var.DATABASE_WRT_SENIOR_USER
-  rails_startup_time = local.rails_startup_time
-  WRC_WEBHOOK_URL = var.WRC_WEBHOOK_URL
-  anycable_path = var.anycable_path
+  rails_startup_time       = local.rails_startup_time
+  WRC_WEBHOOK_URL          = var.WRC_WEBHOOK_URL
+  anycable_path            = var.anycable_path
 }
 
 module "staging" {
-  source = "./staging"
-  name_prefix = "${var.name_prefix}-staging"
-  region = var.region
-  VAULT_ADDR = var.VAULT_ADDR
-  DATABASE_WRT_USER = var.DATABASE_WRT_USER
+  source                   = "./staging"
+  name_prefix              = "${var.name_prefix}-staging"
+  region                   = var.region
+  VAULT_ADDR               = var.VAULT_ADDR
+  DATABASE_WRT_USER        = var.DATABASE_WRT_USER
   DATABASE_WRT_SENIOR_USER = var.DATABASE_WRT_SENIOR_USER
-  shared = module.shared
-  rails_startup_time = local.rails_startup_time
-  WRC_WEBHOOK_URL = var.WRC_WEBHOOK_URL
-  anycable_path = var.anycable_path
+  shared                   = module.shared
+  rails_startup_time       = local.rails_startup_time
+  WRC_WEBHOOK_URL          = var.WRC_WEBHOOK_URL
+  anycable_path            = var.anycable_path
 }
 
 module "shared" {
-  source = "./shared"
-  name_prefix = var.name_prefix
-  region = var.region
+  source             = "./shared"
+  name_prefix        = var.name_prefix
+  region             = var.region
   availability_zones = var.availability_zones
   rails_startup_time = local.rails_startup_time
-  pma_auth_secret = var.pma_auth_secret
-  anycable_path = var.anycable_path
+  pma_auth_secret    = var.pma_auth_secret
+  anycable_path      = var.anycable_path
+  t3_ami_id          = var.t3_ami_id
+  m6i_ami_id         = var.m6i_ami_id
 }

--- a/infra/wca_on_rails/production/rails.tf
+++ b/infra/wca_on_rails/production/rails.tf
@@ -285,14 +285,14 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn      = aws_iam_role.task_role.arn
 
   cpu = "1024"
-  memory = "3900"
+  memory = "3850"
 
   container_definitions = jsonencode([
     {
       name              = "rails-production"
       image             = "${var.shared.ecr_repository.repository_url}:latest"
       cpu    = 1024
-      memory = 3900
+      memory = 3850
       portMappings = [
         {
           name = "rails-port"

--- a/infra/wca_on_rails/production/worker.tf
+++ b/infra/wca_on_rails/production/worker.tf
@@ -14,7 +14,7 @@ resource "aws_ecs_task_definition" "worker" {
   task_role_arn      = aws_iam_role.task_role.arn
 
   cpu = "1024"
-  memory = "3911"
+  memory = "3850"
 
   container_definitions = jsonencode([
 
@@ -22,7 +22,7 @@ resource "aws_ecs_task_definition" "worker" {
       name              = "sqs-worker-production"
       image             = "${var.shared.ecr_repository.repository_url}:production-sqs-worker"
       cpu    = 1024
-      memory = 3911
+      memory = 3850
       portMappings = []
       logConfiguration = {
         logDriver = "awslogs"

--- a/infra/wca_on_rails/shared/ecs.tf
+++ b/infra/wca_on_rails/shared/ecs.tf
@@ -57,7 +57,7 @@ data "aws_ami" "ecs" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*-x86_64-*"]
+    values = ["al2023-ami-ecs-hvm-*-x86_64"]
   }
 }
 
@@ -94,7 +94,7 @@ locals {
 
 resource "aws_launch_template" "t3" {
   name_prefix   = "${var.name_prefix}-t3-"
-  image_id      = coalesce(var.t3_ami_id, data.aws_ami.ecs.id)
+  image_id      = data.aws_ami.ecs.id
   instance_type = "t3.large"
   user_data     = local.ecs_user_data
 
@@ -111,7 +111,7 @@ resource "aws_launch_template" "t3" {
 
 resource "aws_launch_template" "m6i" {
   name_prefix   = "${var.name_prefix}-m6i-"
-  image_id      = coalesce(var.m6i_ami_id, data.aws_ami.ecs.id)
+  image_id      = data.aws_ami.ecs.id
   instance_type = "m6i.large"
   user_data     = local.ecs_user_data
 

--- a/infra/wca_on_rails/shared/ecs.tf
+++ b/infra/wca_on_rails/shared/ecs.tf
@@ -88,28 +88,38 @@ resource "aws_iam_instance_profile" "ecs_instance_profile" {
   role = aws_iam_role.ecs_instance_role.name
 }
 
-resource "aws_launch_configuration" "t3_launch_config" {
-  name_prefix          = "${var.name_prefix}-t3-"
-  image_id             = data.aws_ami.ecs.id
-  iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
-  instance_type        = "t3.large"
-  security_groups      = [aws_security_group.cluster.id]
-  user_data            = templatefile("../templates/user_data.sh.tftpl", { ecs_cluster_name = aws_ecs_cluster.this.name })
+locals {
+  ecs_user_data = base64encode(templatefile("../templates/user_data.sh.tftpl", { ecs_cluster_name = aws_ecs_cluster.this.name }))
+}
 
+resource "aws_launch_template" "t3" {
+  name_prefix   = "${var.name_prefix}-t3-"
+  image_id      = coalesce(var.t3_ami_id, data.aws_ami.ecs.id)
+  instance_type = "t3.large"
+  user_data     = local.ecs_user_data
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ecs_instance_profile.name
+  }
+
+  vpc_security_group_ids = [aws_security_group.cluster.id]
 
   lifecycle {
     create_before_destroy = true
   }
 }
 
-resource "aws_launch_configuration" "m6i_launch_config" {
-  name_prefix          = "${var.name_prefix}-m6i-"
-  image_id             = data.aws_ami.ecs.id
-  iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.name
-  instance_type        = "m6i.large"
-  security_groups      = [aws_security_group.cluster.id]
-  user_data            = templatefile("../templates/user_data.sh.tftpl", { ecs_cluster_name = aws_ecs_cluster.this.name })
+resource "aws_launch_template" "m6i" {
+  name_prefix   = "${var.name_prefix}-m6i-"
+  image_id      = coalesce(var.m6i_ami_id, data.aws_ami.ecs.id)
+  instance_type = "m6i.large"
+  user_data     = local.ecs_user_data
 
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ecs_instance_profile.name
+  }
+
+  vpc_security_group_ids = [aws_security_group.cluster.id]
 
   lifecycle {
     create_before_destroy = true
@@ -122,10 +132,14 @@ resource "aws_autoscaling_group" "t3_group" {
   max_size                  = 10
   desired_capacity          = 1
   vpc_zone_identifier       = [aws_default_subnet.default_az2.id]
-  launch_configuration      = aws_launch_configuration.t3_launch_config.name
   health_check_grace_period = var.rails_startup_time
   health_check_type         = "EC2"
   default_cooldown          = 300
+
+  launch_template {
+    id      = aws_launch_template.t3.id
+    version = aws_launch_template.t3.latest_version
+  }
 
   # Necessary when using managed termination provider on capacity provider
   protect_from_scale_in = true
@@ -165,10 +179,14 @@ resource "aws_autoscaling_group" "m6i_group" {
   max_size                  = 10
   desired_capacity          = 0
   vpc_zone_identifier       = [aws_default_subnet.default_az2.id]
-  launch_configuration      = aws_launch_configuration.m6i_launch_config.name
   health_check_grace_period = var.rails_startup_time
   health_check_type         = "EC2"
   default_cooldown          = 300
+
+  launch_template {
+    id      = aws_launch_template.m6i.id
+    version = aws_launch_template.m6i.latest_version
+  }
 
   # Necessary when using managed termination provider on capacity provider
   protect_from_scale_in = true

--- a/infra/wca_on_rails/shared/variables.tf
+++ b/infra/wca_on_rails/shared/variables.tf
@@ -27,18 +27,3 @@ variable "anycable_path" {
   type        = string
   description = "The Path where anycable is mounted"
 }
-
-# Override the ECS AMI per ASG for the AL2 -> AL2023 migration.
-# Null falls back to the current Amazon Linux 2 ECS-optimized AMI,
-# so flipping one of these moves only that ASG's instances.
-variable "t3_ami_id" {
-  type        = string
-  description = "AMI for the t3 ASG (staging rails + all workers). Null = current AL2 AMI."
-  default     = null
-}
-
-variable "m6i_ami_id" {
-  type        = string
-  description = "AMI for the m6i ASG (production rails). Null = current AL2 AMI."
-  default     = null
-}

--- a/infra/wca_on_rails/shared/variables.tf
+++ b/infra/wca_on_rails/shared/variables.tf
@@ -14,16 +14,31 @@ variable "availability_zones" {
 }
 
 variable "rails_startup_time" {
-  type = number
+  type        = number
   description = "The Startup time of the Ruby on Rails Application"
 }
 
 variable "pma_auth_secret" {
-  type = string
+  type        = string
   description = "The client secret of the pma auth found at https://www.worldcubeassociation.org/oauth/applications/1069"
 }
 
 variable "anycable_path" {
-  type = string
+  type        = string
   description = "The Path where anycable is mounted"
+}
+
+# Override the ECS AMI per ASG for the AL2 -> AL2023 migration.
+# Null falls back to the current Amazon Linux 2 ECS-optimized AMI,
+# so flipping one of these moves only that ASG's instances.
+variable "t3_ami_id" {
+  type        = string
+  description = "AMI for the t3 ASG (staging rails + all workers). Null = current AL2 AMI."
+  default     = null
+}
+
+variable "m6i_ami_id" {
+  type        = string
+  description = "AMI for the m6i ASG (production rails). Null = current AL2 AMI."
+  default     = null
 }

--- a/infra/wca_on_rails/staging/rails.tf
+++ b/infra/wca_on_rails/staging/rails.tf
@@ -317,14 +317,14 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn      = aws_iam_role.task_role.arn
 
   cpu = "1024"
-  memory = "3900"
+  memory = "3850"
 
   container_definitions = jsonencode([
     {
       name              = "rails-staging"
       image             = "${var.shared.ecr_repository.repository_url}:staging"
       cpu    = 1024
-      memory = 3900
+      memory = 3850
 
       portMappings = [
         {

--- a/infra/wca_on_rails/staging/worker.tf
+++ b/infra/wca_on_rails/staging/worker.tf
@@ -59,7 +59,7 @@ resource "aws_ecs_service" "worker" {
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
   task_definition                    = data.aws_ecs_task_definition.worker.arn
-  desired_count                      = 2
+  desired_count                      = 1
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50

--- a/infra/wca_on_rails/staging/worker.tf
+++ b/infra/wca_on_rails/staging/worker.tf
@@ -59,7 +59,7 @@ resource "aws_ecs_service" "worker" {
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
   task_definition                    = data.aws_ecs_task_definition.worker.arn
-  desired_count                      = 1
+  desired_count                      = 2
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50

--- a/infra/wca_on_rails/variables.tf
+++ b/infra/wca_on_rails/variables.tf
@@ -19,9 +19,9 @@ variable "availability_zones" {
 # Environment Variables that are the same between prod/staging
 
 variable "VAULT_ADDR" {
-  type = string
+  type        = string
   description = "The Address that vault is running at"
-  default = "http://vault.private.worldcubeassociation.org:8200"
+  default     = "http://vault.private.worldcubeassociation.org:8200"
 }
 
 variable "DATABASE_WRT_USER" {
@@ -38,18 +38,32 @@ variable "DATABASE_WRT_SENIOR_USER" {
 
 variable "WRC_WEBHOOK_URL" {
   description = "The URL to send delegate report webhook notifications for WRC to"
-  type = string
-  default = "https://joba.me/wca/reports_webhook"
+  type        = string
+  default     = "https://joba.me/wca/reports_webhook"
 }
 
 variable "pma_auth_secret" {
-  type = string
+  type        = string
   description = "The client secret for pma you can get it at https://www.worldcubeassociation.org/oauth/applications/1069"
 }
 
 variable "anycable_path" {
-  type = string
+  type        = string
   description = "The Path where anycable is mounted"
-  default = "/api/v1/live/cable"
+  default     = "/api/v1/live/cable"
+}
+
+# AL2 -> AL2023 migration. Null = current AL2 AMI; set to
+# data.aws_ami.ecs_al2023.id (via override below) to move one pool at a time.
+variable "t3_ami_id" {
+  type        = string
+  description = "AMI for the t3 ASG (staging rails + all workers). Null = current AL2 AMI."
+  default     = null
+}
+
+variable "m6i_ami_id" {
+  type        = string
+  description = "AMI for the m6i ASG (production rails). Null = current AL2 AMI."
+  default     = null
 }
 

--- a/infra/wca_on_rails/variables.tf
+++ b/infra/wca_on_rails/variables.tf
@@ -53,17 +53,3 @@ variable "anycable_path" {
   default     = "/api/v1/live/cable"
 }
 
-# AL2 -> AL2023 migration. Null = current AL2 AMI; set to
-# data.aws_ami.ecs_al2023.id (via override below) to move one pool at a time.
-variable "t3_ami_id" {
-  type        = string
-  description = "AMI for the t3 ASG (staging rails + all workers). Null = current AL2 AMI."
-  default     = null
-}
-
-variable "m6i_ami_id" {
-  type        = string
-  description = "AMI for the m6i ASG (production rails). Null = current AL2 AMI."
-  default     = null
-}
-


### PR DESCRIPTION
Due to the nature of this change, I already ran terraform.

We lost 34MB of available RAM so I dropped everything by about 50MB.

You can no longer create launch configuration as they were replaced by launch templates, so I also had to do that.
 
I also ran terraform format which is were the whitespace changes come in. 