### PR TITLE
Add missing Scoretaker.yaml

### DIFF
--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -31,6 +31,12 @@ jobs:
           cache: 'yarn'
       - name: Install fresh Yarn packages
         run: yarn install
+      - name: Build OpenAPI types
+        # Fails if a $ref points at a schema file that was never committed, and
+        # (via the diff) if the committed types are stale.
+        run: |
+          yarn run types:openapi
+          git diff --exit-code -- src/types/openapi.ts
       - name: Check types
         run: yarn run check:types
       - name: Run Lint

--- a/next-frontend/openapi/schemas/competitions/Scoretaker.yaml
+++ b/next-frontend/openapi/schemas/competitions/Scoretaker.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - user_id
+  - name
+properties:
+  user_id:
+    type: integer
+  name:
+    type: string


### PR DESCRIPTION
Forgot to commit it and build fails now. Should we add a simple "try to build openapi" test to the js tests?