### PR TITLE
Pre-validate WCA ID generation and add UI indicators for semi-ID edits

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -310,9 +310,7 @@ class TicketsController < ApplicationController
       semi_id = data["editedSemiId"]
 
       new_wca_id, wca_id_index = FinishUnfinishedPersons.next_available_wca_id(semi_id, wca_id_index)
-      if new_wca_id.blank?
-        return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{semi_id}" }
-      end
+      return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{semi_id}" } if new_wca_id.blank?
 
       wca_ids_by_person[person_id] = new_wca_id
     end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -309,7 +309,7 @@ class TicketsController < ApplicationController
     end
 
     invalid_data = person_wca_id_data.find { |data| wca_ids_by_person[data["personId"]].nil? }
-    return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{invalid_data["editedSemiId"]}" } if invalid_data
+    return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{invalid_data['editedSemiId']}" } if invalid_data
 
     ActiveRecord::Base.transaction do
       person_wca_id_data.each do |data|

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -301,16 +301,26 @@ class TicketsController < ApplicationController
       return render status: :not_found, json: { error: "Registration with registrant ID #{person_id} not found for competition #{competition.id}" }
     end
 
-    ActiveRecord::Base.transaction do
-      # memoize all WCA IDs, especially useful if we have several identical semi-IDs in the same batch
-      # (siblings with the same last name competing as newcomers at the same competition etc.)
-      wca_id_index = Person.pluck(:wca_id)
+    # Compute all WCA IDs beforehand to ensure they are valid.
+    wca_ids_by_person = {}
+    wca_id_index = Person.pluck(:wca_id)
 
+    person_wca_id_data.each do |data|
+      person_id = data["personId"]
+      semi_id = data["editedSemiId"]
+
+      new_wca_id, wca_id_index = FinishUnfinishedPersons.next_available_wca_id(semi_id, wca_id_index)
+      if new_wca_id.blank?
+        return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{semi_id}" }
+      end
+
+      wca_ids_by_person[person_id] = new_wca_id
+    end
+
+    ActiveRecord::Base.transaction do
       person_wca_id_data.each do |data|
         person_id = data["personId"]
-        semi_id = data["editedSemiId"]
-
-        new_wca_id, wca_id_index = FinishUnfinishedPersons.complete_wca_id(semi_id, wca_id_index)
+        new_wca_id = wca_ids_by_person[person_id]
 
         registration = competition.registrations.find_by(registrant_id: person_id)
 

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -302,18 +302,14 @@ class TicketsController < ApplicationController
     end
 
     # Compute all WCA IDs beforehand to ensure they are valid.
-    wca_ids_by_person = {}
     wca_id_index = Person.pluck(:wca_id)
-
-    person_wca_id_data.each do |data|
-      person_id = data["personId"]
-      semi_id = data["editedSemiId"]
-
-      new_wca_id, wca_id_index = FinishUnfinishedPersons.next_available_wca_id(semi_id, wca_id_index)
-      return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{semi_id}" } if new_wca_id.blank?
-
-      wca_ids_by_person[person_id] = new_wca_id
+    wca_ids_by_person = person_wca_id_data.index_by { |d| d["personId"] }.transform_values do |data|
+      new_wca_id, wca_id_index = FinishUnfinishedPersons.next_available_wca_id(data["editedSemiId"], wca_id_index)
+      new_wca_id
     end
+
+    invalid_data = person_wca_id_data.find { |data| wca_ids_by_person[data["personId"]].blank? }
+    return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{invalid_data["editedSemiId"]}" } if invalid_data
 
     ActiveRecord::Base.transaction do
       person_wca_id_data.each do |data|

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -308,7 +308,7 @@ class TicketsController < ApplicationController
       new_wca_id
     end
 
-    invalid_data = person_wca_id_data.find { |data| wca_ids_by_person[data["personId"]].blank? }
+    invalid_data = person_wca_id_data.find { |data| wca_ids_by_person[data["personId"]].nil? }
     return render status: :unprocessable_content, json: { error: "Could not compute a WCA ID suffix for #{invalid_data["editedSemiId"]}" } if invalid_data
 
     ActiveRecord::Base.transaction do

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/CreateWcaIds.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/CreateWcaIds.jsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Table, Input, Button } from 'semantic-ui-react';
+import {
+  Table, Input, Button, Label,
+} from 'semantic-ui-react';
 import { keyBy, mapValues } from 'lodash';
 import getUnfinishedPersons from '../../api/competitionResult/getUnfinishedPersons';
 import createWcaIds from '../../api/competitionResult/createWcaIds';
@@ -46,19 +48,27 @@ export default function CreateWcaIds({ ticketDetails, currentStakeholder }) {
     },
   });
 
