### PR TITLE
Add test for schedule activity straddling midnight

### DIFF
--- a/spec/lib/results_validators/schedule_activities_validator_spec.rb
+++ b/spec/lib/results_validators/schedule_activities_validator_spec.rb
@@ -70,5 +70,42 @@ RSpec.describe SAV do
         end
       end
     end
+
+    context "with an activity that starts on end_date but ends past midnight in the venue's local timezone" do
+      before do
+        room = competition.competition_venues.first.venue_rooms.first
+        # The factory creates venues in "Europe/Paris" (UTC+1 in winter, UTC+2 in summer).
+        # Start at 20:00 UTC = 21:00 (CET) or 22:00 (CEST) on end_date — still on end_date locally.
+        # End at 03:00 UTC on end_date+1 = 04:00 (CET) or 05:00 (CEST) — past midnight locally.
+        # 03:00 UTC stays below noon UTC (Competition#end_time ceiling), so the record saves.
+        end_date = competition.end_date
+        next_day = end_date + 1
+        room.schedule_activities.create!(
+          wcif_id: 999,
+          name: "Late closing ceremony",
+          activity_code: "other-misc",
+          start_time: Time.utc(end_date.year, end_date.month, end_date.day, 20, 0, 0),
+          end_time: Time.utc(next_day.year, next_day.month, next_day.day, 3, 0, 0),
+        )
+      end
+
+      it "warns about the out-of-range activity" do
+        expected_warnings = [
+          RV::ValidationWarning.new(
+            SAV::ACTIVITY_OUTSIDE_COMPETITION_DATES_WARNING,
+            :schedule,
+            competition.id,
+            activity_name: "Late closing ceremony",
+            activity_code: "other-misc",
+          ),
+        ]
+
+        validator_args.each do |arg|
+          sav = SAV.new.validate(**arg)
+          expect(sav.warnings).to match_array(expected_warnings)
+          expect(sav.errors).to be_empty
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #14850.

The original spec only covered the case where an activity starts on `end_date + 1` (local time), which triggers the validator's second condition (`local_start.to_date > end_date`). The third condition — activity starts on `end_date` but ends past midnight in the venue's local timezone — was untested.

This adds a test for that case: activity starting at 20:00 UTC on `end_date` (21:00–22:00 in Europe/Paris depending on DST, so still on `end_date` locally) and ending at 03:00 UTC on `end_date + 1` (04:00–05:00 locally, past midnight). The validator should warn; this confirms it does.