### PR TITLE
Move live schedule to ClientOnly

### DIFF
--- a/next-frontend/src/components/competitions/Schedule/LiveView.tsx
+++ b/next-frontend/src/components/competitions/Schedule/LiveView.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import {
   Card,
+  ClientOnly,
+  Skeleton,
   HStack,
   SimpleGrid,
   Link,
@@ -34,6 +36,7 @@ import { LuLock } from "react-icons/lu";
 import _ from "lodash";
 import { getRoundName } from "@/lib/wca/live/getRoundName";
 import { useAllRoundsInfo } from "@/providers/RoundInfoProvider";
+import { currentTimeZone } from "@/lib/wca/data/timezones";
 
 interface LiveViewProps {
   timeZones: string[];
@@ -42,7 +45,29 @@ interface LiveViewProps {
   canManage?: boolean;
 }
 
-export default function LiveView({
+export default function LiveView(props: LiveViewProps) {
+  return (
+    <ClientOnly fallback={<LiveScheduleSkeleton />}>
+      <LiveSchedule {...props} />
+    </ClientOnly>
+  );
+}
+
+function LiveScheduleSkeleton() {
+  return (
+    <VStack align="left">
+      <Skeleton width={{ base: "full", md: "3/12" }} height="16" />
+      <Skeleton height="10" />
+      <SimpleGrid columns={{ base: 1, md: 3 }} gap={2}>
+        {_.range(6).map((index) => (
+          <Skeleton key={index} height="28" rounded="md" />
+        ))}
+      </SimpleGrid>
+    </VStack>
+  );
+}
+
+function LiveSchedule({
   timeZones,
   competitionId,
   activities,
@@ -56,13 +81,12 @@ export default function LiveView({
   );
   const firstStartTime = eventActivities[0].startTime;
   const lastStartTime = eventActivities[eventActivities.length - 1].startTime;
-  const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const [timeZone, setTimeZone] = useState(browserTimezone);
+  const [timeZone, setTimeZone] = useState(currentTimeZone);
 
   const collection = createListCollection({
-    items: [...timeZones, browserTimezone].map((t) => ({
-      value: t,
-      label: t,
+    items: _.uniq([...timeZones, currentTimeZone]).map((tz) => ({
+      value: tz,
+      label: tz,
     })),
   });
 


### PR DESCRIPTION
This is an annoying problem we currently have: 
Basically only `ClientOnly` can know the actual timezone of the user. I had a misunderstanding about what "use client" actually means. Basically "use client" does not mean "client-only", it means "this component is part of the client bundle". Next.js still runs it on the server to produce the initial HTML. So this line:                                           
                                                                                                                                         
  `const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;`                                                              
                                                                                                                                         
runs twice: once in Node, where it resolves to the server's TZ (UTC in the containers/hosting), and once in the browser, where it resolves to the real user zone. This is why we see that current flash of UTC.

The easiest way to solve this problem is to wrap this (and everything else we want to deploy in the user's timezone) with a `ClientOnly`. 

This produces a loading skeleton like this:

<img width="1283" height="787" alt="Screenshot 2026-08-24 at 11 55 07" src="https://github.com/user-attachments/assets/af8a5ca6-3c72-4e49-9e24-ae456fa3c4ab" />

The hard way would be to save the user's time zone in a cookie, or in their preferences and then use that. 