### PR TITLE
Use vips methods for resizing instead of ImageMagick

### DIFF
--- a/app/models/regional_organization.rb
+++ b/app/models/regional_organization.rb
@@ -30,7 +30,7 @@ class RegionalOrganization < ApplicationRecord
   end
 
   def logo_url
-    Rails.application.routes.url_helpers.rails_representation_url(logo.variant(resize: "500x300").processed) if logo.attached?
+    Rails.application.routes.url_helpers.rails_representation_url(logo.variant(resize_to_limit: [500, 300]).processed) if logo.attached?
   end
 
   def country_iso2

--- a/app/views/regional_organizations/_regional_organization_form.html.erb
+++ b/app/views/regional_organizations/_regional_organization_form.html.erb
@@ -11,7 +11,7 @@
   <% if @regional_organization.logo.attached? &&
     @regional_organization.logo.blob.present? &&
     @regional_organization.logo.blob.persisted? %>
-    <%= image_tag @regional_organization.logo.variant(resize: "200x200") %>
+    <%= image_tag @regional_organization.logo.variant(resize_to_limit: [200, 200]) %>
   <% end %>
 
   <h3><%= t('.private_information') %></h3>
@@ -24,7 +24,7 @@
     @regional_organization.bylaws.blob.present? &&
     @regional_organization.bylaws.blob.persisted? &&
     @regional_organization.bylaws.previewable? %>
-    <%= link_to(image_tag(@regional_organization.bylaws.preview(resize: "200x200")), rails_blob_path(@regional_organization.bylaws, disposition: "attachment")) %>
+    <%= link_to(image_tag(@regional_organization.bylaws.preview(resize_to_limit: [200, 200])), rails_blob_path(@regional_organization.bylaws, disposition: "attachment")) %>
   <% end %>
 
   <%= f.input :directors_and_officers %>
@@ -35,7 +35,7 @@
 
   <%= f.input :extra_file %>
   <% if @regional_organization.extra_file.attached? && @regional_organization.extra_file.previewable? %>
-    <%= link_to(image_tag(@regional_organization.extra_file.preview(resize: "200x200")), rails_blob_path(@regional_organization.extra_file, disposition: "attachment")) %>
+    <%= link_to(image_tag(@regional_organization.extra_file.preview(resize_to_limit: [200, 200])), rails_blob_path(@regional_organization.extra_file, disposition: "attachment")) %>
   <% end %>
 
   <% if @current_user.can_manage_regional_organizations? %>

--- a/app/views/regional_organizations_mailer/notify_board_and_assistants_of_new_regional_organization_application.html.erb
+++ b/app/views/regional_organizations_mailer/notify_board_and_assistants_of_new_regional_organization_application.html.erb
@@ -10,13 +10,13 @@
     <li><b><%= t "#{i18n_prefix}.website" %>:</b> <%= link_to "#{@regional_organization.website}", @regional_organization.website %></li>
     <% if @regional_organization.logo.attached? %>
       <li><b><%= t "#{i18n_prefix}.logo" %>:</b></li>
-      <%= link_to(image_tag(@regional_organization.logo.variant(resize: "200x200")), rails_blob_url(@regional_organization.logo, disposition: "attachment")) %>
+      <%= link_to(image_tag(@regional_organization.logo.variant(resize_to_limit: [200, 200])), rails_blob_url(@regional_organization.logo, disposition: "attachment")) %>
     <% end %>
     <li><b><%= t "#{i18n_prefix}.email" %>:</b> <%= mail_to @regional_organization.email, "#{@regional_organization.email}" %></li>
     <li><b><%= t "#{i18n_prefix}.address" %>:</b> <%= @regional_organization.address %></li>
     <% if @regional_organization.bylaws.attached? && @regional_organization.bylaws.previewable? %>
       <li><b><%= t "#{i18n_prefix}.bylaws" %>:</b></li>
