### PR TITLE
Cache to ECR instead of GH

### DIFF
--- a/.github/actions/build-js-image/action.yaml
+++ b/.github/actions/build-js-image/action.yaml
@@ -34,7 +34,7 @@ runs:
         context: ./next-frontend
         tags: |
           ${{ inputs.registry }}:${{ inputs.tag }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.tag }}
+        cache-to: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.tag }},mode=max,image-manifest=true,oci-mediatypes=true
         build-args: |
           WCA_SITE=${{ inputs.base_url }}

--- a/.github/actions/build-js-image/action.yaml
+++ b/.github/actions/build-js-image/action.yaml
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: aws s3 cp s3://wca-fonts ./next-frontend/src/styles/fonts/ --recursive
     - name: Build and push JS Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       id: build-js-image
       with:
         push: true

--- a/.github/actions/build-ruby-image/action.yaml
+++ b/.github/actions/build-ruby-image/action.yaml
@@ -47,8 +47,8 @@ runs:
         target: ${{ inputs.target }}
         tags: |
           ${{ inputs.registry }}:${{ inputs.tag }}
-        cache-from: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.target }}-${{ inputs.environment }}
-        cache-to: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.target }}-${{ inputs.environment }},mode=max,image-manifest=true,oci-mediatypes=true
+        cache-from: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.tag }}
+        cache-to: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.tag }},mode=max,image-manifest=true,oci-mediatypes=true
         build-args: |
           BUILD_TAG=${{ inputs.build_tag }}
           WCA_LIVE_SITE=${{ env.WCA_LIVE_SITE }}

--- a/.github/actions/build-ruby-image/action.yaml
+++ b/.github/actions/build-ruby-image/action.yaml
@@ -38,7 +38,7 @@ runs:
           echo "WCA_LIVE_SITE=true" >> $GITHUB_ENV
         fi
     - name: Build and push Ruby Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       id: build-ruby-image
       with:
         push: true

--- a/.github/actions/build-ruby-image/action.yaml
+++ b/.github/actions/build-ruby-image/action.yaml
@@ -47,8 +47,8 @@ runs:
         target: ${{ inputs.target }}
         tags: |
           ${{ inputs.registry }}:${{ inputs.tag }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.target }}-${{ inputs.environment }}
+        cache-to: type=registry,ref=${{ inputs.registry }}:buildcache-${{ inputs.target }}-${{ inputs.environment }},mode=max,image-manifest=true,oci-mediatypes=true
         build-args: |
           BUILD_TAG=${{ inputs.build_tag }}
           WCA_LIVE_SITE=${{ env.WCA_LIVE_SITE }}


### PR DESCRIPTION
Allows us to circumvent the permission issues in https://github.com/docker/build-push-action/issues/1571#issuecomment-4924969423 without having to trigger the workflow manually