### PR TITLE
New warnings on competition creation

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -581,9 +581,14 @@ class Competition < ApplicationRecord
     else
       warnings[:invisible] = I18n.t('competitions.messages.not_visible')
 
-      warnings[:year] = I18n.t('competitions.messages.name_must_end_with_year') unless self.name.end_with?(self.start_date.year.to_s) &&
-        self.id.end_with?(self.start_date.year.to_s) &&
-        self.cell_name.end_with?(self.start_date.year.to_s)
+      if self.start_date.present?
+        year = self.start_date.year.to_s
+        unless self.name.to_s.end_with?(year) &&
+               self.id.to_s.end_with?(year) &&
+               self.cell_name.to_s.end_with?(year)
+          warnings[:year] = I18n.t('competitions.messages.name_must_end_with_year')
+        end
+      end
 
       warnings[:name] = I18n.t('competitions.messages.name_too_long') if self.name.length > 32
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -597,7 +597,7 @@ class Competition < ApplicationRecord
       warnings[:id_casing] = I18n.t('competitions.messages.id_starts_with_lowercase') unless /^[[:upper:]]|^\d/.match?(self.id)
 
       warnings[:venue_coordinates] = I18n.t('competitions.messages.venue_coordinates_too_far_away') if competition_venues.any? do |venue|
-        kilometers_to(venue) > 0.1
+        venue.kilometers_to(self) > 0.1
       end
 
       warnings[:events] = I18n.t('competitions.messages.must_have_events') if no_events?
@@ -1066,7 +1066,7 @@ class Competition < ApplicationRecord
   end
 
   def longitude_radians
-    to_radians longitude_degrees
+    GeoCalculation.to_radians longitude_degrees
   end
 
   def latitude_degrees
@@ -1078,7 +1078,7 @@ class Competition < ApplicationRecord
   end
 
   def latitude_radians
-    to_radians latitude_degrees
+    GeoCalculation.to_radians latitude_degrees
   end
 
   def country_zones
@@ -1294,19 +1294,14 @@ class Competition < ApplicationRecord
                .order(:registration_open)
   end
 
-  private def to_radians(degrees)
-    degrees * Math::PI / 180
-  end
-
   # Source http://www.movable-type.co.uk/scripts/latlong.html
-  def kilometers_to(other)
-    return nil unless latitude_radians && longitude_radians && other&.latitude_radians && other.longitude_radians
-
-    6371 *
-      Math.sqrt(
-        (((other.longitude_radians - longitude_radians) * Math.cos((other.latitude_radians + latitude_radians) / 2))**2) +
-        ((other.latitude_radians - latitude_radians)**2),
-      )
+  def kilometers_to(competition)
+    GeoCalculation.haversine_distance(
+      self.latitude_radians,
+      self.longitude_radians,
+      competition.latitude_radians,
+      competition.longitude_radians
+    )
   end
 
   def registration_start_date_present?

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -806,7 +806,7 @@ class Competition < ApplicationRecord
     # By replacing accented chars with their ascii equivalents, and then
     # removing everything that isn't a digit or a character.
     safe_cell_name_without_year = ActiveSupport::Inflector.transliterate(cell_name_without_year, locale: :en).gsub(/[^a-z0-9]+/i, '')
-    return safe_cell_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
+    safe_cell_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
   end
 
   def create_id_and_cell_name(force_override: false)
@@ -817,13 +817,8 @@ class Competition < ApplicationRecord
     year = " #{m[2]}"
     safe_cell_name = name_without_year.truncate(MAX_CELL_NAME_LENGTH - year.length) + year
 
-    if cell_name.blank? || force_override
-      self.cell_name = safe_cell_name
-    end
-
-    if id.blank? || force_override
-      self.id = create_id_from_cell_name
-    end
+    self.cell_name = safe_cell_name if cell_name.blank? || force_override
+    self.id = create_id_from_cell_name if id.blank? || force_override
   end
 
   attr_writer :staff_delegate_ids, :trainee_delegate_ids
@@ -1305,7 +1300,7 @@ class Competition < ApplicationRecord
 
   # Source http://www.movable-type.co.uk/scripts/latlong.html
   def kilometers_to(other)
