### PR TITLE
Delegate report character limit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,13 +27,17 @@
     },
     "plugins": [
         "react",
-        "jquery"
+        "jquery",
+        "import"
     ],
     "rules": {
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
         "import/no-unresolved": ["error", {
             "ignore": ["semantic-css/"]
+        }],
+        "import/order": ["error", {
+            "groups": ["builtin", "external", "internal"]
         }],
         "no-console": ["error", { "allow": ["warn", "error"] }]
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,17 +27,13 @@
     },
     "plugins": [
         "react",
-        "jquery",
-        "import"
+        "jquery"
     ],
     "rules": {
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
         "import/no-unresolved": ["error", {
             "ignore": ["semantic-css/"]
-        }],
-        "import/order": ["error", {
-            "groups": ["builtin", "external", "internal"]
         }],
         "no-console": ["error", { "allow": ["warn", "error"] }]
     }

--- a/app/models/delegate_report.rb
+++ b/app/models/delegate_report.rb
@@ -2,7 +2,7 @@
 
 class DelegateReport < ApplicationRecord
   REPORTS_ENABLED_DATE = Date.new(2016, 6, 1)
-  # MySQL `TEXT` columns can hold at most 65,535 characters. `summary`, `equipment`, `venue`,
+  # MySQL `TEXT` columns can hold at most 65,535 bytes. `summary`, `equipment`, `venue`,
   #   `organization`, `incidents`, and `remarks` are all `TEXT` columns (see AVAILABLE_SECTIONS),
   #   so this is a hard database-level cap we must also validate against before saving.
   MAX_SECTION_LENGTH = 65_535

--- a/app/models/delegate_report.rb
+++ b/app/models/delegate_report.rb
@@ -5,7 +5,9 @@ class DelegateReport < ApplicationRecord
   # MySQL `TEXT` columns can hold at most 65,535 bytes. `summary`, `equipment`, `venue`,
   #   `organization`, `incidents`, and `remarks` are all `TEXT` columns (see AVAILABLE_SECTIONS),
   #   so this is a hard database-level cap we must also validate against before saving.
