### PR TITLE
Fix Chinese Taipei flag size in region selector and flag icons

### DIFF
--- a/next-frontend/src/components/CompetitionTableEntry.tsx
+++ b/next-frontend/src/components/CompetitionTableEntry.tsx
@@ -98,7 +98,7 @@ const CompetitionTableEntry: React.FC<Props> = ({ comp }) => {
       </Table.Cell>
 
       <Table.Cell minWidth="4em">
-        <Icon size="lg">
+        <Icon asChild size="lg">
           <WcaFlag code={comp.country_iso2} fallback={comp.country_iso2} />
         </Icon>
       </Table.Cell>

--- a/next-frontend/src/components/WcaFlag.tsx
+++ b/next-frontend/src/components/WcaFlag.tsx
@@ -1,18 +1,20 @@
 import _TwFlag from "@/components/icons/flags/_TwFlag";
 
 import type { ComponentPropsWithoutRef } from "react";
-import { Icon } from "@chakra-ui/react";
 import Flag from "react-world-flags";
 
-type FlagProps = ComponentPropsWithoutRef<typeof Flag> &
-  ComponentPropsWithoutRef<typeof Icon>;
+type FlagProps = ComponentPropsWithoutRef<typeof Flag>;
 
-const WcaFlag = ({ code, ...restProps }: FlagProps) => {
+const WcaFlag = ({ code, fallback, ...restProps }: FlagProps) => {
   if (code?.toUpperCase() === "TW") {
-    return <_TwFlag {...restProps} />;
+    return (
+      <_TwFlag
+        {...(restProps as unknown as ComponentPropsWithoutRef<typeof _TwFlag>)}
+      />
+    );
   }
 
-  return <Flag code={code} {...restProps} />;
+  return <Flag code={code} fallback={fallback} {...restProps} />;
 };
 
 export default WcaFlag;

--- a/next-frontend/src/components/competitions/CompetitionShortlist.tsx
+++ b/next-frontend/src/components/competitions/CompetitionShortlist.tsx
@@ -23,7 +23,7 @@ export default function CompetitionShortlist({
       <DataList.Root orientation="horizontal" size="lg" iconLabel>
         <DataList.Item>
           <DataList.ItemLabel>
-            <Icon size="xl">
+            <Icon asChild size="xl">
               <WcaFlag code={comp.country_iso2} fallback={comp.country_iso2} />
             </Icon>
           </DataList.ItemLabel>

--- a/next-frontend/src/components/icons/flags/_TwFlag.tsx
+++ b/next-frontend/src/components/icons/flags/_TwFlag.tsx
@@ -8,6 +8,7 @@ const _TwFlag = createIcon({
   viewBox: "0 0 640 480",
   path: (
     <>
+      <rect width="640" height="480" fill="#fff" />
       <g>
         <path
           fill="#fff"
@@ -138,11 +139,6 @@ const _TwFlag = createIcon({
       </g>
     </>
   ),
-  defaultProps: {
-    bg: "white",
-    aspectRatio: "landscape",
-    height: "auto",
-  },
 });
 
 export default _TwFlag;

--- a/next-frontend/src/components/live/ResultsProjector.tsx
+++ b/next-frontend/src/components/live/ResultsProjector.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { FaPause, FaPlay, FaTimes } from "react-icons/fa";
 import { statColumnsForFormat } from "@/lib/live/statColumnsForFormat";
-import Flag from "react-world-flags";
+import WcaFlag from "@/components/WcaFlag";
 import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
 import { recordTagBadge } from "@/components/results/TableCells";
 import formats from "@/lib/wca/data/formats";
@@ -230,7 +230,7 @@ function ResultsProjector({
                             )}
                             {showText && (
                               <Table.Cell textAlign="center" rowSpan={rowSpan}>
-                                <Flag code={competitor.country_iso2} />
+                                <WcaFlag code={competitor.country_iso2} />
                               </Table.Cell>
                             )}
                             {isLinkedRound && (


### PR DESCRIPTION
### Summary of changes
- **`_TwFlag.tsx`**: Add white background `<rect>` within SVG viewBox (`0 0 640 480`) and remove `defaultProps` (`bg: "white"`, `aspectRatio: "landscape"`, `height: "auto"`) which caused the flag to expand to fill flex containers.
- **`WcaFlag.tsx`**: Forward `...restProps` to `_TwFlag` so explicit dimensions (such as `width={32}` & `height={25}` in `RegionSelector`) and icon styles are applied.
- **`ResultsProjector.tsx`**: Use `WcaFlag` instead of `Flag` from `react-world-flags`.
- **`CompetitionTableEntry.tsx` & `CompetitionShortlist.tsx`**: Use `asChild` on `<Icon>` to properly inherit icon sizing.

### Verification
- `yarn check:types` passed.
- `yarn test` passed.
- `yarn eslint` passed on modified files.