### PR TITLE
Make authentication expire less often

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,6 +125,30 @@ class User < ApplicationRecord
   devise :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable
+
+  ABSOLUTE_SESSION_TIMEOUT = 90.days
+  attr_accessor :remembered_session_started_at
+
+  class << self
+    def serialize_into_cookie(record)
+      super << (record.remembered_session_started_at || Time.current).to_f.to_s
+    end
+
+    def serialize_from_cookie(*args)
+      record = super(*args.first(3))
+      return unless record
+
+      remembered_session_started_at = args.fourth
+      # Existing three-part cookies start their absolute timeout when first used.
+      return record unless remembered_session_started_at
+
+      record.remembered_session_started_at = Time.zone.at(remembered_session_started_at.to_f)
+      return if record.remembered_session_started_at <= ABSOLUTE_SESSION_TIMEOUT.ago
+
+      record
+    end
+  end
+
   devise :two_factor_authenticatable,
          otp_secret_encryption_key: AppSecrets.OTP_ENCRYPTION_KEY
   BACKUP_CODES_LENGTH = 8

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -141,8 +141,8 @@ Devise.setup do |config|
   # The time the user will be remembered without asking for credentials again.
   # config.remember_for = 2.weeks
 
-  # Invalidates all the remember me tokens when the user signs out.
-  config.expire_all_remember_me_on_sign_out = true
+  # Keep remember me tokens on other devices when the user signs out.
+  config.expire_all_remember_me_on_sign_out = false
 
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -145,7 +145,7 @@ Devise.setup do |config|
   config.expire_all_remember_me_on_sign_out = false
 
   # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -278,8 +278,12 @@ end
 Warden::Manager.after_set_user except: :fetch do |user, warden, _opts|
   user.update_attribute(:session_validity_token, Devise.friendly_token) if user.session_validity_token.nil?
   warden.raw_session["validity_token"] = user.session_validity_token
+  warden.raw_session["session_started_at"] = (user.remembered_session_started_at || Time.current).to_f
 end
 
 Warden::Manager.after_fetch do |user, warden, _opts|
-  warden.logout unless user.session_validity_token == warden.raw_session["validity_token"]
+  # Existing sessions start their absolute timeout on their first request after deployment.
+  session_started_at = warden.raw_session["session_started_at"] ||= Time.current.to_f
+  session_expired = Time.zone.at(session_started_at.to_f) <= User::ABSOLUTE_SESSION_TIMEOUT.ago
+  warden.logout if user.session_validity_token != warden.raw_session["validity_token"] || session_expired
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -3,20 +3,23 @@
 require "rails_helper"
 
 RSpec.describe "sessions" do
