### PR TITLE
Remove v1 Qualifications model usage

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -48,6 +48,7 @@ class Api::V0::ApiController < ApplicationController
 
   def user_qualification_data
     date = cutoff_date
+
     return render json: { error: 'Invalid date format. Please provide an iso8601 date string.' }, status: :bad_request if date.blank?
     return render json: { error: 'You cannot request qualification data for a future date.' }, status: :bad_request if date > Date.current
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1435,7 +1435,8 @@ class Competition < ApplicationRecord
   end
 
   def qualification_date_to_events
-    competition_events.select(&:qualification_condition?).group_by { it.qualification_latest_date }
+    competition_events.filter(&:qualification_condition?)
+                      .group_by(&:qualification_latest_date)
   end
 
   # The name `is_probably_over` is meant to be surprising.

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1431,11 +1431,11 @@ class Competition < ApplicationRecord
     # We want to trigger the checks for qualification details even when
     # the actual qualification requirements have not been filled out yet for a newly created competition.
     # In other words, checking the `qualification_results` checkbox should be enough to trigger validations.
-    self.qualification_results? || competition_events.any?(&:qualification)
+    self.qualification_results? || competition_events.any?(&:qualification_condition?)
   end
 
   def qualification_date_to_events
-    competition_events.select(&:qualification).group_by { |e| e.qualification.when_date }
+    competition_events.select(&:qualification_condition?).group_by { it.qualification_latest_date }
   end
 
   # The name `is_probably_over` is meant to be surprising.
@@ -1912,10 +1912,9 @@ class Competition < ApplicationRecord
     return {} unless uses_qualification?
 
     competition_events
-      .where.not(qualification: nil)
+      .where.not(qualification_condition: nil)
       .index_by(&:event_id)
-      .transform_values(&:qualification)
-      .transform_values(&:to_wcif)
+      .transform_values(&:v1_qualification_wcif)
   end
 
   def persons_wcif(authorized: false, version: WCIF_STABLE_VERSION)

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -20,11 +20,10 @@ class CompetitionEvent < ApplicationRecord
            as: "fee",
            with_model_currency: :currency_code
 
-  serialize :qualification, coder: Qualification
-  validates_associated :qualification
-
   serialize :qualification_condition, coder: ResultConditions::ResultCondition
   validates_associated :qualification_condition
+
+  validates :qualification_latest_date, presence: { if: :qualification_condition? }
 
   validate do
     remaining_rounds = rounds.reject(&:marked_for_destruction?)
@@ -65,16 +64,78 @@ class CompetitionEvent < ApplicationRecord
   end
 
   def qualification_to_s
-    qualification&.to_s(self)
+    case qualification_condition
+    when ResultConditions::Ranking
+      I18n.t("qualification.#{qualification_condition.scope}.ranking", ranking: qualification_condition.value)
+    when ResultConditions::ResultAchieved
+      if qualification_condition.value.nil?
+        I18n.t("qualification.#{qualification_condition.scope}.any_result")
+      elsif event.timed_event?
+        I18n.t("qualification.#{qualification_condition.scope}.time", time: SolveTime.centiseconds_to_clock_format(qualification_condition.value))
+      elsif event.fewest_moves?
+        moves = qualification_condition.scope == "average" ? (qualification_condition.value / 100.0).round(2) : qualification_condition.value
+        I18n.t("qualification.#{qualification_condition.scope}.moves", moves: moves)
+      elsif event.multiple_blindfolded?
+        I18n.t("qualification.#{qualification_condition.scope}.points", points: SolveTime.multibld_attempt_to_points(qualification_condition.value))
+      end
+    end
+  end
+
+  def meets_qualification?(user)
+    return true if qualification_condition.nil?
+
+    before_deadline_results = user.person.results.in_event(self.event_id).on_or_before(self.qualification_latest_date)
+
+    case qualification_condition
+    # Allow any competitor with a result to register when type == "ranking".
+    # When type == "ranking", the results need to be manually cleared out later.
+    when ResultConditions::Ranking
+      case qualification_condition.scope
+      when "single"
+        before_deadline_results.succeeded.any?
+      when "average"
+        before_deadline_results.average_succeeded.any?
+      end
+    when ResultConditions::ResultAchieved
+      if qualification_condition.value.nil?
+        case qualification_condition.scope
+        when "single"
+          before_deadline_results.succeeded.any?
+        when "average"
+          before_deadline_results.average_succeeded.any?
+        end
+      else
+        case qualification_condition.scope
+        when "single"
+          before_deadline_results.single_better_than(qualification_condition.value).any?
+        when "average"
+          before_deadline_results.average_better_than(qualification_condition.value).any?
+        end
+      end
+    end
   end
 
   def can_register?(user)
