### PR TITLE
Change "Upload Scrambles" to cube icon

### DIFF
--- a/app/views/competitions/_nav.html.erb
+++ b/app/views/competitions/_nav.html.erb
@@ -102,7 +102,7 @@
           nav_items << {
             text: t('.menu.upload_scrambles'),
             path: competition_upload_scrambles_path(@competition),
-            icon: "spy",
+            icon: "cube",
           }
         end
         if current_user&.can_admin_results?


### PR DESCRIPTION
Can't believe SemUI has one of these, it's perfect

<img width="119" height="80" alt="image" src="https://github.com/user-attachments/assets/836d8845-7320-42c9-8a2c-3f284596f6a0" />