### PR TITLE
Fix two wcif validation errors

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1957,7 +1957,7 @@ class Competition < ApplicationRecord
     end
     # NOTE: unregistered managers may generate N+1 queries on their personal bests,
     # but that's fine because there are very few of them!
-    persons_wcif + managers.map { it.to_wcif(self, authorized: authorized) }
+    persons_wcif + managers.map { it.to_wcif(self, authorized: authorized, version: version) }
   end
 
   def events_wcif(version: WCIF_STABLE_VERSION, include_results: true)

--- a/app/models/schedule_activity.rb
+++ b/app/models/schedule_activity.rb
@@ -194,6 +194,8 @@ class ScheduleActivity < ApplicationRecord
         "startTime" => { "type" => "string" },
         "endTime" => { "type" => "string" },
         "childActivities" => { "type" => "array", "items" => { "$ref" => "activity" } },
+        # NOTE: accepted for WCIF spec compliance, but ignored on import (see the scramble_set_id TODO above).
+        "scrambleSetId" => { "type" => %w[integer null] },
         "extensions" => { "type" => "array", "items" => WcifExtension.wcif_json_schema },
       },
       "required" => %w[id name activityCode startTime endTime childActivities],

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -930,6 +930,20 @@ RSpec.describe "Competition WCIF" do
         end.not_to raise_error
       end
 
+      it "passes when an unregistered manager has personal bests" do
+        create(:ranks_single, person_id: delegate.wca_id)
+
+        wcif = competition.to_wcif(version: '2.0.0')
+        manager_wcif = wcif["persons"].find { it["wcaUserId"] == delegate.id }
+
+        expect(manager_wcif["registration"]).to be_nil
+        expect(manager_wcif["personalBests"].first).to include("value")
+
+        expect do
+          Competition.validate_wcif_schema!(wcif, version: '2.0.0')
+        end.not_to raise_error
+      end
+
       it "passes when activities carry a scrambleSetId" do
         wcif = competition.to_wcif
         wcif["schedule"]["venues"].first["rooms"].first["activities"].first["scrambleSetId"] = nil

--- a/spec/models/competition_wcif_spec.rb
+++ b/spec/models/competition_wcif_spec.rb
@@ -930,6 +930,15 @@ RSpec.describe "Competition WCIF" do
         end.not_to raise_error
       end
 
+      it "passes when activities carry a scrambleSetId" do
+        wcif = competition.to_wcif
+        wcif["schedule"]["venues"].first["rooms"].first["activities"].first["scrambleSetId"] = nil
+
+        expect do
+          Competition.validate_wcif_schema!(wcif)
+        end.not_to raise_error
+      end
+
       it "does not pass on cross-version schema" do
         expect do
           Competition.validate_wcif_schema!(


### PR DESCRIPTION
1. scrambleSetId is listed as required by the spec, but we didn't have it in the validation
2. version wasn't passed for unregistered managers, so they still have best instead of value

This is currently blocking so I might hotfix this if I don't get a review, but I wanted to have this documented