### PR TITLE
Filter delegate regions by active status in LocationEditorForm

### DIFF
--- a/app/webpacker/components/Panel/pages/Regions/LocationEditorForm.jsx
+++ b/app/webpacker/components/Panel/pages/Regions/LocationEditorForm.jsx
@@ -11,7 +11,7 @@ export default function LocationEditorForm({
   groupId, setGroupId, location, setLocation,
 }) {
   const { data: delegateRegions, loading, error } = useLoadedData(
-    apiV0Urls.userGroups.list(groupTypes.delegate_regions),
+    apiV0Urls.userGroups.list(groupTypes.delegate_regions, 'name', { isActive: true }),
   );
   const selectedGroup = useMemo(
     () => delegateRegions?.find((region) => region.id === groupId),


### PR DESCRIPTION
This change is to prevent from selecting non-active regions in delegate admin form.

Also I understand that it would have been better if I replace `useLoadedData` with tanstack query, but didn't had enough time to do it, and this is bit urgent as it is impacting the Board / Senior Delegates by selecting wrong region accidentally