### PR TITLE
Ensure rounds are loaded on /live pages

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/layout.tsx
@@ -1,0 +1,30 @@
+import { getRounds } from "@/lib/wca/live/getRounds";
+import { getT } from "@/lib/i18n/get18n";
+import OpenapiError from "@/components/ui/openapiError";
+import { RoundsInfoProvider } from "@/providers/RoundInfoProvider";
+
+export default async function LiveLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ competitionId: string }>;
+}) {
+  const { competitionId } = await params;
+  const { t } = await getT();
+
+  const { data, error, response } = await getRounds(competitionId);
+
+  if (error) {
+    return <OpenapiError response={response} t={t} />;
+  }
+
+  return (
+    <RoundsInfoProvider
+      competitionId={competitionId}
+      initialRounds={data.rounds}
+    >
+      {children}
+    </RoundsInfoProvider>
+  );
+}


### PR DESCRIPTION
This fixes #14901 when someone goes to /live pages before the competition has started (or after it has ended).
We still don't know if we actually want this when the competition nextjs page is done, but that is to be speced out. 