### PR TITLE
Disallow CAD runs if there are unconfirmed newcomers

### DIFF
--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -2,7 +2,9 @@
 
 class ComputeAuxiliaryData < WcaCronjob
   def self.reason_not_to_run
-    "Some results are missing their corresponding WCA ID, which means that someone hasn't finished submitting results." if Result.exists?(person_id: "")
+    return "Some results are missing their corresponding WCA ID, which means that someone hasn't finished submitting results." if Result.exists?(person_id: "")
+
+    "Some results are linked to unmerged WCA IDs, which means that someone hasn't finished creating newcomers." if Result.unmerged_newcomers.exists?
   end
 
   def perform

--- a/app/models/cronjob_statistic.rb
+++ b/app/models/cronjob_statistic.rb
@@ -14,4 +14,25 @@ class CronjobStatistic < ApplicationRecord
   def scheduled?
     self.enqueued_at.present?
   end
+
+  private def runner_class
+    self.id.safe_constantize
+  end
+
+  def reason_not_to_run
+    self.runner_class&.try(:reason_not_to_run)
+  end
+
+  # Aliases for easier access in JS frontend (which does not like question marks in object properties)
+  alias_method :is_in_progress, :in_progress?
+  alias_method :is_finished, :finished?
+  alias_method :is_scheduled, :scheduled?
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    methods: %w[is_in_progress is_scheduled is_finished reason_not_to_run],
+  }.freeze
+
+  def serializable_hash(options = nil)
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+  end
 end

--- a/app/webpacker/components/Panel/views/CronJobStatus/CronjobActions.jsx
+++ b/app/webpacker/components/Panel/views/CronJobStatus/CronjobActions.jsx
@@ -13,13 +13,15 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
 
   // Usually, we want to reset if we can clearly establish that
   //   the cronjob halted because of an error (i.e. it halted AND an error state was recorded)
-  const terminatedAndErrored = !cronjobDetails?.in_progress && cronjobDetails?.recently_errored;
+  const terminatedAndErrored = !cronjobDetails?.is_in_progress && cronjobDetails?.recently_errored;
   // However, due to deployment chokes, we manually override the button to be enabled
   //   when the debug information is shown (there is still an extra confirmation warning)
   const isResetDisabled = !(terminatedAndErrored || showDebugInfo);
 
+  const reasonNotToRun = cronjobDetails?.reason_not_to_run;
+
   const isDoItDisabled = (
-    cronjobDetails?.reason_not_to_run || cronjobDetails?.scheduled || cronjobDetails?.in_progress
+    reasonNotToRun || cronjobDetails?.is_scheduled || cronjobDetails?.is_in_progress
   );
 
   const confirm = useConfirm();
@@ -37,6 +39,7 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
       updatedCronjobDetails,
     ),
   });
+
   const {
     mutate: resetCronjobMutation,
     isLoading: isResetLoading,
@@ -60,7 +63,8 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
   };
 
   if (isRunLoading || isResetLoading) return <Loading />;
