### PR TITLE
Remove location from CreateModal component

### DIFF
--- a/app/webpacker/components/Panel/pages/RegionManager/index.jsx
+++ b/app/webpacker/components/Panel/pages/RegionManager/index.jsx
@@ -256,7 +256,6 @@ export default function RegionManager() {
         status={(selectedGroup?.parent_group_id
           ? delegateRegionsStatus.regional_delegate
           : delegateRegionsStatus.senior_delegate)}
-        location={selectedGroup?.name}
       />
     </>
   );

--- a/app/webpacker/components/Panel/pages/Regions/Subregion.jsx
+++ b/app/webpacker/components/Panel/pages/Regions/Subregion.jsx
@@ -211,7 +211,6 @@ export default function Subregion({ group }) {
         status={(group.parent_group_id
           ? delegateRegionsStatus.regional_delegate
           : delegateRegionsStatus.senior_delegate)}
-        location={group.name}
       />
       <Modal
         size="fullscreen"

--- a/app/webpacker/components/Panel/views/UserRoles/CreateModal.jsx
+++ b/app/webpacker/components/Panel/views/UserRoles/CreateModal.jsx
@@ -8,7 +8,7 @@ import Errored from '../../../Requests/Errored';
 import useInputState from '../../../../lib/hooks/useInputState';
 
 export default function CreateModal({
-  open, onClose, title, groupId, status, location,
+  open, onClose, title, groupId, status,
 }) {
   const {
     mutate: createUserRoleMutation,
@@ -66,7 +66,6 @@ export default function CreateModal({
                 userId,
                 groupId,
                 status,
-                location,
               });
             }}
           >


### PR DESCRIPTION
Problem: Currently in Delegates page, it's sorting based on `location`, and because of that if lead delegates have location, they go in between the order, and won't stay at top. Ideally lead delegates don't need location, so removing the location input from the CreateModal form.

Long term: CreateModal is currently used only for creating roles of lead delegates, and because of that only required field is the user. But eventually I'm planning to expand this form for any role creation within our website. But I foresee a risk that if we do something like "if user doesn't pass a field, ask for that field as input", it's going to ask for location for lead delegates, which can cause errors. So my future plan is to include one more param in CreateModal named `editableFields`, which will say which all fields to be editable by user. This way, we can force no location for lead delegates from the frontend.

We can have backend validation as well to ensure there is no locations for lead delegates, but I don't think that will be necessary.