### PR TITLE
Fix translation status to account for base-locale chain

### DIFF
--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -5,11 +5,35 @@ class TranslationsController < ApplicationController
 
   def self.compute_bad_i18n_keys
     base_locales = AvailableLocales::ALL.transform_values { it[:base_locale] || 'en' }
+    memo = {}
 
     (I18n.available_locales - [:en]).index_with do |locale|
-      base_locale = base_locales[locale]
-      base_translation = locale_to_translation(base_locale)
-      locale_to_translation(locale).compare_to(base_translation)
+      effective_bad_i18n_keys(locale, base_locales, memo)
+    end
+  end
+
+  # Bad keys for `locale` relative to its base, unioned with the base locale's
+  # own (chain-resolved) bad keys. This way e.g. fr-CA inherits anything fr is
+  # still missing/outdated against en, instead of stopping at the direct fr diff.
+  def self.effective_bad_i18n_keys(locale, base_locales, memo)
+    locale = locale.to_sym
+    memo[locale] ||= begin
+      base_locale = (base_locales[locale] || 'en').to_sym
+      direct = locale_to_translation(locale).compare_to(locale_to_translation(base_locale))
+
+      if base_locale == :en
+        direct
+      else
+        merge_bad_i18n_keys(direct, effective_bad_i18n_keys(base_locale, base_locales, memo))
+      end
+    end
+  end
+
+  # Union per type (:missing / :unused / :outdated). Values are arrays of
+  # path-segment arrays; Array#| dedups them by value.
+  def self.merge_bad_i18n_keys(*key_hashes)
+    key_hashes.each_with_object({}) do |key_hash, merged|
+      key_hash.each { |type, keys| merged[type] = (merged[type] || []) | keys }
     end
   end
 


### PR DESCRIPTION
## Problem

On the translation status page (`GET /translations/status`), each non-English locale is compared **only against its direct base**. `fr-CA` declares `"base_locale": "fr"` (in `lib/static_data/available_locales.json`), and `fr` itself falls back to `en`. So `fr-CA` is diffed against `fr` alone.

If `fr` is missing or outdated relative to `en`, those deficiencies are **not** reflected in `fr-CA`'s status and it can show "All good"/100% even though, transitively, it is missing or outdated work inherited from `fr`. If `fr` needs updating, so does `fr-CA`.

Like this:
<img width="299" height="143" alt="image" src="https://github.com/user-attachments/assets/e83df3de-b199-4998-939d-29970bb34295" />


## Fix

`compute_bad_i18n_keys` now walks the base-locale chain (`fr-CA → fr → en`) and **unions** each locale's direct `compare_to` result with its base locale's (already chain-resolved) bad keys, recursively up to `en`. Results are memoized so each locale's translation is only diffed once even though bases are shared.

`compare_to` returns `{ missing:, unused:, outdated: }` (symbol keys, values are arrays of path-segment arrays), so `Array#|` set-union naturally dedups a key that is flagged both by `fr-CA` vs `fr` and `fr` vs `en`.

- Locales whose base is `en` (the vast majority) are unaffected, their result equals the plain `compare_to(en)` as before.
- The view (`app/views/translations/index.html.erb`) consumes the result unchanged.

## Verification

The chain/merge logic was validated in isolation (Ruby 3.4): for a chained locale, its effective bad keys are a superset of its base's per type (`missing`/`outdated`/`unused`), overlapping keys are deduped, and non-chained (`en`-based) locales are unchanged.

Done with the help of Claude Code