### PR TITLE
Refactor advancement validation to the participation condition model

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3043,7 +3043,8 @@ en:
       missing_cumulative_round_id_error: "[%{original_round_id}] Unable to find the round %{wcif_id} for the cumulative time limit specified in the WCIF. Please go to the competition's Manage Events page and remove %{wcif_id} from the cumulative time limit for %{original_round_id}. WST knows about this bug (GitHub issue #3254)."
       wrong_position_in_results_error: "[%{round_id}] %{person_name} is in the wrong position: expected %{expected_pos}, but got %{pos}."
     rounds:
-      too_many_qualified_warning: "Round %{round_id}: more competitors qualified than what the advancement condition planned (%{actual} instead of %{expected}, the condition was: %{condition}). Please update the round information in the manage events page."
+      too_many_qualified_error: "Round %{round_id}: more competitors qualified than what the advancement condition planned (%{actual} instead of %{expected}, the condition was: %{condition}). Please update the round information in the manage events page."
+      advanced_without_valid_result_error: "Round %{round_id}: the following competitors advanced without a successful result in the round they advanced from: %{ids}. Competitors must not advance without a valid result; please make sure the results are attributed to the correct competitors and remove them if needed."
       regulation_9m1_error: "Round %{round_id} has 99 or fewer competitors but has more than two subsequent rounds, which is not permitted as per Regulation 9m1."
       regulation_9m2_error: "Round %{round_id} has 15 or fewer competitors but has more than one subsequent round, which is not permitted as per Regulation 9m2."
       regulation_9m3_error: "Round %{round_id} has 7 or fewer competitors but has at least one subsequent round, which is not permitted as per Regulation 9m3."

--- a/lib/result_conditions/percent.rb
+++ b/lib/result_conditions/percent.rb
@@ -12,10 +12,12 @@ module ResultConditions
       "percent"
     end
 
-    def max_advancing(results)
-      valid_results = results.count { |r| r.best.positive? }
-      proceeds = results.size * value / 100
-      [valid_results, proceeds].min
+    def to_s(_round, short: false)
+      I18n.t("advancement_condition#{'.short' if short}.percent", percent: value)
+    end
+
+    def nominal_max_advancing(results)
+      results.size * value / 100
     end
   end
 end

--- a/lib/result_conditions/ranking.rb
+++ b/lib/result_conditions/ranking.rb
@@ -12,7 +12,11 @@ module ResultConditions
       "ranking"
     end
 
-    def max_advancing(_results)
+    def to_s(_round, short: false)
+      I18n.t("advancement_condition#{'.short' if short}.ranking", ranking: value)
+    end
+
+    def nominal_max_advancing(_results)
       value
     end
   end

--- a/lib/result_conditions/result_achieved.rb
+++ b/lib/result_conditions/result_achieved.rb
@@ -12,7 +12,18 @@ module ResultConditions
       "resultAchieved"
     end
 
-    def max_advancing(results)
+    def to_s(round, short: false)
+      round_form = I18n.t("formats#{'.short' if short}.#{round.format_id}")
+      if round.event.timed_event?
+        I18n.t("advancement_condition#{'.short' if short}.attempt_result.time", round_format: round_form, time: SolveTime.centiseconds_to_clock_format(value))
+      elsif round.event.fewest_moves?
+        I18n.t("advancement_condition#{'.short' if short}.attempt_result.moves", round_format: round_form, moves: value)
+      elsif round.event.multiple_blindfolded?
+        I18n.t("advancement_condition#{'.short' if short}.attempt_result.points", round_format: round_form, points: SolveTime.multibld_attempt_to_points(value))
+      end
+    end
+
+    def nominal_max_advancing(results)
       return 0 if results.empty?
 
       # We store 'single' and 'average' as a reference to sort-by,

--- a/lib/result_conditions/result_condition.rb
+++ b/lib/result_conditions/result_condition.rb
@@ -74,6 +74,13 @@ module ResultConditions
       (results.count * 0.75).floor
     end
 
+    # Competitors without any successful attempt must not advance, so the
+    # condition's nominal allowance is additionally capped by the number of
+    # competitors holding a valid result.
+    def max_advancing(results)
+      [nominal_max_advancing(results), results.count { it.best.positive? }].min
+    end
+
     def max_qualifying(results)
       [max_advancing(results), regulations_boundary(results)].min
     end

--- a/lib/results_validators/advancement_conditions_validator.rb
+++ b/lib/results_validators/advancement_conditions_validator.rb
@@ -11,9 +11,10 @@ module ResultsValidators
     REGULATION_9P1_ERROR = :regulation_9p1_error
     OLD_REGULATION_9P_ERROR = :no_competitor_eliminated_error
     ROUND_9P1_ERROR = :less_than_twenty_five_percent_eliminated_error
-    TOO_MANY_QUALIFIED_WARNING = :too_many_qualified_warning
+    TOO_MANY_QUALIFIED_ERROR = :too_many_qualified_error
     NOT_ENOUGH_QUALIFIED_WARNING = :not_enough_qualified_warning
     COMPETED_NOT_QUALIFIED_ERROR = :competed_not_qualified_error
+    ADVANCED_WITHOUT_VALID_RESULT_ERROR = :advanced_without_valid_result_error
     ROUND_NOT_FOUND_ERROR = :round_not_found_error
 
     # These are the old "(combined) qualification" and "b-final" rounds.