-    competition.allow_registration_without_qualification || qualification.nil? || qualification.can_register?(user, event_id)
+    competition.allow_registration_without_qualification || self.meets_qualification?(user)
   end
 
   def as_wcif_participation_source(_target_round)
     {
       "type" => "registrations",
+    }
+  end
+
+  def v1_qualification_wcif
+    return nil if qualification_condition.blank?
+
+    v2_wcif_type = qualification_condition.class.wcif_type
+    v1_backported_type = v2_wcif_type == 'resultAchieved' && qualification_condition.value.nil ? "anyResult" : v2_wcif_type.gsub("resultAchieved", "attemptResult")
+
+    {
+      "type" => v1_backported_type,
+      "resultType" => qualification_condition.scope,
+      "whenDate" => qualification_latest_date&.strftime("%Y-%m-%d"),
+      "level" => qualification_condition.value,
     }
   end
 
@@ -95,31 +156,8 @@ class CompetitionEvent < ApplicationRecord
       "id" => self.event.id,
       "rounds" => self.rounds.map { it.to_wcif(version: version, include_results: include_results) },
       "extensions" => wcif_extensions.map(&:to_wcif),
-      "qualification" => at_least_v2 ? v2_qualification_wcif : qualification&.to_wcif,
+      "qualification" => at_least_v2 ? v2_qualification_wcif : v1_qualification_wcif,
     }
-  end
-
-  def self.load_wcif_qualification(wcif_event, version: Competition::WCIF_STABLE_VERSION)
-    if Gem::Version.new(version) >= Gem::Version.new("2.0.0")
-      json_obj = wcif_event['qualification']
-
-      # Most events actually don't have a qualification, so return early.
-      return nil if json_obj.nil?
-
-      result_condition = json_obj['resultCondition']
-
-      v2_wcif_type = result_condition['type']
-      v1_wcif_type = result_condition['value'].present? ? v2_wcif_type.gsub('resultAchieved', 'attemptResult') : v2_wcif_type.gsub('resultAchieved', 'anyResult')
-
-      Qualification.new(
-        wcif_type: v1_wcif_type,
-        when_date: Date.iso8601(json_obj['latestResultDate']),
-        result_type: result_condition['scope'],
-        level: result_condition['value'],
-      )
-    else
-      Qualification.load(wcif_event["qualification"])
-    end
   end
 
   def load_wcif!(wcif, current_user, version: Competition::WCIF_STABLE_VERSION)
@@ -179,11 +217,12 @@ class CompetitionEvent < ApplicationRecord
     new_rounds.zip(wcif["rounds"]).each do |round, round_wcif|
       round.load_live_results!(round_wcif["results"], current_user) if round_wcif["results"].present?
     end
-    wcif_qualification = CompetitionEvent.load_wcif_qualification(wcif, version: version)
+    wcif_qualification = wcif["qualification"]
+    using_v2 = Gem::Version.new(version) >= Gem::Version.new("2.0.0")
+    wcif_qualification_date = using_v2 ? wcif_qualification["latestResultDate"] : wcif["whenDate"]
     self.update!(
       rounds: new_rounds,
-      qualification: wcif_qualification,
-      qualification_latest_date: wcif_qualification&.when_date,
+      qualification_latest_date: Date.iso8601(wcif_qualification_date),
       qualification_condition: ResultConditions::Utils.upcycle_v1_qualification(wcif_qualification),
     )
     WcifExtension.update_wcif_extensions!(self, wcif["extensions"]) if wcif["extensions"]
@@ -206,13 +245,21 @@ class CompetitionEvent < ApplicationRecord
                            {
                              "type" => %w[object null],
                              "properties" => {
-                               "earliestResultDate" => { "type" => %w[string null] },
-                               "latestResultDate" => { "type" => "string" },
+                               "earliestResultDate" => { "type" => %w[string null], "format" => "date" },
+                               "latestResultDate" => { "type" => "string", "format" => "date" },
                                "resultCondition" => ResultConditions::ResultCondition.wcif_json_schema,
                              },
                            }
                          else
