### PR TITLE
Create Manage Registration Oauth scope

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 class Api::V1::ApiController < ApplicationController
+  protect_from_forgery with: :null_session
+
   prepend_before_action :require_user!
 
   def require_user!
     @current_user = current_user || api_user
     raise WcaExceptions::MustLogIn.new if @current_user.nil?
+  end
+
+  # Requests authenticated by a session cookie (i.e. our own Rails frontend) carry no token and
+  # so have no scopes to check. A request that authenticated with an OAuth token, on the other
+  # hand, may only do what that token was explicitly granted.
+  def token_has_scope?(scope)
+    doorkeeper_token.blank? || doorkeeper_token.scopes.include?(scope)
   end
 
   def require_manage!(competition)

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class Api::V1::RegistrationsController < Api::V1::ApiController
+  # Third-party OAuth clients have to be granted this explicitly before they may put anything
+  # into the registration queue on a user's behalf.
+  MANAGE_REGISTRATIONS_SCOPE = 'manage_registrations'
+
   skip_before_action :require_user!, only: [:index]
   # The order of the validations is important to not leak any non public info via the API
   # That's why we should always validate a request first, before taking any other before action
   # before_actions are triggered in the order they are defined
+  before_action :require_registration_scope!, only: %i[create update bulk_update bulk_auto_accept payment_ticket]
   before_action :user_can_create_registration, only: [:create]
   before_action :validate_create_request, only: [:create]
   before_action :ensure_registration_exists, only: [:show_by_user]
@@ -273,6 +278,11 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
   end
 
   private
+
+    def require_registration_scope!
+      raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless
+        token_has_scope?(MANAGE_REGISTRATIONS_SCOPE)
+    end
 
     def action_type(request)
       self_updating = request[:user_id] == @current_user

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,7 +7,7 @@ Doorkeeper.configure do
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
   default_scopes  :public
-  optional_scopes :dob, :email, :manage_competitions, :openid, :profile, :cms
+  optional_scopes :dob, :email, :manage_competitions, :manage_registrations, :openid, :profile, :cms
 
   base_controller 'ApplicationController'
   base_metal_controller 'ApplicationController'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -709,6 +709,7 @@ en:
         dob: 'Access your date of birth'
         email: 'Access your email address'
         manage_competitions: 'Manage any upcoming competitions you are organizing'
+        manage_registrations: 'Register you for competitions, and change or cancel your registrations'
 
     #context: Key used for sign in/sign up
     devise:

--- a/next-frontend/.env.development
+++ b/next-frontend/.env.development
@@ -1,7 +1,7 @@
 AUTH_SECRET="example-auth-secret" # Added by `npx auth`. Read more: https://cli.authjs.dev
 PREVIEW_SECRET="example-preview.secret"
 OIDC_ISSUER=http://wca_on_rails:3000 # Usually your local (Docker-internal!) Rails root URL
-OIDC_CLIENT_ID=example-application-id # Create an OAuth application in the monolith with (at least!) `public`, `oidc`, `profile` and `email` scopes
+OIDC_CLIENT_ID=example-application-id # Create an OAuth application in the monolith with (at least!) `public`, `oidc`, `profile`, `email` and `manage_registrations` scopes
 OIDC_CLIENT_SECRET=example-secret # See above
 DATABASE_URI=mongodb://wca_payload_db:27017/payload?retryWrites=false
 DATABASE_USER=root

--- a/next-frontend/src/auth.config.ts
+++ b/next-frontend/src/auth.config.ts
@@ -19,6 +19,11 @@ const baseWcaProvider: Provider = {
   issuer: WCA_OIDC_ISSUER,
   clientId: WCA_OIDC_CLIENT_ID,
   clientSecret: WCA_OIDC_CLIENT_SECRET,
+  // `manage_registrations` is what lets this frontend submit and edit registrations on the
+  //   signed-in user's behalf; without it the registration endpoints answer 403.
+  authorization: {
+    params: { scope: "openid profile email manage_registrations" },
+  },
   profile: (profile) => {
     return {
       id: profile.sub,

--- a/spec/requests/api_registrations_spec.rb
+++ b/spec/requests/api_registrations_spec.rb
@@ -8,6 +8,53 @@ WEBHOOK_REFUND_MOCK_ID = 're_3RiDX8I8ds2wj1dZ0RDaaCQg'
 RSpec.describe 'API Registrations' do
   include ActiveJob::TestHelper
 
+  # Writing to the registration endpoints requires the `manage_registrations` scope. These specs
+  # are about the registration logic rather than about scopes, so grant it by default and let the
+  # scope specs below opt out by passing their own scopes.
+  def api_sign_in_as(user, scopes: nil)
+    super(
+      user,
+      scopes: scopes || Doorkeeper::OAuth::Scopes.from_string(Api::V1::RegistrationsController::MANAGE_REGISTRATIONS_SCOPE),
+    )
+  end
+
+  describe 'OAuth scopes' do
+    let(:user) { create(:user) }
+    let(:competition) { create(:competition, :registration_open) }
+    let(:registration_request) { build(:registration_request, competition_id: competition.id, user_id: user.id) }
+
+    it 'rejects a token without the manage_registrations scope' do
+      api_sign_in_as(user, scopes: Doorkeeper::OAuth::Scopes.new)
+      post api_v1_competition_registrations_path(competition), params: registration_request
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body['error']).to eq Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS
+    end
+
+    it 'does not enqueue a registration for a token without the scope' do
+      expect do
+        api_sign_in_as(user, scopes: Doorkeeper::OAuth::Scopes.new)
+        post api_v1_competition_registrations_path(competition), params: registration_request
+      end.not_to have_enqueued_job(AddRegistrationJob)
+    end
+
+    it 'accepts a token carrying the manage_registrations scope' do
+      api_sign_in_as(user)
+      post api_v1_competition_registrations_path(competition), params: registration_request
+
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it 'does not require the scope for reading a registration' do
+      registration = create(:registration, competition: competition, user: user)
+
+      api_sign_in_as(user, scopes: Doorkeeper::OAuth::Scopes.new)
+      get api_v1_registration_path(registration)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe 'POST #create' do
     context 'when creating a registration' do
       let(:user) { create(:user) }


### PR DESCRIPTION
Currently we don't allow any cross site POST requests to our v1 APIs at all, but our goal for the future is to allow it. 
In our current development environment we also get an error because localhost:3000 and localhost:3001 are different. We will have the same issue testing out next registrations after I finished setting up the page.

This PR solves it by adding a manage_registration scope. This is currently not a public scope and can only be set by admins. We can give our nextjs superapp this scope so it can handle registrations on the frontend. 

When we start a third party registration Pilot (nothing stopping us after this apart from writing a guide) we can set it for specific apps.