### PR TITLE
Add a WCIF schema validation endpoint

### DIFF
--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -256,7 +256,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     wcif = params.permit!.to_h.except(:controller, :action, :competition, :format)
 
     format_version = wcif["formatVersion"] || Competition::WCIF_STABLE_VERSION
-    expected_schema = Competition.wcif_json_schema(version: format_version)
+    expected_schema = Competition.wcif_json_schema(version: format_version, required_props: true)
 
     validation_errors = JSON::Validator.fully_validate(expected_schema, wcif, **Competition.json_validation_options)
 

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -252,6 +252,15 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     render_wcif(competition, best_version)
   end
 
+  def check_wcif
+    wcif = params.permit!.to_h.except(:controller, :action, :competition_id, :competition, :strict)
+
+    import_version = wcif["formatVersion"]
+    strict_schema_checks = params.key?(:strict) ? ActiveRecord::Type::Boolean.new.cast(params[:strict]) : Rails.env.local?
+
+    Competition.validate_wcif_schema!(wcif, version: import_version, is_strict: strict_schema_checks)
+  end
+
   def update_wcif
     competition = competition_from_params
     require_can_manage!(competition)

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -253,12 +253,17 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def check_wcif
-    wcif = params.permit!.to_h.except(:controller, :action, :competition_id, :competition, :strict)
+    wcif = params.permit!.to_h.except(:controller, :action, :competition_id, :competition)
 
-    import_version = wcif["formatVersion"]
-    strict_schema_checks = params.key?(:strict) ? ActiveRecord::Type::Boolean.new.cast(params[:strict]) : Rails.env.local?
+    import_version = wcif["formatVersion"] || Competition::WCIF_STABLE_VERSION
+    Competition.validate_wcif_schema!(wcif, version: import_version)
 
-    Competition.validate_wcif_schema!(wcif, version: import_version, is_strict: strict_schema_checks)
+    render json: { status: "Your WCIF complies with the specified format" }, status: :ok
+  rescue JSON::Schema::ValidationError => e
+    render json: {
+      status: "Your WCIF does not comply with the specified format. Please see the error property for details",
+      error: e.message,
+    }, status: :bad_request
   end
 
   def update_wcif

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -265,6 +265,13 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     head :ok
   end
 
+  def wcif_json_schema
+    format_version = params.require(:version)
+    expected_schema = Competition.wcif_json_schema(version: format_version, required_props: true)
+
+    render json: expected_schema
+  end
+
   def update_wcif
     competition = competition_from_params
     require_can_manage!(competition)

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -255,15 +255,14 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   def check_wcif
     wcif = params.permit!.to_h.except(:controller, :action, :competition, :format)
 
-    import_version = wcif["formatVersion"] || Competition::WCIF_STABLE_VERSION
-    Competition.validate_wcif_schema!(wcif, version: import_version)
+    format_version = wcif["formatVersion"] || Competition::WCIF_STABLE_VERSION
+    expected_schema = Competition.wcif_json_schema(version: format_version)
 
-    render json: { status: "Your WCIF complies with the specified format" }, status: :ok
-  rescue JSON::Schema::ValidationError => e
-    render json: {
-      status: "Your WCIF does not comply with the specified format. Please see the error property for details",
-      error: e.message,
-    }, status: :bad_request
+    validation_errors = JSON::Validator.fully_validate(expected_schema, wcif, **Competition.json_validation_options)
+
+    return render json: validation_errors, status: :bad_request if validation_errors.present?
+
+    head :ok
   end
 
   def update_wcif

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -253,7 +253,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
   end
 
   def check_wcif
-    wcif = params.permit!.to_h.except(:controller, :action, :competition_id, :competition)
+    wcif = params.permit!.to_h.except(:controller, :action, :competition, :format)
 
     import_version = wcif["formatVersion"] || Competition::WCIF_STABLE_VERSION
     Competition.validate_wcif_schema!(wcif, version: import_version)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2172,12 +2172,10 @@ class Competition < ApplicationRecord
     reload
   end
 