-                           Qualification.wcif_json_schema
+                           {
+                             "type" => %w[object null],
+                             "properties" => {
+                               "whenDate" => { "type" => "string" },
+                               "resultType" => { "type" => "string", "enum" => %w[single average] },
+                               "type" => { "type" => "string", "enum" => %w[attemptResult ranking anyResult] },
+                               "level" => { "type" => %w[integer null] },
+                             },
+                           }
                          end,
       "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
     }

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -84,7 +84,9 @@ class CompetitionEvent < ApplicationRecord
   def meets_qualification?(user)
     return true if qualification_condition.nil?
 
-    before_deadline_results = user.person.results.in_event(self.event_id).on_or_before(self.qualification_latest_date)
+    before_deadline_results = user.person.results
+                                  .in_event(self.event_id)
+                                  .on_or_before(self.qualification_latest_date)
 
     case qualification_condition
     # Allow any competitor with a result to register when type == "ranking".

--- a/app/models/competition_event.rb
+++ b/app/models/competition_event.rb
@@ -20,6 +20,9 @@ class CompetitionEvent < ApplicationRecord
            as: "fee",
            with_model_currency: :currency_code
 
+  serialize :qualification, coder: Qualification
+  validates_associated :qualification
+
   serialize :qualification_condition, coder: ResultConditions::ResultCondition
   validates_associated :qualification_condition
 

--- a/app/views/competitions/_time_limit_cutoff_format_info.html.erb
+++ b/app/views/competitions/_time_limit_cutoff_format_info.html.erb
@@ -45,7 +45,7 @@
     <p>
       <%= t("competitions.events.time_limit_information.qualification_html") %>
       <% date_to_events = competition.qualification_date_to_events %>
-      <% if (date_to_events.length() > 1) %>
+      <% if date_to_events.length > 1 %>
         <% date_to_events.each do |date, events| %>
           <%= t("competitions.events.time_limit_information.qualification_some_events_html",
                 date: wca_date_range(date, date), events: events.map{ |e| e.event.name }.join(", ")) %>

--- a/lib/result_conditions/utils.rb
+++ b/lib/result_conditions/utils.rb
@@ -25,16 +25,16 @@ module ResultConditions
       end
     end
 
-    def self.upcycle_v1_qualification(v1_qualification)
-      return if v1_qualification.blank?
+    def self.upcycle_v1_qualification(v1_qualification_json)
+      return if v1_qualification_json.blank?
 
-      case v1_qualification.wcif_type
+      case v1_qualification_json["type"]
       when 'attemptResult'
-        ResultAchieved.new(scope: v1_qualification.result_type, value: v1_qualification.level)
+        ResultAchieved.new(scope: v1_qualification_json["resultType"], value: v1_qualification_json["level"])
       when 'ranking'
-        Ranking.new(scope: v1_qualification.result_type, value: v1_qualification.level)
+        Ranking.new(scope: v1_qualification_json["resultType"], value: v1_qualification_json["level"])
       when 'anyResult'
-        ResultAchieved.new(scope: v1_qualification.result_type, value: nil)
+        ResultAchieved.new(scope: v1_qualification_json["resultType"], value: nil)
       end
     end
   end

--- a/spec/features/competition_events_spec.rb
+++ b/spec/features/competition_events_spec.rb
@@ -138,7 +138,7 @@ RSpec.feature "Competition events management" do
         comp_event_333.reload
 
         expect(comp_event_333.qualification_to_s).to eq "Any single solve"
-        expect(comp_event_333.qualification.when_date).to eq qualification_date
+        expect(comp_event_333.qualification_latest_date).to eq qualification_date
       end
     end
   end

--- a/spec/lib/qualification_spec.rb
+++ b/spec/lib/qualification_spec.rb
@@ -81,57 +81,6 @@ RSpec.describe Qualification do
   end
 
   context "Single" do
