### PR TITLE
Allow selecting Linked Round siblings for cumulative time limits

### DIFF
--- a/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/SelectRoundsModal.js
+++ b/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/SelectRoundsModal.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Checkbox, Form, Popup } from 'semantic-ui-react';
 import { events } from '../../../../lib/wca-data.js.erb';
 import { useStore } from '../../../../lib/providers/StoreProvider';
@@ -51,7 +51,7 @@ export default function SelectRoundsModal({ timeLimit, currentRound, onOk }) {
     //   whose time limit is currently being edited. Limit for *sibling* Dual Rounds.
     return wcifEvent.rounds.filter(
       (otherRound) => otherRound.id !== currentRound.id
-        && currentRoundLinkedIds.includes(otherRound.id)
+        && currentRoundLinkedIds.includes(otherRound.id),
     );
   }));
 
@@ -67,6 +67,37 @@ export default function SelectRoundsModal({ timeLimit, currentRound, onOk }) {
     }
   };
 
+  const getDisabledReason = useCallback((roundId, isChecked) => {
+    if (isChecked) {
+      return null; // Checked boxes can always be un-checked
+    }
+
+    const { eventId } = parseActivityCode(roundId);
+    const event = events.byId[eventId];
+
+    const eventAlreadySelected = selectedRoundIds.some((selectedRoundId) => (
+      parseActivityCode(selectedRoundId).eventId === eventId
+    ));
+
+    const isLinkedSibling = roundId !== currentRound.id && currentRoundLinkedIds.includes(roundId);
+
+    if (eventAlreadySelected && !isLinkedSibling) {
+      return `Cannot select this round because you've already selected a round with ${event.name}`;
+    }
+
+    const linkedSiblingAlreadySelected = selectedRoundIds.some((selectedRoundId) => (
+      selectedRoundId !== currentRound.id && currentRoundLinkedIds.includes(selectedRoundId)
+    ));
+
+    if (linkedSiblingAlreadySelected && !eventAlreadySelected) {
+      const currentPanelEvent = events.byId[currentRoundEventId];
+
+      return `Cannot select this round because you've already selected a Dual Round shared round with ${currentPanelEvent.name}`;
+    }
+
+    return null;
+  }, [currentRound.id, selectedRoundIds, currentRoundEventId, currentRoundLinkedIds]);
+
   return (
     <ButtonActivatedModal
       title={Title}
@@ -78,16 +109,10 @@ export default function SelectRoundsModal({ timeLimit, currentRound, onOk }) {
     >
       {wcifRounds.map((wcifRound) => {
         const roundId = wcifRound.id;
-        const { eventId } = parseActivityCode(roundId);
-        const event = events.byId[eventId];
-        const checked = selectedRoundIds.indexOf(roundId) > -1;
+        const isChecked = selectedRoundIds.includes(roundId);
 
-        const eventAlreadySelected = !!selectedRoundIds.find((selectedRoundId) => (
-          parseActivityCode(selectedRoundId).eventId === eventId
-        ));
-
-        const disabled = !checked && eventAlreadySelected;
-        const disabledReason = disabled ? `Cannot select this round because you've already selected a round with ${event.name}` : null;
+        const disabledReason = getDisabledReason(roundId, isChecked);
+        const disabled = disabledReason !== null;
 
         return (
           <Form.Field key={roundId}>
@@ -100,7 +125,7 @@ export default function SelectRoundsModal({ timeLimit, currentRound, onOk }) {
                   name="round-id-radio-group"
                   label={roundIdToString(roundId)}
                   value={roundId}
-                  checked={checked}
+                  checked={isChecked}
                   onClick={handleChecked}
                   disabled={disabled}
                 />

--- a/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/SelectRoundsModal.js
+++ b/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/SelectRoundsModal.js
@@ -6,7 +6,7 @@ import { useStore } from '../../../../lib/providers/StoreProvider';
 import { parseActivityCode, roundIdToString } from '../../../../lib/utils/wcif';
 import ButtonActivatedModal from '../ButtonActivatedModal';
 
-export default function SelectRoundsModal({ timeLimit, excludeEventId, onOk }) {
+export default function SelectRoundsModal({ timeLimit, currentRound, onOk }) {
   const { wcifEvents } = useStore();
   const [selectedRoundIds, setSelectedRoundIds] = useState(timeLimit.cumulativeRoundIds);
 
@@ -22,6 +22,9 @@ export default function SelectRoundsModal({ timeLimit, excludeEventId, onOk }) {
     </span>
   ), []);
 
+  const currentRoundEventId = parseActivityCode(currentRound.id).eventId;
+  const currentRoundLinkedIds = currentRound.linkedRounds ?? [];
+
   const handleOk = () => onOk(selectedRoundIds);
 
   const reset = () => {
@@ -32,13 +35,24 @@ export default function SelectRoundsModal({ timeLimit, excludeEventId, onOk }) {
 
   const wcifRounds = _.compact(_.flatMap(wcifEvents, (wcifEvent) => {
     // Cross round cumulative time limits may not include other rounds of
-    // the same event.
-    // See https://github.com/thewca/wca-regulations/issues/457.
+    //   the same event, except for Dual Rounds.
+    // See https://github.com/thewca/wca-regulations/issues/457
+    //  and https://www.worldcubeassociation.org/regulations/#A1a2
     const otherEvent = events.byId[wcifEvent.id];
-    if (!otherEvent.canChangeTimeLimit || excludeEventId === wcifEvent.id) {
+    if (!otherEvent.canChangeTimeLimit) {
       return [];
     }
-    return wcifEvent.rounds;
+    // If we're considering a different event, then all rounds
+    //   of that other event are eligible for sharing the time limit
+    if (wcifEvent.id !== currentRoundEventId) {
+      return wcifEvent.rounds;
+    }
+    // If we reached here, we know this is the same event as the round
+    //   whose time limit is currently being edited. Limit for *sibling* Dual Rounds.
+    return wcifEvent.rounds.filter(
+      (otherRound) => otherRound.id !== currentRound.id
+        && currentRoundLinkedIds.includes(otherRound.id)
+    );
   }));
 
   const handleChecked = (_ev, data) => {

--- a/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/TimeLimitDescription.js
+++ b/app/webpacker/components/EditEvents/Modals/EditTimeLimitModal/TimeLimitDescription.js
@@ -37,7 +37,7 @@ export default function TimeLimitDescription({ wcifRound, timeLimit, onOk }) {
           <br />
           The button below allows you to share this cumulative time limit with other rounds.
         </span>
-        <SelectRoundsModal excludeEventId={wcifRound.id.split('-')[0]} timeLimit={timeLimit} onOk={onOk} />
+        <SelectRoundsModal currentRound={wcifRound} timeLimit={timeLimit} onOk={onOk} />
       </>
     );
   }
@@ -65,7 +65,7 @@ export default function TimeLimitDescription({ wcifRound, timeLimit, onOk }) {
           ))}
         </ul>
       </span>
-      <SelectRoundsModal excludeEventId={wcifRound.id.split('-')[0]} timeLimit={timeLimit} onOk={onOk} />
+      <SelectRoundsModal currentRound={wcifRound} timeLimit={timeLimit} onOk={onOk} />
     </>
   );
 }


### PR DESCRIPTION
The mutual exclusion logic of `A1a2` was really blown out of the water by Dual Rounds. I _think_(??) this PR does what it should(??) in terms of cumulative selection, but it's really hard to grasp all of the subtleties.

Consultation with WRC may be required. I want to make sure this draft does what it should, before adding automated test cases (because if I immediately add test cases now, these might prove to be irrelevant because I misunderstood something)