### PR TITLE
Update edit profile form with detailed instructions regarding proof o…

### DIFF
--- a/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileForm.jsx
+++ b/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileForm.jsx
@@ -111,21 +111,31 @@ export default function EditProfileForm({
           onReasonChange={handleEditReasonChange}
         />
       ))}
+      <Message warning>
+        <Message.Header>IMPORTANT</Message.Header>
+        <Message.List>
+          <Message.Item>
+            Proof is not required when you change your first name or gender.
+          </Message.Item>
+          <Message.Item>
+            If you are changing your last name, region of representation, or birthdate, please
+            upload a
+            {' '}
+            <u>legal document</u>
+            {' '}
+            (e.g., identity card, driver&apos;s licence, passport, marriage certificate, etc.)
+            {' '}
+            that validates the requested field. Feel free to blur-out/obfuscate any other
+            {' '}
+            personal data on the identification.
+          </Message.Item>
+        </Message.List>
+      </Message>
       <Form.Input
         label={I18n.t('page.contact_edit_profile.form.proof_attach.label')}
         type="file"
         onChange={handleProofUpload}
       />
-      <Message warning>
-        <strong>IMPORTANT</strong>
-        : Attach a picture of a
-        {' '}
-        <u>legal document</u>
-        {' '}
-        (identity card, driver license, passport...) that validates the requested fields;
-        {' '}
-        feel free to blur-out/obfuscate any other personal data on the identification.
-      </Message>
       <Form.Field>
         <ReCAPTCHA
           sitekey={recaptchaPublicKey}