-    it "requires single" do
-      input = {
-        'resultType' => 'single',
-        'type' => 'ranking',
-        'whenDate' => '2021-06-01',
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).not_to be_valid
-    end
-
-    it "requires date" do
-      input = {
-        'resultType' => 'single',
-        'type' => 'ranking',
-        'level' => 1000,
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).not_to be_valid
-    end
-
-    it "requires type" do
-      input = {
-        'resultType' => 'single',
-        'level' => 1000,
-        'whenDate' => '2021-06-01',
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).not_to be_valid
-    end
-
-    it "parses correctly" do
-      input = {
-        'resultType' => 'single',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-06-01',
-        'level' => 1000,
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).to be_valid
-    end
-
-    it "parses anyResult correctly" do
-      input = {
-        'resultType' => 'single',
-        'type' => 'anyResult',
-        'whenDate' => '2021-06-01',
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).to be_valid
-    end
-
     it "requires a successful time for ranking" do
       input = {
         'resultType' => 'single',
@@ -139,10 +88,12 @@ RSpec.describe Qualification do
         'whenDate' => '2021-02-15',
         'level' => 50,
       }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::Utils.upcycle_v1_qualification(input)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
-      expect(qualification.can_register?(user, '333oh')).to be false
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333.meets_qualification?(user)).to be true
+      competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333oh.meets_qualification?(user)).to be false
 
       input = {
         'resultType' => 'single',
@@ -150,10 +101,12 @@ RSpec.describe Qualification do
         'whenDate' => '2021-03-15',
         'level' => 50,
       }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::Utils.upcycle_v1_qualification(input)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
-      expect(qualification.can_register?(user, '333oh')).to be true
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-03-15')
+      expect(competition_event_333.meets_qualification?(user)).to be true
+      competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-03-15')
+      expect(competition_event_333oh.meets_qualification?(user)).to be true
     end
 
     it "requires a successful time for anyResult" do
@@ -240,47 +193,6 @@ RSpec.describe Qualification do
   end
 
   context "Average" do
-    it "requires average" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-06-01',
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).not_to be_valid
-    end
-
-    it "requires date" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'level' => 1000,
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).not_to be_valid
-    end
-
-    it "requires type" do
-      input = {
-        'resultType' => 'average',
-        'level' => 1000,
-        'whenDate' => '2021-06-01',
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).not_to be_valid
-    end
-
-    it "parses correctly" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-06-01',
-        'level' => 1000,
-      }
-      qualification = Qualification.load(input)
-      expect(qualification).to be_valid
-    end
-
     it "requires a successful time for ranking" do
       input = {
         'resultType' => 'average',

--- a/spec/lib/qualification_spec.rb
+++ b/spec/lib/qualification_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Qualification do
+RSpec.describe CompetitionEvent do
   let(:user) { create(:user_with_wca_id) }
   let(:first_competition) do
     create(
@@ -82,26 +82,14 @@ RSpec.describe Qualification do
 
   context "Single" do
     it "requires a successful time for ranking" do
-      input = {
-        'resultType' => 'single',
-        'type' => 'ranking',
-        'whenDate' => '2021-02-15',
-        'level' => 50,
-      }
-      qualification = ResultConditions::Utils.upcycle_v1_qualification(input)
+      qualification = ResultConditions::Ranking.new(scope: 'single', value: 50)
       expect(qualification).to be_valid
       competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
       expect(competition_event_333.meets_qualification?(user)).to be true
       competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
       expect(competition_event_333oh.meets_qualification?(user)).to be false
 
-      input = {
-        'resultType' => 'single',
-        'type' => 'ranking',
-        'whenDate' => '2021-03-15',
-        'level' => 50,
-      }
-      qualification = ResultConditions::Utils.upcycle_v1_qualification(input)
+      qualification = ResultConditions::Ranking.new(scope: 'single', value: 50)
       expect(qualification).to be_valid
       competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-03-15')
       expect(competition_event_333.meets_qualification?(user)).to be true
@@ -110,189 +98,111 @@ RSpec.describe Qualification do
     end
 
     it "requires a successful time for anyResult" do
-      input = {
-        'resultType' => 'single',
-        'type' => 'anyResult',
-        'whenDate' => '2021-02-15',
-        'level' => 50,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'single', value: nil)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
-      expect(qualification.can_register?(user, '333oh')).to be false
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333.meets_qualification?(user)).to be true
+      competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333oh.meets_qualification?(user)).to be false
 
