### PR TITLE
Add Perma links to Motions

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -6,6 +6,18 @@ class StaticPagesController < ApplicationController
   def home
   end
 
+  # Permalink to the current version of a motion, so that links elsewhere do not
+  # have to be updated every time a motion is amended.
+  def motion
+    @motion_id = params.expect(:id)
+    section, subsection = @motion_id.split('.')
+    url = latest_motion_url(section, subsection)
+
+    return render 'motion_not_found', status: :not_found if url.nil?
+
+    redirect_to url, allow_other_host: true
+  end
+
   def score_tools
   end
 

--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -4,6 +4,13 @@ require 'aws-sdk-s3'
 module DocumentsHelper
   ARCHIVE_DATE_FILE = "version"
   BUCKET_NAME = 'wca-documents'
+  DOCUMENTS_HOST = 'https://documents.worldcubeassociation.org'
+  MOTIONS_PREFIX = 'documents/motions/'
+  # Motions are named "<section>.<year>.<subsection> - <Title>.pdf", where the
+  # year is the version: amending a motion republishes it under a later year,
+  # sometimes under a different title, but always with the same section and
+  # subsection.
+  MOTION_FILENAME = /\A(?<section>\d+)\.(?<year>\d{4})\.(?<subsection>\d+) - /
 
   private def archive_metadata
     bucket = Aws::S3::Resource.new(
@@ -22,7 +29,23 @@ module DocumentsHelper
 
   def documents_list(directory)
     documents = archive_metadata.filter { |document| document[:key].include? directory }
-                                .map { |document| content_tag(:li, link_to(document[:name], "https://documents.worldcubeassociation.org/#{document[:key]}")) }
+                                .map { |document| content_tag(:li, link_to(document[:name], "#{DOCUMENTS_HOST}/#{document[:key]}")) }
     safe_join documents
+  end
+
+  # Section and subsection are compared numerically because sections are zero-padded
+  # in filenames ("01.2025.1 - Spirit.pdf") but are cited without the padding.
+  def latest_motion_url(section, subsection)
+    versions = archive_metadata.filter_map do |document|
+      next unless document[:key].start_with?(MOTIONS_PREFIX)
+
+      match = MOTION_FILENAME.match(document[:name])
+      next unless match && match[:section].to_i == section.to_i && match[:subsection].to_i == subsection.to_i
+
+      [match[:year].to_i, document[:key]]
+    end
+
+    latest_key = versions.max_by(&:first)&.last
+    "#{DOCUMENTS_HOST}/#{URI::DEFAULT_PARSER.escape(latest_key)}" if latest_key
   end
 end

--- a/app/views/static_pages/motion_not_found.html.erb
+++ b/app/views/static_pages/motion_not_found.html.erb
@@ -1,0 +1,7 @@
+<% provide(:title, t('documents.motion_not_found')) %>
+
+<div class="container">
+  <h1><%= yield(:title) %></h1>
+  <p><%= t('documents.motion_not_found_action', motion_id: @motion_id) %></p>
+  <p><%= link_to t('documents.title'), documents_path %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2637,6 +2637,9 @@ en:
     determination_letter: "IRS Determination Letter"
     bylaws: "Bylaws"
     motions: "Motions"
+    #context: Shown when a permalink points at a motion number that no longer exists, usually because the motion was repealed
+    motion_not_found: "Motion Not Found"
+    motion_not_found_action: "We couldn't find a motion numbered \"%{motion_id}\". It may have been repealed."
     minutes: "Minutes"
     policies: "WCA Policies"
     codeofethics: "Code of Ethics"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,6 +267,7 @@ Rails.application.routes.draw do
 
   get 'about' => 'static_pages#about'
   get 'documents' => 'static_pages#documents'
+  get 'documents/motions/:id' => 'static_pages#motion', as: :motion, constraints: { id: /\d+\.\d+/ }, format: false
   get 'education' => 'static_pages#education'
   get 'delegates' => 'static_pages#delegates'
   get 'disclaimer' => 'static_pages#disclaimer'

--- a/spec/helpers/documents_helper_spec.rb
+++ b/spec/helpers/documents_helper_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DocumentsHelper do
+  before do
+    keys = [
+      "documents/motions/01.2025.1 - Spirit.pdf",
+      "documents/motions/10.2021.3 - Disciplinary Committee.pdf",
+      "documents/motions/10.2025.3 - Integrity Committee.pdf",
+      "documents/motions/10.2024.11 - Software Team.pdf",
+      "documents/minutes/2018-01-16 WCA Board Meeting.pdf",
+    ]
+    metadata = keys.map { |key| { name: File.basename(key, ".pdf"), key: key } }
+    allow(helper).to receive(:archive_metadata).and_return(metadata)
+  end
+
+  describe "#latest_motion_url" do
+    it "resolves to the most recent year, even when the title changed" do
+      expect(helper.latest_motion_url("10", "3"))
+        .to eq "https://documents.worldcubeassociation.org/documents/motions/10.2025.3%20-%20Integrity%20Committee.pdf"
+    end
+
+    it "resolves a motion whose most recent version is not from the latest year" do
+      expect(helper.latest_motion_url("10", "11"))
+        .to eq "https://documents.worldcubeassociation.org/documents/motions/10.2024.11%20-%20Software%20Team.pdf"
+    end
+
+    it "ignores zero padding on the section" do
+      expect(helper.latest_motion_url("1", "1")).to eq helper.latest_motion_url("01", "1")
+    end
+
+    it "returns nil for a motion that no longer exists" do
+      expect(helper.latest_motion_url("20", "0")).to be_nil
+    end
+
+    it "does not match documents outside the motions directory" do
+      expect(helper.latest_motion_url("2018", "16")).to be_nil
+    end
+  end
+end

--- a/spec/requests/motion_permalinks_spec.rb
+++ b/spec/requests/motion_permalinks_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "motion permalinks" do
+  before do
+    keys = [
+      "documents/motions/01.2025.1 - Spirit.pdf",
+      "documents/motions/10.2021.3 - Disciplinary Committee.pdf",
+      "documents/motions/10.2025.3 - Integrity Committee.pdf",
+    ]
+    metadata = keys.map { |key| { name: File.basename(key, ".pdf"), key: key } }
+    allow_any_instance_of(StaticPagesController).to receive(:archive_metadata).and_return(metadata)
+  end
+
+  it "redirects to the current version of the motion" do
+    get "/documents/motions/10.3"
+
+    expect(response).to redirect_to "https://documents.worldcubeassociation.org/documents/motions/10.2025.3%20-%20Integrity%20Committee.pdf"
+  end
+
+  it "keeps the section and subsection out of the format" do
+    get "/documents/motions/01.1"
+
+    expect(response).to redirect_to "https://documents.worldcubeassociation.org/documents/motions/01.2025.1%20-%20Spirit.pdf"
+  end
+
+  it "renders a not found page for a repealed motion" do
+    get "/documents/motions/20.0"
+
+    expect(response).to have_http_status :not_found
+    expect(response.body).to include "Motion Not Found"
+    expect(response.body).to include '<a href="/documents">Documents</a>'
+  end
+end


### PR DESCRIPTION
As per WQAC request. 
The links look like: `/documents/motions/01.1`