### PR TITLE
Disallow CAD runs if there are unconfirmed newcomers

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -123,11 +123,6 @@ class AdminController < ApplicationController
     }
   end
 
-  def do_compute_auxiliary_data
-    ComputeAuxiliaryData.perform_later
-    redirect_to panel_page_path(id: User.panel_pages[:computeAuxiliaryData])
-  end
-
   def override_regional_records
     action_params = params
                     .expect(check_regional_records_form: %i[competition_id event_id refresh_index])

--- a/app/jobs/compute_auxiliary_data.rb
+++ b/app/jobs/compute_auxiliary_data.rb
@@ -2,7 +2,9 @@
 
 class ComputeAuxiliaryData < WcaCronjob
   def self.reason_not_to_run
-    "Some results are missing their corresponding WCA ID, which means that someone hasn't finished submitting results." if Result.exists?(person_id: "")
+    return "Some results are missing their corresponding WCA ID, which means that someone hasn't finished submitting results." if Result.exists?(person_id: "")
+
+    "Some results are linked to unmerged WCA IDs, which means that someone hasn't finished creating newcomers." if Result.unmerged_newcomers.exists?
   end
 
   def perform

--- a/app/models/cronjob_statistic.rb
+++ b/app/models/cronjob_statistic.rb
@@ -14,4 +14,25 @@ class CronjobStatistic < ApplicationRecord
   def scheduled?
     self.enqueued_at.present?
   end
+
+  private def runner_class
+    self.id.safe_constantize
+  end
+
+  def reason_not_to_run
+    self.runner_class&.try(:reason_not_to_run)
+  end
+
+  # Aliases for easier access in JS frontend (which does not like question marks in object properties)
+  alias_method :is_in_progress, :in_progress?
+  alias_method :is_finished, :finished?
+  alias_method :is_scheduled, :scheduled?
+
+  DEFAULT_SERIALIZE_OPTIONS = {
+    methods: %w[is_in_progress is_scheduled is_finished reason_not_to_run],
+  }.freeze
+
+  def serializable_hash(options = nil)
+    super(DEFAULT_SERIALIZE_OPTIONS.merge(options || {}))
+  end
 end

--- a/app/webpacker/components/Panel/views/CronJobStatus/CronjobActions.jsx
+++ b/app/webpacker/components/Panel/views/CronJobStatus/CronjobActions.jsx
@@ -13,13 +13,15 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
 
   // Usually, we want to reset if we can clearly establish that
   //   the cronjob halted because of an error (i.e. it halted AND an error state was recorded)
-  const terminatedAndErrored = !cronjobDetails?.in_progress && cronjobDetails?.recently_errored;
+  const terminatedAndErrored = !cronjobDetails?.is_in_progress && cronjobDetails?.recently_errored;
   // However, due to deployment chokes, we manually override the button to be enabled
   //   when the debug information is shown (there is still an extra confirmation warning)
   const isResetDisabled = !(terminatedAndErrored || showDebugInfo);
 
+  const reasonNotToRun = cronjobDetails?.reason_not_to_run;
+
   const isDoItDisabled = (
-    cronjobDetails?.reason_not_to_run || cronjobDetails?.scheduled || cronjobDetails?.in_progress
+    reasonNotToRun || cronjobDetails?.is_scheduled || cronjobDetails?.is_in_progress
   );
 
   const confirm = useConfirm();
@@ -37,6 +39,7 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
       updatedCronjobDetails,
     ),
   });
+
   const {
     mutate: resetCronjobMutation,
     isLoading: isResetLoading,
@@ -60,7 +63,8 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
   };
 
   if (isRunLoading || isResetLoading) return <Loading />;
