### PR TITLE
Update related inbox_person records when assigning or merging WCA IDs

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -268,7 +268,7 @@ class TicketsController < ApplicationController
     render status: :ok, json: {
       inbox_person_count: competition.inbox_persons.count,
       inbox_person_no_wca_id_count: competition.inbox_persons.where(wca_id: '').count,
-      result_no_wca_id_count: competition.results.select(:person_id).distinct.where("person_id REGEXP '^[0-9]+$'").count,
+      result_no_wca_id_count: competition.results.select(:person_id).distinct.unmerged_newcomers.count,
     }
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,6 +70,9 @@ class UsersController < ApplicationController
 
     @user.update!(user_details)
 
+    @user.newcomer_results.update_all(person_name: @user.name) if @user.saved_change_to_name?
+    @user.newcomer_results.update_all(country_id: @user.country&.id) if @user.saved_change_to_country_iso2?
+
     render status: :ok, json: @user.as_json(
       private_attributes: %w[dob],
     )

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -36,7 +36,7 @@ class Registration < ApplicationRecord
   has_many :payment_intents, as: :holder, dependent: :delete_all
 
   has_one :inbox_person, foreign_key: %i[competition_id id], primary_key: %i[competition_id registrant_id], inverse_of: :registration
-  has_many :newcomer_results, class_name: "Result", foreign_key: %i[competition_id person_id], primary_key: %i[competition_id registrant_id], inverse_of: :newcomer_registration
+  has_many :newcomer_results, -> { unmerged_newcomers }, class_name: "Result", foreign_key: %i[competition_id person_id], primary_key: %i[competition_id registrant_id], inverse_of: :newcomer_registration
 
   enum :competing_status, {
     pending: Registrations::Helper::STATUS_PENDING,

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -36,6 +36,7 @@ class Registration < ApplicationRecord
   has_many :payment_intents, as: :holder, dependent: :delete_all
 
   has_one :inbox_person, foreign_key: %i[competition_id id], primary_key: %i[competition_id registrant_id], inverse_of: :registration
+  has_many :newcomer_results, class_name: "Result", foreign_key: %i[competition_id person_id], primary_key: %i[competition_id registrant_id], inverse_of: :newcomer_registration
 
   enum :competing_status, {
     pending: Registrations::Helper::STATUS_PENDING,

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -52,6 +52,7 @@ class Result < ApplicationRecord
   scope :single_better_than, ->(time) { where("best < ? AND best > 0", time) }
   scope :average_better_than, ->(time) { where("average < ? AND average > 0", time) }
   scope :in_event, ->(event_id) { where(event_id: event_id) }
+  scope :unmerged_newcomers, -> { where("person_id REGEXP '^[0-9]+$'") }
 
   alias_attribute :name, :person_name
   alias_attribute :wca_id, :person_id

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -12,7 +12,7 @@ class Result < ApplicationRecord
   # InboxPerson IDs are only unique per competition. So in addition to querying the ID itself (which is guaranteed by :foreign_key)
   # we also need sure to query the correct competition as well through a composite key.
   belongs_to :inbox_person, foreign_key: %i[person_id competition_id], optional: true, inverse_of: :results
-  belongs_to :newcomer_registration, class_name: "Registration", foreign_key: %i[competition_id person_id], primary_key: %i[competition_id registrant_id], optional: true, inverse_of: :results
+  belongs_to :newcomer_registration, class_name: "Registration", foreign_key: %i[competition_id person_id], primary_key: %i[competition_id registrant_id], optional: true, inverse_of: :newcomer_results
 
   has_many :result_attempts, inverse_of: :result, dependent: :destroy, autosave: true, index_errors: true
   validates_associated :result_attempts

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -12,6 +12,7 @@ class Result < ApplicationRecord
   # InboxPerson IDs are only unique per competition. So in addition to querying the ID itself (which is guaranteed by :foreign_key)
   # we also need sure to query the correct competition as well through a composite key.
   belongs_to :inbox_person, foreign_key: %i[person_id competition_id], optional: true, inverse_of: :results
+  belongs_to :newcomer_registration, class_name: "Registration", foreign_key: %i[competition_id person_id], primary_key: %i[competition_id registrant_id], optional: true, inverse_of: :results
 
   has_many :result_attempts, inverse_of: :result, dependent: :destroy, autosave: true, index_errors: true
   validates_associated :result_attempts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,7 +329,7 @@ class User < ApplicationRecord
     errors.add(:wca_id, cannot_be_assigned_reasons.xss_aware_to_sentence) unless cannot_be_assigned_reasons.empty?
   end
 
-  after_update :update_newcomer_results, if: -> { saved_change_to_name? || saved_change_to_country_iso2? }
+
 
   # To handle profile pictures that predate our user account system, we created
   # a bunch of dummy accounts (accounts with no password). When someone finally
@@ -1690,8 +1690,4 @@ class User < ApplicationRecord
     end
   end
 
-  private def update_newcomer_results
-    newcomer_results.update_all(person_name: name) if saved_change_to_name?
-    newcomer_results.update_all(country_id: country&.id) if saved_change_to_country_iso2?
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   has_many :organized_competitions, through: :competition_organizers, source: "competition"
   has_many :votes
   has_many :registrations
+  has_many :newcomer_results, through: :registrations, source: :newcomer_results
   has_many :scoretaking_registrations, -> { scoretakers }, class_name: "Registration", inverse_of: :user
   has_many :scoretaking_competitions, -> { joins(registrations: [:assignments]) }, through: :scoretaking_registrations, source: "competition"
   has_many :competitions_registered_for, through: :registrations, source: "competition"
@@ -1601,7 +1602,7 @@ class User < ApplicationRecord
       registrations.update_all(user_id: new_user.id)
 
       final_wca_id = new_user.wca_id.presence || self.wca_id.presence
-      new_user.update_inbox_persons_wca_id(final_wca_id)
+      new_user.newcomer_results.update_all(person_id: final_wca_id) if final_wca_id.present?
 
       return if wca_id.blank?
 
@@ -1631,17 +1632,13 @@ class User < ApplicationRecord
       stale_claims.update_all(**CLEAR_WCA_ID_CLAIM_ATTRIBUTES)
       potential_duplicate_persons.delete_all
 
-      update_inbox_persons_wca_id(wca_id)
+      newcomer_results.update_all(person_id: wca_id)
     end
 
     stale_claims_before_update.each { |user| WcaIdClaimMailer.notify_user_of_claim_cancelled(user, wca_id).deliver_later }
   end
 
-  def update_inbox_persons_wca_id(wca_id)
-    return if wca_id.blank?
 
-    InboxPerson.joins(:registration).where(registrations: { user_id: id }).update_all(wca_id: wca_id)
-  end
 
   MY_COMPETITIONS_SERIALIZATION_HASH = {
     only: %w[id name website start_date end_date registration_open],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1600,6 +1600,9 @@ class User < ApplicationRecord
       roles.update_all(user_id: new_user.id)
       registrations.update_all(user_id: new_user.id)
 
+      final_wca_id = new_user.wca_id.presence || self.wca_id.presence
+      new_user.update_inbox_persons_wca_id(final_wca_id)
+
       return if wca_id.blank?
 
       wca_id_to_be_transferred = self.wca_id
@@ -1627,9 +1630,17 @@ class User < ApplicationRecord
       update!(wca_id: wca_id)
       stale_claims.update_all(**CLEAR_WCA_ID_CLAIM_ATTRIBUTES)
       potential_duplicate_persons.delete_all
+
+      update_inbox_persons_wca_id(wca_id)
     end
 
     stale_claims_before_update.each { |user| WcaIdClaimMailer.notify_user_of_claim_cancelled(user, wca_id).deliver_later }
+  end
+
+  def update_inbox_persons_wca_id(wca_id)
+    return if wca_id.blank?
+
+    InboxPerson.joins(:registration).where(registrations: { user_id: id }).update_all(wca_id: wca_id)
   end
 
   MY_COMPETITIONS_SERIALIZATION_HASH = {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1638,8 +1638,6 @@ class User < ApplicationRecord
     stale_claims_before_update.each { |user| WcaIdClaimMailer.notify_user_of_claim_cancelled(user, wca_id).deliver_later }
   end
 
-
-
   MY_COMPETITIONS_SERIALIZATION_HASH = {
     only: %w[id name website start_date end_date registration_open],
     methods: %w[url city country_iso2 results_posted? visible? confirmed? cancelled? report_posted? short_display_name registration_status],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,8 +329,6 @@ class User < ApplicationRecord
     errors.add(:wca_id, cannot_be_assigned_reasons.xss_aware_to_sentence) unless cannot_be_assigned_reasons.empty?
   end
 
-
-
   # To handle profile pictures that predate our user account system, we created
   # a bunch of dummy accounts (accounts with no password). When someone finally
   # claims their WCA ID, we want to delete the dummy account and copy over their
@@ -1689,5 +1687,4 @@ class User < ApplicationRecord
       [grouped_competitions, registered_for_by_competition_id]
     end
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1691,11 +1691,6 @@ class User < ApplicationRecord
   end
 
   private def update_newcomer_results
-    user_registrations = Registration.where(user_id: id).pluck(:competition_id, :registrant_id)
-    return if user_registrations.empty?
-
-    newcomer_results = Result.where(user_registrations.map { |comp_id, reg_id| { competition_id: comp_id, person_id: reg_id.to_s } })
-
     newcomer_results.update_all(person_name: name) if saved_change_to_name?
     newcomer_results.update_all(country_id: country&.id) if saved_change_to_country_iso2?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,6 +329,8 @@ class User < ApplicationRecord
     errors.add(:wca_id, cannot_be_assigned_reasons.xss_aware_to_sentence) unless cannot_be_assigned_reasons.empty?
   end
 
+  after_update :update_newcomer_results, if: -> { saved_change_to_name? || saved_change_to_country_iso2? }
+
   # To handle profile pictures that predate our user account system, we created
   # a bunch of dummy accounts (accounts with no password). When someone finally
   # claims their WCA ID, we want to delete the dummy account and copy over their
@@ -1686,5 +1688,15 @@ class User < ApplicationRecord
 
       [grouped_competitions, registered_for_by_competition_id]
     end
+  end
+
+  private def update_newcomer_results
+    user_registrations = Registration.where(user_id: id).pluck(:competition_id, :registrant_id)
+    return if user_registrations.empty?
+
+    newcomer_results = Result.where(user_registrations.map { |comp_id, reg_id| { competition_id: comp_id, person_id: reg_id.to_s } })
+
+    newcomer_results.update_all(person_name: name) if saved_change_to_name?
+    newcomer_results.update_all(country_id: country&.id) if saved_change_to_country_iso2?
   end
 end

--- a/lib/finish_unfinished_persons.rb
+++ b/lib/finish_unfinished_persons.rb
@@ -18,7 +18,7 @@ module FinishUnfinishedPersons
 
     results_scope = results_scope.where(competition_id: competition_ids) if competition_ids.present?
 
-    results_scope.where("(person_id = '' OR person_id REGEXP '^[0-9]+$')")
+    results_scope.merge(Result.where(person_id: '').or(Result.unmerged_newcomers))
                  .group(:person_id, :person_name, :competition_id, :country_id)
                  .order(:person_name)
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -343,17 +343,17 @@ RSpec.describe UsersController do
         expect(user2.competitions_results_posted.count).to eq 0
       end
 
-      it 'updates corresponding inbox_person records during merge' do
+      it 'updates corresponding result records during merge' do
         user1.update!(wca_id: nil)
         user2_wca_id = user2.wca_id
 
         comp1 = create(:competition, :past)
         reg1 = create(:registration, :accepted, user: user1, competition: comp1)
-        inbox_person1 = create(:inbox_person, competition_id: comp1.id, ref_id: reg1.registrant_id.to_s, wca_id: "")
+        result1 = create(:result, competition: comp1, person_id: reg1.registrant_id.to_s)
 
         comp2 = create(:competition, :past)
         reg2 = create(:registration, :accepted, user: user2, competition: comp2)
-        inbox_person2 = create(:inbox_person, competition_id: comp2.id, ref_id: reg2.registrant_id.to_s, wca_id: user2_wca_id)
+        result2 = create(:result, competition: comp2, person_id: reg2.registrant_id.to_s)
 
         post :merge, params: {
           toUserId: user1.id,
@@ -362,8 +362,8 @@ RSpec.describe UsersController do
 
         expect(response).to have_http_status :ok
         expect(user1.reload.wca_id).to eq user2_wca_id
-        expect(inbox_person1.reload.wca_id).to eq user2_wca_id
-        expect(inbox_person2.reload.wca_id).to eq user2_wca_id
+        expect(result1.reload.person_id).to eq user2_wca_id
+        expect(result2.reload.person_id).to eq user2_wca_id
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -342,6 +342,29 @@ RSpec.describe UsersController do
         expect(user2.competitions_announced.count).to eq 0
         expect(user2.competitions_results_posted.count).to eq 0
       end
+
+      it 'updates corresponding inbox_person records during merge' do
+        user1.update!(wca_id: nil)
+        user2_wca_id = user2.wca_id
+
+        comp1 = create(:competition, :past)
+        reg1 = create(:registration, :accepted, user: user1, competition: comp1)
+        inbox_person1 = create(:inbox_person, competition_id: comp1.id, ref_id: reg1.registrant_id.to_s, wca_id: "")
+
+        comp2 = create(:competition, :past)
+        reg2 = create(:registration, :accepted, user: user2, competition: comp2)
+        inbox_person2 = create(:inbox_person, competition_id: comp2.id, ref_id: reg2.registrant_id.to_s, wca_id: user2_wca_id)
+
+        post :merge, params: {
+          toUserId: user1.id,
+          fromUserId: user2.id,
+        }
+
+        expect(response).to have_http_status :ok
+        expect(user1.reload.wca_id).to eq user2_wca_id
+        expect(inbox_person1.reload.wca_id).to eq user2_wca_id
+        expect(inbox_person2.reload.wca_id).to eq user2_wca_id
+      end
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -367,4 +367,31 @@ RSpec.describe UsersController do
       end
     end
   end
+
+  describe 'POST #update_user_data' do
+    let(:user) { create(:user, wca_id: nil) }
+    let(:admin) { create(:admin) }
+
+    before :each do
+      sign_in admin
+    end
+
+    it 'updates user data and matching newcomer results' do
+      comp = create(:competition, :past)
+      reg = create(:registration, :accepted, user: user, competition: comp)
+      result = create(:result, competition: comp, person_id: reg.registrant_id.to_s, person_name: user.name, country_id: user.country.id)
+
+      post :update_user_data, params: {
+        id: user.id,
+        name: "New Name",
+        country_iso2: "FR",
+      }
+
+      expect(response).to have_http_status :ok
+      expect(user.reload.name).to eq "New Name"
+      expect(user.country_iso2).to eq "FR"
+      expect(result.reload.person_name).to eq "New Name"
+      expect(result.country_id).to eq "France"
+    end
+  end
 end

--- a/spec/models/inbox_result_spec.rb
+++ b/spec/models/inbox_result_spec.rb
@@ -11,4 +11,5 @@ RSpec.describe InboxResult do
     result = create(:inbox_result, person: p2, competition: c2)
     expect(result.person_name).to eq p2.name
   end
+
 end

--- a/spec/models/inbox_result_spec.rb
+++ b/spec/models/inbox_result_spec.rb
@@ -11,5 +11,4 @@ RSpec.describe InboxResult do
     result = create(:inbox_result, person: p2, competition: c2)
     expect(result.person_name).to eq p2.name
   end
-
 end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe Result do
     expect(result).to be_valid
   end
 
+  it "belongs to newcomer_registration" do
+    competition = create(:competition)
+    registration = create(:registration, competition: competition)
+    result = create(:result, competition: competition, person_id: registration.registrant_id.to_s)
+    expect(result.newcomer_registration).to eq registration
+    expect(registration.reload.newcomer_results).to include(result)
+  end
+
   context "with previous light_result methods" do
     let(:competition) { create(:competition) }
     let(:format_id) { "a" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -221,6 +221,16 @@ RSpec.describe User do
         .to change { user.potential_duplicate_persons.count }.from(1).to(0)
     end
 
+    it "updates corresponding inbox_person records for the user's registrations" do
+      comp = create(:competition, :past)
+      reg = create(:registration, :accepted, user: user, competition: comp)
+      inbox_person = create(:inbox_person, competition_id: comp.id, ref_id: reg.registrant_id.to_s, wca_id: "")
+
+      user.assign_wca_id(person.wca_id)
+
+      expect(inbox_person.reload.wca_id).to eq person.wca_id
+    end
+
     context "when other users have pending claims for the same WCA ID" do
       let(:delegate_role) { create(:delegate_role) }
       let!(:claimant1) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -221,14 +221,14 @@ RSpec.describe User do
         .to change { user.potential_duplicate_persons.count }.from(1).to(0)
     end
 
-    it "updates corresponding inbox_person records for the user's registrations" do
+    it "updates corresponding result records for the user's registrations" do
       comp = create(:competition, :past)
       reg = create(:registration, :accepted, user: user, competition: comp)
-      inbox_person = create(:inbox_person, competition_id: comp.id, ref_id: reg.registrant_id.to_s, wca_id: "")
+      result = create(:result, competition: comp, person_id: reg.registrant_id.to_s)
 
       user.assign_wca_id(person.wca_id)
 
-      expect(inbox_person.reload.wca_id).to eq person.wca_id
+      expect(result.reload.person_id).to eq person.wca_id
     end
 
     context "when other users have pending claims for the same WCA ID" do


### PR DESCRIPTION
Assigning WCA ID to inbox_person when the persons are merged using newcomer check page during results posting.