### PR TITLE
Rename @current_user to @authenticated_user in v1 api controller

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,29 +3,33 @@
 class Api::V1::ApiController < ApplicationController
   prepend_before_action :require_user!
 
-  # Deliberately not `@current_user`: Devise memoises its own session-based user into that
-  # variable and wipes it whenever it handles an unverified request (see
+  # Deliberately not memoised into `@current_user`: Devise memoises its own session-based user
+  # into that variable and wipes it whenever it handles an unverified request (see
   # `Devise::Controllers::Helpers#handle_unverified_request`, which signs out every scope). A
   # token-authenticated request that trips CSRF would otherwise lose the user we just resolved
   # and dereference nil further down the callback chain. Note that no spec can catch this,
-  # because forgery protection is disabled in the test environment.
-  def require_user!
-    @authenticated_user = current_user || api_user
-    raise WcaExceptions::MustLogIn.new if @authenticated_user.nil?
+  # because forgery protection is disabled in the test environment. The `prepend_before_action`
+  # above forces this to resolve before `verify_authenticity_token` runs.
+  def authenticated_user
+    @authenticated_user ||= api_user || current_user
+  end
+
+  private def require_user!
+    raise WcaExceptions::MustLogIn.new if authenticated_user.nil?
   end
 
   def require_manage!(competition)
     require_user!
-    raise WcaExceptions::NotPermitted.new("Organizer privileges required") unless @authenticated_user.can_manage_competition?(competition)
+    raise WcaExceptions::NotPermitted.new("Organizer privileges required") unless authenticated_user.can_manage_competition?(competition)
   end
 
   def require_scoretake!(competition)
     require_user!
-    raise WcaExceptions::NotPermitted.new("Score taking privileges required") unless @authenticated_user.can_scoretake_competition?(competition)
+    raise WcaExceptions::NotPermitted.new("Score taking privileges required") unless authenticated_user.can_scoretake_competition?(competition)
   end
 
   def api_user
-    User.find_by(id: doorkeeper_token&.resource_owner_id) if doorkeeper_token&.accessible?
+    @api_user ||= User.find_by(id: doorkeeper_token&.resource_owner_id) if doorkeeper_token&.accessible?
   end
 
   def render_error(http_status, error, data = nil)

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -3,19 +3,25 @@
 class Api::V1::ApiController < ApplicationController
   prepend_before_action :require_user!
 
+  # Deliberately not `@current_user`: Devise memoises its own session-based user into that
+  # variable and wipes it whenever it handles an unverified request (see
+  # `Devise::Controllers::Helpers#handle_unverified_request`, which signs out every scope). A
+  # token-authenticated request that trips CSRF would otherwise lose the user we just resolved
+  # and dereference nil further down the callback chain. Note that no spec can catch this,
+  # because forgery protection is disabled in the test environment.
   def require_user!
-    @current_user = current_user || api_user
-    raise WcaExceptions::MustLogIn.new if @current_user.nil?
+    @authenticated_user = current_user || api_user
+    raise WcaExceptions::MustLogIn.new if @authenticated_user.nil?
   end
 
   def require_manage!(competition)
     require_user!
-    raise WcaExceptions::NotPermitted.new("Organizer privileges required") unless @current_user.can_manage_competition?(competition)
+    raise WcaExceptions::NotPermitted.new("Organizer privileges required") unless @authenticated_user.can_manage_competition?(competition)
   end
 
   def require_scoretake!(competition)
     require_user!
-    raise WcaExceptions::NotPermitted.new("Score taking privileges required") unless @current_user.can_scoretake_competition?(competition)
+    raise WcaExceptions::NotPermitted.new("Score taking privileges required") unless @authenticated_user.can_scoretake_competition?(competition)
   end
 
   def api_user

--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "Values cannot be 0, please omit them instead" }, status: :unprocessable_content if results.any? { it[:value].to_i.zero? }
 
-    UpdateLiveResultJob.perform_later(live_result, results, @authenticated_user.id)
+    UpdateLiveResultJob.perform_later(live_result, results, authenticated_user.id)
 
     render json: { status: "ok" }
   end