-  if (isRunError || isResetError) return <Errored error={runError || resetError} />;
+  if (isRunError) return <Errored error={runError} />;
+  if (isResetError) return <Errored error={resetError} />;
 
   return (
     <>
@@ -70,12 +74,20 @@ export default function CronjobActions({ cronjobName, cronjobDetails }) {
       >
         Reset
       </Button>
-      <Button
-        disabled={isDoItDisabled}
-        onClick={() => runCronjobMutation({ cronjobName })}
-      >
-        Do it!
-      </Button>
+      {reasonNotToRun ? (
+        <>
+          This cronjob cannot be run currently because:
+          {' '}
+          {reasonNotToRun}
+        </>
+      ) : (
+        <Button
+          disabled={isDoItDisabled}
+          onClick={() => runCronjobMutation({ cronjobName })}
+        >
+          Do it!
+        </Button>
+      )}
       <Button
         toggle
         active={showDebugInfo}

--- a/app/webpacker/components/Panel/views/CronJobStatus/index.jsx
+++ b/app/webpacker/components/Panel/views/CronJobStatus/index.jsx
@@ -31,18 +31,14 @@ const timeDuration = (timestamp1, timestamp2) => (
   DateTime.fromISO(timestamp2).diff(DateTime.fromISO(timestamp1)).rescale().toHuman());
 
 function getCronjobMessage(cronjobDetails) {
-  const isScheduled = !!cronjobDetails.enqueued_at;
-  const isInProgress = cronjobDetails.run_start && !cronjobDetails.run_end;
-  const isFinished = !!cronjobDetails.run_end;
-
-  if (isScheduled) {
+  if (cronjobDetails.is_scheduled) {
     return [
       `The job has been scheduled ${timeSince(cronjobDetails.enqueued_at)}, but it hasn't been picked up by the job handler yet. Please come back later.`,
       'info',
     ];
   }
 
-  if (isInProgress) {
+  if (cronjobDetails.is_in_progress) {
     if (cronjobDetails.recently_errored) {
       return [
         `The job started to run but crashed :O The error message was: ${cronjobDetails.last_error_message}`,
@@ -56,13 +52,14 @@ function getCronjobMessage(cronjobDetails) {
     ];
   }
 
-  if (isFinished) {
+  if (cronjobDetails.is_finished) {
     if (cronjobDetails.last_run_successful) {
       return [
         `Job was last completed ${timeSince(cronjobDetails.run_end)} and took ${timeDuration(cronjobDetails.run_start, cronjobDetails.run_end)}.`,
         'success',
       ];
     }
+
     return [
       `Job was last completed ${timeSince(cronjobDetails.run_end)} but it raised an error: ${cronjobDetails.last_error_message}. Note that our job handler has an automatic retry mechanism. The more times a job fails, the longer it waits to try again. If this problem persists for several hours, feel free to contact the Software Team.`,
       'error',

--- a/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/FinalSteps.jsx
+++ b/app/webpacker/components/Tickets/TicketWorkbenches/CompetitionResultActionerView/FinalSteps.jsx
@@ -4,7 +4,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Loading from '../../../Requests/Loading';
 import Errored from '../../../Requests/Errored';
 import postResults from '../../api/competitionResult/postResults';
-import { viewUrls, competitionAllResultsUrl } from '../../../../lib/requests/routes.js.erb';
+import {
+  viewUrls,
+  competitionAllResultsUrl,
+  panelPageUrl,
+} from '../../../../lib/requests/routes.js.erb';
+import { PANEL_PAGES } from '../../../../lib/wca-data.js.erb';
 
 export default function FinalSteps({ ticketDetails }) {
   const { ticket: { id, metadata: { competition_id: competitionId } } } = ticketDetails;
@@ -45,7 +50,7 @@ export default function FinalSteps({ ticketDetails }) {
           <Button
             as="a"
             primary
-            href={viewUrls.competitions.adminDoComputeAuxiliaryData}
+            href={panelPageUrl(PANEL_PAGES.computeAuxiliaryData)}
             target="_blank"
           >
             Compute auxiliary data

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -298,7 +298,6 @@ export const viewUrls = {
     lastDuplicateCheckerJobRun: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_last_duplicate_checker_job_run_path(competition_id: "${competitionId}")) %>`,
     newcomerNameFormatCheck: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_newcomer_name_format_check_path(competition_id: "${competitionId}")) %>`,
     newcomerDobFormatCheck: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_newcomer_dob_check_path(competition_id: "${competitionId}")) %>`,
-    adminDoComputeAuxiliaryData: `<%= CGI.unescape(Rails.application.routes.url_helpers.admin_do_compute_auxiliary_data_path) %>`,
     unfinishedPersons: (competitionId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_unfinished_persons_path(competition_id: "${competitionId}")) %>`,
   },
   persons: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -323,7 +323,6 @@ Rails.application.routes.draw do
   get '/admin/regional-voters' => 'admin#regional_voters', as: :regional_voters
   post '/admin/merge_people' => 'admin#do_merge_people', as: :admin_do_merge_people
   get '/admin/person_data' => 'admin#person_data'
-  get '/admin/do_compute_auxiliary_data' => 'admin#do_compute_auxiliary_data'
   get '/admin/generate_db_token' => 'admin#generate_db_token'
   get '/admin/override_regional_records' => 'admin#override_regional_records'
   post '/admin/override_regional_records' => 'admin#do_override_regional_records'


### PR DESCRIPTION
Two parts:
1. The actual reason_not_to_run within the CAD job pipeline
2. Communicating that reason to the frontend as required