### PR TITLE
Fix name validation 8163

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,13 +27,17 @@
     },
     "plugins": [
         "react",
-        "jquery"
+        "jquery",
+        "import"
     ],
     "rules": {
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
         "import/no-unresolved": ["error", {
             "ignore": ["semantic-css/"]
+        }],
+        "import/order": ["error", {
+            "groups": ["builtin", "external", "internal"]
         }],
         "no-console": ["error", { "allow": ["warn", "error"] }]
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,7 +322,7 @@ class User < ApplicationRecord
 
   validate :name_parenthesis_format
   def name_parenthesis_format
-    return unless name.present?
+    return if name.blank?
 
     # Check if there's a closing paren without an opening paren
     return errors.add(:name, I18n.t('users.errors.name_invalid_parentheses')) if name.include?(')') && !name.include?('(')
@@ -334,12 +334,10 @@ class User < ApplicationRecord
     return errors.add(:name, I18n.t('users.errors.name_invalid_parentheses')) if name.count('(') > 1 || name.count(')') > 1
 
     # If there's a parenthesis, check format: must be " (text)" at the end
-    if name.include?('(')
-      # Must have space before opening paren and closing paren at the end
-      unless name.match?(/\s\([^)]*\)\z/)
-        return errors.add(:name, I18n.t('users.errors.name_invalid_parentheses'))
-      end
-    end
+    return unless name.include?('(')
+    return if name.match?(/\s\([^)]*\)\z/)
+
+    errors.add(:name, I18n.t('users.errors.name_invalid_parentheses'))
   end
 
   validate :wca_id_prereqs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -320,6 +320,28 @@ class User < ApplicationRecord
     self.name = self.name.strip if self.name.present?
   end
 
+  validate :name_parenthesis_format
+  def name_parenthesis_format
+    return unless name.present?
+
+    # Check if there's a closing paren without an opening paren
+    return errors.add(:name, I18n.t('users.errors.name_invalid_parentheses')) if name.include?(')') && !name.include?('(')
+
+    # Check if there's an opening paren without a closing paren
+    return errors.add(:name, I18n.t('users.errors.name_invalid_parentheses')) if name.include?('(') && !name.include?(')')
+
+    # Check if there are multiple sets of parentheses
+    return errors.add(:name, I18n.t('users.errors.name_invalid_parentheses')) if name.count('(') > 1 || name.count(')') > 1
+
+    # If there's a parenthesis, check format: must be " (text)" at the end
+    if name.include?('(')
+      # Must have space before opening paren and closing paren at the end
+      unless name.match?(/\s\([^)]*\)\z/)
+        return errors.add(:name, I18n.t('users.errors.name_invalid_parentheses'))
+      end
+    end
+  end
+
   validate :wca_id_prereqs
   def wca_id_prereqs
     p = person || unconfirmed_person

--- a/app/webpacker/components/Persons/Badges.jsx
+++ b/app/webpacker/components/Persons/Badges.jsx
@@ -66,26 +66,42 @@ export default function Badges({ userId }) {
   ));
   const roles = data || [];
 
+  const badges = [];
+  const badgesByKey = {};
+  roles.forEach((role) => {
+    const {
+      roleTitle, groupTitle, badgeClass, url,
+    } = badgeParams(role);
+    const key = `${badgeClass}-${roleTitle}-${url}`;
+    if (badgesByKey[key]) {
+      badgesByKey[key].groupTitles.push(groupTitle);
+    } else {
+      const badge = {
+        roleTitle, groupTitles: [groupTitle], badgeClass, url,
+      };
+      badgesByKey[key] = badge;
+      badges.push(badge);
+    }
+  });
+
   return (
     <div className="positions-container">
       {
-        roles.map((role) => {
-          const {
-            roleTitle, groupTitle, badgeClass, url,
-          } = badgeParams(role);
-          return (
-            <Popup
-              content={groupTitle}
-              position="bottom center"
-              inverted
-              trigger={(
-                <span className={`badge ${badgeClass}`}>
-                  <a href={url}>{roleTitle}</a>
-                </span>
+        badges.map(({
+          roleTitle, groupTitles, badgeClass, url,
+        }) => (
+          <Popup
+            key={`${badgeClass}-${roleTitle}-${url}`}
+            content={groupTitles.join(', ')}
+            position="bottom center"
+            inverted
+            trigger={(
+              <span className={`badge ${badgeClass}`}>
+                <a href={url}>{roleTitle}</a>
+              </span>
             )}
-            />
-          );
-        })
+          />
+        ))
       }
     </div>
   );

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1126,6 +1126,7 @@ en:
       wca_id_no_name_html: "We do not have a name recorded for this WCA ID. Please contact the <a href='%{wrt_contact_path}' target='_blank'>WCA Results Team</a> to resolve this."
       email_used_by_locked_account_html: "is already used by another account. It has been created automatically as a result of you registering for a competition via an external service. If you are the owner of this email, you can use the account after resetting your password <a href='/users/password/new'>here</a>."
       must_match_person: "must match person details corresponding to the WCA ID"
+      name_invalid_parentheses: "can only contain parentheses for a localized name at the end (e.g., 'Seung Hyuk Nahm (남승혁)')"
     #context: when an action was successful
     successes:
       messages:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,6 +61,52 @@ RSpec.describe User do
     expect(user).to be_invalid_with_errors(email: ["is invalid"])
   end
 
+  describe "name validation" do
+    it "allows names without parentheses" do
+      user = build(:user, name: "John Doe")
+      expect(user).to be_valid
+    end
+
+    it "allows names with localized name in parentheses at the end" do
+      user = build(:user, name: "Seung Hyuk Nahm (남승혁)")
+      expect(user).to be_valid
+    end
+
+    it "invalidates names with multiple sets of parentheses" do
+      user = build(:user, name: "John (Preferred) Doe (한글)")
+      expect(user).to be_invalid_with_errors(name: [I18n.t('users.errors.name_invalid_parentheses')])
+    end
+
+    it "invalidates names with parentheses not at the end" do
+      user = build(:user, name: "Legal (Preferred) Last")
+      expect(user).to be_invalid_with_errors(name: [I18n.t('users.errors.name_invalid_parentheses')])
+
+      user = build(:user, name: "John (Nickname) Doe Smith")
+      expect(user).to be_invalid_with_errors(name: [I18n.t('users.errors.name_invalid_parentheses')])
+    end
+
+    it "invalidates names with opening parenthesis not preceded by space" do
+      user = build(:user, name: "John(Nickname)")
+      expect(user).to be_invalid_with_errors(name: [I18n.t('users.errors.name_invalid_parentheses')])
+    end
+
+    it "invalidates names with opening parenthesis but no closing parenthesis" do
+      user = build(:user, name: "John Doe (incomplete")
+      expect(user).to be_invalid_with_errors(name: [I18n.t('users.errors.name_invalid_parentheses')])
+    end
+
+    it "invalidates names with closing parenthesis but no opening parenthesis" do
+      user = build(:user, name: "John Doe) incomplete")
+      expect(user).to be_invalid_with_errors(name: [I18n.t('users.errors.name_invalid_parentheses')])
+    end
+
+    it "trims whitespace from names" do
+      user = build(:user, name: "  John Doe  ")
+      user.valid?
+      expect(user.name).to eq "John Doe"
+    end
+  end
+
   it "can confirm a user who has never competed before" do
     user = build(:user, unconfirmed_wca_id: "")
     user.confirm


### PR DESCRIPTION
Fixes #8163

Add name validation to ensure parentheses are only used for localized names at the end.

Prevents invalid formats like "Legal (Preferred) Last". Only allows: "Name (localized)".