@@ -41,6 +42,10 @@ module ResultsValidators
       [primary <= 0 ? 1 : 0, primary, result.best <= 0 ? 1 : 0, result.best, result.id]
     end
 
+    private def competitor_label(result)
+      "#{result.name}#{" (#{result.wca_id})" if result.wca_id.present?}"
+    end
+
     def run_validation(validator_data)
       validator_data.each do |competition_data|
         competition = competition_data.competition
@@ -50,121 +55,184 @@ module ResultsValidators
         results_by_event_id.each do |event_id, results_for_event|
           results_by_round_id = results_for_event.group_by(&:round_id)
 
-          # We are filtering out H2H finals as their results are loaded via a different process until we transition
-          # all results to be loaded via the live_results/live_attempts pipeline. See #13200 for more information.
-          rounds_without_deprecated_types = competition.rounds
-                                                       .filter { it.event_id == event_id }
-                                                       .reject { IGNORE_ROUND_TYPES.include?(it.round_type_id) }
-                                                       .reject(&:is_h2h_mock?)
+          event_rounds = competition.rounds
+                                    .filter { it.event_id == event_id }
+                                    .reject { IGNORE_ROUND_TYPES.include?(it.round_type_id) }
+                                    .sort_by(&:number)
 
-          previous_round = nil
+          rounds_by_id = event_rounds.index_by(&:id)
+          rounds_by_linked_round_id = event_rounds.filter(&:linked_round_id).group_by(&:linked_round_id)
 
-          rounds_without_deprecated_types.each do |round|
-            results = results_by_round_id[round.id]
-            number_of_people_in_round = results.size
-            remaining_number_of_rounds = round.total_number_of_rounds - round.number
+          # The linked rounds of a dual round are run as a single combined round per
+          # https://www.worldcubeassociation.org/regulations/#9v5, so they are grouped
+          # together and checked as one round.
+          chunked_rounds = event_rounds.chunk_while { |a, b| a.linked_round_id.present? && a.linked_round_id == b.linked_round_id }.to_a
+
+          chunked_rounds.each do |linked_rounds|
+            # H2H rounds are not checked themselves: their results are loaded via a different
+            # process until we transition all results to be loaded via the live_results/live_attempts
+            # pipeline (see #13200). They still occupy a round slot, which the 9m checks below
+            # account for via `total_number_of_rounds`.
+            next if linked_rounds.any?(&:is_h2h_mock?)
+
+            round_results = linked_rounds.flat_map { results_by_round_id[it.id] || [] }
+            next if round_results.empty?
+
+            round_human_id = linked_rounds.map(&:human_id).uniq.join("/")
+            number_of_people_in_round = round_results.map(&:person_id).uniq.size
+            # Subsequent rounds are counted in round slots, per
+            # https://www.worldcubeassociation.org/regulations/#9o: a dual round counts as
+            # two rounds (9o2, one slot per linked round) and an H2H round as one (9o3).
+            last_round = linked_rounds.last
+            remaining_number_of_rounds = last_round.total_number_of_rounds - last_round.number
 
             if number_of_people_in_round <= 7 && remaining_number_of_rounds.positive?
               # https://www.worldcubeassociation.org/regulations/#9m3: Rounds with 7 or fewer competitors must not have subsequent rounds.
               @errors << ValidationError.new(REGULATION_9M3_ERROR,
                                              :rounds, competition.id,
-                                             round_id: round.human_id)
+                                             round_id: round_human_id)
             end
 
             if number_of_people_in_round <= 15 && remaining_number_of_rounds > 1
               # https://www.worldcubeassociation.org/regulations/#9m2: Rounds with 15 or fewer competitors must have at most one subsequent round.
               @errors << ValidationError.new(REGULATION_9M2_ERROR,
                                              :rounds, competition.id,
-                                             round_id: round.human_id)
+                                             round_id: round_human_id)
             end
 
             if number_of_people_in_round <= 99 && remaining_number_of_rounds > 2
               # https://www.worldcubeassociation.org/regulations/#9m1: Rounds with 99 or fewer competitors must have at most two subsequent rounds.
               @errors << ValidationError.new(REGULATION_9M1_ERROR,
                                              :rounds, competition.id,
-                                             round_id: round.human_id)
+                                             round_id: round_human_id)
             end
 
-            if previous_round.present?
-              # Linked (dual) rounds are run as a single combined round, so the previous results
-              # are the union of the previous round and any of its colinked rounds, keeping only
-              # each competitor's best result (mirrors Result.merged_dual_rounds).
-              previous_round_ids = [previous_round.id, *previous_round.colinked_rounds.ids]
-              previous_results = previous_round_ids
-                                 .flat_map { |id| results_by_round_id[id] || [] }
-                                 .group_by(&:person_id)
-                                 .map { |_, person_results| person_results.min_by { |r| dual_round_sort_key(r) } }
-              number_of_people_in_previous_round = previous_results.size
-              condition = previous_round.advancement_condition
+            # Both linked rounds of a dual round share the same participation source and
+            # condition (they describe entry into the dual round), so we read them from the first round.
+            first_round = linked_rounds.first
+            source_rounds = case first_round.participation_source_type
+                            when "Round" then [rounds_by_id[first_round.participation_source_id]].compact
+                            when "LinkedRound" then rounds_by_linked_round_id[first_round.participation_source_id] || []
+                            else []
+                            end
+            next if source_rounds.empty?
 
