### PR TITLE
Add search-by-name filter to registrations list

### DIFF
--- a/app/webpacker/components/Registrations/List/Competitors.jsx
+++ b/app/webpacker/components/Registrations/List/Competitors.jsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import React, { useMemo, useReducer, useState } from 'react';
-import { Icon, Input, Segment, Table } from 'semantic-ui-react';
+import {
+  Icon, Input, Segment, Table,
+} from 'semantic-ui-react';
 import _ from 'lodash';
 import {
   getConfirmedRegistrations,

--- a/app/webpacker/components/Registrations/List/Competitors.jsx
+++ b/app/webpacker/components/Registrations/List/Competitors.jsx
@@ -106,7 +106,7 @@ export default function Competitors({
         returnerCount={returnerCount}
         onScrollToMeClick={onScrollToMeClick}
       />
-      <div style={{ marginBottom: '1em' }}>
+      <Segment basic>
         <Input
           fluid
           icon={<Icon name="search" />}
@@ -115,7 +115,7 @@ export default function Competitors({
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
         />
-      </div>
+      </Segment>
       <div style={{ overflowX: 'auto' }}>
         <Table striped sortable unstackable compact singleLine textAlign="left">
           <CompetitorsHeader

--- a/app/webpacker/components/Registrations/List/Competitors.jsx
+++ b/app/webpacker/components/Registrations/List/Competitors.jsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import React, { useMemo, useReducer } from 'react';
-import { Segment, Table } from 'semantic-ui-react';
+import React, { useMemo, useReducer, useState } from 'react';
+import { Icon, Input, Segment, Table } from 'semantic-ui-react';
 import _ from 'lodash';
 import {
   getConfirmedRegistrations,
@@ -32,6 +32,8 @@ export default function Competitors({
     retry: false,
   });
 
+  const [searchQuery, setSearchQuery] = useState('');
+
   const [sortState, sortDispatch] = useReducer(sortReducer, {
     sortColumn: 'name',
     sortDirection: 'ascending',
@@ -39,9 +41,15 @@ export default function Competitors({
   const { sortColumn: sortedColumn, sortDirection: sortedDirection } = sortState;
   const changeSortColumn = (name) => sortDispatch({ type: 'CHANGE_SORT', sortColumn: name });
 
-  // TODO: use react table (future PR)
   const data = useMemo(() => {
     if (registrations) {
+      let filtered = registrations;
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        filtered = registrations.filter(
+          (r) => r.user.name.toLowerCase().includes(q),
+        );
+      }
       let orderBy = [];
       switch (sortedColumn) {
         case 'country':
@@ -61,10 +69,10 @@ export default function Competitors({
       orderBy.push((item) => item.user.name.toLowerCase());
       const direction = sortedDirection === 'descending' ? 'desc' : 'asc';
 
-      return _.orderBy(registrations, orderBy, [direction]);
+      return _.orderBy(filtered, orderBy, [direction]);
     }
     return [];
-  }, [registrations, sortedColumn, sortedDirection]);
+  }, [registrations, searchQuery, sortedColumn, sortedDirection]);
 
   if (isError) {
     return (
@@ -96,6 +104,16 @@ export default function Competitors({
         returnerCount={returnerCount}
         onScrollToMeClick={onScrollToMeClick}
       />
+      <div style={{ marginBottom: '1em' }}>
+        <Input
+          fluid
+          icon={<Icon name="search" />}
+          iconPosition="left"
+          placeholder={I18n.t('registrations.list.search_by_name')}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
       <div style={{ overflowX: 'auto' }}>
         <Table striped sortable unstackable compact singleLine textAlign="left">
           <CompetitorsHeader

--- a/app/webpacker/components/Registrations/List/PsychSheet.jsx
+++ b/app/webpacker/components/Registrations/List/PsychSheet.jsx
@@ -116,7 +116,7 @@ export default function PsychSheet({
         returnerCount={returnerCount}
         onScrollToMeClick={onScrollToMeClick}
       />
-      <div style={{ marginBottom: '1em' }}>
+      <Segment basic>
         <Input
           fluid
           icon={<Icon name="search" />}
@@ -125,7 +125,7 @@ export default function PsychSheet({
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
         />
-      </div>
+      </Segment>
       <div style={{ overflowX: 'auto' }}>
         <Table striped sortable unstackable compact singleLine textAlign="left">
           <PsychSheetHeader

--- a/app/webpacker/components/Registrations/List/PsychSheet.jsx
+++ b/app/webpacker/components/Registrations/List/PsychSheet.jsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import {
-  Icon, Segment, Table,
+  Icon, Input, Segment, Table,
 } from 'semantic-ui-react';
 import {
   getPsychSheetForEvent,
@@ -71,6 +71,17 @@ export default function PsychSheet({
     retry: false,
   });
 
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredRankings = useMemo(() => {
+    if (!rankings) return [];
+    if (!searchQuery) return rankings;
+    const q = searchQuery.toLowerCase();
+    return rankings.filter(
+      (r) => r.user.name.toLowerCase().includes(q),
+    );
+  }, [rankings, searchQuery]);
+
   if (isError) {
     return (
       <Errored componentName="PsychSheet" />
@@ -86,12 +97,12 @@ export default function PsychSheet({
   }
 
   const { userIsInTable, userPosition } = getUserPositionInfo(
-    rankings,
+    filteredRankings,
     userId,
   );
 
   const { registrationCount, newcomerCount, returnerCount } = getPeopleCounts(
-    rankings,
+    filteredRankings,
   );
 
   return (
@@ -105,6 +116,16 @@ export default function PsychSheet({
         returnerCount={returnerCount}
         onScrollToMeClick={onScrollToMeClick}
       />
+      <div style={{ marginBottom: '1em' }}>
+        <Input
+          fluid
+          icon={<Icon name="search" />}
+          iconPosition="left"
+          placeholder={I18n.t('registrations.list.search_by_name')}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
       <div style={{ overflowX: 'auto' }}>
         <Table striped sortable unstackable compact singleLine textAlign="left">
           <PsychSheetHeader
@@ -114,14 +135,14 @@ export default function PsychSheet({
             hideAverage={eventIsMbf}
           />
           <PsychSheetBody
-            registrations={rankings}
+            registrations={filteredRankings}
             selectedEvent={selectedEvent}
             userId={userId}
             userRowRef={userRowRef}
             hideAverage={eventIsMbf}
           />
           <PsychSheetFooter
-            registrations={rankings}
+            registrations={filteredRankings}
             hideAverage={eventIsMbf}
           />
         </Table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1262,7 +1262,7 @@ en:
       payment_requested_on: "Payment requested on: %{date}"
       #context: Counts how many parallel registrations in the same Series there are. Will display a number behind this label.
       series_registrations: "Series registrations"
-      search_by_name: "Search by name..."
+      search_by_name: "Search by name"
       total: "Total"
     new_registration:
       title: "Register for %{comp}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1262,6 +1262,7 @@ en:
       payment_requested_on: "Payment requested on: %{date}"
       #context: Counts how many parallel registrations in the same Series there are. Will display a number behind this label.
       series_registrations: "Series registrations"
+      search_by_name: "Search by name..."
       total: "Total"
     new_registration:
       title: "Register for %{comp}"


### PR DESCRIPTION
## Overview
This PR adds a search bar to the registrations tab that filters competitors by name in real time. Previously, with many registrations, you had to scroll through the entire table to find a specific participant, which was quite tedious, especially for competitions with 150+ entries.

## Changes
- **`Competitors.jsx`**: Added a search input (with a search icon) above the registrations table. The list is filtered case-insensitively by `user.name` before sorting is applied.
- **`PsychSheet.jsx`**: Added the same search input to the psych sheet list, so organizers can quickly find a competitor's psych sheet entries.
- **`en.yml`**: Added the `registrations.list.search_by_name` i18n key ("Search by name...").

## Why
Finding a specific participant in a large competition list was cumbersome. The search bar solves this with instant filtering, which is especially useful to see who is registered and for which events.

## Testing
- Verified locally that typing a name filters the list in real time
- Works together with existing sorting (name/country/total)

## Screenshots
<img width="1538" height="613" alt="Screenshot 2026-07-30 152454" src="https://github.com/user-attachments/assets/614e15af-65fa-470b-ad92-98b282ad6f7d" />

<img width="1507" height="177" alt="Screenshot 2026-07-30 152710" src="https://github.com/user-attachments/assets/a69b810b-f099-407b-819a-c1e66c3e62df" />




