### PR TITLE
New Nextjs Color Proposal

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/dashboard/SlateRoleExamples.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/dashboard/SlateRoleExamples.tsx
@@ -1,0 +1,251 @@
+"use client";
+// Static markup, but a client component on purpose: it reads `slateRoleRungs`
+//   from `@/theme`, and importing that module runs Chakra's `createSystem`,
+//   which pulls in Ark UI's anatomies and cannot be evaluated in the RSC graph.
+
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  HStack,
+  SimpleGrid,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import { slateRoleRungs, type SlatePalette } from "@/theme";
+
+const PALETTES = Object.keys(slateRoleRungs) as SlatePalette[];
+
+const ROLES = [
+  { token: "2B", name: "Pastel" },
+  { token: "2C", name: "Bright" },
+  { token: "1A", name: "Solid" },
+  { token: "2A", name: "Deep" },
+] as const;
+
+const CARD_LAYERS = [
+  { layerStyle: "card.pastel", name: "card.pastel", pairing: "1A + contrast" },
+  { layerStyle: "card.bright", name: "card.bright", pairing: "2C + 2A" },
+  { layerStyle: "card.dark", name: "card.dark", pairing: "2A + 2B" },
+] as const;
+
+const CUBE_FACES = [
+  { token: "cubeShades.left", name: "Left" },
+  { token: "cubeShades.top", name: "Top" },
+  { token: "cubeShades.right", name: "Right" },
+] as const;
+
+const Section = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) => (
+  <Stack gap="4">
+    <Stack gap="1">
+      <Text textStyle="s3">{title}</Text>
+      <Text textStyle="annotation" color="fg.muted">
+        {description}
+      </Text>
+    </Stack>
+    {children}
+  </Stack>
+);
+
+// Each role is labelled with the rung it resolves to, which is the whole point:
+//   `2C` is not a colour of its own, it is whichever step the family assigns.
+const RoleStrip = ({ palette }: { palette: SlatePalette }) => (
+  <Stack gap="2" colorPalette={palette}>
+    <Text textStyle="s4">{palette}</Text>
+    <HStack gap="1" alignItems="stretch">
+      {ROLES.map((role) => (
+        <Stack key={role.token} flex="1" gap="1">
+          <Box
+            bg={`colorPalette.${role.token}`}
+            height="12"
+            borderRadius="sm"
+            borderWidth="1px"
+            borderColor="border"
+          />
+          <Text textStyle="annotation">{role.name}</Text>
+          <Text textStyle="annotation" color="fg.muted">
+            {role.token} · {slateRoleRungs[palette][role.token]}
+          </Text>
+        </Stack>
+      ))}
+    </HStack>
+  </Stack>
+);
+
+const LadderStrip = ({ palette }: { palette: SlatePalette }) => {
+  // Widened: the `as const` rung map narrows to only the steps that happen to
+  //   carry a role, which would reject the unused steps below.
+  const rungs: ReadonlyArray<string> = Object.values(slateRoleRungs[palette]);
+
+  return (
+    <Stack gap="2" colorPalette={palette}>
+      <Text textStyle="s4">{palette}</Text>
+      <HStack gap="0.5" alignItems="stretch">
+        {(
+          [
+            "50",
+            "100",
+            "200",
+            "300",
+            "400",
+            "500",
+            "600",
+            "700",
+            "800",
+            "900",
+            "950",
+          ] as const
+        ).map((step) => (
+          <Stack key={step} flex="1" gap="1">
+            <Box
+              bg={`colorPalette.${step}`}
+              height="10"
+              borderRadius="xs"
+              borderWidth="1px"
+              borderColor="border"
+            />
+            <Text
+              textStyle="annotation"
+              textAlign="center"
+              color={rungs.includes(step) ? "fg" : "fg.muted"}
+              fontWeight={rungs.includes(step) ? "bold" : "light"}
+            >
+              {step}
+            </Text>
+          </Stack>
+        ))}
+      </HStack>
+    </Stack>
+  );
+};
+
+const CardLayerRow = ({ palette }: { palette: SlatePalette }) => (
+  <Stack gap="2" colorPalette={palette}>
+    <Text textStyle="s4">{palette}</Text>
+    <SimpleGrid columns={3} gap="2">
+      {CARD_LAYERS.map((layer) => (
+        <Stack
+          key={layer.name}
+          layerStyle={layer.layerStyle}
+          borderRadius="wca"
+          padding="3"
+          gap="1"
+        >
+          <Text textStyle="bodyEmphasis">{layer.name}</Text>
+          <Text textStyle="annotation">{layer.pairing}</Text>
+        </Stack>
+      ))}
+    </SimpleGrid>
+  </Stack>
+);
+
+export default function SlateRoleExamples() {
+  return (
+    <Card.Root width="full">
+      <Card.Body gap="10">
+        <Stack gap="1">
+          <Card.Title>Slate roles in use</Card.Title>
+          <Text textStyle="annotation" color="fg.muted">
+            The brand vocabulary (1A / 2A / 2B / 2C) resolves to positions on
+            each family&#39;s generated scale rather than to standalone colours.
+            Solid and Deep are Slate&#39;s hexes verbatim; Pastel and Bright are
+            read off the ladder.
+          </Text>
+        </Stack>
+
+        <Section
+          title="Every role is a rung"
+          description="The rung each role lands on is per-family, because the primaries differ in lightness. Solid sits at 600 in green and red, 700 in blue, 500 in orange, 400 in yellow and 100 in white."
+        >
+          <SimpleGrid columns={{ base: 1, lg: 2 }} gap="6">
+            {PALETTES.map((palette) => (
+              <RoleStrip key={palette} palette={palette} />
+            ))}
+          </SimpleGrid>
+        </Section>
+
+        <Section
+          title="The ladder each role is drawn from"
+          description="Bold steps are the ones carrying a brand role. Every family runs light to dark without reversing, so a component written against a step number behaves the same in all six."
+        >
+          <Stack gap="5">
+            {PALETTES.map((palette) => (
+              <LadderStrip key={palette} palette={palette} />
+            ))}
+          </Stack>
+        </Section>
+
+        <Section
+          title="Card layer styles"
+          description="These three pairings are why Bright sits in the light half of the ladder: card.bright uses it as a background for Deep-toned text."
+        >
+          <Stack gap="5">
+            {PALETTES.map((palette) => (
+              <CardLayerRow key={palette} palette={palette} />
+            ))}
+          </Stack>
+        </Section>
+
+        <Section
+          title="One component, six palettes"
+          description="None of these buttons or badges name a colour. They inherit colorPalette and read the same rungs, which is what the scale contract buys."
+        >
+          <Stack gap="4">
+            {PALETTES.map((palette) => (
+              <HStack key={palette} gap="3" wrap="wrap" colorPalette={palette}>
+                <Text textStyle="s4" width="24">
+                  {palette}
+                </Text>
+                <Button variant="solid">Solid</Button>
+                <Button variant="subtle">Subtle</Button>
+                <Button variant="outline">Outline</Button>
+                <Button variant="pastelOutline">Pastel outline</Button>
+                <Badge variant="solid">Solid</Badge>
+                <Badge variant="subtle">Subtle</Badge>
+                <Badge variant="outline">Outline</Badge>
+              </HStack>
+            ))}
+          </Stack>
+        </Section>
+
+        <Section
+          title="Cube faces"
+          description="The three isometric face shades stay as Slate delivered them — they are decorative, never asked to carry text, and so were left outside the ladder."
+        >
+          <SimpleGrid columns={{ base: 2, md: 3, lg: 6 }} gap="4">
+            {PALETTES.map((palette) => (
+              <Stack key={palette} gap="2" colorPalette={palette}>
+                <Text textStyle="s4">{palette}</Text>
+                <HStack gap="1" alignItems="stretch">
+                  {CUBE_FACES.map((face) => (
+                    <Stack key={face.name} flex="1" gap="1">
+                      <Box
+                        bg={`colorPalette.${face.token}`}
+                        height="10"
+                        borderRadius="xs"
+                        borderWidth="1px"
+                        borderColor="border"
+                      />
+                      <Text textStyle="annotation" color="fg.muted">
+                        {face.name}
+                      </Text>
+                    </Stack>
+                  ))}
+                </HStack>
+              </Stack>
+            ))}
+          </SimpleGrid>
+        </Section>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/next-frontend/src/app/(wca)/(with-background)/dashboard/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import { iconMap } from "@/components/icons/iconMap";
 import { route } from "nextjs-routes";
 import AttemptResultField from "./AttemptResultField";
+import SlateRoleExamples from "./SlateRoleExamples";
 import {
   ColorSemanticTokenDoc,
   ColorTokenDoc,
@@ -92,6 +93,7 @@ export default async function Dashboard() {
           </SimpleGrid>
         </Card.Body>
       </Card.Root>
+      <SlateRoleExamples />
       <Card.Root width="full">
         <Card.Body>
           <Card.Title>Theme Explorer</Card.Title>

--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -3,17 +3,6 @@ import { oklch, toGamut, formatHex, parseHex, lerp } from "culori";
 import _ from "lodash";
 import type { Rgb, Oklch } from "culori";
 
-interface WcaPaletteInput {
-  primary: string; // 1A (Solid / Top Face)
-  pantoneDescription: string;
-  secondaryLight: string; // 2B (Pastel)
-  secondaryMedium: string; // 2C (Bright)
-  secondaryDark: string; // 2A (Deep)
-  cubeLight: string; // Left Face
-  cubeDark: string; // Right Face
-  pastelContrast: "white" | "black";
-}
-
 type LuminanceKey =
   | "50"
   | "100"
@@ -27,71 +16,99 @@ type LuminanceKey =
   | "900"
   | "950";
 
+type BrandRole = "1A" | "2A" | "2B" | "2C";
+
+type RoleRungs = Readonly<Record<BrandRole, LuminanceKey>>;
+
+// Each brand role is a *position on the scale*, not a free-standing colour.
+// The default assignment is Deep 800 / Solid 600 / Bright 300 / Pastel 200;
+//   families whose Solid cannot sit at 600 shift the lighter roles up to keep
+//   every role on its own rung.
+// Bright stays in the light half because `card.bright` pairs it as a background
+//   for Deep-toned text, which needs it to hold ~4.5:1 against the Deep tone.
+// Exported so the theme documentation on /dashboard can state which rung each
+//   role resolves to without restating the mapping and letting it drift.
+export const slateRoleRungs = {
+  // Gamut exception: the Solid is a near-white, so it can only sit at 100.
+  wcaWhite: { "2A": "800", "1A": "100", "2C": "50", "2B": "200" },
+  green: { "2A": "800", "1A": "600", "2C": "300", "2B": "200" },
+  red: { "2A": "800", "1A": "600", "2C": "300", "2B": "200" },
+  // Gamut exception: no screen can show a yellow this vivid below L≈0.80,
+  //   so the Solid sits at 400 and Bright moves up to 300.
+  yellow: { "2A": "800", "1A": "400", "2C": "300", "2B": "200" },
+  blue: { "2A": "800", "1A": "700", "2C": "300", "2B": "200" },
+  orange: { "2A": "800", "1A": "500", "2C": "300", "2B": "200" },
+} as const satisfies Readonly<Record<string, RoleRungs>>;
+
+export type SlatePalette = keyof typeof slateRoleRungs;
+
+interface WcaPaletteInput {
+  primary: string; // 1A (Solid / Top Face)
+  pantoneDescription: string;
+  secondaryDark: string; // 2A (Deep)
+  cubeLight: string; // Left Face
+  cubeDark: string; // Right Face
+  pastelContrast: "white" | "black";
+  rungs: RoleRungs;
+}
+
 type ColorScale = Readonly<Record<LuminanceKey, string>>;
 type ChakraColorScale = Readonly<Record<LuminanceKey, { value: string }>>;
-
-type ColorDelta = Readonly<Oklch> & { h: number };
 
 const slateColors = {
   green: {
     primary: "#029347",
     pantoneDescription: "Pantone 348 C",
-    secondaryLight: "#C1E6CD",
-    secondaryMedium: "#00FF7F",
     secondaryDark: "#1B4D3E",
     cubeLight: "#1AB55C",
     cubeDark: "#04632D",
     pastelContrast: "white",
+    rungs: slateRoleRungs.green,
   } satisfies WcaPaletteInput,
   white: {
     primary: "#EEEEEE",
     pantoneDescription: "Pantone Cool Gray 1 C",
-    secondaryLight: "#E0DDD5",
-    secondaryMedium: "#F4F1ED",
     secondaryDark: "#3B3B3B",
     cubeLight: "#FFFFFF",
     cubeDark: "#CCCCCC",
     pastelContrast: "black",
+    rungs: slateRoleRungs.wcaWhite,
   } satisfies WcaPaletteInput,
   red: {
     primary: "#C62535",
     pantoneDescription: "Pantone 1797 C",
-    secondaryLight: "#F6C5C5",
-    secondaryMedium: "#FF6B6B",
     secondaryDark: "#7A1220",
     cubeLight: "#E53841",
     cubeDark: "#A3131A",
     pastelContrast: "white",
+    rungs: slateRoleRungs.red,
   } satisfies WcaPaletteInput,
   yellow: {
     primary: "#FFD313",
     pantoneDescription: "Pantone 116 C",
-    secondaryLight: "#FFF5B8",
-    secondaryMedium: "#FFF5AA",
     secondaryDark: "#664D00",
     cubeLight: "#FFDE55",
     cubeDark: "#CEA705",
     pastelContrast: "black",
+    rungs: slateRoleRungs.yellow,
   } satisfies WcaPaletteInput,
   blue: {
     primary: "#0051BA",
     pantoneDescription: "Pantone 293 C",
-    secondaryLight: "#99C7FF",
-    secondaryMedium: "#42D0FF",
     secondaryDark: "#003366",
     cubeLight: "#066AC4",
     cubeDark: "#03458C",
     pastelContrast: "white",
+    rungs: slateRoleRungs.blue,
   } satisfies WcaPaletteInput,
   orange: {
     primary: "#FF5800",
     pantoneDescription: "Pantone Orange 021 C",
-    secondaryLight: "#FFD5BD",
-    secondaryMedium: "#FFD59E",
     secondaryDark: "#7A2B00",
     cubeLight: "#F96E32",
     cubeDark: "#D34405",
     pastelContrast: "white",
+    rungs: slateRoleRungs.orange,
   } satisfies WcaPaletteInput,
 } as const;
 
@@ -102,240 +119,141 @@ const rgbToHex = (rgb: Rgb) => formatHex(rgb).toUpperCase();
 const rgbToOklch = (rgb: Rgb): Oklch => oklch(rgb);
 const oklchToRgb = toGamut("rgb", "oklch");
 
-const getHueDelta = (sourceH: number = 0, targetH: number = 0): number =>
-  ((targetH - sourceH + 540) % 360) - 180;
+const SCALE_KEYS = [
+  "50",
+  "100",
+  "200",
+  "300",
+  "400",
+  "500",
+  "600",
+  "700",
+  "800",
+  "900",
+  "950",
+] as const satisfies ReadonlyArray<LuminanceKey>;
 
-const calculateDelta = (source: Oklch, target: Oklch): ColorDelta => ({
-  mode: "oklch",
-  l: target.l - source.l,
-  c: target.c - source.c,
-  h: getHueDelta(source.h, target.h),
-});
+type Anchor = { readonly idx: number; readonly color: Oklch };
 
-const typedKeys = <K extends string, V>(object: Record<K, V>): K[] =>
-  Object.keys(object).filter((k): k is K => k in object);
+// Chakra is not very friendly about exporting its pre-defined schemes and tokens…
+const readChakraScale = (chakraRefScheme: string): ReadonlyArray<Oklch> => {
+  const modelScheme = defaultConfig.theme?.tokens?.colors?.[
+    chakraRefScheme
+  ] as unknown as ChakraColorScale;
 
-const getSortedKeys = (scale: ColorScale): ReadonlyArray<LuminanceKey> =>
-  typedKeys(scale).toSorted((a, b) => parseInt(a) - parseInt(b));
-
-const findNearestSlotKey = (
-  scale: ColorScale,
-  targetOklch: Oklch,
-): LuminanceKey => {
-  const keys = typedKeys(scale);
-
-  const bestKey = _.minBy(keys, (key) => {
-    const currentOklch = rgbToOklch(hexToRgb(scale[key]));
-    return Math.abs(currentOklch.l - targetOklch.l);
-  });
-
-  // ColorScale is never empty, so the `minBy` above is safe
-  return bestKey!;
+  return SCALE_KEYS.map((key) => rgbToOklch(hexToRgb(modelScheme[key].value)));
 };
 
-const generateSequence = (
-  start: number,
-  end: number,
-): ReadonlyArray<number> => {
-  const length = Math.abs(end - start);
-  const step = end > start ? 1 : -1;
+// Locates the two anchors bracketing `idx`, together with how far between them
+//   it sits. Positions outside the anchored range clamp onto the nearest one,
+//   so a scale never extrapolates past a colour we were actually given.
+const findSegment = (anchors: ReadonlyArray<Anchor>, idx: number) => {
+  const upperPtr = anchors.findIndex((anchor) => anchor.idx >= idx);
+  const upper = upperPtr < 1 ? 1 : upperPtr;
 
-  return Array.from({ length }, (_, i) => start + i * step);
+  const [lighter, darker] = [anchors[upper - 1], anchors[upper]];
+  const span = darker.idx - lighter.idx;
+
+  return {
+    lighter,
+    darker,
+    position: span === 0 ? 0 : _.clamp((idx - lighter.idx) / span, 0, 1),
+  };
 };
 
-const createAnchorMap = (
-  baseScale: ColorScale,
-  colors: ReadonlyArray<string>,
-): Readonly<Record<LuminanceKey, string>> => {
-  const sortedScaleKeys = getSortedKeys(baseScale);
-  const maxIdx = sortedScaleKeys.length;
+// Rescales the reference ladder so it passes exactly through the brand anchors,
+//   preserving the relative spacing Chakra tuned between them.
+const remapLightness = (
+  reference: ReadonlyArray<Oklch>,
+  anchors: ReadonlyArray<Anchor>,
+  idx: number,
+): number => {
+  const { lighter, darker } = findSegment(anchors, idx);
 
-  const sortedInputs = colors.toSorted((a, b) => {
-    const lA = rgbToOklch(hexToRgb(a)).l;
-    const lB = rgbToOklch(hexToRgb(b)).l;
+  const refSpan = reference[lighter.idx].l - reference[darker.idx].l;
+  const position =
+    refSpan === 0
+      ? 0
+      : _.clamp((reference[idx].l - reference[darker.idx].l) / refSpan, 0, 1);
 
-    return lB - lA; // Descending Lightness
-  });
-
-  return sortedInputs.reduce(
-    (assignments, color) => {
-      const colorOklch = rgbToOklch(hexToRgb(color));
-      const idealKey = findNearestSlotKey(baseScale, colorOklch);
-      const idealIdx = sortedScaleKeys.indexOf(idealKey);
-
-      const searchPath = [
-        idealIdx,
-        ...generateSequence(idealIdx + 1, maxIdx),
-        ...generateSequence(idealIdx - 1, -1),
-      ];
-
-      const foundIdx = searchPath.find((idx) => {
-        const key = sortedScaleKeys[idx];
-        return !(key in assignments);
-      });
-
-      if (foundIdx === undefined) return assignments;
-
-      const foundKey = sortedScaleKeys[foundIdx];
-      return { ...assignments, [foundKey]: color };
-    },
-    {} as Record<LuminanceKey, string>,
-  );
+  return lerp(darker.color.l, lighter.color.l, position);
 };
 
-const getInterpolatedDelta = (
-  currentIdx: number,
-  sortedKeys: ReadonlyArray<string>,
-  anchorIndices: ReadonlyArray<number>,
-  anchorDeltas: Readonly<Record<string, ColorDelta>>,
-): { delta: ColorDelta; distanceToAnchor: number } => {
-  const nextAnchorPtr = anchorIndices.findIndex((idx) => idx >= currentIdx);
+// Chroma keeps the reference curve's shape (it peaks mid-scale rather than
+//   running monotonically), scaled to meet the brand anchors' colourfulness.
+const remapChroma = (
+  reference: ReadonlyArray<Oklch>,
+  anchors: ReadonlyArray<Anchor>,
+  idx: number,
+): number => {
+  const { lighter, darker, position } = findSegment(anchors, idx);
 
-  if (nextAnchorPtr === 0) {
-    const anchorIdx = anchorIndices[0];
+  const ratioAt = (anchor: Anchor) =>
+    reference[anchor.idx].c === 0
+      ? 0
+      : anchor.color.c / reference[anchor.idx].c;
 
-    return {
-      delta: anchorDeltas[sortedKeys[anchorIdx]],
-      distanceToAnchor: Math.abs(currentIdx - anchorIdx),
-    };
-  }
-
-  if (nextAnchorPtr === -1) {
-    const anchorIdx = anchorIndices[anchorIndices.length - 1];
-
-    return {
-      delta: anchorDeltas[sortedKeys[anchorIdx]],
-      distanceToAnchor: Math.abs(currentIdx - anchorIdx),
-    };
-  }
-
-  const idxPrev = anchorIndices[nextAnchorPtr - 1];
-  const idxNext = anchorIndices[nextAnchorPtr];
-
-  const deltaPrev = anchorDeltas[sortedKeys[idxPrev]];
-  const deltaNext = anchorDeltas[sortedKeys[idxNext]];
-
-  const t = (currentIdx - idxPrev) / (idxNext - idxPrev);
-
-  const interpolatedDelta = {
-    mode: "oklch",
-    l: lerp(deltaPrev.l, deltaNext.l, t),
-    c: lerp(deltaPrev.c, deltaNext.c, t),
-    h: lerp(deltaPrev.h, deltaNext.h, t),
-  } as const;
-
-  const distanceToAnchor = Math.min(
-    Math.abs(currentIdx - idxPrev),
-    Math.abs(currentIdx - idxNext),
-  );
-
-  return { delta: interpolatedDelta, distanceToAnchor };
+  return reference[idx].c * lerp(ratioAt(lighter), ratioAt(darker), position);
 };
 
-type AdjustmentConfig = {
-  readonly strength?: number;
-  readonly baseInfluence?: number;
-  readonly sigma?: number;
-};
+// Hue travels the shortest arc between the anchors, so the family holds the
+//   Solid's hue across the light half and settles onto the Deep tone's own hue
+//   at the bottom, instead of wandering wherever the reference scale went.
+const remapHue = (anchors: ReadonlyArray<Anchor>, idx: number): number => {
+  const { lighter, darker, position } = findSegment(anchors, idx);
 
-const adjustScale = (
-  baseScale: ColorScale,
-  anchors: Readonly<Record<LuminanceKey, string>>,
-  config: AdjustmentConfig = {},
-): ColorScale => {
-  const sortedKeys = getSortedKeys(baseScale);
+  const from = lighter.color.h ?? darker.color.h ?? 0;
+  const to = darker.color.h ?? from;
+  const arc = ((to - from + 540) % 360) - 180;
 
-  const anchorData = Object.entries(anchors)
-    .map(([key, targetHex]) => {
-      const sourceHex = baseScale[key as LuminanceKey];
-
-      const src = rgbToOklch(hexToRgb(sourceHex));
-      const tgt = rgbToOklch(hexToRgb(targetHex));
-
-      return {
-        key,
-        idx: sortedKeys.indexOf(key as LuminanceKey),
-        delta: calculateDelta(src, tgt),
-      };
-    })
-    .sort((a, b) => a.idx - b.idx);
-
-  if (anchorData.length === 0) return baseScale;
-
-  const anchorIndices = anchorData.map((d) => d.idx);
-  const anchorDeltas = Object.fromEntries(
-    anchorData.map((d) => [d.key, d.delta]),
-  );
-
-  return _.mapValues(baseScale, (hex, key) => {
-    const currentIdx = sortedKeys.indexOf(key as LuminanceKey);
-    const sourceOklch = rgbToOklch(hexToRgb(hex));
-
-    const { delta: rawDelta, distanceToAnchor } = getInterpolatedDelta(
-      currentIdx,
-      sortedKeys,
-      anchorIndices,
-      anchorDeltas,
-    );
-
-    const {
-      strength = 1.0 / Object.entries(anchors).length,
-      baseInfluence = 0,
-      sigma,
-    } = config;
-
-    const decayFactor =
-      sigma !== undefined
-        ? Math.exp(-(distanceToAnchor * distanceToAnchor) / (2 * sigma * sigma))
-        : 1.0;
-    const effectiveStrength = lerp(baseInfluence, strength, decayFactor);
-
-    const newOklch = {
-      mode: "oklch",
-      l: Math.max(
-        0,
-        Math.min(1, sourceOklch.l + rawDelta.l * effectiveStrength),
-      ),
-      c: Math.max(0, sourceOklch.c + rawDelta.c * effectiveStrength),
-      h: (sourceOklch.h || 0) + rawDelta.h * effectiveStrength,
-    } as const;
-
-    return rgbToHex(oklchToRgb(newOklch));
-  });
+  return from + arc * position;
 };
 
 const deriveLuminanceScale = (
   chakraRefScheme: string,
   colorScheme: WcaPaletteInput,
-  config: AdjustmentConfig = {},
 ): ChakraColorScale => {
-  // Chakra is not very friendly about exporting its pre-defined schemes and tokens…
-  const modelScheme = defaultConfig.theme?.tokens?.colors?.[
-    chakraRefScheme
-  ] as unknown as ChakraColorScale;
-  const baseScale = _.mapValues(
-    modelScheme,
-    (chakraToken) => chakraToken.value,
+  const reference = readChakraScale(chakraRefScheme);
+  const lastIdx = SCALE_KEYS.length - 1;
+
+  const solid = rgbToOklch(hexToRgb(colorScheme.primary));
+  const deep = rgbToOklch(hexToRgb(colorScheme.secondaryDark));
+
+  const solidIdx = SCALE_KEYS.indexOf(colorScheme.rungs["1A"]);
+  const deepIdx = SCALE_KEYS.indexOf(colorScheme.rungs["2A"]);
+
+  // The two brand colours we keep verbatim pin hue and chroma. Lightness gets
+  //   the endpoints as extra anchors, so the extremes stay where Chakra put
+  //   them and remain usable as page surfaces.
+  const brandAnchors: ReadonlyArray<Anchor> = [
+    { idx: solidIdx, color: solid },
+    { idx: deepIdx, color: deep },
+  ];
+
+  const lightnessAnchors: ReadonlyArray<Anchor> = _.sortBy(
+    [
+      { idx: 0, color: reference[0] },
+      ...brandAnchors,
+      { idx: lastIdx, color: reference[lastIdx] },
+    ],
+    "idx",
   );
 
-  const secondaryAnchors = createAnchorMap(baseScale, [
-    colorScheme.secondaryDark,
-    colorScheme.secondaryMedium,
-    colorScheme.secondaryLight,
-  ]);
+  const scale = Object.fromEntries(
+    SCALE_KEYS.map((key, idx) => [
+      key,
+      rgbToHex(
+        oklchToRgb({
+          mode: "oklch",
+          l: remapLightness(reference, lightnessAnchors, idx),
+          c: remapChroma(reference, brandAnchors, idx),
+          h: remapHue(brandAnchors, idx),
+        }),
+      ),
+    ]),
+  ) as ColorScale;
 
-  const ambientScale = adjustScale(baseScale, secondaryAnchors, {
-    ...config,
-    sigma: 1.5,
-  });
-
-  const primaryAnchors = createAnchorMap(baseScale, [colorScheme.primary]);
-  const heroScale = adjustScale(ambientScale, primaryAnchors, {
-    ...config,
-    sigma: 2.5,
-  });
-
-  return _.mapValues(heroScale, (rgbHex) => ({ value: rgbHex }));
+  return _.mapValues(scale, (rgbHex) => ({ value: rgbHex }));
 };
 
 const compileColorScheme = (
@@ -357,48 +275,41 @@ const compileColorScheme = (
   },
 });
 
-const defineColorAliases = (colorPalette: WcaPaletteInput) => ({
-  "1A": { value: colorPalette.primary },
-  "2A": { value: colorPalette.secondaryDark },
-  "2B": { value: colorPalette.secondaryLight },
-  "2C": { value: colorPalette.secondaryMedium },
-  pastelContrast: {
-    value: colorPalette.pastelContrast === "white" ? "#FCFCFC" : "#1E1E1E",
-  },
-  lighter: { value: colorPalette.cubeLight },
-  darker: { value: colorPalette.cubeDark },
-});
+// The brand names stay in the theme, but they now resolve to rungs of the
+//   generated scale rather than standing beside it as a second set of colours.
+const buildPalette = (
+  chakraRefScheme: string,
+  colorPalette: WcaPaletteInput,
+) => {
+  const scale = deriveLuminanceScale(chakraRefScheme, colorPalette);
+  const atRung = (role: BrandRole) => ({
+    value: scale[colorPalette.rungs[role]].value,
+  });
+
+  return {
+    ...scale,
+    "1A": atRung("1A"),
+    "2A": atRung("2A"),
+    "2B": atRung("2B"),
+    "2C": atRung("2C"),
+    pastelContrast: {
+      value: colorPalette.pastelContrast === "white" ? "#FCFCFC" : "#1E1E1E",
+    },
+    lighter: { value: colorPalette.cubeLight },
+    darker: { value: colorPalette.cubeDark },
+  };
+};
 
 const customConfig = defineConfig({
   theme: {
     tokens: {
       colors: {
-        wcaWhite: {
-          ...defineColorAliases(slateColors.white),
-          ...deriveLuminanceScale("gray", slateColors.white, {
-            baseInfluence: 1,
-          }),
-        },
-        green: {
-          ...defineColorAliases(slateColors.green),
-          ...deriveLuminanceScale("green", slateColors.green),
-        },
-        red: {
-          ...defineColorAliases(slateColors.red),
-          ...deriveLuminanceScale("red", slateColors.red),
-        },
-        yellow: {
-          ...defineColorAliases(slateColors.yellow),
-          ...deriveLuminanceScale("yellow", slateColors.yellow),
-        },
-        blue: {
-          ...defineColorAliases(slateColors.blue),
-          ...deriveLuminanceScale("blue", slateColors.blue),
-        },
-        orange: {
-          ...defineColorAliases(slateColors.orange),
-          ...deriveLuminanceScale("orange", slateColors.orange),
-        },
+        wcaWhite: buildPalette("gray", slateColors.white),
+        green: buildPalette("green", slateColors.green),
+        red: buildPalette("red", slateColors.red),
+        yellow: buildPalette("yellow", slateColors.yellow),
+        blue: buildPalette("blue", slateColors.blue),
+        orange: buildPalette("orange", slateColors.orange),
         // Interpolated gray scale, anchored at the `supplementary.bg` values.
         // There is an additional added "zinc" nudge on the blue channel,
         //   which it seems most modern UI frameworks do.


### PR DESCRIPTION
For reason outlined in https://docs.google.com/document/d/1V1YE0Ro-I9kcRykFTNgsWdNdLXJj5sf4WVtqe6RMKWI (which are pretty obvious if you look at some of the pages) we need to slightly adjust our color palette, especially the pastel and bright tones. 

This PR makes those changes and also adds a new component to /dashboard that shows the slate colors and how they are situated in the color ladder with some component examples.

<img width="1442" height="612" alt="Screenshot 2026-08-04 at 13 21 13" src="https://github.com/user-attachments/assets/ad26f65a-da60-43de-8acc-285b29a0b672" />
<img width="1442" height="748" alt="Screenshot 2026-08-04 at 13 21 19" src="https://github.com/user-attachments/assets/66927155-87a8-401c-a5bc-aa2bc78c5114" />
<img width="1442" height="759" alt="Screenshot 2026-08-04 at 13 21 25" src="https://github.com/user-attachments/assets/c89bede8-1f5a-4cd2-9260-23576f603c25" />
<img width="1442" height="618" alt="Screenshot 2026-08-04 at 13 21 34" src="https://github.com/user-attachments/assets/e4b0abb4-42d7-4a9d-ade1-80585aa3a502" />
