### PR TITLE
Replace hasPassed with hasPassedEndOfDay where necessary

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/competitors/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/competitors/page.tsx
@@ -1,6 +1,6 @@
 import TabCompetitors from "@/components/competitions/TabCompetitors";
 import { getCompetitionInfo } from "@/lib/wca/competitions/getCompetitionInfo";
-import { hasPassed } from "@/lib/wca/dates";
+import { hasPassed, hasPassedEndOfDay } from "@/lib/wca/dates";
 import OpenapiError from "@/components/ui/openapiError";
 import { getT } from "@/lib/i18n/get18n";
 import getPermissions from "@/lib/wca/permissions";
@@ -22,7 +22,7 @@ export default async function Competitors({
 
   const isLive =
     hasPassed(competitionInfo.start_date) &&
-    !hasPassed(competitionInfo.end_date);
+    !hasPassedEndOfDay(competitionInfo.end_date);
 
   return (
     <TabCompetitors

--- a/next-frontend/src/components/competitions/CompetitionMenu.tsx
+++ b/next-frontend/src/components/competitions/CompetitionMenu.tsx
@@ -1,5 +1,5 @@
 import { components } from "@/types/openapi";
-import { hasPassed } from "@/lib/wca/dates";
+import { hasPassed, hasPassedEndOfDay } from "@/lib/wca/dates";
 import {
   afterCompetitionTabs,
   beforeCompetitionTabs,
@@ -27,7 +27,7 @@ export default function CompetitionMenu({
     );
   }
 
-  if (!hasPassed(competitionInfo.end_date) || LIVE_RESULT_BETA) {
+  if (!hasPassedEndOfDay(competitionInfo.end_date) || LIVE_RESULT_BETA) {
     return (
       <LiveMenu
         competitionInfo={competitionInfo}

--- a/next-frontend/src/components/competitions/Schedule/LiveView.tsx
+++ b/next-frontend/src/components/competitions/Schedule/LiveView.tsx
@@ -25,7 +25,7 @@ import { components } from "@/types/openapi";
 import {
   getDatesBetweenInclusive,
   getSimpleTimeString,
-  hasPassed,
+  hasPassedEndOfDay,
 } from "@/lib/wca/dates";
 import EventIcon from "@/components/EventIcon";
 import { route } from "nextjs-routes";
@@ -76,7 +76,8 @@ export default function LiveView({
   // if all of them have passed, show the last day
   const lastDate = dates[dates.length - 1];
   const defaultDate =
-    dates.filter((d) => !hasPassed(d.endOf("day").toISO()!))[0] ?? lastDate;
+    dates.filter((d) => !hasPassedEndOfDay(d.toISO()!, timeZone))[0] ??
+    lastDate;
 
   const roundsByWcifId = _.keyBy(rounds, "id");
 

--- a/next-frontend/src/lib/wca/dates.ts
+++ b/next-frontend/src/lib/wca/dates.ts
@@ -60,6 +60,13 @@ export function hasPassed(dateTime: string, timeZone?: string | Zone) {
   return DateTime.fromISO(dateTime, { zone: timeZone }) < DateTime.now();
 }
 
+// for date-only strings, which would otherwise parse as midnight
+export function hasPassedEndOfDay(date: string, timeZone?: string | Zone) {
+  return (
+    DateTime.fromISO(date, { zone: timeZone }).endOf("day") < DateTime.now()
+  );
+}
+
 export function hasNotPassed(dateTime: string, timeZone?: string | Zone) {
   return DateTime.now() < DateTime.fromISO(dateTime, { zone: timeZone });
 }


### PR DESCRIPTION
Fix #15021 and the same bug in CompetitionMenu.tsx which just hasn't surfaced because `LIVE_RESULT_BETA` is set to true. I can also use this new helper in LiveView.tsx