-              # Check that no one proceeded if they shouldn't have
-              if condition.instance_of? AdvancementConditions::AttemptResultCondition
-                current_persons = results.map(&:person_id)
-                people_over_condition = previous_results.filter do |r|
-                  sort_by_column = r.format.sort_by == "single" ? :best : :average
-                  current_persons.include?(r.person_id) && r.send(sort_by_column) > condition.attempt_result
-                end.map do |competitor|
-                  "#{competitor.name}#{" (#{competitor.wca_id})" if competitor.wca_id.present?}"
-                end
-                if people_over_condition.any?
-                  @errors << ValidationError.new(COMPETED_NOT_QUALIFIED_ERROR,
-                                                 :rounds, competition.id,
-                                                 round_id: round.human_id,
-                                                 ids: people_over_condition.join(","),
-                                                 condition: condition.to_s(previous_round))
-                end
+            # Merge the source results per person, keeping only each competitor's best
+            # result (mirrors Result.merged_dual_rounds).
+            source_results = source_rounds
+                             .flat_map { results_by_round_id[it.id] || [] }
+                             .group_by(&:person_id)
+                             .map { |_, person_results| person_results.min_by { dual_round_sort_key(it) } }
+            number_of_people_in_source = source_results.size
+            next if number_of_people_in_source.zero?
+
+            source_result_by_person_id = source_results.index_by(&:person_id)
+            round_results_by_person_id = round_results.group_by(&:person_id)
+
+            # Regardless of any participation condition: competitors must have a
+            # successful result in the source round in order to advance. Until 2009,
+            # competitors could be admitted directly into subsequent rounds under
+            # special circumstances, so this only applies to modern competitions.
+            if comp_start_date >= Date.new(2009, 1, 1)
+              people_without_valid_result = round_results_by_person_id.filter_map do |person_id, person_results|
+                source_result = source_result_by_person_id[person_id]
+                competitor_label(person_results.first) if source_result.nil? || !source_result.best.positive?
               end
+              if people_without_valid_result.any?
+                @errors << ValidationError.new(ADVANCED_WITHOUT_VALID_RESULT_ERROR,
+                                               :rounds, competition.id,
+                                               round_id: round_human_id,
+                                               ids: people_without_valid_result.join(","))
+              end
+            end
 
-              # Dual Rounds per https://www.worldcubeassociation.org/regulations/#9v5 do not need checks
-              #   on their advancement criteria, because everyone will advance anyways (and that's fine)
-              is_within_dual_round = round.linked_round.present? && previous_round.linked_round.present?
+            # The condition for participating in this round lives on the round itself.
+            # (The legacy `advancement_condition` on the source round is only kept as a
+            # backport for WCIF v1 compatibility and is deliberately not used here.)
+            condition = first_round.participation_condition
+            # Historic data may carry a "result achieved" condition without a concrete
+            # value; there is nothing to check against in that case.
+            condition = nil if condition.is_a?(ResultConditions::ResultAchieved) && condition.value.nil?
 
-              # Article 9p, since July 20, 2006 until April 13, 2010
-              if comp_start_date.between?(Date.new(2006, 7, 20), Date.new(2010, 4, 13))
-                if number_of_people_in_round >= number_of_people_in_previous_round
-                  @errors << ValidationError.new(OLD_REGULATION_9P_ERROR,
-                                                 :rounds, competition.id,
-                                                 round_id: round.human_id)
-                end
-              elsif !is_within_dual_round
-                max_advancing = 3 * number_of_people_in_previous_round / 4
+            # Check that no one proceeded if they shouldn't have
+            if condition.instance_of? ResultConditions::ResultAchieved
+              scope_column = condition.scope == "single" ? :best : :average
+              people_over_condition = source_results.filter do |r|
+                scope_result = r.send(scope_column)
+                # People without any successful attempt are already flagged above.
+                round_results_by_person_id.key?(r.person_id) && r.best.positive? &&
+                  (scope_result <= 0 || scope_result >= condition.value)
+              end.map { competitor_label(it) }
+              if people_over_condition.any?
+                @errors << ValidationError.new(COMPETED_NOT_QUALIFIED_ERROR,
+                                               :rounds, competition.id,
+                                               round_id: round_human_id,
+                                               ids: people_over_condition.join(","),
+                                               condition: condition.to_s(source_rounds.first))
+              end
+            end
+
+            # Article 9p, since July 20, 2006 until April 13, 2010
+            if comp_start_date.between?(Date.new(2006, 7, 20), Date.new(2010, 4, 13))
+              if number_of_people_in_round >= number_of_people_in_source
+                @errors << ValidationError.new(OLD_REGULATION_9P_ERROR,
+                                               :rounds, competition.id,
+                                               round_id: round_human_id)
+              end
+            else
+              max_advancing = 3 * number_of_people_in_source / 4
+
+              linked_rounds.each do |round|
+                number_of_results_in_round = (results_by_round_id[round.id] || []).size
                 # Article 9p1, since April 14, 2010
                 # https://www.worldcubeassociation.org/regulations/#9p1: At least 25% of competitors must be eliminated between consecutive rounds of the same event.
-                if number_of_people_in_round > max_advancing
-                  @errors << ValidationError.new(REGULATION_9P1_ERROR,
+                next unless number_of_results_in_round > max_advancing
+
+                @errors << ValidationError.new(REGULATION_9P1_ERROR,
+                                               :rounds, competition.id,
+                                               round_id: round.human_id)
+              end
+
+              if condition
+                condition_string = condition.to_s(source_rounds.first)
+
+                # The declared condition itself must eliminate at least 25% of the
+                # source round's competitors (9p1), regardless of how many of them
+                # actually continued or achieved a successful result.
+                nominal_number_of_people = condition.nominal_max_advancing(source_results)
+                if nominal_number_of_people > max_advancing
+                  @errors << ValidationError.new(ROUND_9P1_ERROR,
                                                  :rounds, competition.id,
-                                                 round_id: round.human_id)
+                                                 round_id: round_human_id,
+                                                 condition: condition_string)
                 end
-                if condition
-                  theoretical_number_of_people = condition.max_advancing(previous_results)
-                  if number_of_people_in_round > theoretical_number_of_people
-                    @warnings << ValidationWarning.new(TOO_MANY_QUALIFIED_WARNING,
-                                                       :rounds, competition.id,
-                                                       round_id: round.human_id,
-                                                       actual: number_of_people_in_round,
-                                                       expected: theoretical_number_of_people,
-                                                       condition: condition.to_s(previous_round))
-                  end
-                  if theoretical_number_of_people > max_advancing
-                    @errors << ValidationError.new(ROUND_9P1_ERROR,
-                                                   :rounds, competition.id,
-                                                   round_id: round.human_id,
-                                                   condition: condition.to_s(previous_round))
-                  end
-                  # This comes from https://github.com/thewca/worldcubeassociation.org/issues/5587
-                  if theoretical_number_of_people - number_of_people_in_round >= 3 &&
-                     (number_of_people_in_round / theoretical_number_of_people) <= 0.8
-                    @warnings << ValidationWarning.new(NOT_ENOUGH_QUALIFIED_WARNING,
-                                                       :rounds, competition.id,
-                                                       round_id: round.human_id,
-                                                       expected: theoretical_number_of_people,
-                                                       actual: number_of_people_in_round)
-                  end
+
+                linked_rounds.each do |round|
+                  number_of_results_in_round = (results_by_round_id[round.id] || []).size
+                  next unless number_of_results_in_round > nominal_number_of_people
+
+                  @errors << ValidationError.new(TOO_MANY_QUALIFIED_ERROR,
+                                                 :rounds, competition.id,
+                                                 round_id: round.human_id,
+                                                 actual: number_of_results_in_round,
+                                                 expected: nominal_number_of_people,
+                                                 condition: condition_string)
+                end
+
+                # Competitors declining to continue is normal, but a large shortfall
+                # relative to what the condition permits deserves a comment.
+                # This comes from https://github.com/thewca/worldcubeassociation.org/issues/5587
+                theoretical_number_of_people = condition.max_advancing(source_results)
+                if theoretical_number_of_people - number_of_people_in_round >= 3 &&
+                   number_of_people_in_round <= 0.8 * theoretical_number_of_people
+                  @warnings << ValidationWarning.new(NOT_ENOUGH_QUALIFIED_WARNING,
+                                                     :rounds, competition.id,
+                                                     round_id: round_human_id,
+                                                     expected: theoretical_number_of_people,
+                                                     actual: number_of_people_in_round)
                 end
               end
             end
-
-            previous_round = round
           end
         end
       end

--- a/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -6,7 +6,6 @@ RV = ResultsValidators
 ACV = RV::AdvancementConditionsValidator
 
 # TODO: Refactor these tests to be more atomic, and make better use of RSpec conventions
-# Once refactor is complete, refactor advancement_conditions_validator
 RSpec.describe ResultsValidators::AdvancementConditionsValidator do
   context "on InboxResult and Result" do
     let!(:competition1) { create(:competition, starts: Date.new(2010, 3, 1), event_ids: ["333oh"]) }
@@ -25,19 +24,39 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
       end
     end
 
+    def people_pool(model, competition, count)
+      if model == Result
+        create_list(:person, count)
+      else
+        create_list(:inbox_person, count, competition_id: competition.id)
+      end
+    end
+
+    def build_round_results(model, people, competition, round, event_id:, round_type_id:)
+      result_kind = model.model_name.singular.to_sym
+      people.map do |person|
+        build(result_kind, competition: competition, event_id: event_id, round_type_id: round_type_id, round: round, person: person)
+      end
+    end
+
     it "doesn't complain when it's fine" do
       round_333oh_1, round_333oh_2, round_333oh_3, round_333oh_f = (1..4).map { |i| create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 4, number: i) }
