### PR TITLE
Switch from delay to receive_wait_time_seconds in sqs

### DIFF
--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,7 +1,6 @@
 groups:
   registrations:
     concurrency: 2
-    delay: 1
     queues:
       - <%= EnvConfig.REGISTRATION_QUEUE %>
   live_results:

--- a/infra/wca_on_rails/production/sqs.tf
+++ b/infra/wca_on_rails/production/sqs.tf
@@ -7,7 +7,7 @@ resource "aws_sqs_queue" "this" {
   delay_seconds              = 0
   max_message_size           = 262144
   message_retention_seconds  = 345600
-  receive_wait_time_seconds  = 0
+  receive_wait_time_seconds  = 20
   visibility_timeout_seconds = 60
   tags = {
     Env = "Production"
@@ -19,7 +19,7 @@ resource "aws_sqs_queue" "results" {
   delay_seconds              = 0
   max_message_size           = 262144
   message_retention_seconds  = 345600
-  receive_wait_time_seconds  = 0
+  receive_wait_time_seconds  = 20
   visibility_timeout_seconds = 60
   tags = {
     Env = "Production"

--- a/infra/wca_on_rails/staging/sqs.tf
+++ b/infra/wca_on_rails/staging/sqs.tf
@@ -7,7 +7,7 @@ resource "aws_sqs_queue" "this" {
   delay_seconds              = 0
   max_message_size           = 262144
   message_retention_seconds  = 345600
-  receive_wait_time_seconds  = 0
+  receive_wait_time_seconds  = 20
   visibility_timeout_seconds = 60
   tags = {
     Env = "staging"
@@ -19,7 +19,7 @@ resource "aws_sqs_queue" "results" {
   delay_seconds              = 0
   max_message_size           = 262144
   message_retention_seconds  = 345600
-  receive_wait_time_seconds  = 0
+  receive_wait_time_seconds  = 20
   visibility_timeout_seconds = 60
   tags = {
     Env = "Staging"


### PR DESCRIPTION
I misunderstood how `receive_wait_time_seconds` worked when setting this up for registration years ago which why I chose the delay route for registration. Delay means that every time shoryuken gets an empty receive it waits for 1 second, which I did to save costs. 
Delay isn't what you want for ILR though because it means worst case you enter a result and it is delayed by 1 sec + processing time so I removed it. That means shoryuken was hammering the SQS API to the cost of ~70 dollars a month.
The solution is `receive_wait_time_seconds`, if you configure it like this, shoryuken/sqs will keep the connection open for 20 seconds, but will immediately process a message once it arrives. So this actually reduces the amount of API calls while not sacrificing latency.