@@ -54,7 +54,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       { live_result: live_result, results: results }
     end
 
-    BatchUpdateLiveResultJob.perform_later(round, job_entries, @authenticated_user.id)
+    BatchUpdateLiveResultJob.perform_later(round, job_entries, authenticated_user.id)
 
     render json: { status: "ok" }
   end
@@ -107,7 +107,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "round is not open" }, status: :bad_request if state != Round::STATE_OPEN
 
-    recreated_rows = round.clear_round!(@authenticated_user)
+    recreated_rows = round.clear_round!(authenticated_user)
 
     render json: { status: "ok", recreated_rows: recreated_rows, state: round.lifecycle_state }
   end
@@ -150,7 +150,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       deleted
     end
 
-    result.live_result_history_entries.create(action_source: "live_results", action_type: "cleared", entered_by: @authenticated_user)
+    result.live_result_history_entries.create(action_source: "live_results", action_type: "cleared", entered_by: authenticated_user)
 
     render json: { status: "ok", deleted_attempts: delete_count }
   end
@@ -174,7 +174,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       return render json: { status: "regulation #{violation}: #{Round::INSUFFICIENT_COMPETITORS_MESSAGES[violation]}" }, status: :bad_request
     end
 
-    created_rows, locked_rows = round.open_and_lock_previous(@authenticated_user)
+    created_rows, locked_rows = round.open_and_lock_previous(authenticated_user)
 
     render json: { status: "ok", locked_rows: locked_rows, created_rows: created_rows, state: round.lifecycle_state }
   end
@@ -197,7 +197,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "The advancing competitor doesn't match who should be advancing.", should_advance: to_advance }, status: :bad_request if advancing_ids.present? && advancing_ids.map(&:to_i) != to_advance&.pluck(:registration_id)
 
-    quit_count = round.quit_from_round!(registration_id, @authenticated_user, to_advance: to_advance)
+    quit_count = round.quit_from_round!(registration_id, authenticated_user, to_advance: to_advance)
 
     render json: { status: "ok", quit: quit_count }
   end
@@ -219,7 +219,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "The advancing competitors don't match who should be advancing.", should_advance: to_advance }, status: :bad_request if advancing_ids.present? && advancing_ids.map(&:to_i) != to_advance&.pluck(:registration_id)
 
-    quit_count = round.bulk_quit_from_round!(registration_ids, @authenticated_user, to_advance: to_advance)
+    quit_count = round.bulk_quit_from_round!(registration_ids, authenticated_user, to_advance: to_advance)
 
     render json: { status: "ok", quit: quit_count }
   end

--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "Values cannot be 0, please omit them instead" }, status: :unprocessable_content if results.any? { it[:value].to_i.zero? }
 
-    UpdateLiveResultJob.perform_later(live_result, results, @current_user.id)
+    UpdateLiveResultJob.perform_later(live_result, results, @authenticated_user.id)
 
     render json: { status: "ok" }
   end
@@ -54,7 +54,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       { live_result: live_result, results: results }
     end
 
-    BatchUpdateLiveResultJob.perform_later(round, job_entries, @current_user.id)
+    BatchUpdateLiveResultJob.perform_later(round, job_entries, @authenticated_user.id)
 
     render json: { status: "ok" }
   end
@@ -107,7 +107,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "round is not open" }, status: :bad_request if state != Round::STATE_OPEN
 
-    recreated_rows = round.clear_round!(@current_user)
+    recreated_rows = round.clear_round!(@authenticated_user)
 
     render json: { status: "ok", recreated_rows: recreated_rows, state: round.lifecycle_state }
   end
@@ -150,7 +150,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       deleted
     end
 
-    result.live_result_history_entries.create(action_source: "live_results", action_type: "cleared", entered_by: @current_user)
+    result.live_result_history_entries.create(action_source: "live_results", action_type: "cleared", entered_by: @authenticated_user)
 
     render json: { status: "ok", deleted_attempts: delete_count }
   end
@@ -174,7 +174,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
       return render json: { status: "regulation #{violation}: #{Round::INSUFFICIENT_COMPETITORS_MESSAGES[violation]}" }, status: :bad_request
     end
 