+      round_333oh_2.update!(participation_source: round_333oh_1)
+      round_333oh_3.update!(participation_source: round_333oh_2)
+      round_333oh_f.update!(participation_source: round_333oh_3)
       round_222_1, round_222_f = (1..2).map { |i| create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: i) }
+      round_222_f.update!(participation_source: round_222_1)
       [Result, InboxResult].each do |model|
-        result_kind = model.model_name.singular.to_sym
+        people1 = people_pool(model, competition1, 100)
+        people2 = people_pool(model, competition2, 8)
         # Collecting all the results and using bulk import for better performance.
         results = []
-        results += build_list(result_kind, 100, competition: competition1, event_id: "333oh", round_type_id: "1", round: round_333oh_1)
-        results += build_list(result_kind, 16, competition: competition1, event_id: "333oh", round_type_id: "2", round: round_333oh_2)
-        results += build_list(result_kind, 8, competition: competition1, event_id: "333oh", round_type_id: "3", round: round_333oh_3)
-        results += build_list(result_kind, 7, competition: competition1, event_id: "333oh", round_type_id: "f", round: round_333oh_f)
-        results += build_list(result_kind, 8, competition: competition2, event_id: "222", round_type_id: "1", round: round_222_1)
-        results += build_list(result_kind, 5, competition: competition2, event_id: "222", round_type_id: "f", round: round_222_f)
+        results += build_round_results(model, people1, competition1, round_333oh_1, event_id: "333oh", round_type_id: "1")
+        results += build_round_results(model, people1.first(16), competition1, round_333oh_2, event_id: "333oh", round_type_id: "2")
+        results += build_round_results(model, people1.first(8), competition1, round_333oh_3, event_id: "333oh", round_type_id: "3")
+        results += build_round_results(model, people1.first(7), competition1, round_333oh_f, event_id: "333oh", round_type_id: "f")
+        results += build_round_results(model, people2, competition2, round_222_1, event_id: "222", round_type_id: "1")
+        results += build_round_results(model, people2.first(5), competition2, round_222_f, event_id: "222", round_type_id: "f")
         model.import(results)
       end
 
