### PR TITLE
Add the numeric WCA user id to the AuthJS session

### DIFF
--- a/next-frontend/src/auth.config.ts
+++ b/next-frontend/src/auth.config.ts
@@ -29,6 +29,9 @@ const baseWcaProvider: Provider = {
       image: profile.picture,
       roles: profile.roles,
       wcaId: profile.preferred_username,
+      // AuthJS overwrites `id` with a random UUID of its own, so the numeric WCA user id that
+      //   our provider issues as the OIDC subject needs a name AuthJS will leave alone.
+      wcaUserId: Number(profile.sub),
     };
   },
 };
@@ -61,6 +64,7 @@ export const authConfig: NextAuthConfig = {
         return {
           ...token,
           wcaId: user?.wcaId,
+          wcaUserId: user?.wcaUserId,
           access_token: account.access_token!,
           expires_at: account.expires_at!,
           refresh_token: account.refresh_token,
@@ -94,6 +98,7 @@ export const authConfig: NextAuthConfig = {
     async session({ session, token }) {
       session.accessToken = token.access_token;
       session.user.wcaId = token.wcaId;
+      session.wcaUserId = token.wcaUserId;
       return session;
     },
   },

--- a/next-frontend/src/lib/types/oauth.ts
+++ b/next-frontend/src/lib/types/oauth.ts
@@ -8,6 +8,7 @@ import type { JWT } from "next-auth/jwt";
 declare module "@auth/core/types" {
   interface User extends PayloadAuthjsUser<PayloadUser> {
     wcaId?: string;
+    wcaUserId?: number;
   }
 }
 
@@ -17,6 +18,12 @@ declare module "next-auth" {
    */
   interface Session {
     accessToken: string;
+    /**
+     * The numeric WCA user id, i.e. `User#id` in the Rails backend.
+     * Not to be confused with `user.wcaId`, which is the public WCA ID like "2015ABCD01".
+     * Absent on sessions that were issued before this claim was carried through the token.
+     */
+    wcaUserId?: number;
     user: {} & DefaultSession["user"];
     error?: "RefreshTokenError";
   }
@@ -25,6 +32,7 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     wcaId?: string;
+    wcaUserId?: number;
     access_token: string;
     expires_at: number;
     refresh_token?: string;


### PR DESCRIPTION
There are some APIs that need the `user_id`. I thought that authjs would just take the `sub` as `id`, but it does not. So this PR especially writes the sub into the `wcaUserId` field.

Extracted out of #15342