### PR TITLE
Add OpenSearch link to front page (#724)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,8 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%= auto_discovery_link_tag(:rss, rss_url(format: :xml)) %>
+  <link rel="search" type="application/opensearchdescription+xml" title="WCA" href="/opensearch.xml">
+
   <% if EnvConfig.WCA_LIVE_SITE? %>
     <script data-ad-client="ca-pub-8682718775826560" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
     <!-- New Google tag (gtag.js) -->

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+ <ShortName>WCA</ShortName>
+ <Description>World Cube Association</Description>
+ <Url type="text/html" method="get" template="https://www.worldcubeassociation.org/search?q={searchTerms}"/>
+</OpenSearchDescription>


### PR DESCRIPTION
Fixes #724

Adds an OpenSearchDescription XML file and links it from the front-page layout so browsers (Firefox/Chrome) can offer "search this site from the address bar" support.

## Test plan
- Confirmed `public/opensearch.xml` is valid XML matching the format the issue specifies
- Confirmed the `<link rel="search">` tag renders in the page `<head>`