-  if (isRunError || isResetError) return <Errored error={runError || resetError} />;
+  if (isRunError) return <Errored error={runError} />;
+  if (isResetError) return <Errored error={resetError} />;
 
   return (
     <>
@@ -70,12 +74,20 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
       >
         Reset
       </Button>
-      <Button
-        disabled={isDoItDisabled}
-        onClick={() => runCronjobMutation({ cronjobName })}
-      >
-        Do it!
-      </Button>
+      {reasonNotToRun ? (
+        <>
+          This cronjob cannot be run currently because:
+          {' '}
+          {reasonNotToRun}
+        </>
+      ) : (
+        <Button
+          disabled={isDoItDisabled}
+          onClick={() => runCronjobMutation({ cronjobName })}
+        >
+          Do it!
+        </Button>
+      )}
       <Button
         toggle
         active={showDebugInfo}

--- a/app/webpacker/components/Panel/views/CronJobStatus/index.jsx
+++ b/app/webpacker/components/Panel/views/CronJobStatus/index.jsx
@@ -31,18 +31,14 @@ const timeDuration = (timestamp1, timestamp2) => (
   DateTime.fromISO(timestamp2).diff(DateTime.fromISO(timestamp1)).rescale().toHuman());
 
 function getCronjobMessage(cronjobDetails) {
-  const isScheduled = !!cronjobDetails.enqueued_at;
-  const isInProgress = cronjobDetails.run_start && !cronjobDetails.run_end;
-  const isFinished = !!cronjobDetails.run_end;
-
-  if (isScheduled) {
+  if (cronjobDetails.is_scheduled) {
     return [
       `The job has been scheduled ${timeSince(cronjobDetails.enqueued_at)}, but it hasn't been picked up by the job handler yet. Please come back later.`,
       'info',
     ];
   }
 
-  if (isInProgress) {
+  if (cronjobDetails.is_in_progress) {
     if (cronjobDetails.recently_errored) {
       return [
         `The job started to run but crashed :O The error message was: ${cronjobDetails.last_error_message}`,
@@ -56,13 +52,14 @@ function getCronjobMessage(cronjobDetails) {
     ];
   }
 
-  if (isFinished) {
+  if (cronjobDetails.is_finished) {
     if (cronjobDetails.last_run_successful) {
       return [
         `Job was last completed ${timeSince(cronjobDetails.run_end)} and took ${timeDuration(cronjobDetails.run_start, cronjobDetails.run_end)}.`,
         'success',
       ];
     }
+
     return [
       `Job was last completed ${timeSince(cronjobDetails.run_end)} but it raised an error: ${cronjobDetails.last_error_message}. Note that our job handler has an automatic retry mechanism. The more times a job fails, the longer it waits to try again. If this problem persists for several hours, feel free to contact the Software Team.`,
       'error',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,9 @@ services:
       RUNNING_IN_DOCKER: true
     tty: true
     # Start the server and bind to 0.0.0.0 (vs 127.0.0.1) so Docker's port mappings work correctly
-    command: bin/dev -b 0.0.0.0
+    command: >
+      bash -c './package-install.dev.sh packages.runtime.txt &&
+      bin/dev -b 0.0.0.0'
     depends_on:
       wca_environment:
         condition: service_completed_successfully
@@ -80,7 +82,8 @@ services:
       - "3001:3001"
     working_dir: /app
     command: >
-      bash -c 'corepack install && yarn install &&
+      bash -c 'corepack install &&
+      yarn install &&
       yarn run dev'
     volumes:
       - ./next-frontend:/app
@@ -129,7 +132,10 @@ services:
       SHAKAPACKER_DEV_SERVER_HOST: 0.0.0.0
     # The dev server never runs Shakapacker's precompile hook, so the auto-bundled
     # packs have to be generated before webpack enumerates its entrypoints.
-    command: bash -c 'bin/rake react_on_rails:generate_packs && bin/shakapacker-dev-server'
+    command: >
+      bash -c './package-install.dev.sh packages.runtime.txt &&
+      bin/rake react_on_rails:generate_packs &&
+      bin/shakapacker-dev-server'
     depends_on:
       wca_environment:
         # We need to make sure that the database is populated because our frontend code
@@ -155,7 +161,9 @@ services:
       # Cronjobs are disabled in development by default. If you wish to run cronjobs,
       # set this env variable to any integer value greater than zero
       # CRONJOB_POLLING_MINUTES: 30
-    command: bin/sidekiq
+    command: >
+      bash -c './package-install.dev.sh packages.runtime.txt &&
+      bin/sidekiq'
     depends_on:
       wca_environment:
         condition: service_completed_successfully

--- a/packages.dev.txt
+++ b/packages.dev.txt
@@ -1,10 +1,6 @@
 git
 build-essential
-mariadb-client
 libssl-dev
 libyaml-dev
-tzdata
-tzdata-legacy
 libclang-dev
 cargo
-libvips

--- a/packages.runtime.txt
+++ b/packages.runtime.txt
@@ -1,0 +1,4 @@
+mariadb-client
+tzdata
+tzdata-legacy
+libvips


### PR DESCRIPTION
Two parts:
1. The actual `reason_not_to_run` within the CAD job pipeline
2. Communicating that reason to the frontend as required