@@ -51,13 +70,14 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
     it "ignores b-final" do
       round_333oh_b_final = create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 2, number: 0, old_type: "b")
       round_33_oh_1, round_33_oh_f = (1..2).map { |i| create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 2, number: i) }
+      round_33_oh_f.update!(participation_source: round_33_oh_1)
       [Result, InboxResult].each do |model|
-        result_kind = model.model_name.singular.to_sym
+        people = people_pool(model, competition1, 100)
         # Collecting all the results and using bulk import for better performance.
         results = []
-        results += build_list(result_kind, 100, competition: competition1, event_id: "333oh", round_type_id: "1", round: round_33_oh_1)
-        results += build_list(result_kind, 8, competition: competition1, event_id: "333oh", round_type_id: "b", round: round_333oh_b_final)
-        results += build_list(result_kind, 32, competition: competition1, event_id: "333oh", round_type_id: "f", round: round_33_oh_f)
+        results += build_round_results(model, people, competition1, round_33_oh_1, event_id: "333oh", round_type_id: "1")
+        results += build_round_results(model, people.first(8), competition1, round_333oh_b_final, event_id: "333oh", round_type_id: "b")
+        results += build_round_results(model, people.first(32), competition1, round_33_oh_f, event_id: "333oh", round_type_id: "f")
         model.import(results, validate: false)
       end
 
@@ -72,23 +92,25 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
 
     # Triggers:
     # ROUND_9P1_ERROR
-    # TOO_MANY_QUALIFIED_WARNING
+    # TOO_MANY_QUALIFIED_ERROR
     # NOT_ENOUGH_QUALIFIED_WARNING
     # COMPETED_NOT_QUALIFIED_ERROR
-    it "validates round's advancement condition" do
+    it "validates round's participation condition" do
       first_round = create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 1)
-      first_round.update(advancement_condition: AdvancementConditions::AttemptResultCondition.new(1700))
-      second_round = create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 2)
+      second_round = create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 2,
+                                    participation_source: first_round,
+                                    participation_condition: ResultConditions::ResultAchieved.new(scope: "average", value: 1700))
 
       first_round2 = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 1)
-      first_round2.update(advancement_condition: AdvancementConditions::RankingCondition.new(4))
-      second_round2 = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 2)
+      second_round2 = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 2,
+                                     participation_source: first_round2,
+                                     participation_condition: ResultConditions::Ranking.new(scope: "average", value: 4))
 
       expected_errors = []
       # We create 20 competitors:
-      #   - for 2x2 this would actually let 17/20 people proceed, which breaks 9P1.
-      #   - for second round we let a valid number of competitors proceed, which
-      #   trigger the warning about letting less competitor proceed than expected.
+      #   - for 2x2 the "result achieved" condition would allow 16/20 people to
+      #   proceed, which breaks 9P1. We let a valid number of competitors proceed,
+      #   which triggers the warning about fewer competitors proceeding than expected.
       #   - for 3x3 we set a ranking condition arbitrarily low, and we let more
       #   competitors proceed than expected.
       (1..20).each do |i|
@@ -108,20 +130,20 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
                                                    :rounds, competition2.id,
                                                    round_id: "222-f",
                                                    ids: "#{fake_person.name} (#{fake_person.wca_id})",
-                                                   condition: first_round.advancement_condition.to_s(first_round))
+                                                   condition: second_round.participation_condition.to_s(first_round))
       end
       expected_errors << RV::ValidationError.new(ACV::ROUND_9P1_ERROR,
                                                  :rounds, competition2.id,
                                                  round_id: "222-f",
-                                                 condition: first_round.advancement_condition.to_s(first_round))
+                                                 condition: second_round.participation_condition.to_s(first_round))
+      expected_errors << RV::ValidationError.new(ACV::TOO_MANY_QUALIFIED_ERROR,
+                                                 :rounds, competition3.id,
+                                                 round_id: "333-f", actual: 9, expected: 4,
+                                                 condition: second_round2.participation_condition.to_s(first_round2))
       expected_warnings = [
         RV::ValidationWarning.new(ACV::NOT_ENOUGH_QUALIFIED_WARNING,
                                   :rounds, competition2.id,
                                   round_id: "222-f", expected: 16, actual: 10),
-        RV::ValidationWarning.new(ACV::TOO_MANY_QUALIFIED_WARNING,
-                                  :rounds, competition3.id,
-                                  round_id: "333-f", actual: 9, expected: 4,
-                                  condition: first_round2.advancement_condition.to_s(first_round2)),
       ]
       acv = ACV.new.validate(competition_ids: [competition2.id, competition3.id], model: Result)
       expect(acv.warnings).to match_array(expected_warnings)
