### PR TITLE
Rework 'Submit Results' panel into step-by-step process

### DIFF
--- a/app/views/admin/new_results.html.erb
+++ b/app/views/admin/new_results.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, "Upload results") %>
 <%= render layout: 'competitions/nav' do %>
   <h1><%= yield(:title) %></h1>
-  <%= react_component("CompetitionResultSubmissionAdmin", {
+  <%= react_component("CompetitionResultSubmission/Admin", {
     competitionId: @competition.id,
     hasTemporaryResults: @competition.inbox_results.present?,
     uploadedScrambleFilesCount: @competition.scramble_file_uploads.count,

--- a/app/views/results_submission/new.html.erb
+++ b/app/views/results_submission/new.html.erb
@@ -5,7 +5,7 @@
 
   <%= react_component("CompetitionResultSubmission", {
     competitionId: @competition.id,
-    resultsSubmitted: @competition.results_submitted?,
+    areResultsSubmitted: @competition.results_submitted?,
     hasTemporaryResults: @competition.inbox_results.present?,
     uploadedScrambleFilesCount: @competition.scramble_file_uploads.count,
     showWcaLiveBeta: @show_wca_live_beta,

--- a/app/webpacker/components/CompetitionResultSubmission/Admin/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/Admin/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Message } from 'semantic-ui-react';
-import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
-import { ImportResultsData } from '../CompetitionResultSubmission/ImportResultsData';
-import { viewUrls } from '../../lib/requests/routes.js.erb';
+import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvider';
+import { ImportResultsData } from '../ImportResultsData';
+import { viewUrls } from '../../../lib/requests/routes.js.erb';
 
 export default function Wrapper({
   competitionId,

--- a/app/webpacker/components/CompetitionResultSubmission/Admin/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/Admin/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Message } from 'semantic-ui-react';
 import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvider';
-import { ImportResultsData } from '../ImportResultsData';
+import ImportResultsData from '../ImportResultsData';
 import { viewUrls } from '../../../lib/requests/routes.js.erb';
 
 export default function Wrapper({
@@ -22,7 +22,7 @@ export default function Wrapper({
   );
 }
 
-function CompetitionResultSubmissionAdmin({
+export function CompetitionResultSubmissionAdmin({
   competitionId,
   hasTemporaryResults,
   uploadedScrambleFilesCount,
@@ -37,6 +37,7 @@ function CompetitionResultSubmissionAdmin({
       </Message>
     );
   }
+
   return (
     <>
       <p>

--- a/app/webpacker/components/CompetitionResultSubmission/CheckExistingResults/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/CheckExistingResults/index.jsx
@@ -12,7 +12,7 @@ export default function Wrapper({ competitionId }) {
   );
 }
 
-function CheckExistingResults({ competitionId }) {
+export function CheckExistingResults({ competitionId }) {
   return (
     <>
       <Header>Check results</Header>

--- a/app/webpacker/components/CompetitionResultSubmission/CheckValidations.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/CheckValidations.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Form } from 'semantic-ui-react';
+import ValidationOutput from '../Panel/pages/RunValidatorsPage/ValidationOutput';
+import useCheckboxState from '../../lib/hooks/useCheckboxState';
+
+export default function CheckValidations({
+  validationOutput,
+  isValidationPending,
+  isValidationFetchError,
+  validationFetchError,
+  onUserConfirmed,
+}) {
+  const [isCheckboxTicked, setCheckboxTicked] = useCheckboxState(false);
+
+  const hasValidationErrors = validationOutput && validationOutput.errors.length > 0;
+
+  return (
+    <>
+      <ValidationOutput
+        validationOutput={validationOutput}
+        isPending={isValidationPending}
+        isError={isValidationFetchError}
+        error={validationFetchError}
+      />
+      {!hasValidationErrors && (
+        <Form onSubmit={onUserConfirmed}>
+          <Form.Checkbox
+            label="I confirm that all warnings are in order"
+            checked={isCheckboxTicked}
+            onChange={setCheckboxTicked}
+            required
+          />
+          <Form.Button
+            disabled={!isCheckboxTicked}
+            onClick={onUserConfirmed}
+          >
+            Continue
+          </Form.Button>
+        </Form>
+      )}
+    </>
+  );
+}

--- a/app/webpacker/components/CompetitionResultSubmission/CheckValidations.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/CheckValidations.jsx
@@ -1,28 +1,54 @@
 import React from 'react';
-import { Form } from 'semantic-ui-react';
+import { Button, Form } from 'semantic-ui-react';
+import { useQuery } from '@tanstack/react-query';
 import ValidationOutput from '../Panel/pages/RunValidatorsPage/ValidationOutput';
 import useCheckboxState from '../../lib/hooks/useCheckboxState';
+import { ALL_VALIDATORS } from '../../lib/wca-data.js.erb';
+import runValidatorsForCompetitionList
+  from '../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
 
 export default function CheckValidations({
-  validationOutput,
-  isValidationPending,
-  isValidationFetchError,
-  validationFetchError,
+  competitionId,
+  hasTemporaryResults,
   onUserConfirmed,
 }) {
   const [isCheckboxTicked, setCheckboxTicked] = useCheckboxState(false);
+
+  const {
+    data: validationOutput,
+    isFetching: isValidationFetching,
+    isError: isValidationFetchError,
+    error: validationFetchError,
+    refetch: refetchValidationOutput,
+  } = useQuery({
+    queryKey: ['competition-validation-output', competitionId],
+    queryFn: () => runValidatorsForCompetitionList(
+      competitionId,
+      ALL_VALIDATORS,
+      false,
+      false,
+    ),
+    enabled: hasTemporaryResults,
+  });
 
   const hasValidationErrors = validationOutput && validationOutput.errors.length > 0;
 
   return (
     <>
+      <Button
+        primary
+        floated="right"
+        icon="refresh"
+        content="Refresh validations"
+        onClick={() => refetchValidationOutput()}
+      />
       <ValidationOutput
         validationOutput={validationOutput}
-        isPending={isValidationPending}
+        isPending={isValidationFetching}
         isError={isValidationFetchError}
         error={validationFetchError}
       />
-      {!hasValidationErrors && (
+      {!isValidationFetching && !hasValidationErrors && (
         <Form onSubmit={onUserConfirmed}>
           <Form.Checkbox
             label="I confirm that all warnings are in order"

--- a/app/webpacker/components/CompetitionResultSubmission/FormToWrt.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/FormToWrt.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Accordion, Form, Message } from 'semantic-ui-react';
+import { Form, Message } from 'semantic-ui-react';
 import { useMutation } from '@tanstack/react-query';
 import Errored from '../Requests/Errored';
 import useInputState from '../../lib/hooks/useInputState';
@@ -30,47 +30,47 @@ export default function FormToWrt({ competitionId, canSubmitResults }) {
   if (isSuccess) return <Message success>Thank you for submitting the results!</Message>;
   if (isErrorInCurrentUpload) return <Errored error={errorInSubmission} />;
 
+  if (!canSubmitResults) {
+    return (
+      <Message warning>
+        You do not have permission to submit the results to WRT.
+        Please check with the competition Delegates to clarify who will make the final submission.
+      </Message>
+    );
+  }
+
   return (
-    <Accordion fluid styled>
-      <Accordion.Title active>
-        Submit to WRT
-      </Accordion.Title>
-      <Accordion.Content active>
-        {canSubmitResults && (
-          <>
-            <p>Please enter the body of your email to the Results Team.</p>
-            <p>
-              Make sure the schedule on the WCA website actually reflects what happened during the
-              competition.
-            </p>
-            <p>
-              Please also make sure to include any other additional details required by the
-              {' '}
-              <a href={DELEGATE_HANDBOOK_COMPETITION_RESULTS_URL}>
-                &apos;Competition Results&apos; section of the Delegate Handbook.
-              </a>
-            </p>
-            <Form onSubmit={formSubmitHandler}>
-              <MarkdownEditor
-                id="message"
-                value={message}
-                onChange={setMessage}
-              />
-              <Form.Checkbox
-                value={confirmDetails}
-                onChange={setConfirmDetails}
-                label="I confirm the information displayed on the WCA website's events page and on the competition's schedule page reflect what happened during the competition."
-              />
-              <Form.Button
-                type="submit"
-                disabled={!confirmDetails || !message}
-              >
-                Submit
-              </Form.Button>
-            </Form>
-          </>
-        )}
-      </Accordion.Content>
-    </Accordion>
+    <>
+      <p>Please enter the body of your email to the Results Team.</p>
+      <p>
+        Make sure the schedule on the WCA website actually reflects what happened during the
+        competition.
+      </p>
+      <p>
+        Please also make sure to include any other additional details required by the
+        {' '}
+        <a href={DELEGATE_HANDBOOK_COMPETITION_RESULTS_URL}>
+          &apos;Competition Results&apos; section of the Delegate Handbook.
+        </a>
+      </p>
+      <Form onSubmit={formSubmitHandler}>
+        <MarkdownEditor
+          id="message"
+          value={message}
+          onChange={setMessage}
+        />
+        <Form.Checkbox
+          value={confirmDetails}
+          onChange={setConfirmDetails}
+          label="I confirm the information displayed on the WCA website's events page and on the competition's schedule page reflect what happened during the competition."
+        />
+        <Form.Button
+          type="submit"
+          disabled={!confirmDetails || !message}
+        >
+          Submit
+        </Form.Button>
+      </Form>
+    </>
   );
 }

--- a/app/webpacker/components/CompetitionResultSubmission/FormToWrt.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/FormToWrt.jsx
@@ -1,36 +1,18 @@
 import React from 'react';
 import { Accordion, Form, Message } from 'semantic-ui-react';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import Errored from '../../Requests/Errored';
-import useInputState from '../../../lib/hooks/useInputState';
-import MarkdownEditor from '../../wca/FormBuilder/input/MarkdownEditor';
-import useCheckboxState from '../../../lib/hooks/useCheckboxState';
-import submitToWrt from '../api/submitToWrt';
-import Loading from '../../Requests/Loading';
-import runValidatorsForCompetitionList from '../../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
-import { ALL_VALIDATORS } from '../../../lib/wca-data.js.erb';
-import ValidationOutput from '../../Panel/pages/RunValidatorsPage/ValidationOutput';
+import { useMutation } from '@tanstack/react-query';
+import Errored from '../Requests/Errored';
+import useInputState from '../../lib/hooks/useInputState';
+import MarkdownEditor from '../wca/FormBuilder/input/MarkdownEditor';
+import useCheckboxState from '../../lib/hooks/useCheckboxState';
+import submitToWrt from './api/submitToWrt';
+import Loading from '../Requests/Loading';
 
 const DELEGATE_HANDBOOK_COMPETITION_RESULTS_URL = 'https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf#competition-results';
-const ERROR_MESSAGE_UPLOADED_RESULTS = "Please upload a JSON file and make sure the results don't contain any errors.";
 
 export default function FormToWrt({ competitionId, canSubmitResults }) {
   const [confirmDetails, setConfirmDetails] = useCheckboxState(false);
   const [message, setMessage] = useInputState();
-
-  const {
-    data: validationOutput,
-    isPending: isValidationPending,
-    isError: isErrorInPreviousUpload,
-  } = useQuery({
-    queryKey: ['competition-validation-output', competitionId],
-    queryFn: () => runValidatorsForCompetitionList(
-      competitionId,
-      ALL_VALIDATORS,
-      false,
-      false,
-    ),
-  });
 
   const {
     mutate: submitToWrtMutate,
@@ -44,9 +26,8 @@ export default function FormToWrt({ competitionId, canSubmitResults }) {
     submitToWrtMutate({ competitionId, message });
   };
 
-  if (isValidationPending || isSubmitPending) return <Loading />;
+  if (isSubmitPending) return <Loading />;
   if (isSuccess) return <Message success>Thank you for submitting the results!</Message>;
-  if (isErrorInPreviousUpload) return <Errored error={ERROR_MESSAGE_UPLOADED_RESULTS} />;
   if (isErrorInCurrentUpload) return <Errored error={errorInSubmission} />;
 
   return (
@@ -55,7 +36,6 @@ export default function FormToWrt({ competitionId, canSubmitResults }) {
         Submit to WRT
       </Accordion.Title>
       <Accordion.Content active>
-        <ValidationOutput validationOutput={validationOutput} />
         {canSubmitResults && (
           <>
             <p>Please enter the body of your email to the Results Team.</p>

--- a/app/webpacker/components/CompetitionResultSubmission/FormToWrt.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/FormToWrt.jsx
@@ -10,7 +10,7 @@ import Loading from '../Requests/Loading';
 
 const DELEGATE_HANDBOOK_COMPETITION_RESULTS_URL = 'https://documents.worldcubeassociation.org/edudoc/delegate-handbook/delegate-handbook.pdf#competition-results';
 
-export default function FormToWrt({ competitionId, canSubmitResults }) {
+export default function FormToWrt({ competitionId, canSubmitResults, onSubmitSuccess }) {
   const [confirmDetails, setConfirmDetails] = useCheckboxState(false);
   const [message, setMessage] = useInputState();
 
@@ -20,7 +20,10 @@ export default function FormToWrt({ competitionId, canSubmitResults }) {
     isSuccess,
     isError: isErrorInCurrentUpload,
     error: errorInSubmission,
-  } = useMutation({ mutationFn: submitToWrt });
+  } = useMutation({
+    mutationFn: submitToWrt,
+    onSuccess: onSubmitSuccess,
+  });
 
   const formSubmitHandler = () => {
     submitToWrtMutate({ competitionId, message });

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
@@ -16,7 +16,10 @@ export default function ImportWcaLiveResults({
   const [markResultSubmitted, setMarkResultSubmitted] = useCheckboxState(isAdminView);
 
   const {
-    mutate: importWcaLiveResultsMutate, error, isPending, isError,
+    mutate: importWcaLiveResultsMutate,
+    isPending,
+    isError,
+    error,
   } = useMutation({
     mutationFn: () => importWcaLiveResults({
       competitionId,

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/UploadResultsJson.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/UploadResultsJson.jsx
@@ -32,6 +32,7 @@ export default function UploadResultsJson({ competitionId, isAdminView, onImport
     <Form onSubmit={uploadResultsJsonMutate}>
       <Form.Input
         type="file"
+        accept="application/json"
         onChange={(event) => setResultFile(event.target.files[0])}
       />
       {isAdminView && (

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/UploadResultsJson.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/UploadResultsJson.jsx
@@ -11,7 +11,10 @@ export default function UploadResultsJson({ competitionId, isAdminView, onImport
   const [markResultSubmitted, setMarkResultSubmitted] = useCheckboxState(isAdminView);
 
   const {
-    mutate: uploadResultsJsonMutate, isPending, error, isError,
+    mutate: uploadResultsJsonMutate,
+    isPending,
+    isError,
+    error,
   } = useMutation({
     mutationFn: () => uploadResultsJson({
       competitionId,

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
@@ -1,7 +1,5 @@
-import React, { useState } from 'react';
-import {
-  Accordion, Container, Message, Tab,
-} from 'semantic-ui-react';
+import React from 'react';
+import { Container, Message, Tab } from 'semantic-ui-react';
 import UploadResultsJson from './UploadResultsJson';
 import ImportWcaLiveResults from './ImportWcaLiveResults';
 
@@ -12,8 +10,6 @@ export default function ImportResultsData({
   uploadedScrambleFilesCount = 0,
   showWcaLiveBeta = false,
 }) {
-  const [activeAccordion, setActiveAccordion] = useState(!hasTemporaryResults);
-
   const onImportSuccess = () => {
     // Ideally page should not be reloaded, but this is currently required to re-render
     // the rails HTML portion. Once that rails HTML portion is also migrated to React,
@@ -51,25 +47,15 @@ export default function ImportResultsData({
 
   return (
     <Container fluid>
-      <Accordion fluid styled>
-        <Accordion.Title
-          active={activeAccordion}
-          onClick={() => setActiveAccordion((prevValue) => !prevValue)}
-        >
-          Import Results Data
-        </Accordion.Title>
-        <Accordion.Content active={activeAccordion}>
-          <Message
-            warning={hasTemporaryResults}
-            info={!hasTemporaryResults}
-          >
-            {hasTemporaryResults
-              ? 'Some results have already been uploaded before, importing results data again will override all of them!'
-              : 'Please start by selecting a JSON file to import.'}
-          </Message>
-          <Tab panes={panes} />
-        </Accordion.Content>
-      </Accordion>
+      <Message
+        warning={hasTemporaryResults}
+        info={!hasTemporaryResults}
+      >
+        {hasTemporaryResults
+          ? 'Some results have already been uploaded before, importing results data again will override all of them!'
+          : 'Please start by selecting a JSON file to import.'}
+      </Message>
+      <Tab panes={panes} />
     </Container>
   );
 }

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
@@ -1,22 +1,16 @@
 import React from 'react';
-import { Container, Message, Tab } from 'semantic-ui-react';
+import { Message, Tab } from 'semantic-ui-react';
 import UploadResultsJson from './UploadResultsJson';
 import ImportWcaLiveResults from './ImportWcaLiveResults';
 
 export default function ImportResultsData({
   competitionId,
   hasTemporaryResults,
+  onImportSuccess,
   isAdminView = false,
   uploadedScrambleFilesCount = 0,
   showWcaLiveBeta = false,
 }) {
-  const onImportSuccess = () => {
-    // Ideally page should not be reloaded, but this is currently required to re-render
-    // the rails HTML portion. Once that rails HTML portion is also migrated to React,
-    // then this reload will be removed.
-    window.location.reload();
-  };
-
   const panes = [
     {
       menuItem: 'Upload Results JSON',
@@ -46,16 +40,14 @@ export default function ImportResultsData({
   ];
 
   return (
-    <Container fluid>
-      <Message
-        warning={hasTemporaryResults}
-        info={!hasTemporaryResults}
-      >
-        {hasTemporaryResults
-          ? 'Some results have already been uploaded before, importing results data again will override all of them!'
-          : 'Please start by selecting a JSON file to import.'}
-      </Message>
+    <>
+      {hasTemporaryResults && (
+        <Message warning>
+          Some results have already been uploaded before,
+          importing results data again will override all of them!
+        </Message>
+      )}
       <Tab panes={panes} />
-    </Container>
+    </>
   );
 }

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
@@ -2,29 +2,10 @@ import React, { useState } from 'react';
 import {
   Accordion, Container, Message, Tab,
 } from 'semantic-ui-react';
-import WCAQueryClientProvider from '../../../lib/providers/WCAQueryClientProvider';
 import UploadResultsJson from './UploadResultsJson';
 import ImportWcaLiveResults from './ImportWcaLiveResults';
 
-export default function Wrapper({
-  competitionId,
-  alreadyHasSubmittedResult,
-  isAdminView,
-  uploadedScrambleFilesCount,
-}) {
-  return (
-    <WCAQueryClientProvider>
-      <ImportResultsData
-        competitionId={competitionId}
-        hasTemporaryResults={alreadyHasSubmittedResult}
-        isAdminView={isAdminView}
-        uploadedScrambleFilesCount={uploadedScrambleFilesCount}
-      />
-    </WCAQueryClientProvider>
-  );
-}
-
-export function ImportResultsData({
+export default function ImportResultsData({
   competitionId,
   hasTemporaryResults,
   isAdminView = false,

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -1,8 +1,13 @@
 import React, { useState } from 'react';
 import { Icon, Message, Step } from 'semantic-ui-react';
+import { useQuery } from '@tanstack/react-query';
 import ImportResultsData from './ImportResultsData';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
 import FormToWrt from './FormToWrt';
+import ValidationOutput from '../Panel/pages/RunValidatorsPage/ValidationOutput';
+import runValidatorsForCompetitionList
+  from '../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
+import { ALL_VALIDATORS } from '../../lib/wca-data.js.erb';
 
 export default function Wrapper({
   competitionId,
@@ -34,9 +39,26 @@ function CompetitionResultSubmission({
   showWcaLiveBeta,
   canSubmitResults,
 }) {
-  const defaultStep = resultsSubmitted ? 3 : 0;
+  // eslint-disable-next-line no-nested-ternary
+  const defaultStep = resultsSubmitted ? 3 : (hasTemporaryResults ? 1 : 0);
 
   const [activeStep, setActiveStep] = useState(defaultStep);
+
+  const {
+    data: validationOutput,
+    isPending: isValidationPending,
+    isError: isValidationFetchError,
+    error: validationFetchError,
+  } = useQuery({
+    queryKey: ['competition-validation-output', competitionId],
+    queryFn: () => runValidatorsForCompetitionList(
+      competitionId,
+      ALL_VALIDATORS,
+      false,
+      false,
+    ),
+    enabled: hasTemporaryResults,
+  });
 
   return (
     <>
@@ -87,6 +109,14 @@ function CompetitionResultSubmission({
           uploadedScrambleFilesCount={uploadedScrambleFilesCount}
           hasTemporaryResults={hasTemporaryResults}
           showWcaLiveBeta={showWcaLiveBeta}
+        />
+      )}
+      {activeStep === 1 && (
+        <ValidationOutput
+          validationOutput={validationOutput}
+          isPending={isValidationPending}
+          isError={isValidationFetchError}
+          error={validationFetchError}
         />
       )}
       {activeStep === 2 && (

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import ImportResultsData from './ImportResultsData';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
 import FormToWrt from './FormToWrt';
-import ValidationOutput from '../Panel/pages/RunValidatorsPage/ValidationOutput';
+import CheckValidations from './CheckValidations';
 import runValidatorsForCompetitionList
   from '../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
 import { ALL_VALIDATORS } from '../../lib/wca-data.js.erb';
@@ -44,8 +44,9 @@ function CompetitionResultSubmission({
 
   const [activeStep, setActiveStep] = useState(defaultStep);
 
-  const [areResultsSubmitted, setAreResultsSubmitted] = useState(areResultsSubmittedInitial);
   const [hasTemporaryResults, setHasTemporaryResults] = useState(hasTemporaryResultsInitial);
+  const [areValidationsConfirmed, setAreValidationsConfirmed] = useState(false);
+  const [areResultsSubmitted, setAreResultsSubmitted] = useState(areResultsSubmittedInitial);
 
   const {
     data: validationOutput,
@@ -75,6 +76,11 @@ function CompetitionResultSubmission({
     setHasTemporaryResults(!!response.success);
     advanceStep();
   }, [setHasTemporaryResults, refetchValidationOutput, advanceStep]);
+
+  const onValidationsConfirmed = useCallback(() => {
+    setAreValidationsConfirmed(true);
+    advanceStep();
+  }, [advanceStep, setAreValidationsConfirmed]);
 
   return (
     <>
@@ -129,11 +135,12 @@ function CompetitionResultSubmission({
         />
       )}
       {activeStep === 1 && (
-        <ValidationOutput
+        <CheckValidations
           validationOutput={validationOutput}
           isPending={isValidationPending}
           isError={isValidationFetchError}
           error={validationFetchError}
+          onUserConfirmed={onValidationsConfirmed}
         />
       )}
       {activeStep === 2 && (

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -34,16 +34,9 @@ function CompetitionResultSubmission({
   showWcaLiveBeta,
   canSubmitResults,
 }) {
-  const [activeStep, setActiveStep] = useState(0);
+  const defaultStep = resultsSubmitted ? 3 : 0;
 
-  if (!resultsSubmitted) {
-    return (
-      <Message positive>
-        The results have already been submitted. If you have any more questions or
-        comments please reply to the email sent with the first results submission.
-      </Message>
-    );
-  }
+  const [activeStep, setActiveStep] = useState(defaultStep);
 
   return (
     <>
@@ -52,6 +45,7 @@ function CompetitionResultSubmission({
           active={activeStep === 0}
           completed={activeStep > 0}
           onClick={() => setActiveStep(0)}
+          disabled={resultsSubmitted}
         >
           <Icon name="cloud upload" />
           <Step.Content>
@@ -66,6 +60,7 @@ function CompetitionResultSubmission({
           active={activeStep === 1}
           completed={activeStep > 1}
           onClick={() => setActiveStep(1)}
+          disabled={resultsSubmitted}
         >
           <Icon name="warning sign" />
           <Step.Content>
@@ -77,6 +72,7 @@ function CompetitionResultSubmission({
           active={activeStep === 2}
           completed={activeStep > 2}
           onClick={() => setActiveStep(2)}
+          disabled={resultsSubmitted}
         >
           <Icon name="cloud upload" />
           <Step.Content>
@@ -95,6 +91,12 @@ function CompetitionResultSubmission({
       )}
       {activeStep === 2 && (
         <FormToWrt competitionId={competitionId} canSubmitResults={canSubmitResults} />
+      )}
+      {activeStep === 3 && (
+        <Message positive>
+          The results have already been submitted. If you have any more questions or
+          comments please reply to the email sent with the first results submission.
+        </Message>
       )}
     </>
   );

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -100,7 +100,7 @@ function CompetitionResultSubmission({
           onClick={() => setActiveStep(2)}
           disabled={areResultsSubmitted || !hasTemporaryResults || !areValidationsConfirmed}
         >
-          <Icon name="cloud upload" />
+          <Icon name="send" />
           <Step.Content>
             <Step.Title>Submit</Step.Title>
             <Step.Description>Make the final submission to WRT</Step.Description>

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List, Message } from 'semantic-ui-react';
+import { Icon, Message, Step } from 'semantic-ui-react';
 import ImportResultsData from './ImportResultsData';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
 import FormToWrt from './FormToWrt';
@@ -45,22 +45,32 @@ function CompetitionResultSubmission({
 
   return (
     <>
-      The result submission process has two steps:
-      <List ordered>
-        <List.Item>
-          Providing valid results data to the website.
-          This can be done in one of the following ways:
-          <List.List>
-            <List.Item value="a">Uploading a Results JSON file</List.Item>
-            {showWcaLiveBeta && (
-              <List.Item value="b">Importing results directly from WCA Live</List.Item>
-            )}
-          </List.List>
-        </List.Item>
-        <List.Item>
-          Submit these results to the WRT after addressing warnings (if any).
-        </List.Item>
-      </List>
+      <Step.Group ordered widths={3}>
+        <Step>
+          <Icon name="cloud upload" />
+          <Step.Content>
+            <Step.Title>Results Data</Step.Title>
+            <Step.Description>
+              Upload a file
+              {showWcaLiveBeta && ' or WCA Live data'}
+            </Step.Description>
+          </Step.Content>
+        </Step>
+        <Step>
+          <Icon name="warning sign" />
+          <Step.Content>
+            <Step.Title>Validations</Step.Title>
+            <Step.Description>Address any warnings or errors</Step.Description>
+          </Step.Content>
+        </Step>
+        <Step>
+          <Icon name="cloud upload" />
+          <Step.Content>
+            <Step.Title>Submit</Step.Title>
+            <Step.Description>Make the final submission to WRT</Step.Description>
+          </Step.Content>
+        </Step>
+      </Step.Group>
       <ImportResultsData
         competitionId={competitionId}
         uploadedScrambleFilesCount={uploadedScrambleFilesCount}

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -75,12 +75,17 @@ function CompetitionResultSubmission({
 
     setHasTemporaryResults(!!response.success);
     advanceStep();
-  }, [setHasTemporaryResults, refetchValidationOutput, advanceStep]);
+  }, [refetchValidationOutput, setHasTemporaryResults, advanceStep]);
 
   const onValidationsConfirmed = useCallback(() => {
     setAreValidationsConfirmed(true);
     advanceStep();
-  }, [advanceStep, setAreValidationsConfirmed]);
+  }, [setAreValidationsConfirmed, advanceStep]);
+
+  const onSubmitSuccess = useCallback(() => {
+    setAreResultsSubmitted(true);
+    advanceStep();
+  }, [setAreResultsSubmitted, advanceStep]);
 
   return (
     <>
@@ -147,6 +152,7 @@ function CompetitionResultSubmission({
         <FormToWrt
           competitionId={competitionId}
           canSubmitResults={canSubmitResults}
+          onSubmitSuccess={onSubmitSuccess}
         />
       )}
       {activeStep === 3 && (

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -120,7 +120,10 @@ function CompetitionResultSubmission({
         />
       )}
       {activeStep === 2 && (
-        <FormToWrt competitionId={competitionId} canSubmitResults={canSubmitResults} />
+        <FormToWrt
+          competitionId={competitionId}
+          canSubmitResults={canSubmitResults}
+        />
       )}
       {activeStep === 3 && (
         <Message positive>

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -1,13 +1,9 @@
 import React, { useCallback, useState } from 'react';
 import { Icon, Message, Step } from 'semantic-ui-react';
-import { useQuery } from '@tanstack/react-query';
 import ImportResultsData from './ImportResultsData';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
 import FormToWrt from './FormToWrt';
 import CheckValidations from './CheckValidations';
-import runValidatorsForCompetitionList
-  from '../Panel/pages/RunValidatorsPage/api/runValidatorsForCompetitionList';
-import { ALL_VALIDATORS } from '../../lib/wca-data.js.erb';
 
 export default function Wrapper({
   competitionId,
@@ -48,34 +44,15 @@ function CompetitionResultSubmission({
   const [areValidationsConfirmed, setAreValidationsConfirmed] = useState(false);
   const [areResultsSubmitted, setAreResultsSubmitted] = useState(areResultsSubmittedInitial);
 
-  const {
-    data: validationOutput,
-    isPending: isValidationPending,
-    isError: isValidationFetchError,
-    error: validationFetchError,
-    refetch: refetchValidationOutput,
-  } = useQuery({
-    queryKey: ['competition-validation-output', competitionId],
-    queryFn: () => runValidatorsForCompetitionList(
-      competitionId,
-      ALL_VALIDATORS,
-      false,
-      false,
-    ),
-    enabled: hasTemporaryResults,
-  });
-
   const advanceStep = useCallback(
     () => setActiveStep((stepWas) => stepWas + 1),
     [setActiveStep],
   );
 
   const onImportComplete = useCallback((response) => {
-    refetchValidationOutput();
-
     setHasTemporaryResults(!!response.success);
     advanceStep();
-  }, [refetchValidationOutput, setHasTemporaryResults, advanceStep]);
+  }, [setHasTemporaryResults, advanceStep]);
 
   const onValidationsConfirmed = useCallback(() => {
     setAreValidationsConfirmed(true);
@@ -141,10 +118,8 @@ function CompetitionResultSubmission({
       )}
       {activeStep === 1 && (
         <CheckValidations
-          validationOutput={validationOutput}
-          isPending={isValidationPending}
-          isError={isValidationFetchError}
-          error={validationFetchError}
+          competitionId={competitionId}
+          hasTemporaryResults={hasTemporaryResults}
           onUserConfirmed={onValidationsConfirmed}
         />
       )}

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -49,6 +49,7 @@ function CompetitionResultSubmission({
     isPending: isValidationPending,
     isError: isValidationFetchError,
     error: validationFetchError,
+    refetch: refetchValidationOutput,
   } = useQuery({
     queryKey: ['competition-validation-output', competitionId],
     queryFn: () => runValidatorsForCompetitionList(

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Icon, Message, Step } from 'semantic-ui-react';
 import { useQuery } from '@tanstack/react-query';
 import ImportResultsData from './ImportResultsData';
@@ -11,7 +11,7 @@ import { ALL_VALIDATORS } from '../../lib/wca-data.js.erb';
 
 export default function Wrapper({
   competitionId,
-  resultsSubmitted,
+  areResultsSubmitted,
   hasTemporaryResults,
   uploadedScrambleFilesCount,
   showWcaLiveBeta,
@@ -21,7 +21,7 @@ export default function Wrapper({
     <WCAQueryClientProvider>
       <CompetitionResultSubmission
         competitionId={competitionId}
-        resultsSubmitted={resultsSubmitted}
+        areResultsSubmitted={areResultsSubmitted}
         hasTemporaryResults={hasTemporaryResults}
         uploadedScrambleFilesCount={uploadedScrambleFilesCount}
         showWcaLiveBeta={showWcaLiveBeta}
@@ -33,16 +33,19 @@ export default function Wrapper({
 
 function CompetitionResultSubmission({
   competitionId,
-  resultsSubmitted,
-  hasTemporaryResults,
+  areResultsSubmitted: areResultsSubmittedInitial,
+  hasTemporaryResults: hasTemporaryResultsInitial,
   uploadedScrambleFilesCount,
   showWcaLiveBeta,
   canSubmitResults,
 }) {
   // eslint-disable-next-line no-nested-ternary
-  const defaultStep = resultsSubmitted ? 3 : (hasTemporaryResults ? 1 : 0);
+  const defaultStep = areResultsSubmittedInitial ? 3 : (hasTemporaryResultsInitial ? 1 : 0);
 
   const [activeStep, setActiveStep] = useState(defaultStep);
+
+  const [areResultsSubmitted, setAreResultsSubmitted] = useState(areResultsSubmittedInitial);
+  const [hasTemporaryResults, setHasTemporaryResults] = useState(hasTemporaryResultsInitial);
 
   const {
     data: validationOutput,
@@ -61,6 +64,18 @@ function CompetitionResultSubmission({
     enabled: hasTemporaryResults,
   });
 
+  const advanceStep = useCallback(
+    () => setActiveStep((stepWas) => stepWas + 1),
+    [setActiveStep],
+  );
+
+  const onImportComplete = useCallback((response) => {
+    refetchValidationOutput();
+
+    setHasTemporaryResults(!!response.success);
+    advanceStep();
+  }, [setHasTemporaryResults, refetchValidationOutput, advanceStep]);
+
   return (
     <>
       <Step.Group widths={3}>
@@ -68,7 +83,7 @@ function CompetitionResultSubmission({
           active={activeStep === 0}
           completed={activeStep > 0}
           onClick={() => setActiveStep(0)}
-          disabled={resultsSubmitted}
+          disabled={areResultsSubmitted}
         >
           <Icon name="cloud upload" />
           <Step.Content>
@@ -83,7 +98,7 @@ function CompetitionResultSubmission({
           active={activeStep === 1}
           completed={activeStep > 1}
           onClick={() => setActiveStep(1)}
-          disabled={resultsSubmitted}
+          disabled={areResultsSubmitted}
         >
           <Icon name="warning sign" />
           <Step.Content>
@@ -95,7 +110,7 @@ function CompetitionResultSubmission({
           active={activeStep === 2}
           completed={activeStep > 2}
           onClick={() => setActiveStep(2)}
-          disabled={resultsSubmitted}
+          disabled={areResultsSubmitted}
         >
           <Icon name="cloud upload" />
           <Step.Content>
@@ -110,6 +125,7 @@ function CompetitionResultSubmission({
           uploadedScrambleFilesCount={uploadedScrambleFilesCount}
           hasTemporaryResults={hasTemporaryResults}
           showWcaLiveBeta={showWcaLiveBeta}
+          onImportSuccess={onImportComplete}
         />
       )}
       {activeStep === 1 && (

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -92,7 +92,7 @@ function CompetitionResultSubmission({
       <Step.Group widths={3}>
         <Step
           active={activeStep === 0}
-          completed={activeStep > 0}
+          completed={hasTemporaryResults}
           onClick={() => setActiveStep(0)}
           disabled={areResultsSubmitted}
         >
@@ -107,9 +107,9 @@ function CompetitionResultSubmission({
         </Step>
         <Step
           active={activeStep === 1}
-          completed={activeStep > 1}
+          completed={areValidationsConfirmed}
           onClick={() => setActiveStep(1)}
-          disabled={areResultsSubmitted}
+          disabled={areResultsSubmitted || !hasTemporaryResults}
         >
           <Icon name="warning sign" />
           <Step.Content>
@@ -119,9 +119,9 @@ function CompetitionResultSubmission({
         </Step>
         <Step
           active={activeStep === 2}
-          completed={activeStep > 2}
+          completed={areResultsSubmitted}
           onClick={() => setActiveStep(2)}
-          disabled={areResultsSubmitted}
+          disabled={areResultsSubmitted || !hasTemporaryResults || !areValidationsConfirmed}
         >
           <Icon name="cloud upload" />
           <Step.Content>

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { List, Message } from 'semantic-ui-react';
-import { ImportResultsData } from './ImportResultsData';
+import ImportResultsData from './ImportResultsData';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
 import FormToWrt from './FormToWrt';
 

--- a/app/webpacker/components/CompetitionResultSubmission/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Icon, Message, Step } from 'semantic-ui-react';
 import ImportResultsData from './ImportResultsData';
 import WCAQueryClientProvider from '../../lib/providers/WCAQueryClientProvider';
@@ -34,7 +34,9 @@ function CompetitionResultSubmission({
   showWcaLiveBeta,
   canSubmitResults,
 }) {
-  if (resultsSubmitted) {
+  const [activeStep, setActiveStep] = useState(0);
+
+  if (!resultsSubmitted) {
     return (
       <Message positive>
         The results have already been submitted. If you have any more questions or
@@ -45,8 +47,12 @@ function CompetitionResultSubmission({
 
   return (
     <>
-      <Step.Group ordered widths={3}>
-        <Step>
+      <Step.Group widths={3}>
+        <Step
+          active={activeStep === 0}
+          completed={activeStep > 0}
+          onClick={() => setActiveStep(0)}
+        >
           <Icon name="cloud upload" />
           <Step.Content>
             <Step.Title>Results Data</Step.Title>
@@ -56,14 +62,22 @@ function CompetitionResultSubmission({
             </Step.Description>
           </Step.Content>
         </Step>
-        <Step>
+        <Step
+          active={activeStep === 1}
+          completed={activeStep > 1}
+          onClick={() => setActiveStep(1)}
+        >
           <Icon name="warning sign" />
           <Step.Content>
             <Step.Title>Validations</Step.Title>
             <Step.Description>Address any warnings or errors</Step.Description>
           </Step.Content>
         </Step>
-        <Step>
+        <Step
+          active={activeStep === 2}
+          completed={activeStep > 2}
+          onClick={() => setActiveStep(2)}
+        >
           <Icon name="cloud upload" />
           <Step.Content>
             <Step.Title>Submit</Step.Title>
@@ -71,13 +85,15 @@ function CompetitionResultSubmission({
           </Step.Content>
         </Step>
       </Step.Group>
-      <ImportResultsData
-        competitionId={competitionId}
-        uploadedScrambleFilesCount={uploadedScrambleFilesCount}
-        hasTemporaryResults={hasTemporaryResults}
-        showWcaLiveBeta={showWcaLiveBeta}
-      />
-      {hasTemporaryResults && (
+      {activeStep === 0 && (
+        <ImportResultsData
+          competitionId={competitionId}
+          uploadedScrambleFilesCount={uploadedScrambleFilesCount}
+          hasTemporaryResults={hasTemporaryResults}
+          showWcaLiveBeta={showWcaLiveBeta}
+        />
+      )}
+      {activeStep === 2 && (
         <FormToWrt competitionId={competitionId} canSubmitResults={canSubmitResults} />
       )}
     </>


### PR DESCRIPTION
The existing "Submit Results" panel for Delegates is essentially a three-step process:
1. Upload a JSON file [or in the future: Use TNoodle results]
2. Check validation warnings and errors. Confirm that everything is fine
3. Add a message to WRT and confirm final submission

So I redid the UI using SemUI `Step` component :D

## Upload step
<img width="2560" height="691" alt="image" src="https://github.com/user-attachments/assets/8a8fc358-5e24-499b-8691-8d112fbc22c6" />

## Validations step
<img width="2560" height="1252" alt="image" src="https://github.com/user-attachments/assets/d2d058fb-f84c-41db-bf56-a8080e882774" />

After fixing all errors, a "Continue" button appears
<img width="2560" height="1029" alt="image" src="https://github.com/user-attachments/assets/0b9a07cc-387c-4a6b-9e20-6750994817fd" />

## 'Message to WRT' step
<img width="2560" height="1029" alt="image" src="https://github.com/user-attachments/assets/4f3902c1-34ca-43d2-b2a2-b7ab8f9cfb0d" />