--- a/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileForm.jsx
+++ b/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileForm.jsx
@@ -7,6 +7,7 @@ import { contactEditProfileActionUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../../components/Requests/Loading';
 import useSaveAction from '../../lib/hooks/useSaveAction';
 import useCheckboxState from '../../lib/hooks/useCheckboxState';
+import useLoggedInUserPermissions from '../../lib/hooks/useLoggedInUserPermissions';
 import EditNameField from './fields/EditNameField';
 import EditRegionField from './fields/EditRegionField';
 import EditGenderField from './fields/EditGenderField';
@@ -38,6 +39,9 @@ export default function EditProfileForm({
   const [saveError, setSaveError] = useState();
   const [verified, setVerified] = useCheckboxState(false);
   const { save, saving } = useSaveAction();
+  const { loggedInUserPermissions } = useLoggedInUserPermissions();
+
+  const isProofOptional = loggedInUserPermissions?.canRequestToEditOthersProfile;
 
   const hasFieldBeenChanged = useCallback((field) => !_.isEqual(
     profileDetails?.[field],
@@ -56,7 +60,14 @@ export default function EditProfileForm({
     );
 
     return noChanges || hasMissingReason;
-  }, [captchaValue, editOthersProfileMode, verified, editedProfileDetails, hasFieldBeenChanged, profileDetails]);
+  }, [
+    captchaValue,
+    editOthersProfileMode,
+    verified,
+    editedProfileDetails,
+    hasFieldBeenChanged,
+    profileDetails,
+  ]);
 
   const handleValueChange = (_event, { name, value }) => {
     setEditedProfileDetails((prev) => ({
@@ -117,6 +128,14 @@ export default function EditProfileForm({
       ))}
       <Message warning>
         <Message.Header>IMPORTANT</Message.Header>
+        {isProofOptional && (
+          <p>
+            <strong>
+              Note: Since you are an authorized user, attaching proof is optional for you. However,
+              the following are the usual requirements that you need to validate:
+            </strong>
+          </p>
+        )}
         <Message.List>
           <Message.Item>
             Proof is not required when you change your first name or gender.
@@ -136,7 +155,7 @@ export default function EditProfileForm({
         </Message.List>
       </Message>
       <Form.Input
-        label={I18n.t('page.contact_edit_profile.form.proof_attach.label')}
+        label={`${I18n.t('page.contact_edit_profile.form.proof_attach.label')}${isProofOptional ? ' (optional for authorized users)' : ''}`}
         type="file"
         onChange={handleProofUpload}
       />

--- a/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileForm.jsx
+++ b/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileForm.jsx
@@ -6,6 +6,7 @@ import I18n from '../../lib/i18n';
 import { contactEditProfileActionUrl } from '../../lib/requests/routes.js.erb';
 import Loading from '../../components/Requests/Loading';
 import useSaveAction from '../../lib/hooks/useSaveAction';
+import useCheckboxState from '../../lib/hooks/useCheckboxState';
 import EditNameField from './fields/EditNameField';
 import EditRegionField from './fields/EditRegionField';
 import EditGenderField from './fields/EditGenderField';
@@ -20,6 +21,7 @@ const EDITABLE_FIELDS = [
 
 export default function EditProfileForm({
   wcaId,
+  editOthersProfileMode,
   profileDetails,
   onContactSuccess,
   recaptchaPublicKey,
@@ -34,6 +36,7 @@ export default function EditProfileForm({
   const [captchaValue, setCaptchaValue] = useState();
   const [captchaError, setCaptchaError] = useState(false);
   const [saveError, setSaveError] = useState();
+  const [verified, setVerified] = useCheckboxState(false);
   const { save, saving } = useSaveAction();
 
   const hasFieldBeenChanged = useCallback((field) => !_.isEqual(
@@ -43,6 +46,7 @@ export default function EditProfileForm({
 
   const isSubmitDisabled = useMemo(() => {
     if (!profileDetails || !captchaValue) return true;
+    if (editOthersProfileMode && !verified) return true;
 
     const changedFields = Object.keys(editedProfileDetails).filter(hasFieldBeenChanged);
 
@@ -52,7 +56,7 @@ export default function EditProfileForm({
     );
 
     return noChanges || hasMissingReason;
-  }, [captchaValue, editedProfileDetails, hasFieldBeenChanged, profileDetails]);
+  }, [captchaValue, editOthersProfileMode, verified, editedProfileDetails, hasFieldBeenChanged, profileDetails]);
 
   const handleValueChange = (_event, { name, value }) => {
     setEditedProfileDetails((prev) => ({
@@ -152,6 +156,13 @@ export default function EditProfileForm({
           />
         )}
       </Form.Field>
+      {editOthersProfileMode && (
+        <Form.Checkbox
+          label={I18n.t('page.contact_edit_profile.form.verified_checkbox.label')}
+          checked={verified}
+          onChange={setVerified}
+        />
+      )}
       <Form.Button
         type="submit"
         disabled={isSubmitDisabled}

--- a/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileFormHolder.jsx
+++ b/app/webpacker/react_on_rails_components/ContactEditProfilePage/EditProfileFormHolder.jsx
@@ -8,6 +8,7 @@ import EditProfileForm from './EditProfileForm';
 
 export default function EditProfileFormHolder({
   wcaId,
+  editOthersProfileMode,
   onContactSuccess,
   recaptchaPublicKey,
 }) {
@@ -24,6 +25,7 @@ export default function EditProfileFormHolder({
   return (
     <EditProfileForm
       wcaId={wcaId}
+      editOthersProfileMode={editOthersProfileMode}
       profileDetails={profileDetails}
       onContactSuccess={onContactSuccess}
       recaptchaPublicKey={recaptchaPublicKey}

--- a/app/webpacker/react_on_rails_components/ContactEditProfilePage/index.jsx
+++ b/app/webpacker/react_on_rails_components/ContactEditProfilePage/index.jsx
@@ -104,6 +104,7 @@ function ContactEditProfilePage({ loggedInUserId, recaptchaPublicKey }) {
       {wcaId && (
         <EditProfileFormHolder
           wcaId={wcaId}
+          editOthersProfileMode={editOthersProfileMode}
           onContactSuccess={(res) => {
             setContactSuccess(true);
             setTicketId(res?.ticket_id);

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,6 +912,8 @@ en:
           label: "Submit Edit Request"
         captcha:
           validation_error: "Please verify that you are not a robot."
+        verified_checkbox:
+          label: "By submitting this form, you confirm that you have already reviewed their legal document and verified the information provided."
       success_message: "Request submitted - we'll get back to you soon."
       success_message_with_ticket_link_html: "Request submitted - we'll get back to you soon. To view the status of this request, please visit <a href=\"%{link}\">this link</a>."
   #context: Key used on the website homepage


### PR DESCRIPTION
…f identity requirements

This was a feedback from @sarahstrong314.

### Screenshots:
Authorized user requesting for themselves:
<img width="782" height="774" alt="Screenshot 2026-07-04 at 11 50 16" src="https://github.com/user-attachments/assets/ffe7120e-0b60-4c9c-9af2-f42da38dba5f" />

Authorized user requesting for others (see the additional checkbox as well at the end):
<img width="796" height="735" alt="Screenshot 2026-07-04 at 11 51 27" src="https://github.com/user-attachments/assets/edc1f124-6cb0-41dc-bc3d-f91e743664a3" />

Other users:
<img width="752" height="743" alt="Screenshot 2026-07-04 at 11 52 42" src="https://github.com/user-attachments/assets/5acc8af5-b874-4b77-a251-b38a7a82c44d" />