@@ -130,7 +152,7 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
 
     context 'competed_not_qualified' do
       let(:first_round) { create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 1) }
-      let(:second_round) { create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 2) }
+      let(:second_round) { create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 2, participation_source: first_round) }
 
       before do
         # This creates 8 competitors (to not trigger 9m3), only 1 of whom has a result in the second round
@@ -162,15 +184,15 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
       # _actually_ participated in the round
       it 'recognizes that WCA_ID: nil users are distinct' do
         # Only the first inbox_result created above will pass this
-        first_round.update(advancement_condition: AdvancementConditions::AttemptResultCondition.new(150))
+        second_round.update(participation_condition: ResultConditions::ResultAchieved.new(scope: "average", value: 150))
 
         acv = ACV.new.validate(competition_ids: [competition3.id], model: InboxResult)
         expect(acv.errors).to be_empty
       end
 
       it "triggers when user achieves a results in 2nd round they shouldn't have advanced to" do
-        # Set an advancement condition that all inbox_results created above will fail
-        first_round.update(advancement_condition: AdvancementConditions::AttemptResultCondition.new(99))
+        # Set a participation condition that all inbox_results created above will fail
+        second_round.update(participation_condition: ResultConditions::ResultAchieved.new(scope: "average", value: 99))
 
         acv = ACV.new.validate(competition_ids: [competition3.id], model: InboxResult)
         expect(acv.errors.length).to be(1)
@@ -178,7 +200,7 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
       end
 
       it 'returns name, and WCA ID when available' do
-        first_round.update(advancement_condition: AdvancementConditions::AttemptResultCondition.new(99))
+        second_round.update(participation_condition: ResultConditions::ResultAchieved.new(scope: "average", value: 99))
 
         # Create a second round result for an existing person, so that we see both output formats
         inbox_result = create(
@@ -198,8 +220,9 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
 
     it "ignores incomplete results when computing qualified people" do
       first_round = create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 1)
-      first_round.update(advancement_condition: AdvancementConditions::PercentCondition.new(75))
-      second_round = create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 2)
+      second_round = create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: 2,
+                                    participation_source: first_round,
+                                    participation_condition: ResultConditions::Percent.new(scope: "average", value: 75))
       # This creates 20 results: 10 complete, 10 DNF. With 75% proceeding it used to report a
       # warning that 15 could have proceeded but only 10 did. Now we take into account
       # the number of valid results when emitting the warning.
@@ -215,6 +238,73 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
       expect(acv.errors).to be_empty
     end
 
+    it "flags competitors advancing without a valid result, regardless of any condition" do
+      first_round = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 1)
+      second_round = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 2, number: 2, participation_source: first_round)
+
+      # 12 competitors in round 1, the last of which DNFs all their attempts.
+      people = (1..12).map do |i|
+        fake_person = create(:person)
+        value = i == 12 ? -1 : i * 100
+        create(:result, competition: competition3, event_id: "333", round_type_id: "1", person: fake_person, best: value, average: value, round: first_round)
+        fake_person
+      end
+
+      # 9 competitors in the final (exactly 75% of 12, so no 9P1 issues): 7 valid
+      # qualifiers, the all-DNF competitor, and one person without any round 1 result.
+      finalists = people.first(7) + [people.last, create(:person)]
+      finalists.each_with_index do |fake_person, i|
+        value = (i + 1) * 100
+        create(:result, competition: competition3, event_id: "333", round_type_id: "f", person: fake_person, best: value, average: value, round: second_round)
+      end
+
+      acv = ACV.new.validate(competition_ids: [competition3.id], model: Result)
+      expect(acv.warnings).to be_empty
+      expect(acv.errors.length).to be(1)
+      expect(acv.errors.first.instance_variable_get(:@id)).to eq(:advanced_without_valid_result_error)
+      flagged_ids = acv.errors.first.instance_variable_get(:@args)[:ids]
+      expect(flagged_ids).to include(people.last.name)
+      expect(flagged_ids).to include(finalists.last.name)
+    end
+
+    it "checks participation conditions of linked (dual) destination rounds" do
+      # Rounds 2 and 3 form a dual round (9v5): they are run as a single combined round,
+      # and both carry the participation condition for entry into the pair. One competitor
+      # too many in either of the linked rounds must be flagged.
+      linked_round = create(:linked_round)
+      first_round = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 3, number: 1)
+      condition = ResultConditions::Ranking.new(scope: "average", value: 4)
+      round_333_2 = create(:round, competition: competition3, event_id: "333", linked_round: linked_round, total_number_of_rounds: 3, number: 2,
+                                   participation_source: first_round, participation_condition: condition)
+      round_333_3 = create(:round, competition: competition3, event_id: "333", linked_round: linked_round, total_number_of_rounds: 3, number: 3,
+                                   participation_source: first_round, participation_condition: condition)
+
+      people = (1..20).map do |i|
+        fake_person = create(:person)
+        create(:result, competition: competition3, event_id: "333", round_type_id: "1", person: fake_person, best: i * 100, average: i * 100, round: first_round)
+        fake_person
+      end
+
+      # 4 people are allowed into the pair, but 5 distinct people show up in the second linked round.
+      people.first(4).each_with_index do |fake_person, i|
+        create(:result, competition: competition3, event_id: "333", round_type_id: "2", person: fake_person, best: (i + 1) * 100, average: (i + 1) * 100, round: round_333_2)
+      end
+      people.first(5).each_with_index do |fake_person, i|
+        create(:result, competition: competition3, event_id: "333", round_type_id: "f", person: fake_person, best: (i + 1) * 100, average: (i + 1) * 100, round: round_333_3)
+      end
+
+      expected_errors = [
+        RV::ValidationError.new(ACV::TOO_MANY_QUALIFIED_ERROR,
+                                :rounds, competition3.id,
+                                round_id: "333-f", actual: 5, expected: 4,
+                                condition: round_333_3.participation_condition.to_s(first_round)),
+      ]
+
+      acv = ACV.new.validate(competition_ids: [competition3.id], model: Result)
+      expect(acv.warnings).to be_empty
+      expect(acv.errors).to match_array(expected_errors)
+    end
+
     it "merges linked (dual) rounds when checking advancement to the next round" do
       # Dual round (9v5): rounds 1 and 2 are run as a single combined round, then round 3 follows.
       # 60 competitors in round 1 and 40 (different) in round 2 => 100 combined. 70 advance to
