### PR TITLE
Fix duplicate badges 8858

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,13 +27,17 @@
     },
     "plugins": [
         "react",
-        "jquery"
+        "jquery",
+        "import"
     ],
     "rules": {
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
         "import/no-unresolved": ["error", {
             "ignore": ["semantic-css/"]
+        }],
+        "import/order": ["error", {
+            "groups": ["builtin", "external", "internal"]
         }],
         "no-console": ["error", { "allow": ["warn", "error"] }]
     }

--- a/app/webpacker/components/Persons/Badges.jsx
+++ b/app/webpacker/components/Persons/Badges.jsx
@@ -66,26 +66,42 @@ export default function Badges({ userId }) {
   ));
   const roles = data || [];
 
+  const badges = [];
+  const badgesByKey = {};
+  roles.forEach((role) => {
+    const {
+      roleTitle, groupTitle, badgeClass, url,
+    } = badgeParams(role);
+    const key = `${badgeClass}-${roleTitle}-${url}`;
+    if (badgesByKey[key]) {
+      badgesByKey[key].groupTitles.push(groupTitle);
+    } else {
+      const badge = {
+        roleTitle, groupTitles: [groupTitle], badgeClass, url,
+      };
+      badgesByKey[key] = badge;
+      badges.push(badge);
+    }
+  });
+
   return (
     <div className="positions-container">
       {
-        roles.map((role) => {
-          const {
-            roleTitle, groupTitle, badgeClass, url,
-          } = badgeParams(role);
-          return (
-            <Popup
-              content={groupTitle}
-              position="bottom center"
-              inverted
-              trigger={(
-                <span className={`badge ${badgeClass}`}>
-                  <a href={url}>{roleTitle}</a>
-                </span>
+        badges.map(({
+          roleTitle, groupTitles, badgeClass, url,
+        }) => (
+          <Popup
+            key={`${badgeClass}-${roleTitle}-${url}`}
+            content={groupTitles.join(', ')}
+            position="bottom center"
+            inverted
+            trigger={(
+              <span className={`badge ${badgeClass}`}>
+                <a href={url}>{roleTitle}</a>
+              </span>
             )}
-            />
-          );
-        })
+          />
+        ))
       }
     </div>
   );


### PR DESCRIPTION
Fixes #8858

When a person holds the same role (e.g., Regional Delegate) across multiple regions, they previously saw duplicate badges. This change combines those badges into a single badge, displaying all associated regions in the tooltip on hover, separated by commas.

For example, a Regional Delegate for Europe and Asia now shows one "Regional Delegate" badge with a tooltip reading "Europe, Asia" instead of two separate badges.