### PR TITLE
Add FTO to Event Picker in Preferred Events page

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1650,13 +1650,6 @@ class Competition < ApplicationRecord
     end
   end
 
-  # For associated_events_picker
-  def events_to_associated_events(events)
-    events.map do |event|
-      competition_events.find_by(event_id: event.id) || competition_events.build(event_id: event.id)
-    end
-  end
-
   def self.years
     Competition.where(show_at_all: true).pluck(:start_date).map(&:year).uniq.sort!.reverse!
   end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -461,14 +461,6 @@ class Registration < ApplicationRecord
     competition&.force_comment_in_registration?
   end
 
-  # For associated_events_picker
-  def events_to_associated_events(events)
-    events.map do |event|
-      competition_event = competition.competition_events.find_by!(event: event)
-      registration_competition_events.find_by(competition_event_id: competition_event.id) || registration_competition_events.build(competition_event: competition_event)
-    end
-  end
-
   def permit_user_cancellation?
     case competition.competitor_can_cancel.to_sym
     when :always

--- a/app/views/shared/_associated_events_picker.html.erb
+++ b/app/views/shared/_associated_events_picker.html.erb
@@ -15,12 +15,11 @@ Note: form_builder.object is the object having associated events.
   disabled ||= false
   hint ||= false
   show_select_hint ||= false
-  allowed_events ||= Event.official
+  allowed_events ||= Event.official_with_future
   disabled_events ||= []
   disabled_tooltip ||= false
 
   label = I18n.t("activerecord.attributes.#{form_builder.object.class.name.underscore}.#{events_association_name}")
-  using_competition_events = events_association_name == :registration_competition_events
   all_events = form_builder.object.events_to_associated_events(allowed_events)
   errors = form_builder.object.errors.messages[events_association_name] || []
 
@@ -47,11 +46,7 @@ Note: form_builder.object is the object having associated events.
       <% event = f.object.event %>
       <% e_disabled = disabled_events.include?(event) %>
       <span class="event-checkbox <%= "disabled" if disabled || e_disabled %>">
-        <% if using_competition_events %>
-          <%= f.hidden_field :competition_event_id %>
-        <% else %>
-          <%= f.hidden_field :event_id %>
-        <% end %>
+        <%= f.hidden_field :event_id %>
         <% if e_disabled %>
           <%= f.hidden_field "_destroy", { value: "1" } %>
           <%= cubing_icon(event.id, data: { toggle: "tooltip", placement: "top" }, title: disabled_tooltip, style: "color: #FFBBBB" ) %>


### PR DESCRIPTION
I also checked any other usages of the `_associated_events_picker.rb` and it's not used apart from the user preferences, which why I removed the dead code that was used there before.