@@ -223,12 +313,13 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
       linked_round = create(:linked_round)
       round_333_1 = create(:round, competition: competition3, event_id: "333", linked_round: linked_round, total_number_of_rounds: 3, number: 1)
       round_333_2 = create(:round, competition: competition3, event_id: "333", linked_round: linked_round, total_number_of_rounds: 3, number: 2)
-      round_333_3 = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 3, number: 3)
+      round_333_3 = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 3, number: 3, participation_source: linked_round)
 
+      people = create_list(:person, 100)
       results = []
-      results += build_list(:result, 60, competition: competition3, event_id: "333", round_type_id: "1", round: round_333_1)
-      results += build_list(:result, 40, competition: competition3, event_id: "333", round_type_id: "2", round: round_333_2)
-      results += build_list(:result, 70, competition: competition3, event_id: "333", round_type_id: "f", round: round_333_3)
+      results += people.first(60).map { build(:result, competition: competition3, event_id: "333", round_type_id: "1", person: it, round: round_333_1) }
+      results += people.last(40).map { build(:result, competition: competition3, event_id: "333", round_type_id: "2", person: it, round: round_333_2) }
+      results += people.first(70).map { build(:result, competition: competition3, event_id: "333", round_type_id: "f", person: it, round: round_333_3) }
       Result.import(results, validate: false)
 
       acv = ACV.new.validate(competition_ids: [competition3.id], model: Result)
@@ -244,17 +335,22 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
     # OLD_REGULATION_9P_ERROR
     it "complains when it should" do
       round_333oh_1, round_333oh_2, round_333oh_3, round_333oh_f = (1..4).map { |i| create(:round, competition: competition1, event_id: "333oh", total_number_of_rounds: 4, number: i) }
+      round_333oh_2.update!(participation_source: round_333oh_1)
+      round_333oh_3.update!(participation_source: round_333oh_2)
+      round_333oh_f.update!(participation_source: round_333oh_3)
       round_222_1, round_222_f = (1..2).map { |i| create(:round, competition: competition2, event_id: "222", total_number_of_rounds: 2, number: i) }
+      round_222_f.update!(participation_source: round_222_1)
       [Result, InboxResult].each do |model|
-        result_kind = model.model_name.singular.to_sym
+        people1 = people_pool(model, competition1, 99)
+        people2 = people_pool(model, competition2, 8)
         # Collecting all the results and using bulk import for better performance.
         results = []
-        results += build_list(result_kind, 99, competition: competition1, event_id: "333oh", round_type_id: "1", round: round_333oh_1)
-        results += build_list(result_kind, 15, competition: competition1, event_id: "333oh", round_type_id: "2", round: round_333oh_2)
-        results += build_list(result_kind, 7, competition: competition1, event_id: "333oh", round_type_id: "3", round: round_333oh_3)
-        results += build_list(result_kind, 7, competition: competition1, event_id: "333oh", round_type_id: "f", round: round_333oh_f)
-        results += build_list(result_kind, 8, competition: competition2, event_id: "222", round_type_id: "1", round: round_222_1)
-        results += build_list(result_kind, 7, competition: competition2, event_id: "222", round_type_id: "f", round: round_222_f)
+        results += build_round_results(model, people1, competition1, round_333oh_1, event_id: "333oh", round_type_id: "1")
+        results += build_round_results(model, people1.first(15), competition1, round_333oh_2, event_id: "333oh", round_type_id: "2")
+        results += build_round_results(model, people1.first(7), competition1, round_333oh_3, event_id: "333oh", round_type_id: "3")
+        results += build_round_results(model, people1.first(7), competition1, round_333oh_f, event_id: "333oh", round_type_id: "f")
+        results += build_round_results(model, people2, competition2, round_222_1, event_id: "222", round_type_id: "1")
+        results += build_round_results(model, people2.first(7), competition2, round_222_f, event_id: "222", round_type_id: "f")
         model.import(results, validate: false)
       end
       expected_errors = [

--- a/spec/lib/results_validators/advancement_conditions_validator_spec.rb
+++ b/spec/lib/results_validators/advancement_conditions_validator_spec.rb
@@ -195,8 +195,9 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
         second_round.update(participation_condition: ResultConditions::ResultAchieved.new(scope: "average", value: 99))
 
         acv = ACV.new.validate(competition_ids: [competition3.id], model: InboxResult)
-        expect(acv.errors.length).to be(1)
-        expect(acv.errors.first.instance_variable_get(:@id)).to eq(:competed_not_qualified_error)
+        # Since nobody satisfies the condition, the round as a whole is also over-advanced
+        error_ids = acv.errors.map { it.instance_variable_get(:@id) }
+        expect(error_ids).to contain_exactly(:competed_not_qualified_error, :too_many_qualified_error)
       end
 
       it 'returns name, and WCA ID when available' do
@@ -213,8 +214,8 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
         )
 
         acv = ACV.new.validate(competition_ids: [competition3.id], model: InboxResult)