-    created_rows, locked_rows = round.open_and_lock_previous(@current_user)
+    created_rows, locked_rows = round.open_and_lock_previous(@authenticated_user)
 
     render json: { status: "ok", locked_rows: locked_rows, created_rows: created_rows, state: round.lifecycle_state }
   end
@@ -197,7 +197,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "The advancing competitor doesn't match who should be advancing.", should_advance: to_advance }, status: :bad_request if advancing_ids.present? && advancing_ids.map(&:to_i) != to_advance&.pluck(:registration_id)
 
-    quit_count = round.quit_from_round!(registration_id, @current_user, to_advance: to_advance)
+    quit_count = round.quit_from_round!(registration_id, @authenticated_user, to_advance: to_advance)
 
     render json: { status: "ok", quit: quit_count }
   end
@@ -219,7 +219,7 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     return render json: { status: "The advancing competitors don't match who should be advancing.", should_advance: to_advance }, status: :bad_request if advancing_ids.present? && advancing_ids.map(&:to_i) != to_advance&.pluck(:registration_id)
 
-    quit_count = round.bulk_quit_from_round!(registration_ids, @current_user, to_advance: to_advance)
+    quit_count = round.bulk_quit_from_round!(registration_ids, @authenticated_user, to_advance: to_advance)
 
     render json: { status: "ok", quit: quit_count }
   end

--- a/app/controllers/api/v1/registration_history_controller.rb
+++ b/app/controllers/api/v1/registration_history_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::RegistrationHistoryController < Api::V1::ApiController
     registration_id = params.require(:registration_id)
     registration = Registration.find(registration_id)
 
-    return head :unauthorized unless @authenticated_user.id == registration.user_id || @authenticated_user.can_manage_competition?(registration.competition)
+    return head :unauthorized unless authenticated_user.id == registration.user_id || authenticated_user.can_manage_competition?(registration.competition)
 
     render json: registration.registration_history
   end

--- a/app/controllers/api/v1/registration_history_controller.rb
+++ b/app/controllers/api/v1/registration_history_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::RegistrationHistoryController < Api::V1::ApiController
     registration_id = params.require(:registration_id)
     registration = Registration.find(registration_id)
 
-    return head :unauthorized unless @current_user.id == registration.user_id || @current_user.can_manage_competition?(registration.competition)
+    return head :unauthorized unless @authenticated_user.id == registration.user_id || @authenticated_user.can_manage_competition?(registration.competition)
 
     render json: registration.registration_history
   end

--- a/app/controllers/api/v1/registration_payments_controller.rb
+++ b/app/controllers/api/v1/registration_payments_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::RegistrationPaymentsController < Api::V1::ApiController
     registration_id = params.require(:registration_id)
     registration = Registration.includes(:competition, registration_payments: [:refunding_registration_payments]).find(registration_id)
 
-    return head :unauthorized unless @authenticated_user.id == registration.user_id || @authenticated_user.can_manage_competition?(registration.competition)
+    return head :unauthorized unless authenticated_user.id == registration.user_id || authenticated_user.can_manage_competition?(registration.competition)
 
     # Use `filter` here on purpose because the whole `registration_payments` list has been included above.
     #   Using `where` would create an SQL query, but it would also break (i.e. make redundant) the `includes` call above.

--- a/app/controllers/api/v1/registration_payments_controller.rb
+++ b/app/controllers/api/v1/registration_payments_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::RegistrationPaymentsController < Api::V1::ApiController
     registration_id = params.require(:registration_id)
     registration = Registration.includes(:competition, registration_payments: [:refunding_registration_payments]).find(registration_id)
 
-    return head :unauthorized unless @current_user.id == registration.user_id || @current_user.can_manage_competition?(registration.competition)
+    return head :unauthorized unless @authenticated_user.id == registration.user_id || @authenticated_user.can_manage_competition?(registration.competition)
 
     # Use `filter` here on purpose because the whole `registration_payments` list has been included above.
     #   Using `where` would create an SQL query, but it would also break (i.e. make redundant) the `includes` call above.

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     @competition_id = @registration.competition_id
     @competition = @registration.competition
     @user_id = @registration.user_id
