### PR TITLE
Remove blank keys from translation files

### DIFF
--- a/app/views/competitions/payment_integration_setup.html.erb
+++ b/app/views/competitions/payment_integration_setup.html.erb
@@ -78,7 +78,9 @@
       <h2><%= t('payments.payment_setup.provider_heading', provider: t("payments.payment_providers.#{type}")) %></h2>
 
       <p>
-        <b><%= t("payments.payment_setup.connect_account_warning.#{type}") %></b>
+        <%# Not every provider has a warning (manual has none), so render nothing
+            rather than "Translation missing: ...". %>
+        <b><%= t("payments.payment_setup.connect_account_warning.#{type}", default: "") %></b>
       </p>
       <p>
         <%= t("payments.payment_setup.connect_account_info.#{type}") %>

--- a/app/views/competitions/payment_integration_setup.html.erb
+++ b/app/views/competitions/payment_integration_setup.html.erb
@@ -78,9 +78,7 @@
       <h2><%= t('payments.payment_setup.provider_heading', provider: t("payments.payment_providers.#{type}")) %></h2>
 
       <p>
-        <%# Not every provider has a warning (manual has none), so render nothing
-            rather than "Translation missing: ...". %>
-        <b><%= t("payments.payment_setup.connect_account_warning.#{type}", default: "") %></b>
+        <b><%= I18nUtils.optional_t("payments.payment_setup.connect_account_warning.#{type}") %></b>
       </p>
       <p>
         <%= t("payments.payment_setup.connect_account_info.#{type}") %>