-      input = {
-        'resultType' => 'single',
-        'type' => 'anyResult',
-        'whenDate' => '2021-03-15',
-        'level' => 50,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'single', value: nil)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
-      expect(qualification.can_register?(user, '333oh')).to be true
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-03-15')
+      expect(competition_event_333.meets_qualification?(user)).to be true
+      competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-03-15')
+      expect(competition_event_333oh.meets_qualification?(user)).to be true
     end
 
     it "requires strictly less than for attemptResult" do
-      input = {
-        'resultType' => 'single',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-02-15',
-        'level' => 1200,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'single', value: 1200)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be false
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333.meets_qualification?(user)).to be false
 
-      input = {
-        'resultType' => 'single',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-02-15',
-        'level' => 1201,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'single', value: 1201)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333.meets_qualification?(user)).to be true
     end
 
     # User's qualifying result was achieved on the 2nd
     it "requires end date before" do
       # Result must be achieved by the 3rd - user qualifies because result achieved before whenDate
-      input = {
-        'resultType' => 'single',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-03-03',
-        'level' => 1150,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'single', value: 1150)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-03-03')
+      expect(competition_event_333.meets_qualification?(user)).to be true
 
       # Result must be achieved by the 2nd - user qualifies because result achieved on whenDate
-      input = {
-        'resultType' => 'single',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-03-02',
-        'level' => 1150,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'single', value: 1150)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-03-02')
+      expect(competition_event_333.meets_qualification?(user)).to be true
 
       # Result must be achieved by the 1st - user does not qualify because result achieved after whenDate
-      input = {
-        'resultType' => 'single',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-03-01',
-        'level' => 1150,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'single', value: 1150)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be false
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-03-01')
+      expect(competition_event_333.meets_qualification?(user)).to be false
     end
   end
 
   context "Average" do
     it "requires a successful time for ranking" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'ranking',
-        'whenDate' => '2021-02-15',
-        'level' => 50,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::Ranking.new(scope: 'average', value: 50)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '444')).to be false
+      competition_event_444 = CompetitionEvent.new(event_id: '444', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_444.meets_qualification?(user)).to be false
 
-      input = {
-        'resultType' => 'average',
-        'type' => 'ranking',
-        'whenDate' => '2021-03-15',
-        'level' => 50,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::Ranking.new(scope: 'average', value: 50)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '444')).to be true
+      competition_event_444 = CompetitionEvent.new(event_id: '444', qualification_condition: qualification, qualification_latest_date: '2021-03-15')
+      expect(competition_event_444.meets_qualification?(user)).to be true
     end
 
     it "requires a successful time for anyResult" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'anyResult',
-        'whenDate' => '2021-02-15',
-        'level' => 50,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'average', value: nil)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '444')).to be false
+      competition_event_444 = CompetitionEvent.new(event_id: '444', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_444.meets_qualification?(user)).to be false
 
-      input = {
-        'resultType' => 'average',
-        'type' => 'anyResult',
-        'whenDate' => '2021-03-15',
-        'level' => 50,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'average', value: nil)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '444')).to be true
+      competition_event_444 = CompetitionEvent.new(event_id: '444', qualification_condition: qualification, qualification_latest_date: '2021-03-15')
+      expect(competition_event_444.meets_qualification?(user)).to be true
     end
 
     it "requires strictly less than for attemptResult" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-02-15',
-        'level' => 1500,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'average', value: 1500)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be false
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333.meets_qualification?(user)).to be false
 
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-02-15',
-        'level' => 1501,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'average', value: 1501)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333')).to be true
+      competition_event_333 = CompetitionEvent.new(event_id: '333', qualification_condition: qualification, qualification_latest_date: '2021-02-15')
+      expect(competition_event_333.meets_qualification?(user)).to be true
     end
 
     # User's qualifying result was achieved on the 2nd
     it "supports achieving result on qualification date" do
       # Result must be achieved by the 3rd - user qualifies because result achieved before whenDate
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-03-03',
-        'level' => 2500,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'average', value: 2500)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333oh')).to be true
+      competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-03-03')
+      expect(competition_event_333oh.meets_qualification?(user)).to be true
 
       # Result must be achieved by the 2nd - user qualifies because result achieved on whenDate
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-03-02',
-        'level' => 2500,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'average', value: 2500)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333oh')).to be true
+      competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-03-02')
+      expect(competition_event_333oh.meets_qualification?(user)).to be true
 
       # Result must be achieved by the 1st - user does not qualify because result achieved after whenDate
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-03-01',
-        'level' => 2500,
-      }
-      qualification = Qualification.load(input)
+      qualification = ResultConditions::ResultAchieved.new(scope: 'average', value: 2500)
       expect(qualification).to be_valid