-      <%= link_to(image_tag(@regional_organization.bylaws.preview(resize: "200x200")), rails_blob_url(@regional_organization.bylaws, disposition: "attachment")) %>
+      <%= link_to(image_tag(@regional_organization.bylaws.preview(resize_to_limit: [200, 200])), rails_blob_url(@regional_organization.bylaws, disposition: "attachment")) %>
     <% end %>
     <li><b><%= t "#{i18n_prefix}.directors_and_officers" %>:</b> <%= @regional_organization.directors_and_officers %></li>
     <li><b><%= t "#{i18n_prefix}.area_description" %>:</b> <%= @regional_organization.area_description %></li>
@@ -27,7 +27,7 @@
     <% end %>
     <% if @regional_organization.extra_file.attached? && @regional_organization.extra_file.previewable? %>
       <li><b>Extra file:</b></li>
-      <%= link_to(image_tag(@regional_organization.extra_file.preview(resize: "200x200")), rails_blob_url(@regional_organization.extra_file, disposition: "attachment")) %>
+      <%= link_to(image_tag(@regional_organization.extra_file.preview(resize_to_limit: [200, 200])), rails_blob_url(@regional_organization.extra_file, disposition: "attachment")) %>
     <% end %>
   </ul>
 </p>


### PR DESCRIPTION
The [RO's page](https://www.worldcubeassociation.org/organizations) is currently broken with this error: 

```bash
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816] 
Information for: ActionView::Template::Error (no implicit conversion to float from string):
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]     1: <% provide(:title, t('regional_organizations.title')) %>
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]     2: 
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]     3: <div class="container">
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]     4:   <%= react_component("RegionalOrganizations", props: {
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]     5:     orgs: @acknowledged_regional_organizations,
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]     6:   }) %>
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]     7: </div>
[dc35cf9d-cee4-4456-9d56-d720dfcc3dbb] [user:158816]   
```

Reproducing in terminal, it is because of this resize code in line 33 of the RO controller:
```ruby
logo.variant(resize: "500x300").processed
```

After LLM discussion, it seems that we are using an ImageMagick method but we have changed to vips. Using vips-specific syntax, I was able to get the resize to work without error in the console: 

```bash
wca-on-rails(prod):010> ro.logo.variant(resize_to_limit: [500, 300]).processed
I, [2026-08-25T12:07:29.024518 #7350]  INFO -- :   S3 Storage (186.7ms) Downloaded file from key: v89aer8d0jwu4t8nas58tv3p2ror
I, [2026-08-25T12:07:29.321683 #7350]  INFO -- :   S3 Storage (150.1ms) Uploaded file to key: jaecjefwukpgxsk86wg536he5xi4 (checksum: /D0WLjesp4xMdWXB17u5Ng==)
INFO  2026-08-25T12:07:29.325Z pid=7350 tid=3ge: Sidekiq 8.1.7 connecting to Redis with options {size: 10, pool_name: "internal", url: "redis://wca-main-sidekiq.iebvzt.ng.0001.usw2.cache.amazonaws.com:6379"}
I, [2026-08-25T12:07:29.330586 #7350]  INFO -- : [ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: e50d7260-9f1b-41f2-8d41-b3614abe568f) to Sidekiq(default) with arguments: #<GlobalID:0x00007f2b9e0e3460 @uri=#<URI::GID gid://wca-on-rails/ActiveStorage::Blob/209928>>
=> 
#<ActiveStorage::VariantWithRecord:0x00007f2bb01c79c8
 @blob=
  #<ActiveStorage::Blob:0x00007f2b9f142388
   id: 209907,
   key: "v89aer8d0jwu4t8nas58tv3p2ror",
   filename: "CCA Logo.png",
   content_type: "image/png",
   metadata: {"identified" => true, "width" => 547, "height" => 242, "analyzed" => true},
   byte_size: 28558,
   checksum: "o+fiG4OgqdH2r8vnfDVzBg==",
   created_at: "2026-08-25 10:27:22.000000000 +0000",
   service_name: "amazon">,
 @record=#<ActiveStorage::VariantRecord:0x00007f2b9dfbd798 id: 74938, blob_id: 209907, variation_digest: "z484+i75QZTEJo5g2XmWWuoRCgQ=">,
 @variation=#<ActiveStorage::Variation:0x00007f2bb01c7d10 @transformations={format: "png", resize_to_limit: [500, 300]}>>
```