### PR TITLE
Add validation for country during registration import

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -170,7 +170,10 @@ class RegistrationsController < ApplicationController
       end
     end
 
+    invalid_countries = csv_rows.pluck(:country).reject { |c| Country.c_find(c) }.uniq
+
     [
+      invalid_countries.map { |c| I18n.t("registrations.import.errors.invalid_country", country: c) },
       event_column_errors,
       validate_dob_formats(csv_rows.pluck(:birth_date)),
       validate_no_duplicates(csv_rows.pluck(:email), 'email_duplicates', :emails),

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -170,7 +170,7 @@ class RegistrationsController < ApplicationController
       end
     end
 
-    invalid_countries = csv_rows.pluck(:country).reject { |c| Country.c_find(c) }.uniq
+    invalid_countries = csv_rows.pluck(:country).uniq - Country::WCA_COUNTRY_IDS
 
     [
       invalid_countries.map { |c| I18n.t("registrations.import.errors.invalid_country", country: c) },
@@ -183,7 +183,7 @@ class RegistrationsController < ApplicationController
 
   private def validate_registrations(registration_rows, competition)
     # Validate country codes
-    invalid_countries = registration_rows.filter_map { |e| e[:countryIso2] }.uniq.reject { |iso2| Country.c_find_by_iso2(iso2) }
+    invalid_countries = registration_rows.pluck(:countryIso2).compact_blank.uniq - Country::WCA_COUNTRY_ISO_CODES
 
     # Validate event IDs against competition events
     valid_event_ids = competition.competition_events.pluck(:event_id)
@@ -191,7 +191,7 @@ class RegistrationsController < ApplicationController
     invalid_event_ids = all_event_ids - valid_event_ids
 
     [
-      invalid_countries.any? && "Invalid country codes: #{invalid_countries.join(', ')}",
+      invalid_countries.map { |c| I18n.t("registrations.import.errors.invalid_country", country: c) },
       invalid_event_ids.any? && "Invalid event IDs for this competition: #{invalid_event_ids.join(', ')}",
       validate_dob_formats(registration_rows.filter_map { |e| e[:birthdate] }),
       validate_no_duplicates(registration_rows.filter_map { |e| e[:email]&.downcase }, 'email_duplicates', :emails),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1356,6 +1356,7 @@ en:
         email_duplicates: "Email must be unique, found the following duplicates: %{emails}."
         wca_id_duplicates: "WCA ID must be unique, found the following duplicates: %{wca_ids}."
         wrong_dob_format: "Birthdate must follow the YYYY-mm-dd format (year-month-day, for example 1944-07-13), found the following dates which cannot be parsed: %{raw_dobs}."
+        invalid_country: "Invalid country: %{country}."
         empty_file: "The file is empty."
     add:
       title: "Add registration for %{comp}"

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "registrations" do
           post competition_registrations_do_import_path(competition), params: { registrations: registrations }, as: :json
         end.not_to(change { competition.registrations.count })
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to include "Invalid country codes: XX"
+        expect(response.body).to include I18n.t("registrations.import.errors.invalid_country", country: "XX")
       end
 
       it "renders an error when there are invalid event IDs" do


### PR DESCRIPTION
This is to help delegates to understand the error properly when they import a CSV with wrong country.