### PR TITLE
Speed up next /competitions page

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -161,8 +161,8 @@ class Api::V0::ApiController < ApplicationController
   # These results are rendered through each model's default `as_json`, so preload whatever that
   # serialization walks. `Regulation` is not an ActiveRecord model and has no associations at all.
   private def search_scope_for(model, query)
-    scope = model.search(query, params: params)
-    scope.try(:with_serialization_preloads) || scope
+    scope = model.try(:with_serialization_preloads) || model
+    scope.search(query, params: params)
   end
 
   def posts_search

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -143,7 +143,7 @@ class Api::V0::ApiController < ApplicationController
     # instead should be private to the corresponding microservice.
     result = Rails.cache.fetch(cache_key, force: current_user&.results_team?) do
       ActiveRecord::Base.connected_to(role: :read_replica) do
-        models.flat_map { |model| model.search(query, params: params).limit(DEFAULT_API_RESULT_LIMIT) }
+        models.flat_map { |model| search_scope_for(model, query).limit(DEFAULT_API_RESULT_LIMIT) }
       end
     end
 
@@ -156,6 +156,13 @@ class Api::V0::ApiController < ApplicationController
               end
 
     render status: :ok, json: { result: result.as_json(options) }
+  end
+
+  # These results are rendered through each model's default `as_json`, so preload whatever that
+  # serialization walks. `Regulation` is not an ActiveRecord model and has no associations at all.
+  private def search_scope_for(model, query)
+    scope = model.search(query, params: params)
+    scope.respond_to?(:with_serialization_preloads) ? scope.with_serialization_preloads : scope
   end
 
   def posts_search

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -162,7 +162,7 @@ class Api::V0::ApiController < ApplicationController
   # serialization walks. `Regulation` is not an ActiveRecord model and has no associations at all.
   private def search_scope_for(model, query)
     scope = model.search(query, params: params)
-    scope.respond_to?(:with_serialization_preloads) ? scope.with_serialization_preloads : scope
+    scope.try(:with_serialization_preloads) || scope
   end
 
   def posts_search

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -11,7 +11,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
       managed_by_user = current_api_user || current_user
     end
 
-    competitions = Competition.search(params[:q], params: params, managed_by_user: managed_by_user).with_serialization_preloads
+    competitions = Competition.with_serialization_preloads.search(params[:q], params: params, managed_by_user: managed_by_user)
 
     paginate json: competitions
   end

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -11,11 +11,7 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
       managed_by_user = current_api_user || current_user
     end
 
-    competitions = Competition.search(params[:q], params: params, managed_by_user: managed_by_user)
-    # The delegates and organizers get run through `User#serializable_hash`, so eager load the
-    # associations it touches to avoid an N+1 explosion (one set of queries per delegate/organizer
-    # per competition). See `User::SERIALIZATION_INCLUDES`.
-    competitions = competitions.includes(delegates: User::SERIALIZATION_INCLUDES, organizers: User::SERIALIZATION_INCLUDES)
+    competitions = Competition.search(params[:q], params: params, managed_by_user: managed_by_user).with_serialization_preloads
 
     paginate json: competitions
   end

--- a/app/controllers/api/v0/competitions_controller.rb
+++ b/app/controllers/api/v0/competitions_controller.rb
@@ -12,7 +12,10 @@ class Api::V0::CompetitionsController < Api::V0::ApiController
     end
 
     competitions = Competition.search(params[:q], params: params, managed_by_user: managed_by_user)
-    competitions = competitions.includes(:delegates, :organizers, :events)
+    # The delegates and organizers get run through `User#serializable_hash`, so eager load the
+    # associations it touches to avoid an N+1 explosion (one set of queries per delegate/organizer
+    # per competition). See `User::SERIALIZATION_INCLUDES`.
+    competitions = competitions.includes(delegates: User::SERIALIZATION_INCLUDES, organizers: User::SERIALIZATION_INCLUDES)
 
     paginate json: competitions
   end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1773,13 +1773,8 @@ class Competition < ApplicationRecord
     # Respect other `includes` associations that might have been specified ahead of time
     previous_includes = competitions.includes_values
 
-    # The delegates and organizers get run through `User#serializable_hash`, so eager load the
-    # associations it touches to avoid an N+1 explosion (one set of queries per delegate/organizer
-    # per competition). See `User::SERIALIZATION_INCLUDES`.
     competitions.includes(
       :events, # serialized via the `event_ids` method, one query per competition otherwise
-      { delegates: User::SERIALIZATION_INCLUDES },
-      { organizers: User::SERIALIZATION_INCLUDES },
       *previous_includes,
     ).order(**order)
   end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -110,6 +110,10 @@ class Competition < ApplicationRecord
   scope :pending_posting, -> { where.not(results_submitted_at: nil).where(results_posted_at: nil) }
   scope :pending_report_or_results_posting, -> { includes(:delegate_report).where(delegate_report: { posted_at: nil }).or(where(results_posted_at: nil)) }
   scope :results_posted, -> { where.not(results_posted_at: nil).where.not(results_posted_by: nil) }
+  # `DEFAULT_SERIALIZE_OPTIONS` renders delegates and organizers through `User#serializable_hash`,
+  # which reads every association in `User::SERIALIZATION_INCLUDES`. Callers that serialize with
+  # those defaults need this, or each competition fires one set of queries per delegate/organizer.
+  scope :with_serialization_preloads, -> { includes(delegates: User::SERIALIZATION_INCLUDES, organizers: User::SERIALIZATION_INCLUDES) }
   scope :pending_results_submission, -> { not_cancelled.visible.where(results_submitted_at: nil, end_date: ..Date.today) }
 
   enum :guest_entry_status, {

--- a/next-frontend/src/components/RegionSelector.tsx
+++ b/next-frontend/src/components/RegionSelector.tsx
@@ -123,6 +123,7 @@ export default function RegionSelector({
     <Field.Root alignItems="start">
       <Field.Label textStyle="label">{label}</Field.Label>
       <Combobox.Root
+        lazyMount
         collection={collection}
         onInputValueChange={(e) => filter(e.inputValue)}
         onValueChange={(e) => onRegionChange(e.value[0])}


### PR DESCRIPTION
I added the delegates/organizer includes in `competition.rb` which made it include them in the competitions index, but it doesn't actually need them. To still have code reuse I added a scope. This reduced the queries from 34 to 5.

I also reduced the amount of HTML streamed in 98kb to 3.8kb by adding the combobox lazy mount