### PR TITLE
Add Tests for Medal function for rounds with dual rounds and add global_pos in brackets to results

### DIFF
--- a/app/controllers/persons_controller.rb
+++ b/app/controllers/persons_controller.rb
@@ -42,7 +42,7 @@ class PersonsController < ApplicationController
     @ranks_average = @person.ranks_average.select { |r| r.event.official? }
     @medals = @person.medals
     @records = @person.records
-    @results = @person.results.includes(:competition, :event, :format, :round_type, :result_attempts).order("events.rank, competitions.start_date DESC, competitions.id, round_types.rank DESC")
+    @results = @person.results.includes(:competition, :event, :format, :round_type, :round, :result_attempts).order("events.rank, competitions.start_date DESC, competitions.id, round_types.rank DESC")
     @championship_podiums = @person.championship_podiums
     params[:event] ||= @results.first.event.id
   end

--- a/app/views/persons/_results_by_event.html.erb
+++ b/app/views/persons/_results_by_event.html.erb
@@ -41,8 +41,9 @@
                       <%= link_to result.competition.name, result.competition %>
                     <% end %>
                   </td>
-                  <td class="round"><%= t "rounds.#{result.round_type_id}.cell_name" %></td>
-                  <td class="place"><%= result.pos %></td>
+                  <% dual_round = result.round.linked_round_id? %>
+                  <td class="round"><%= t "rounds.#{result.round_type_id}.cell_name" %><%= " (#{t 'persons.show.dual'})" if dual_round %></td>
+                  <td class="place"><%= result.pos %><%= " (#{result.global_pos})" if dual_round %></td>
                   <td class="single <%= pb_type_class_for_result(result.regional_single_record, pb_markers[result.id][:single]) %>">
                     <%= result.best_solve.clock_format %>
                   </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2461,6 +2461,7 @@ en:
         national: "National Championship Podiums"
         greater_china: "Greater China Championship Podiums"
       place: "Place"
+      dual: "Dual"
       medal_collection: "Medal Collection"
       record_collection: "Record Collection"
       medals:

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -322,4 +322,84 @@ RSpec.describe Person do
       end
     end
   end
