### PR TITLE
Case insensitive name check

### DIFF
--- a/lib/results_validators/persons_validator.rb
+++ b/lib/results_validators/persons_validator.rb
@@ -145,11 +145,12 @@ module ResultsValidators
 
         without_wca_id, with_wca_id = persons_by_id.values.partition { |p| p.wca_id.empty? }
         if without_wca_id.any?
-          existing_person_in_db_by_name = Person.where(name: without_wca_id.map(&:name)).group_by(&:name)
-          existing_person_in_db_by_name.each do |name, persons|
+          newcomer_names = without_wca_id.map { |p| p.name.downcase }
+          existing_person_in_db_by_name = Person.where("LOWER(name) IN (?)", newcomer_names).group_by { |p| p.name.downcase }
+          existing_person_in_db_by_name.each_value do |persons|
             @warnings << ValidationWarning.new(SAME_PERSON_NAME_WARNING,
                                                :persons, competition.id,
-                                               name: name,
+                                               name: persons.first.name,
                                                wca_ids: persons.map(&:wca_id).join(", "))
           end
         end

--- a/spec/lib/results_validators/persons_validator_spec.rb
+++ b/spec/lib/results_validators/persons_validator_spec.rb
@@ -121,6 +121,31 @@ RSpec.describe PV do
         end
       end
 
+      it "detects duplicate names case-insensitively" do
+        # The DB person's name is stored in a different case than the uploaded
+        # newcomer's name; the check should still flag them as the same person.
+        person = create(:person, name: "SHERLOCK HOLMES")
+        dup_name = create(:inbox_person, name: "Sherlock Holmes", competition_id: competition1.id)
+        create(:inbox_result,
+               person: dup_name, competition: competition1,
+               event_id: "333oh")
+
+        expected_warnings = [
+          RV::ValidationWarning.new(PV::SAME_PERSON_NAME_WARNING,
+                                    :persons, competition1.id,
+                                    name: person.name, wca_ids: person.wca_id),
+        ]
+        validator_args = [
+          { competition_ids: [competition1.id], model: InboxResult },
+          { results: InboxResult.where(competition_id: competition1.id), model: InboxResult },
+        ]
+        validator_args.each do |arg|
+          pv = PV.new.validate(**arg)
+          expect(pv.errors).to be_empty
+          expect(pv.warnings).to match_array(expected_warnings)
+        end
+      end
+
       # Triggers:
       # PERSON_WITHOUT_RESULTS_ERROR
       # WRONG_WCA_ID_ERROR


### PR DESCRIPTION
Fixes #7486

Makes the duplicate person name detection case-insensitive, so "John Smith" and "john smith" are now correctly identified as potential duplicates.

