### PR TITLE
Don't show synchronize message when using ILR

### DIFF
--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
@@ -12,6 +12,7 @@ export default function ImportWcaLiveResults({
   uploadedScrambleFilesCount,
   isAdminView,
   onImportSuccess,
+  scoretakingSoftware,
 }) {
   const [markResultSubmitted, setMarkResultSubmitted] = useCheckboxState(isAdminView);
 
@@ -37,13 +38,20 @@ export default function ImportWcaLiveResults({
           <Message.Item>
             You may use this feature to import results from WCA Live or Integrated Live Results.
           </Message.Item>
-          <Message.Item>
-            If you are using WCA Live, make sure to hit
-            {' '}
-            <b>&quot;Synchronize&quot;</b>
-            {' '}
-            first. This button can only use results which have been synchronized!
-          </Message.Item>
+          {scoretakingSoftware === 'wca_live' && (
+            <Message.Item>
+              If you are using WCA Live, make sure to hit
+              {' '}
+              <b>&quot;Synchronize&quot;</b>
+              {' '}
+              first. This button can only use results which have been synchronized!
+            </Message.Item>
+          )}
+          {scoretakingSoftware === 'internal' && (
+            <Message.Item>
+              Make sure that every competitor has a result, then press &#39;Import Live Results&#39;
+            </Message.Item>
+          )}
           <Message.Item>
             Don&apos;t forget to also
             {' '}

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
@@ -49,7 +49,8 @@ export default function ImportWcaLiveResults({
           )}
           {scoretakingSoftware === 'internal' && (
             <Message.Item>
-              Make sure that every competitor has a result, then press &#39;Import Live Results&#39;
+              Make sure that every competitor has a result, then press
+              &quot;Import Live Results&quot;
             </Message.Item>
           )}
           <Message.Item>

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/index.jsx
@@ -35,6 +35,7 @@ export default function ImportResultsData({
             uploadedScrambleFilesCount={uploadedScrambleFilesCount}
             isAdminView={isAdminView}
             onImportSuccess={onImportSuccess}
+            scoretakingSoftware={scoretakingSoftware}
           />
         </Tab.Pane>
       ),


### PR DESCRIPTION
Only show
```
<Message.Item>
  If you are using WCA Live, make sure to hit
  {' '}
  <b>&quot;Synchronize&quot;</b>
  {' '}
  first. This button can only use results which have been synchronized!
</Message.Item>
```
if they are actually using wca live.
I replaced it with
```
<Message.Item>
  Make sure that every competitor has a result, then press &#39;Import Live Results&#39;
</Message.Item>
```
but open to not display anything