+
+  describe "#medals" do
+    context "with a dual final round" do
+      let!(:competition) { create(:competition, event_ids: ["333"]) }
+      let!(:round_one) { create(:round, competition: competition, event_id: "333", number: 1, total_number_of_rounds: 2) }
+      let!(:round_two) { create(:round, competition: competition, event_id: "333", number: 2, total_number_of_rounds: 2) }
+
+      let!(:gold_person) { create(:person) }
+      let!(:silver_person) { create(:person) }
+      let!(:bronze_person) { create(:person) }
+      let!(:fourth_person) { create(:person) }
+
+      before do
+        create(:linked_round, rounds: [round_one, round_two])
+
+        create(:result, person: gold_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 50, average: 100, pos: 1, global_pos: 1)
+        create(:result, person: silver_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 150, average: 200, pos: 2, global_pos: 2)
+      end
+
+      context "when the bronze medalist's better average was in the second round" do
+        before do
+          # Third in round one, but only fourth across the linked rounds.
+          create(:result, person: fourth_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 350, average: 400, pos: 3, global_pos: 4)
+          # Competed in both rounds, so both results carry the same global_pos.
+          create(:result, person: bronze_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 450, average: 500, pos: 4, global_pos: 3)
+          create(:result, person: bronze_person, competition: competition, event_id: "333", round: round_two, round_type_id: "f", best: 250, average: 300, pos: 1, global_pos: 3)
+        end
+
+        it "awards the bronze medal to the person with global_pos 3" do
+          expect(bronze_person.medals).to eq(gold: 0, silver: 0, bronze: 1, total: 1)
+        end
+
+        it "does not award a medal to the person who was third in only one of the linked rounds" do
+          expect(fourth_person.medals).to eq(gold: 0, silver: 0, bronze: 0, total: 0)
+        end
+
+        it "awards gold and silver by global_pos" do
+          expect(gold_person.medals).to eq(gold: 1, silver: 0, bronze: 0, total: 1)
+          expect(silver_person.medals).to eq(gold: 0, silver: 1, bronze: 0, total: 1)
+        end
+      end
+
+      context "when the bronze medalist's better average was in the first round" do
+        before do
+          create(:result, person: bronze_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 250, average: 300, pos: 3, global_pos: 3)
+          create(:result, person: bronze_person, competition: competition, event_id: "333", round: round_two, round_type_id: "f", best: 450, average: 500, pos: 1, global_pos: 3)
+          create(:result, person: fourth_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 350, average: 400, pos: 4, global_pos: 4)
+        end
+
+        it "awards the bronze medal only once" do
+          expect(bronze_person.medals).to eq(gold: 0, silver: 0, bronze: 1, total: 1)
+        end
+
+        it "does not award a medal to the person with global_pos 4" do
+          expect(fourth_person.medals).to eq(gold: 0, silver: 0, bronze: 0, total: 0)
+        end
+      end
+
+      context "when everyone competes in both rounds" do
+        before do
+          create(:result, person: gold_person, competition: competition, event_id: "333", round: round_two, round_type_id: "f", best: 100, average: 150, pos: 1, global_pos: 1)
+          create(:result, person: silver_person, competition: competition, event_id: "333", round: round_two, round_type_id: "f", best: 130, average: 180, pos: 2, global_pos: 2)
+          create(:result, person: bronze_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 250, average: 300, pos: 3, global_pos: 3)
+          create(:result, person: bronze_person, competition: competition, event_id: "333", round: round_two, round_type_id: "f", best: 300, average: 350, pos: 3, global_pos: 3)
+          create(:result, person: fourth_person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 400, average: 450, pos: 4, global_pos: 4)
+          create(:result, person: fourth_person, competition: competition, event_id: "333", round: round_two, round_type_id: "f", best: 350, average: 400, pos: 4, global_pos: 4)
+        end
+
+        it "awards each medal exactly once" do
+          expect(gold_person.medals).to eq(gold: 1, silver: 0, bronze: 0, total: 1)
+          expect(silver_person.medals).to eq(gold: 0, silver: 1, bronze: 0, total: 1)
+          expect(bronze_person.medals).to eq(gold: 0, silver: 0, bronze: 1, total: 1)
+        end
+
+        it "does not award a medal to the person with global_pos 4" do
+          expect(fourth_person.medals).to eq(gold: 0, silver: 0, bronze: 0, total: 0)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/persons_spec.rb
+++ b/spec/requests/persons_spec.rb
@@ -12,5 +12,22 @@ RSpec.describe "persons" do
       get person_path(person.wca_id)
       expect(response).to be_successful
     end
+
+    context "with results in a dual round" do
+      let!(:competition) { create(:competition, event_ids: ["333"]) }
+      let!(:round_one) { create(:round, competition: competition, event_id: "333", number: 1, total_number_of_rounds: 2) }
+      let!(:round_two) { create(:round, competition: competition, event_id: "333", number: 2, total_number_of_rounds: 2) }
+
+      before do
+        create(:linked_round, rounds: [round_one, round_two])
+        create(:result, person: person, competition: competition, event_id: "333", round: round_one, round_type_id: "1", best: 350, average: 400, pos: 4, global_pos: 2)
+      end
+
+      it 'marks the round as dual and shows the local and global position' do
+        get person_path(person.wca_id)
+        expect(response.body).to include("First round (Dual)")
+        expect(response.body).to include("4 (2)")
+      end
+    end
   end
 end


### PR DESCRIPTION
@dunkOnIT I can not replicate the medal issue in #15073. Am I missing some edge case in the tests?
I also checked https://www.worldcubeassociation.org/persons/2023CARD19 and his podium count is correct and does recognize dual rounds