### PR TITLE
Transfer organizer roles when a dummy account's WCA ID is claimed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,13 +27,17 @@
     },
     "plugins": [
         "react",
-        "jquery"
+        "jquery",
+        "import"
     ],
     "rules": {
         "react/prop-types": "off",
         "react/jsx-filename-extension": "off",
         "import/no-unresolved": ["error", {
             "ignore": ["semantic-css/"]
+        }],
+        "import/order": ["error", {
+            "groups": ["builtin", "external", "internal"]
         }],
         "no-console": ["error", { "allow": ["warn", "error"] }]
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -347,6 +347,10 @@ class User < ApplicationRecord
     # Transfer historic avatars
     self.user_avatars = dummy_user.user_avatars
 
+    # Transfer organizer roles held by the dummy account, so the competitions
+    # it organized don't end up pointing at a deleted user id.
+    self.competition_organizers.concat(dummy_user.competition_organizers)
+
     # The `reload` is necessary because otherwise, the old pre-reload `user_avatars`
     # association on `dummy_user` would pull the avatars to the grave.
     dummy_user.reload.destroy!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -349,7 +349,12 @@ class User < ApplicationRecord
 
     # Transfer organizer roles held by the dummy account, so the competitions
     # it organized don't end up pointing at a deleted user id.
-    self.competition_organizers.concat(dummy_user.competition_organizers)
+    dummy_user.competition_organizers.each do |co|
+      competition_organizers
+        .find_or_initialize_by(competition_id: co.competition_id)
+        .tap { |record| record.receive_registration_emails ||= co.receive_registration_emails }
+    end
+    dummy_user.competition_organizers.delete_all
 
     # The `reload` is necessary because otherwise, the old pre-reload `user_avatars`
     # association on `dummy_user` would pull the avatars to the grave.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe User do
       expect(dummy_avatar).to be_valid
       dummy_user.update!(current_avatar: dummy_avatar)
       expect(dummy_user.avatar.filename).to eq(dummy_avatar.filename)
+      organized_competition = create(:competition, organizers: [dummy_user])
 
       # Assigning a WCA ID to user should copy over the name from the Persons table.
       expect(user.name).to eq user.person.name
@@ -172,6 +173,27 @@ RSpec.describe User do
       # Check that the dummy account was deleted, and we inherited its avatar.
       expect(User.find_by(id: dummy_user.id)).to be_nil
       expect(user.reload.avatar).to eq dummy_avatar
+
+      # Check that the dummy account's organizer roles were transferred over.
+      expect(organized_competition.reload.organizers).to eq [user]
+    end
+
+    it "transfers dummy account's organizer roles when claiming a WCA ID on a new locked account" do
+      dummy_user = create(:dummy_user)
+      organized_competition = create(:competition, organizers: [dummy_user])
+
+      locked_account = User.new_locked_account(
+        name: dummy_user.person.name,
+        email: "new_competitor@example.com",
+        wca_id: dummy_user.wca_id,
+        country_iso2: dummy_user.person.country_iso2,
+        gender: dummy_user.person.gender,
+        dob: dummy_user.person.dob,
+      )
+      locked_account.save!
+
+      expect(User.find_by(id: dummy_user.id)).to be_nil
+      expect(organized_competition.reload.organizers).to eq [locked_account]
     end
 
     it "does not allow duplicate WCA IDs" do


### PR DESCRIPTION
Transfers a dummy account's competition organizer roles to the claiming user when its WCA ID is claimed, so competitions don't end up pointing at a deleted user id.

Fixes #13346