### PR TITLE
Add sanity check 74 and fix resultAchieved boundary in check 71

### DIFF
--- a/lib/sanity_check_sql/12 - consistency_of_results_and_rounds_data/71 - participation_condition_violated.sql
+++ b/lib/sanity_check_sql/12 - consistency_of_results_and_rounds_data/71 - participation_condition_violated.sql
@@ -59,8 +59,9 @@ source_agg AS (
   SELECT
     psb.dest_round_id,
     COUNT(*) AS participants_source,
-    -- Only used for resultAchieved; ranking and percent derive participants_eligible from condition_value directly
-    SUM(IF(psb.max_best > 0 AND psb.best_scope_result <= dr.condition_value, 1, 0)) AS participants_eligible_ra
+    -- Only used for resultAchieved; ranking and percent derive participants_eligible from condition_value directly.
+    -- A "result achieved" condition requires a result strictly better than the threshold, hence `<`.
+    SUM(IF(psb.max_best > 0 AND psb.best_scope_result < dr.condition_value, 1, 0)) AS participants_eligible_ra
   FROM person_source_best AS psb
   INNER JOIN dest_rounds AS dr
   ON psb.dest_round_id = dr.round_id

--- a/lib/sanity_check_sql/12 - consistency_of_results_and_rounds_data/74 - advanced_without_valid_source_result.sql
+++ b/lib/sanity_check_sql/12 - consistency_of_results_and_rounds_data/74 - advanced_without_valid_source_result.sql
@@ -1,0 +1,84 @@
+WITH qualification_events AS (
+  -- Old-style qualification rounds ('0' and 'h') allowed pre-qualified competitors to skip
+  -- straight into the main rounds, so the backfilled participation sources are unreliable
+  -- for the entire competition/event combination
+  SELECT DISTINCT
+    ce.competition_id,
+    ce.event_id
+  FROM rounds AS r
+  INNER JOIN competition_events AS ce
+  ON r.competition_event_id = ce.id
+  WHERE r.old_type IN ('0', 'h')
+),
+dest_rounds AS (
+  SELECT
+    r.id AS round_id,
+    r.number AS round_number,
+    ce.competition_id,
+    ce.event_id,
+    r.participation_source_type,
+    r.participation_source_id
+  FROM rounds AS r
+  INNER JOIN competition_events AS ce
+  ON r.competition_event_id = ce.id
+  INNER JOIN competitions AS c
+  ON ce.competition_id = c.id
+  LEFT JOIN qualification_events AS qe
+  ON qe.competition_id = ce.competition_id
+    AND qe.event_id = ce.event_id
+  -- First rounds have a CompetitionEvent source and are governed by registration, not by results
+  WHERE r.participation_source_type IN ('Round', 'LinkedRound')
+    -- Until 2009, competitors could be admitted directly into subsequent rounds under special circumstances
+    AND c.start_date >= '2009-01-01'
+    -- Old qualification rounds and b-finals are not governed by participation conditions
+    AND (r.old_type IS NULL OR r.old_type NOT IN ('0', 'h', 'b'))
+    AND qe.competition_id IS NULL
+),
+source_round_mapping AS (
+  SELECT
+    dr.round_id AS dest_round_id,
+    dr.participation_source_id AS source_round_id
+  FROM dest_rounds AS dr
+  WHERE dr.participation_source_type = 'Round'
+
+  UNION ALL
+
+  SELECT
+    dr.round_id AS dest_round_id,
+    sr.id AS source_round_id
+  FROM dest_rounds AS dr
+  INNER JOIN rounds AS sr
+  ON dr.participation_source_id = sr.linked_round_id
+  WHERE dr.participation_source_type = 'LinkedRound'
+),
+-- Best single per person across the source round(s); for LinkedRound sources this
+-- naturally merges the dual rounds
+person_source_best AS (
+  SELECT
+    srm.dest_round_id,
+    res.person_id,
+    MAX(res.best) AS max_best
+  FROM source_round_mapping AS srm
+  INNER JOIN results AS res
+  ON res.round_id = srm.source_round_id
+  GROUP BY srm.dest_round_id, res.person_id
+)
+SELECT
+  dr.competition_id,
+  dr.event_id,
+  res.round_type_id,
+  dr.round_id,
+  dr.round_number,
+  res.person_id,
+  res.person_name,
+  psb.max_best AS best_in_source_round
+FROM dest_rounds AS dr
+INNER JOIN results AS res
+ON res.round_id = dr.round_id
+LEFT JOIN person_source_best AS psb
+ON psb.dest_round_id = dr.round_id
+  AND psb.person_id = res.person_id
+-- Flag competitors with no result in the source round at all, or without any successful attempt there
+WHERE psb.person_id IS NULL
+  OR psb.max_best <= 0
+ORDER BY RIGHT(dr.competition_id, 4), dr.competition_id, dr.event_id, dr.round_number, res.person_id;

--- a/lib/static_data/sanity_checks.json
+++ b/lib/static_data/sanity_checks.json
@@ -488,5 +488,12 @@
     "topic": "Schedule activities outside competition date range",
     "comments": null,
     "query_file": "consistency_of_schedule_activities_with_competition_days.sql"
+  },
+  {
+    "id": "74",
+    "sanity_check_category_id": "12",
+    "topic": "Competitors advancing without a valid result in the source round",
+    "comments": null,
+    "query_file": "advanced_without_valid_source_result.sql"
   }
 ]


### PR DESCRIPTION
### Background

Companion to #14954: while porting the participation condition rules into the result submission validators, we identified a rule no check covers so far. Competitors must have a successful result in the source round in order to advance, but sanity check 71 only compares counts, so an individual advancing without a valid result can go unnoticed as long as the totals stay within limits.

### Changes

**New sanity check 74** (category 12): flags competitors who have a result in a round but no successful result, or no result at all, in the round they advanced from. Source rounds are resolved via the `participation_source` model, with dual rounds merged on the source side. Two exclusions to avoid false positives:
- Competitions before 2009 are skipped, since direct admission into later rounds was possible until then.
- Competition/event combinations with old-style qualification rounds (`0`/`h`) are skipped entirely, since pre-qualified competitors legitimately skipped rounds there and the backfilled participation sources are unreliable; legacy round types themselves (`0`/`h`/`b`) are also never treated as destination rounds.

**Fix in check 71:** a `resultAchieved` condition requires a result strictly better than the threshold, so the eligibility count now uses `<` instead of `<=` (matching the validator behavior from #14954).

The check 74 query was tested end-to-end against the production database; it currently returns 2 rows, which I am investigating.
