### PR TITLE
Fix doubled bookmark issue

### DIFF
--- a/app/jobs/registration_reminder_job.rb
+++ b/app/jobs/registration_reminder_job.rb
@@ -15,8 +15,7 @@ class RegistrationReminderJob < WcaCronjob
       .select { |c| should_send_reminder?(c) }.each do |competition|
         ActiveRecord::Base.transaction do
           competition.update_attribute(:registration_reminder_sent_at, Time.now)
-          users_to_email = competition.bookmarked_users.to_a
-          users_to_email.concat(competition.managers)
+          users_to_email = competition.bookmarked_users | competition.managers
           registered_users = competition.registrations.accepted.pluck(:user_id)
           pending_registered_users = competition.registrations.pending.pluck(:user_id)
           users_to_email.select { |user| registered_users.exclude?(user.id) }.uniq.each do |user|

--- a/app/jobs/registration_reminder_job.rb
+++ b/app/jobs/registration_reminder_job.rb
@@ -15,7 +15,7 @@ class RegistrationReminderJob < WcaCronjob
       .select { |c| should_send_reminder?(c) }.each do |competition|
         ActiveRecord::Base.transaction do
           competition.update_attribute(:registration_reminder_sent_at, Time.now)
-          users_to_email = competition.bookmarked_users
+          users_to_email = competition.bookmarked_users.to_a
           users_to_email.concat(competition.managers)
           registered_users = competition.registrations.accepted.pluck(:user_id)
           pending_registered_users = competition.registrations.pending.pluck(:user_id)


### PR DESCRIPTION
Closes #12739

This solution was suggested by an LLM. I tested it locally, and it works as expected. The description below was also provided by Claude and has been slightly edited by me.

## Root cause of the issue

In `RegistrationReminderJob#perform`, `competition.bookmarked_users` returns an ActiveRecord `CollectionProxy` (not a plain Array). Calling `.concat(competition.managers)` on this proxy triggers Rails' association `<<` operator, which **writes to the database** - creating new `bookmarked_competitions` rows for each manager (organizer, delegate). Since the table has no unique constraint on `(competition_id, user_id)`, organizers/delegates who had already bookmarked the competition ended up with a duplicate row.

## Fix

Call `.to_a` on the collection proxy before concatenating, converting it to a plain Ruby Array. `Array#concat` is a pure in-memory operation and does not interact with ActiveRecord at all.