--- a/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
+++ b/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
@@ -41,14 +41,17 @@ function getFieldLabel(id, section = []) {
 function getFieldHint(id, section = [], isMarkdown = false) {
   const yamlId = snakifyId(id, section);
 
-  // TODO: Maybe this should be forced within the translation file?
+  // Most fields have no hint. Without defaultValue, a missing key renders as
+  // `[missing "en...." translation]` in the form, which is why the locale files
+  // used to carry an empty entry for every hint-less field.
   if (isMarkdown) {
     return I18n.t(`competitions.competition_form.hints.${yamlId}_html`, {
+      defaultValue: '',
       md: I18n.t('competitions.competition_form.supports_md_html'),
     });
   }
 
-  return I18n.t(`competitions.competition_form.hints.${yamlId}`);
+  return I18n.t(`competitions.competition_form.hints.${yamlId}`, { defaultValue: '' });
 }
 
 function getHtmlId(id, section = []) {

--- a/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
+++ b/app/webpacker/components/wca/FormBuilder/input/FormInputs.js
@@ -41,17 +41,13 @@ function getFieldLabel(id, section = []) {
 function getFieldHint(id, section = [], isMarkdown = false) {
   const yamlId = snakifyId(id, section);
 
-  // Most fields have no hint. Without defaultValue, a missing key renders as
-  // `[missing "en...." translation]` in the form, which is why the locale files
-  // used to carry an empty entry for every hint-less field.
   if (isMarkdown) {
-    return I18n.t(`competitions.competition_form.hints.${yamlId}_html`, {
-      defaultValue: '',
+    return I18n.tOptional(`competitions.competition_form.hints.${yamlId}_html`, {
       md: I18n.t('competitions.competition_form.supports_md_html'),
     });
   }
 
-  return I18n.t(`competitions.competition_form.hints.${yamlId}`, { defaultValue: '' });
+  return I18n.tOptional(`competitions.competition_form.hints.${yamlId}`);
 }
 
 function getHtmlId(id, section = []) {

--- a/app/webpacker/lib/i18n.js
+++ b/app/webpacker/lib/i18n.js
@@ -48,6 +48,18 @@ function tArray(scope, options) {
   return res.filter(Boolean);
 }
 
+/**
+ * Use for keys that are built from a dynamic value (an event ID, a form field name)
+ * and only exist for some of those values. Absence is the intended state for the
+ * rest, so render nothing instead of `[missing "en...." translation]`.
+ * @param {string | string[]} scope
+ * @param {*} options
+ * @returns {string}
+ */
+function tOptional(scope, options) {
+  return window.I18n.t(scope, { ...options, defaultValue: '' });
+}
+
 window.I18n = window.I18n || new I18n();
 
 // We always load English + the user locale so that we can fallback.
@@ -56,6 +68,7 @@ window.I18n.enableFallback = true;
 // load the actual locale as determined by app/views/layouts/application.html.erb
 window.I18n.locale = window.wca.currentLocale;
 window.I18n.tArray = tArray;
+window.I18n.tOptional = tOptional;
 
 /**
  * The global translation object.
@@ -64,9 +77,11 @@ window.I18n.tArray = tArray;
  *  import I18n from '../../lib/i18n';
  *  I18n.t('regional_organizations.requirements.title'); // -> string
  *  I18n.tArray('regional_organizations.requirements.list'); // -> string[]
+ *  I18n.tOptional(`time_limit.${eventId}`); // -> string, '' if the key is absent
  *
  * @type {I18n & {
- *  tArray: (scope: string | string[], options?: *) => string[]
+ *  tArray: (scope: string | string[], options?: *) => string[],
+ *  tOptional: (scope: string | string[], options?: *) => string
  * }}
  */
 export default window.I18n;

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -146,10 +146,8 @@ export function timeLimitToString(wcifRound, wcifEvents) {
 
   // From WCIF specification:
   // For events with unchangeable time limit (3x3x3 MBLD, 3x3x3 FM) the value is null.
-  // Not every such event has wording for it, so fall back to showing nothing
-  // rather than `[missing "en.time_limit.333mbo" translation]`.
   if (wcifTimeLimit === null) {
-    return I18n.t(`time_limit.${eventId}`, { defaultValue: '' });
+    return I18n.tOptional(`time_limit.${eventId}`);
   }
 
   const timeStr = centisecondsToClockFormat(wcifTimeLimit.centiseconds);

--- a/app/webpacker/lib/utils/wcif.js
+++ b/app/webpacker/lib/utils/wcif.js
@@ -146,8 +146,10 @@ export function timeLimitToString(wcifRound, wcifEvents) {
 
   // From WCIF specification:
   // For events with unchangeable time limit (3x3x3 MBLD, 3x3x3 FM) the value is null.
+  // Not every such event has wording for it, so fall back to showing nothing
+  // rather than `[missing "en.time_limit.333mbo" translation]`.
   if (wcifTimeLimit === null) {
-    return I18n.t(`time_limit.${eventId}`);
+    return I18n.t(`time_limit.${eventId}`, { defaultValue: '' });
   }
 
   const timeStr = centisecondsToClockFormat(wcifTimeLimit.centiseconds);

--- a/config/i18n-tasks.yml.erb
+++ b/config/i18n-tasks.yml.erb
@@ -95,8 +95,14 @@ ignore_missing:
   - 'devise.{mailer,passwords,registrations,sessions,shared,confirmations,unlocks}.*'
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
+  # CustomWcaI18nScanner marks `simple_form.hints.<model>.<attribute>` as used
+  # for every form input that does not pass an inline `hint:`, but most inputs
+  # have no hint at all. simple_form's lookup ends in '' and then `.presence`,
+  # so an absent hint renders nothing — exactly like the empty string these keys
+  # used to hold in all 33 locale files. Only flag hints as unused, never as
+  # missing. (Subsumes the old `simple_form.hints.translation.*` entry.)
+  - 'simple_form.hints.*'
   # We don't want to translate these.
-  - 'simple_form.hints.translation.*'
   - 'activerecord.attributes.translation.*'
 
 ## Consider these keys used:

--- a/config/i18n-tasks.yml.erb
+++ b/config/i18n-tasks.yml.erb
@@ -175,6 +175,7 @@ ignore:
 <%
   require './lib/custom_wca_i18n_scanner.rb'
   I18n::Tasks.add_scanner 'CustomWcaI18nScanner', only: %w(*.erb)
+  I18n::Tasks.add_ast_matcher 'OptionalTMatcher'
 
   I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
     only: %w(*.js),

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -102,7 +102,12 @@ SimpleForm.setup do |config|
   # config.item_wrapper_class = nil
 
   # How the label text should be generated altogether with the required text.
-  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+  # WCA shows no required marker. This used to be done by setting
+  # `simple_form.required.html` to an empty string in every locale file, which
+  # only worked because simple_form falls back to `<abbr title="required">*</abbr>`
+  # when that key is absent. Dropping the marker here instead means the locale
+  # files do not have to carry a blank entry in all 33 languages.
+  config.label_text = ->(label, _required, _explicit_label) { label }
 
   # You can define the class to use on all labels. Default is nil.
   # config.label_class = nil

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -257,8 +257,6 @@ ca:
     333fm: 1 hora
     #original_hash: cc7d8bb
     333mbf: '10:00.00 per cub, fins a 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Tipus de qualificació
@@ -766,8 +764,6 @@ ca:
       text: requerit
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Si us plau revisa els següents problemes:'
@@ -787,12 +783,6 @@ ca:
         public_summary: >-
           Una descripció general de l'incident i la decisió presa, serà públic.
           Si us plau, omple-ho en anglès.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 87e1e6f
         dob: Introdueix la teva data de naixement en aquest format YYYY-MM-DD.
@@ -802,40 +792,18 @@ ca:
           <strong>Stefan Pochmann</strong>. Sense abreviacions com  <strong>s
           pochman</strong>. <br/>Cognoms (ja siguin complets o inicials) són
           opcionals.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Després d'enviar un nou avatar, hauràs d'esperar que l'equip de
           resultats de la WCA l'aprovi.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Això només s'aplica a les competicions que organitzis o deleguis, i
           pot ser anul·lat a escala de competició.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 81a76a3
         receive_delegate_reports: >-
           Si ets un delegat en pràctiques, delegat junior, delegat sènior o
@@ -1022,12 +990,6 @@ ca:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: La teva data de naixement en el format YYYY-MM-DD
         #original_hash: 49ee4af
@@ -1087,8 +1049,6 @@ ca:
           fer cometaris referint-se a ells pels nombres. Fins i tot si semblen
           genèrics, menciona com a mínim els casos més notables. Marca la
           casella apropiada si vols rebre feedback activament.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Llista dels números d'incidències de les quals t'agradaria rebre
@@ -1105,13 +1065,9 @@ ca:
           exemple una millora/regressió de la comunitat local, plans de futur
           per la regió). Si no has dit alguna cosa a les seccions anteriors, ara
           és el moment de comentar-ho.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Exemples: Viatge, Pagaments, Premis, Estància'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: La data de naixement ha de tenir el format YYY-MM-DD.
@@ -1122,47 +1078,16 @@ ca:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
         #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
         #original_hash: da39a3e
         guests: ''
-        #original_hash: da39a3e
-        status: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
         #original_hash: da39a3e
         status: ''
       results_submission:
@@ -1173,10 +1098,6 @@ ca:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Ha de ser un enllaç http(s) vàlid. Recomanem que sigui HTTPS.
         #original_hash: 2ace571
@@ -1185,28 +1106,12 @@ ca:
         email: >-
           Hauria de ser una llista de correu electrònic que contingués tots els
           Directors i Oficials.
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Ha de ser en format PDF.
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Ha de ser en format PDF. Si necessites afegir més d'un fitxer, si us
           plau ajunta'ls.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -3064,10 +2969,6 @@ ca:
         remarks: Observacions
         clone_tabs: M'agradaria clonar totes les pàgines inclosa la informació addicional
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: 'El nom complet de la competició incloent l''any al final (exemple:
           Danish Open 2016). Revisa les majúscules. El nom ha de contenir només caràcters
           alfanumèrics, guions(-), ampersands(&), punts(.), dos punts(:), apòstrofs('')
@@ -3078,17 +2979,13 @@ ca:
           de complir amb <a href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Competition Requirements Policy</a>.
         venue:
-          country_id: ''
           city_name: 'Nom de la ciutat i estat (si és possible) on hi haurà la competició.
             No incloguis el país (exemple: París o San Francisco, Califòrnia).'
           name_html: 'El local on tindrà lloc la competició. %{md}. Per exemple: [Cité
             des Sciences et de l''Industrie](http://www.cite-sciences.fr)'
           details_html: Detalls sobre el local (per exemple, Al fons de la primera
             planta, segueix els signes). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         information: Informació important que els competidors haurien de saber. Sortirà
           a la pàgina principal de la competició. <br/>Si us plau, emplena-ho <b>en
           anglès</b> i qualsevol altre idioma que els competidors puguin parlar.
@@ -3111,15 +3008,11 @@ ca:
             dels organitzadors. %{md}. Exemple: [Text to display](mailto:some@email.com)'
         championships: ''
         website:
-          generate_website: ''
           external_website: Pàgina web de la competició. Ha de tenir un enllaç http(s)
             vàlid.
           external_registration_page: La pàgina on els competidors s'han de registrar
             per la competició. Ha de ser un enllaç http(s) vàlid.
-          uses_wca_registration: ''
           uses_wca_live:
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: El codi de moneda per les quotes.
           base_entry_fee: 'La quota de registre bàsica per la competició. Es mostrarà
@@ -3136,7 +3029,6 @@ ca:
           guest_entry_fee: Per ara aquest nombre és només informatiu, les quotes d'espectador
             no poden ser administrades per aquesta pàgina web. Si s'introdueix un
             0, es mostrarà una frase que escullis referent a la política pels espectadors.
-          donations_enabled: ''
           refund_policy_percent: Per ara aquest nombre es només informatiu, els retorns
             s'han de fer manualment. Si s'introdueix 0, es mostrarà una frase dient
             que les quotes de registre mai seran retornades sota cap circumstància.
@@ -3145,7 +3037,6 @@ ca:
         registration:
           opening_date_time: 'Important: L''obertura i clausura del registre està
             en horari UTC'
-          closing_date_time: ''
           waiting_list_deadline_date: La data a partir de la qual no s'acceptaran
             més persones de la llista d'espera. Si tens una data límit pels retorns
             de quota, la data per ser acceptat no hauria de ser abans de la data límit
@@ -3157,11 +3048,7 @@ ca:
             poden afegir una categoria més per competir fins al mateix moment de la
             competició. Si acceptes registres al lloc, aquesta data ha de ser la mateixa
             que l'inici de la competició.
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance: ''
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration:
           extra_requirements: Si us plau, indica aquí qualsevol requisit extra pel
             registre que encara no s'hagi indicat, com per exemple instruccions de
@@ -3172,16 +3059,13 @@ ca:
           force_comment:
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Si us plau, explica perquè voldries requerir als competidors que
               entriguin els cubs més aviat. Omple-ho en anglès!
           qualification_results:
-            enabled: ''
             reason: Si us plau, explica aquí perquè voldries utilitzar temps de qualificació.
               Omple-ho en anglès!
             allow_registration_without:
           event_limitation:
-            enabled: ''
             reason: Si us plau, explica aquí perquè voldries limitar una combinació
               especifica de categories. Omple-ho en anglès!
             per_registration_limit:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -262,8 +262,6 @@ cs:
     333fm: 1 hodina
     #original_hash: cc7d8bb
     333mbf: '10:00.00 na kostku, až 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Typ kvalifikace
@@ -780,8 +778,6 @@ cs:
       text: povinné
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Prosíme, překontrolujte níže uvedené problémy:'
@@ -803,12 +799,6 @@ cs:
         public_summary: >-
           Celkový popis incidentu a jeho závěr, který bude možno publikovat
           veřejně. Prosíme, vyplňte toto pole v angličtině.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Zadejte datum narození soutěžícího ve formátu RRRR-MM-DD.
@@ -818,40 +808,18 @@ cs:
           <strong>Béďa Trávníček</strong>. Ne nedbale jako <strong>b
           travnicek</strong>.<br/>Prostřední jména (celá i iniciály) jsou
           nepovinná.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Po nahrání nového avataru budete muset počkat na schválení od WCA
           Results Teamu.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Toto se týká jen soutěží, které organizujete nebo delegujete a lze to
           změnit i pro každou konkrétní soutěž.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 81a76a3
         receive_delegate_reports: >-
           Pokud jste Trainee delegát, Junior delegát, Senior delegát, nebo člen
@@ -1052,12 +1020,6 @@ cs:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Vaše správné datum narození ve formátu RRRR-MM-DD
         #original_hash: 49ee4af
@@ -1113,8 +1075,6 @@ cs:
           čísel. I pokud se vše zdálo obyčejné, vypište alespoň nejdůležitější
           případy. Prosíme zaškrtněte správná pole níže, pokud aktivně chcete
           zpětnou vazbu.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: 'Seznam čísel incidentů, ke kterým chcete zpětnou vazbu WRC.'
         #original_hash: da39a3e
@@ -1127,13 +1087,9 @@ cs:
           zlepšení/zhoršení v rámci komunity, plány do budoucna v daném
           regionu). Pokud jste kvůli stručnosti v předešlých sekcích něco
           vynechali, neváhejte se k tomu zde vyjádřit.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Příklady: cestování, platby, ocenění, ubytování'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: Datum narození by mělo být uvedeno ve formátu RRRR-MM-DD.
@@ -1144,22 +1100,11 @@ cs:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
         #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
@@ -1169,26 +1114,6 @@ cs:
         status: ''
         #original_hash: 34ef763
         administrative_notes: Dodatečné poznámky pro správu registrace. Soutěžící je nevidí.
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       results_submission:
         #original_hash: da39a3e
         schedule_url: ''
@@ -1197,10 +1122,6 @@ cs:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Musí být platné HTTP(S) URL. HTTPS je doporučené.
         #original_hash: 2ace571
@@ -1211,28 +1132,12 @@ cs:
         email: >-
           Mělo by se jednat o mailing list, který obsahuje všechny ředitele a
           úředníky.
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Musí být v PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Musí být ve formátu PDF. Pokud chcete přidat více souborů, prosíme,
           spojte je dohromady.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -3174,10 +3079,6 @@ cs:
         remarks: Poznámky
         clone_tabs: Chci zkopírovat všechny záložky s dalšími informacemi
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: Celý název soutěže včetně roku na konci (např. Czech Open 2016). Dodržujte
           velká písmena. Název může obsahovat pouze písmena, čísla, pomlčky (-), ampersandy
           (&), tečky (.), dvojtečky (:), apostrofy (') a mezery ( ).
@@ -3187,19 +3088,14 @@ cs:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA Competition
           Requirements Policy</a>.
         venue:
-          country_id: ''
           city_name: Název města a (případně) stát, ve kterém se bude soutěž konat.
             Nezahrnujte zemi (např. Brno NEBO San Francisco, California).
           name_html: 'Místo konání soutěže. %{md}. Například: [Cité des Sciences et
             de l''Industrie](http://www.cite-sciences.fr)'
           details_html: Podrobnosti o místě konání (např. V prvním poschodí vzadu,
             následujte šipky). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         series:
-          series_id: ''
           name: >-
             Celé jméno série soutěží včetně roku na konci (např. Southern
             Australia 2022). Slova začínejte velkými písmeny. Platí stejná
@@ -3233,14 +3129,10 @@ cs:
             %{md}. Například: [Text k zobrazení](mailto:some@email.com)'
         championships:
         website:
-          generate_website: ''
           external_website: Webové stránky soutěže. Musí to být platná http(s) url.
           external_registration_page: Stránka, na které se budou soutěží přihlašovat
             na soutěž. Musí to být platná http(s) url.
-          uses_wca_registration: ''
           uses_wca_live: ''
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Kód měny pro poplatky.
           base_entry_fee: 'Základní registrační poplatek pro soutěž. Zobrazí se na
@@ -3255,7 +3147,6 @@ cs:
           guest_entry_fee: Prozatím je toto číslo pouze informativní a poplatky za
             hosty nelze řešit pomocí této stránky. Pokud toto nastavíte na 0, zobrazí
             se věta o divácích dle vaší volby.
-          donations_enabled: ''
           refund_policy_percent: Nyní je toto číslo pouze informativní, vrácení peněz
             se bude muset řešit manuálně. Pokud to nastavíte na 0, zobrazí se věta,
             že se registrační poplatky nebudou vracet za žádných podmínek.
@@ -3264,7 +3155,6 @@ cs:
         registration:
           opening_date_time: 'Poznámka: Zahájení a ukončení registrace jsou uvedeny
             v UTC čase.'
-          closing_date_time: ''
           waiting_list_deadline_date: Datum po kterém osoby na waiting listu už nemohou
             být přijaty. Pokud máte deadline na vrácení poplatků, tento deadline by
             neměl být před ním.
@@ -3273,11 +3163,7 @@ cs:
             nesmí být nastavena před datum konce registrace. Pokud toto pole necháte
             prázdné, soutěžící budou moci měnit eventy až do jejich začátku. Pokud
             máte povolené registrace na místě, toto musí být nastaveno na den soutěže.
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance: ''
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration: Počet hostů na jednu registraci povolený na této
             soutěži. Registrace s příliš velkým počtem hostů bude zablokována. Nechte
             prázdné, pokud nechcete stanovit limit.
@@ -3286,19 +3172,14 @@ cs:
             napište to <b>v Angličtině</b> a v jakémkoli dalším jazyce, kterým vaši
             soutěžící mluví; zobrazí se to na stránkách s informacemi o soutěži a
             na registrační stránce, pokud používáte registrační stránky WCA.
-          force_comment: ''
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Prosíme rozeberte, proč byste chtěli požadovat, aby soutěžící
               odevzdali své kostky dříve. Prosíme, vyplňte toto v angličtině!
           qualification_results:
-            enabled: ''
             reason: Prosíme rozeberte, proč byste chtěli používat kvalifikační časy.
               Prosíme, vyplňte toto v angličtině!
-            allow_registration_without: ''
           event_limitation:
-            enabled: ''
             reason: Prosíme rozepište, proč byste chtěli zakázat některé kombinace
               eventů. Prosíme, vyplňte toto v angličtině!
             per_registration_limit: Volitelně vynuťte maximální počet eventů, na které

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -259,8 +259,6 @@ da:
     333fm: 1 time
     #original_hash: cc7d8bb
     333mbf: '10:00.00 pr. terning op til 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   common:
     #original_hash: 70c07ec
     world: Verden
@@ -718,8 +716,6 @@ da:
       text: behøvet
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Gennemgå venligst problemerne nedenfor:'
@@ -739,12 +735,6 @@ da:
         public_summary: >-
           En beskrivelse af hændelsen og afgørelsen. Det vises offentligt.
           Udfyld det her på engelsk.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 87e1e6f
         dob: Skriv din Fødselsdag in denne format ÅÅÅÅ-MM-DD
@@ -753,36 +743,14 @@ da:
           Skriv dit fulde navn korrekt, for eksempel <strong>Stefan
           Pochmann</strong>. Ikke sjusket som <strong>s pochman</strong>.
           <br/>Mellem navne (enten fulde eller som initialer) er valgfrie.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Efter at du har uploadet en ny avatar, bliver du nødt til at vente på
           at WCA's Resultathold accepterer den.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 81a76a3
         receive_delegate_reports: >-
           If you are a Trainee Delegate, Junior Delegate, Senior Delegate, or
@@ -962,12 +930,6 @@ da:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Din korrekte fødselsdag i formatet ÅÅÅÅ-MM-DD
         #original_hash: 49ee4af
@@ -1023,8 +985,6 @@ da:
           til dem ved deres numre. Selv hvis alt virkede normalt, så nævn bare
           det mest specielle situationer. Klik på de relevante bokse nedenfor
           hvis der er nogle situationer du aktivt søger hjælp for.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: Numrene af de hændelser du gerne vil have WRC feedback på.
         #original_hash: da39a3e
@@ -1037,13 +997,9 @@ da:
           forbedring/tilbagegang indenfor samfundet/fællesskabet, fremtidige
           planer for denne region). Hvis du mener du mangler at få nævnt noget
           som du ikke fik nævnt tidligere, så kan du tilføje dem her.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Eksempler: Transport, Betaling, Priser, Husly'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: Fødselsdatoer skal have formatet ÅÅÅÅ-MM-DD
@@ -1054,47 +1010,16 @@ da:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
         #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
         #original_hash: da39a3e
         guests: ''
-        #original_hash: da39a3e
-        status: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
         #original_hash: da39a3e
         status: ''
       results_submission:
@@ -1105,10 +1030,6 @@ da:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Skal være en gyldig http(s) url. HTTPS er foreslået.
         #original_hash: 2ace571
@@ -1117,28 +1038,12 @@ da:
         email: >-
           Burde være en mail adresse som indeholder alle Direktører og
           Officerer.
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Skal være i PDF format
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Skal være i en PDF format. Hvis du har brug for flere filer, så sæt
           dem sammen i en
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -2927,10 +2832,6 @@ da:
         remarks: Bemærkninger
         clone_tabs: Jeg vil gerne kopiere alle faner med yderligere informationer
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: Konkurrencens fulde navn inklusiv året i slutningen (eksempel, Danish
           Open 2016). Husk at lave store bogstaver. Navnet må kun indeholde alfanumeriske
           tegn, streger(-), og-tegn(&), punktummer(.), kolonner(:), apostroffer(')
@@ -2941,17 +2842,13 @@ da:
           <a href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Konkurrence Kravs Politikken</a>.
         venue:
-          country_id: ''
           city_name: Byens navn og stat (hvis det er relevant) hvor konkurrencen bliver
             afholdt. Inkluder ikke land (eksempel, Paris eller San Francisco, California).
           name_html: 'Lokalet som konkurrencen vil blive afholdt. %{md}. For eksempel:  [Cité
             des Sciences et de l''Industrie](http://www.cite-sciences.fr)'
           details_html: Detaljer om lokalet (eksempel, På første sal lagt bagved,
             følg skiltene). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         information: Vigtig information som deltagerne burde vide. Det vil blive vist
           på konkurrencens forside. <br/>Udfyld venligst det her på engelsk</b> og
           andre sprog som dine deltagere snakker.
@@ -2972,15 +2869,11 @@ da:
             emails. %{md}. Example: [Text to display](mailto:some@email.com)'
         championships: ''
         website:
-          generate_website: ''
           external_website: Konkurrencens hjemmeside. Skal være en gyldig http(s)
             url.
           external_registration_page: Siden hvor deltagerne skal tilmelde for konkurrencen.
             Det skal være en http(s) url.
-          uses_wca_registration: ''
           uses_wca_live:
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Valutakoden for deltagergebyret.
           base_entry_fee: Basis deltagergebyret for konkurrencen. Deltagergebyret
@@ -2992,7 +2885,6 @@ da:
           guest_entry_fee: For now this number is informational only, guest fees cannot
             be managed through this website. If this is set to 0, a sentence of your
             choice will be displayed about the spectator policy.
-          donations_enabled: ''
           refund_policy_percent: For nu, er dette tal kun for information. Refunderinger
             skal stadig tilbagebetales manuelt. Hvis dette bliver sat til 0, så vil
             en sætning blive vist, der vil sige, at det ikke vil være nogle refunderinger.
@@ -3001,7 +2893,6 @@ da:
         registration:
           opening_date_time: 'Note: Registreringens åbningstider og lukketider er
             i UTC-tid'
-          closing_date_time: ''
           waiting_list_deadline_date: The date when waitlisted registrants will no
             longer be accepted. If you have a deadline for refunds, the deadline for
             being accepted should not be before the deadline for refunds.
@@ -3011,11 +2902,7 @@ da:
             to close. Leaving this field blank means that competitors may add an event
             to their registered events up until that event is held. If you have on
             the spot registration, this must be set to the same day as the competition.
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance:
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration:
           extra_requirements: Indikere venligst her ekstra tilmeldingskrav, som ikke
             er nævnt oven over. Det kan være eksempler på hvordan man betaler. <br/>Udfyld
@@ -3025,16 +2912,13 @@ da:
           force_comment:
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Uddyb hvorfor du gerne vil have at deltagerne skal aflevere deres
               terninger tidligt. Udfyld det på engelsk!
           qualification_results:
-            enabled: ''
             reason: Uddyb hvorfor du gerne vil bruge kvalifikationsresultater. Udfyld
               det på engelsk!
             allow_registration_without:
           event_limitation:
-            enabled: ''
             reason: Uddyb hvorfor du gerne vil begrænse kombinationen af bestemte
               discipliner. Udfyld det på engelsk!
             per_registration_limit:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -259,8 +259,6 @@ de:
     333fm: 1 Stunde
     #original_hash: cc7d8bb
     333mbf: '10:00.00 Minuten pro Würfel, bis zu 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Art der Qualifikation
@@ -804,8 +802,6 @@ de:
       text: benötigt
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Bitte die folgenden Probleme klären:'
@@ -827,12 +823,6 @@ de:
         public_summary: >-
           Eine Gesamtbeschreibung des Incidents und der Entscheidung, die
           öffentlich angezeigt wird. Bitte in Englisch ausfüllen.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: >-
@@ -844,36 +834,14 @@ de:
           ein, zum Beispiel <strong>Stefan Pochmann</strong>. Nicht unachtsam
           wie etwa <strong>s pochman</strong>. Zweite Vornamen (entweder ganz
           oder als Initial) sind optional.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Nachdem Du ein neues Profilbild hochgeladen hast, muss dieses erst vom
           WCA Results Team bestätigt werden.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Dies gilt nur für Wettbewerbe, die du organisierst oder delegierst,
           und kann pro Wettbewerb überschrieben werden.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 81a76a3
         receive_delegate_reports: >-
           Wenn du ein Trainee Delegate, Junior Delegate, Senior Delegate oder
@@ -1080,12 +1048,6 @@ de:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Dein korrektes Geburtsdatum im Format YYYY-MM-DD (Jahr - Monat - Tag)
         #original_hash: 49ee4af
@@ -1152,8 +1114,6 @@ de:
           erscheinen, erwähne zumindest die wichtigsten Zwischenfälle. Bitte
           kreuze die entsprechenden Boxen an, wenn du aktiv nach Feedback fragen
           möchtest.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Liste von Referenznummern der Zwischenfälle, für die du das Feedback
@@ -1171,27 +1131,12 @@ de:
           Pläne für diese Region). Alles was in den vorherigen Bereichen im
           Sinne der klaren und präzisen Ausdrucksweise ausgelassen wurde, kann
           hier erscheinen.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Beispiele: Anreise, Zahlung, Preise/Auszeichnungen, Unterkunft'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
@@ -1203,26 +1148,6 @@ de:
         administrative_notes: >-
           Zusätzliche Anmerkungen zur Verwaltung dieser Anmeldung. Diese können
           vom Teilnehmer nicht eingesehen werden.
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       results_submission:
         #original_hash: da39a3e
         schedule_url: ''
@@ -1231,10 +1156,6 @@ de:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Muss eine gültige http(s) Adresse sein. HTTPS ist empfohlen.
         #original_hash: 2ace571
@@ -1243,28 +1164,12 @@ de:
           transparenten Hintergrund.
         #original_hash: da54ab5
         email: Sollte eine Mailingliste mit allen Direktoren und Beauftragten sein.
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Muss im PDF-Format sein.
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Muss im PDF-Format sein. Falls du mehrere Dateien hinzufügen willst,
           fasse diese bitte zu einer zusammen.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3323,10 +3228,6 @@ de:
         clone_tabs: Ich möchte auch alle Registerkarten mit zusätzlichen Informationen
           kopieren
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: Der volle Name eines Wettbewerbs, inklusive Jahreszahl am Ende (z.B.
           Danish Open 2016). Achte auf Großschreibung. Der Name darf nur alphanumerische
           Zeichen, Bindestriche(-), Und-Zeichen(&), Punkte(.), Doppelpunkte(:), Apostrophe(')
@@ -3337,7 +3238,6 @@ de:
           der <a href='/documents/policies/external/Competition%20Name20Requirements.pdf'>WCA
           Competition Requirements Policy</a> entsprechen.
         venue:
-          country_id: ''
           city_name: Name der Stadt und des Verwaltungsbezirks (wenn möglich) in dem
             der Wettbewerb stattfindet. Lasse hierbei das Land aus (z.B. Paris ODER
             San Francisco, Kalifornien).
@@ -3345,12 +3245,8 @@ de:
             Zum Beispiel: [Cité des Sciences et de l''Industrie](http://www.cite-sciences.fr)'
           details_html: Details über den Veranstaltungsort (z.B. Im hinteren Teil
             des ersten Stocks, Beschilderung folgen). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         series:
-          series_id: ''
           name: >-
             Der volle Name der Wettbewerbsserie, inklusive des Jahres am Ende
             (z.B. Southern Australia 2022). Achte auf Großschreibung. Dieselben
@@ -3385,15 +3281,11 @@ de:
             der Organisatoren zu veröffentlichen. %{md}. Beispiel: [Text zum Anzeigen](mailto:some@email.com)'
         championships:
         website:
-          generate_website: ''
           external_website: Die Website des Wettbewerbs. Muss als gültige http(s)-URL
             vorliegen.
           external_registration_page: Die Seite, auf der Teilnehmer sich für die Competition
             anmelden können. Dies muss eine gültige http(s) Adresse sein.
-          uses_wca_registration: ''
           uses_wca_live: ''
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Der Währungscode für Eintrittsgebühren.
           base_entry_fee: 'Eintrittsgebühr für den Wettbewerb. Die Eintrittsgebühr
@@ -3409,7 +3301,6 @@ de:
             für Gäste nicht über die Webseite verwaltet werden können. Wenn dies auf
             0 gesetzt wird, wird ein im Folgenden auswählbarer Satz bezüglich der
             Registrierung für Gäste angezeigt.
-          donations_enabled: ''
           refund_policy_percent: Aktuell dient diese Angabe nur zur Information und
             Rückerstattungen müssen manuell veranlasst werden. Wenn dies auf 0 gesetzt
             wird, wird ein Hinweis angezeigt, dass Eintrittsgebühren unter keinen
@@ -3417,7 +3308,6 @@ de:
           refund_policy_limit_date: Datum, nachdem keine Rückerstattungen mehr erfolgen
         registration:
           opening_date_time: 'Anmerkung: Anmeldebeginn und -schluss sind in UTC anzugeben'
-          closing_date_time: ''
           waiting_list_deadline_date: Der Zeitpunkt, ab welchem Personen auf der Warteliste
             nicht mehr akzeptiert werden. Wenn du eine Deadline für Rückerstattungen
             angegeben hast, sollte die Deadline für das Akzeptieren der Teilnahme
@@ -3429,11 +3319,7 @@ de:
             Events bis zum Stattfinden des jeweiligen Events hinzufügen. Wenn du vor-Ort-Registrierungen
             zulässt, muss dieser Zeitpunkt auf den selben Tag wie die Competition
             gelegt werden.
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance: ''
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration: Die Anzahl erlaubter Gäste pro Anmeldung bei dieser
             Competition. Eine Anmeldung mit zu vielen Gästen wird blockiert. Lasse
             dies frei, wenn es keine Begrenzung gibt.
@@ -3442,19 +3328,14 @@ de:
             fülle diese <b>auf Englisch</b> und in jeder anderen Sprache, die die
             Teilnehmer sprechen, aus. Dies wird auf der Seite des Wettbewerbs und
             auf der Registrierungsseite angezeigt.
-          force_comment: ''
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Bitte führe aus, warum du möchtest, dass Teilnehmer ihre Puzzle
               früher abgeben. Fülle dies in Englisch aus!
           qualification_results:
-            enabled: ''
             reason: Bitte erläutere hier, warum du Qualifikationszeiten nutzen möchtest.
               Fülle dies in Englisch aus!
-            allow_registration_without: ''
           event_limitation:
-            enabled: ''
             reason: Bitte erläutere hier, warum du die Anmeldung bestimmter Eventkombinationen
               verbieten willst. Bitte fülle dies in Englisch aus!
             per_registration_limit: Lege wahlweise fest, für wie viele Events sich

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,7 +192,6 @@ en:
       across_rounds: "%{time} total for %{rounds}"
     333fm: "1 hour"
     333mbf: "10:00.00 per cube, up to 60:00.00"
-    333mbo: ""
   #context: Words used to describe qualification limits.
   qualification:
     type_label: "Qualification Type"
@@ -460,9 +459,6 @@ en:
     required:
       text: 'required'
       mark: '*'
-      # You can uncomment the line below if you need to overwrite the whole required html.
-      # When using html, text and mark won't be used.
-      html: ''
     error_notification:
       default_message: "Please review the problems below:"
     #context: and a hint given about a specific field
@@ -473,34 +469,17 @@ en:
         private_description: "A description of the incident which can only be viewed by Delegates. Please fill this in English."
         private_wrc_decision: "The final WRC decision, including private details. Please fill this in English."
         public_summary: "An overall description of the incident and its decision, to be displayed publicly. Please fill this in English."
-        digest_worthy: ""
-        tags: ""
-        competition_id: ""
       #context: for a user
       user:
         dob: "Enter the competitor's date of birth in the format YYYY-MM-DD."
         name: "Enter the competitor's full name correctly, for example <strong>Stefan Pochmann</strong>. Not sloppily like <strong>s pochman</strong>.<br/>Middle names (either full or as initials) are optional."
-        email: ""
         pending_avatar: "After uploading a new avatar, you will have to wait for the WCA Results Team to approve it."
-        country_iso2: ""
-        dob_verification: ""
-        gender: ""
-        login: ""
-        password: ""
-        password_confirmation: ""
-        remember_me: ""
-        results_notifications_enabled: ""
         registration_notifications_enabled: "This only applies for competitions you organize or delegate, and can be overridden on a per-competition basis."
-        unconfirmed_wca_id: ""
-        wca_id: ""
         receive_developer_mails: "This is limited to notifications for major version changes to resources like data exports, WCIF schema and public APIs. Recommended for developers maintaing software that relies on these tools."
         receive_delegate_reports: "If you are a Senior Delegate or Member of the WRC or the WQAC, you receive Delegate Reports by default. Note: the change may take up to 12 hours to take effect."
         delegate_reports_region: "If you want to receive all reports, leave this field blank (the dropdown option at the very top). Note: the change may take up to 12 hours to take effect."
         otp_attempt: "Check your configured mobile application for a one-time password, or input one of your recovery codes."
       dob_contact:
-        name: ""
-        your_email: ""
-        wca_id: ""
         dob: "Your correct day of birth in the format YYYY-MM-DD"
         document: "To prove your identity and your correct date of birth to us, you have to attach a picture of any legal document (identity card, driver license, student card, passport, birth certificate, ...) where your name and date of birth are visible and understandable for an English speaker (or contact your local WCA Delegate if you don't have such a document). On the identification we need at minimum your name and date of birth; feel free to blur-out/obfuscate any other personal data on the identification."
       #context: for a post
@@ -516,52 +495,19 @@ en:
         organization: "The listed points above are just for guidance for a complete report. Use them at your discretion for what you see fit. Please remove unused parts!"
         incidents: "Please report all incidents which are non-standard cases. Number the incidents starting from 1., so that other Delegates can comment referring to them by their numbers. Even if everything seemed generic, just list at least the most noteworthy cases. Please check off the appropriate boxes below if you are actively seeking feedback."
         setup_images: "You MUST include at least %{image_count} images which illustrate the scrambling and competition areas from this current competition, preferably during the competition (other images are also welcome). You can select multiple files at once. You can delete images only when enough other images have been uploaded (if you want to replace an image, you need to upload the new one first, and then delete the old one). If you do not have current pictures of the competition area and/or the scrambling area while in use, please explain why."
-        wrc_feedback_requested: ""
         wrc_incidents: "List of numbers referencing any incidents that you would like the WRC's feedback on."
-        wic_feedback_requested: ""
         wic_incidents_html: "List of numbers referencing any incidents that you would like the WIC's feedback on. <br> <strong>%{wic_incident_alert}</strong>"
         wic_incident_alert: "If the WIC incident is sensitive (including but not limited to crimes, harassment, assault, etc.), please exclude this from your report and email the WIC separately. For other WIC incidents, default to a brief, anonymized version of the incident and follow-up with the WIC privately with further details. The WIC will still provide feedback on anonymized versions for general awareness. For all WIC incidents involving a WCA Volunteer, please exclude all details from the report, and contact the WIC privately."
         remarks: "Talk about any other detail that you'd like to share (e.g., improvement/regression within the community, future plans for this region). If for the sake of conciseness you left something unsaid in the previous sections, feel free to comment them here."
-        discussion_url: ""
       #context: for a competition tab
       competition_tab:
         name: "Examples: Travel, Payments, Awards, Accommodation"
-        content: ""
-      #context: for a person
-      person:
-        person1_wca_id: ""
-        person2_wca_id: ""
-      poll:
-        comment: ""
-        multiple: ""
-        question: ""
-      vote:
-        comment: ""
-      competition_medium:
-        competition_id: ""
-        media_type: ""
-        text: ""
-        uri: ""
-        submitter_name: ""
-        submitter_email: ""
-        submitter_comment: ""
-        status: ""
       regional_organization:
-        name: ""
-        country: ""
         website: "Must be a valid http(s) url. HTTPS is recommended"
         logo: "Must be in PNG format, in good resolution, and with a transparent background"
         email: "Should be a mailing list containing all the Directors and Officers"
-        address: ""
         bylaws: "Must be in PDF format"
-        directors_and_officers: ""
-        area_description: ""
-        past_and_current_activities: ""
-        future_plans: ""
-        extra_information: ""
         extra_file: "Must be in PDF format. If you need to add more files, please merge them together"
-        start_date: ""
-        end_date: ""
     #context: and a label for an option
     options:
       #context: about registration
@@ -1820,27 +1766,16 @@ en:
       #context: for a competition
       hints:
         admin:
-          is_confirmed: ""
-          is_visible: ""
           uses_new_registration_system: "If this is disabled, changing the registration system will cause technical issues. Please contact WST for assistance if you still need to change the registration system."
-        competition_id: ""
         name: "The full name of the competition including the year at the end (e.g., Danish Open 2016). Be sure to capitalize. The name must contain only alphanumeric characters, dashes(-), ampersands(&), periods(.), colons(:), apostrophes('), and spaces( )."
         short_name: "A short name for displaying. If the name of the competition is below %{short_name_limit} characters this should not be edited and should be the same as the normal name."
         name_reason_html: "A brief explanation of the competition name. The name must comply with the <a href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA Competition Requirements Policy</a>."
         venue:
-          country_id: ""
           city_name: "Name of the city and state (if applicable) where the competition takes place. Do not include country (e.g., Paris OR San Francisco, California)."
           name_html: "The venue where the competition takes place. %{md}. For example: [Cité des Sciences et de l'Industrie](http://www.cite-sciences.fr)"
           details_html: "Details about the venue (e.g., On the first floor far in the back, follow the signs). %{md}"
-          address: ""
-          coordinates:
-            lat: ""
-            long: ""
-        start_date: ""
-        end_date: ""
         #context: when part of a Competition Series
         series:
-          series_id: ""
           name: "The full name of the Competition Series including the year at the end (e.g., Southern Australia 2022). Be sure to capitalize. The same rules as for the name of the individual competition apply."
           short_name: "A short name for displaying. The same rules as for the name of the individual competition apply.."
           competition_ids: "<b>This field cannot be edited!</b><br/>To add competitions to this Series, you have to go to the individual 'Edit' pages of the competitions that you want to add."
@@ -1860,53 +1795,34 @@ en:
           contact_html: "Optional contact information. If you do not fill this in, contact inquiries will be submitted through a form without revealing organizers' emails. %{md}. Example: [Text to display](mailto:some@email.com)"
           lead_delegate_id: "The Lead Delegate is responsible for the administrative aspects of a competition (Results, Report, Dues Invoice)"
         website:
-          generate_website: ""
           external_website: "The website of the competition. Must be a valid http(s) url."
           external_registration_page: "The page where the competitors have to register for the competition. Must be a valid http(s) url."
-          uses_wca_registration: ""
           scoretaking_software: "Select '%{choice_ilr}' if you want to use Dual Rounds"
-        user_settings:
-          receive_registration_emails: ""
         entry_fees:
           currency_code: "The currency code for fees."
           base_entry_fee: 'The base registration fee for the competition. It will be displayed on the competition information page and the registration page if used. If this is set to 0, a sentence will be displayed saying that registrations will be accepted for free. <br><br><b>DISCLAIMER: The following WCA Dues estimate is solely an approximation based on current exchange rates and is in no way legally binding for the Dues payment.</b>'
           on_the_spot_entry_fee: "If this is set to 0, a sentence will be displayed saying that on the spot registrations will be accepted for free."
           guest_entry_fee: "For now this number is informational only, guest fees cannot be managed through this website. If this is set to 0, a sentence of your choice will be displayed about the spectator policy."
-          donations_enabled: ""
           refund_policy_percent: "For now this number is informational only, refunds will have to be issued manually. If this is set to 0, a sentence will be displayed saying that registration fees won't be refunded under any circumstance."
           refund_policy_limit_date: "Date after which no more refunds will be issued."
         registration:
           opening_date_time: "Note: Registration open and close are in UTC time"
-          closing_date_time: ""
           waiting_list_deadline_date: "The date when waitlisted registrants will no longer be accepted. If you have a deadline for refunds, the deadline for being accepted should not be before the deadline for refunds."
           event_change_deadline_date: "Registered competitors have the right to update their registered events until this time by contacting the organization team. This deadline must not be set to a time before registration is set to close. Leaving this field blank means that competitors may add an event to their registered events up until that event is held. If you have on the spot registration, this must be set to the same day as the competition."
-          allow_on_the_spot: ""
-          competitor_can_cancel: ""
-          allow_self_edits: ""
-          guests_enabled: ""
-          guest_entry_status: ""
           guests_per_registration: "The number of guests per registration allowed at this competition. Registration with too many guests will be blocked. Leave blank if there is no limit."
           extra_requirements: "Please indicate here any extra registration requirements not covered above, like for example directions on how to pay. <br/>Please fill this out <b>in English</b> and whatever other languages your competitors speak; this will be displayed on the competition's information page, as well on the registration page if you are using the WCA website registrations."
-          force_comment: ""
         event_restrictions:
           forbid_newcomers:
-            enabled: ""
             reason: "Please elaborate here why you would not like newcomers to register for your competition. Please fill this out in English!"
           early_puzzle_submission:
-            enabled: ""
             reason: "Please elaborate here why you would like to require competitors to submit puzzles early. Please fill this out in English!"
           qualification_results:
-            enabled: ""
             reason: "Please elaborate here why you would like to use qualification times. Please fill this out in English!"
-            allow_registration_without: ""
           event_limitation:
-            enabled: ""
             reason: "Please elaborate here why you would like to restrict certain event combinations. Please fill this out in English!"
             per_registration_limit: "Optionally enforce the total number of events a competitor can register for (commonly used for \"Favorites\" competitions). You should add events before using this field. Registrations with too many events will be blocked. Leave blank if there is no limit."
           main_event_id: "The winner of this event will be the winner of the competition."
         remarks: "Some additional information you want to pass on to the WCAT. For example, if there is something you are uncertain about, or if there are any special requests for the WCAT. Please fill this out in English!"
-        cloning:
-          clone_tabs: ""
       choices:
         #context: about guests
         guests_enabled:
@@ -2428,7 +2344,6 @@ en:
       connect_account_warning:
         stripe: "Connecting your Stripe account gives the WCA website the ability to create charges, and issue refunds directly on your Stripe account."
         paypal: "Connecting your PayPal account gives the WCA website the ability to route payments to you, and issue refunds directly on your PayPal account."
-        manual:  ""
       currently_connected_info: "This competition is set up to accept payments through %{provider}. The Delegate(s) of the competition should contact WCAT to make any changes to connected accounts."
       before_disconnect_warning: "Disconnecting on this page will make our website forget the connection to your %{provider} account. But your %{provider} dashboard (see link below) may still list the WCA website based on the authorization that you previously granted. Note that revoking authorization in the %{provider} dashboard will also affect any other competition linked to accept payments through this account!"
       before_disconnect_info: "Keep in mind that disconnecting an account should only be done in exceptional situations, such as the current account being unable to receive payments."

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -261,8 +261,6 @@ eo:
     333fm: 1 horo
     #original_hash: cc7d8bb
     333mbf: '10:00:00 po kubo, ĝis 60:00:00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Kvalifika Tipo
@@ -703,8 +701,6 @@ eo:
       text: estas deviga
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Bonvolu ekzameni la malsuprajn problemojn:'
@@ -724,12 +720,6 @@ eo:
         public_summary: >-
           Tuta priskribo de la incidento kaj ĝia decido, por publikigi ĝin.
           Bonvolu plenigi ĝin en la angla.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Enigu la naskiĝdaton de la konkursanto kiel JJJJ-MM-TT
@@ -739,36 +729,14 @@ eo:
           Pochmann</strong>. Ne neglekteme kiel <strong>s pochman</strong> aŭ
           <strong>POCHMAN Stefan</strong>. Mezaj nomoj eblas (aŭ tute skribitaj
           aŭ per komencliteroj).
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Kiam via nova profilbildo estas alŝutita, vi devas atendi la aprobon
           de la Rezulta Teamo de la WCA.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Ĉi tio validas nur por konkursoj, kiujn vi organizas aŭ delegas, kaj
           povas esti anstataŭita por specifaj konkursoj.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 27c2251
         receive_delegate_reports: >-
           Se vi estas Ĉefa Delegito aŭ Membro de la WRC aŭ WQAC, vi defaŭlte
@@ -784,12 +752,6 @@ eo:
           Kontrolu vian konfigurintan poŝtelefonan apon por unufoja pasvorto, aŭ
           enigu unu el viaj restaŭrkopiaj kodoj.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Via ĝusta naskiĝtago kiel JJJJ-MM-TT
         #original_hash: 49ee4af
@@ -848,14 +810,10 @@ eo:
           plurajn dosierojn samtempe. Vi povas forigi bildojn nur kiam sufiĉe da
           aliaj bildoj estas alŝutitaj (se vi volas anstataŭigi bildon, vi devas
           unue alŝuti la novan, kaj poste forigi la malnovan).
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Listo de la numeroj de la incidentoj por kiuj vi ŝatus ricevi opinion
           de la WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Listo de la numeroj de la incidentoj por kiuj vi ŝatus ricevi opinion
@@ -876,78 +834,22 @@ eo:
           plibonigo/malplibonigo ene de la komunumo, estontaj projektoj por tiu
           ĉi regiono). Se vi ne diris ion pro la volo esti konciza antaŭe, diru
           ĝin tie!
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Ekzemploj: Vojaĝo, Pagoj, Premioj, Tranoktejo'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Devas esti valida http(s) reteja adreso. HTTPS estas rekomendita.
         #original_hash: 2ace571
         logo: 'Devas esti PNG-dosiero, bonkvalite kaj kun travidebla fono'
         #original_hash: da54ab5
         email: Devus esti dissendolisto kiu enhavas ĉiujn Direktorojn kaj Oficistojn
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Devas esti en dosierformo PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Devas esti en dosierformo PDF. Se vi bezonas aldoni pliajn dosierojn,
           bonvolu kunfandi ilin
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3334,17 +3236,11 @@ eo:
           clone_tabs: Mi ankaŭ ŝatus kloni ĉiujn langetojn kun aldonaj informoj
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Se ĉi tio estas malŝaltita, ŝanĝi la registriĝ-sistemon kaŭzos
             teknikajn problemojn. Bonvolu kontakti WST por ricevi helpon se vi
             tamen bezonas ŝanĝi la registriĝ-sistemon.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           La tuta nomo de la konkurso kun la jaro en la fino (t.e., Danish Open
@@ -3362,8 +3258,6 @@ eo:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Politiko
           pri Postuloj de Konkursoj de la WCA</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Urbonomo kaj ŝtatnomo (se aplikebla) kie la konkurso okazas. Ne
@@ -3376,20 +3270,7 @@ eo:
           details_html: >-
             Detaloj pri la konkursejo (ekz., Je la unua etaĝo, funde, sekvu la
             ŝildojn). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             La plena nomo de la Konkursa Serio kun la jaro ĉe la fino (ekz.,
@@ -3459,8 +3340,6 @@ eo:
             organizantoj. %{md}. Ekzemple: [Videbla
             teksto](mailto:iu@retpoŝto.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: >-
             La retejo de la konkurso. Ĝi devas esti valida reteja adreso
@@ -3470,12 +3349,7 @@ eo:
             La paĝo kie la konkursantoj povas registriĝi por la konkurso. Ĝi
             devas esti valida reteja adreso (http(s)).
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: La valuto uzata por la kostoj.
@@ -3496,8 +3370,6 @@ eo:
             Nuntempe, tiu nombro estas nur sciiga ĉar pagoj de akompanantoj ne
             povas esti faritaj per tiu retejo. Se vi enigas 0, vi povos elekti
             frazon pri kiel vi traktos spektantojn.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Nun, tiu nombro estas nur sciiga, repagoj devos esti farita permane.
@@ -3510,8 +3382,6 @@ eo:
           opening_date_time: >-
             Noto: Horoj de komenco kaj fino de registriĝperiodo estas indikitaj
             laŭ UTC
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             La dato post kiam oni ne plu akceptos registriĝoj de la atendolisto.
@@ -3525,16 +3395,6 @@ eo:
             signifas ke konkursantoj povas aldoni konkurseron ĝis kiam tiu
             konkursero okazas. Se vi havas surlokajn registriĝojn, vi devas
             enigi la tagon de la konkurso.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             La nombro da gastoj permesitaj per registriĝo ĉe ĉi tiu konkurso.
@@ -3548,35 +3408,23 @@ eo:
             viaj konkursontoj; tio aperos ĉe la informa paĝo de la konkurso, kaj
             ankaŭ en la paĝo por registriĝi se vi uzas la registran sistemon de
             retejo de la WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Bonvolu detali ĉi tie kial vi ne ŝatus ke novuloj registriĝu por
               via konkurenco. Bonvolu plenigi ĉi tion en la angla!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Bonvolu detali tie kial vi ŝatus devigi konkursantojn antaŭtempe
               submetiĝi puzloj. Bonvolu plenigi tion en la angla!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Bonvolu detali tie kial vi ŝatus uzi kvalifikajn rezultojn.
               Bonvolu plenigi tion en la angla!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Bonvolu detali tie kial vi ŝatus limigi specifajn kombinadojn de
@@ -3595,9 +3443,6 @@ eo:
           Iujn aldonajn informojn kiujn vi ŝatus komuniki al la WCAT. Ekzemple,
           se vi ne certas pri io aŭ se vi havas specifajn petojn por la WCAT.
           Bonvolu plenigi tion en la angla!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -282,8 +282,6 @@ es-419:
     333fm: 1 hora
     #original_hash: cc7d8bb
     333mbf: '10:00.00 por cubo, hasta 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Tipo de calificación
@@ -738,8 +736,6 @@ es-419:
       text: Requerido
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Por favor, revisa los siguientes errores:'
@@ -761,12 +757,6 @@ es-419:
         public_summary: >-
           Una descripción general del incidente y su decisión asociada, para
           mostrar públicamente. Por favor, rellénalo en inglés.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: >-
@@ -776,36 +766,14 @@ es-419:
         name: >-
           Introduce el nombre completo del competidor correctamente, por ejemplo
           <strong>Martín López</strong> y no <strong>martin lopez</strong>.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Después de subir un nuevo avatar, tendrás que esperar que el Equipo de
           Resultados lo apruebe.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Esto sólo aplica en competiciones que organizas o delegas, y puede ser
           anulado en cada competición.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Esto se limita a notificaciones para cambios de versiones mayores de
@@ -828,12 +796,6 @@ es-419:
           Comprueba tu aplicación de móvil configurada para una contraseña de un
           sólo uso, o introduce uno de los códigos de recuperación.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Tu fecha de nacimiento correcta en formato AAAA-MM-DD
         #original_hash: 49ee4af
@@ -898,14 +860,10 @@ es-419:
           hayan subido (si quieres reemplazar una imagen, necesitas subir la
           nueva primero, y luego eliminar la antigua). Si no tienes imágenes de
           estas zonas en uso, por favor explica la razón.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Lista de números que referenciando a algún incidente sobre el que te
           gustaría obtener feedback del WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Lista de números haciendo referencia a los incidentes en los cuales
@@ -928,50 +886,10 @@ es-419:
           progreso / regresión dentro de la comunidad o planes futuros para la
           región). Si por ser conciso dejaste algo sin decir en las secciones
           anteriores, ahora puedes hacerlo.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Ejemplos: Cómo llegar, Pagos, Premios, Dónde dormir'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Debe ser una URL http(s) válida. Se recomienda HTTPS
         #original_hash: 2ace571
@@ -982,28 +900,12 @@ es-419:
         email: >-
           Debería ser una lista de correo conteniendo todos los cargos de la
           Junta directiva
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Debe estar en formato PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Debe estar en formato PDF.  Si necesitas  añadir más ficheros, por
           favor únelos en uno solo
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3711,17 +3613,11 @@ es-419:
             también
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Si esto se deshabilita, cambiar el sistema de registro causará
             problemas técnicos. Por favor, contacta al WST para recibir
             asistencia si aún así necesitas cambiar el sistema de registro.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Nombre completo de la competición incluyendo el año al final (ejemplo,
@@ -3742,8 +3638,6 @@ es-419:
           de Requisitos de Competiciones de la WCA</a>. ¡Por favor, <b>rellena
           este campo en inglés</b>!
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nombre de la ciudad y provincia donde tendrá lugar la competición.
@@ -3756,20 +3650,7 @@ es-419:
           details_html: >-
             Detalles sobre el local (por ejemplo, "primera planta" o "sigue los
             carteles"). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             El nombre completo de la serie de competiciones incluyendo el año al
@@ -3846,21 +3727,14 @@ es-419:
             El Delegado principal es responsable de los aspectos administrativos
             de la competición (resultados, reporte, pago de la cuota)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Sitio web de la competición. Tiene que ser una URL http(s) válida.
           #original_hash: b2af5f5
           external_registration_page: >-
             La página donde los competidores deben hacer el registro para la
             competición. Debe ser una URL http o https válida.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'Selecciona "%{choice_ilr}" si deseas usar Rondas Duales'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Moneda en que se especifican los pagos.
@@ -3883,8 +3757,6 @@ es-419:
             espectadores no se pueden gestionar desde este sitio web. Si se pone
             en $0, se mostrará la frase seleccionada en "Mostrar mensaje para
             acceso gratuito de invitados".
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Por ahora esta cifra es informativa, los reembolsos deberán
@@ -3896,8 +3768,6 @@ es-419:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Nota: la apertura y cierre se registra según la hora UTC.'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Fecha a partir de la cual los competidores en lista de espera
@@ -3913,16 +3783,6 @@ es-419:
             blanco quiere decir que los competidores pueden añadir eventos hasta
             que empiecen. Si hay registro in situ, se debe poner la fecha en la
             que ocurra la competición.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             El número de invitados por inscripción permitidos en esta
@@ -3936,36 +3796,24 @@ es-419:
             adicional que hablen tus competidores; será mostrado en la página de
             registro de la competición si estás usando el registro de la web de
             la WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Por favor elabora a continuación por qué no te gustaría que se
               registren primerizos en tu torneo. ¡Por favor, en inglés!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Por favor explica aquí por que te gustaría requerir que los
               competidores entreguen sus puzzles con anelación. Por favor
               rellena esto en inglés
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Por favor explica aquí por que te gustaría requerir usar tiempos
               de calificación. Por favor rellena esto en inglés
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Por favor explica aquí por que te gustaría restringir ciertas
@@ -3983,9 +3831,6 @@ es-419:
           Alguna información adicional que quieras pasar al WCAT. Por ejemplo,
           si hay algo de lo que no estés seguro o si hay alguna petición para el
           WCAT. Por favor rellénalo en inglés.
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -5110,8 +4955,6 @@ es-419:
         paypal: >-
           Conectar tu cuenta de PayPal permite al sitio web de la WCA rutear
           pagos a tí y emitir reembolsos directamente a tu cuenta.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Esta competición ha sido configurada para recibir pagos a través de

--- a/config/locales/es-ES.yml
+++ b/config/locales/es-ES.yml
@@ -282,8 +282,6 @@ es-ES:
     333fm: Una hora
     #original_hash: cc7d8bb
     333mbf: '10:00.00 por cubo, hasta 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Tipo de clasificación
@@ -738,8 +736,6 @@ es-ES:
       text: requerido
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Por favor, revisa los siguientes problemas:'
@@ -761,12 +757,6 @@ es-ES:
         public_summary: >-
           Una descripción general del incidente y la decisión, para mostrar
           públicamente. Por favor, rellénalo en inglés.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Introduce la fecha de nacimiento del competidor en formato AAAA-MM-DD.
@@ -776,36 +766,14 @@ es-ES:
           ejemplo <strong>Carlos Méndez</strong> y no <strong>C
           Mendez</strong>.<br/>Los segundos nombres (completos o con iniciales)
           son opcionales.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Después de subir un nuevo avatar, tendrás que esperar a que el Equipo
           de Resultados de la WCA lo apruebe.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Esto solo se aplica en competiciones que organices o delegues y puedes
           cambiarlo en cada competición.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Esto se limita a notificaciones sobre cambios mayores de versión en
@@ -827,12 +795,6 @@ es-ES:
           Comprueba tu aplicación de móvil configurada para una contraseña de un
           sólo uso o introduce uno de tus códigos de recuperación.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Tu fecha de nacimiento correcta en formato AAAA-MM-DD
         #original_hash: 49ee4af
@@ -901,14 +863,10 @@ es-ES:
           primero y luego eliminar la antigua). Si no dispones de fotografías
           actuales de la zona de competición y/o de la zona de mezclas mientras
           se utilizan, explica por qué.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Lista de números referenciando los incidentes de los cuales te
           gustaría obtener retroalimentación del WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Lista de números referenciando los incidentes de los cuales te
@@ -932,50 +890,10 @@ es-ES:
           progreso o regresión dentro de la comunidad o planes de futuro para la
           región). Si por ser conciso te has dejado algo sin decir en las
           secciones anteriores, puedes comentarlo ahora.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Ejemplos: Cómo llegar, Pago, Premios, Alojamiento'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Tiene que ser una URL http(s) válida. Se recomienda HTTPS
         #original_hash: 2ace571
@@ -986,28 +904,12 @@ es-ES:
         email: >-
           Debería ser una lista de correo electrónico que incluya a todos los
           miembros de la Junta Directiva y Oficiales
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Tiene que estar en formato PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Tiene que estar en formato PDF. Si necesitas añadir más archivos, por
           favor, únelos en un único archivo
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3771,17 +3673,11 @@ es-ES:
             adicional
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Si esto se desactiva, cambiar el sistema de registro causará
             problemas técnicos. Por favor, ponte en contacto con el WST para
             recibir asistencia si aún necesitas cambiar el sistema de registro.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           El nombre completo de la competición incluyendo el año al final (por
@@ -3801,8 +3697,6 @@ es-ES:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Política
           de Requisitos de Competiciones de la WCA</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nombre de la ciudad y provincia donde tendrá lugar la competición.
@@ -3815,20 +3709,7 @@ es-ES:
           details_html: >-
             Detalles sobre el recinto (por ejemplo, «En la primera planta, al
             fondo, sigue los carteles»). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             El nombre completo de la serie de competiciones incluyendo el año al
@@ -3908,8 +3789,6 @@ es-ES:
             administrativos de una competición (Resultados, Informe, pago de la
             Cuota)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: >-
             La página web de la competición. Tiene que ser una URL http(s)
@@ -3918,13 +3797,8 @@ es-ES:
           external_registration_page: >-
             La página donde los competidores se tienen que registrar para la
             competición. Tiene que ser una URL http(s) válida.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'Selecciona «%{choice_ilr}» si quieres utilizar Rondas Duales'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Divisa para la cuota.
@@ -3948,8 +3822,6 @@ es-ES:
             acompañantes no pueden ser gestionadas a través de esta página web.
             Si esto se pone en 0, se mostrará una frase de tu elección sobre la
             política de espectadores.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Por ahora, este número es solo informativo, los reembolsos se
@@ -3961,8 +3833,6 @@ es-ES:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Nota: La apertura y el cierre del registro están en horario UTC'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Fecha tras la cual no se aceptarán registros en lista de espera. Si
@@ -3979,16 +3849,6 @@ es-ES:
             a sus categorías registradas hasta que empiecen esas categoría. Si
             tienes registro in situ, esto tiene que ponerse en el mismo día que
             la competición.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             El número de acompañantes permitidos por registro en esta
@@ -4002,36 +3862,24 @@ es-ES:
             idioma adicional que hablen tus competidores; será mostrado en la
             página de información de la competición, así como en página de
             registro si estás usando el registro de la página web de la WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Por favor, elabora aquí por qué no te gustaría que se registren
               nuevos en tu competición. ¡Por favor, rellénalo en inglés!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Por favor, explica aquí por qué te gustaría requerir que los
               competidores entreguen sus puzzles con antelación. ¡Por favor,
               rellena esto en inglés!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Por favor, explica aquí por qué te gustaría usar tiempos de
               clasificación. ¡Por favor, rellena esto en inglés!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Por favor, explica aquí por qué te gustaría restringir ciertas
@@ -4050,9 +3898,6 @@ es-ES:
           Alguna información adicional que quieras pasar al WCAT. Por ejemplo,
           si hay algo de lo que no estés seguro o si hay alguna petición
           especial para el WCAT. ¡Por favor, rellena esto en inglés!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -5187,8 +5032,6 @@ es-ES:
           Conectar tu cuenta de PayPal permite a la página web de la WCA
           redirigirte pagos y realizar reembolsos directamente en tu cuenta de
           Stripe.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Esta competición ha sido configurada para recibir pagos a través de

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -280,8 +280,6 @@ eu:
     333fm: Ordu 1
     #original_hash: cc7d8bb
     333mbf: 'Kubo bakoitzeko 10:00.00, 60:00.00-ra arte'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Sailkatze mota
@@ -726,8 +724,6 @@ eu:
       text: beharrezkoa
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Hurrengo arazo hauek azter itzazu mesedez:'
@@ -747,12 +743,6 @@ eu:
         public_summary: >-
           Gertaeraren deskribapen orokorra eta erabakia, publikoki ager dadin.
           Mesedez, bete hau ingelesez.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Lehiatzailearen jaioteguna UUUU-HH-EE formatuan sartu.
@@ -762,36 +752,14 @@ eu:
           <strong>José Miguel Beguiristain</strong>. Ez erratikotiki <strong>jm
           beguiristain</strong> bezala. <br/>Bigarren izenak (osoak edo
           inizialak) aukerakoak dira.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Irudi berri bat igo ondoren, WCAko Emaitzen Taldeak onartu arte
           itxaron beharko duzu.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Hau antolatzen edo ordezkatzen dituzun lehiaketetan aplikatzen da
           besterik, eta lehiaketa bakoitzean berridatz dezakezu.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Hau baliabideen bertsio aldaketa nagusietara mugatuta dago, hala nola
@@ -812,12 +780,6 @@ eu:
           Ikuskatu zure behin-behineko pasahitz bat lortzeko konfiguratutako
           aplikazio mugikorra  edo sartu zure berreskuratze-kodeetako bat.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: 'Zure jaiotegun zuzena, UUUU-HH-EE formatuan'
         #original_hash: 49ee4af
@@ -883,14 +845,10 @@ eu:
           duzu, eta gero zaharra ezabatu). Ez baduzu lehia-guneko mementuko
           irudirik edota nahas-gunea erabiltzen ari zen bitarteko irudirik
           azaldu zergatik mesedez.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           WRCren feedbacka jasotzea nahi zenukeen edozein gertaeren zenbakien
           zerrenda.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           WICren feedbacka jasotzea nahi zenukeen edozein gertaeren zenbakien
@@ -912,50 +870,10 @@ eu:
           (adibidez, komunitatearen barruko hobekuntza/erregresioa, eskualde
           honetarako etorkizunerako planak). Aurreko atalak laburragoak izateko
           ezer idatzirik utzi baduzu, hemen apia ditzakezu.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Adibideak: bidaiak, ordainketak, sariak, ostatua'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Baliozko http(s) helbidea izan behar du. HTTPS gomendatzen da
         #original_hash: 2ace571
@@ -964,28 +882,12 @@ eu:
         email: >-
           Zuzendari eta Ofizial guztiak biltzen dituen posta-zerrenda izan behar
           luke
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: PDF formatuan egon behar du
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           PDF formatuan egon behar du. Fitxategi gehiago gehitu behar badituzu,
           mesedez, bateratu
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3651,17 +3553,11 @@ eu:
             batera
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Hau desaktibatzen bada, erregistrazio sistema aldatzeak arazo
             teknikoak sortuko ditu. Mesedez, jarri WSTrekin harremanetan
             laguntzarako oraindik erregistrazio sistema aldatu behar baduzu.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Lehiaketaren izen osoa, urtea bukaeran jarriz (adibidez, Basauri Open
@@ -3679,8 +3575,6 @@ eu:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCAko
           Lehiaketen Baldintza Politikarekin</a> bat egin behar du.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Hiria eta estatuaren izena (aplikagarri bada) non lehiaketa
@@ -3695,20 +3589,7 @@ eu:
           details_html: >-
             Tokiari buruzko zehaztasunak (adibidez, lehenengo pisuko atzealdean,
             ikurrak jarraitu). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Lehiaketa seriearen izen osoa, urtea bukaeran jarriz (adibidez,
@@ -3781,21 +3662,14 @@ eu:
             Ordezkari Nagusia lehiaketa baten alde administratiboez arduratzen
             da (emaitzez, txostenez, kuoten fakturez)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Lehiaketaren webgunea. Http(s) url baliozko bat izan behar du.
           #original_hash: b2af5f5
           external_registration_page: >-
             Lehiakideek lehiaketarako izena eman behar duten webgunea. Http(s)
             url baliozkoa izan behar du.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'Hautatu "%{choice_ilr}" txanda bikoitzak erabili nahi badituzu'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Kuotentzako moneta kodea
@@ -3816,8 +3690,6 @@ eu:
             Oraingoz zenbaki hau informatiboa baino ez da, ikusle tarifak ezin
             dira webgune honen bidez kudeatu. Hau 0n ezartzen bada, zuk
             aukeratutako esaldi bat erakutsiko da ikusleen politikari buruz.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Izan ere, orain zenbaki hau informatiboa da. Itzulketak eskuz egin
@@ -3830,8 +3702,6 @@ eu:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Oharra: izen ematea zabaldu eta ixten den datak UCT orduan daude.'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Itxaron-zerrendako erregistratuak onartzeko epemuga. Itzulketarako
@@ -3846,16 +3716,6 @@ eu:
             ahal izango dutela esan nahi du, proba hori gauzatzen den arte.
             Unean bertako izena eman ahal bada epea lehiaketaren egun berean
             ezarri beharko duzu.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Erregistro bakoitzeko baimendutako gonbidatu kopurua. Gonbidatu
@@ -3869,35 +3729,23 @@ eu:
             egiten duten beste edozein hizkuntzatan; hau lehiaketaren
             informazio-orrian agertuko da, baita izen-emate orrian ere, WCAko
             webguneko izen-ematea erabiltzen ari bazara.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Mesedez, zehaztu hemen zergatik zure lehiaketan ez zenukeen nahi
               lehiakide berririk izena ematea. Mesedez, bete hau ingelesez!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Mesedez, zehaztu hemen zergatik eskatu nahi diezun lehiakideei
               puzzleak goiz aurkezteko. Mesedez, bete hau ingelesez!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Zehaztu hemen zergatik erabili nahi dituzun sailkatze-denborak.
               Bete hau ingelesez mesedez!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Zehaztu hemen zergatik murriztu nahi dituzun proba konbinazio
@@ -3916,9 +3764,6 @@ eu:
           WCATri pasatu nahi diozun informazio gehigarria. Adibidez, zerbaitez
           ziur ez bazaude edota WCATrentzako eskaera berezirik baduzu. Bete hau
           ingelesez mesedez!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -5019,8 +4864,6 @@ eu:
         paypal: >-
           PayPal kontua konektatzeak WCAri ordainketak zuri bideratzeko eta
           diru-itzulketak zeure PayPal kontuan jaulkitzeko ahalmena ematen dio.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Lehiaketa honetako ordainketak %{provider} hornitzailearen bidez

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -267,8 +267,6 @@ fi:
     333fm: 1 tunti
     #original_hash: cc7d8bb
     333mbf: '10:00.00/kuutio, max. 60:00:00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Karsintatyyppi
@@ -711,8 +709,6 @@ fi:
       text: vaaditaan
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Tarkista allaolevat ongelmat:'
@@ -732,12 +728,6 @@ fi:
         public_summary: >-
           Kokonaiskuvaus tapauksesta ja sitä koskevasta päätöksestä (nähtävillä
           julkisesti). Täytäthän tämän englanniksi.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Syötä kilpailijan syntymäpäivä muodossa VVVV-KK-PP.
@@ -747,36 +737,14 @@ fi:
           <strong>Stefan Pochmann</strong>. Ei huolimattomasti, kuten <strong>s
           pochman</strong>. Muut (toinen, kolmas jne.) etunimet (joko kokonaan
           tai pelkkänä alkukirjaimena) ovat vapaaehtoisia.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Uuden profiilikuvan lataamisen jälkeen sinun täytyy odottaa, että WCA
           Results Team hyväksyy sen.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Tämä pätee ainoastaan kilpailuihin, joissa olet järjestäjä tai
           delegaatti, ja voidaan poistaa käytöstä kilpailukohtaisesti.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           This is limited to notifications for major version changes to
@@ -797,12 +765,6 @@ fi:
           Tarkista määritetty mobiilisovelluksesi saadaksesi kertakäyttöisen
           salasanan tai syötä palautuskoodi.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Oikea syntymäpäiväsi muodossa VVVV-KK-PP
         #original_hash: 49ee4af
@@ -864,14 +826,10 @@ fi:
           enough other images have been uploaded (if you want to replace an
           image, you need to upload the new one first, and then delete the old
           one).
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           List of numbers referencing any incidents that you would like the
           WRC's feedback on.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           List of numbers referencing any incidents that you would like the
@@ -892,50 +850,10 @@ fi:
           yhteisöllisyyden paraneminen/huononeminen tai aluetta koskevat
           tulevaisuudensuunnitelmat). Jos jätit aikaisemmissa osioissa jotakin
           tiivistämisen vuoksi kertomatta, kerro tässä.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Esimerkkejä: Matkustus, Palkinnot, Majoitus'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Must be a valid http(s) url. HTTPS is recommended
         #original_hash: 2ace571
@@ -944,28 +862,12 @@ fi:
           background
         #original_hash: da54ab5
         email: Should be a mailing list containing all the Directors and Officers
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: PDF-muodossa
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Must be in PDF format. If you need to add more files, please merge
           them together
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3379,17 +3281,11 @@ fi:
           clone_tabs: I would like to clone all tabs with additional information as well
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             If this is disabled, changing the registration system will cause
             technical issues. Please contact WST for assistance if you still
             need to change the registration system.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Kilpailun koko nimi sisältäen vuosiluvun lopussa (esim. Danish Open
@@ -3406,8 +3302,6 @@ fi:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Competition Name Policyn</a> vaatimuksia.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Kaupunki (ja osavaltio, jos olemassa), jossa kilpailu pidetään. Älä
@@ -3421,20 +3315,7 @@ fi:
           details_html: >-
             Lisätietoa kilpailupaikasta (esim. Ensimmäisen kerroksen perällä,
             seuraa opasteita). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             The full name of the Competition Series including the year at the
@@ -3501,8 +3382,6 @@ fi:
             sähköpostiosoitteita. %{md}. Esimerkiksi: [Näytettävä
             teksti](mailto:esim@email.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Kilpailun verkkosivusto. Pätevä http(s)-osoite.
           #original_hash: b2af5f5
@@ -3510,12 +3389,7 @@ fi:
             Sivu, jolla kilpailijoiden täytyy rekisteröityä kilpailuun. Pätevä
             http(s)-osoite.
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Osallistumismaksujen valuuttatunnus.
@@ -3539,8 +3413,6 @@ fi:
             Vaikka vieraiden pääsymaksun suuruus näytetään kilpailusivulla,
             näitä maksuja ei voi hallita tämän sivuston kautta. Jos arvoksi
             asetetaan 0, itse valitsemasi teksti näytetään.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Tämä numero ilmoitetaan kilpailusivulla, mutta palautukset täytyy
@@ -3553,8 +3425,6 @@ fi:
           opening_date_time: >-
             Huomio: Rekisteröitymisen alkamis- ja päättymisajat ovat
             UTC-yleisaikoja
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Päivä, jolloin jonotuslistalla olevia kilpailijoita ei enää
@@ -3569,16 +3439,6 @@ fi:
             rekisteröitymiseensä siihen asti, kun laji pidetään kilpailussa. Jos
             paikan päällä rekisteröityminen on käytössä, tähän tulee asettaa
             kilpailun päivä.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             The number of guests per registration allowed at this competition.
@@ -3591,35 +3451,23 @@ fi:
             <b>englanniksi<b/> ja muilla kilpailijoiden todennäköisesti
             puhumilla kielillä. Tämä näytetään kilpailusivun Tietoa-osiossa sekä
             rekisteröitymissivulla, jos käytät sitä.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Please elaborate here why you would not like newcomers to register
               for your competition. Please fill this out in English!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Please elaborate here why you would like to require competitors to
               submit puzzles early. Please fill this out in English!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Please elaborate here why you would like to use qualification
               times. Please fill this out in English!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Please elaborate here why you would like to restrict certain event
@@ -3638,9 +3486,6 @@ fi:
           example, if there is something you are uncertain about, or if there
           are any special requests for the WCAT. Please fill this out in
           English!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -4696,8 +4541,6 @@ fi:
           Connecting your PayPal account gives the WCA website the ability to
           route payments to you, and issue refunds directly on your PayPal
           account.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         This competition is set up to accept payments through %{provider}. The

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -280,8 +280,6 @@ fr-CA:
     333fm: 1 heure
     #original_hash: 5298c53
     333mbf: '10:00.00 par cube, au plus 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: b98c3f2
     type_label: Type de qualification
@@ -730,8 +728,6 @@ fr-CA:
       text: requis
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: 1b46a03
       default_message: 'Merci de corriger les problèmes ci-dessous :'
@@ -753,12 +749,6 @@ fr-CA:
         public_summary: >-
           Une description générale de l'incident et de sa décision, qui sera
           affichée publiquement. Merci de la renseigner en Anglais.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 2bd0758
         dob: >-
@@ -769,36 +759,14 @@ fr-CA:
           Entrez le prénom et le nom complet du compétiteur/de la compétitrice,
           par exemple <strong>Maxime Dupont</strong>. Pas négligemment comme
           <strong>m dupont</strong>.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: b93e58f
         pending_avatar: >-
           Après avoir téléchargé une nouvelle photo de profil, vous devrez
           attendre que l'équipe des résultats (WCA Results Team) l'approuve.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: 7b664ce
         registration_notifications_enabled: >-
           Ceci ne s’applique qu’aux compétitions que vous organisez ou déléguez,
           et peut être configuré indépendamment pour chaque compétition.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: ccb179b
         receive_developer_mails: >-
           Cela se limite aux notifications concernant les changements de version
@@ -820,12 +788,6 @@ fr-CA:
           Consultez l'application mobile que vous avez configuré pour obtenir un
           code à usage unique, ou utilisez l'un de vos codes de secours.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 0b147a8
         dob: Votre date de naissance au format AAAA-MM-JJ
         #original_hash: 00090c0
@@ -894,14 +856,10 @@ fr-CA:
           vous ne disposez pas de photos récentes de la zone de compétition
           et/ou de la zone de mélange pendant leur utilisation, veuillez
           expliquer pourquoi.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: c1474f2
         wrc_incidents: >-
           Listes numérotée des incidents pour lesquels vous souhaitez l'avis du
           WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: a54581f
         wic_incidents_html: >-
           Liste des numéros faisant référence à tout incident pour lequel vous
@@ -924,50 +882,10 @@ fr-CA:
           amélioration ou régression de la communauté, projets futurs dans la
           région). Si pour être concis dans l'une des sections précédentes vous
           avez omis certains détails, vous pouvez en parlez ici.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: 0d011af
         name: 'Exemples : Transport, prix, hébergement, salle'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: e338a54
         website: Doit être une URL http(s) valide. HTTPS est recommandé
         #original_hash: bc9021c
@@ -976,28 +894,12 @@ fr-CA:
           transparent
         #original_hash: 9c3a770
         email: Devrait être une liste de diffusion contenant les membres du Bureau
-        #original_hash: da39a3e
-        address: ''
         #original_hash: f5313eb
         bylaws: Doit être au format PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: c45922b
         extra_file: >-
           Doit être au format PDF. Si vous devez joindre plusieurs fichiers,
           merci de les fusionner
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3791,18 +3693,12 @@ fr-CA:
             supplémentaires
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 7803053
           uses_new_registration_system: >-
             Si cette option est désactivée, le fait de changer de système
             d'inscription entraînera des problèmes techniques. Veuillez
             contacter WST pour obtenir de l'aide si vous avez toujours besoin de
             modifier le système d'inscription.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 10742b4
         name: >-
           Le nom complet de la compétition, avec la date à la fin ex : Gros
@@ -3822,8 +3718,6 @@ fr-CA:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Competition Requirements Policy</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: ddb4917
           city_name: >-
             Nom de la ville où la compétition a lieu ainsi que la province /
@@ -3837,20 +3731,7 @@ fr-CA:
           details_html: >-
             Détails concernant la salle (par exemple, au première étage au fond
             à gauche, suivez les panneaux). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: cdcea34
           name: >-
             Le nom complet de la série de compétitions, en incluant l'année à la
@@ -3930,8 +3811,6 @@ fr-CA:
             Le délégué principal est chargé des aspects administratifs d'une
             compétition (résultats, rapport, facturation des redevances WCA)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: e70bf31
           external_website: >-
             Le site internet de la compétition. Doit être une adresse http(s)
@@ -3940,15 +3819,10 @@ fr-CA:
           external_registration_page: >-
             La page sur laquelle les compétiteurs doivent s'inscrire pour la
             compétition. Doit être une url http(s) valide.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: 89b0eba
           scoretaking_software: >-
             Sélectionnez « %{choice_ilr} » si vous souhaitez utiliser le système
             de double confrontation.
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 83dc650
           currency_code: La devise utilisée pour les différents frais.
@@ -3964,8 +3838,6 @@ fr-CA:
             d'entrée pour les accompagnateurs ne peuvent pas être gérés via ce
             site. Si ce nombre est défini à 0, une phrase de votre choix sera
             affichée concernant votre politique sur l'admission des spectateurs.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 7cae5c0
           refund_policy_percent: >-
             Pour le moment ce nombre est fourni à titre informatif, les
@@ -3979,8 +3851,6 @@ fr-CA:
           opening_date_time: >-
             Note : Les dates d'ouverture et de fermeture des inscriptions sont
             au fuseau horaire UTC !
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 1b49f9a
           waiting_list_deadline_date: >-
             La date à laquelle les participants en liste d'attente ne sont plus
@@ -3998,16 +3868,6 @@ fr-CA:
             jusqu'à ce que cette épreuve ait lieu. Si vous acceptez les
             inscriptions sur place, cette date doit être positionnée le jour de
             la compétition.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 6a6004a
           guests_per_registration: >-
             Le nombre d’invités par inscription autorisés pour cette
@@ -4023,37 +3883,25 @@ fr-CA:
             informations seront affichées sur la page principale de la
             compétition, ainsi que sur la page d'inscription si vous utilisez
             les inscriptions sur le site de la WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f193d2c
             reason: >-
               Veuillez expliquer ici pourquoi vous ne souhaitez pas que les
               nouveaux compétiteurs s’inscrivent à votre compétition. Veuillez
               le remplir en Anglais !
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: e30fd8a
             reason: >-
               Merci de détailler ici pourquoi vous souhaiteriez imposer aux
               compétiteurs la soumission avancée de leurs casse-têtes. Merci de
               remplir ce champ en Anglais !
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 8421a55
             reason: >-
               Merci de détailler ici pourquoi vous souhaiteriez utiliser des
               résultats de qualification. Merci de remplir ce champ en Anglais !
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 94c5386
             reason: >-
               Merci de détailler ici pourquoi vous souhaiteriez restreindre
@@ -4074,9 +3922,6 @@ fr-CA:
           Par exemple, s'il y a certaines choses dont vous n'êtes pas sûr, ou si
           vous avez des requêtes spéciales à faire au WCAT. Merci de remplir
           cela en Anglais !
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: 365e07e
@@ -5243,8 +5088,6 @@ fr-CA:
           La connexion de votre compte PayPal permet au site WCA d’acheminer les
           paiements vers vous et d’émettre des remboursements directement sur
           votre compte PayPal.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: f7842cb
       currently_connected_info: >-
         Cette compétition est configurée pour accepter les paiements par

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -280,8 +280,6 @@ fr:
     333fm: 1 heure
     #original_hash: cc7d8bb
     333mbf: '10:00.00 par cube, au plus 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Type de qualification
@@ -730,8 +728,6 @@ fr:
       text: requis
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Merci de corriger les problèmes ci-dessous :'
@@ -753,12 +749,6 @@ fr:
         public_summary: >-
           Une description générale de l'incident et de sa décision, qui sera
           affichée publiquement. Merci de la renseigner en Anglais.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: >-
@@ -769,36 +759,14 @@ fr:
           Entrez le prénom et le nom complet du compétiteur/de la compétitrice,
           par exemple <strong>Maxime Dupont</strong>. Pas négligemment comme
           <strong>m dupont</strong>.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Après avoir téléchargé une nouvelle photo de profil, vous devrez
           attendre que l'équipe des résultats (WCA Results Team) l'approuve.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Ceci ne s’applique qu’aux compétitions que vous organisez ou déléguez,
           et peut être configuré indépendamment pour chaque compétition.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Cela se limite aux notifications concernant les changements de version
@@ -820,12 +788,6 @@ fr:
           Consultez l'application mobile que vous avez configuré pour obtenir un
           code à usage unique, ou utilisez l'un de vos codes de secours.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Votre date de naissance au format AAAA-MM-JJ
         #original_hash: 49ee4af
@@ -894,14 +856,10 @@ fr:
           vous ne disposez pas de photos récentes de la zone de compétition
           et/ou de la zone de mélange pendant leur utilisation, veuillez
           expliquer pourquoi.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Listes numérotée des incidents pour lesquels vous souhaitez l'avis du
           WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Liste des numéros faisant référence à tout incident pour lequel vous
@@ -924,50 +882,10 @@ fr:
           amélioration ou régression de la communauté, projets futurs dans la
           région). Si pour être concis dans l'une des sections précédentes vous
           avez omis certains détails, vous pouvez en parlez ici.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Exemples : Transport, prix, hébergement, salle'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Doit être une URL http(s) valide. HTTPS est recommandé
         #original_hash: 2ace571
@@ -976,28 +894,12 @@ fr:
           transparent
         #original_hash: da54ab5
         email: Devrait être une liste de diffusion contenant les membres du Bureau
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Doit être au format PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Doit être au format PDF. Si vous devez joindre plusieurs fichiers,
           merci de les fusionner
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3791,18 +3693,12 @@ fr:
             supplémentaires
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Si cette option est désactivée, le fait de changer de système
             d'inscription entraînera des problèmes techniques. Veuillez
             contacter WST pour obtenir de l'aide si vous avez toujours besoin de
             modifier le système d'inscription.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Le nom complet de la compétition, avec la date à la fin ex : Paris
@@ -3822,8 +3718,6 @@ fr:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Competition Requirements Policy</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nom de la ville où la compétition a lieu. Ne pas mettre le pays (ex
@@ -3836,20 +3730,7 @@ fr:
           details_html: >-
             Détails concernant la salle (par exemple, au première étage au fond
             à gauche, suivez les panneaux). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Le nom complet de la série de compétitions, en incluant l'année à la
@@ -3929,8 +3810,6 @@ fr:
             Le délégué principal est chargé des aspects administratifs d'une
             compétition (résultats, rapport, facturation des redevances WCA)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: >-
             Le site internet de la compétition. Doit être une adresse http(s)
@@ -3939,15 +3818,10 @@ fr:
           external_registration_page: >-
             La page sur laquelle les compétiteurs doivent s'inscrire pour la
             compétition. Doit être une url http(s) valide.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: >-
             Sélectionnez « %{choice_ilr} » si vous souhaitez utiliser le système
             de double confrontation.
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: La devise utilisée pour les différents frais.
@@ -3963,8 +3837,6 @@ fr:
             d'entrée pour les accompagnateurs ne peuvent pas être gérés via ce
             site. Si ce nombre est défini à 0, une phrase de votre choix sera
             affichée concernant votre politique sur l'admission des spectateurs.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Pour le moment ce nombre est fourni à titre informatif, les
@@ -3978,8 +3850,6 @@ fr:
           opening_date_time: >-
             Note : Les dates d'ouverture et de fermeture des inscriptions sont
             au fuseau horaire UTC !
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             La date à laquelle les participants en liste d'attente ne sont plus
@@ -3997,16 +3867,6 @@ fr:
             jusqu'à ce que cette épreuve ait lieu. Si vous acceptez les
             inscriptions sur place, cette date doit être positionnée le jour de
             la compétition.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Le nombre d’invités par inscription autorisés pour cette
@@ -4022,37 +3882,25 @@ fr:
             informations seront affichées sur la page principale de la
             compétition, ainsi que sur la page d'inscription si vous utilisez
             les inscriptions sur le site de la WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Veuillez expliquer ici pourquoi vous ne souhaitez pas que les
               nouveaux compétiteurs s’inscrivent à votre compétition. Veuillez
               le remplir en Anglais !
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Merci de détailler ici pourquoi vous souhaiteriez imposer aux
               compétiteurs la soumission avancée de leurs puzzles. Merci de
               remplir ce champ en Anglais !
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Merci de détailler ici pourquoi vous souhaiteriez utiliser des
               résultats de qualification. Merci de remplir ce champ en Anglais !
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Merci de détailler ici pourquoi vous souhaiteriez restreindre
@@ -4073,9 +3921,6 @@ fr:
           Par exemple, s'il y a certaines choses dont vous n'êtes pas sûr, ou si
           vous avez des requêtes spéciales à faire au WCAT. Merci de remplir
           cela en Anglais !
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -5242,8 +5087,6 @@ fr:
           La connexion de votre compte PayPal permet au site WCA d’acheminer les
           paiements vers vous et d’émettre des remboursements directement sur
           votre compte PayPal.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Cette compétition est configurée pour accepter les paiements par

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -264,8 +264,6 @@ hr:
     333fm: 1 sat
     #original_hash: cc7d8bb
     333mbf: '10:00.00 po kocki, maksimalno do 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Kvalifikacijski tip
@@ -699,8 +697,6 @@ hr:
       text: potrebno
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Molimo pogledaj probleme ispod:'
@@ -720,12 +716,6 @@ hr:
         public_summary: >-
           Cjelokupni opis incidenta i njegovo rješenje, vidljivo javnosti.
           Ispuni na engleskom jeziku.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Unesi datum rođenja natjecatelja u formatu YYYY-MM-DD.
@@ -734,36 +724,14 @@ hr:
           Unesi puno ime natjecatelja točno, primjerice <strong>Pero
           Perić</strong>. Nemoj unijeti loše kao <strong>p perić</strong>. <br/>
           Srednje ime ili inicijali su neobavezni.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Nakon prijenosa novog avatara, mora se čekati potvrda WCA Tima za
           rezultate.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Ovo se primjenjuje samo za natjecanja koja ti organiziraš ili
           delegiraš i može biti promijenjeno od jednog do drugog natjecanja.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 27c2251
         receive_delegate_reports: >-
           Ukoliko si Senior Delegat, član WRC ili WQAC, svakako primaš
@@ -779,12 +747,6 @@ hr:
           Provjeri odabranu mobilnu aplikaciju za jednokratnu lozinku ili unesi
           jedan od kodova za oporavak.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Tvoj točan datum rođenja u formatu YYYY-MM-DD
         #original_hash: 49ee4af
@@ -847,14 +809,10 @@ hr:
           fotografije nakon što je priloženo više ostalih datoteka (ukoliko
           želite zamijeniti fotografiju, morate pričožiti prvo novu pa tek
           obrisati staru).
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Lista brojeva koji su referenca na incidente za koje se zahtjeva
           povratna informacija od WRC-a.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 0aca3b0
         wic_incidents: >-
           Lista numeriranih referenci na incidente za koju treba WIC povratna
@@ -864,45 +822,9 @@ hr:
           Par rečenica o bilo kojim detaljima koje želiš podijeliti (npr.
           poboljšanje/pogoršanje unutar zajednice, buduće planove za tu regiju).
           Ukoliko je nešto u prijašnjim sekcijama zaboravljeno, dodaj ovdje.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Primjerice: Put, Plaćanje, Nagrade, Smještaj'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       results_submission:
         #original_hash: da39a3e
         schedule_url: ''
@@ -911,10 +833,6 @@ hr:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Mora biti valjan http(s) url. HTTPS je preporučljiv
         #original_hash: 2ace571
@@ -923,28 +841,12 @@ hr:
           pozadinom
         #original_hash: da54ab5
         email: Trebala bi biti mailing lista koja uključuje sve službene osobe
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Mora biti u PDF formatu
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Mora biti u PDF formatu. Ukoliko treba dodati više datoteka, spoji ih
           zajedno
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3324,17 +3226,11 @@ hr:
           clone_tabs: Želim klonirati sve tabove s dodatnim informacijama
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Ako je ovo onemogućeno, promjena sustava registracije uzrokovat će
             tehničke probleme. Molimo kontaktirajte WST za pomoć ako i dalje
             trebate promijeniti sustav registracije.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Puni naziv natjecanja uključujući godinu na kraju (npr. Danish Open
@@ -3352,8 +3248,6 @@ hr:
           <ahref='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Politikom
           zahtjeva WCA natjecanja</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Naziv grada i države (ako postoji) u kojoj se natjecanje održava.
@@ -3367,20 +3261,7 @@ hr:
           details_html: >-
             Pojedinosti o mjestu (npr. Na prvom katu daleko straga, slijedite
             znakove). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Puni naziv serije natjecanja uključujući godinu na kraju (npr. Južna
@@ -3434,8 +3315,6 @@ hr:
             organizatora. %{md}. Primjer: [Tekst za
             prikaz](mailto:some@email.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Web stranica natjecanja. Mora biti važeći http(s) url.
           #original_hash: b2af5f5
@@ -3443,12 +3322,7 @@ hr:
             Stranica na kojoj se natjecatelji moraju prijaviti za natjecanje.
             Mora biti važeći http(s) url.
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Kod valute za kotizacije.
@@ -3471,8 +3345,6 @@ hr:
             moguće upravljati putem ove web stranice. Ako je ovo postavljeno na
             0, prikazat će se rečenica po vašem izboru o politici dolaska
             gledatelja.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Za sada je ovaj broj samo informativan, povrati će se morati
@@ -3484,8 +3356,6 @@ hr:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Napomena: otvaranje i zatvaranje registracija je u UTC vremenu'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Datum kada se natjecatelji na listi čekanja više neće prihvaćati.
@@ -3500,16 +3370,6 @@ hr:
             mogu dodati discipline svojim prijavljenim disciplinama do
             održavanja te discipline. Ako imate registracije na licu mjesta, to
             mora biti postavljeno na isti dan kao i natjecanje.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Broj gostiju po natjecatelju dopušten za ovo natjecanje.
@@ -3523,35 +3383,23 @@ hr:
             govore vaši natjecatelji; ovo će biti prikazano na stranici s
             informacijama o natjecanju, kao i na stranici za registraciju ako
             koristite registracije na web stranici WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Ovdje razjasnite zašto ne želite da se novi natjecatelji
               registriraju za vaše natjecanje. Molimo ispunite ovo na engleskom!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Ovdje navedite zašto želite zahtijevati od natjecatelja da ranije
               predaju kocke. Molimo ispunite ovo na engleskom!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Ovdje navedite zašto želite koristiti kvalifikacijska vremena.
               Molimo ispunite ovo na engleskom!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Ovdje navedite zašto želite ograničiti određene kombinacije
@@ -3570,9 +3418,6 @@ hr:
           Neke dodatne informacije koje želite proslijediti WCAT-u. Na primjer,
           ako postoji nešto oko čega niste sigurni ili ako postoje posebni
           zahtjevi za WCAT. Molimo ispunite ovo na engleskom!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -256,8 +256,6 @@ id:
     333fm: 1 jam
     #original_hash: cc7d8bb
     333mbf: '10:00.00 per kubus, total hingga 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Tipe Kualifikasi
@@ -663,8 +661,6 @@ id:
       text: wajib diisi
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Silakan tinjau ulang masalah di bawah:'
@@ -686,12 +682,6 @@ id:
         public_summary: >-
           Deskripsi keseluruhan dari insiden dan keputusannya untuk ditampilkan
           secara publik. Harap isi dalam Bahasa Inggris.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Isi tanggal lahir kompetitor dengan format YYYY-MM-DD.
@@ -701,36 +691,14 @@ id:
           Pochmann</strong>. Tidak sembarangan seperti <strong>s
           pochman</strong>.<br/>Nama tengah (lengkap atau disingkat) tidak
           diharuskan.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Setelah mengunggah avatar baru, Anda harus menunggu Tim Hasil WCA
           untuk disetujui.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Hal ini hanya berlaku untuk kompetisi yang Anda selenggarakan atau
           delegasikan, dan dapat dibatalkan dalam basis per-kompetisi.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 81a76a3
         receive_delegate_reports: >-
           Jika Anda adalah Delegasi Pelatihan, Delegasi Junior, Delegasi Senior,
@@ -742,12 +710,6 @@ id:
           Cek aplikasi mobile Anda untuk one-time password (OTP), atau isi
           dengan kode pemulihan Anda.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Tanggal lahir Anda dengan format YYYY-MM-DD
         #original_hash: 49ee4af
@@ -809,8 +771,6 @@ id:
           Meskipun semua kasus terlihat biasa, tulis kasus yang setidaknya perlu
           ditindaklanjuti. Centang kotak di bawah jika Anda menginginkan umpan
           balik.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Daftar angka yang mereferensikan insiden yang Anda inginkan untuk
@@ -828,27 +788,12 @@ id:
           ini). Jika Anda menyadari bahwa ada sesuatu yang belum disampaikan
           karena ingin menyampaikannya secara singkat, jangan ragu untuk
           menuliskannya di dalam komentar.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Contoh: Perjalanan, Pembayaran, Hadiah, Akomodasi'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
@@ -860,26 +805,6 @@ id:
         administrative_notes: >-
           Catatan tambahan disimpan sebagai bagian untuk mengatur pendaftaran
           ini. Hal ini tidak dapat dilihat oleh kompetitor.
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       results_submission:
         #original_hash: da39a3e
         schedule_url: ''
@@ -888,10 +813,6 @@ id:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: >-
           Wajib merupakan url http(s) yang valid. Direkomendasikan untuk memakai
@@ -902,28 +823,12 @@ id:
         email: >-
           Harus merupakan mailing list yang berisikan seluruh Direktur dan
           Pengurus
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Wajib dalam format PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Wajib dalam format PDF. Jika Anda perlu menambahkan berkas lainnya,
           harap digabung menjadi satu
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3202,13 +3107,6 @@ id:
           #original_hash: c305010
           clone_tabs: Saya ingin menduplikasi semua tab dan juga dengan informasi tambahan
       hints:
-        admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Nama lengkap kompetisi yang disertai tahun di bagian akhir (contohnya
@@ -3226,8 +3124,6 @@ id:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Kebijakan
           Syarat Kompetisi WCA</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nama kota dan negara bagian (jika ada) di mana kompetisi
@@ -3241,20 +3137,7 @@ id:
           details_html: >-
             Detail mengenai venue (contohnya, Di lantai pertama bagian belakang,
             ikuti papan petunjuk). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Nama lengkap dari Rangkaian Kompetisi termasuk tahun di bagian akhir
@@ -3307,8 +3190,6 @@ id:
             pertanyaan akan dikirim melalui formulir tanpa memunculkan email
             panitia. %{md}. Contoh: [Teks yang muncul](mailto:some@email.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Situs web kompetisi. Harus url http(s) yang valid.
           #original_hash: b2af5f5
@@ -3316,12 +3197,7 @@ id:
             Laman di mana kompetitor mendaftar untuk kompetisi tersebut. Harus
             url http(s) yang valid.
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Kode mata uang untuk biaya.
@@ -3343,8 +3219,6 @@ id:
             tamu/pendamping tidak dapat diatur pada situs web ini. Jika diisi 0,
             pernyataan yang Anda pilih tentang kebijakan penonton akan
             ditampilkan.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Untuk sekarang, angka ini hanya sebagai informasi, pengembalian dana
@@ -3356,8 +3230,6 @@ id:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Catatan: Pembukaan dan penutupan pendaftaran dalam zona waktu UTC'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Tanggal di mana pendaftar dalam daftar tunggu tidak dapat lagi
@@ -3374,15 +3246,7 @@ id:
             pendaftaran di tempat, hal ini harus diisi dengan hari yang sama
             dengan hari kompetisi.
           #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
           allow_self_delete_after_acceptance: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Jumlah pendamping per pendaftaran yang diperbolehkan pada kompetisi
@@ -3396,28 +3260,18 @@ id:
             secara umum; hal ini akan ditampilkan pada laman informasi
             kompetisi, juga pada laman pendaftaran jika Anda menggunakan
             pendaftaran pada situs web WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Mohon jelaskan di sini alasan Anda mengharuskan kompetitor untuk
               mengumpulkan puzzle lebih awal. Mohon isi dengan Bahasa Inggris!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Mohon jelaskan di sini alasan Anda ingin menggunakan waktu
               kualifikasi. Mohon isi dengan Bahasa Inggris!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Mohon jelaskan di sini alasan Anda ingin membatasi kombinasi
@@ -3436,9 +3290,6 @@ id:
           Beberapa informasi tambahan yang ingin Anda sampaikan ke WCAT.
           Contohnya, jika ada hal yang Anda masih ragu, atau jika ada permintaan
           khusus kepada WCAT. Mohon isi dengan Bahasa Inggris!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -276,8 +276,6 @@ it:
     333fm: 1 ora
     #original_hash: cc7d8bb
     333mbf: '10:00.00 per cubo, fino a 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Metodo di qualificazione
@@ -732,8 +730,6 @@ it:
       text: richiesto
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Correggi i seguenti problemi:'
@@ -753,12 +749,6 @@ it:
         public_summary: >-
           Una descrizione generale dell'incidente e della decisione, da mostrare
           pubblicamente. Da scrivere in inglese.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Inserisci la data di nascita del partecipante nel formato AAAA-MM-GG
@@ -768,36 +758,14 @@ it:
           <strong>Lorenzo Vigani Poli</strong>. Non inserire abbreviazioni come
           <strong> l vigani</strong>.<br/>I secondi nomi (sia completi o anche
           solo le iniziali) sono opzionali.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Dopo aver caricato il nuovo avatar, dovrai aspettare che il WCA
           Results Team lo approvi.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Si applica soltanto a competizioni che organizzi o deleghi, e può
           essere sovrascritta gara per gara.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Questo è limitato alle notifiche relative a cambiamenti di versione
@@ -819,12 +787,6 @@ it:
           Controlla la tua applicazione mobile per una password temporanea, o
           inserisci uno dei tuoi codici di recupero.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: La tua data di nascita nel formato AAAA-MM-GG
         #original_hash: 49ee4af
@@ -892,14 +854,10 @@ it:
           un'immagine, è necessario caricare prima quella nuova e poi eliminare
           quella vecchia). Se non possiedi immagini dell'area di gara e/o di
           scrambling durante la competizione, spiega il perché.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Lista dei numeri riferiti a incidenti per i quali richiedi un feedback
           del WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Lista dei numeri relativi a incidenti su cui si desidera avere un
@@ -921,50 +879,10 @@ it:
           miglioramenti o peggioramenti della community, piani futuri per la
           regione). Se per essere conciso hai tralasciato qualcosa nei form
           precedenti, puoi approfittare di questo form per riportarlo.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Esempi: viaggio, pagamenti, premi, alloggi.'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Deve essere un valido URL http(s). È raccomandato il protocollo HTTPS.
         #original_hash: 2ace571
@@ -975,28 +893,12 @@ it:
         email: >-
           Dovrebbe essere una mailing list contenente tutti i Direttori ed
           Ufficiali
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Deve essere in formato PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Deve essere in formato PDF. Se hai bisogno di aggiungere altri file,
           puoi fonderli insieme.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3675,17 +3577,11 @@ it:
           clone_tabs: Desidero clonare tutte le schede comprese di informazioni aggiuntive
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Se disattivato, modificare successivamente il sistema di iscrizioni
             causerà problemi tecnici. Contatta il WCA Software Team per
             assistenza se avrai bisogno di cambiare il sistema di iscrizioni.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Il nome completo della competizione con incluso l'anno, alla fine (es.
@@ -3703,8 +3599,6 @@ it:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Competition Requirements Policy</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nome della città e (se applicabile) dello stato dove si svolge la
@@ -3718,20 +3612,7 @@ it:
           details_html: >-
             Dettagli riguardo la sede (es. Al primo piano, seguire le
             indicazioni; suonare il citofono per aprire il cancello). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Il nome completo della Serie di competizioni gemelle, incluso l'anno
@@ -3811,21 +3692,14 @@ it:
             della competizione (risultati, report, ricevute delle quote
             associative)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Sito web della competizione. Deve essere un URL http(s) valido.
           #original_hash: b2af5f5
           external_registration_page: >-
             La pagina dove i partecipanti devono iscriversi alla competizione.
             Deve avere un url http(s) valido.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'Seleziona "%{choice_ilr}" se desideri usare i doppi turni'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: La valuta delle tasse di iscrizione.
@@ -3849,8 +3723,6 @@ it:
             non possono essere gestite attraverso questo sito. Se impostato a 0,
             verrà visualizzato un messaggio personalizzato relativo alle
             restrizioni per gli spettatori.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Per ora questo numero è solo informativo, i rimborsi dovranno essere
@@ -3864,8 +3736,6 @@ it:
           opening_date_time: >-
             Note: Gli orari di apertura e chiusura della competizione sono in
             orario UTC
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             La scadenza oltre la quale gli iscritti in lista d'attesa non
@@ -3880,16 +3750,6 @@ it:
             eventi fino al giorno della competizione. Se sono previste
             iscrizioni in loco, il limite deve essere posto al giorno stesso
             della competizione.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Il numero di accompagnatori per iscrizione consentiti a questa
@@ -3903,36 +3763,24 @@ it:
             i tuoi concorrenti; questo sarà visualizzato sulla pagina delle
             informazioni della competizione, nonché sulla pagina di iscrizione
             se si utilizzano le iscrizioni del sito web WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Spiega qui perché non desideri che gli esordienti si iscrivano
               alla tua competizione. Da compilare in inglese.
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Per favore, elabora le motivazioni per cui desideri che i
               partecipanti consegnino i propri puzzle anticipatamente. Compila
               questo campo in inglese!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Per favore, elabora le motivazioni per cui desideri utilizzare i
               risultati di qualificazione. Compila questo campo in inglese!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Per favore, elabora le motivazioni per cui desideri vietare alcune
@@ -3950,9 +3798,6 @@ it:
           Informazioni aggiuntive che desideri fornire al WCAT. In questo campo
           puoi includere domande, se hai dei dubbi, o richieste speciali al
           WCAT. Si prega di compilare in inglese!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -5086,8 +4931,6 @@ it:
         paypal: >-
           Connettendo il tuo account PayPal, abiliti il sito WCA a inoltrare i
           pagamenti ed emettere i rimborsi direttamente sul tuo conto PayPal.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Per questa competizione si accettano pagamenti tramite %{provider}. I

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -256,8 +256,6 @@ ja:
     333fm: 1時間
     #original_hash: cc7d8bb
     333mbf: 1個あたり10分（最大60分）
-    #original_hash: da39a3e
-    333mbo: ''
   common:
     #original_hash: 70c07ec
     world: 世界
@@ -571,8 +569,6 @@ ja:
       text: 必須
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: '以下のエラー内容をご確認ください:'
@@ -586,12 +582,6 @@ ja:
         private_wrc_decision: WRC の最終決議です。非公開情報を含みます。英語で記述してください。
         #original_hash: 3de5729
         public_summary: 全体的な内容 (インシデントと決議) です。公開されます。英語で記述してください。
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: 競技者の生年月日を「西暦-月-日」の形式で記入してください。　例：2001-04-01
@@ -599,44 +589,16 @@ ja:
         name: >-
           競技者の氏名をフルネームで記載してください。<br/>例：Shuhei Omura
           (大村周平)<br/>※<strong>ローマ字表記は必須</strong>です。パスポートなどに記載の正確な表記を使用してください。ミドルネームは省略可です。<br/>※母国語表記（漢字表記など）は、上の例のようにカッコ書きで併記することができます。
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: プロフィール画像の変更は、 WCA 競技結果チームの承認後に反映されます。
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: 自分が運営または代理人として担当する大会に適用されます。ただし大会ごとに別途設定した場合は、その設定が優先されます。
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           データエクスポート・WCIFスキーマやAPI等の変更といったメジャーバージョン変更のみに対してのみ通知が行われます。これらのツールに依存したソフトウェア開発・保守を行う開発者向けの項目です。
         #original_hash: 0627e5c
         otp_attempt: 設定済みの携帯端末でワンタイムパスワードを確認するか、復旧コードを入力してください。
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: 生年月日を YYYY-MM-DD (西暦-月-日) の形式で入力してください
         #original_hash: 49ee4af
@@ -659,84 +621,24 @@ ja:
         #original_hash: 74affff
         incidents: >-
           典型的でないすべてのインシデントについて報告してください。インシデントは1.から順に番号づけをして、代理人が個別のインシデントに言及しやすくしてください。基本的なインシデントしか発生していない場合は、そのうち最も代表的なものを記載してください。フィードバックを求める場合は、以下のチェックボックスにチェックを入れてください。
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: WCA 規則委員会のフィードバックを求めるインシデントの番号
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: f30abdc
         remarks: その他報告事項 (コミュニティーの変化、地域的の今後の計画等ほか、前項までで省いた軽微な事項も構いません)
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: '例: 参加費徴収、表彰、渡航、宿泊施設等'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: 有効なhttp(s)アドレス。https推奨。
         #original_hash: 2ace571
         logo: 高解像度、透過背景のPNG形式としてください
         #original_hash: da54ab5
         email: すべての役員・事務を含むメーリングリストが好ましい
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: pdf形式
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: pdf形式。複数にわたる場合は、統合してください。
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -2369,15 +2271,9 @@ ja:
           clone_tabs: すべての追加情報とタブをコピーする
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             無効化した場合、申し込みシステムの変更により技術的問題が発生する場合があります。申し込みシステムの変更が必要な場合は、WSTに相談してください。
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           大会の正式名称 (英名) 。<p> (1) 必ず末尾に年号を含める (例 : SCJ Kansai Winter 2020)</p><p>
@@ -2390,8 +2286,6 @@ ja:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           大会要件方針</a>に沿っている必要があります。
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: '開催都市名 (例 : Kawasaki, Kanagawa や Shibuya, Tokyo など「市区町村, 都道府県」の順)'
           #original_hash: 9d9126e
@@ -2400,20 +2294,7 @@ ja:
             Hall](http://www.city.kawasaki.jp/takatsu/category/111-11-1-0-0-0-0-0-0-0.html)。
           #original_hash: 2651d1a
           details_html: '会場の詳細 (例: 12階)。%{md}'
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: シリーズ大会の正式名称 (英名) 。大会名と同様のルールで設定してください。
           #original_hash: 778c20c
@@ -2442,19 +2323,12 @@ ja:
             speedcubing.or.jpドメインのメーリングリストを使用することを推奨します。詳細はSCJ社員に尋ねてください。記載がない場合、主催者がWCAアカウントに登録しているメールアドレスが公開されます。%{md}の文法で書いてください　例:
             [○○大会実行委員会](mailto:○○@speedcubing.or.jp)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: 大会ウェブサイトの URL
           #original_hash: b2af5f5
           external_registration_page: 競技者が参加申し込みを行うためのページ。httpまたはhttpsのURLとしてください。
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: 参加費の通貨コード
@@ -2468,8 +2342,6 @@ ja:
           guest_entry_fee: >-
             現在のところ見学者入場料集金システムは未実装のため、この値は表示されるのみで自動処理は行われません。実際の集金は手動で行ってください。<br/>0
             と入力した場合、「見学者入場料は無料です。」と表示されます。
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             現在のところ返金システムは未実装のため、この値は表示されるのみで自動処理は行われません。実際の返金は手動で行ってください。<br/>0
@@ -2479,24 +2351,12 @@ ja:
         registration:
           #original_hash: 9965635
           opening_date_time: 申し込み受付期間 (世界標準時。日本時間 -9 時間)
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             キャンセル待ちリストにいる競技参加者を繰り上げ承認できる期限。もし返金にも期限を設けていれば、返金期限が先、繰り上げ期限はそれと同時か後の関係とする。
           #original_hash: 75e6c1f
           event_change_deadline_date: >-
             参加種目や同伴者の人数など、いったん承認済みの参加申し込み内容でも実行委員に問い合わせることで変更を受け付けることができます。この期限は参加申し込み期間の終了時と同じか、あるいは終了後も一定の猶予を設けることが可能。このフィールドを空欄にした場合、大会当日に実際に試技をする直前まで変更可能なことになる。もし飛び込み参加可能な大会を企画する場合は空欄となるが、日本での前例はほとんどありません。
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             競技参加者 1
@@ -2504,29 +2364,17 @@ ja:
           #original_hash: 3de153b
           extra_requirements: >-
             支払い方法など、「大会申し込み要領」で不足する内容はこちらに入力してください。<br/>必ず<b>英語を併記して</b>記入してください。<br/>入力内容は大会情報ページと参加申し込みページに表示されます。
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: 初参加者の参加を拒否する理由を英語で詳細に記載してください。
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: パズル提出を早く設定する理由を英語で詳しく説明してください。
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: 過去の記録の適用の理由および詳細を英語で記載してください。
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: 特定種目への同時参加を制限する理由および詳細を英語で記載してください。
             #original_hash: d09af8f
@@ -2536,9 +2384,6 @@ ja:
           main_event_id: この種目の優勝者が本大会の優勝者として表示されます。
         #original_hash: 9ea6021
         remarks: WCATに伝達する追加情報（例：何か不安がある場合や、要望がある場合に記入）。必ず英語で記入してください。
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -3230,11 +3075,6 @@ ja:
   notifications:
     #original_hash: 10bcdbd
     connect_wca_id: WCA ID をアカウントに連携しましょう！
-  payments:
-    payment_setup:
-      connect_account_warning:
-        #original_hash: da39a3e
-        manual: ''
   persons:
     index:
       #original_hash: 5934b4c

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -734,8 +734,6 @@ kk:
     333fm: 1 сағат
     #original_hash: cc7d8bb
     333mbf: 'Әр кубик үшін 10:00.00, барлығы 60:00.00 дейін'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Біліктілік Түрі
@@ -1184,8 +1182,6 @@ kk:
       text: қажетті
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Төмендегі мәселелерді қарастырыңыз:'
@@ -1207,12 +1203,6 @@ kk:
         public_summary: >-
           Оқиға мен оның шешімінің жалпы сипаттамасы, көпшілікке көрсету үшін.
           Оны Ағылшын тілінде толтырыңыз.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Қатысушының туған күнін ЖЖЖЖ-АА-КК форматында енгізіңіз.
@@ -1223,36 +1213,14 @@ kk:
           Nurtas</strong>.<br/>Егер сізде шетелдік төлқұжат болса, оған сәйкес
           атауды енгізуді ұсынамыз. Қаласаңыз, жақшаға атаудың жергілікті
           тілдегі нұсқасын жаза аласыз, мысалы, Kairat Nurtas (Қайрат Нұртас)
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Жаңа аватар жүктегеннен кейін, оны WCA Нәтижелер Тобының мақұлдауын
           күтуіңіз қажет.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Бұл тек сіз ұйымдастыратын немесе делегат ретінде қатысатын жарыстарға
           қолданылады және әр жарыс үшін жеке өзгертілуі мүмкін.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Бұл деректер экспорттары, WCIF схемасы және ашық API сияқты
@@ -1274,12 +1242,6 @@ kk:
           Бір реттік құпия сөз үшін бапталған мобильді қосымшаңызды тексеріңіз
           немесе қалпына келтіру кодтарының бірін енгізіңіз.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: 'Туған күніңізді дұрыс форматта енгізіңіз: ЖЖЖЖ-АА-КК'
         #original_hash: 49ee4af
@@ -1345,14 +1307,10 @@ kk:
           кейін ескісін өшіріңіз). Егер жарыс аймағының және/немесе скрамблинг
           аймағының қолданылып жатқан сәтіндегі қазіргі фотосуреттері болмаса,
           себебін түсіндіріңіз.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           WRC-ның пікірін алғыңыз келетін оқиғаларға сілтеме жасайтын нөмірлер
           тізімі.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           WIC-тен кері байланыс алғыңыз келетін оқиғалардың нөмірлер тізімі.
@@ -1373,50 +1331,10 @@ kk:
           жетілдіру/кері кету, осы аймаққа арналған болашақ жоспарлар). Алдыңғы
           бөлімдерде қысқалық үшін айтылмай қалған нәрсе болса, оны осында
           түсіндіре аласыз.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Мысалдар: Саяхат, Төлемдер, Марапаттар, Тұру орындары'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: HTTP(S) дұрыс URL болуы керек. HTTPS ұсынылады.
         #original_hash: 2ace571
@@ -1425,28 +1343,12 @@ kk:
         email: >-
           Барлық Директорлар мен Қызметкерлерді қамтитын пошта тізімі болуы
           керек.
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: PDF форматында болуы керек.
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           PDF форматында болуы керек. Егер қосымша файлдар қосу қажет болса,
           оларды біріктіріңіз.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3995,17 +3897,11 @@ kk:
           clone_tabs: Қосымша ақпарат бар барлық қойындыларды да көшіруді қалаймын
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Егер бұл өшірілсе, тіркелу жүйесін өзгерту техникалық ақауларға
             әкелуі мүмкін. Тіркелу жүйесін өзгерту қажет болса, көмек алу үшін
             WST (WCA Support Team) тобына хабарласыңыз.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Жарыстың толық атауы, соңында жылы көрсетілуі керек (мысалы: Danish
@@ -4023,8 +3919,6 @@ kk:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Жарыс Талаптары Саясатына</a> сәйкес болуы керек.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Жарыс өтетін қала мен (қажет болса) штат атауы. Елді қоспаңыз
@@ -4037,20 +3931,7 @@ kk:
           details_html: >-
             Өтетін орын туралы мәліметтер (мысалы: Бірінші қабаттың соңында,
             белгілерді басшылыққа алыңыз). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Жарыс Сериясының толық атауы, соңында жылы көрсетілуі тиіс (мысалы:
@@ -4126,8 +4007,6 @@ kk:
             Жетекші делегат конкурстың әкімшілік аспектілеріне жауап береді
             (нәтижелер, есеп беру, алымдар бойынша шот-фактура)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Жарыстың веб-сайты. Қолданыстағы http(s) сілтемесі болуы қажет.
           #original_hash: b2af5f5
@@ -4135,12 +4014,7 @@ kk:
             Қатысушылар жарысқа тіркелуі қажет бет. Қолданыстағы http(s)
             сілтемесі болуы тиіс.
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Төлемдерге арналған валюта коды.
@@ -4163,8 +4037,6 @@ kk:
             көрермендерге арналған төлемдер осы веб-сайт арқылы басқарылмайды.
             Егер бұл мән 0 болса, көрермендерге қатысты саясат туралы өз
             таңдауыңыз бойынша сөйлем көрсетіледі.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Қазіргі уақытта бұл сан тек ақпараттық мақсатта көрсетіледі,
@@ -4177,8 +4049,6 @@ kk:
           opening_date_time: >-
             Ескерту: Тіркелудің ашылу және жабылу уақыты UTC уақыты бойынша
             көрсетілген.
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Күту тізіміндегі тіркелушілерді қабылдау тоқтатылатын күн. Егер
@@ -4192,16 +4062,6 @@ kk:
             қалдырсаңыз, қатысушылар іс-шара басталғанға дейін оны тіркелген
             іс-шаралар тізіміне қоса алады. Егер орнында тіркеу болса, бұл күн
             жарыс өтетін күнмен бірдей болуы тиіс.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Бұл жарысқа бір тіркеуге рұқсат етілген көрермендер саны.
@@ -4215,37 +4075,25 @@ kk:
             басқа тілдерде толтырылуы тиіс; ол жарыс туралы ақпарат бетінде және
             егер сіз WCA веб-сайты арқылы тіркеуді қолдансаңыз, тіркеу бетінде
             көрсетіледі.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Жаңадан келгендердің бұл жарысқа тіркелуін не себепті
               қаламайтыныңызды осында нақтылап жазыңыз. Бұл ақпаратты ағылшын
               тілінде толтырыңыз!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Неліктен қатысушылардан тапсырмаларды алдын ала тапсыруды талап
               еткіңіз келетінін мұнда нақтылап жазыңыз. Бұл бөлікті ағылшын
               тілінде толтырыңыз!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Неліктен біліктілік уақыттарын пайдаланғыңыз келетінін мұнда
               нақтылап жазыңыз. Бұл бөлікті ағылшын тілінде толтырыңыз!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Неліктен кейбір жарыс түрлерінің комбинацияларына шектеу қойғыңыз
@@ -4265,9 +4113,6 @@ kk:
           WCAT-қа жеткізгіңіз келетін қосымша ақпарат. Мысалы, егер сенімсіз бір
           нәрсе болса немесе WCAT-қа арнайы өтініштеріңіз болса. Бұл жолақты
           ағылшын тілінде толтырыңыз!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -5341,8 +5186,6 @@ kk:
         paypal: >-
           PayPal тіркелгісін қосу WCA веб-сайтына төлемдерді сізге бағыттау және
           төлемдерді тікелей PayPal тіркелгіңізге қайтару мүмкіндігін береді.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Бұл конкурс %{provider} арқылы төлемдерді қабылдау үшін орнатылған.

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -279,8 +279,6 @@ ko:
     333fm: 1시간
     #original_hash: cc7d8bb
     333mbf: '큐브 당 10분, 최대 60분'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: 참가 자격 유형
@@ -720,8 +718,6 @@ ko:
       text: 필수
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 아래 문제를 검토하십시오.
@@ -735,12 +731,6 @@ ko:
         private_wrc_decision: 비공개 정보를 포함한 WRC 최종 판단. 영어로 작성해 주십시오.
         #original_hash: 3de5729
         public_summary: 공개적으로 표시될 사건에 대한 전반적인 설명과 판단. 영어로 작성해 주십시오.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: 선수의 생년월일을 YYYY-MM-DD 형식으로 입력하십시오.
@@ -749,32 +739,10 @@ ko:
           선수의 성명을 정확히 입력하십시오. 예: <strong>Gildong Hong</strong>. 잘못된 예:
           <strong>GILDONG HONG</strong>, <strong>홍길동</strong>, <strong>G
           Hong</strong>
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: '새로운 아바타를 업로드한 후, WCA 결과 팀의 승인을 기다려야 합니다.'
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: '이는 귀하가 주최하거나 파견위원 역할을 수행하는 대회에만 적용되며, 대회별로 재정의될 수 있습니다.'
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           이 기능은 데이터 내보내기, WCIF 스키마, 공개 API 등 리소스의 주요 버전 변경에 대한 알림으로만 제한됩니다. 이러한
@@ -790,12 +758,6 @@ ko:
         #original_hash: 0627e5c
         otp_attempt: 구성된 모바일 애플리케이션에서 일회용 비밀번호를 확인하거나 복구 코드 중 하나를 입력하십시오.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: 생년월일의 올바른 형식은 YYYY-MM-DD입니다.
         #original_hash: 49ee4af
@@ -843,12 +805,8 @@ ko:
           선택할 수 있습니다. 다른 이미지가 충분히 업로드된 경우에만 이미지를 삭제할 수 있습니다(이미지를 교체하려면 먼저 새 이미지를
           업로드한 다음 이전 이미지를 삭제해야 합니다). 기록 측정 구역 및 스크램블 구역의 현재 사진이 없는 경우, 그 이유를 설명해
           주십시오.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: WRC의 피드백을 받고 싶은 사건을 참조하는 번호 나열입니다.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           WIC의 피드백을 받고 싶은 사건을 참조하는 번호 목록입니다. <br>
@@ -863,76 +821,20 @@ ko:
         remarks: >-
           공유하고 싶은 다른 세부 사항에 대해 이야기하십시오(예: 커뮤니티 내 발전/퇴보, 이 지역의 미래 계획). 간결함을 위해 이전
           섹션에서 언급하지 않은 내용이 있다면 여기에 자유롭게 의견을 남겨주십시오.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: '예: 여행 경비, 참가비, 상금, 숙박 비용'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: 유효한 http(s) url이어야 합니다. HTTPS를 권장합니다
         #original_hash: 2ace571
         logo: 'PNG 형식이어야 하며, 해상도가 좋고 배경이 투명해야 합니다'
         #original_hash: da54ab5
         email: 모든 이사 및 임원을 포함하는 메일링 리스트이어야 합니다.
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: PDF 형식이어야 합니다
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: 'PDF 형식이어야 합니다. 더 많은 파일을 추가해야 하는 경우, 하나로 병합해 주십시오.'
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3186,16 +3088,10 @@ ko:
           clone_tabs: 추가 정보가 있는 모든 탭을 복제하고 싶습니다
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             이것이 비활성화될 경우 참가 신청 시스템을 변경하면 기술적인 문제가 발생합니다. 여전히 참가 신청 시스템을 변경해야 하는
             경우 WST에 문의하여 도움을 받으십시오.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           대회의 전체 이름(연도 포함)(예: Seoul Summer 2025). 어절의 첫 글자는 대문자로 시작해야 합니다. 이름에는
@@ -3210,8 +3106,6 @@ ko:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           대회 요건 정책</a>을 준수해야 합니다.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: '대회가 이루어지는 도시와 도(해당되는 경우)의 이름. 국가명을 포함하지 마십시오(예: 서울특별시, 강원도 춘천시).'
           #original_hash: 9d9126e
@@ -3220,20 +3114,7 @@ ko:
             Center)](https://4gbw.org/main/main.php)
           #original_hash: 2651d1a
           details_html: '장소에 대한 세부 정보 (예: 1층 맨 뒤편에서 표지판을 따라가십시오). %{md}'
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             시리즈 대회의 풀네임(마지막에 연도 포함)(예: Korea Newcomers 2025). 어절의 첫 글자는 대문자로
@@ -3284,19 +3165,12 @@ ko:
           #original_hash: 7a51d00
           lead_delegate_id: '대표 파견위원은 대회 운영의 행정적인 측면(결과, 보고서, 참가비 청구서)을 담당합니다'
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: 대회 웹사이트. 유효한 http(s) url이어야 합니다.
           #original_hash: b2af5f5
           external_registration_page: 선수들이 참가 신청을 진행해야 하는 페이지입니다. 유효한 http(s) url이어야 합니다.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: '듀얼 라운드를 사용하려면 ''%{choice_ilr}''을 선택하세요'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: 참가비에 대한 통화 코드입니다.
@@ -3311,8 +3185,6 @@ ko:
           guest_entry_fee: >-
             현재 이 숫자는 정보 제공용일 뿐이며, 이 웹사이트를 통해 관람료를 관리할 수 없습니다. 이 값을 0으로 설정하면 관람객
             정책에 대해 선택한 문장이 표시됩니다.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             현재 이 숫자는 정보 제공용일 뿐이며, 환불은 수동으로 이루어져야 합니다. 이 값을 0으로 설정하면 어떠한 상황에서도
@@ -3322,8 +3194,6 @@ ko:
         registration:
           #original_hash: 9965635
           opening_date_time: '참고: 참가 신청 시작 및 마감은 UTC 시간입니다'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             대기 명단에 있는 선수가 더 이상 수락되지 않는 날짜입니다. 환불 마감일이 있는 경우 수락 마감일은 환불 마감일
@@ -3333,16 +3203,6 @@ ko:
             참가 신청된 선수는 주최 팀에 연락하여 이 시점까지 신청한 종목을 업데이트할 권리가 있습니다. 이 마감일은 참가 신청이
             마감되기 전의 시간으로 설정해서는 안 됩니다. 이 영역을 비워두면 선수는 해당 종목이 시작될 때까지 신청된 종목에 해당
             종목을 추가할 수 있습니다. 현장 참가 신청이 있는 경우 대회가 진행되는 날과 같은 날로 설정해야 합니다.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             이 대회에서 허용되는 참가 신청 당 관람객 수입니다. 관람객이 너무 많은 등록은 차단됩니다. 관람객 제한이 없으면
@@ -3352,29 +3212,17 @@ ko:
             위에 언급되지 않은 참가 신청 추가 요건(예: 결제 방법)이 있으면 여기에 명시하십시오. <br/>이 내용은
             <b>영어</b>로 작성하고 선수가 사용하는 언어로도 작성하십시오. 이 내용은 대회 정보 페이지에 표시되고, WCA
             웹사이트 참가 신청을 사용하는 경우 참가 신청 페이지에도 표시됩니다.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: 첫 참가자가 대회에 참가 신청하는 것을 원하지 않는 이유를 여기에 자세히 설명해 주십시오. 영어로 작성해야 합니다!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: 선수들이 퍼즐을 일찍 제출하도록 요구받는 이유를 여기에 자세히 설명해 주십시오. 영어로 작성해야 합니다!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: 참가 자격 요건 기록을 사용하고 싶은 이유를 여기에 자세히 설명해 주십시오. 영어로 작성해야 합니다!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: 특정 종목 조합을 제한하려는 이유를 여기에 자세히 설명해 주십시오. 영어로 작성해야 합니다!
             #original_hash: d09af8f
@@ -3387,9 +3235,6 @@ ko:
         remarks: >-
           WCAT에 전달하고 싶은 추가 정보. 예를 들어, 불확실한 점이 있거나 WCAT에 대한 특별 요청이 있는 경우. 영어로 작성해
           주십시오!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -4329,8 +4174,6 @@ ko:
         paypal: >-
           PayPal 계정을 연결하면 WCA 웹사이트에서 결제를 사용자 계정으로 전달하고, PayPal 계정에서 직접 환불을 처리할 수
           있습니다.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         이 대회는 %{provider}를 통해 결제를 받도록 설정되었습니다. 대회의 파견위원은 연결된 계정을 변경하려면 WCAT에

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -259,8 +259,6 @@ nl:
     333fm: 1 uur
     #original_hash: cc7d8bb
     333mbf: 10 minuten per kubus
-    #original_hash: da39a3e
-    333mbo: ''
   common:
     #original_hash: 70c07ec
     world: Wereld
@@ -718,8 +716,6 @@ nl:
       text: vereist
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Los de onderstaande problemen op:'
@@ -739,12 +735,6 @@ nl:
         public_summary: >-
           Een globale omschrijving van het incident en de beslissing, voor
           openbare publicatie. Graag in het Engels invullen.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 87e1e6f
         dob: Voer je geboortedatum in met formaat jjjj-mm-dd.
@@ -753,36 +743,14 @@ nl:
           Voer je naam volledig en juist in, bijvoorbeeld <strong>Stefan
           Pochmann</strong>. Niet: <strong>s pochmann</strong>. Tussennamen
           (volledige of als initialen) zijn optioneel.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Na het uploaden van je profielfoto, is het wachten tot het
           WCA-resultaten deze goedkeurt.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: d5ccc15
         receive_delegate_reports: >-
           Als je een Junior Delegate, Senior Delegate, of Lid van de WRC of WQAC
@@ -959,12 +927,6 @@ nl:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Je correcte geboortedatum in het formaat jjjj-mm-dd
         #original_hash: 49ee4af
@@ -1025,8 +987,6 @@ nl:
           door naar hun nummers te verwijzen. Ook al leek alles generiek, noteer
           in ieder geval de meest opmerkelijke gevallen. Vink de juiste vakjes
           hieronder aan als je actief op zoek bent naar feedback.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: Lijst van incidentnummers waarvoor je feedback wilt van WRC
         #original_hash: da39a3e
@@ -1038,13 +998,9 @@ nl:
           Vermeld overige punten die je wilt delen (bijv. ontwikkeling in de
           community, plannen voor de regio). Als je opmerkingen niet kwijt kon
           bij de andere vragen, neem ze dan hier op.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Voorbeelden: Reisinformatie, Betaling, Prijzen, Overnachtingen'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: Geboortedatum moet het formaat jjjj-mm-dd hebben.
@@ -1055,45 +1011,14 @@ nl:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
         #original_hash: da39a3e
         guests: ''
-        #original_hash: da39a3e
-        status: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
         #original_hash: da39a3e
         status: ''
       results_submission:
@@ -1104,10 +1029,6 @@ nl:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Moet een valide http(s) URL zijn. HTTPS wordt aanbevolen.
         #original_hash: 2ace571
@@ -1118,28 +1039,12 @@ nl:
         email: >-
           Moest een maillijst zijn waarin alle Directors en Officers zijn
           opgenomen
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Moet in PDF-formaat zijn
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Moet in PDF-formaat zijn. Als je meerdere bestanden moet toevoegen,
           voeg deze dan samen
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -2970,10 +2875,6 @@ nl:
         remarks: Opmerkingen
         clone_tabs: Ik wil de tabbladen met aanvullende informatie klonen
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: De volledige wedstrijdnaam afgesloten met jaartal (bijv. Danish Open
           2016). Gebruik hoofdletters. De naam mag alleen letters, cijfers en spaties
           bevatten, en verder -&.:'.
@@ -2983,17 +2884,13 @@ nl:
           aan de <a href='/documents/policies/external/Competition%20Name20Requirements.pdf'>WCA
           Competition Requirements Policy</a>.
         venue:
-          country_id: ''
           city_name: Naam van de stad, zonder provincie of land. (voor sommige landen
             laten we de staat zien)
           name_html: 'De locatie waar de wedstrijd plaatsvindt. %{md}. Bijvoorbeeld:
             [Cité des Sciences et de l''Industrie](http://www.cite-sciences.fr)'
           details_html: Details van de wedstrijdlocatie (bijv. Op de eerste etage
             achterin, volg de borden). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         information: Informatie over maximumaantal deelnemers, de aanmeldkosten voor
           deelnemers en toeschouwers, en andere details die relevant zijn voor mensen
           die zijn geïnteresseerd om deel te nemen of te komen kijken.
@@ -3016,14 +2913,10 @@ nl:
             van de organisatoren worden getoond. %{md}. Voorbeeld: [Tekst](mailto:some@email.com)'
         championships: ''
         website:
-          generate_website: ''
           external_website: Link naar de website van de wedstrijd, inclusief http(s).
           external_registration_page: De pagina waar deelnemers zich moeten aanmelden
             voor de wedstrijd. Moet een valide http-link zijn.
-          uses_wca_registration: ''
           uses_wca_live:
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Valutacode van de deelnamekosten.
           base_entry_fee: Het basisbedrag voor aanmelding voor de wedstrijd. Het bedrag
@@ -3034,7 +2927,6 @@ nl:
           guest_entry_fee: Dit getal is vooralsnog ter informatie, de toegangsprijs
             voor gasten kun je niet via deze website regelen. Als het bedrag 0 is,
             dan wordt een zin naar keuze getoond over het beleid rond gasten.
-          donations_enabled: ''
           refund_policy_percent: Dit getal is slechts ter informatie, teruggaves moeten
             handmatig worden uitgevoerd. Als het bedrag 0 is, dan wordt een zin dat
             aanmeldkosten onder geen enkele omstandigheid worden teruggegeven.
@@ -3042,7 +2934,6 @@ nl:
             worden.
         registration:
           opening_date_time: 'Let op: de tijden van de aanmelding zijn in UTC tijdzone'
-          closing_date_time: ''
           waiting_list_deadline_date: De datum waarop aangemelde personen op de wachtlijst
             niet meer worden geaccepteerd. Als je een deadline hebt voor refunds,
             moet de datum voor wachtlijst niet voor de deadline voor refunds liggen.
@@ -3052,11 +2943,7 @@ nl:
             de registratie is gesloten. Als het veld leeg is mogen deelnemers wedstrijdonderdelen
             toevoegen tot de dag van de wedstrijd. Als registratie op de dag van de
             wedstrijd mogelijk is, moet dit dezelfde dag zijn als de wedstrijd.
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance:
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration:
           extra_requirements: Geef hier alle extra aanmeldingseisen aan die niet boven
             zijn genoemd, zoals aanwijzingen over hoe te betalen.</br>Geef de tekst
@@ -3066,16 +2953,13 @@ nl:
           force_comment:
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Leg uit waarom je deelnemers hun puzzels vroegtijdig wilt laten
               inleveren. In het Engels!
           qualification_results:
-            enabled: ''
             reason: Leg uit waarom je kwalificatietijden wil gebruiken. Invullen in
               Engels!
             allow_registration_without:
           event_limitation:
-            enabled: ''
             reason: Leg uit waarom je bepaalde combinaties van wedstrijdonderdelen
               wilt uitsluiten. Invullen in Engels!
             per_registration_limit:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -288,8 +288,6 @@ pl:
     333fm: 1 godzina
     #original_hash: cc7d8bb
     333mbf: '10 minut na kostkę, do 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Rodzaj kwalifikacji
@@ -740,8 +738,6 @@ pl:
       text: wymagane
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Proszę przejrzeć problemy poniżej:'
@@ -763,12 +759,6 @@ pl:
         public_summary: >-
           Ogólny opis incydentu wraz z opisem, wyświetlane publicznie. Prosimy o
           wypełnienie w języku angielskim.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Wprowadź datę urodzenia zawodnika w formacie RRRR-MM-DD
@@ -777,36 +767,14 @@ pl:
           Wprowadź pełne imię i nazwisko zawodnika poprawnie, na przykład
           <strong>Jan Kowalski</strong>. Nie zdrobniale jak <strong>j
           kowalski</strong>.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Po przesłaniu nowego zdjęcia profilowego, będziesz musiał zaczekać, aż
           Zespół do Spraw Wyników go zaakceptuje.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Dotyczy to wyłącznie zawodów które organizujesz lub delegujesz, można
           to nadpisać dla poszczególnych zawodów.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Powiadomienia będą ograniczone do głównych zmian wersji zasobów takich
@@ -828,12 +796,6 @@ pl:
           Sprawdź swoje skonfigurowane urządzenie mobilne, w celu pozyskania
           jednorazowego hasła, lub podaj jeden z kodów odzyskiwania.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Twoja poprawna data urodzenia w formacie RRRR-MM-DD
         #original_hash: 49ee4af
@@ -901,12 +863,8 @@ pl:
           zostało przesłanych (jeżeli chcesz zastąpić obraz, najpierw prześlij
           nowy, a następnie usuń poprzedni). Jeżeli nie masz aktualnych zdjęć
           sceny lub strefy mieszania, wytłumacz dlaczego.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: Lista numerów incydentów dla których chciałbyś uzyskać opinię WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Lista numerów odnoszących się do incydentów co do których chcesz
@@ -929,50 +887,10 @@ pl:
           regionem). Jeżeli ze względu na zwięzłość pominąłeś w poprzednich
           sekcjach coś, co chciałbyś powiedzieć, nie wahaj się zamieścić ich
           tutaj.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Przykłady: Dojazd, Płatność, Nagrody, Zakwaterowanie'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: >-
           Musi być poprawnym adresem url, zawierającym protokół http(s). HTTPS
@@ -983,28 +901,12 @@ pl:
           przeźroczyste tło
         #original_hash: da54ab5
         email: Powinien być adresem grupowym członków zarządu
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Musi być w formacie PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Musi być w formacie PDF. Jeżeli potrzebujesz dodać więcej plików, scal
           je w jeden.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3726,17 +3628,11 @@ pl:
           clone_tabs: Chcę sklonować wszystkie zakładki z dodatkowymi informacjami
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Jeżeli ta opcja jest wyłączona, zmiana systemu do rejestracji może
             spowodować problemy techniczne. Prosimy o kontakt z WST z prośbą o
             pomoc jeżeli potrzebujesz zmienić system rejestracji.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Pełna nazwa zawodów kończąca się rokiem (np. Danish Open 2016).
@@ -3753,8 +3649,6 @@ pl:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Polityką
           Wymagań Zawodów WCA</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nazwa miasta gdzie zawody mają miejsce. Nie powinna zawierać nazwy
@@ -3767,20 +3661,7 @@ pl:
           details_html: >-
             Szczegóły na temat miejsca (np. Na pierwszym piętrze, podążaj za
             znakami). %{md}.
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Pełna nazwa Serii Zawodów razem z rokiem na końcu (np. Southern
@@ -3856,8 +3737,6 @@ pl:
             Wiodący Delegat jest odpowiedzialny za administracyjne aspekty
             zawodów (wyniki, raport, WCA Dues)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: >-
             Strona internetowa zawodów. Musi być poprawnym adresem url,
@@ -3866,13 +3745,8 @@ pl:
           external_registration_page: >-
             Strona na której zawodnicy muszą się zarejestrować na zawody. Musi
             być poprawnym adresem url, zawierającym protokół http(s).
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'Wybierz "%{choice_ilr}" jeżeli chcesz używać Rund Podwójnych'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Kod waluty w której wyrażone są opłaty wpisowe.
@@ -3897,8 +3771,6 @@ pl:
             nie może być zarządzane za pomocą strony. Jeżeli wynosi 0, zostanie
             wyświetlone wybrane przez ciebie zdanie informujące o polityce
             wstępu dla gości.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Obecnie liczba ta pełni jedynie rolę informacyjną, zwroty płatności
@@ -3910,8 +3782,6 @@ pl:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Zauważ: Daty startowa i końcowa rejestracji są w czasie UTC.'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Data po której zawodnicy z listy rezerwowej nie będą akceptowani.
@@ -3927,16 +3797,6 @@ pl:
             konkurencje do swoich rejestracji aż do początku trwania danej
             konkurencji. Jeżeli dozwolona jest rejestracja na miejscu to pole
             musi być ustawione na dzień zawodów.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Liczba gości na rejestrację dozwolonych na tych zawodach.
@@ -3950,36 +3810,24 @@ pl:
             innych językach używanych przez twoich zawodników. Tekst ten będzie
             wyświetlany na stronie informacyjnej zawodów oraz na stronie
             rejestracji, jeżeli używasz systemu rejestracji WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Prosimy opisz czemu nie chcesz aby nowi zawodnicy mogli
               zarejestrować się na twoje zawody. Prosimy wypełnić w języku
               angielskim!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Opisz dlaczego chciałbyś, aby zawodnicy dostarczyli układanki
               wcześniej. Prosimy o wypełnienie w języku angielskim!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Opisz dlaczego chciałbyś użyć wyników kwalifikujących. Prosimy o
               wypełnienie w języku angielskim!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Opisz dlaczego chciałbyś uniemożliwić branie udziału w konkretnych
@@ -3999,9 +3847,6 @@ pl:
           Dodatkowe informacje które chcesz przekazać WCAT. Przykładowo, jeżeli
           nie masz co do czegoś pewności lub jeśli masz specjalne prośby dla
           WCAT. Prosimy o wypełnienie w języku angielskim!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -5121,8 +4966,6 @@ pl:
           Połączenie twojego konta PayPal daje stronie WCA możliwość
           przekazywania płatności i dokonywania zwrotów bezpośrednio na twoim
           koncie PayPal
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Te zawody są skonfigurowane do otrzymywania płatności przez %{provider}.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -261,8 +261,6 @@ pt-BR:
     333fm: 1 hora
     #original_hash: cc7d8bb
     333mbf: '10 minutos por cubo, no máximo 60 minutos'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Tipo de Qualificação
@@ -699,8 +697,6 @@ pt-BR:
       text: obrigatório
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Por favor verifique os problemas abaixo:'
@@ -722,12 +718,6 @@ pt-BR:
         public_summary: >-
           Uma descrição geral do incidente e sua decisão, para ser mostrada
           publicamente. Por favor preencha em Inglês.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Informe a data de nascimento do competidor no formato AAAA-MM-DD.
@@ -736,36 +726,14 @@ pt-BR:
           Informe o nome completo do competidor corretamente, por exemplo
           <strong>Ayrton Senna da Silva</strong>, não desleixadamente como
           <strong>ayrton s</strong>.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Após enviar um novo avatar, será necessário esperar a Equipe de
           Resultados da WCA aprová-lo.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Isso só se aplica para competições que você organiza ou delega, e pode
           ser sobrescrito em cada competição.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 27c2251
         receive_delegate_reports: >-
           Se você é um Delegado Sênior ou Membro do WRC ou WQAC, você receberá
@@ -781,12 +749,6 @@ pt-BR:
           Verifique seu aplicativo móvel para uma senha única, ou informe um de
           seus códigos de recuperação.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Sua data de nascimento no formato AAAA-MM-DD
         #original_hash: 49ee4af
@@ -851,14 +813,10 @@ pt-BR:
           selecionados em número suficiente (se quiser substituir uma imagem,
           você deve primeiro fazer o upload da nova imagem, e depois excluir a
           antiga).
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Lista dos números de incidentes para os quais você deseja uma resposta
           do WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 0aca3b0
         wic_incidents: >-
           Lista de números referenciando os incidentes para os quais você
@@ -869,45 +827,20 @@ pt-BR:
           (p. ex. melhora/piora na comunidade, planos futuros para esta região).
           Se você omitiu algo nas seções anteriores para ser conciso, pode
           comentar aqui.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Exemplos: Como chegar, Pagamento, Prêmios, Acomodações'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
       competition_medium:
         #original_hash: da39a3e
         competitionId: ''
         #original_hash: da39a3e
         type: ''
         #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
         submitterName: ''
         #original_hash: da39a3e
         submitterEmail: ''
         #original_hash: da39a3e
         submitterComment: ''
-        #original_hash: da39a3e
-        status: ''
       results_submission:
         #original_hash: da39a3e
         schedule_url: ''
@@ -918,38 +851,18 @@ pt-BR:
         #original_hash: da39a3e
         confirm_information: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Deve ser um url http(s) válido. HTTPS é recomendado.
         #original_hash: 2ace571
         logo: 'Deve estar em formato PNG, com boa resolução e fundo transparente'
         #original_hash: da54ab5
         email: Deve ser uma lista de email contendo todos os Diretores e Oficiais
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Deve estar em formato PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Deve estar em formato PDF. Se você precisar incluir mais de um
           arquivo, por favor faça um arquivo único.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3354,17 +3267,11 @@ pt-BR:
             também
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Se isso estiver desabilitado, alterar o sistema de inscrição irá
             causar problemas técnicos. Por favor contate o WST para assistência
             se você ainda precisa alterar o sistema de inscrição.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           O nome completo da competição, incluindo o ano no final (p. ex.
@@ -3382,8 +3289,6 @@ pt-BR:
           href='/documents/policies/Competition%20Requirements.pdf'>WCA
           Competition Requirements Policy</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nome da cidade e estado onde a competição acontecerá. Não inclua o
@@ -3396,20 +3301,7 @@ pt-BR:
           details_html: >-
             Detalhes do local (p. ex. No primeiro andar, ao fundo. Siga as
             placas). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             O nome completo da Série de Competições, incluindo o ano no final
@@ -3471,8 +3363,6 @@ pt-BR:
             emails dos organizadores. %{md}. Exemplo: [Texto
             mostrado](mailto:alguem@email.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Website da competição. Deve ser uma URL http(s) válida.
           #original_hash: b2af5f5
@@ -3480,12 +3370,7 @@ pt-BR:
             A página na qual os competidores se inscrevem. Deve ser uma URL
             http(s) válida.
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: O código da moeda da taxa de inscrição.
@@ -3507,8 +3392,6 @@ pt-BR:
             convidados não são gerenciadas por este website. Se for configurado
             como 0, uma frase a sua escolha será mostrada acerca da política de
             espectadores.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Por enquanto este número é apenas informacional; devoluções terão
@@ -3520,8 +3403,6 @@ pt-BR:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Nota: início e término das inscrições no fuso horário UTC.'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             A data em que os inscritos na lista de espera não serão mais
@@ -3535,16 +3416,6 @@ pt-BR:
             campo em branco significa que competidores podem adicionar eventos
             até que o evento aconteça. Se você terá inscrições no local, esta
             data deve ser a mesma da competição.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             O número máximo de convidados por competidor permitido nessa
@@ -3558,35 +3429,23 @@ pt-BR:
             competidores falem; estes serão mostrados na página de informações
             da competição, e também na página de inscrições se você estiver
             usando a inscrição pelo website da WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Por favor elabore aqui porque você não quer permitir a inscrição
               de novatos para sua competição. Preencha em inglês!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Por favor detalhe aqui os motivos para exigir a entrega antecipada
               dos quebra-cabeças. Por favor preencha em Inglês!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Por favor detalhe aqui os motivos para o uso de resultados de
               qualificação. Por favor preencha em Inglês!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Por favor detalhe aqui os motivos para restrição de combinações de
@@ -3605,9 +3464,6 @@ pt-BR:
           Alguma informação adicional que você queira passar para o WCAT. Por
           exemplo, se há algo sobre o qual você não tem certeza, ou algum pedido
           especial. Por favor preencha em Inglês!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -267,8 +267,6 @@ pt:
     333fm: 1 hora
     #original_hash: cc7d8bb
     333mbf: '10:00.00 por cubo, até 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Tipo de Qualificação
@@ -715,8 +713,6 @@ pt:
       text: obrigatório
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Por favor verifique os problems abaixo:'
@@ -736,12 +732,6 @@ pt:
         public_summary: >-
           Uma descrição geral do incidente e sua decisão, para ser apresentada
           publicamente. Por favor preencha em inglês.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Introduza a data de nascimento do competidor no formato AAAA-MM-DD.
@@ -750,36 +740,14 @@ pt:
           Introduza o nome do competidor corretamente, por exemplo <strong>Luís
           Vaz de Camões</strong>, não desleixadamente como <strong>luis v
           camoes</strong>. Nomes do meio (completos ou iniciais) são opcionais.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Após carregar um avatar novo, terá que aguardar a sua aprovação pela
           Equipa de Resultados da WCA.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Isto aplica-se apenas para competições que organizar ou for delegado e
           podem ser alteradas para cada competição.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Isto limita-se a notificações de alterações de versão principais em
@@ -801,12 +769,6 @@ pt:
           Verifique a aplicação móvel configurada para uma password ou insira um
           dos seus códigos de recuperação.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: A sua data de nascimento válida no formato AAAA-MM-DD
         #original_hash: 49ee4af
@@ -873,14 +835,10 @@ pt:
           nova primeiro e depois eliminar a antiga). Caso não possua fotos
           atuais da área de competição e/ou da área de embaralhamento em
           utilização, por favor, explique o motivo.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Lista de números referenciando qualquer incidente que gostaria de
           obter feedback pelo WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Lista de números que fazem referência a quaisquer incidentes sobre os
@@ -902,78 +860,22 @@ pt:
           melhoria/regressão na comunidade, planos futuros para esta região). Se
           omitiu algo nas seções anteriores para ser conciso, pode comentar
           aqui.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Exemplos: Como chegar, Pagamento, Prémios, Acomodações'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Tem que ser um url http(s) válido. HTTPS é recomendado.
         #original_hash: 2ace571
         logo: 'Deve ser em formato PNG, com boa resolução e de fundo transparente'
         #original_hash: da54ab5
         email: Deve ser uma mailing list que contenha todos os Diretores e Oficiais
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Tem de ser em formato PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Tem de ser em formato PDF. Se precisar de mais ficheiros, deverá
           uni-los num mesmo ficheiro
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3457,17 +3359,11 @@ pt:
           clone_tabs: Gostaria de clonar todas as abas com informações adicionais também
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Se isto estiver desativado, a alteração do sistema de registo
             causará problemas técnicos. Contacte a WST para obter assistência se
             ainda precisar de alterar o sistema de registo.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           O nome completo da competição incluindo o ano no final (por exemplo,
@@ -3487,8 +3383,6 @@ pt:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Política
           de Requisitos de Competições WCA</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Nome da cidade e estado (se aplicável) onde a competição será
@@ -3502,20 +3396,7 @@ pt:
           details_html: >-
             Detalhes sobre o local (por exemplo, no primeiro andar lá bem atrás,
             siga as indicações). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             O nome completo da Série de Competições incluindo o ano no final
@@ -3587,8 +3468,6 @@ pt:
             sem revelar os e-mails dos organizadores. %{md}. Exemplo: [Texto a
             ser exibido](mailto:some@email.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: O website da competição. Tem que ser um URL http(s) válido.
           #original_hash: b2af5f5
@@ -3596,12 +3475,7 @@ pt:
             A página onde os competidores devem inscrever-se para a competição.
             Deve ser um URL http(s) válido.
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: O código da moeda para taxas.
@@ -3624,8 +3498,6 @@ pt:
             convidados não podem ser geridas através deste site. Se for definido
             como 0, uma frase da sua escolha será exibida sobre a política de
             espectadores.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Por enquanto este número é apenas informativo, os reembolsos terão
@@ -3637,8 +3509,6 @@ pt:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Nota: a abertura e o encerramento das inscrições são em horário UTC'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             A data em que os inscritos em lista de espera não serão mais
@@ -3654,16 +3524,6 @@ pt:
             registou até que esse evento seja realizado. Caso tenha inscrições
             no local da competição, esta deverá ser marcada para o mesmo dia da
             competição.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             O número de convidados por inscrição permitido nesta competição. As
@@ -3677,36 +3537,24 @@ pt:
             competidores falem; isto será exibido na página de informações da
             competição, bem como na página de inscrição, se estiver a usar o
             site de inscrição da WCA.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Por favor elabore aqui o motivo de não querer competidores
               iniciantes na sua competição. Por favor preencha em Inglês!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Explique aqui porque gostaria de exigir que os competidores
               submetam os puzzles com antecedência. Por favor preencha isto em
               Inglês!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Explique aqui por que gostaria de usar tempos de qualificação. Por
               favor preencha isto em Inglês!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Explique aqui porque gostaria de restringir certas combinações de
@@ -3725,9 +3573,6 @@ pt:
           Algumas informações adicionais que deseje remeter ao WCAT. Por
           exemplo, se houver algo sobre o qual não tenha certeza ou se houver
           algum pedido especial para o WCAT. Por favor preencha isto em Inglês!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -4825,8 +4670,6 @@ pt:
           Conectar a sua conta PayPal dá ao site da WCA a capacidade de
           encaminhar pagamentos para si e emitir reembolsos diretamente na sua
           conta PayPal.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Esta competição está configurada para aceitar pagamentos através de

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -262,8 +262,6 @@ ro:
     333fm: 1 oră
     #original_hash: cc7d8bb
     333mbf: '10:00.00 per cube, până la 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Tipul Calificării
@@ -792,8 +790,6 @@ ro:
       text: necesar
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Te rugăm să corectezi problemele:'
@@ -813,12 +809,6 @@ ro:
         public_summary: >-
           O descriere completă a evenimentului și a deciziei luate, pentru a fi
           afișată public. Te rugăm să completezi în engleză.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: >-
@@ -830,40 +820,18 @@ ro:
           <strong>Stefan Pochmann</strong>. Nu introdu numele neglijent, de
           exemplu <strong>s pochman</strong>.<br/> Prenumele suplimentare
           (complete sau doar inițialele) sunt opționale.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           După încărcarea unui nou avatar, va trebui să aștepți ca Echipa de
           Rezultate WCA să îl aprobe.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Se aplică doar competițiilor pe care le organizezi sau delegi și poate
           fi suprascris individual per competiție.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 81a76a3
         receive_delegate_reports: >-
           Dacă ești Delegat Stagiar, Junior sau Senior, ori Membru al WRC sau al
@@ -1067,12 +1035,6 @@ ro:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: 'Data ta de naștere corectă, în formatul AAAA-LL-ZZ'
         #original_hash: 49ee4af
@@ -1139,8 +1101,6 @@ ro:
           Simte-te liber să ceri feedback de la Delegați sau de la WRC. Dacă
           dorești intervenția WDC pentru unele incidente, menționează clar
           această cerere.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: Lista cu numerele incidentelor pentru care ai vrea feedback de la WRC
         #original_hash: da39a3e
@@ -1153,13 +1113,9 @@ ro:
           (exemplu: îmbunătățiri/regres în rândul comunității, planuri de viitor
           pentru regiunea respectivă). Dacă ai uitat să menționezi ceva în
           secțiunile trecute, scrie aici.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Exemple: Călătorie, Plăți, Premii, Cazare'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: Data nașterii trebuie să fie în formatul an-lună-zi (AAAA-LL-ZZ)
@@ -1170,22 +1126,11 @@ ro:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
         #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
@@ -1197,26 +1142,6 @@ ro:
         administrative_notes: >-
           Note suplimentare cu privire la managementul acestei înregistrări.
           Concurentul nu are acces la aceste note.
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       results_submission:
         #original_hash: da39a3e
         schedule_url: ''
@@ -1225,10 +1150,6 @@ ro:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: >-
           Trebuie să fie un URL http(s) valid. Se recomandă folosirea linkurilor
@@ -1237,28 +1158,12 @@ ro:
         logo: 'Trebuie să fie în format PNG, cu rezoluție bună și fundal transparent.'
         #original_hash: da54ab5
         email: Trebuie să fie o listă de mailuri care conține toți Directorii
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Trebuie să fie în format PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Trebuie să fie în format PDF. Dacă mai trebuie să adaugi alte fișiere,
           te rugăm să le unești.
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -3318,10 +3223,6 @@ ro:
         clone_tabs: Vreau să multiplic, de asemenea, toate taburile cu informații
           suplimentare
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: 'Numele complet al competiției, inclusiv anul la sfârșitul ei (de exemplu
           U.R.A. Spring 2016). Asigură-te că începi cuvintele cu literă mare. Numele
           trebuie să conțină numai caractere alfanumerice, spații și următoareel caractere
@@ -3333,19 +3234,14 @@ ro:
           să respecte <a href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Politica
           de Competiții WCA</a>.
         venue:
-          country_id: ''
           city_name: 'Numele orașului și statului (unde este cazul) în care are loc
             competiția. Nu scrieți țara (exemplu: Paris SAU San Francisco, California)'
           name_html: 'Locația unde se desfășoară competiția. %{md}. De exemplu: [Cité
             des Sciences et de l''Industrie](http://www.cite-sciences.fr)'
           details_html: 'Detalii despre locație (exemplu: La parter, urmați semnele
             din partea dreaptă a holului).  %{md}'
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         series:
-          series_id: ''
           name: >-
             Numele complet al Seriei de Competiții, incluzând anul la sfârșit
             (de ex. Southern Australia 2022). Folosește majuscule pentru prima
@@ -3380,15 +3276,11 @@ ro:
             adresele de e-mail ale organizatorilor. %{md} Exemplu: [Text de afișat](mailto:some@email.com)'
         championships:
         website:
-          generate_website: ''
           external_website: Site-ul competiției. Trebuie să aiba un URL http sau https
             valid.
           external_registration_page: Pagina unde concurenții se pot înregistra pentru
             competiție. Trebuie să fi un URL http(s) valid .
-          uses_wca_registration: ''
           uses_wca_live: ''
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Codul valutei pentru taxe
           base_entry_fee: 'Taxa de înregistrare de bază. Va fi afișată pe pagina de
@@ -3403,7 +3295,6 @@ ro:
           guest_entry_fee: Deocamdată, acest număr este doar informativ, taxele pentru
             spectatori nu pot fi administrate prin acest site. Dacă este setat la
             0, va fi afișat un mesaj la alegerea ta despre regimul spectatorilor.
-          donations_enabled: ''
           refund_policy_percent: Deocamdată, acest număr este doar informativ, restituirile
             vor trebui să fie cerute manual. Dacă este setat la 0, va fi afișat un
             mesaj conform căruia taxele de înregistrare nu vor fi restituite sub nicio
@@ -3412,7 +3303,6 @@ ro:
         registration:
           opening_date_time: 'Notă: Orele pentru începutul și sfarșitul înregistrării
             sunt în UTC'
-          closing_date_time: ''
           waiting_list_deadline_date: Data la care ce înscriși pe lista de așteptare
             nu vor mai fi aceptați. Dacă ai termen limită pentru rambursări, termenul
             limită pentru acceptare nu ar trebui să preceadă celui pentru rambursări.
@@ -3422,11 +3312,7 @@ ro:
             Dacă acest câmp nu este completat, atunci concurenții își pot adăuga o
             probă până la momentul desfășurării acesteia. Dacă accepți înscrieri pe
             loc, acest lucru trebuie să se întâmple în ziua competiției.
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance: ''
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration: Numărul de spectatori per înregistrare permis în
             cadrul acestei competiții. Înregistrările care au prea mulți spectatori
             asociați vor fi blocate. Lasă câmpul gol dacă nu există limită.
@@ -3436,19 +3322,14 @@ ro:
             orice alte limbi care te aștepți să fie vorbite la competiție; acestea
             vor fi afișate pe pagina de informații a competiției, precum și pe pagina
             de înregistrări (dacă folosești interfața WCA).
-          force_comment: ''
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Te rugăm să elaborezi aici de ce soliciți depunerea puzzle-urilor
               mai devreme. Completează în engleză!
           qualification_results:
-            enabled: ''
             reason: Te rugăm să elaborezi aici de ce soliciți utilizarea timpilor
               din calificări. Completează în engleză!
-            allow_registration_without: ''
           event_limitation:
-            enabled: ''
             reason: Te rugăm să elaborezi aici de ce soliciți restricționarea participării
               la anumite combinații de probe. Completează în engleză!
             per_registration_limit: Opțional, setează numărul total de probe pentru

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -265,8 +265,6 @@ ru:
     333fm: 1 час
     #original_hash: cc7d8bb
     333mbf: '10 минут на куб, до 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Тип квалификации
@@ -783,8 +781,6 @@ ru:
       text: обязательное поле
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Возникли следующие проблемы:'
@@ -806,12 +802,6 @@ ru:
         public_summary: >-
           Описание инцидента, а также его решение, которые будут доступны всем.
           Пожалуйста, заполняйте по-английски.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Введите день рождения участника в формате ГГГГ-ММ-ДД.
@@ -825,41 +815,19 @@ ru:
           ввести имя в соответствии с ним. При желании, можно написать в скобках
           вариант имени на местном языке, например, <strong>Anton Rostovikov
           (Антон Ростовиков)</strong>
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           После загрузки новой аватарки вам придётся подождать, пока её одобрит
           WCA Results Team.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Это применяется только для соревнований, где вы организатор или
           делегат. Вы можете изменить значение для каждого отдельного
           соревнования.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 81a76a3
         receive_delegate_reports: >-
           Если вы — Делегат-стажёр, Младший Делегат, Старший Делегат или член
@@ -1072,12 +1040,6 @@ ru:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: День Рождения в формате ГГГГ-ММ-ДД
         #original_hash: 49ee4af
@@ -1136,8 +1098,6 @@ ru:
           номерам. Даже если не было особенных инцидентов, хотя бы перечислите
           самые примечательные. Отметьте галочки ниже, если вам нужна обратная
           связь.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: 'Номера инцидентов, к которым требуется обратная связь от WRC'
         #original_hash: da39a3e
@@ -1150,13 +1110,9 @@ ru:
           улучшения/ухудшения в сообществе, планы на будущее в этом регионе).
           Если ради краткости вы не написали чего-либо в предыдущих полях,
           можете написать это здесь.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Например: как добраться, оплата, проживание.'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: День рождения должен быть в формате ГГГГ-ММ-ДД.
@@ -1167,47 +1123,16 @@ ru:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
         #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
         #original_hash: da39a3e
         guests: ''
-        #original_hash: da39a3e
-        status: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
         #original_hash: da39a3e
         status: ''
       results_submission:
@@ -1218,10 +1143,6 @@ ru:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Должен быть правильный http(s) url. Рекомендуется HTTPS
         #original_hash: 2ace571
@@ -1230,28 +1151,12 @@ ru:
           фоном
         #original_hash: da54ab5
         email: Email-адрес Совета Директоров
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Должен быть в формате PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Должен быть в формате PDF. Если вы хотите добавить больше файлов,
           пожалуйста, объедините их в один
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -3222,10 +3127,6 @@ ru:
         remarks: Заметки
         clone_tabs: Скопировать также все вкладки с дополнительной информацией
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: Полное название соревнования, включая год в конце (например, Moscow
           North-West Open 2011). Слова лучше писать с большой буквы. Название должно
           содержать только английские буквы, цифры, дефисы (-), амперсанды (&), точки
@@ -3237,7 +3138,6 @@ ru:
           удовлетворять <a href='/documents/policies/external/Competition%20Name20Requirements.pdf'>Требованиям
           к Соревнованиям WCA</a>.
         venue:
-          country_id: ''
           city_name: Название города, и штат (если применимо), где будет проходить
             соревнование. Не пишите здесь страну. Например, <strong>Moscow</strong>,
             или <strong>San Francisco, California</strong>. <br/>Это поле, а также
@@ -3246,12 +3146,8 @@ ru:
             [Moscow Aviation Institute](http://intstudy.mai.ru/)'
           details_html: Детали помещения (например, главный вход, второй этаж, следуйте
             указателям). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         series:
-          series_id: ''
           name: >-
             Полное название серии соревнований, включая год в конце, каждое
             слово начинается с заглавной буквы, например, Southern Australia
@@ -3285,14 +3181,10 @@ ru:
             адресов организаторов. %{md}. Например: [Вася Пупкин](mailto:vasya@pupkin.ru)'
         championships:
         website:
-          generate_website: ''
           external_website: Сайт соревнования. Должен быть правильный http(s) URL.
           external_registration_page: Страница, где участники должны регистрироваться
             на соревнование. Должна быть правильным http(s) URL.
-          uses_wca_registration: ''
           uses_wca_live: ''
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Код валюты для взноса за участие.
           base_entry_fee: 'Базовый взнос за участие на соревнованиях. Он будет отображаться
@@ -3311,7 +3203,6 @@ ru:
           guest_entry_fee: Пока что это число только для информации, на этом сайте
             нельзя принимать взносы для гостей. Если здесь стоит 0, на странице соревнований
             будет показано выбранное сообщение о политике в отношении гостей.
-          donations_enabled: ''
           refund_policy_percent: Пока что это поле только для информации, вы должны
             сами возвращать взносы. Если здесь стоит 0, участникам будет показано,
             что взносы не будут возвращаться.
@@ -3319,7 +3210,6 @@ ru:
         registration:
           opening_date_time: Время открытия и закрытия регистрации указаны в часовом
             поясе UTC.
-          closing_date_time: ''
           waiting_list_deadline_date: Дата, после которой регистрации из списка ожидания
             больше не будут приниматься. Эта дата не должна быть до крайнего срока
             возвратов, если он есть.
@@ -3329,11 +3219,7 @@ ru:
             оставить это поле пустым то участники смогут добавлять дисциплины до первого
             раунда этой дисциплины. Если у вас есть регистрация на месте, то срок
             изменения списка дисциплин должен включать дни регистрации на месте.
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance: ''
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration: Число гостей на одну регистрацию, разрешённое для
             этих соревнований. Регистрации с превышением этого числа будут недоступны.
             Оставьте пустым, если лимита нет.
@@ -3343,19 +3229,14 @@ ru:
             которых разговаривают ваши участники; эти требования будут отображаться
             на странице соревнования, а также на странице регистрации, если вы используете
             для них сайт WCA.
-          force_comment: ''
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Пожалуйста, объясните, почему вы хотите заставить участников заранее
               сдать головоломки. Заполняйте это поле по-английски!
           qualification_results:
-            enabled: ''
             reason: Пожалуйста, объясните, почему вы хотите использовать квалификацию.
               Заполняйте это поле по-английски!
-            allow_registration_without: ''
           event_limitation:
-            enabled: ''
             reason: Пожалуйста, объясните, почему вы хотите запретить участникам регистрироваться
               на некоторые комбинации дисциплин. Заполняйте это поле по-английски!
             per_registration_limit: Вы можете ограничить количество дисциплин, на

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -504,8 +504,6 @@ sk:
       text: potrebné
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Prosím, pozrite si problémy uvedené nižšie:'
@@ -525,12 +523,6 @@ sk:
         public_summary: >-
           Celkový popis incidentu a jeho rozhodnutia, bude videný verejne.
           Prosím, vyplňte toto v angličtine.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 87e1e6f
         dob: Napíšte váš dátum narodenia vo formáte YYYY-MM-DD
@@ -544,31 +536,11 @@ sk:
           Po tom, ako nahráte svojho nového Avatara, budete musieť počkať,
           pokiaľ ho Výsledkový Tím WCA schváli.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         current_password: ''
         #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: da39a3e
         location_description: ''
         #original_hash: da39a3e
@@ -661,12 +633,6 @@ sk:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Váš správny deň narodenia vo formáte YYYY-MM-DD
         #original_hash: c6d8a97
@@ -732,13 +698,9 @@ sk:
           zlepšenie/zhoršenie v komunite, budúce plány pre tento región). Ak ste
           kvôli stručnosti niečo vynechali v predošlých sekciách, nebojte sa ich
           napísať sem.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Príklady:Cestovanie, Platenie, Ceny, Ubytovanie'
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: Dátum narodenia by mal mať formát YYYY-MM-DD.
@@ -749,18 +711,7 @@ sk:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
@@ -771,26 +722,6 @@ sk:
       team:
         #original_hash: da39a3e
         friendly_id: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
     options:
       registration:
         status:
@@ -1763,8 +1694,6 @@ sk:
       hints:
         admin:
           is_confirmed:
-          is_visible: ''
-        competition_id: ''
         name: Celé meno súťaže aj s rokom na konci(napr. Danish Open 2016).Dávajte
           si pozor, aby meno bolo kapitalizované. Meno musí obsahovať iba alfanumerické
           znaky, pomlčky(-), ampersandy(&), bodky(.), dvojbodky(:), apostrofy(') a
@@ -1773,17 +1702,13 @@ sk:
           krátke, môžete ho znovu použiť(napr. Europe 2006).
         name_reason_html:
         venue:
-          country_id: ''
           city_name: Meno mesta a štátu(ak je), kde sa súťaž bude nachádzať. Nepíšte
             krajinu(napr. Paris ALEBO San Francisco, Kalifornia)
           name_html: 'Miesto, kde sa daná súťaž bude konať. %{md}. Napríklad: [Cité
             des Sciences et de l''Industrie](http://www.cite-sciences.fr)'
           details_html: Detaily o mieste (napr. On the first floor far in the back,
             follow the signs). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         information: Informácie o limite súťažiacich, vstupných poplatkoch pre súťažiacich
           a divákov a iné detaily relevantné pre ľudí, ktorí maju záujem v zúčastnení
           sa súťaže.
@@ -1803,13 +1728,9 @@ sk:
             organizátorov budú publikované verejnosti. %{md}. Príklad: [Text na ukážku](mailto:some@email.com)'
         championships: ''
         website:
-          generate_website: ''
           external_website: Webová stránka súťaže. Musí mať pravý http(s) url.
           external_registration_page:
-          uses_wca_registration: ''
           uses_wca_live:
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Kód meny pre vstupné poplatky.
           base_entry_fee: Základný vstupný poplatok pre súťaž. Vstupný poplatok bude
@@ -1817,18 +1738,15 @@ sk:
             je použitá).
           on_the_spot_entry_fee:
           guest_entry_fee:
-          donations_enabled: ''
           refund_policy_percent:
           refund_policy_limit_date:
         registration:
           opening_date_time: 'Poznámka: Otvorenie a zatvorenie súťaže sú v čase UTC.'
-          closing_date_time: ''
           waiting_list_deadline_date:
           event_change_deadline_date:
           allow_on_the_spot:
           allow_self_delete_after_acceptance:
           allow_self_edits:
-          guests_enabled: ''
           guest_entry_status:
           guests_per_registration:
           extra_requirements:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -286,8 +286,6 @@ sl:
     333fm: 1 ura
     #original_hash: cc7d8bb
     333mbf: '10:00.00 na kocko, največ 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Način kvalifikacije
@@ -734,8 +732,6 @@ sl:
       text: obvezno
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Prosimo, preglejte sledeče težave:'
@@ -755,12 +751,6 @@ sl:
         public_summary: >-
           Splošen opis incidenta in odločitev, povezanih z njim. Te informacije
           bodo javno prikazane. Prosimo, izpolnite v angleščini.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Vnesite datum rojstva tekmovalca v formatu LLLL-MM-DD.
@@ -770,36 +760,14 @@ sl:
           Novak</strong>. Izogibajte se površnim zapisom, kot je <strong>j
           novak</strong>.<br/>Srednja imena (v celoti ali kot začetnice) so
           neobvezna.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Po prenosu novega avatarja morate počakati na odobritev s strani WCA
           ekipe za rezultate.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Velja le za tekmovanja, ki jih organizirate ali delegirate. To
           nastavitev lahko spremenite za vsako tekmovanje posebej.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Omejeno na obvestila ob večjih spremembah med različicami orodij, kot
@@ -820,12 +788,6 @@ sl:
           Preverite vašo nastavljeno mobilno aplikacijo za enkratno geslo ali
           vnesite eno izmed vaših obnovitvenih kod.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Vaš točen datum rojstva v formatu LLLL-MM-DD
         #original_hash: 49ee4af
@@ -891,14 +853,10 @@ sl:
           najprej naložiti novo, šele potem izbrisati staro). Če slik z območij
           mešanja in tekmovanja, medtem ko sta ti v uporabi, nimate, prosimo,
           razložite zakaj.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Seznam številk, ki se sklicujejo na incidente, za katere želite dobiti
           povratno informacijo WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Seznam številk, ki se sklicujejo na incidente, za katere želite dobiti
@@ -920,78 +878,22 @@ sl:
           (npr. izboljšanje/upadanje znotraj skupnosti, prihodnji načrti za to
           regijo). Če ste z namenom jedrnatosti v prejšnjih predelih kaj
           izpustili, lahko pišete o tem tu.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Primeri: potovanje, plačila, nagrade, nastanitve'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Mora biti veljaven http(s) URL. HTTPS je priporočen
         #original_hash: 2ace571
         logo: 'Mora biti v formatu PNG, v dobri resoluciji, s prozornim ozadjem'
         #original_hash: da54ab5
         email: Naj bo seznam e-naslovov vseh direktorjev in vodstvenih delavcev
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Mora biti v formatu PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Mora biti v formatu PDF. Če morate dodati več datotek, jih, prosimo,
           združite
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3617,17 +3519,11 @@ sl:
           clone_tabs: Podvojiti želim tudi vse zavihke z dodatnimi informacijami
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Če to onemogočite, bo sprememba sistema za prijave povzročila
             tehnične težave. Če vseeno želite spremeniti sistem za prijave,
             kontaktirajte WST.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Polno ime tekmovanja, vključno z letnico na koncu (npr. Slovenian Open
@@ -3644,8 +3540,6 @@ sl:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Politiki
           zahtev za WCA tekmovanja</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Ime mesta in pokrajine (če je potrebno), kjer bo potekalo
@@ -3659,20 +3553,7 @@ sl:
           details_html: >-
             Podrobnosti o prizorišču (npr. prvo nadstropje, sledite znakom).
             %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Polno ime serije tekmovanj, vključno z letnico na koncu (npr.
@@ -3747,21 +3628,14 @@ sl:
             Glavni delegat je zadolžen za administrativne vidike tekmovanje
             (rezultati, poročilo, dajatve)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Spletna stran tekmovanja. To mora biti veljaven http(s) URL.
           #original_hash: b2af5f5
           external_registration_page: >-
             Spletna stran, kjer se tekmovalci prijavijo na tekmovanje. To mora
             biti veljaven http(s) URL.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'Izberite ''%{choice_ilr}'', če želite uporabiti dvojne kroge'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Koda valute za vstopnine.
@@ -3781,8 +3655,6 @@ sl:
             Trenutno je to število le informacijske narave, vstopnine za goste
             ni možno urejati preko spletne strani. Če nastavite na 0, bo
             prikazano besedilo po vaši izbiri.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Trenutno je ta številka le informativne narave, vračila morate
@@ -3793,8 +3665,6 @@ sl:
         registration:
           #original_hash: 9965635
           opening_date_time: Odprtje in zaprtje prijav v univerzalnem koordiniranem času (UTC)
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Datum, po katerem se tekmovalcev s čakalnega seznama več ne
@@ -3808,16 +3678,6 @@ sl:
             dodatne discipline lahko prijavijo do pričetka posamezne discipline.
             Če ste omogočili prijave na samem tekmovanju, mora biti ta datum
             nastavljen na datum samega tekmovanja.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Največje dovoljeno število gostov na tekmovalca za to tekmovanje.
@@ -3831,35 +3691,23 @@ sl:
             govorijo vaši tekmovalci; to bo prikazano na strani z informacijami
             in na strani za prijave, če za prijave uporabljate WCA spletno
             stran.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Razložite, zakaj ne želite, da se na to tekmovanje prijavljajo
               novinci. Prosimo, izpolnite v angleščini!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Razložite, zakaj želite, da tekmovalci uganke oddajo predčasno.
               Prosimo, izpolnite v angleščini!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Razložite, zakaj želite uporabiti kvalifikacijske pogoje. Prosimo,
               izpolnite v angleščini!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Razložite, zakaj želite omejiti kombinacije disciplin, na katere
@@ -3877,9 +3725,6 @@ sl:
           Dodatne informacije, ki jih želite posredovati WCAT. Na primer, če
           imate kakršna koli vprašanja ali posebne zahteve v zvezi z WCAT.
           Prosimo, izpolnite v angleščini!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -4969,8 +4814,6 @@ sl:
         paypal: >-
           Povezava vašega PayPal računa omogoča WCA spletni strani, da vam
           usmerja plačila in izdaja vračila neposredno na vaš PayPal račun.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         To tekmovanje sprejema plačila preko ponudnika %{provider}. Delegat(i)

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -261,8 +261,6 @@ sv:
     333fm: 1 timme
     #original_hash: cc7d8bb
     333mbf: '10:00.00 per kub, upp till 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Kvalificeringstyp
@@ -701,8 +699,6 @@ sv:
       text: krävs
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Var vänlig granska problemen nedan:'
@@ -724,12 +720,6 @@ sv:
         public_summary: >-
           En övergripande beskrivning av händelsen och dess beslut som visas
           offentligt. Fyll i detta på engelska.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: Ange den tävlandes födelsedatum i formatet ÅÅÅÅ-MM-DD.
@@ -739,36 +729,14 @@ sv:
           <strong>Stefan Pochmann</strong>. Inte slarvigt som <strong>s
           pochman</strong>.<br/>Mellannamn (antingen hela eller som initialer)
           är valfria.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           När du har laddat upp en ny profilbild behöver du vänta på att WCA
           Results Team godkänner den.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Detta gäller endast tävlingar som du är arrangör eller delegat för,
           och kan ändras för varje enskild tävling.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: c564b74
         receive_delegate_reports: >-
           Om du är senior-delegat eller medlem i WRC eller WQAC, får du
@@ -784,12 +752,6 @@ sv:
           Se din konfigurerade mobilapplikation för ett engångslösenord eller
           ange en av dina återställningskoder.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Din korrekta födelsedag i formatet ÅÅÅÅ-MM-DD
         #original_hash: 49ee4af
@@ -852,14 +814,10 @@ sv:
           flera filer samtidigt. Du kan ta bort bilder först när tillräckligt
           många andra bilder har laddats upp (om du vill byta ut en bild måste
           du först ladda upp den nya bilden och sedan ta bort den gamla).
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: >-
           Lista över nummer på alla incidenter som du vill ha feedback från WRC
           på.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Lista med incidentnummer som du vill ha WIC-feedbacken på. <br>
@@ -880,50 +838,10 @@ sv:
           förbättring/försämring inom communityt, framtida planer för regionen).
           Om du för korthetens skull lämnade något osagt i de föregående
           avsnitten, är du välkommen att kommentera dem här.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Exempel: Resor, betalningar, priser, boende'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Måste vara en giltig http(s)-url. HTTPS rekommenderas
         #original_hash: 2ace571
@@ -932,28 +850,12 @@ sv:
           bakgrund
         #original_hash: da54ab5
         email: Bör vara en e-postlista som innehåller alla i organisationens ledning
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Måste vara i PDF-format
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Måste vara i PDF-format. Om du behöver lägga till fler filer, vänligen
           lägg ihop dem till en
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3362,17 +3264,11 @@ sv:
           clone_tabs: Jag vill även klona alla flikar med ytterligare information
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Om detta är inaktiverat kommer byte av anmälningssystem att orsaka
             tekniska problem. Kontakta WST för att få hjälp om du fortfarande
             behöver byta anmälningssystem.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Tävlingens fullständiga namn inklusive årtalet i slutet (t.ex. Danish
@@ -3390,8 +3286,6 @@ sv:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Competition Requirements Policy</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Namn på staden och delstaten (om tillämpligt) som tävlingen äger rum
@@ -3405,20 +3299,7 @@ sv:
           details_html: >-
             Detaljer för lokalen (t.ex. På första våningen längst in, följ
             skyltarna). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Tävlingsseriens fulla namn, inklusive årtalet på slutet (t.ex.
@@ -3492,8 +3373,6 @@ sv:
             arrangörernas e-postadresser. %{md}. Exempel: [Text att
             visa](mailto:some@email.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Tävlingens hemsida. Måste vara en giltig http(s)-url.
           #original_hash: b2af5f5
@@ -3501,12 +3380,7 @@ sv:
             Sida där de tävlande behöver anmäla sig till tävlingen. Måste vara
             en giltig http(s)-url.
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Valutakoden för avgifterna.
@@ -3525,8 +3399,6 @@ sv:
             För närvarande är detta nummer endast informativt, gästavgifter kan
             inte hanteras via denna webbplats. Om detta är satt till 0, kommer
             en valfri mening att visas om åskådarpolicyn.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             För närvarande är detta nummer endast informativt, återbetalningar
@@ -3538,8 +3410,6 @@ sv:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Notera: Start- och sluttider för anmälan anges i UTC-tid.'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Det datum då personer på väntelistan inte längre kommer att
@@ -3554,16 +3424,6 @@ sv:
             tävlande kan lägga till ett grenar till sina registrerade grenar
             fram till dess att grenen hålls. Om anmälan på plats används måste
             detta sättas till samma dag som tävlingen.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Antal gäster per anmälan som tillåts för denna tävling. Anmälningar
@@ -3576,35 +3436,23 @@ sv:
             detta på <b>engelska</b> och eventuella språk som de tävlande talar;
             detta kommer att visas på tävlingens informationssida, samt på
             anmälningssidan om du använder WCAs hemsida för anmälningar.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Vänligen förklara här varför du inte vill att nykomlingar ska
               anmäla sig till din tävling. Vänligen fyll i detta på engelska!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Vänligen utveckla här varför du vill att tävlande ska lämna in
               sina pussel tidigt. Vänligen fyll i detta på engelska!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Vänligen utveckla här varför du vill använda kvalgränser. Vänligen
               fyll i detta på engelska.
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Vänligen utveckla här varför du vill begränsa vissa kombinationer
@@ -3623,9 +3471,6 @@ sv:
           Ytterligare information du vill skicka med till WCAT. Till exempel om
           det är något du är osäker på , eller om det finns speciella önskemål
           till WCAT. Vänligen fyll i detta på engelska!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -4688,8 +4533,6 @@ sv:
           Genom att ansluta ditt PayPal-konto får WCA:s webbplats möjlighet att
           dirigera betalningar till dig och utfärda återbetalningar direkt på
           ditt PayPal-konto.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Denna tävling är inställd på att acceptera betalningar via %{provider}.

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -279,8 +279,6 @@ th:
     333fm: 1 ชั่วโมง
     #original_hash: cc7d8bb
     333mbf: '10:00.00 ต่อลูก, ไม่เกิน 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: ประเภทการคัดเลือก
@@ -722,8 +720,6 @@ th:
       text: จำเป็น
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: โปรดตรวจสอบปัญหาด้านล่าง
@@ -741,12 +737,6 @@ th:
         public_summary: >-
           คำอธิบายโดยรวมของ incident และการตัดสินใจที่จะแสดงต่อสาธารณะ
           กรุณากรอกเป็นภาษาอังกฤษ
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: กรอกวันเกิดของผู้เข้าแข่งขันในรูปแบบ YYYY-MM-DD
@@ -757,34 +747,12 @@ th:
           <strong>Chanatupe Songrasai (ชนาธูป สรงกระสัย)</strong>,
           ไม่กรอกรูปแบบนี้ <strong>c songrasai</strong>.<br/>ชื่อกลาง
           (เต็มหรือย่อ) ไม่จำเป็น
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: หลังจากอัปโหลดภาพแทนตัวใหม่คุณจะต้องรอให้ทีม WCA Results อนุมัติ
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           ใช้ได้เฉพาะกับการแข่งขันที่คุณจัดหรือ delegate เท่านั้น
           และสามารถแทนที่ได้ในแต่ละการแข่งขัน
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           ข้อจำกัดนี้จำกัดเฉพาะการแจ้งเตือนการเปลี่ยนแปลงเวอร์ชันหลักของ เช่น
@@ -805,12 +773,6 @@ th:
           ตรวจสอบโทรศัพท์มือถือของคุณสำหรับ one-time password หรือ ใส่ recovery
           codes
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: วันเกิดของคุณในรูปแบบ YYYY-MM-DD
         #original_hash: 49ee4af
@@ -875,12 +837,8 @@ th:
           จากนั้นจึงลบรูปภาพเก่า)
           หากคุณไม่มีรูปของพื้นที่แข่งขันและ/หรือพื้นที่ตั้งโจทย์ขณะกำลังใช้งาน
           กรุณาแจ้งเหตุผล
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: หมายเลขของ incident ที่ต้องการข้อเสนอแนะจาก WRC
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           รายการตัวเลขที่อ้างอิงถึง Incidents ที่คุณต้องการให้ WIC
@@ -901,76 +859,20 @@ th:
           พูดเกี่ยวกับรายละเอียดอย่างอื่นที่คุณต้องการแบ่งปัน (เช่น
           การพัฒนา/การถดถอยของกลุ่มผู้เข้าแข่งขัน, แผนงานในอนาคต)
           คุณสามารถอธิบายเนื้อหาจากส่วนก่อนหน้าเพื่มเติมได้
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: เช่น การเดินทาง การชำระเงิน รางวัล ที่พัก
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: 'ต้องเป็น http(s) url ที่ถูกต้อง, แนะนำ HTTPS'
         #original_hash: 2ace571
         logo: 'ต้องเป็น PNG, ความละเอียดที่ดี และพื้นหลังต้องโปร่งใส'
         #original_hash: da54ab5
         email: ควรเป็นรายชื่อผู้รับ email ที่มีกรรมการและเจ้าหน้าที่ทั้งหมด
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: ต้องเป็น PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: 'ต้องเป็น PDF, ถ้าคุณต้องการเพิ่มไฟล์ กรุณารวมมันเข้าด้วยกัน'
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3480,16 +3382,10 @@ th:
           clone_tabs: ฉันต้องการโคลนแท็บทั้งหมดพร้อมข้อมูลเพิ่มเติมเช่นกัน
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             หากปิดใช้งาน การเปลี่ยนระบบการสมัครนจะทำให้เกิดปัญหาทางเทคนิค
             โปรดติดต่อ WST เพื่อขอความช่วยเหลือหากคุณยังต้องเปลี่ยนระบบการสมัคร
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           ชื่อเต็มของการแข่งขันรวมถึงปีที่สิ้นสุด (เช่น Danish Open 2016)
@@ -3507,8 +3403,6 @@ th:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA
           Competition Requirements Policy</a>
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             ชื่อของเมืองหรือรัฐ (ถ้ามี) ที่จะมีการแข่งขัน ไม่ต้องใส่ประเทศ (เช่น
@@ -3519,20 +3413,7 @@ th:
             de l'Industrie](http://www.cite-sciences.fr)
           #original_hash: 2651d1a
           details_html: 'รายละเอียดเกี่ยวกับสถานที่ (เช่น ชั้นที่ 1 ด้านหลัง ตามป้าย) %{md}'
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             ชื่อเต็มของการแข่งขันซีรีส์รวมทั้งปีที่สิ้นสุด (เช่น Southern
@@ -3599,19 +3480,12 @@ th:
             หัวหน้า Delegate รับผิดชอบด้านการบริหารจัดการการแข่งขัน
             (ผลการแข่งขัน รายงาน ใบแจ้งค่าธรรมเนียม)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: website ของการแข่งขัน ต้องเป็น http(s) url ที่ถูกต้อง
           #original_hash: b2af5f5
           external_registration_page: หน้าเว็บที่ผู้เข้าแข่งขันต้องสมัครการแข่งขัน ต้องเป็น URL ที่ถูกต้อง
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'เลือก ''%{choice_ilr}'' หากคุณต้องการใช้ Dual Rounds'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: สกลุเงินสำหรับต่าสมัคร
@@ -3633,8 +3507,6 @@ th:
             สำหรับตอนนี้ตัวเลขนี้เป็นข้อมูลเท่านั้น
             ค่าเข้าชมการแข่งขันไม่สามารถจัดการผ่าน website นี้ได้ หากตั้งเป็น 0
             จะแสดงข้อความที่คุณเลือกเกี่ยวกับนโยบายของผู้เข้าชมการแข่งขัน
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             สำหรับตอนนี้ตัวเลขนี้เป็นข้อมูลเท่านั้น
@@ -3645,8 +3517,6 @@ th:
         registration:
           #original_hash: 9965635
           opening_date_time: เวลาเปิดและปิดรับสมัคร (UTC time)
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             วันที่ผู้เข้าแข่งขันที่อยู่ใน waitlisted registrants
@@ -3659,16 +3529,6 @@ th:
             เว้นว่างไว้หากผู้เข้าแข่งขันสามารถเพิ่มประเภทการแข่งขันได้จนถึงวันแข่งขัน
             หากคุณมีการรับสมัครที่การแข่งขัน
             จะต้องตั้งเป็นวันเดียวกับวันที่แข่งขัน
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             จำนวนผู้ติดตามที่ได้รับอนุญาติในการแข่งขันนี้
@@ -3681,35 +3541,23 @@ th:
             <br/>กรุณากรอกเป็น <b>ภาษาอังกฤษ</b> และภาษาอื่นที่ผู้เข้าแข่งขันใช้
             สิ่งนี้จะปรากฏในหน้าข้อมูลการแข่งขันรวมถึงหน้าลงสมัครการแข่งขันหากคุณใช้การสมัครการแข่งขันในเว็บไซต์
             WCA
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               โปรดอธิบายรายละเอียดที่นี่ว่าทำไมคุณถึงไม่อยากให้ผู้เข้าแข่งขันใหม่สมัครการแข่งขันของคุณ
               กรุณากรอกเป็นภาษาอังกฤษ!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               โปรดอธิบายรายละเอียดที่นี่ทำไมคุณต้องการให้ผู้เข้าแข่งขันส่ง
               puzzle ก่อน กรุณากรอกเป็นภาษาอังกฤษ!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               ปรดอธิบายรายละเอียดที่นี่ ทำไมคุณถึงต้องการใช้การคัดเลือก
               กรุณากรอกเป็นภาษาอังกฤษ!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               โปรดอธิบายรายละเอียดที่นี่ ทำไมคุณต้องการจำกัดการสมัครบางประเภท
@@ -3727,9 +3575,6 @@ th:
         remarks: >-
           ข้อมูลบางอย่างที่คุณอยากส่งให้ WCAT เช่น บางอย่างที่คุณไม่มั่นใจกับมัน
           หรือคำขอพิเศษที่จะส่งไปให้ WCAT กรุณากรอกเป็นภาษาอังกฤษ!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -4780,8 +4625,6 @@ th:
           การเชื่อมต่อบัญชี PayPal ของคุณทำให้เว็บไซต์ WCA
           สามารถกำหนดเส้นทางการชำระเงินให้กับคุณ และคืนเงืนได้โดยตรงในบัญชี
           PayPal ของคุณ
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         การแข่งขันนี้จัดทำขึ้นเพื่อรับการชำระเงินผ่าน %{provider} Delegate

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -703,8 +703,6 @@ uk:
       text: обов’язкове
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Будь ласка, перегляньте проблеми нижче:'
@@ -726,12 +724,6 @@ uk:
         public_summary: >-
           Загальний опис інциденту та його рішення, що будуит опублівані. Будь
           ласка, заповніть це англійською.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 87e1e6f
         dob: Введіть Вашу дату народження в форматі РРРР-ММ-ДД.
@@ -741,38 +733,16 @@ uk:
           Сковорода</strong>. Будь ласка, не скорочуйте імена і не забувайте
           писати прізвище.<br/>По-батькові додаються лише у випадках, коли
           потрібна додаткова ідентифікація учасника.
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Після завантаження нового аватару, Ви маєте дочекатись, доки WCA
           Results Team узгодить її.
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         current_password: ''
         #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: da39a3e
         location_description: ''
         #original_hash: da39a3e
@@ -934,12 +904,6 @@ uk:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: Ваша дата народження в форматі РРРР-ММ-ДД
         #original_hash: c6d8a97
@@ -995,8 +959,6 @@ uk:
           Навіть якщо всі інциденти здаються Вам звичайними, опишіть найбільш
           цікаві з них. Будь ласка, поставте відповідні галочки, якщо Вам
           необхідний зворотний зв’язок.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: 'Номери інцидентів, стосовно яких Ви б хотіли почути відгук від WRC.'
         #original_hash: da39a3e
@@ -1008,15 +970,11 @@ uk:
           Розкажіть про будь-які інші подробиці, якими хочете поділитись
           (прогрес/регрес спільноти, майбутні плани в регіоні тощо). Якщо Ви про
           щось не розповіли в попередніх розділах, опишіть все це тут.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: >-
           Приклади: Як дістатись, Призовий фонд, Розміщення, Харчування,
           Контакти
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: Дата народження повинна мати формат РРРР-ММ-ДД
@@ -1027,45 +985,14 @@ uk:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
         #original_hash: da39a3e
         guests: ''
-        #original_hash: da39a3e
-        status: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
         #original_hash: da39a3e
         status: ''
       results_submission:
@@ -1076,10 +1003,6 @@ uk:
         #original_hash: da39a3e
         message: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: >-
           Має бути працююче http(s) посилання. Рекомендується використовувати
@@ -1090,28 +1013,12 @@ uk:
           фон
         #original_hash: da54ab5
         email: Має бути список електронних адрес всіх директорів та заступників
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Має бути в форматі PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Має бути в форматі PDF. Якщо Вам необхідно додати більше файлів, будь
           ласка, поєднайте їх разом
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -2647,10 +2554,6 @@ uk:
         remarks: Примітки
         clone_tabs: Клонувати також всі вкладки з додатковою інформацією
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: Повна назва змагання включно з роком (наприклад, Kyiv Open 2011). Переконайтесь,
           що всі слова починаються з великої літери. Ім’я має містити лише букви,
           цифри, дефіси(-), амперсанди(&), крапки(.), двокрапки(:), апострофи(') та
@@ -2661,7 +2564,6 @@ uk:
           <a href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Вимогам
           до Змагань WCA</a>.
         venue:
-          country_id: ''
           city_name: Назва міста та району/області (якщо треба) де буде відбуватись
             змагання (наприклад, Sultan-Sarai, Bilogirs'kyi, Crimea). Країну вказувати
             не потрібно.
@@ -2669,10 +2571,7 @@ uk:
             [Верховна Рада України](https://rada.gov.ua/)'
           details_html: Детальний опис приміщення (розташування під’їзду, на якому
             поверсі знаходиться зал тощо). %{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         information: Важлива інформація, яку мають знати учасники. Вона буде відображена
           на основній сторінці змагання. <br/>Будь ласка, заповніть її як <strong>українською</strong>,
           так і <strong>англійською</strong>.
@@ -2693,14 +2592,10 @@ uk:
             [Олег Ляшко](mailto:some@email.com)'
         championships: ''
         website:
-          generate_website: ''
           external_website: Веб-сторінка змагання. Це має бути працююче http(s) посилання.
           external_registration_page: Сторінка, на якій учасники будуть реєструватись.
             Це має бути працююче http(s) посилання.
-          uses_wca_registration: ''
           uses_wca_live:
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: Валютний код для внесків.
           base_entry_fee: Базовий реєстраційний внесок. Буде відображатись на основній
@@ -2711,7 +2606,6 @@ uk:
           guest_entry_fee: На даний момент це число носить інформаційний характер;
             гостьові внески не сплачуються через сайт WCA. Якщо вказати 0, то учасники
             будуть бачити повідомлення, що вхід для гостей безкоштовний.
-          donations_enabled: ''
           refund_policy_percent: Це число носить лише інформаційний характер. Якщо
             встановити "0", то учасник буде бачити повідомлення, що реєстраційні внески
             не будуть повертатись ні за яких обставин.
@@ -2719,13 +2613,10 @@ uk:
         registration:
           opening_date_time: 'Примітка: Реєстрація відкриється і закриється за часом
             UTC.'
-          closing_date_time: ''
           waiting_list_deadline_date:
           event_change_deadline_date:
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance:
           allow_self_edits:
-          guests_enabled: ''
           guest_entry_status:
           guests_per_registration:
           extra_requirements: Напишіть тут ті додаткові реєстраційні вимоги, які не
@@ -2736,16 +2627,13 @@ uk:
           force_comment:
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason: Будь ласка, опишіть тут, чому Ви просите учасників принести головоломки
               заздалегідь. Будь ласка, заповніть це англійською!
           qualification_results:
-            enabled: ''
             reason: Будь ласка, опишіть тут, чому Ви бажаєте використовувати кваліфікаційний
               час. Будь ласка, заповніть це англійською!
             allow_registration_without:
           event_limitation:
-            enabled: ''
             reason: Будь ласка, опишіть тут, чому Ви б хотіли обмежити участь у комбінації
               деяких дисциплін. Будь ласка, заповніть це англійською!
             per_registration_limit:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -279,8 +279,6 @@ vi:
     333fm: 1 giờ
     #original_hash: cc7d8bb
     333mbf: '10:00.00 mỗi khối hình, tối đa 60:00.00'
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: Loại điều kiện
@@ -726,8 +724,6 @@ vi:
       text: bắt buộc
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 'Vui lòng kiểm tra các vấn đề sau đây:'
@@ -747,12 +743,6 @@ vi:
         public_summary: >-
           Mô tả tổng quan về sự cố và quyết định cuối cùng để hiển thị công
           khai. Vui lòng điền bằng tiếng Anh.
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: >-
@@ -764,37 +754,15 @@ vi:
           A</strong>. Không nhập cẩu thả như <strong>nguyen van a</strong> hay
           <strong>NGUYEN VAN A</strong>.<br/>Không bắt buộc nhập tên đệm (đầy đủ
           hoặc viết tắt).
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: >-
           Sau khi đăng tải hình đại diện mới, bạn cần đợi Đội ngũ Kết quả WCA
           (WCA Results Team) xét duyệt trước khi hình đại diện được hiển thị
           công khai.
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: >-
           Cài đặt này chỉ áp dụng cho các giải đấu bạn tổ chức hoặc làm nhiệm vụ
           Delegate, và có thể thiết lập riêng cho mỗi giải đấu.
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           Tùy chọn này chỉ áp dụng đối với các bản cập nhật lớn của các tài
@@ -815,12 +783,6 @@ vi:
           Kiểm tra ứng dụng tạo mã đã cài đặt trên điện thoại để lấy mã OTP,
           hoặc nhập mã phục hồi.
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: >-
           Ngày sinh chính xác của bạn, viết dưới dạng YYYY-MM-DD
@@ -886,12 +848,8 @@ vi:
           khác (nếu muốn thay thế, bạn phải đăng hình mới lên trước khi xóa hình
           cũ). Vui lòng giải thích lý do nếu không có hình chụp khu vực thi đấu
           và/hoặc khu vực tráo đổi khi giải đấu đang diễn ra.
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: Số thứ tự của các sự cố cần phản hồi từ WRC.
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: >-
           Số thứ tự của các sự cố cần phản hồi từ WIC. <br>
@@ -912,50 +870,10 @@ vi:
           Nói về bất kỳ điều gì khác mà bạn muốn chia sẻ (VD: cộng đồng phát
           triển hơn/suy thoái đi, các kế hoạch sắp tới của khu vực). Nếu bạn
           muốn bổ sung nội dung cho các phần trước, xin mời viết thêm tại đây.
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 'Ví dụ: Đi lại, Thanh toán lệ phí, Giải thưởng, Nhà tài trợ'
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: Bắt buộc phải là đường dẫn HTTP(S) hợp lệ. Khuyến khích sử dụng HTTPS
         #original_hash: 2ace571
@@ -964,28 +882,12 @@ vi:
           suốt
         #original_hash: da54ab5
         email: Nên là một danh sách gửi thư đến toàn bộ các Giám đốc và Cán bộ
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: Bắt buộc dùng định dạng PDF
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: >-
           Bắt buộc dùng định dạng PDF. Nếu bạn cần thêm file, vui lòng gộp các
           file lại
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -3588,17 +3490,11 @@ vi:
           clone_tabs: Tôi muốn sao chép các tab nội dung thêm
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: >-
             Nếu lựa chọn này bị tắt, việc thay đổi hệ thống đăng ký sẽ gây vấn
             đề kỹ thuật. Liên hệ WST để được hỗ trợ nếu vẫn cần đổi hệ thông
             đăng ký.
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           Tên đầy đủ của giải đấu bao gồm năm (v.d Hanoi Open 2018). Để ý tên
@@ -3616,8 +3512,6 @@ vi:
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>Chính
           sách về Quy định Giải đấu của WCA</a>.
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: >-
             Tên của thành phố và bang (nếu có thể) nơi giải đấu diễn ra. Không
@@ -3630,20 +3524,7 @@ vi:
           details_html: >-
             Thông tin chi tiết về địa điểm (v.d. ở hội trường tầng đầu tiên, đi
             theo biển chỉ dẫn). %{md}
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: >-
             Tên đầy đủ của Chuỗi Giải đấu, bao gồm năm ở cuối tên (VD: Southern
@@ -3714,21 +3595,14 @@ vi:
             Trưởng nhóm Delegate chịu trách nhiệm thực hiện các nhiệm vụ điều
             hành của giải đấu (nộp kết quả, báo cáo, nộp hội phí WCA)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: Trang chủ của giải đấu. Bắt buộc phải là đường dẫn http(s) hợp lệ.
           #original_hash: b2af5f5
           external_registration_page: >-
             Trang web dành cho thí sinh để đăng ký tham gia giải đấu. Bắt buộc
             phải điền một đường dẫn có hiệu lực.
-          #original_hash: da39a3e
-          uses_wca_registration: ''
           #original_hash: cc7d557
           scoretaking_software: 'Chọn ''%{choice_ilr}'' nếu muốn dùng Vòng thi kép'
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: Mã tiền tệ cho lệ phí.
@@ -3747,8 +3621,6 @@ vi:
             Hiện tại con số này chỉ mang tính thông báo, lệ phí cho khách mời
             không thể được quản lý qua trang này. Nếu được đặt bằng 0, một thông
             báo sẽ được hiển thị rằng khách mời có thể vào cửa miễn phí.
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: >-
             Hiện tại con số này chỉ mang tính thông báo, phần hoàn tiền sẽ được
@@ -3760,8 +3632,6 @@ vi:
         registration:
           #original_hash: 9965635
           opening_date_time: 'Ghi chú: Thời gian mở và đóng đơn đăng ký theo múi giờ UTC.'
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: >-
             Hạn cuối chấp nhận các thí sinh trên danh sach chờ. Nếu bạn có hạn
@@ -3774,16 +3644,6 @@ vi:
             trước khi đóng đơn đăng ký. Để trống ô này để cho phép thí sinh thêm
             nội dung cho đến khi nội dung tương ứng bắt đầu. Nếu bạn bật đăng ký
             tại chỗ, hạn cuối này phải đặt cùng ngày với giải đấu.
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: >-
             Số khách mời tối đa cho mỗi thí sinh cho giải đấu này. Các đơn đăng
@@ -3796,35 +3656,23 @@ vi:
             tiếng Anh</b> và bất kỳ ngôn ngữ nào thí sinh sử dụng; thông tin này
             sẽ được hiển thị trên trang thông tin của giải đấu, và trang đăng ký
             của WCA nếu được sử dụng.
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: >-
               Xin giải thích vì sao bạn không muốn thí sinh lần đầu tham gia
               đăng ký thi. Vui lòng điền bằng tiếng Anh!
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: >-
               Vui lòng nói rõ vì sao bạn muốn yêu cầu thí sinh nộp khối hình
               sớm. Vui lòng viết bằng tiếng Anh!
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: >-
               Vui lòng giải thích vì sao bạn muốn đặt giới hạn thời gian. Vui
               lòng viết bằng tiếng Anh!
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: >-
               Vui lòng giải thích vì sao bạn muốn giới hạn một số tổ hợp nội
@@ -3843,9 +3691,6 @@ vi:
         remarks: >-
           Thông tin bổ sung dành cho WCAT, ví dụ nếu còn thắc mắc hoặc yêu cầu
           đặc biệt dành cho WCAT. Vui lòng điền bằng tiếng Anh!
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -4922,8 +4767,6 @@ vi:
         paypal: >-
           Việc kết nối tài khoản PayPal cho phép website WCA trực tiếp cộng và
           trừ tiền (khi hoàn tiền) vào tài khoản PayPal của bạn.
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: >-
         Giải đấu này được cài đặt nhận lệ phí thi qua %{provider}. Delegate nên

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -258,8 +258,6 @@ zh-CN:
     333fm: 一小时
     #original_hash: cc7d8bb
     333mbf: 每魔方十分钟
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: 资格类型
@@ -788,8 +786,6 @@ zh-CN:
       text: 必填
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 请查看下列问题：
@@ -803,12 +799,6 @@ zh-CN:
         private_wrc_decision: WRC的最终裁决，包括非公开的资讯。请用英文填写。
         #original_hash: 3de5729
         public_summary: 关于意外事件以及其裁决的完整描述，并将公开显示。请用英文填写。
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: 按“YYYY-MM-DD"格式输入你的生日。
@@ -816,40 +806,18 @@ zh-CN:
         name: >-
           正确输入你的全名，比如<strong>Baiqiang Dong (董百强)</strong>。别偷懒只输入<strong>Baiqiang
           (百强)</strong>
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: 你需要等待WCA成绩组通过你上传的新头像。
         #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
         delegate_status: ''
         #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
         region: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
         #original_hash: 27c2251
         receive_delegate_reports: 如果您是高级代表、WRC或WQAC的成员，您会自动收到比赛报告。注：此变更可能得花一个小时才生效。
         #original_hash: 364624c
         delegate_reports_region: 如果您想要收到所有的报告，请在这个栏位留白(下拉式选单的最上面)。请注意：这个变更可能需要一个小时才会生效。
         #original_hash: 0627e5c
         otp_attempt: 请开启您的行动装置上的应用程式来取得一次性的密码，或是输入您其中一个备用码。
-        #original_hash: da39a3e
-        wca_id: ''
       competition:
         #original_hash: 2c812a0
         name: '比赛全名需在结尾包含年份（例：Danish Open 2016）。注意大小写。名字只能包含字母、数字、标点（-&.:''）和空格。'
@@ -946,12 +914,6 @@ zh-CN:
         #original_hash: da39a3e
         your_email: ''
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: 你正确的出生日期，格式为YYYY-MM-DD
         #original_hash: 49ee4af
@@ -987,12 +949,8 @@ zh-CN:
         #original_hash: 8af00aa
         setup_images: >-
           请至少选择 %{image_count} 张能够说明比赛现场设置的照片（如打乱区、比赛区等）。您可以一次选择多个文件。只有在上传足够数量的其他图片后，才能删除现有图片（如果您想替换某张图片，请先上传新的，再删除旧的）。
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: 列出希望WRC反馈的意外事件编号。
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: '请列出您希望WIC提供意见的事件编号清单。<br><strong>%{wic_incident_alert}</strong>'
         #original_hash: c4fd7a6
@@ -1001,13 +959,9 @@ zh-CN:
 
         #original_hash: f30abdc
         remarks: 说一说你想分享的其他方面（例：社群的提升，当地未来的计划等）。如果为了所谓的简洁性你有一些之前部分没提及的，尽情在这里说。
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 例如：交通、支付、奖项、住宿
-        #original_hash: da39a3e
-        content: ''
       person:
         #original_hash: 498f4c5
         dob: 生日必须是 YYYY-MM-DD 格式。
@@ -1018,22 +972,11 @@ zh-CN:
         #original_hash: da39a3e
         name: ''
         #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-        #original_hash: da39a3e
         wca_id: ''
         #original_hash: da39a3e
         incorrect_wca_id_claim_count: ''
         #original_hash: da39a3e
         person_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
       registration:
         #original_hash: da39a3e
         comments: ''
@@ -1041,26 +984,9 @@ zh-CN:
         guests: ''
         #original_hash: da39a3e
         status: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
       competition_medium:
         #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
         type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       results_submission:
         #original_hash: da39a3e
         schedule_url: ''
@@ -1068,27 +994,6 @@ zh-CN:
         results_file: ''
         #original_hash: da39a3e
         message: ''
-      regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
-        #original_hash: da39a3e
-        address: ''
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
       wfc:
         #original_hash: da39a3e
         from_date: ''
@@ -2455,22 +2360,14 @@ zh-CN:
         remarks: 备注
         clone_tabs: 我想复制所有 tab，连同额外信息
       hints:
-        admin:
-          is_confirmed: ''
-          is_visible: ''
-        competition_id: ''
         name: 比赛全名需在结尾包含年份（例：Danish Open 2016）。注意大小写。名字只能包含字母、数字、标点（-&.:'）和空格。
         short_name: 用于显示的短名。如果比赛名字已经很短了，你可以重复使用（例：Europe 2006）。
         name_reason_html:
         venue:
-          country_id: ''
           city_name: 比赛举办地的城市名和省份名（如果有的话）。不要包括国家/地区（例：Paris OR San Francisco, California）。
           name_html: 比赛举办的地点。%{md}。比如[Cité des Sciences et de l'Industrie](http://www.cite-sciences.fr)
           details_html: 详细地点（例：教学楼一楼）。%{md}
-          address: ''
           coordinates:
-        start_date: ''
-        end_date: ''
         information: 关于比赛人数限制、报名费、观众及其他相关细节的信息。
         competitor_limit:
           enabled: 目前这个数字只是纯展示，不会限制选手报名。我们在努力为注册流程添加人数限制的功能。
@@ -2483,45 +2380,31 @@ zh-CN:
           contact_html: 可选的联系信息。如果你不填写此项，将会显示主办方的邮件。%{md}。例：[Text to display](mailto:some@email.com)
         championships:
         website:
-          generate_website: ''
           external_website: 比赛官网。必须是一个合法的http(s)地址。
           external_registration_page:
-          uses_wca_registration: ''
           uses_wca_live: ''
-        user_settings:
-          receive_registration_emails: ''
         entry_fees:
           currency_code: 报名费的货币代码。
           base_entry_fee: 比赛的基础报名费。如果填写报名费，将在比赛信息页和报名页显示。如果设置为 0，将显示一句话，表示将免费接受报名。<br><br><b>免责声明：以下
             WCA 费用估算仅是基于当前汇率的近似值，费用没有任何法律约束力。</b>
           on_the_spot_entry_fee:
           guest_entry_fee:
-          donations_enabled: ''
           refund_policy_percent:
           refund_policy_limit_date:
         registration:
           opening_date_time: 注意：报名开放和结束是UTC时间
-          closing_date_time: ''
           waiting_list_deadline_date:
           event_change_deadline_date:
-          allow_on_the_spot: ''
           allow_self_delete_after_acceptance: ''
-          allow_self_edits: ''
-          guests_enabled: ''
-          guest_entry_status: ''
           guests_per_registration:
           extra_requirements:
           force_comment:
         event_restrictions:
           early_puzzle_submission:
-            enabled: ''
             reason:
           qualification_results:
-            enabled: ''
             reason:
-            allow_registration_without: ''
           event_limitation:
-            enabled: ''
             reason:
             per_registration_limit:
           main_event_id:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -273,8 +273,6 @@ zh-TW:
     333fm: 1小時
     #original_hash: cc7d8bb
     333mbf: 10分鐘/每顆，最多60分鐘
-    #original_hash: da39a3e
-    333mbo: ''
   qualification:
     #original_hash: a2b25bf
     type_label: 參賽資格取得方式
@@ -714,8 +712,6 @@ zh-TW:
       text: 必須
       #original_hash: df58248
       mark: '*'
-      #original_hash: da39a3e
-      html: ''
     error_notification:
       #original_hash: d70e9cb
       default_message: 請確認以下的問題：
@@ -729,12 +725,6 @@ zh-TW:
         private_wrc_decision: WRC的最終裁決，包括非公開的資訊。請用英文填寫。
         #original_hash: 3de5729
         public_summary: 關於意外事件以及其裁決的完整描述，並將公開顯示。請用英文填寫。
-        #original_hash: da39a3e
-        digest_worthy: ''
-        #original_hash: da39a3e
-        tags: ''
-        #original_hash: da39a3e
-        competition_id: ''
       user:
         #original_hash: 7588d71
         dob: 請依照YYYY-MM-DD格式輸入參賽者的出生年月日。
@@ -745,32 +735,10 @@ zh-TW:
           Chieh-Lun Chou </strong>。而不是<strong> Jay Chou（綽號）、Chou
           Chieh-Lun（姓名相反）或chiehlun chou（沒有大寫） </strong>。<br/>若名字有中間名(middle
           name)，則可以不用輸入。
-        #original_hash: da39a3e
-        email: ''
         #original_hash: 8a91e53
         pending_avatar: 上傳新的頭像之後，必須等待WCA成績組的審核。
-        #original_hash: da39a3e
-        country_iso2: ''
-        #original_hash: da39a3e
-        dob_verification: ''
-        #original_hash: da39a3e
-        gender: ''
-        #original_hash: da39a3e
-        login: ''
-        #original_hash: da39a3e
-        password: ''
-        #original_hash: da39a3e
-        password_confirmation: ''
-        #original_hash: da39a3e
-        remember_me: ''
-        #original_hash: da39a3e
-        results_notifications_enabled: ''
         #original_hash: f62eb10
         registration_notifications_enabled: 這只適用您是比賽的代表或是主辦團隊的時候，且可以在各別比賽中設定忽視此規則。
-        #original_hash: da39a3e
-        unconfirmed_wca_id: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 7ea7d12
         receive_developer_mails: >-
           此通知僅限於與資料匯出、WCIF 結構（schema）及公開 API
@@ -782,12 +750,6 @@ zh-TW:
         #original_hash: 0627e5c
         otp_attempt: 請開啟您的行動裝置上的應用程式來取得一次性的密碼，或是輸入您其中一個備用碼。
       dob_contact:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        your_email: ''
-        #original_hash: da39a3e
-        wca_id: ''
         #original_hash: 8723825
         dob: 將您的生日填成YYYY-MM-DD的格式
         #original_hash: 49ee4af
@@ -819,12 +781,8 @@ zh-TW:
         setup_images: >-
           您必須選擇 %{image_count}
           張能夠說明比賽現場打亂區、比賽區的照片等來自本次比賽的照片，最好是在比賽進行期間拍攝(其他照片也沒問題)。您可以一次選擇多個檔案。只有在上傳足夠數量的其他圖片後，才能刪除現有圖片（如果您想替換某張圖片，請先上傳新的，再刪除舊的）。如果您沒有最新的比賽區域和／或打亂區域的最新照片，請說明原因。
-        #original_hash: da39a3e
-        wrc_feedback_requested: ''
         #original_hash: 98bb5cd
         wrc_incidents: 列出希望WRC回饋的意外事件編號。
-        #original_hash: da39a3e
-        wic_feedback_requested: ''
         #original_hash: 74a092e
         wic_incidents_html: '請列出您希望WIC提供意見的事件編號清單。<br><strong>%{wic_incident_alert}</strong>'
         #original_hash: c4fd7a6
@@ -832,76 +790,20 @@ zh-TW:
           如果WIC事件內容較為敏感（包括但不限於犯罪、騷擾、攻擊等），請勿在報告中提及，並另行以電子郵件單獨聯繫WIC。對於其他WIC事件，請以簡要、匿名的方式進行描述，並私下向WIC補充詳細資訊。即使是匿名版本，WIC仍會提供意見以提升整體認識。若事件涉及WCA志工，請完全不要在報告中提及任何細節，務必私下聯繫WIC。
         #original_hash: f30abdc
         remarks: 分享任何關於比賽的其他細節(例如：進步/社群/這區域的未來展望)。如果您是為了讓前面章節比較簡潔而沒有提到一些事情，盡情在這邊留下評論。
-        #original_hash: da39a3e
-        discussion_url: ''
       competition_tab:
         #original_hash: e396d28
         name: 例如：交通、付款方式、獎品、住宿
-        #original_hash: da39a3e
-        content: ''
-      person:
-        #original_hash: da39a3e
-        person1_wca_id: ''
-        #original_hash: da39a3e
-        person2_wca_id: ''
-      poll:
-        #original_hash: da39a3e
-        comment: ''
-        #original_hash: da39a3e
-        multiple: ''
-        #original_hash: da39a3e
-        question: ''
-      vote:
-        #original_hash: da39a3e
-        comment: ''
-      competition_medium:
-        #original_hash: da39a3e
-        competition_id: ''
-        #original_hash: da39a3e
-        media_type: ''
-        #original_hash: da39a3e
-        text: ''
-        #original_hash: da39a3e
-        uri: ''
-        #original_hash: da39a3e
-        submitter_name: ''
-        #original_hash: da39a3e
-        submitter_email: ''
-        #original_hash: da39a3e
-        submitter_comment: ''
-        #original_hash: da39a3e
-        status: ''
       regional_organization:
-        #original_hash: da39a3e
-        name: ''
-        #original_hash: da39a3e
-        country: ''
         #original_hash: 72448d6
         website: 必須要是正確的http(s)網址。建議是HTTPS。
         #original_hash: 2ace571
         logo: 必須是PNG格式，有好的解析度，且背景是透明的。
         #original_hash: da54ab5
         email: 應該含有所有理事和專員的郵件清單。
-        #original_hash: da39a3e
-        address: ''
         #original_hash: 7d25ff5
         bylaws: 必須是PDF格式。
-        #original_hash: da39a3e
-        directors_and_officers: ''
-        #original_hash: da39a3e
-        area_description: ''
-        #original_hash: da39a3e
-        past_and_current_activities: ''
-        #original_hash: da39a3e
-        future_plans: ''
-        #original_hash: da39a3e
-        extra_information: ''
         #original_hash: 79555ff
         extra_file: 必須是PDF格式。如果您想要加入更多檔案，請合併檔案。
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
     options:
       registration:
         status:
@@ -2955,14 +2857,8 @@ zh-TW:
           clone_tabs: 我想要複製所有索引標籤以及當中的附加訊息
       hints:
         admin:
-          #original_hash: da39a3e
-          is_confirmed: ''
-          #original_hash: da39a3e
-          is_visible: ''
           #original_hash: 68d3cc6
           uses_new_registration_system: 如果停用這功能，更改報名系統會產生技術問題。如果您仍要更改報名系統請聯絡WCA軟體組來取得協助。
-        #original_hash: da39a3e
-        competition_id: ''
         #original_hash: 2c812a0
         name: >-
           比賽的全名且必須以年份為結尾（例如：All is Well
@@ -2974,8 +2870,6 @@ zh-TW:
           簡短解釋比賽名稱。名稱必須要符合<a
           href='https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf'>WCA比賽要求政策</a>
         venue:
-          #original_hash: da39a3e
-          country_id: ''
           #original_hash: bce4589
           city_name: 比賽舉行的城市或州（如果適用）。不要包含國家名稱（例如使用：Taipei、Taichung或Kaohsiung）。
           #original_hash: 9d9126e
@@ -2984,20 +2878,7 @@ zh-TW:
             University](https://www.ntnu.edu.tw/)
           #original_hash: 2651d1a
           details_html: '場地的細節（例如：一樓的正後方，跟隨指標走）%{md}'
-          #original_hash: da39a3e
-          address: ''
-          coordinates:
-            #original_hash: da39a3e
-            lat: ''
-            #original_hash: da39a3e
-            long: ''
-        #original_hash: da39a3e
-        start_date: ''
-        #original_hash: da39a3e
-        end_date: ''
         series:
-          #original_hash: da39a3e
-          series_id: ''
           #original_hash: 77811b5
           name: 系列賽比賽全名的最後有年份，（例如：Southern Australia 2022）。務必要首字母大寫。單獨比賽所用的名字規則也適用。
           #original_hash: 778c20c
@@ -3029,19 +2910,12 @@ zh-TW:
             可任意選擇聯絡資訊。若您未填寫，聯繫請求內容會由表格方式送出，主辦人的電子郵件將不會被顯示。%{md}
             範例：[顯示內容](mailto:some@email.com)
         website:
-          #original_hash: da39a3e
-          generate_website: ''
           #original_hash: cabe7fb
           external_website: 這場比賽的網站網站。必須為有效的http(s)網址。
           #original_hash: b2af5f5
           external_registration_page: 參賽者報名比賽的頁面，必須為有效的http(s)網址。
           #original_hash: da39a3e
-          uses_wca_registration: ''
-          #original_hash: da39a3e
           uses_wca_live: ''
-        user_settings:
-          #original_hash: da39a3e
-          receive_registration_emails: ''
         entry_fees:
           #original_hash: 9735ddf
           currency_code: 報名費的貨幣代碼。
@@ -3052,8 +2926,6 @@ zh-TW:
           on_the_spot_entry_fee: 如果此處設為0，會有一個句子表示現場報名為免費的。
           #original_hash: 0419547
           guest_entry_fee: 目前這個數字僅供顯示資訊用，本網站不處理陪同者入場費。如果此處設為0，可以選擇顯示一個觀眾政策的文字。
-          #original_hash: da39a3e
-          donations_enabled: ''
           #original_hash: 180b7b3
           refund_policy_percent: 目前這個數字僅供顯示資訊用，退費還是由人工處理。如果此處設為0，會有一個句子表示報名費在任何情況下皆不退費。
           #original_hash: f64d853
@@ -3061,52 +2933,28 @@ zh-TW:
         registration:
           #original_hash: 9965635
           opening_date_time: 備註：報名開始和結束時間採用UTC時間
-          #original_hash: da39a3e
-          closing_date_time: ''
           #original_hash: 664db64
           waiting_list_deadline_date: 不再接受候補名單的日期。如果您有退費的截止日期，不受理候補的日期不應該早於退費的截止日期。
           #original_hash: 75e6c1f
           event_change_deadline_date: >-
             在這個時間以前，參賽者都有權利聯絡主辦團隊更新報名的比賽項目。這個期限禁止設在報名截止之前。如果這裡留白，代表參賽者在該比賽項目開始之前都可以追加該比賽項目。如果允許現場報名，這個期限必須是比賽當天。
-          #original_hash: da39a3e
-          allow_on_the_spot: ''
-          #original_hash: da39a3e
-          competitor_can_cancel: ''
-          #original_hash: da39a3e
-          allow_self_edits: ''
-          #original_hash: da39a3e
-          guests_enabled: ''
-          #original_hash: da39a3e
-          guest_entry_status: ''
           #original_hash: 4b51faa
           guests_per_registration: 這個比賽每個參賽者所允許的陪同者人數。太多陪同者的報名會被擋下來。如果沒有人數限制，請留空白。
           #original_hash: 3de153b
           extra_requirements: >-
             請在此處說明任何以上未提及到的額外報名條件，例如有關如何支付。<br/>請用 <b>英文</b>
             和您當地參賽者使用的語言填寫此欄。它將顯示在比賽的資訊頁面上，如果您使用WCA網站報名，它也會顯示在報名頁面上。
-          #original_hash: da39a3e
-          force_comment: ''
         event_restrictions:
           forbid_newcomers:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d75332f
             reason: 請詳細說明為什麼您不希望新手報名您的比賽。填入請使用英文！
           early_puzzle_submission:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: 4e8488b
             reason: 請在這裡說明為什麼您希望參賽者提早繳交方塊。請用英文填寫！
           qualification_results:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: f859883
             reason: 請在這裡說明為什麼您希望設定特定成績。請用英文填寫！
-            #original_hash: da39a3e
-            allow_registration_without: ''
           event_limitation:
-            #original_hash: da39a3e
-            enabled: ''
             #original_hash: d3329d7
             reason: 請在這裡說明為什麼您希望設定禁止報名特定的項目組合。請用英文填寫！
             #original_hash: d09af8f
@@ -3116,9 +2964,6 @@ zh-TW:
           main_event_id: 這個項目的優勝參賽者將會是這場比賽的優勝參賽者
         #original_hash: 9ea6021
         remarks: 任何您想跟WCAT說明的事。例如，有疑問的事項，或是您想向WCAT請求特別事項。請用英文填寫！
-        cloning:
-          #original_hash: da39a3e
-          clone_tabs: ''
       choices:
         guests_enabled:
           #original_hash: cb8809d
@@ -3928,8 +3773,6 @@ zh-TW:
         stripe: 連結Stripe帳號能讓您在WCA網站上面做變更以及直接退款到您的Stripe帳號。
         #original_hash: 7cedd12
         paypal: 連結PayPal帳號到WCA網站能讓款項直接進入到您的戶頭，以及直接用您的PayPal帳號退款。
-        #original_hash: da39a3e
-        manual: ''
       #original_hash: ef7e7f6
       currently_connected_info: '這場比賽被設定成接受%{provider}的付款。這場比賽的WCA代表應該要聯絡比賽公告組 (WCAT)來做連結帳號的更改。'
       #original_hash: bc14f0f

--- a/lib/custom_wca_i18n_scanner.rb
+++ b/lib/custom_wca_i18n_scanner.rb
@@ -2,6 +2,17 @@
 
 unless Rails.env.production?
   require 'i18n/tasks/scanners/file_scanner'
+  require 'i18n/tasks/scanners/ruby_ast_scanner'
+
+  # `I18nUtils.optional_t` wraps `I18n.t`, which the built-in matchers only
+  # recognise when it is called as `t`/`I18n.t`. Without this the wrapped keys
+  # would look unused.
+  class OptionalTMatcher < I18n::Tasks::Scanners::AstMatchers::MessageReceiversMatcher
+    def initialize(scanner:)
+      super(scanner: scanner, receivers: [::AST::Node.new(:const, [nil, :I18nUtils])], message: :optional_t)
+    end
+  end
+
   class CustomWcaI18nScanner < I18n::Tasks::Scanners::FileScanner
     include I18n::Tasks::Scanners::RelativeKeys
     include I18n::Tasks::Scanners::OccurrenceFromPosition

--- a/lib/i18n_utils.rb
+++ b/lib/i18n_utils.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module I18nUtils
+  # For keys that are built from a dynamic value (an event ID, a payment provider)
+  # and only exist for some of those values. Absence is the intended state for the
+  # rest, so render nothing instead of "Translation missing: ...".
+  def self.optional_t(key, **)
+    I18n.t(key, **, default: "")
+  end
+
   def self.localized_sort_by!(wca_locale, array, &)
     # Unfortunately, it looks like the set of languages supported by
     # twitter-cldr-rb is not exactly the same as the languages we support, so I

--- a/lib/time_limit.rb
+++ b/lib/time_limit.rb
@@ -89,7 +89,9 @@ class TimeLimit
       if round.can_change_time_limit?
         time_str
       else
-        I18n.t "time_limit.#{round.event.id}"
+        # Not every unchangeable-limit event has wording for it (333mbo has
+        # none), so render nothing rather than "Translation missing: ...".
+        I18n.t("time_limit.#{round.event.id}", default: "")
       end
     when 1
       I18n.t("time_limit.cumulative.one_round", time: time_str)

--- a/lib/time_limit.rb
+++ b/lib/time_limit.rb
@@ -89,9 +89,7 @@ class TimeLimit
       if round.can_change_time_limit?
         time_str
       else
-        # Not every unchangeable-limit event has wording for it (333mbo has
-        # none), so render nothing rather than "Translation missing: ...".
-        I18n.t("time_limit.#{round.event.id}", default: "")
+        I18nUtils.optional_t("time_limit.#{round.event.id}")
       end
     when 1
       I18n.t("time_limit.cumulative.one_round", time: time_str)


### PR DESCRIPTION
There were 75 blank keys in the translations yaml:
- 45 simple form hints (already falls back to rendering nothing if omitted)
- 27 competition form hints (added a default value for `getFieldHint`)
- simple_form.required (we overrode this explicitly to not show a `*`, I changed the label instead)
- time_limit 333mbo (added default)
- connect_account_warning manual (added default)

This is another step to make sure our translations are up to standard so we can make use of already existing tools.