### PR TITLE
Correctly write logs in their own cloudwatch groups

### DIFF
--- a/infra/wca_on_rails/production/anycable.tf
+++ b/infra/wca_on_rails/production/anycable.tf
@@ -34,6 +34,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "anycable" {
   name = "${var.name_prefix}-anycable"
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "anycable" {

--- a/infra/wca_on_rails/production/anycable.tf
+++ b/infra/wca_on_rails/production/anycable.tf
@@ -66,7 +66,7 @@ resource "aws_ecs_task_definition" "anycable" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.anycable.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }

--- a/infra/wca_on_rails/production/auxiliary_services.tf
+++ b/infra/wca_on_rails/production/auxiliary_services.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "auxiliary" {
   name = "${var.name_prefix}-auxiliary"
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "auxiliary" {

--- a/infra/wca_on_rails/production/auxiliary_services.tf
+++ b/infra/wca_on_rails/production/auxiliary_services.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "auxiliary" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.auxiliary.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }
@@ -55,7 +55,7 @@ resource "aws_ecs_task_definition" "auxiliary" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.auxiliary.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }

--- a/infra/wca_on_rails/production/nextjs.tf
+++ b/infra/wca_on_rails/production/nextjs.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "nextjs" {
   name = "${var.name_prefix}-next"
+  retention_in_days = 30
 }
 
 locals {

--- a/infra/wca_on_rails/production/nextjs.tf
+++ b/infra/wca_on_rails/production/nextjs.tf
@@ -145,7 +145,7 @@ resource "aws_ecs_task_definition" "nextjs" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.nextjs.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }
@@ -196,7 +196,7 @@ resource "aws_ecs_task_definition" "nextjs_live_results" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.nextjs.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }

--- a/infra/wca_on_rails/production/worker.tf
+++ b/infra/wca_on_rails/production/worker.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "worker" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.worker.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }

--- a/infra/wca_on_rails/production/worker.tf
+++ b/infra/wca_on_rails/production/worker.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "worker" {
   name = "${var.name_prefix}-sqs-worker"
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "worker" {

--- a/infra/wca_on_rails/shared/ecs.tf
+++ b/infra/wca_on_rails/shared/ecs.tf
@@ -294,6 +294,28 @@ resource "aws_ecr_lifecycle_policy" "this" {
   })
 }
 
+resource "aws_ecr_lifecycle_policy" "nextjs" {
+  repository = aws_ecr_repository.nextjs.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire images older than 14 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
 output "ecr_repository" {
   value = aws_ecr_repository.this
 }

--- a/infra/wca_on_rails/staging/anycable.tf
+++ b/infra/wca_on_rails/staging/anycable.tf
@@ -32,7 +32,8 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "anycable" {
-  name = "${var.name_prefix}-anycable"
+  name              = "${var.name_prefix}-anycable"
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "anycable" {
@@ -65,7 +66,7 @@ resource "aws_ecs_task_definition" "anycable" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.anycable.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }

--- a/infra/wca_on_rails/staging/auxiliary_services.tf
+++ b/infra/wca_on_rails/staging/auxiliary_services.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "auxiliary" {
-  name = "${var.name_prefix}-auxiliary"
+  name              = "${var.name_prefix}-auxiliary"
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "auxiliary" {
@@ -31,7 +32,7 @@ resource "aws_ecs_task_definition" "auxiliary" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.auxiliary.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }
@@ -59,7 +60,7 @@ resource "aws_ecs_task_definition" "auxiliary" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.auxiliary.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }

--- a/infra/wca_on_rails/staging/nextjs.tf
+++ b/infra/wca_on_rails/staging/nextjs.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "nextjs" {
-  name = "${var.name_prefix}-next"
+  name              = "${var.name_prefix}-next"
+  retention_in_days = 30
 }
 
 locals {
@@ -131,7 +132,7 @@ resource "aws_ecs_task_definition" "nextjs" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.nextjs.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }

--- a/infra/wca_on_rails/staging/rails.tf
+++ b/infra/wca_on_rails/staging/rails.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "this" {
-  name = var.name_prefix
+  name              = var.name_prefix
+  retention_in_days = 30
 }
 
 locals {

--- a/infra/wca_on_rails/staging/worker.tf
+++ b/infra/wca_on_rails/staging/worker.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "worker" {
-  name = "${var.name_prefix}-sqs-worker"
+  name              = "${var.name_prefix}-sqs-worker"
+  retention_in_days = 30
 }
 
 resource "aws_ecs_task_definition" "worker" {
@@ -27,7 +28,7 @@ resource "aws_ecs_task_definition" "worker" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-group         = aws_cloudwatch_log_group.worker.name
           awslogs-region        = var.region
           awslogs-stream-prefix = var.name_prefix
         }


### PR DESCRIPTION
I noticed that we were writing every prod log into the same cloudwatch prod group, even though we created separate ones for each service (sqs, anycable, sidekiq, etc.)

Bonus: adds expiry to log groups and ecs images that were missing it.

This does NOT add an expiry to the 700GB rails log group. We need to decide on what we do with that and how long we should keep logs