### PR TITLE
Fix foreign key constraint error when merging users with potential duplicates

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,6 +13,7 @@ class Person < ApplicationRecord
   has_many :ranks_single, primary_key: "wca_id", class_name: "RanksSingle"
   has_many :inbox_persons, primary_key: "wca_id", foreign_key: "wca_id", inverse_of: :person
   has_many :tickets_edit_person, primary_key: "wca_id", foreign_key: "wca_id", class_name: "TicketsEditPerson", inverse_of: :person
+  has_many :potential_duplicate_persons, foreign_key: :duplicate_person_id, class_name: "PotentialDuplicatePerson", dependent: :destroy, inverse_of: :duplicate_person
 
   enum :gender, User::ALLOWABLE_GENDERS.index_with(&:to_s)
 

--- a/db/migrate/20260725121610_change_potential_duplicate_persons_foreign_key_to_cascade.rb
+++ b/db/migrate/20260725121610_change_potential_duplicate_persons_foreign_key_to_cascade.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangePotentialDuplicatePersonsForeignKeyToCascade < ActiveRecord::Migration[8.1]
+  def change
+    remove_foreign_key :potential_duplicate_persons, column: :duplicate_person_id
+    add_foreign_key :potential_duplicate_persons, :persons, column: :duplicate_person_id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260725121610_change_potential_duplicate_persons_foreign_key_to_cascade.rb
+++ b/db/migrate/20260725121610_change_potential_duplicate_persons_foreign_key_to_cascade.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 class ChangePotentialDuplicatePersonsForeignKeyToCascade < ActiveRecord::Migration[8.1]
-  def change
+  def up
     remove_foreign_key :potential_duplicate_persons, column: :duplicate_person_id
     add_foreign_key :potential_duplicate_persons, :persons, column: :duplicate_person_id, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :potential_duplicate_persons, column: :duplicate_person_id
+    add_foreign_key :potential_duplicate_persons, :persons, column: :duplicate_person_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_05_050115) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_25_121610) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1680,7 +1680,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_050115) do
   add_foreign_key "payment_intents", "users", column: "initiated_by_id"
   add_foreign_key "paypal_records", "paypal_records", column: "parent_record_id"
   add_foreign_key "potential_duplicate_persons", "duplicate_checker_job_runs"
-  add_foreign_key "potential_duplicate_persons", "persons", column: "duplicate_person_id"
+  add_foreign_key "potential_duplicate_persons", "persons", column: "duplicate_person_id", on_delete: :cascade
   add_foreign_key "potential_duplicate_persons", "users", column: "original_user_id"
   add_foreign_key "regional_records_lookup", "results", on_update: :cascade, on_delete: :cascade
   add_foreign_key "registration_competition_events", "competition_events", on_delete: :cascade

--- a/spec/models/merge_people_spec.rb
+++ b/spec/models/merge_people_spec.rb
@@ -68,4 +68,19 @@ RSpec.describe MergePeople do
     expect(result2.reload.person_id).to eq person1.wca_id
     expect(decoy_result.reload.person_id).to eq old_decoy_person_id
   end
+
+  it "destroys potential duplicate persons associated with the merged person" do
+    job_run = DuplicateCheckerJobRun.create!(competition: create(:competition), run_status: :not_started)
+    user = create(:user)
+    pdp = PotentialDuplicatePerson.create!(
+      duplicate_checker_job_run_id: job_run.id,
+      original_user: user,
+      duplicate_person: person2,
+      name_matching_algorithm: :jarowinkler,
+      score: 90
+    )
+
+    expect(merge_people.do_merge).to be true
+    expect(PotentialDuplicatePerson.exists?(pdp.id)).to be false
+  end
 end

--- a/spec/models/merge_people_spec.rb
+++ b/spec/models/merge_people_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe MergePeople do
       original_user: user,
       duplicate_person: person2,
       name_matching_algorithm: :jarowinkler,
-      score: 90
+      score: 90,
     )
 
     expect(merge_people.do_merge).to be true


### PR DESCRIPTION
### Problem
Merging two WCA profiles in `AdminController#do_merge_people` triggers `MergePeople#do_merge`, which destroys the duplicate person record (`person2`). However, if `person2` is referenced by any records in the `potential_duplicate_persons` table (via the `duplicate_person_id` foreign key), this deletion fails with an `ActiveRecord::InvalidForeignKey` database error.

### Solution
- Added the `potential_duplicate_persons` association to the `Person` model with `dependent: :destroy` configuration so that any referencing potential duplicate records are automatically cleaned up when the `Person` is deleted.
- Added a unit test in `MergePeopleSpec` verifying that when a merge happens, any associated potential duplicates targeting the merged person are successfully destroyed.

(AI generated)