-    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.id == @user_id || @authenticated_user.can_manage_competition?(@competition)
+    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless authenticated_user.id == @user_id || authenticated_user.can_manage_competition?(@competition)
   end
 
   def show
@@ -69,7 +69,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
 
   def validate_show_registration_by_user
     @competition = Competition.find(@competition_id)
-    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.id == @user_id || @authenticated_user.can_manage_competition?(@competition)
+    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless authenticated_user.id == @user_id || authenticated_user.can_manage_competition?(@competition)
   end
 
   def show_by_user
@@ -78,7 +78,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
 
   def registration_config
     competition = Competition.find(params.require(:id))
-    render json: competition.available_registration_lanes(@authenticated_user)
+    render json: competition.available_registration_lanes(authenticated_user)
   end
 
   def create
@@ -106,10 +106,10 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
       Registration.exists?(competition: @competition, user: @target_user)
 
     # Only the user themselves can create a registration for the user
-    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.id == @target_user.id
+    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless authenticated_user.id == @target_user.id
 
     # Only organizers can register when registration is closed
-    raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) unless @competition.registration_currently_open? || @authenticated_user.can_manage_competition?(@competition)
+    raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) unless @competition.registration_currently_open? || authenticated_user.can_manage_competition?(@competition)
 
     # Users must have the necessary permissions to compete - eg, they cannot be banned or have incomplete profiles
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_CANNOT_COMPETE) unless @target_user.cannot_register_for_competition_reasons(@competition).empty?
@@ -121,7 +121,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
 
   def update
     if params[:competing]
-      @registration.update_lanes!(@request, @authenticated_user.id)
+      @registration.update_lanes!(@request, authenticated_user.id)
       return render json: { status: 'ok', registration: @registration.to_v2_json(admin: true) }, status: :ok
     end
     render json: { status: 'bad request', message: 'You need to supply at least one lane' }, status: :bad_request
@@ -141,21 +141,21 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     target_user = @registration.user
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless
-      can_administer_or_current_user?(@competition, @authenticated_user, target_user)
+      can_administer_or_current_user?(@competition, authenticated_user, target_user)
 
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::USER_EDITS_NOT_ALLOWED) unless
-      @competition.registration_edits_currently_permitted? || @authenticated_user.can_manage_competition?(@competition) || user_uncancelling_registration?(@registration, new_status)
+      @competition.registration_edits_currently_permitted? || authenticated_user.can_manage_competition?(@competition) || user_uncancelling_registration?(@registration, new_status)
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::REGISTRATION_IS_REJECTED) if
-      user_is_rejected?(@authenticated_user, target_user, @registration) && !organizer_modifying_own_registration?(@competition, @authenticated_user, target_user)
+      user_is_rejected?(authenticated_user, target_user, @registration) && !organizer_modifying_own_registration?(@competition, authenticated_user, target_user)
 
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
-      existing_registration_in_series?(@competition, target_user) && !@authenticated_user.can_manage_competition?(@competition)
+      existing_registration_in_series?(@competition, target_user) && !authenticated_user.can_manage_competition?(@competition)
 
-    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_admin_fields?(@request) && !@authenticated_user.can_manage_competition?(@competition)
+    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_admin_fields?(@request) && !authenticated_user.can_manage_competition?(@competition)
 
     # The rest of these are status + normal user related
-    return if @authenticated_user.can_manage_competition?(@competition)
+    return if authenticated_user.can_manage_competition?(@competition)
     return if new_status.nil?
 
     # A competitor (ie, these restrictions don't apply to organizers) is only allowed to:
@@ -195,7 +195,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
       will_exceed_competitor_limit?(@update_requests, @competition)
 
     raise WcaExceptions::BulkUpdateError.new(:unauthorized, [Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS]) unless
-      @authenticated_user.can_manage_competition?(@competition)
+      authenticated_user.can_manage_competition?(@competition)
   end
 
   def validate_bulk_update_request
