### PR TITLE
Fix issue with disabling region

### DIFF
--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -43,6 +43,15 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
     render json: groups, methods: %w[lead_user]
   end
 
+  def show
+    user_group_id = params.require(:id)
+    user_group = UserGroup.find(user_group_id)
+
+    return head :unauthorized unless user_group.readable_by?(current_user)
+
+    render json: user_group
+  end
+
   def create
     group_type = params.require(:group_type)
     name = params.require(:name)
@@ -83,16 +92,7 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
         success: true,
       }
     else
-      render json: { error: user_group.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      render json: { error: user_group.errors.full_messages.join(", ") }, status: :unprocessable_content
     end
-  end
-
-  def show
-    user_group_id = params.require(:id)
-    user_group = UserGroup.find(user_group_id)
-
-    return head :unauthorized unless user_group.readable_by?(current_user)
-
-    render json: user_group
   end
 end

--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -69,10 +69,30 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
 
     return head :unauthorized unless current_user&.has_permission?(:can_edit_groups, user_group_id)
 
-    user_group.update!(user_group_params)
+    deactivating = user_group.is_active && user_group_params.key?(:is_active) && !ActiveRecord::Type::Boolean.new.cast(user_group_params[:is_active])
+    active_roles_to_end = deactivating ? user_group.active_roles.to_a : []
 
-    render json: {
-      success: true,
-    }
+    if user_group.update(user_group_params)
+      if deactivating
+        active_roles_to_end.each do |role|
+          RoleChangeMailer.notify_role_end(role, current_user).deliver_later
+        end
+      end
+
+      render json: {
+        success: true,
+      }
+    else
+      render json: { error: user_group.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    user_group_id = params.require(:id)
+    user_group = UserGroup.find(user_group_id)
+
+    return head :unauthorized unless user_group.readable_by?(current_user)
+
+    render json: user_group
   end
 end

--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -79,10 +79,11 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
     return head :unauthorized unless current_user&.has_permission?(:can_edit_groups, user_group_id)
 
     deactivating = user_group.is_active && user_group_params.key?(:is_active) && !ActiveRecord::Type::Boolean.new.cast(user_group_params[:is_active])
+    active_roles_to_end = deactivating ? user_group.active_roles.to_a : []
 
     if user_group.update(user_group_params)
       if deactivating
-        user_group.active_roles.find_each do |role|
+        active_roles_to_end.each do |role|
           RoleChangeMailer.notify_role_end(role, current_user).deliver_later
         end
       end

--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -79,7 +79,6 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
     return head :unauthorized unless current_user&.has_permission?(:can_edit_groups, user_group_id)
 
     deactivating = user_group.is_active && user_group_params.key?(:is_active) && !ActiveRecord::Type::Boolean.new.cast(user_group_params[:is_active])
-    active_roles_to_end = deactivating ? user_group.active_roles.to_a : []
 
     if user_group.update(user_group_params)
       if deactivating
@@ -92,7 +91,7 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
         success: true,
       }
     else
-      render json: { error: user_group.errors.full_messages.join(", ") }, status: :unprocessable_content
+      render json: { error: user_group.errors.full_messages }, status: :unprocessable_content
     end
   end
 end

--- a/app/controllers/api/v0/user_groups_controller.rb
+++ b/app/controllers/api/v0/user_groups_controller.rb
@@ -83,7 +83,7 @@ class Api::V0::UserGroupsController < Api::V0::ApiController
 
     if user_group.update(user_group_params)
       if deactivating
-        active_roles_to_end.each do |role|
+        user_group.active_roles.find_each do |role|
           RoleChangeMailer.notify_role_end(role, current_user).deliver_later
         end
       end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -38,6 +38,7 @@ class UserGroup < ApplicationRecord
   #   and thus the old memberships.
   # The `touch` makes it so that a small change to the metadata is written, which triggers an `after_commit` hook
   #   in our custom caching mechanism (see also concerns/cachable.rb)
+  before_validation :end_active_lead_roles, if: -> { is_active_changed? && !is_active }
   belongs_to :metadata, polymorphic: true, optional: true, touch: true
   belongs_to :parent_group, class_name: "UserGroup", optional: true
 
@@ -330,11 +331,27 @@ class UserGroup < ApplicationRecord
     metadata&.email
   end
 
+  def readable_by?(user)
+    return true unless is_hidden
+
+    return false if user.nil?
+
+    permission = is_active ? :can_read_groups_current : :can_read_groups_past
+    user.has_permission?(permission, id)
+  end
+
   DEFAULT_SERIALIZE_OPTIONS = {
     include: %w[metadata],
   }.freeze
 
   def serializable_hash(options = nil)
     super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+  end
+
+  private def end_active_lead_roles
+    active_roles.each do |role|
+      role.update!(end_date: Date.today) if role.lead?
+    end
+    active_roles.reset
   end
 end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -349,9 +349,8 @@ class UserGroup < ApplicationRecord
   end
 
   private def end_active_lead_roles
-    active_roles.each do |role|
-      role.update!(end_date: Date.today) if role.lead?
-    end
+    active_roles.select(&:lead?).each { |role| role.update!(end_date: Date.today) }
+    # Clear the association cache to prevent the absence validation from failing on stale data.
     active_roles.reset
   end
 end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -29,6 +29,8 @@ class UserGroup < ApplicationRecord
   has_many :direct_child_users, through: :direct_child_roles, source: :user
   has_many :active_direct_child_users, through: :active_direct_child_roles, source: :user
 
+  before_validation :end_active_lead_roles, if: -> { is_active_changed? && !is_active }
+
   # The `touch` is important because we generally access "semantic" UserGroups
   #   (ie T/Cs, DelegateRegions, Translators, etc.) through their metadata.
   #   This metadata however is cached, because we don't want to fire a SELECT call every time the code wants to know
@@ -38,7 +40,6 @@ class UserGroup < ApplicationRecord
   #   and thus the old memberships.
   # The `touch` makes it so that a small change to the metadata is written, which triggers an `after_commit` hook
   #   in our custom caching mechanism (see also concerns/cachable.rb)
-  before_validation :end_active_lead_roles, if: -> { is_active_changed? && !is_active }
   belongs_to :metadata, polymorphic: true, optional: true, touch: true
   belongs_to :parent_group, class_name: "UserGroup", optional: true
 
@@ -350,7 +351,8 @@ class UserGroup < ApplicationRecord
 
   private def end_active_lead_roles
     active_roles.select(&:lead?).each { |role| role.update!(end_date: Date.today) }
-    # Clear the association cache to prevent the absence validation from failing on stale data.
+    # Since `active_roles` is cached in memory, we must reset it so the
+    # `validates :active_roles, absence: true` validation doesn't fail.
     active_roles.reset
   end
 end

--- a/app/models/user_group.rb
+++ b/app/models/user_group.rb
@@ -351,8 +351,10 @@ class UserGroup < ApplicationRecord
 
   private def end_active_lead_roles
     active_roles.select(&:lead?).each { |role| role.update!(end_date: Date.today) }
-    # Since `active_roles` is cached in memory, we must reset it so the
-    # `validates :active_roles, absence: true` validation doesn't fail.
+    # Since `active_roles` is loading the data based on timestamps, the
+    # association may currently be loaded based on older timestamps. We have
+    # just changed some of the timestamps in the update calls above, so
+    # force-reset the association to ensure time-accurate data.
     active_roles.reset
   end
 end

--- a/app/webpacker/components/Panel/pages/RegionManager/index.jsx
+++ b/app/webpacker/components/Panel/pages/RegionManager/index.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import {
-  Button, ButtonGroup, Confirm, Form, Header, Icon, List, Modal, Table,
+  Button, ButtonGroup, Form, Header, Icon, List, Modal, Table,
 } from 'semantic-ui-react';
 import useLoadedData from '../../../../lib/hooks/useLoadedData';
 import {
-  fetchUserGroupsUrl, addUserGroupsUrl, userGroupsUpdateUrl,
+  fetchUserGroupsUrl, addUserGroupsUrl,
 } from '../../../../lib/requests/routes.js.erb';
 import { delegateRegionsStatus } from '../../../../lib/wca-data.js.erb';
 import Errored from '../../../Requests/Errored';
 import Loading from '../../../Requests/Loading';
 import useSaveAction from '../../../../lib/hooks/useSaveAction';
 import CreateModal from '../../views/UserRoles/CreateModal';
+import UpdateModal from '../../views/UserGroups/UpdateModal';
 
 const defaultRegion = {
   name: '',
@@ -20,37 +21,6 @@ const defaultRegion = {
   is_hidden: false,
   friendlyId: '',
 };
-
-function UserGroupVisibility({
-  userGroup, save, sync, setSaveError,
-}) {
-  const [open, setOpen] = React.useState(false);
-  const iconName = userGroup.is_active ? 'eye' : 'eye slash';
-  return (
-    <>
-      <List.Icon
-        name={iconName}
-        link
-        onClick={() => setOpen(true)}
-      />
-      <Confirm
-        open={open}
-        content={`Are you sure you want to ${userGroup.is_active ? 'deactivate' : 'activate'} ${userGroup.name}?`}
-        onCancel={() => setOpen(false)}
-        onConfirm={() => {
-          setOpen(false);
-          save(
-            userGroupsUpdateUrl(userGroup.id),
-            { is_active: !userGroup.is_active, is_hidden: userGroup.is_hidden },
-            sync,
-            {},
-            setSaveError,
-          );
-        }}
-      />
-    </>
-  );
-}
 
 export default function RegionManager() {
   const {
@@ -62,9 +32,9 @@ export default function RegionManager() {
   const [saveError, setSaveError] = React.useState();
   const [selectedGroup, setSelectedGroup] = React.useState();
 
-  const selectedGroupAndShowModal = (group) => {
+  const selectedGroupAndShowModal = (group, modalType) => {
     setSelectedGroup(group);
-    setOpenModalType('newLeadDelegate');
+    setOpenModalType(modalType);
   };
 
   const closeModal = () => setOpenModalType(null);
@@ -93,6 +63,7 @@ export default function RegionManager() {
             <Table.HeaderCell>Sub-Regions</Table.HeaderCell>
             <Table.HeaderCell>Regional Delegate</Table.HeaderCell>
             <Table.HeaderCell>Visibility</Table.HeaderCell>
+            <Table.HeaderCell>Edit</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -109,7 +80,7 @@ export default function RegionManager() {
                         <Icon
                           name="edit"
                           link
-                          onClick={() => selectedGroupAndShowModal(region)}
+                          onClick={() => selectedGroupAndShowModal(region, 'newLeadDelegate')}
                         />
                         {region.lead_user.name}
                       </>
@@ -117,19 +88,17 @@ export default function RegionManager() {
                       <Icon
                         name="plus"
                         link
-                        onClick={() => selectedGroupAndShowModal(region)}
+                        onClick={() => selectedGroupAndShowModal(region, 'newLeadDelegate')}
                       />
                     )}
                 </Table.Cell>
                 <Table.Cell />
                 <Table.Cell />
                 <Table.Cell>
-                  <UserGroupVisibility
-                    userGroup={region}
-                    save={save}
-                    sync={sync}
-                    setSaveError={setSaveError}
-                  />
+                  <List.Icon name={region.is_active ? 'eye' : 'eye slash'} />
+                </Table.Cell>
+                <Table.Cell>
+                  <Button onClick={() => selectedGroupAndShowModal(region, 'edit')}>Edit</Button>
                 </Table.Cell>
               </Table.Row>
               {subRegions[region.id]?.map((subRegion) => (
@@ -146,7 +115,7 @@ export default function RegionManager() {
                           <Icon
                             name="edit"
                             link
-                            onClick={() => selectedGroupAndShowModal(subRegion)}
+                            onClick={() => selectedGroupAndShowModal(subRegion, 'newLeadDelegate')}
                           />
                           {subRegion.lead_user.name}
                         </>
@@ -154,17 +123,15 @@ export default function RegionManager() {
                         <Icon
                           name="plus"
                           link
-                          onClick={() => selectedGroupAndShowModal(subRegion)}
+                          onClick={() => selectedGroupAndShowModal(subRegion, 'newLeadDelegate')}
                         />
                       )}
                   </Table.Cell>
                   <Table.Cell>
-                    <UserGroupVisibility
-                      userGroup={subRegion}
-                      save={save}
-                      sync={sync}
-                      setSaveError={setSaveError}
-                    />
+                    <List.Icon name={subRegion.is_active ? 'eye' : 'eye slash'} />
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Button onClick={() => selectedGroupAndShowModal(subRegion, 'edit')}>Edit</Button>
                   </Table.Cell>
                 </Table.Row>
               ))}
@@ -257,6 +224,16 @@ export default function RegionManager() {
           ? delegateRegionsStatus.regional_delegate
           : delegateRegionsStatus.senior_delegate)}
         location={selectedGroup?.name}
+      />
+      <UpdateModal
+        open={openModalType === 'edit'}
+        onClose={() => {
+          closeModal();
+          setSelectedGroup(null);
+          sync();
+        }}
+        title="Edit Region"
+        userGroupId={selectedGroup?.id}
       />
     </>
   );

--- a/app/webpacker/components/Panel/views/UserGroups/UpdateModal/ActiveStatus.jsx
+++ b/app/webpacker/components/Panel/views/UserGroups/UpdateModal/ActiveStatus.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {
+  Button, Form, Header, Message,
+} from 'semantic-ui-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import updateUserGroup from '../api/updateUserGroup';
+import Errored from '../../../../Requests/Errored';
+import { useConfirm } from '../../../../../lib/providers/ConfirmProvider';
+
+export default function ActiveStatus({ userGroup, nonLeadRoles }) {
+  const queryClient = useQueryClient();
+  const confirm = useConfirm();
+  const isActive = userGroup?.is_active;
+
+  const {
+    mutate: updateUserGroupMutation, isPending, isError, error,
+  } = useMutation({
+    mutationFn: updateUserGroup,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['user_group', userGroup.id], data);
+    },
+  });
+
+  const hasNonLeadRoles = nonLeadRoles.length > 0;
+  const disableSwitch = isPending || (isActive && hasNonLeadRoles);
+  const showWarning = isActive && hasNonLeadRoles;
+
+  const handleToggleActive = () => {
+    if (isActive) {
+      confirm({
+        content: 'Deactivating this group will automatically end any lead roles of this group. Are you sure you want to proceed?',
+      }).then(() => {
+        updateUserGroupMutation({
+          id: userGroup.id,
+          is_active: false,
+        });
+      });
+    } else {
+      updateUserGroupMutation({
+        id: userGroup.id,
+        is_active: true,
+      });
+    }
+  };
+
+  return (
+    <Form loading={isPending} warning={showWarning} error={isError}>
+      {isError && <Errored error={error.message || error} />}
+      <Form.Field>
+        <Header as="h4">Active Status</Header>
+        <div style={{ marginBottom: '1em' }}>
+          {'Current Status: '}
+          <strong>
+            {isActive ? 'Active' : 'Inactive'}
+          </strong>
+        </div>
+        <Button
+          type="button"
+          onClick={handleToggleActive}
+          disabled={disableSwitch}
+        >
+          {'Switch to '}
+          {isActive ? 'inactive' : 'active'}
+        </Button>
+        {showWarning && (
+          <Message warning>
+            <p>Cannot deactivate group while it has active non-lead roles.</p>
+          </Message>
+        )}
+      </Form.Field>
+    </Form>
+  );
+}

--- a/app/webpacker/components/Panel/views/UserGroups/UpdateModal/ActiveStatus.jsx
+++ b/app/webpacker/components/Panel/views/UserGroups/UpdateModal/ActiveStatus.jsx
@@ -16,9 +16,7 @@ export default function ActiveStatus({ userGroup, nonLeadRoles }) {
     mutate: updateUserGroupMutation, isPending, isError, error,
   } = useMutation({
     mutationFn: updateUserGroup,
-    onSuccess: (data) => {
-      queryClient.setQueryData(['user_group', userGroup.id], data);
-    },
+    onSuccess: (data) => queryClient.setQueryData(['user_group', userGroup.id], data),
   });
 
   const hasNonLeadRoles = nonLeadRoles.length > 0;

--- a/app/webpacker/components/Panel/views/UserGroups/UpdateModal/index.jsx
+++ b/app/webpacker/components/Panel/views/UserGroups/UpdateModal/index.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Modal } from 'semantic-ui-react';
+import { useQuery } from '@tanstack/react-query';
+import ActiveStatus from './ActiveStatus';
+import readUserGroup from '../api/readUserGroup';
+import readUserRoles from '../api/readUserRoles';
+import Loading from '../../../../Requests/Loading';
+import Errored from '../../../../Requests/Errored';
+
+export default function UpdateModal({
+  open, onClose, title, userGroupId,
+}) {
+  const { data: userGroup, isLoading: isGroupLoading, error: groupError } = useQuery({
+    queryKey: ['user_group', userGroupId],
+    queryFn: () => readUserGroup({ id: userGroupId }),
+    enabled: !!userGroupId,
+  });
+
+  const { data: nonLeadRolesData, isLoading: isRolesLoading, error: rolesError } = useQuery({
+    queryKey: ['user_roles', userGroupId, { isActive: true, isLead: false }],
+    queryFn: () => readUserRoles({ groupId: userGroupId, isActive: true, isLead: false }),
+    enabled: !!userGroupId,
+  });
+
+  const isLoading = isGroupLoading || isRolesLoading;
+  const error = groupError || rolesError;
+
+  if (isLoading) {
+    return (
+      <Modal open={open} onClose={onClose}>
+        <Modal.Content>
+          <Loading />
+        </Modal.Content>
+      </Modal>
+    );
+  }
+
+  if (error) {
+    return (
+      <Modal open={open} onClose={onClose}>
+        <Modal.Content>
+          <Errored error={error.message || error} />
+        </Modal.Content>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Modal.Header>{title || 'Edit User Group'}</Modal.Header>
+      <Modal.Content>
+        {userGroup && (
+          <ActiveStatus userGroup={userGroup} nonLeadRoles={nonLeadRolesData || []} />
+        )}
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/app/webpacker/components/Panel/views/UserGroups/UpdateModal/index.jsx
+++ b/app/webpacker/components/Panel/views/UserGroups/UpdateModal/index.jsx
@@ -25,31 +25,15 @@ export default function UpdateModal({
   const isLoading = isGroupLoading || isRolesLoading;
   const error = groupError || rolesError;
 
-  if (isLoading) {
-    return (
-      <Modal open={open} onClose={onClose}>
-        <Modal.Content>
-          <Loading />
-        </Modal.Content>
-      </Modal>
-    );
-  }
-
-  if (error) {
-    return (
-      <Modal open={open} onClose={onClose}>
-        <Modal.Content>
-          <Errored error={error.message || error} />
-        </Modal.Content>
-      </Modal>
-    );
-  }
-
   return (
     <Modal open={open} onClose={onClose}>
-      <Modal.Header>{title || 'Edit User Group'}</Modal.Header>
+      {!isLoading && !error && (
+        <Modal.Header>{title || 'Edit User Group'}</Modal.Header>
+      )}
       <Modal.Content>
-        {userGroup && (
+        {isLoading && <Loading />}
+        {error && <Errored error={error.message || error} />}
+        {!isLoading && !error && userGroup && (
           <ActiveStatus userGroup={userGroup} nonLeadRoles={nonLeadRolesData || []} />
         )}
       </Modal.Content>

--- a/app/webpacker/components/Panel/views/UserGroups/api/readUserGroup.js
+++ b/app/webpacker/components/Panel/views/UserGroups/api/readUserGroup.js
@@ -1,0 +1,7 @@
+import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
+import { fetchUserGroupUrl } from '../../../../../lib/requests/routes.js.erb';
+
+export default async function readUserGroup({ id }) {
+  const { data } = await fetchJsonOrError(fetchUserGroupUrl(id));
+  return data;
+}

--- a/app/webpacker/components/Panel/views/UserGroups/api/readUserRoles.js
+++ b/app/webpacker/components/Panel/views/UserGroups/api/readUserRoles.js
@@ -1,0 +1,7 @@
+import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
+import { apiV0Urls } from '../../../../../lib/requests/routes.js.erb';
+
+export default async function readUserRoles({ groupId, isActive, isLead }) {
+  const { data } = await fetchJsonOrError(apiV0Urls.userRoles.list({ groupId, isActive, isLead }));
+  return data;
+}

--- a/app/webpacker/components/Panel/views/UserGroups/api/updateUserGroup.js
+++ b/app/webpacker/components/Panel/views/UserGroups/api/updateUserGroup.js
@@ -1,0 +1,16 @@
+import { fetchJsonOrError } from '../../../../../lib/requests/fetchWithAuthenticityToken';
+import { userGroupsUpdateUrl } from '../../../../../lib/requests/routes.js.erb';
+
+export default async function updateUserGroup({ id, ...updateData }) {
+  const { data } = await fetchJsonOrError(
+    userGroupsUpdateUrl(id),
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(updateData),
+    },
+  );
+  return data;
+}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -173,6 +173,7 @@ export const fetchUserGroupsUrl = (groupType) => {
 export const addUserGroupsUrl = `<%= Rails.application.routes.url_helpers.api_v0_user_groups_path %>`;
 
 export const userGroupsUpdateUrl = (userGroupId) => `<%= Rails.application.routes.url_helpers.api_v0_user_groups_path %>/${userGroupId}`;
+export const fetchUserGroupUrl = (userGroupId) => `<%= Rails.application.routes.url_helpers.api_v0_user_groups_path %>/${userGroupId}`;
 
 export const countryBandsUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.country_bands_path) %>`;
 export const subordinateDelegateClaimsUrl = `<%= CGI.unescape(Rails.application.routes.url_helpers.pending_claims_path) %>`;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -483,7 +483,7 @@ Rails.application.routes.draw do
         get '/search' => 'user_roles#search', as: :user_roles_search
       end
       resources :user_roles, only: %i[index show create update destroy]
-      resources :user_groups, only: %i[index create update]
+      resources :user_groups, only: %i[index show create update]
       namespace :wrt do
         resources :persons, only: %i[update destroy] do
           put '/reset_claim_count' => 'persons#reset_claim_count', as: :reset_claim_count

--- a/spec/controllers/api/v0/user_groups_controller_spec.rb
+++ b/spec/controllers/api/v0/user_groups_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Api::V0::UserGroupsController do
 
   describe 'GET #show' do
     let(:user_group) { GroupsMetadataDelegateRegions.find_by!(friendly_id: 'africa').user_group }
-    let(:hidden_user_group) { UserGroup.find_by!(name: 'North America').tap { |g| g.update!(is_hidden: true) } }
+    let(:hidden_user_group) { UserGroup.find_by!(name: 'North America').tap { |g| g.update!(is_hidden: true) }.reload }
 
     context 'when group is not hidden' do
       it 'returns the user group for guests' do
@@ -96,7 +96,7 @@ RSpec.describe Api::V0::UserGroupsController do
       end
 
       it 'returns the user group for normal users' do
-        allow(controller).to receive(:current_user) { create(:user) }
+        allow(controller).to receive(:current_user).and_return(create(:user))
         get :show, params: { id: user_group.id }
         expect(response).to have_http_status(:success)
         expect(response.body).to eq(user_group.to_json)
@@ -110,13 +110,13 @@ RSpec.describe Api::V0::UserGroupsController do
       end
 
       it 'returns unauthorized for normal users' do
-        allow(controller).to receive(:current_user) { create(:user) }
+        allow(controller).to receive(:current_user).and_return(create(:user))
         get :show, params: { id: hidden_user_group.id }
         expect(response).to have_http_status(:unauthorized)
       end
 
       it 'returns the user group for admins' do
-        allow(controller).to receive(:current_user) { create(:admin) }
+        allow(controller).to receive(:current_user).and_return(create(:admin))
         get :show, params: { id: hidden_user_group.id }
         expect(response).to have_http_status(:success)
         expect(response.body).to eq(hidden_user_group.to_json)
@@ -129,12 +129,12 @@ RSpec.describe Api::V0::UserGroupsController do
     let(:admin) { create(:admin) }
 
     before do
-      allow(controller).to receive(:current_user) { admin }
+      allow(controller).to receive(:current_user).and_return(admin)
     end
 
     context 'when deactivating the group' do
       it 'ends active lead roles and sends email notifications' do
-        role = FactoryBot.create(:user_role, :active, :delegate_regions, :delegate_regions_senior_delegate, group: user_group, end_date: nil)
+        role = create(:user_role, :active, :delegate_regions, :delegate_regions_senior_delegate, group: user_group, end_date: nil)
 
         expect(RoleChangeMailer).to receive(:notify_role_end).with(role, admin).and_call_original
 
@@ -145,7 +145,7 @@ RSpec.describe Api::V0::UserGroupsController do
       end
 
       it 'returns unprocessable entity if there are active non-lead roles' do
-        FactoryBot.create(:user_role, :active, :delegate_regions, :delegate_regions_delegate, group: user_group, end_date: nil)
+        create(:user_role, :active, :delegate_regions, :delegate_regions_delegate, group: user_group, end_date: nil)
       end
     end
   end

--- a/spec/controllers/api/v0/user_groups_controller_spec.rb
+++ b/spec/controllers/api/v0/user_groups_controller_spec.rb
@@ -83,4 +83,70 @@ RSpec.describe Api::V0::UserGroupsController do
       end
     end
   end
+
+  describe 'GET #show' do
+    let(:user_group) { GroupsMetadataDelegateRegions.find_by!(friendly_id: 'africa').user_group }
+    let(:hidden_user_group) { UserGroup.find_by!(name: 'North America').tap { |g| g.update!(is_hidden: true) } }
+
+    context 'when group is not hidden' do
+      it 'returns the user group for guests' do
+        get :show, params: { id: user_group.id }
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq(user_group.to_json)
+      end
+
+      it 'returns the user group for normal users' do
+        allow(controller).to receive(:current_user) { create(:user) }
+        get :show, params: { id: user_group.id }
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq(user_group.to_json)
+      end
+    end
+
+    context 'when group is hidden' do
+      it 'returns unauthorized for guests' do
+        get :show, params: { id: hidden_user_group.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns unauthorized for normal users' do
+        allow(controller).to receive(:current_user) { create(:user) }
+        get :show, params: { id: hidden_user_group.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns the user group for admins' do
+        allow(controller).to receive(:current_user) { create(:admin) }
+        get :show, params: { id: hidden_user_group.id }
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq(hidden_user_group.to_json)
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:user_group) { GroupsMetadataDelegateRegions.find_by!(friendly_id: 'africa').user_group }
+    let(:admin) { create(:admin) }
+
+    before do
+      allow(controller).to receive(:current_user) { admin }
+    end
+
+    context 'when deactivating the group' do
+      it 'ends active lead roles and sends email notifications' do
+        role = FactoryBot.create(:user_role, :active, :delegate_regions, :delegate_regions_senior_delegate, group: user_group, end_date: nil)
+
+        expect(RoleChangeMailer).to receive(:notify_role_end).with(role, admin).and_call_original
+
+        patch :update, params: { id: user_group.id, user_group: { is_active: false } }
+
+        expect(response).to have_http_status(:success)
+        expect(role.reload.active?).to be false
+      end
+
+      it 'returns unprocessable entity if there are active non-lead roles' do
+        FactoryBot.create(:user_role, :active, :delegate_regions, :delegate_regions_delegate, group: user_group, end_date: nil)
+      end
+    end
+  end
 end

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -203,8 +203,8 @@ RSpec.describe UserGroup do
   describe "deactivation" do
     it "ends all active lead roles when deactivated" do
       group = UserGroup.create!(group_type: :officers, name: "Officers Group Test", is_active: true, is_hidden: false)
-      role1 = FactoryBot.create(:user_role, :active, :officers, group: group, end_date: nil)
-      role2 = FactoryBot.create(:user_role, :active, :officers, group: group, end_date: Date.today + 5.days)
+      role1 = create(:user_role, :active, :officers, group: group, end_date: nil)
+      role2 = create(:user_role, :active, :officers, group: group, end_date: Date.today + 5.days)
 
       group.update!(is_active: false)
 
@@ -216,11 +216,11 @@ RSpec.describe UserGroup do
 
     it "fails validation if there are active non-lead roles when deactivating" do
       group = UserGroup.create!(group_type: :translators, name: "Catalan Test", is_active: true, is_hidden: false)
-      FactoryBot.create(:translator_role, group: group, end_date: nil)
+      create(:translator_role, group: group, end_date: nil)
 
-      expect {
+      expect do
         group.update!(is_active: false)
-      }.to raise_error(ActiveRecord::RecordInvalid, /Active roles must be blank/)
+      end.to raise_error(ActiveRecord::RecordInvalid, /Active roles must be blank/)
     end
   end
 end

--- a/spec/models/user_group_spec.rb
+++ b/spec/models/user_group_spec.rb
@@ -199,4 +199,28 @@ RSpec.describe UserGroup do
       expect(UserGroup.teams_committees_group_wrc.changes_in_group_for_digest).to eq expected_output
     end
   end
+
+  describe "deactivation" do
+    it "ends all active lead roles when deactivated" do
+      group = UserGroup.create!(group_type: :officers, name: "Officers Group Test", is_active: true, is_hidden: false)
+      role1 = FactoryBot.create(:user_role, :active, :officers, group: group, end_date: nil)
+      role2 = FactoryBot.create(:user_role, :active, :officers, group: group, end_date: Date.today + 5.days)
+
+      group.update!(is_active: false)
+
+      expect(role1.reload.active?).to be false
+      expect(role1.end_date).to eq Date.today
+      expect(role2.reload.active?).to be false
+      expect(role2.end_date).to eq Date.today
+    end
+
+    it "fails validation if there are active non-lead roles when deactivating" do
+      group = UserGroup.create!(group_type: :translators, name: "Catalan Test", is_active: true, is_hidden: false)
+      FactoryBot.create(:translator_role, group: group, end_date: nil)
+
+      expect {
+        group.update!(is_active: false)
+      }.to raise_error(ActiveRecord::RecordInvalid, /Active roles must be blank/)
+    end
+  end
 end


### PR DESCRIPTION
Currently disabling a region is not possible because of the deadlock - lead roles cannot be removed from a region without replacing, and a group (region) cannot be disabled with any roles in it.