### PR TITLE
Chinese taipei flag size

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,13 +27,17 @@
     },
     "plugins": [
         "react",
-        "jquery"
+        "jquery",
+        "import"
     ],
     "rules": {
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
         "import/no-unresolved": ["error", {
             "ignore": ["semantic-css/"]
+        }],
+        "import/order": ["error", {
+            "groups": ["builtin", "external", "internal"]
         }],
         "no-console": ["error", { "allow": ["warn", "error"] }]
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,17 +27,13 @@
     },
     "plugins": [
         "react",
-        "jquery",
-        "import"
+        "jquery"
     ],
     "rules": {
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
         "import/no-unresolved": ["error", {
             "ignore": ["semantic-css/"]
-        }],
-        "import/order": ["error", {
-            "groups": ["builtin", "external", "internal"]
         }],
         "no-console": ["error", { "allow": ["warn", "error"] }]
     }

--- a/next-frontend/src/components/WcaFlag.tsx
+++ b/next-frontend/src/components/WcaFlag.tsx
@@ -5,12 +5,35 @@ import Flag from "react-world-flags";
 
 type FlagProps = ComponentPropsWithoutRef<typeof Flag>;
 
-const WcaFlag = ({ code, ...restProps }: FlagProps) => {
+const WcaFlag = ({
+  code,
+  width,
+  height,
+  className,
+  style,
+  ...restProps
+}: FlagProps) => {
   if (code?.toUpperCase() === "TW") {
-    return <_TwFlag />;
+    return (
+      <_TwFlag
+        width={width}
+        height={height}
+        className={className}
+        style={style}
+      />
+    );
   }
 
-  return <Flag code={code} {...restProps} />;
+  return (
+    <Flag
+      code={code}
+      width={width}
+      height={height}
+      className={className}
+      style={style}
+      {...restProps}
+    />
+  );
 };
 
 export default WcaFlag;

--- a/next-frontend/src/components/WcaFlag.tsx
+++ b/next-frontend/src/components/WcaFlag.tsx
@@ -1,39 +1,18 @@
 import _TwFlag from "@/components/icons/flags/_TwFlag";
 
 import type { ComponentPropsWithoutRef } from "react";
+import { Icon } from "@chakra-ui/react";
 import Flag from "react-world-flags";
 
-type FlagProps = ComponentPropsWithoutRef<typeof Flag>;
+type FlagProps = ComponentPropsWithoutRef<typeof Flag> &
+  ComponentPropsWithoutRef<typeof Icon>;
 
-const WcaFlag = ({
-  code,
-  width,
-  height,
-  className,
-  style,
-  ...restProps
-}: FlagProps) => {
+const WcaFlag = ({ code, ...restProps }: FlagProps) => {
   if (code?.toUpperCase() === "TW") {
-    return (
-      <_TwFlag
-        width={width}
-        height={height}
-        className={className}
-        style={style}
-      />
-    );
+    return <_TwFlag {...restProps} />;
   }
 
-  return (
-    <Flag
-      code={code}
-      width={width}
-      height={height}
-      className={className}
-      style={style}
-      {...restProps}
-    />
-  );
+  return <Flag code={code} {...restProps} />;
 };
 
 export default WcaFlag;


### PR DESCRIPTION
Fixes #14593

`WcaFlag` special-cases the Chinese Taipei ("TW") country code to render a custom `_TwFlag` icon, but it dropped every prop passed to it (`width`/`height`/`className`/`style`). Every call site sizes its flag via Chakra's `<Icon asChild size="...">` wrapper, which injects sizing through those props — so Chinese Taipei's flag ignored the intended size and
rendered oversized everywhere else.

This forwards those props to `_TwFlag` the same way they're already forwarded to the regular `react-world-flags` `<Flag>`.