### PR TITLE
Set global_pos in h2h_results_import.rake

### DIFF
--- a/lib/tasks/h2h_results_import.rake
+++ b/lib/tasks/h2h_results_import.rake
@@ -93,7 +93,8 @@ namespace :h2h_results do
             person: lr.registration.person,
             person_name: lr.registration.name,
             country_id: lr.registration.country.id,
-            pos: lr.global_pos,
+            pos: lr.local_pos,
+            global_pos: lr.global_pos,
           )
 
           result_attempts = lr.live_attempts.map { ResultAttempt.new(attempt_number: it.attempt_number, value: it.value) }


### PR DESCRIPTION
In the created h2h live_results `local_pos = global_pos` but I still changed both it so it's less confusing.
Fixes #15076