### PR TITLE
Disable new UI by default in VerifyNewcomers and clarify reason for fallback

### DIFF
--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/VerifyNewcomers.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/VerifyNewcomers.jsx
@@ -21,7 +21,7 @@ export default function VerifyNewcomers({ ticketDetails, currentStakeholder }) {
       },
     },
   } = ticketDetails;
-  const [newUi, setNewUi] = useState(useWcaRegistration);
+  const [newUi, setNewUi] = useState(false);
 
   const queryClient = useQueryClient();
   const {
@@ -71,7 +71,8 @@ export default function VerifyNewcomers({ ticketDetails, currentStakeholder }) {
         <>
           {useWcaRegistration && (
             <Message info>
-              Currently using old UI for competitions that use WCA registrations.
+              Currently using old UI for competitions that use WCA registrations due to a bug in
+              the new UI.
               <Button onClick={() => setNewUi(true)}>
                 Click here to switch to new view
               </Button>


### PR DESCRIPTION
Temporarily disabling new flow in results posting, there are some major bugs which needs to be resolved.

The major bug is that the merge action is actually not changing the inbox_persons, while still some are dependent on inbox_results.