@@ -220,7 +220,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     updated_registrations = {}
 
     @update_requests.each do |update|
-      updated_registrations[update['user_id']] = Registrations::Lanes::Competing.update_raw!(update, @competition, @authenticated_user.id)
+      updated_registrations[update['user_id']] = Registrations::Lanes::Competing.update_raw!(update, @competition, authenticated_user.id)
     end
 
     render json: { status: 'ok', updated_registrations: updated_registrations }
@@ -231,7 +231,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     competition_id = params_competition_id
     @competition = Competition.find(competition_id)
 
-    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.can_manage_competition?(@competition)
+    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless authenticated_user.can_manage_competition?(@competition)
   end
 
   def index_admin
@@ -268,14 +268,14 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     # in the long-term we want to decouple registrations from payments, so I'm deliberately not introducing any more tight coupling
     ruby_money = @registration.entry_fee_with_donation(iso_donation_amount)
     payment_account = @competition.payment_account_for(:stripe)
-    payment_intent = payment_account.prepare_intent(@registration, ruby_money.cents, ruby_money.currency.iso_code, @authenticated_user)
+    payment_intent = payment_account.prepare_intent(@registration, ruby_money.cents, ruby_money.currency.iso_code, authenticated_user)
     render json: { client_secret: payment_intent.client_secret }
   end
 
   private
 
     def action_type(request)
-      self_updating = request[:user_id] == @authenticated_user
+      self_updating = request[:user_id] == authenticated_user
       status = request.dig('competing', 'status')
       if status == 'cancelled'
         return self_updating ? 'Competitor delete' : 'Admin delete'

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -275,7 +275,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
   private
 
     def action_type(request)
-      self_updating = request[:user_id] == authenticated_user
+      self_updating = request[:user_id] == authenticated_user.id
       status = request.dig('competing', 'status')
       if status == 'cancelled'
         return self_updating ? 'Competitor delete' : 'Admin delete'

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     @competition_id = @registration.competition_id
     @competition = @registration.competition
     @user_id = @registration.user_id
-    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @current_user.id == @user_id || @current_user.can_manage_competition?(@competition)
+    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.id == @user_id || @authenticated_user.can_manage_competition?(@competition)
   end
 
   def show
@@ -69,7 +69,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
 
   def validate_show_registration_by_user
     @competition = Competition.find(@competition_id)
-    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @current_user.id == @user_id || @current_user.can_manage_competition?(@competition)
+    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.id == @user_id || @authenticated_user.can_manage_competition?(@competition)
   end
 
   def show_by_user
@@ -78,7 +78,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
 
   def registration_config
     competition = Competition.find(params.require(:id))
-    render json: competition.available_registration_lanes(@current_user)
+    render json: competition.available_registration_lanes(@authenticated_user)
   end
 
   def create
@@ -106,10 +106,10 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
       Registration.exists?(competition: @competition, user: @target_user)
 
     # Only the user themselves can create a registration for the user
-    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @current_user.id == @target_user.id
+    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.id == @target_user.id
 
     # Only organizers can register when registration is closed
-    raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) unless @competition.registration_currently_open? || @current_user.can_manage_competition?(@competition)
+    raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::REGISTRATION_CLOSED) unless @competition.registration_currently_open? || @authenticated_user.can_manage_competition?(@competition)
 
     # Users must have the necessary permissions to compete - eg, they cannot be banned or have incomplete profiles
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_CANNOT_COMPETE) unless @target_user.cannot_register_for_competition_reasons(@competition).empty?
@@ -121,7 +121,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
 
   def update
     if params[:competing]
-      @registration.update_lanes!(@request, @current_user.id)
+      @registration.update_lanes!(@request, @authenticated_user.id)
       return render json: { status: 'ok', registration: @registration.to_v2_json(admin: true) }, status: :ok
     end
     render json: { status: 'bad request', message: 'You need to supply at least one lane' }, status: :bad_request