-  it "keeps other devices remembered after signing out" do
-    user = create(:user)
-    phone = ActionDispatch::Integration::Session.new(Rails.application)
-    laptop = ActionDispatch::Integration::Session.new(Rails.application)
-    sign_in_params = {
+  def sign_in_params(user)
+    {
       user: {
         login: user.email,
         password: user.password,
         remember_me: "1",
       },
     }
+  end
 
-    phone.post(user_session_path, params: sign_in_params)
-    laptop.post(user_session_path, params: sign_in_params)
+  it "keeps other devices remembered after signing out" do
+    user = create(:user)
+    phone = ActionDispatch::Integration::Session.new(Rails.application)
+    laptop = ActionDispatch::Integration::Session.new(Rails.application)
+
+    phone.post(user_session_path, params: sign_in_params(user))
+    laptop.post(user_session_path, params: sign_in_params(user))
 
     expect(phone.cookies["remember_user_token"]).to be_present
     expect(laptop.cookies["remember_user_token"]).to be_present
@@ -26,5 +29,27 @@ RSpec.describe "sessions" do
     laptop.get(profile_edit_path)
 
     expect(laptop.response).to be_successful
+  end
+
+  it "refreshes the remember period when a cookie restores the session" do
+    user = create(:user)
+    browser = ActionDispatch::Integration::Session.new(Rails.application)
+
+    travel_to(Time.current) do
+      browser.post(user_session_path, params: sign_in_params(user))
+      original_remember_cookie = browser.cookies["remember_user_token"]
+      browser.cookies.delete("_WcaOnRails_session")
+
+      travel 1.week
+      browser.get(profile_edit_path)
+      expect(browser.response).to be_successful
+      expect(browser.cookies["remember_user_token"]).not_to eq(original_remember_cookie)
+
+      browser.cookies.delete("_WcaOnRails_session")
+
+      travel 13.days
+      browser.get(profile_edit_path)
+      expect(browser.response).to be_successful
+    end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -34,20 +34,21 @@ RSpec.describe "sessions" do
   it "refreshes the remember period when a cookie restores the session" do
     user = create(:user)
     browser = ActionDispatch::Integration::Session.new(Rails.application)
+    signed_in_at = Time.current
 
-    freeze_time do
-      browser.post(user_session_path, params: sign_in_params(user))
-      original_remember_cookie = browser.cookies["remember_user_token"]
-      browser.cookies.delete("_WcaOnRails_session")
+    browser.post(user_session_path, params: sign_in_params(user))
+    original_remember_cookie = browser.cookies["remember_user_token"]
+    browser.cookies.delete("_WcaOnRails_session")
 
-      travel 1.week
+    travel_to(signed_in_at + 1.week) do
       browser.get(profile_edit_path)
       expect(browser.response).to be_successful
       expect(browser.cookies["remember_user_token"]).not_to eq(original_remember_cookie)
+    end
 
-      browser.cookies.delete("_WcaOnRails_session")
+    browser.cookies.delete("_WcaOnRails_session")
 
-      travel 13.days
+    travel_to(signed_in_at + 20.days) do
       browser.get(profile_edit_path)
       expect(browser.response).to be_successful
     end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "sessions" do
     user = create(:user)
     browser = ActionDispatch::Integration::Session.new(Rails.application)
 
-    travel_to(Time.current) do
+    freeze_time do
       browser.post(user_session_path, params: sign_in_params(user))
       original_remember_cookie = browser.cookies["remember_user_token"]
       browser.cookies.delete("_WcaOnRails_session")

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "sessions" do
+  it "keeps other devices remembered after signing out" do
+    user = create(:user)
+    phone = ActionDispatch::Integration::Session.new(Rails.application)
+    laptop = ActionDispatch::Integration::Session.new(Rails.application)
+    sign_in_params = {
+      user: {
+        login: user.email,
+        password: user.password,
+        remember_me: "1",
+      },
+    }
+
+    phone.post(user_session_path, params: sign_in_params)
+    laptop.post(user_session_path, params: sign_in_params)
+
+    expect(phone.cookies["remember_user_token"]).to be_present
+    expect(laptop.cookies["remember_user_token"]).to be_present
+
+    phone.delete(destroy_user_session_path)
+    laptop.cookies.delete("_WcaOnRails_session")
+    laptop.get(profile_edit_path)
+
+    expect(laptop.response).to be_successful
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe "sessions" do
-  def sign_in_params(user)
+  def sign_in_params(user, remember_me: true)
     {
       user: {
         login: user.email,
         password: user.password,
-        remember_me: "1",
+        remember_me: remember_me ? "1" : "0",
       },
     }
   end
@@ -51,6 +51,48 @@ RSpec.describe "sessions" do
     travel_to(signed_in_at + 20.days) do
       browser.get(profile_edit_path)
       expect(browser.response).to be_successful
+    end
+  end
+
+  it "expires an active session after the absolute timeout" do
+    user = create(:user)
+    browser = ActionDispatch::Integration::Session.new(Rails.application)
+    signed_in_at = Time.current
+
+    browser.post(user_session_path, params: sign_in_params(user, remember_me: false))
+
+    travel_to(signed_in_at + User::ABSOLUTE_SESSION_TIMEOUT - 1.second) do
+      browser.get(profile_edit_path)
+      expect(browser.response).to be_successful
+    end
+
+    travel_to(signed_in_at + User::ABSOLUTE_SESSION_TIMEOUT + 1.second) do
+      browser.get(profile_edit_path)
+      expect(browser.response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  it "expires a rolling remembered session after the absolute timeout" do
+    user = create(:user)
+    browser = ActionDispatch::Integration::Session.new(Rails.application)
+    signed_in_at = Time.current
+
+    browser.post(user_session_path, params: sign_in_params(user))
+
+    12.times do |week|
+      browser.cookies.delete("_WcaOnRails_session")
+
+      travel_to(signed_in_at + (week + 1).weeks) do
+        browser.get(profile_edit_path)
+        expect(browser.response).to be_successful
+      end
+    end
+
+    browser.cookies.delete("_WcaOnRails_session")
+
+    travel_to(signed_in_at + 13.weeks) do
+      browser.get(profile_edit_path)
+      expect(browser.response).to redirect_to(new_user_session_path)
     end
   end
 end


### PR DESCRIPTION
Authentication has been a pain with the WCA website for years.

Its the only website that I repeatedly need to log back in on. Its not just me, I know many others who find that they often need to log back in. So much so that I know several delegates who do not enable mfa because of this pain. The behavior we are encouraging is less secure authentication. 

We can alleviate this through 2 different ways:

1. Refresh the 2 week "remember me" expiration so that it gets pushed back as a user uses the WCA website. 
2. Fix an issue where "remember me" is invalidated for all devices when a user logs out of a single device. 

I can confirm that #2 is an issue, I logged out on my phone and saw the "remember me" cookie was no longer respected. 


