### PR TITLE
Return JSON for all API requests

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -139,7 +139,7 @@ Rails.application.configure do
 
   # Error pages for production
   config.exceptions_app = lambda { |env|
-    if EnvConfig.API_ONLY?
+    if EnvConfig.API_ONLY? || request.path.start_with?("/api/")
       ApiErrorsController.action(:show).call(env)
     else
       ErrorsController.action(:show).call(env)


### PR DESCRIPTION
A catch all rescue_from is actually not the solution here, because it would disrupt new relic reporting and middleware failures down the line would still return HTML. Luckily request is just in scope so this just works