-        expect(acv.errors.length).to be(1)
-        expect(acv.errors.first.instance_variable_get(:@args)[:ids]).to eq("#{@finalist.name},#{person.name} (#{person.wca_id})")
+        competed_error = acv.errors.find { it.instance_variable_get(:@id) == :competed_not_qualified_error }
+        expect(competed_error.instance_variable_get(:@args)[:ids]).to eq("#{@finalist.name},#{person.name} (#{person.wca_id})")
       end
     end
 
@@ -315,7 +316,7 @@ RSpec.describe ResultsValidators::AdvancementConditionsValidator do
       round_333_2 = create(:round, competition: competition3, event_id: "333", linked_round: linked_round, total_number_of_rounds: 3, number: 2)
       round_333_3 = create(:round, competition: competition3, event_id: "333", total_number_of_rounds: 3, number: 3, participation_source: linked_round)
 
-      people = create_list(:person, 100)
+      people = people_pool(Result, competition3, 100)
       results = []
       results += people.first(60).map { build(:result, competition: competition3, event_id: "333", round_type_id: "1", person: it, round: round_333_1) }
       results += people.last(40).map { build(:result, competition: competition3, event_id: "333", round_type_id: "2", person: it, round: round_333_2) }


### PR DESCRIPTION
### Background

While investigating the results of the new sanity check 71 (#14569), I set out to cover its two violation types (too permissive participation conditions and over-advancement) in the result submission validators, only to find that `AdvancementConditionsValidator` already checks both in principle, via `ROUND_9P1_ERROR` and `TOO_MANY_QUALIFIED_WARNING`.

However, the validator still reads the legacy `advancement_condition` on the source round, while WCA Live and the sanity checks work with the new `participation_condition` / `participation_source` model on the destination round. The two representations are only kept in sync on the WCIF save path, so they can drift apart on other write paths. This may explain why some real violations were not flagged at posting time (not verified in all cases), and regardless of that, the validators should work on the same data model as the rest of the system. In one confirmed case (over-advancement at SwissNationals2025) the warning was actually raised during results posting but overlooked, which motivates upgrading it to an error.

### Changes

**Refactor:**
- `AdvancementConditionsValidator` is now driven entirely by `participation_source` / `participation_condition`: every round with a `Round` or `LinkedRound` source is validated against that source's results.
- Dual rounds are fully included: both linked rounds carry the entry condition into the dual round and are checked against it (the previous within-dual-round skip is removed).
- 9m checks: the competitors of a dual round are counted as the union across its linked rounds, while subsequent rounds are counted in round slots per Regulation 9o2/9o3.
- `ResultCondition` API split: `nominal_max_advancing` returns what the condition nominally allows (used for the 9p1 legality check and the too-many check), while `max_advancing` caps that by the number of competitors holding a valid result (used for the not-enough warning). For WCA Live this only tightens the `advancing_questionable` marking in DNF-heavy rounds.
- `to_s` implementations added to the `ResultCondition` classes, reusing the existing `advancement_condition` locale keys, so message texts are unchanged.

**Behavior changes:**
- `TOO_MANY_QUALIFIED` is upgraded from warning to error.
- New `ADVANCED_WITHOUT_VALID_RESULT_ERROR`: competitors must have a successful result in the source round to advance, independent of any condition (applies to competitions from 2009 onwards, when direct admission into later rounds stopped being possible).
- The `resultAchieved` boundary is now strict: a result exactly equal to the threshold does not qualify, so `COMPETED_NOT_QUALIFIED_ERROR` flags `>=` instead of `>`.
- The 9p1 legality check and the too-many check now use the nominal (uncapped) allowance: previously the eligible count for percent conditions was capped by valid results, which could mask a too permissive condition in DNF-heavy rounds.
- Conversely, the not-enough warning now uses the valid-result-capped count for ranking conditions as well (previously uncapped), avoiding false warnings when many competitors have no successful result.

**Specs:**
- Rewritten to set conditions exclusively via the participation model (doubling as a regression test for the sync gap) and to share competitors across rounds, which the new person-level check requires.

**Note:** This PR was co-authored by Claude Code and has not been tested locally, so the rewritten specs rely on CI for verification. Please review with corresponding care.
