### PR TITLE
Link confirmed WCA ID on edit user form to profile page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -91,7 +91,7 @@
               <% end %>
             </div>
             <div class="col-xs-6">
-              <%= f.input :wca_id, as: :wca_id, disabled: !editable_fields.include?(:wca_id)%>
+              <%= f.input :wca_id, as: :wca_id, disabled: !editable_fields.include?(:wca_id), hint: @user.wca_id.present? ? link_to(t('.profile'), person_path(@user.wca_id), target: "_blank") : nil %>
               <% if current_user.can_edit_any_user? && @user.special_account? %>
                 <p class="help-block">
                   <%= t '.account_is_special' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,7 +489,6 @@ en:
         results_notifications_enabled: ""
         registration_notifications_enabled: "This only applies for competitions you organize or delegate, and can be overridden on a per-competition basis."
         unconfirmed_wca_id: ""
-        wca_id: ""
         receive_developer_mails: "This is limited to notifications for major version changes to resources like data exports, WCIF schema and public APIs. Recommended for developers maintaing software that relies on these tools."
         receive_delegate_reports: "If you are a Senior Delegate or Member of the WRC or the WQAC, you receive Delegate Reports by default. Note: the change may take up to 12 hours to take effect."
         delegate_reports_region: "If you want to receive all reports, leave this field blank (the dropdown option at the very top). Note: the change may take up to 12 hours to take effect."


### PR DESCRIPTION
Fixes #4983

Add profile link to confirmed WCA ID field on edit user form, matching the unconfirmed field's behavior.