### PR TITLE
Add Newcomer Icon

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -323,7 +323,7 @@ class Registration < ApplicationRecord
   end
 
   def to_live_json
-    as_json(methods: %i[name country_iso2], only: %i[id user_id registrant_id])
+    as_json(methods: %i[name country_iso2 wca_id], only: %i[id user_id registrant_id])
   end
 
   def to_v2_json(admin: false, pii: false)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1446,6 +1446,8 @@ en:
         close: "Close"
         competitors_entered: "%{competitors_live_results_entered}/%{total_competitors} entered"
         round_locked: "locked"
+        #context: tooltip on an icon next to competitors who don't have a WCA ID yet
+        first_timer: "First-timer"
         edit: "Edit"
         results: "Results"
         registration: "Registration"

--- a/next-frontend/openapi/schemas/live/LiveCompetitor.yaml
+++ b/next-frontend/openapi/schemas/live/LiveCompetitor.yaml
@@ -5,6 +5,7 @@ required:
   - name
   - country_iso2
   - user_id
+  - wca_id
 properties:
   id:
     type: number
@@ -16,3 +17,6 @@ properties:
     type: string
   country_iso2:
     type: string
+  wca_id:
+    type: string
+    nullable: true

--- a/next-frontend/src/components/live/Cells.tsx
+++ b/next-frontend/src/components/live/Cells.tsx
@@ -1,5 +1,5 @@
 import { Format } from "@/lib/wca/data/formats";
-import { Box, Link, Table } from "@chakra-ui/react";
+import { Box, HStack, Icon, Link, Table } from "@chakra-ui/react";
 import { Stat, statColumnsForFormat } from "@/lib/live/statColumnsForFormat";
 import { rankingCellColorPalette } from "@/lib/live/rankingCellColorPalette";
 import { padSkipped } from "@/lib/live/padSkipped";
@@ -8,6 +8,7 @@ import { WithRecordTag } from "@/components/results/TableCells";
 import { Tooltip } from "@/components/ui/tooltip";
 import { LiveAttempt, LiveCompetitor, LiveResult } from "@/types/live";
 import { TFunction } from "i18next";
+import { LuPersonStanding } from "react-icons/lu";
 
 export function LiveTableHeader({
   isLinked = false,
@@ -122,25 +123,40 @@ export function LiveCompetitorCell({
   rowSpan,
   competitionId,
   competitor,
+  showFirstTimer = false,
+  t,
 }: {
   link?: boolean;
   rowSpan?: number;
   competitionId: string;
-  competitor: Pick<LiveCompetitor, "id" | "name">;
+  competitor: Pick<LiveCompetitor, "id" | "name" | "wca_id">;
+  showFirstTimer?: boolean;
+  t: TFunction;
 }) {
   return (
     <Table.Cell rowSpan={rowSpan}>
-      {link && (
-        <Link
-          href={`/competitions/${competitionId}/live/competitors/${competitor.id}`}
-          hideBelow="md"
-        >
+      <HStack gap={1}>
+        {link && (
+          <Link
+            href={`/competitions/${competitionId}/live/competitors/${competitor.id}`}
+            hideBelow="md"
+          >
+            {competitor.name}
+          </Link>
+        )}
+        <Box as="span" hideFrom={link ? "md" : undefined}>
           {competitor.name}
-        </Link>
-      )}
-      <Box as="span" hideFrom={link ? "md" : undefined}>
-        {competitor.name}
-      </Box>
+        </Box>
+        {showFirstTimer && !competitor.wca_id && (
+          <Tooltip
+            content={t("competitions.live.admin.first_timer")}
+            showArrow
+            openDelay={200}
+          >
+            <Icon as={LuPersonStanding} size="md" />
+          </Tooltip>
+        )}
+      </HStack>
     </Table.Cell>
   );
 }

--- a/next-frontend/src/components/live/LiveResultsTable.tsx
+++ b/next-frontend/src/components/live/LiveResultsTable.tsx
@@ -177,6 +177,8 @@ export default function LiveResultsTable({
                       competitor={competitorAndTheirResults}
                       rowSpan={rowSpan}
                       link={!isAdmin}
+                      showFirstTimer={isAdmin}
+                      t={t}
                     />
                   )}
                   {showText && (

--- a/next-frontend/src/lib/live/mergeAndOrderResults.test.ts
+++ b/next-frontend/src/lib/live/mergeAndOrderResults.test.ts
@@ -12,6 +12,7 @@ const makeCompetitor = (registrationId: number): LiveCompetitor => ({
   user_id: registrationId,
   name: `Competitor ${registrationId}`,
   country_iso2: "DE",
+  wca_id: null,
 });
 
 const makeCompetitorsMap = (

--- a/next-frontend/src/types/openapi.ts
+++ b/next-frontend/src/types/openapi.ts
@@ -1239,6 +1239,7 @@ export interface components {
             user_id: number;
             name: string;
             country_iso2: string;
+            wca_id: string | null;
         };
         LiveRound: components["schemas"]["BaseWcifRound"] & {
             results: components["schemas"]["RoundLiveResult"][];


### PR DESCRIPTION
This just shows the classic wca live new comer icon.
<img width="533" height="374" alt="Screenshot 2026-08-11 at 13 52 16" src="https://github.com/user-attachments/assets/e0c69cb6-0cd1-43a2-aa29-fae068964920" />

I have not added the "event newcomer" icon as described in #15323 as that is quite expensive to compute and I can't think of a cheap way to add it right now