### PR TITLE
Fix Combobox not updating on websocket updates

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/rounds/[roundId]/admin/AddPerson.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/rounds/[roundId]/admin/AddPerson.tsx
@@ -6,14 +6,14 @@ import {
   Button,
   CloseButton,
   Combobox,
+  createListCollection,
   Dialog,
   Portal,
   Text,
-  useListCollection,
   VStack,
 } from "@chakra-ui/react";
 import { LiveCompetitor } from "@/types/live";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useT } from "@/lib/i18n/useI18n";
 import Loading from "@/components/ui/loading";
 import { RegistrationData } from "@/types/registrations";
@@ -124,16 +124,29 @@ function AddPersonCombobox({
 }) {
   const { t } = useT();
 
-  const { collection, filter } = useListCollection({
-    initialItems: registrations.toSorted(
-      (a, b) => a.registrant_id - b.registrant_id,
-    ),
-    itemToValue: (competitor) => competitor.id.toString(),
-    itemToString: (competitor) => competitor.user.name,
-    filter: (itemText, filterText, item) =>
-      itemText.toLowerCase().includes(filterText.toLowerCase()) ||
-      parseInt(filterText, 10) === item.registrant_id,
-  });
+  const [filterText, setFilterText] = useState("");
+
+  // Derived from `registrations` (instead of useListCollection's mount-time
+  // snapshot) so the list stays correct when the dialog is reopened after
+  // competitors were added or quit (the dialog stays mounted via lazyMount).
+  const collection = useMemo(() => {
+    const items = registrations
+      .toSorted((a, b) => a.registrant_id - b.registrant_id)
+      .filter(
+        (competitor) =>
+          !filterText ||
+          competitor.user.name
+            .toLowerCase()
+            .includes(filterText.toLowerCase()) ||
+          parseInt(filterText, 10) === competitor.registrant_id,
+      );
+
+    return createListCollection({
+      items,
+      itemToValue: (competitor) => competitor.id.toString(),
+      itemToString: (competitor) => competitor.user.name,
+    });
+  }, [registrations, filterText]);
 
   const isDualRound = coLinkedStatus.length > 0;
 
@@ -150,7 +163,7 @@ function AddPersonCombobox({
       <Combobox.Root
         collection={collection}
         inputBehavior="autohighlight"
-        onInputValueChange={(e) => filter(e.inputValue)}
+        onInputValueChange={(e) => setFilterText(e.inputValue)}
         onValueChange={(e) => setSelectedCompetitor(parseInt(e.value[0], 10))}
       >
         <Combobox.Control>

--- a/next-frontend/src/components/live/AttemptsForm.tsx
+++ b/next-frontend/src/components/live/AttemptsForm.tsx
@@ -3,9 +3,9 @@ import {
   Button,
   Checkbox,
   Combobox,
+  createListCollection,
   Heading,
   Portal,
-  useListCollection,
   VStack,
   Text,
 } from "@chakra-ui/react";
@@ -14,7 +14,13 @@ import _ from "lodash";
 import { useResultsAdmin } from "@/providers/LiveResultAdminProvider";
 import { useLiveResults } from "@/providers/LiveResultProvider";
 import { LiveCompetitor } from "@/types/live";
-import { useCallback, useImperativeHandle, useRef } from "react";
+import {
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { flushSync } from "react-dom";
 import type { KeyboardEvent, ReactNode, Ref } from "react";
 import { attemptResultsWarning, meetsCutoff } from "@/lib/live/attempt-result";
@@ -60,16 +66,28 @@ export default function AttemptsForm({ header }: AttemptsFormProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const attemptFieldsRef = useRef<AttemptFieldsNavHandle>(null);
 
-  const { collection, filter } = useListCollection({
-    initialItems: Array.from(competitors.values()).toSorted(
-      (a, b) => a.registrant_id - b.registrant_id,
-    ),
-    itemToValue: (competitor) => competitor.id.toString(),
-    itemToString: toCompetitorString,
-    filter: (itemText, filterText, item) =>
-      itemText.toLowerCase().includes(filterText.toLowerCase()) ||
-      parseInt(filterText, 10) === item.registrant_id,
-  });
+  const [filterText, setFilterText] = useState("");
+
+  // Derived from `competitors` (instead of useListCollection's mount-time
+  // snapshot) so websocket updates like quits are reflected in the dropdown.
+  const collection = useMemo(() => {
+    const items = Array.from(competitors.values())
+      .toSorted((a, b) => a.registrant_id - b.registrant_id)
+      .filter(
+        (competitor) =>
+          !filterText ||
+          toCompetitorString(competitor)
+            .toLowerCase()
+            .includes(filterText.toLowerCase()) ||
+          parseInt(filterText, 10) === competitor.registrant_id,
+      );
+
+    return createListCollection({
+      items,
+      itemToValue: (competitor) => competitor.id.toString(),
+      itemToString: toCompetitorString,
+    });
+  }, [competitors, filterText]);
 
   const selectedCompetitor = registrationId
     ? competitors.get(registrationId)
@@ -118,7 +136,7 @@ export default function AttemptsForm({ header }: AttemptsFormProps) {
       <VStack align="left">
         <Combobox.Root
           collection={collection}
-          onInputValueChange={(e) => filter(e.inputValue)}
+          onInputValueChange={(e) => setFilterText(e.inputValue)}
           inputValue={inputDisplayValue}
           onValueChange={(e) => {
             if (e.value.length > 0) {


### PR DESCRIPTION
if you pass list collection an initialItems and update it, it will not update without doing something like
```
const { collection, filter, set } = useListCollection({ ... });                                                                                  
                                                                                                                                                   
  useEffect(() => {                                                                                                                                
    set(Array.from(competitors.values()).toSorted(                                                                                                 
      (a, b) => a.registrant_id - b.registrant_id,                                                                                                 
    ));                                                                                                                                            
  }, [competitors, set]);
```
because it's just the initial data.
I wanted to avoid the useEffect so I switched to using a memo + createSetCollection