-  MAX_SECTION_LENGTH = 65_535
+  # MySQL TEXT columns store 65,535 bytes. With utf8mb4 encoding, characters can use up to 4 bytes each.
+  # To safely avoid database errors with multibyte characters (e.g., emoji), limit to 16,383 characters.
+  MAX_SECTION_LENGTH = 16_383
   # Any potentially available section, regardless of versioning.
   #   Use with care, some sections may not be available for some versions!
   AVAILABLE_SECTIONS = %i[

--- a/app/models/delegate_report.rb
+++ b/app/models/delegate_report.rb
@@ -2,6 +2,10 @@
 
 class DelegateReport < ApplicationRecord
   REPORTS_ENABLED_DATE = Date.new(2016, 6, 1)
+  # MySQL `TEXT` columns can hold at most 65,535 characters. `summary`, `equipment`, `venue`,
+  #   `organization`, `incidents`, and `remarks` are all `TEXT` columns (see AVAILABLE_SECTIONS),
+  #   so this is a hard database-level cap we must also validate against before saving.
+  MAX_SECTION_LENGTH = 65_535
   # Any potentially available section, regardless of versioning.
   #   Use with care, some sections may not be available for some versions!
   AVAILABLE_SECTIONS = %i[
@@ -73,6 +77,8 @@ class DelegateReport < ApplicationRecord
   validates :discussion_url, url: true
   validates :wrc_incidents, presence: true, if: :wrc_feedback_requested
   validates :wic_incidents, presence: true, if: :wic_feedback_requested
+
+  validates(*AVAILABLE_SECTIONS, length: { maximum: MAX_SECTION_LENGTH })
 
   validates :setup_images, blob: { content_type: :web_image },
                            length: { minimum: :required_setup_images_count, if: %i[posted? requires_setup_images?] }

--- a/app/views/delegate_reports/edit.html.erb
+++ b/app/views/delegate_reports/edit.html.erb
@@ -16,7 +16,7 @@
     <%= @competition.any_venues? ? f.hidden_field(:schedule_url) : f.input(:schedule_url) %>
 
     <% @delegate_report.md_sections.each do |section| %>
-      <%= f.input section, input_html: { class: "markdown-editor markdown-editor-image-upload" } %>
+      <%= f.input section, input_html: { class: "markdown-editor markdown-editor-image-upload", data: { max_length: DelegateReport::MAX_SECTION_LENGTH } } %>
 
       <% if section == :venue && @delegate_report.requires_setup_images? %>
         <% @delegate_report.setup_images.each do |image| %>

--- a/app/webpacker/lib/markdown-editor.js
+++ b/app/webpacker/lib/markdown-editor.js
@@ -47,6 +47,7 @@ $(() => {
   }).trigger('change');
 
   $('.markdown-editor').each(function toggleInput() {
+    const maxLength = parseInt(this.dataset.maxLength, 10) || null;
     const textFormattings = ['bold', 'italic', 'heading'];
     const textStructures = ['quote', 'unordered-list', 'ordered-list', 'table'];
     const allowImageUploads = this.classList.contains('markdown-editor-image-upload');
@@ -96,11 +97,29 @@ $(() => {
       '|', ...previews,
       '|', ...helps,
     ];
-    const editor = new EasyMDE({
+    let editor;
+    const status = ['upload-image'];
+    if (maxLength) {
+      status.push({
+        className: 'markdown-editor-character-count',
+        defaultValue: (el) => {
+          const target = el;
+          target.innerHTML = `${this.value.length} / ${maxLength} characters`;
+        },
+        onUpdate: (el) => {
+          const target = el;
+          const { length } = editor.value();
+          target.innerHTML = `${length} / ${maxLength} characters`;
+          target.classList.toggle('markdown-editor-character-count-warning', length >= maxLength * 0.9);
+        },
+      });
+    }
+    editor = new EasyMDE({
       element: this,
       spellChecker: false,
       promptURLs: true,
       toolbar,
+      status,
       previewRender(plainText, preview) {
         const previewTarget = preview;
         if (this.markdownReqest) {
@@ -116,7 +135,6 @@ $(() => {
         return 'Waiting...';
       },
 
-      status: ['upload-image'],
       uploadImage: true,
       async imageUploadFunction(file, onSuccess, onError) {
         const formData = new FormData();
@@ -136,6 +154,25 @@ $(() => {
       this.value = editor.value();
       $(this).trigger('change');
     });
+
+    if (maxLength) {
+      // Prevent typing/pasting past the character limit, rather than letting the user
+      // hit a validation error only after submitting the form.
+      editor.codemirror.on('beforeChange', (instance, changeObj) => {
+        if (changeObj.origin === 'setValue') {
+          return;
+        }
+
+        const currentLength = instance.getValue().length;
+        const removedLength = instance.getRange(changeObj.from, changeObj.to).length;
+        const addedLength = changeObj.text.join('\n').length;
+        const newLength = currentLength - removedLength + addedLength;
+
+        if (newLength > maxLength) {
+          changeObj.cancel();
+        }
+      });
+    }
     // So edited value does not persist on refresh
     editor.value(this.defaultValue);
 

--- a/app/webpacker/lib/markdown-editor.js
+++ b/app/webpacker/lib/markdown-editor.js
@@ -51,14 +51,9 @@ $(() => {
     const textFormattings = ['bold', 'italic', 'heading'];
     const textStructures = ['quote', 'unordered-list', 'ordered-list', 'table'];
     const allowImageUploads = this.classList.contains('markdown-editor-image-upload');
-    let uploadsAndInserts = [
-      'link',
-    ];
-    if (allowImageUploads) {
-      uploadsAndInserts.push('upload-image');
-    }
-    uploadsAndInserts = [
-      ...uploadsAndInserts,
+    const baseInserts = ['link'];
+    const imageInserts = allowImageUploads ? ['upload-image'] : [];
+    const customInserts = [
       {
         name: 'map',
         action: function insertMap(editor) {
@@ -88,6 +83,7 @@ $(() => {
         title: 'Insert YouTube Video',
       },
     ];
+    const uploadsAndInserts = [...baseInserts, ...imageInserts, ...customInserts];
     const previews = ['preview', 'side-by-side', 'fullscreen'];
     const helps = ['guide'];
     const toolbar = [
@@ -97,24 +93,19 @@ $(() => {
       '|', ...previews,
       '|', ...helps,
     ];
-    let editor;
-    const status = ['upload-image'];
-    if (maxLength) {
-      status.push({
-        className: 'markdown-editor-character-count',
-        defaultValue: (el) => {
-          const target = el;
-          target.innerHTML = `${this.value.length} / ${maxLength} characters`;
-        },
-        onUpdate: (el) => {
-          const target = el;
-          const { length } = editor.value();
-          target.innerHTML = `${length} / ${maxLength} characters`;
-          target.classList.toggle('markdown-editor-character-count-warning', length >= maxLength * 0.9);
-        },
-      });
-    }
-    editor = new EasyMDE({
+    const characterCountStatus = maxLength ? [{
+      className: 'markdown-editor-character-count',
+      defaultValue: (el) => {
+        el.innerHTML = `${this.value.length} / ${maxLength} characters`;
+      },
+      onUpdate: (el) => {
+        const { length } = editor.value();
+        el.innerHTML = `${length} / ${maxLength} characters`;
+        el.classList.toggle('markdown-editor-character-count-warning', length >= maxLength * 0.9);
+      },
+    }] : [];
+    const status = ['upload-image', ...characterCountStatus];
+    const editor = new EasyMDE({
       element: this,
       spellChecker: false,
       promptURLs: true,

--- a/app/webpacker/lib/markdown-editor.js
+++ b/app/webpacker/lib/markdown-editor.js
@@ -93,19 +93,24 @@ $(() => {
       '|', ...previews,
       '|', ...helps,
     ];
+    // `editor` is referenced inside the status bar callbacks below, but can only be
+    // assigned once EasyMDE has been constructed, which itself needs `status` as input.
+    let editor;
     const characterCountStatus = maxLength ? [{
       className: 'markdown-editor-character-count',
       defaultValue: (el) => {
-        el.innerHTML = `${this.value.length} / ${maxLength} characters`;
+        const target = el;
+        target.innerHTML = `${this.value.length} / ${maxLength} characters`;
       },
       onUpdate: (el) => {
+        const target = el;
         const { length } = editor.value();
-        el.innerHTML = `${length} / ${maxLength} characters`;
-        el.classList.toggle('markdown-editor-character-count-warning', length >= maxLength * 0.9);
+        target.innerHTML = `${length} / ${maxLength} characters`;
+        target.classList.toggle('markdown-editor-character-count-warning', length >= maxLength * 0.9);
       },
     }] : [];
     const status = ['upload-image', ...characterCountStatus];
-    const editor = new EasyMDE({
+    editor = new EasyMDE({
       element: this,
       spellChecker: false,
       promptURLs: true,

--- a/app/webpacker/stylesheets/markdown-editor.scss
+++ b/app/webpacker/stylesheets/markdown-editor.scss
@@ -4,3 +4,8 @@
 .editor-preview-active-side {
   z-index: 1001; // on top of navbar
 }
+
+.markdown-editor-character-count-warning {
+  color: #a94442; // matches Bootstrap's has-error text color
+  font-weight: bold;
+}

--- a/spec/models/delegate_report_spec.rb
+++ b/spec/models/delegate_report_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe DelegateReport do
     expect(dr).to be_valid
 
     dr.remarks = "a" * (DelegateReport::MAX_SECTION_LENGTH + 1)
-    expect(dr).to be_invalid_with_errors remarks: ["is too long (maximum is 65535 characters)"]
+    expect(dr).to be_invalid_with_errors remarks: ["is too long (maximum is #{DelegateReport::MAX_SECTION_LENGTH} characters)"]
   end
 
   context "can_view_delegate_report?" do

--- a/spec/models/delegate_report_spec.rb
+++ b/spec/models/delegate_report_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe DelegateReport do
     expect(dr).to be_valid
   end
 
+  it "rejects sections longer than the database character limit" do
+    dr = build(:delegate_report, remarks: "a" * DelegateReport::MAX_SECTION_LENGTH)
+    expect(dr).to be_valid
+
+    dr.remarks = "a" * (DelegateReport::MAX_SECTION_LENGTH + 1)
+    expect(dr).to be_invalid_with_errors remarks: ["is too long (maximum is 65535 characters)"]
+  end
+
   context "can_view_delegate_report?" do
     let(:other_delegate) { create(:delegate) }
     let(:board_member) { create(:user, :board_member) }


### PR DESCRIPTION
Fixes #15310

Delegate report sections (summary, equipment, venue, organization, incidents, remarks) are stored in TEXT columns, which have a hard 65,535-character database limit. Previously, exceeding it caused an unhandled DB error and a generic "Something went wrong" message with no indication of what went wrong.

This adds a Rails validation enforcing the limit so users get a real error message, plus a live character counter and input cap in the report editor so they can't hit the limit in the first place.