@@ -141,21 +141,21 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     target_user = @registration.user
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless
-      can_administer_or_current_user?(@competition, @current_user, target_user)
+      can_administer_or_current_user?(@competition, @authenticated_user, target_user)
 
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::USER_EDITS_NOT_ALLOWED) unless
-      @competition.registration_edits_currently_permitted? || @current_user.can_manage_competition?(@competition) || user_uncancelling_registration?(@registration, new_status)
+      @competition.registration_edits_currently_permitted? || @authenticated_user.can_manage_competition?(@competition) || user_uncancelling_registration?(@registration, new_status)
 
     raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::REGISTRATION_IS_REJECTED) if
-      user_is_rejected?(@current_user, target_user, @registration) && !organizer_modifying_own_registration?(@competition, @current_user, target_user)
+      user_is_rejected?(@authenticated_user, target_user, @registration) && !organizer_modifying_own_registration?(@competition, @authenticated_user, target_user)
 
     raise WcaExceptions::RegistrationError.new(:forbidden, Registrations::ErrorCodes::ALREADY_REGISTERED_IN_SERIES) if
-      existing_registration_in_series?(@competition, target_user) && !@current_user.can_manage_competition?(@competition)
+      existing_registration_in_series?(@competition, target_user) && !@authenticated_user.can_manage_competition?(@competition)
 
-    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_admin_fields?(@request) && !@current_user.can_manage_competition?(@competition)
+    raise WcaExceptions::RegistrationError.new(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) if contains_admin_fields?(@request) && !@authenticated_user.can_manage_competition?(@competition)
 
     # The rest of these are status + normal user related
-    return if @current_user.can_manage_competition?(@competition)
+    return if @authenticated_user.can_manage_competition?(@competition)
     return if new_status.nil?
 
     # A competitor (ie, these restrictions don't apply to organizers) is only allowed to:
@@ -195,7 +195,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
       will_exceed_competitor_limit?(@update_requests, @competition)
 
     raise WcaExceptions::BulkUpdateError.new(:unauthorized, [Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS]) unless
-      @current_user.can_manage_competition?(@competition)
+      @authenticated_user.can_manage_competition?(@competition)
   end
 
   def validate_bulk_update_request
@@ -220,7 +220,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     updated_registrations = {}
 
     @update_requests.each do |update|
-      updated_registrations[update['user_id']] = Registrations::Lanes::Competing.update_raw!(update, @competition, @current_user.id)
+      updated_registrations[update['user_id']] = Registrations::Lanes::Competing.update_raw!(update, @competition, @authenticated_user.id)
     end
 
     render json: { status: 'ok', updated_registrations: updated_registrations }
@@ -231,7 +231,7 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     competition_id = params_competition_id
     @competition = Competition.find(competition_id)
 
-    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @current_user.can_manage_competition?(@competition)
+    render_error(:unauthorized, Registrations::ErrorCodes::USER_INSUFFICIENT_PERMISSIONS) unless @authenticated_user.can_manage_competition?(@competition)
   end
 
   def index_admin
@@ -268,14 +268,14 @@ class Api::V1::RegistrationsController < Api::V1::ApiController
     # in the long-term we want to decouple registrations from payments, so I'm deliberately not introducing any more tight coupling
     ruby_money = @registration.entry_fee_with_donation(iso_donation_amount)
     payment_account = @competition.payment_account_for(:stripe)
-    payment_intent = payment_account.prepare_intent(@registration, ruby_money.cents, ruby_money.currency.iso_code, @current_user)
+    payment_intent = payment_account.prepare_intent(@registration, ruby_money.cents, ruby_money.currency.iso_code, @authenticated_user)
     render json: { client_secret: payment_intent.client_secret }
   end
 
   private
 
     def action_type(request)
-      self_updating = request[:user_id] == @current_user
+      self_updating = request[:user_id] == @authenticated_user
       status = request.dig('competing', 'status')
       if status == 'cancelled'
         return self_updating ? 'Competitor delete' : 'Admin delete'


### PR DESCRIPTION
I noticed this when working off #15340 in my local branch. Devise already sets `@current_user`, but then resets it when you use the `null_session` csrf protection. So setting `@current_user` ourselves before gets reset

This PR renames it to `@authenticated_user`. 

This PR has to be merged before (or with) #15340!