### PR TITLE
Make buttons and links more contrasty in all announcements

### DIFF
--- a/next-frontend/src/components/announcements/AnnouncementMarkdown.tsx
+++ b/next-frontend/src/components/announcements/AnnouncementMarkdown.tsx
@@ -4,13 +4,22 @@ import { ChakraMarkdown } from "@/components/Markdown";
 /// accordion and the /posts cards can't drift apart. Announcement text always
 /// inherits its card's color: Chakra's `Card.Description` default would
 /// otherwise mute it on /posts only.
+///
+/// Links inherit too, for the same reason: the `link` recipe pins
+/// `colorPalette: "link"`, which would paint them fixed WCA blue on top of a
+/// `card.pastel` background drawn from the card's own `1A` — invisible on the
+/// blue card. Inheriting costs the colour cue, so underline them instead.
 export default function AnnouncementMarkdown({
   children,
 }: {
   children?: string | null;
 }) {
   return (
-    <ChakraMarkdown textStyle="body" color="currentColor">
+    <ChakraMarkdown
+      textStyle="body"
+      color="currentColor"
+      linkProps={{ color: "currentColor", textDecoration: "underline" }}
+    >
       {children}
     </ChakraMarkdown>
   );

--- a/next-frontend/src/components/announcements/ReadMoreButton.tsx
+++ b/next-frontend/src/components/announcements/ReadMoreButton.tsx
@@ -2,13 +2,29 @@ import { Button, Link as ChakraLink } from "@chakra-ui/react";
 import { announcementReadMoreHref } from "@/components/announcements/announcement";
 import { Announcement } from "@/types/payload";
 
+/// Announcement cards are `card.pastel`, so their background is the card's own
+/// `1A` and the palette varies per card. `pastelSolid` is locked to blue and
+/// paints `blue.1A`, which is exactly the blue card's background — so the
+/// button vanishes into it. Border and label follow the card's contrast colour
+/// instead, which works on every palette. The hover veil has to come from
+/// `pastelContrast` rather than the built-in `outline` variant's
+/// `colorPalette.subtle`: a pale tint of the card's own hue would leave the
+/// `currentColor` label unreadable.
 export default function ReadMoreButton({
   announcement,
 }: {
   announcement: Announcement;
 }) {
   return (
-    <Button variant="pastelSolid" size="sm" alignSelf="flex-start" asChild>
+    <Button
+      variant="outline"
+      size="sm"
+      alignSelf="flex-start"
+      asChild
+      color="currentColor"
+      borderColor="currentColor"
+      _hover={{ bg: "colorPalette.pastelContrast/15" }}
+    >
       <ChakraLink
         href={announcementReadMoreHref(announcement)}
         color="currentColor"


### PR DESCRIPTION
The Blue Card is 1A and the button is Solid which is also 1A for blue so it looks weird. One of the ways we can keep the color but fix the contrast is use outline:
<img width="1341" height="335" alt="Screenshot 2026-08-06 at 11 08 51" src="https://github.com/user-attachments/assets/c9cfe5cf-d87f-4a06-8b75-8f9e95375f44" />

We also need to override link color as we do title for the same reasons