-    return nil unless latitude_radians && longitude_radians && other&.latitude_radians && other&.longitude_radians
+    return nil unless latitude_radians && longitude_radians && other&.latitude_radians && other.longitude_radians
 
     6371 *
       Math.sqrt(

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -581,6 +581,10 @@ class Competition < ApplicationRecord
     else
       warnings[:invisible] = I18n.t('competitions.messages.not_visible')
 
+      warnings[:year] = I18n.t('competitions.messages.name_must_end_with_year') if !self.name.end_with?(self.start_date.year.to_s) ||
+        !self.id.end_with?(self.start_date.year.to_s) ||
+        !self.cell_name.end_with?(self.start_date.year.to_s)
+
       warnings[:name] = I18n.t('competitions.messages.name_too_long') if self.name.length > 32
 
       warnings[:id] = I18n.t('competitions.messages.id_starts_with_lowercase') unless /^[[:upper:]]|^\d/.match?(self.id)
@@ -781,23 +785,33 @@ class Competition < ApplicationRecord
   alias_attribute :latitude_microdegrees, :latitude
   alias_attribute :longitude_microdegrees, :longitude
 
+  def create_id_from_cell_name
+    m = VALID_NAME_RE.match(cell_name)
+
+    cell_name_without_year = m[1]
+    year = m[2]
+
+    # Generate competition id from name
+    # By replacing accented chars with their ascii equivalents, and then
+    # removing everything that isn't a digit or a character.
+    safe_cell_name_without_year = ActiveSupport::Inflector.transliterate(cell_name_without_year, locale: :en).gsub(/[^a-z0-9]+/i, '')
+    return safe_cell_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
+  end
+
   def create_id_and_cell_name(force_override: false)
     m = VALID_NAME_RE.match(name)
     return unless m
 
     name_without_year = m[1]
-    year = m[2]
-    if id.blank? || force_override
-      # Generate competition id from name
-      # By replacing accented chars with their ascii equivalents, and then
-      # removing everything that isn't a digit or a character.
-      safe_name_without_year = ActiveSupport::Inflector.transliterate(name_without_year, locale: :en).gsub(/[^a-z0-9]+/i, '')
-      self.id = safe_name_without_year[0...(MAX_ID_LENGTH - year.length)] + year
-    end
-    return unless cell_name.blank? || force_override
+    year = " #{m[2]}"
+    safe_cell_name = name_without_year.truncate(MAX_CELL_NAME_LENGTH - year.length) + year
 
-    year = " #{year}"
-    self.cell_name = name_without_year.truncate(MAX_CELL_NAME_LENGTH - year.length) + year
+    if id.blank? || force_override
+      self.id = create_id_from_cell_name
+    end
+
+    return unless cell_name.blank? || force_override
+    self.cell_name = safe_cell_name
   end
 
   attr_writer :staff_delegate_ids, :trainee_delegate_ids

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -581,13 +581,13 @@ class Competition < ApplicationRecord
     else
       warnings[:invisible] = I18n.t('competitions.messages.not_visible')
 
-      warnings[:year] = I18n.t('competitions.messages.name_must_end_with_year') if !self.name.end_with?(self.start_date.year.to_s) ||
-        !self.id.end_with?(self.start_date.year.to_s) ||
-        !self.cell_name.end_with?(self.start_date.year.to_s)
+      warnings[:year] = I18n.t('competitions.messages.name_must_end_with_year') unless self.name.end_with?(self.start_date.year.to_s) &&
+        self.id.end_with?(self.start_date.year.to_s) &&
+        self.cell_name.end_with?(self.start_date.year.to_s)
 
       warnings[:name] = I18n.t('competitions.messages.name_too_long') if self.name.length > 32
 
-      warnings[:id] = I18n.t('competitions.messages.id_must_match_short_name') if !self.id.match?(create_id_from_cell_name)
+      warnings[:id] = I18n.t('competitions.messages.id_must_match_short_name') unless self.id.match?(create_id_from_cell_name)
 
       warnings[:id_casing] = I18n.t('competitions.messages.id_starts_with_lowercase') unless /^[[:upper:]]|^\d/.match?(self.id)
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -591,6 +591,10 @@ class Competition < ApplicationRecord
 
       warnings[:id_casing] = I18n.t('competitions.messages.id_starts_with_lowercase') unless /^[[:upper:]]|^\d/.match?(self.id)
 
+      warnings[:venue_coordinates] = I18n.t('competitions.messages.venue_coordinates_too_far_away') if competition_venues.any? do |venue|
+        kilometers_to(venue) > 0.1
+      end
+
       warnings[:events] = I18n.t('competitions.messages.must_have_events') if no_events?
 
       warnings[:waiting_list_deadline_missing] = I18n.t('competitions.messages.no_waiting_list_specified') unless self.waiting_list_deadline_date
@@ -1295,11 +1299,13 @@ class Competition < ApplicationRecord
   end
 
   # Source http://www.movable-type.co.uk/scripts/latlong.html
-  def kilometers_to(competition)
+  def kilometers_to(other)
+    return nil unless latitude_radians && longitude_radians && other&.latitude_radians && other&.longitude_radians
+
     6371 *
       Math.sqrt(
-        (((competition.longitude_radians - longitude_radians) * Math.cos((competition.latitude_radians + latitude_radians) / 2))**2) +
-        ((competition.latitude_radians - latitude_radians)**2),
+        (((other.longitude_radians - longitude_radians) * Math.cos((other.latitude_radians + latitude_radians) / 2))**2) +
+        ((other.latitude_radians - latitude_radians)**2),
       )
   end
 

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -587,7 +587,9 @@ class Competition < ApplicationRecord
 
       warnings[:name] = I18n.t('competitions.messages.name_too_long') if self.name.length > 32
 
-      warnings[:id] = I18n.t('competitions.messages.id_starts_with_lowercase') unless /^[[:upper:]]|^\d/.match?(self.id)
+      warnings[:id] = I18n.t('competitions.messages.id_must_match_short_name') if !self.id.match?(create_id_from_cell_name)
+
+      warnings[:id_casing] = I18n.t('competitions.messages.id_starts_with_lowercase') unless /^[[:upper:]]|^\d/.match?(self.id)
 
       warnings[:events] = I18n.t('competitions.messages.must_have_events') if no_events?
 
@@ -806,12 +808,13 @@ class Competition < ApplicationRecord
     year = " #{m[2]}"
     safe_cell_name = name_without_year.truncate(MAX_CELL_NAME_LENGTH - year.length) + year
 
+    if cell_name.blank? || force_override
+      self.cell_name = safe_cell_name
+    end
+
     if id.blank? || force_override
       self.id = create_id_from_cell_name
     end
-
-    return unless cell_name.blank? || force_override
-    self.cell_name = safe_cell_name
   end
 
   attr_writer :staff_delegate_ids, :trainee_delegate_ids

--- a/app/models/competition_venue.rb
+++ b/app/models/competition_venue.rb
@@ -31,16 +31,12 @@ class CompetitionVenue < ApplicationRecord
     self
   end
 
-  private def to_radians(degrees)
-    degrees * Math::PI / 180
-  end
-
   def latitude_degrees
     latitude_microdegrees / 1e6
   end
 
   def latitude_radians
-    to_radians latitude_degrees
+    GeoCalculation.to_radians latitude_degrees
   end
 
   def longitude_degrees
@@ -48,7 +44,7 @@ class CompetitionVenue < ApplicationRecord
   end
 
   def longitude_radians
-    to_radians longitude_degrees
+    GeoCalculation.to_radians longitude_degrees
   end
 
   def all_activities
@@ -57,6 +53,15 @@ class CompetitionVenue < ApplicationRecord
 
   def top_level_activities
     venue_rooms.flat_map(&:schedule_activities)
+  end
+
+  def kilometers_to(competition)
+    GeoCalculation.haversine_distance(
+      self.latitude_radians,
+      self.longitude_radians,
+      competition.latitude_radians,
+      competition.longitude_radians,
+    )
   end
 
   def to_wcif

--- a/app/models/competition_venue.rb
+++ b/app/models/competition_venue.rb
@@ -31,12 +31,24 @@ class CompetitionVenue < ApplicationRecord
     self
   end
 
+  private def to_radians(degrees)
+    degrees * Math::PI / 180
+  end
+
   def latitude_degrees
     latitude_microdegrees / 1e6
   end
 
+  def latitude_radians
+    to_radians latitude_degrees
+  end
+
   def longitude_degrees
     longitude_microdegrees / 1e6
+  end
+
+  def longitude_radians
+    to_radians longitude_degrees
   end
 
   def all_activities

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1380,6 +1380,7 @@ en:
       must_have_events: "Please add at least one event before confirming the competition."
       schedule_must_match_rounds: "Please make sure the competition has at least one round per event and that the schedule you created includes all rounds you declared before confirming the competition."
       advancement_condition_must_be_present_for_all_non_final_rounds: "Please make sure that all non-final rounds have an advancement condition specified."
+      name_must_end_with_year: "The name must end with the year of the first day of the competition."
       cutoff_is_greater_than_time_limit: "Round %{round_number} in %{event} has a cutoff greater than the time limit. Please make sure the cutoff is not greater than the time limit."
       cutoff_is_too_fast: "Round %{round_number} in %{event} has a cutoff less than 5 seconds. Please make sure that it is correct."
       cutoff_is_too_slow: "Round %{round_number} in %{event} has a cutoff more than 10 minutes. Please make sure that it is correct."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1380,7 +1380,7 @@ en:
       must_have_events: "Please add at least one event before confirming the competition."
       schedule_must_match_rounds: "Please make sure the competition has at least one round per event and that the schedule you created includes all rounds you declared before confirming the competition."
       advancement_condition_must_be_present_for_all_non_final_rounds: "Please make sure that all non-final rounds have an advancement condition specified."
-      name_must_end_with_year: "The name must end with the year of the first day of the competition."
+      name_must_end_with_year: "The name, ID and short name must all end with the year of the first day of the competition."
       id_must_match_short_name: "The competition ID should be the same as the short name without spaces."
       cutoff_is_greater_than_time_limit: "Round %{round_number} in %{event} has a cutoff greater than the time limit. Please make sure the cutoff is not greater than the time limit."
       cutoff_is_too_fast: "Round %{round_number} in %{event} has a cutoff less than 5 seconds. Please make sure that it is correct."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1381,6 +1381,7 @@ en:
       schedule_must_match_rounds: "Please make sure the competition has at least one round per event and that the schedule you created includes all rounds you declared before confirming the competition."
       advancement_condition_must_be_present_for_all_non_final_rounds: "Please make sure that all non-final rounds have an advancement condition specified."
       name_must_end_with_year: "The name must end with the year of the first day of the competition."
+      id_must_match_short_name: "The ID must match the short name of the competition."
       cutoff_is_greater_than_time_limit: "Round %{round_number} in %{event} has a cutoff greater than the time limit. Please make sure the cutoff is not greater than the time limit."
       cutoff_is_too_fast: "Round %{round_number} in %{event} has a cutoff less than 5 seconds. Please make sure that it is correct."
       cutoff_is_too_slow: "Round %{round_number} in %{event} has a cutoff more than 10 minutes. Please make sure that it is correct."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1387,6 +1387,7 @@ en:
       cutoff_is_too_slow: "Round %{round_number} in %{event} has a cutoff more than 10 minutes. Please make sure that it is correct."
       time_limit_is_too_fast: "Round %{round_number} in %{event} has a time limit less than 10 seconds. Please make sure that it is correct."
       time_limit_is_too_slow: "Round %{round_number} in %{event} has a time limit more than 10 minutes in a fast event. Please make sure that it is correct."
+      venue_coordinates_too_far_away: "A venue pin is far away from the competition pin. Please make sure this is intended."
       create_success: "Successfully created new competition!"
       registration_payment_info: "This competition has registration fees but no Stripe account is linked. If you are using Stripe through the WCA website, please remember to link your Stripe account. If you are using an external payment system, please remember to add all the relevant details to the registration requirements."
       not_announced: "This competition is visible to the public but hasn't been announced yet."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1381,7 +1381,7 @@ en:
       schedule_must_match_rounds: "Please make sure the competition has at least one round per event and that the schedule you created includes all rounds you declared before confirming the competition."
       advancement_condition_must_be_present_for_all_non_final_rounds: "Please make sure that all non-final rounds have an advancement condition specified."
       name_must_end_with_year: "The name must end with the year of the first day of the competition."
-      id_must_match_short_name: "The ID must match the short name of the competition."
+      id_must_match_short_name: "The competition ID should be the same as the short name without spaces."
       cutoff_is_greater_than_time_limit: "Round %{round_number} in %{event} has a cutoff greater than the time limit. Please make sure the cutoff is not greater than the time limit."
       cutoff_is_too_fast: "Round %{round_number} in %{event} has a cutoff less than 5 seconds. Please make sure that it is correct."
       cutoff_is_too_slow: "Round %{round_number} in %{event} has a cutoff more than 10 minutes. Please make sure that it is correct."

--- a/lib/geo_calculation.rb
+++ b/lib/geo_calculation.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GeoCalculation
+  module_function
+
+  # Source http://www.movable-type.co.uk/scripts/latlong.html
+  def haversine_distance(lat_rad_from, long_rad_from, lat_rad_to, long_rad_to)
+    delta_lat = lat_rad_to - lat_rad_from
+    delta_long = long_rad_to - long_rad_from
+
+    a = (Math.sin(delta_lat / 2.0)**2) +
+        (Math.cos(lat_rad_from) * Math.cos(lat_rad_to) * (Math.sin(delta_long / 2.0)**2))
+
+    c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+
+    6371 * c
+  end
+
+  def to_radians(degrees)
+    degrees * Math::PI / 180
+  end
+end


### PR DESCRIPTION
I have added three new pre-announcement warnings to the competition page. These are:

1.  The year in the name does not match the start date of the competition (Announcement Criteria 1.3)
2. The competition ID does not match the short name (Announcement Criteria 1.13.2)
3. The venue pin is more than 100 meters away from the competition pin. 

Regarding the pin warning: The 100 meter numbers was an arbitrary choice to balance an effective warning, which catches a real mismatch, with the fact that some competitions may have a venue that is a bit further away than the main room (e.g. a side room in a different part of  a large venue)

The comparison between a competition and a venue reuses the kilometers_to() function on the competition model. It has been altered to take other types as input and makes a check that it has the expected methods before running the calculations.