-      expect(qualification.can_register?(user, '333oh')).to be false
+      competition_event_333oh = CompetitionEvent.new(event_id: '333oh', qualification_condition: qualification, qualification_latest_date: '2021-03-01')
+      expect(competition_event_333oh.meets_qualification?(user)).to be false
     end
   end
 end

--- a/spec/lib/result_condition_spec.rb
+++ b/spec/lib/result_condition_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ResultConditions::ResultCondition do
+  shared_examples "a basic result condition" do |condition_type, valid_value, requires_value: true|
+    if requires_value
+      it "requires value" do
+        input = {
+          'type' => condition_type,
+          'scope' => 'single',
+        }
+        result_condition = ResultConditions::ResultCondition.load(input)
+        expect(result_condition).not_to be_valid
+      end
+    else
+      it "does not require value" do
+        input = {
+          'type' => condition_type,
+          'scope' => 'single',
+        }
+        result_condition = ResultConditions::ResultCondition.load(input)
+        expect(result_condition).to be_valid
+      end
+    end
+
+    it "requires scope" do
+      input = {
+        'type' => condition_type,
+        'value' => valid_value,
+      }
+      result_condition = ResultConditions::ResultCondition.load(input)
+      expect(result_condition).not_to be_valid
+    end
+
+    context "parses correctly" do
+      it "with scope single" do
+        input = {
+          'type' => condition_type,
+          'scope' => 'single',
+          'value' => valid_value,
+        }
+        result_condition = ResultConditions::ResultCondition.load(input)
+        expect(result_condition).to be_valid
+      end
+
+      it "with scope average" do
+        input = {
+          'type' => condition_type,
+          'scope' => 'average',
+          'value' => valid_value,
+        }
+        result_condition = ResultConditions::ResultCondition.load(input)
+        expect(result_condition).to be_valid
+      end
+    end
+  end
+
+  context "Percent" do
+    it_behaves_like "a basic result condition", 'percent', 50
+  end
+
+  context "Ranking" do
+    it_behaves_like "a basic result condition", 'ranking', 100
+  end
+
+  context "Result Achieved" do
+    it_behaves_like "a basic result condition", 'resultAchieved', 1000, requires_value: false
+  end
+end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -301,13 +301,8 @@ RSpec.describe Registration do
     end
 
     it "allows unqualified registration when not required" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-06-21',
-        'level' => 1300,
-      }
-      competition_event.qualification = Qualification.load(input)
+      competition_event.qualification_condition = ResultConditions::ResultAchieved.new(scope: 'average', value: 1300)
+      competition_event.qualification_latest_date = '2021-06-21'
       competition_event.save!
       competition.allow_registration_without_qualification = true
       competition.save!
@@ -316,13 +311,8 @@ RSpec.describe Registration do
     end
 
     it "allows qualified registration" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-06-21',
-        'level' => 1600,
-      }
-      competition_event.qualification = Qualification.load(input)
+      competition_event.qualification_condition = ResultConditions::ResultAchieved.new(scope: 'average', value: 1600)
+      competition_event.qualification_latest_date = '2021-06-21'
       competition_event.save!
       competition.allow_registration_without_qualification = false
       competition.save!
@@ -331,13 +321,8 @@ RSpec.describe Registration do
     end
 
     it "doesn't allow unqualified registration" do
-      input = {
-        'resultType' => 'average',
-        'type' => 'attemptResult',
-        'whenDate' => '2021-06-21',
-        'level' => 1000,
-      }
-      competition_event.qualification = Qualification.load(input)
+      competition_event.qualification_condition = ResultConditions::ResultAchieved.new(scope: 'average', value: 1000)
+      competition_event.qualification_latest_date = '2021-06-21'
       competition_event.save!
       competition.allow_registration_without_qualification = false
       competition.save!


### PR DESCRIPTION
This PR sunsets the active usage of the `Qualification` model in the `qualification` column. It switches to actively using the new `qualification_condition` and `qualification_latest_date` directly on `CompetitionEvent`, following WCIFv2