### PR TITLE
Decouple pre-submission validator UI from webpack-compiled validator list

### DIFF
--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -48,8 +48,11 @@ class PanelController < ApplicationController
   end
 
   private def validators_for_competition_ids(competition_ids)
-    validators = params.require(:selectedValidators).split(',').map do |validator_name|
-      ResultsValidators::Utils.validator_class_from_name(validator_name)
+    selected = params[:selectedValidators]
+    validators = if selected.present?
+      selected.split(',').map { |name| ResultsValidators::Utils.validator_class_from_name(name) }.compact
+    else
+      ResultsValidators::Utils::ALL_VALIDATORS
     end
 
     apply_fix_when_possible = ActiveRecord::Type::Boolean.new.cast(params.require(:applyFixWhenPossible))

--- a/app/controllers/panel_controller.rb
+++ b/app/controllers/panel_controller.rb
@@ -50,10 +50,10 @@ class PanelController < ApplicationController
   private def validators_for_competition_ids(competition_ids)
     selected = params[:selectedValidators]
     validators = if selected.present?
-      selected.split(',').map { |name| ResultsValidators::Utils.validator_class_from_name(name) }.compact
-    else
-      ResultsValidators::Utils::ALL_VALIDATORS
-    end
+                   selected.split(',').filter_map { |name| ResultsValidators::Utils.validator_class_from_name(name) }
+                 else
+                   ResultsValidators::Utils::ALL_VALIDATORS
+                 end
 
     apply_fix_when_possible = ActiveRecord::Type::Boolean.new.cast(params.require(:applyFixWhenPossible))
     check_real_results = ActiveRecord::Type::Boolean.new.cast(params.require(:checkRealResults))

--- a/app/webpacker/components/CompetitionResultSubmission/FormToWrt/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/FormToWrt/index.jsx
@@ -8,7 +8,6 @@ import useCheckboxState from '../../../lib/hooks/useCheckboxState';
 import submitToWrt from '../api/submitToWrt';
 import Loading from '../../Requests/Loading';
 import runValidatorsForCompetitionList from '../../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
-import { ALL_VALIDATORS } from '../../../lib/wca-data.js.erb';
 import ValidationOutput from '../../Panel/pages/RunValidatorsPage/ValidationOutput';
 
 const DELEGATE_HANDBOOK_COMPETITION_RESULTS_URL = 'https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf#competition-results';
@@ -26,7 +25,7 @@ export default function FormToWrt({ competitionId, canSubmitResults }) {
     queryKey: ['competition-validation-output', competitionId],
     queryFn: () => runValidatorsForCompetitionList(
       competitionId,
-      ALL_VALIDATORS,
+      null,
       false,
       false,
     ),

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/WarningsAndMessage.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/WarningsAndMessage.jsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { Header, Segment } from 'semantic-ui-react';
 import ValidationOutput from '../../../Panel/pages/RunValidatorsPage/ValidationOutput';
 import runValidatorsForCompetitionList from '../../../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
-import { ALL_VALIDATORS } from '../../../../lib/wca-data.js.erb';
 import Markdown from '../../../Markdown';
 
 export default function WarningsAndMessage({ ticketDetails }) {
@@ -14,7 +13,7 @@ export default function WarningsAndMessage({ ticketDetails }) {
     queryKey: ['ticketCompetitionResultValidationOutput', id],
     queryFn: () => runValidatorsForCompetitionList(
       metadata.competition_id,
-      ALL_VALIDATORS,
+      null,
       false,
       false,
     ),


### PR DESCRIPTION
Assessed and implemented together with Claude (claude.ai).

Inspired by @maxidragon being unable to trigger the schedule warning from #14850 in their local testing environment, I traced through the full validation flow and found a structural mismatch between how the pre-submission UI and the WRT submission email determine which validators to run.

## The problem

The pre-submission validation UI (`FormToWrt` for delegates, `WarningsAndMessage` for WRT on tickets) previously imported `ALL_VALIDATORS` from `wca-data.js.erb`. This file is processed by webpack at **build time**: it asks Ruby for `ALL_VALIDATORS` once and bakes the result as a static array into the compiled JS bundle. Any validator added to `utils.rb` after that webpack build is invisible to the UI until the bundle is rebuilt.

By contrast, the `create` action (which sends the submission email to WRT) calls `CompetitionsResultsValidator.create_full_validation` directly, which reads Ruby's `ALL_VALIDATORS` **at request time**.

This means:
- A delegate whose browser is serving a pre-deploy bundle (cached page, long-lived session, CDN cache) will not see warnings from any validator added since that build
- Those same warnings **will** appear in the WRT email, since the email uses the runtime Ruby list
- WRT has received multiple reports in the past of delegates claiming they did not see a warning in the UI that appeared in the email; this is the likely root cause of at least some of those reports
- In local dev, any contributor testing a newly added validator will never see it in the UI without manually rebuilding webpack assets, which is not obvious

## The fix

Three small changes:

**`panel_controller.rb`**: the `validators_for_competition_ids` method previously required `selectedValidators` from the request params. It now treats that param as optional. When it is absent, the backend defaults to Ruby's full `ALL_VALIDATORS` at request time. When it is present (the panel's "Run Validators" page, which lets WRT select specific validators to run), the existing behaviour is preserved unchanged. A `.compact` is added defensively to handle any unknown validator names without crashing.

**`FormToWrt/index.jsx`**: stops passing `ALL_VALIDATORS` to `runValidatorsForCompetitionList` and passes `null` instead. `jsonToQueryString` already filters out null values, so `selectedValidators` is simply absent from the request and the backend falls back to its full list.

**`WarningsAndMessage.jsx`**: identical change. WRT's validation view on the ticket workbench had the same issue.

## What is not changed

The panel's "Run Validators" page (`RunValidatorsForm`) still sends an explicit `selectedValidators` list and is unaffected. The `runValidatorsForCompetitionList` API function and its route builder are unaffected.

## Risk

Low. The only observable behaviour change is that the pre-submission UI now always runs all validators rather than the subset the JS bundle knew about at build time. This is strictly more correct. The panel's validator selection is unchanged.