+  useEffect(() => {
+    if (isMutationError) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [isMutationError]);
+
   if (isFetching || isPending) return <Loading />;
   if (isError) return <Errored error={error} />;
-  if (isMutationError) return <Errored error={mutationError} />;
 
   return (
-    <UnfinishedPersonsTable
-      persons={unfinishedPersons?.persons_to_finish || []}
-      onSubmit={(unfinishedPersonsData) => createWcaIdsMutate({
-        ticketId: id,
-        actingStakeholderId: currentStakeholder.id,
-        unfinishedPersons: unfinishedPersonsData,
-      })}
-    />
+    <>
+      {isMutationError && <Errored error={mutationError} />}
+      <UnfinishedPersonsTable
+        persons={unfinishedPersons?.persons_to_finish || []}
+        onSubmit={(unfinishedPersonsData) => createWcaIdsMutate({
+          ticketId: id,
+          actingStakeholderId: currentStakeholder.id,
+          unfinishedPersons: unfinishedPersonsData,
+        })}
+      />
+    </>
   );
 }
 
@@ -80,6 +90,14 @@ function UnfinishedPersonsTable({ persons, onSubmit }) {
     }));
   };
 
+  const isEdited = (person) => {
+    const data = unfinishedPersonsData[person.person_id];
+    return data && data.editedSemiId !== person.computed_semi_id;
+  };
+
+  const editedCount = persons.filter(isEdited).length;
+  const nonEditedCount = persons.length - editedCount;
+
   return (
     <>
       <Table celled>
@@ -91,20 +109,41 @@ function UnfinishedPersonsTable({ persons, onSubmit }) {
         </Table.Header>
 
         <Table.Body>
-          {persons.map((person, index) => (
-            <Table.Row key={person.person_id || index}>
-              <Table.Cell>{person.person_name}</Table.Cell>
-              <Table.Cell>
-                <Input
-                  value={unfinishedPersonsData[person.person_id]?.editedSemiId || ''}
-                  onChange={(e) => handleSemiIdChange(person.person_id, e.target.value)}
-                  fluid
-                />
-              </Table.Cell>
-            </Table.Row>
-          ))}
+          {persons.map((person, index) => {
+            const hasBeenEdited = isEdited(person);
+            return (
+              <Table.Row key={person.person_id || index}>
+                <Table.Cell>{person.person_name}</Table.Cell>
+                <Table.Cell>
+                  <Input
+                    value={unfinishedPersonsData[person.person_id]?.editedSemiId || ''}
+                    onChange={(e) => handleSemiIdChange(person.person_id, e.target.value)}
+                    fluid
+                  />
+                  {hasBeenEdited && (
+                    <Label basic color="orange" pointing size="small">
+                      Edited (originally:
+                      {' '}
+                      {person.computed_semi_id}
+                      )
+                    </Label>
+                  )}
+                </Table.Cell>
+              </Table.Row>
+            );
+          })}
         </Table.Body>
       </Table>
+      <Label.Group>
+        <Label color="orange">
+          Edited
+          <Label.Detail>{editedCount}</Label.Detail>
+        </Label>
+        <Label color="grey">
+          Non-edited
+          <Label.Detail>{nonEditedCount}</Label.Detail>
+        </Label>
+      </Label.Group>
       <Button
         primary
         onClick={() => onSubmit(Object.values(unfinishedPersonsData))}

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/CreateWcaIds.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/CreateWcaIds.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Table, Input, Button, Label,
@@ -21,6 +21,9 @@ export default function CreateWcaIds({ ticketDetails, currentStakeholder, unfini
     error: mutationError,
   } = useMutation({
     mutationFn: createWcaIds,
+    onError: () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    },
     onSuccess: () => {
       queryClient.setQueryData(
         ['ticket-details', id],
@@ -34,12 +37,6 @@ export default function CreateWcaIds({ ticketDetails, currentStakeholder, unfini
       queryClient.setQueryData(['imported-temporary-scrambles', competitionId], []);
     },
   });
-
-  useEffect(() => {
-    if (isMutationError) {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-  }, [isMutationError]);
 
   if (isPending) return <Loading />;
 

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/CreateWcaIds.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/CreateWcaIds.jsx
@@ -1,31 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   Table, Input, Button, Label,
 } from 'semantic-ui-react';
 import { keyBy, mapValues } from 'lodash';
-import getUnfinishedPersons from '../../api/competitionResult/getUnfinishedPersons';
 import createWcaIds from '../../api/competitionResult/createWcaIds';
 import Loading from '../../../Requests/Loading';
 import Errored from '../../../Requests/Errored';
 import { ticketsCompetitionResultStatuses } from '../../../../lib/wca-data.js.erb';
 import { updateTicketMetadata } from '../../../../lib/helpers/update-ticket-query-data';
 
-export default function CreateWcaIds({ ticketDetails, currentStakeholder }) {
+export default function CreateWcaIds({ ticketDetails, currentStakeholder, unfinishedPersons }) {
   const { ticket: { id, metadata: { competition: { id: competitionId } } } } = ticketDetails;
   const queryClient = useQueryClient();
-
-  const {
-    data: unfinishedPersons,
-    isFetching,
-    isError,
-    error,
-  } = useQuery({
-    queryKey: ['unfinished-persons', competitionId],
-    queryFn: () => getUnfinishedPersons({
-      competitionId,
-    }),
-  });
 
   const {
     mutate: createWcaIdsMutate,
@@ -54,8 +41,7 @@ export default function CreateWcaIds({ ticketDetails, currentStakeholder }) {
     }
   }, [isMutationError]);
 
-  if (isFetching || isPending) return <Loading />;
-  if (isError) return <Errored error={error} />;
+  if (isPending) return <Loading />;
 
   return (
     <>

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/index.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DateTime } from 'luxon';
+import { useQuery } from '@tanstack/react-query';
 import { ticketsCompetitionResultStatuses } from '../../../../lib/wca-data.js.erb';
 import WarningsVerification from './WarningsVerification';
 import TimelineView from './TimelineView';
@@ -9,9 +10,31 @@ import CreateWcaIds from './CreateWcaIds';
 import FinalSteps from './FinalSteps';
 import MiscActions from './MiscActions';
 import I18n from '../../../../lib/i18n';
+import getUnfinishedPersons from '../../api/competitionResult/getUnfinishedPersons';
+import Loading from '../../../Requests/Loading';
+import Errored from '../../../Requests/Errored';
 
 export default function CompetitionResultActionerView({ ticketDetails, currentStakeholder }) {
-  const { ticket: { metadata: { status } } } = ticketDetails;
+  const { ticket: { metadata: { status, competition: { id: competitionId } } } } = ticketDetails;
+
+  const {
+    data: unfinishedPersons,
+    isFetching,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['unfinished-persons', competitionId],
+    queryFn: () => getUnfinishedPersons({
+      competitionId,
+    }),
+    enabled: !!competitionId && [
+      ticketsCompetitionResultStatuses.merged_inbox_scrambles,
+      ticketsCompetitionResultStatuses.newcomers_verified,
+    ].includes(status),
+  });
+
+  if (isFetching) return <Loading />;
+  if (isError) return <Errored error={error} />;
 
   return (
     <>
@@ -20,6 +43,7 @@ export default function CompetitionResultActionerView({ ticketDetails, currentSt
         status={status}
         ticketDetails={ticketDetails}
         currentStakeholder={currentStakeholder}
+        unfinishedPersons={unfinishedPersons}
       />
       <MiscActions
         ticketDetails={ticketDetails}
@@ -29,7 +53,10 @@ export default function CompetitionResultActionerView({ ticketDetails, currentSt
 }
 
 function ViewForStatus({
-  status, ticketDetails, currentStakeholder,
+  status,
+  ticketDetails,
+  currentStakeholder,
+  unfinishedPersons,
 }) {
   const {
     ticket: {
@@ -38,6 +65,10 @@ function ViewForStatus({
       },
     },
   } = ticketDetails;
+
+  const hasUnfinishedPersons = (
+    unfinishedPersons?.persons_to_finish && unfinishedPersons.persons_to_finish.length > 0
+  );
 
   switch (status) {
     case ticketsCompetitionResultStatuses.submitted:
@@ -68,6 +99,13 @@ function ViewForStatus({
       );
 
     case ticketsCompetitionResultStatuses.merged_inbox_scrambles:
+      if (!hasUnfinishedPersons) {
+        return (
+          <FinalSteps
+            ticketDetails={ticketDetails}
+          />
+        );
+      }
       return (
         <VerifyNewcomers
           ticketDetails={ticketDetails}
@@ -76,10 +114,18 @@ function ViewForStatus({
       );
 
     case ticketsCompetitionResultStatuses.newcomers_verified:
+      if (!hasUnfinishedPersons) {
+        return (
+          <FinalSteps
+            ticketDetails={ticketDetails}
+          />
+        );
+      }
       return (
         <CreateWcaIds
           ticketDetails={ticketDetails}
           currentStakeholder={currentStakeholder}
+          unfinishedPersons={unfinishedPersons}
         />
       );
     case ticketsCompetitionResultStatuses.created_wca_ids:

--- a/lib/finish_unfinished_persons.rb
+++ b/lib/finish_unfinished_persons.rb
@@ -170,7 +170,7 @@ module FinishUnfinishedPersons
     [semi_id, available_per_semi]
   end
 
-  def self.complete_wca_id(semi_id, used_ids = nil)
+  def self.next_available_wca_id(semi_id, used_ids = nil)
     used_ids ||= Person.where("wca_id LIKE ?", "#{semi_id}%").pluck(:wca_id)
 
     (1..99).each do |i|
@@ -182,7 +182,14 @@ module FinishUnfinishedPersons
       end
     end
 
-    raise "Could not compute a WCA ID suffix for #{semi_id}"
+    [nil, used_ids]
+  end
+
+  def self.complete_wca_id(semi_id, used_ids = nil)
+    new_id, used_ids = next_available_wca_id(semi_id, used_ids)
+    raise "Could not compute a WCA ID suffix for #{semi_id}" if new_id.nil?
+
+    [new_id, used_ids]
   end
 
   def self.insert_person(gender: :o, **attrs)


### PR DESCRIPTION
Raising this PR mainly for two reasons:
1. The UI currently doesn't show error properly if user enters wrong WCA ID semi ID
2. UI was not saying if the user has edited any WCA ID semi ID