-  def self.wcif_json_schema(version: WCIF_STABLE_VERSION)
+  def self.wcif_json_schema(version: WCIF_STABLE_VERSION, required_props: false)
     {
       "type" => "object",
-      # Normally we want to force tools to tell us which version they're patching,
-      #   but as of writing this comment we need more time to tell that to tools.
-      # "required" => %w[formatVersion],
+      "required" => required_props ? %w[id formatVersion] : [],
       "properties" => {
         "formatVersion" => { "type" => "string" },
         "id" => { "type" => "string" },

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2174,7 +2174,10 @@ class Competition < ApplicationRecord
 
   def self.wcif_json_schema(version: WCIF_STABLE_VERSION, required_props: false)
     {
+      # This $id property is the actual JsonSchema URI
       "$id" => Rails.application.routes.url_helpers.wcif_json_schema_api_v0_competitions_url(version, host: EnvConfig.ROOT_URL),
+      # This id property is used by the Ruby Gem that checks JsonSchema when printing error messages.
+      # Without specifying an ID, it will use random UUIDs so we use this field to make error messages clear and predictable.
       "id" => "WCIFv#{version}",
       "type" => "object",
       "required" => required_props ? %w[id formatVersion] : [],

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1977,9 +1977,15 @@ class Competition < ApplicationRecord
     }
   end
 
+  def self.json_validation_options(is_strict: true)
+    { noAdditionalProperties: is_strict }
+  end
+
   def self.validate_wcif_schema!(wcif, version: WCIF_STABLE_VERSION, is_strict: true)
-    expected_schema = Competition.wcif_json_schema(version: version)
-    JSON::Validator.validate!(expected_schema, wcif, noAdditionalProperties: is_strict)
+    expected_schema = self.wcif_json_schema(version: version)
+    validation_opts = self.json_validation_options(is_strict: is_strict)
+
+    JSON::Validator.validate!(expected_schema, wcif, **validation_opts)
   end
 
   def set_wcif!(wcif, current_user, strict_schema_checks: true)

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2174,6 +2174,7 @@ class Competition < ApplicationRecord
 
   def self.wcif_json_schema(version: WCIF_STABLE_VERSION, required_props: false)
     {
+      "$id" => Rails.application.routes.url_helpers.wcif_json_schema_api_v0_competitions_url(version, host: EnvConfig.ROOT_URL),
       "id" => "WCIFv#{version}",
       "type" => "object",
       "required" => required_props ? %w[id formatVersion] : [],

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -2174,6 +2174,7 @@ class Competition < ApplicationRecord
 
   def self.wcif_json_schema(version: WCIF_STABLE_VERSION, required_props: false)
     {
+      "id" => "WCIFv#{version}",
       "type" => "object",
       "required" => required_props ? %w[id formatVersion] : [],
       "properties" => {

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1989,7 +1989,7 @@ class Competition < ApplicationRecord
   end
 
   def set_wcif!(wcif, current_user, strict_schema_checks: true)
-    import_version = wcif["formatVersion"]
+    import_version = wcif["formatVersion"] || WCIF_STABLE_VERSION
 
     Competition.validate_wcif_schema!(wcif, version: import_version, is_strict: strict_schema_checks)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -475,6 +475,10 @@ Rails.application.routes.draw do
         get '/scrambles/:event_id' => 'competitions#event_scrambles', as: :event_scrambles
         get '/psych-sheet/:event_id' => 'competitions#event_psych_sheet', as: :event_psych_sheet
         patch '/wcif' => 'competitions#update_wcif', as: :update_wcif
+
+        collection do
+          put '/wcif/check' => 'competitions#check_wcif'
+        end
       end
 
       post '/registration-data' => 'competitions#registration_data', as: :registration_data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -478,6 +478,7 @@ Rails.application.routes.draw do
 
         collection do
           put '/wcif/check' => 'competitions#check_wcif'
+          get '/wcif/schema/:version' => 'competitions#wcif_json_schema', constraints: { version: /(\d\.){0,2}\d/ }, as: :wcif_json_schema
         end
       end
 

--- a/spec/controllers/api_competitions_controller_spec.rb
+++ b/spec/controllers/api_competitions_controller_spec.rb
@@ -406,5 +406,34 @@ RSpec.describe Api::V0::CompetitionsController do
         expect(parsed_body['series']['competitionIds']).to eq ['TestComp2014']
       end
     end
+
+    context 'schema checks' do
+      it 'validates a compliant schema' do
+        put :check_wcif, params: competition.to_wcif, as: :json
+        expect(response).to have_http_status :ok
+      end
+
+      it 'complains about missing keys' do
+        put :check_wcif, params: competition.to_wcif.except("formatVersion"), as: :json
+        expect(response).to have_http_status :bad_request
+        expect(response.parsed_body["error"]).to eq("The property '#/' did not contain a required property of 'formatVersion'")
+      end
+
+      it 'complains about extraneous keys' do
+        extraneous_wcif = { **competition.to_wcif, "extraProperty" => "yippie" }
+
+        put :check_wcif, params: extraneous_wcif, as: :json
+        expect(response).to have_http_status :bad_request
+        expect(response.parsed_body["error"]).to eq("The property '#/' contained undefined properties: 'extraProperty'")
+      end
+
+      it 'complains about values in the wrong format' do
+        wrong_format_wcif = { **competition.to_wcif, "id" => 123 }
+
+        put :check_wcif, params: wrong_format_wcif, as: :json
+        expect(response).to have_http_status :bad_request
+        expect(response.parsed_body["error"]).to eq("The property '#/id' of type integer did not match the following type: string")
+      end
+    end
   end
 end

--- a/spec/controllers/api_competitions_controller_spec.rb
+++ b/spec/controllers/api_competitions_controller_spec.rb
@@ -408,31 +408,52 @@ RSpec.describe Api::V0::CompetitionsController do
     end
 
     context 'schema checks' do
+      let(:wcif_version) { '2.1.1' }
+      let(:competition_wcif) { competition.to_wcif(version: wcif_version) }
+
+      context 'legacy v1' do
+        let(:wcif_version) { '1.1' }
+
+        it 'validates a compliant schema' do
+          put :check_wcif, params: competition_wcif, as: :json
+          expect(response).to have_http_status :ok
+        end
+      end
+
       it 'validates a compliant schema' do
-        put :check_wcif, params: competition.to_wcif, as: :json
+        put :check_wcif, params: competition_wcif, as: :json
         expect(response).to have_http_status :ok
       end
 
       it 'complains about missing keys' do
-        put :check_wcif, params: competition.to_wcif.except("formatVersion"), as: :json
+        put :check_wcif, params: competition_wcif.except("formatVersion"), as: :json
         expect(response).to have_http_status :bad_request
-        expect(response.parsed_body["error"]).to eq("The property '#/' did not contain a required property of 'formatVersion'")
+        expect(response.parsed_body).to contain_exactly("The property '#/' did not contain a required property of 'formatVersion' in schema WCIFv#{Competition::WCIF_STABLE_VERSION}")
       end
 
       it 'complains about extraneous keys' do
-        extraneous_wcif = { **competition.to_wcif, "extraProperty" => "yippie" }
+        extraneous_wcif = { **competition_wcif, "extraProperty" => "yippie" }
 
         put :check_wcif, params: extraneous_wcif, as: :json
         expect(response).to have_http_status :bad_request
-        expect(response.parsed_body["error"]).to eq("The property '#/' contained undefined properties: 'extraProperty'")
+        expect(response.parsed_body).to contain_exactly("The property '#/' contained undefined properties: 'extraProperty' in schema WCIFv2.1.1")
       end
 
       it 'complains about values in the wrong format' do
-        wrong_format_wcif = { **competition.to_wcif, "id" => 123 }
+        wrong_format_wcif = { **competition_wcif, "id" => 123 }
 
         put :check_wcif, params: wrong_format_wcif, as: :json
         expect(response).to have_http_status :bad_request
-        expect(response.parsed_body["error"]).to eq("The property '#/id' of type integer did not match the following type: string")
+        expect(response.parsed_body).to contain_exactly("The property '#/id' of type integer did not match the following type: string in schema WCIFv2.1.1")
+      end
+
+      it 'reports multiple errors at once' do
+        put :check_wcif, params: { id: 123 }, as: :json
+        expect(response).to have_http_status :bad_request
+        expect(response.parsed_body).to contain_exactly(
+          "The property '#/id' of type integer did not match the following type: string in schema WCIFv#{Competition::WCIF_STABLE_VERSION}",
+          "The property '#/' did not contain a required property of 'formatVersion' in schema WCIFv#{Competition::WCIF_STABLE_VERSION}",
+        )
       end
     end
   end

--- a/spec/requests/api_competitions_spec.rb
+++ b/spec/requests/api_competitions_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe "API Competitions" do
             personalBests: [],
           }]
           expect do
-            patch api_v0_competition_update_wcif_path(competition), params: { persons: persons }.to_json, headers: headers
+            patch api_v0_competition_update_wcif_path(competition), params: { formatVersion: Competition::WCIF_STABLE_VERSION, persons: persons }.to_json, headers: headers
           end.not_to(change { competition.reload.to_wcif["persons"] })
         end
       end


### PR DESCRIPTION
`PUT /api/v0/competitions/wcif/check` with the WCIF JSON as the request body.

This currently implements the "strict" version of the schema, ie it _does require_ `formatVersion` and `id`. That's where we want to nudge people anyways, so implementing a schema check which does not check what we want it to check feels silly.