### PR TITLE
ILR Schedule optimizations

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/live/page.tsx
@@ -32,10 +32,17 @@ export default async function LiveOverview({
   const canManage =
     !!permissions && permissions.canScoretakeCompetition(competitionId);
 
-  const allActivitiesSorted = wcifSchedule.venues
+  const eventActivitiesSorted = wcifSchedule.venues
     .flatMap((venue) => venue.rooms)
     .flatMap((room) => room.activities)
-    .toSorted(earliestWithLongestTieBreaker);
+    .filter((activity) => !activity.activityCode.startsWith("other"))
+    .toSorted(earliestWithLongestTieBreaker)
+    .map(({ id, activityCode, startTime, endTime }) => ({
+      id,
+      activityCode,
+      startTime,
+      endTime,
+    }));
 
   const uniqueTimeZones = [
     ...new Set(wcifSchedule.venues.map((venue) => venue.timezone)),
@@ -45,7 +52,7 @@ export default async function LiveOverview({
     <Container bg="bg">
       <LiveView
         competitionId={competitionId}
-        activities={allActivitiesSorted}
+        activities={eventActivitiesSorted}
         timeZones={uniqueTimeZones}
         canManage={canManage}
       />

--- a/next-frontend/src/components/competitions/Schedule/LiveView.tsx
+++ b/next-frontend/src/components/competitions/Schedule/LiveView.tsx
@@ -22,8 +22,8 @@ import {
   getActivityEventId,
   getActivityRoundId,
   groupActivities,
+  ScheduleActivity,
 } from "@/lib/wca/wcif/activities";
-import { components } from "@/types/openapi";
 import {
   getDatesBetweenInclusive,
   getSimpleTimeString,
@@ -41,7 +41,7 @@ import { currentTimeZone } from "@/lib/wca/data/timezones";
 interface LiveViewProps {
   timeZones: string[];
   competitionId: string;
-  activities: components["schemas"]["WcifActivity"][];
+  activities: ScheduleActivity[];
   canManage?: boolean;
 }
 
@@ -76,11 +76,8 @@ function LiveSchedule({
   const { t } = useT();
   const { rounds } = useAllRoundsInfo();
 
-  const eventActivities = activities.filter(
-    (a) => !a.activityCode.startsWith("other"),
-  );
-  const firstStartTime = eventActivities[0].startTime;
-  const lastStartTime = eventActivities[eventActivities.length - 1].startTime;
+  const firstStartTime = activities[0].startTime;
+  const lastStartTime = activities[activities.length - 1].startTime;
   const [timeZone, setTimeZone] = useState(currentTimeZone);
 
   const collection = createListCollection({
@@ -163,11 +160,7 @@ function LiveSchedule({
           ))}
         </Tabs.List>
         {dates.map((date) => {
-          const activitiesOnDay = activitiesOnDate(
-            activities,
-            date,
-            timeZone,
-          ).filter((a) => !a.activityCode.startsWith("other"));
+          const activitiesOnDay = activitiesOnDate(activities, date, timeZone);
           const groupedActivities = groupActivities(activitiesOnDay);
 
           return (

--- a/next-frontend/src/lib/wca/wcif/activities.ts
+++ b/next-frontend/src/lib/wca/wcif/activities.ts
@@ -16,9 +16,17 @@ export type WcifActivity = components["schemas"]["WcifActivity"];
 export type WcifVenue = components["schemas"]["WcifVenue"];
 export type WcifRoom = components["schemas"]["WcifRoom"];
 
+// The activity fields the schedule views read. Server components pass these
+// instead of full activities so that `childActivities` and `extensions` — half
+// a megabyte of JSON on a big competition — stay out of the client payload.
+export type ScheduleActivity = Pick<
+  WcifActivity,
+  "id" | "activityCode" | "startTime" | "endTime"
+>;
+
 export const earliestWithLongestTieBreaker = (
-  a: WcifActivity,
-  b: WcifActivity,
+  a: ScheduleActivity,
+  b: ScheduleActivity,
 ) => {
   if (a.startTime < b.startTime) {
     return -1;
@@ -35,14 +43,16 @@ export const earliestWithLongestTieBreaker = (
   return 0;
 };
 
-const areGroupable = (a: WcifActivity, b: WcifActivity) =>
+const areGroupable = (a: ScheduleActivity, b: ScheduleActivity) =>
   a.startTime === b.startTime &&
   a.endTime === b.endTime &&
   a.activityCode === b.activityCode;
 
 // assumes they are sorted
-export const groupActivities = (activities: WcifActivity[]) => {
-  const grouped: WcifActivity[][] = [];
+export const groupActivities = <T extends ScheduleActivity>(
+  activities: T[],
+) => {
+  const grouped: T[][] = [];
   activities.forEach((activity) => {
     if (
       grouped.length > 0 &&
@@ -56,10 +66,10 @@ export const groupActivities = (activities: WcifActivity[]) => {
   return grouped;
 };
 
-export const getActivityEventId = (activity: WcifActivity) =>
+export const getActivityEventId = (activity: ScheduleActivity) =>
   activity.activityCode.split("-")[0];
 
-export const getActivityRoundId = (activity: WcifActivity) =>
+export const getActivityRoundId = (activity: ScheduleActivity) =>
   activity.activityCode.split("-").slice(0, 2).join("-");
 
 export const findActivityEvent = (
@@ -78,8 +88,8 @@ export const findActivityRound = (
   return wcifRounds.find((round) => round.id === roundId);
 };
 
-export const activitiesOnDate = (
-  activities: WcifActivity[],
+export const activitiesOnDate = <T extends ScheduleActivity>(
+  activities: T[],
   date: DateTime,
   timeZone: string | Zone,
 ) =>

--- a/next-frontend/src/providers/LiveResultProvider.tsx
+++ b/next-frontend/src/providers/LiveResultProvider.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/live/decompressDiff";
 import { countCompletedResults } from "@/lib/live/countCompletedResults";
 import { useAllRoundsInfo } from "@/providers/RoundInfoProvider";
+import { SERVER_SEEDED_STALE_TIME } from "@/providers/WCAQueryClientProvider";
 
 export type LiveResultsByRegistrationId = Record<string, LiveResult[]>;
 interface LiveResultContextType {
@@ -125,6 +126,8 @@ export function MultiRoundResultProvider({
   const queries = initialRounds.map((round) => ({
     ...roundQueryOptions(round.id),
     initialData: round,
+    refetchOnMount: true,
+    staleTime: SERVER_SEEDED_STALE_TIME,
   }));
 
   const {

--- a/next-frontend/src/providers/RoundInfoProvider.tsx
+++ b/next-frontend/src/providers/RoundInfoProvider.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { LiveRoundAdmin, LiveRoundState } from "@/types/live";
 import { useT } from "@/lib/i18n/useI18n";
 import useAPI from "@/lib/wca/useAPI";
+import { SERVER_SEEDED_STALE_TIME } from "@/providers/WCAQueryClientProvider";
 import Loading from "@/components/ui/loading";
 
 interface AllRoundInfoProviderType {
@@ -71,6 +72,8 @@ export function RoundsInfoProvider({
   const { data, isLoading } = useQuery({
     ...roundsQueryOptions,
     initialData: { rounds: initialRounds },
+    refetchOnMount: true,
+    staleTime: SERVER_SEEDED_STALE_TIME,
   });
 
   const patchRound = useCallback(

--- a/next-frontend/src/providers/WCAQueryClientProvider.tsx
+++ b/next-frontend/src/providers/WCAQueryClientProvider.tsx
@@ -21,6 +21,13 @@ function makeQueryClient() {
   });
 }
 
+// Queries that a server component seeds with `initialData` should opt out of
+// the `refetchOnMount: "always"` default by passing `refetchOnMount: true` and
+// this staleTime: the server fetched that data for this very render, so
+// refetching on mount only duplicates the request. A remount after this window
+// still refreshes, which `refetchOnMount: false` would not.
+export const SERVER_SEEDED_STALE_TIME = 30 * 1000;
+
 // Lazily initialized: this module is also evaluated on the server during SSR,
 // and an eager `const` would construct a throwaway client on every server render.
 // The `??=` defers construction until we're actually in the browser.


### PR DESCRIPTION
Three distinct optimizations:
- Filter wcif for relevant activities on the server first, not the client (saves transferring up to 500kb for big wcif)
- Disable `refetchOnMount: always` for server fetched initial data, as that meant it would immediately fetch again on the client (hitting 304, but still took a round trip)
