### PR TITLE
Move locked account notification logic

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -282,30 +282,7 @@ class RegistrationsController < ApplicationController
   end
 
   def do_import
-    new_locked_users = []
-    # registered_at stores millisecond precision, but we want all registrations
-    #   from CSV import to be considered as one "batch". So we mark a timestamp
-    #   once, and then reuse it throughout the loop.
-    import_time = Time.now.utc
-    emails = @registrations.pluck(:email)
-    ActiveRecord::Base.transaction do
-      @competition.registrations.accepted.each do |registration|
-        registration.update!(competing_status: Registrations::Helper::STATUS_CANCELLED) unless emails.include?(registration.user.email)
-      end
-      @registrations.each do |registration_data|
-        user, locked_account_created = Registrations::Helper.user_for_registration!(registration_data)
-        new_locked_users << user if locked_account_created
-        registration = @competition.registrations.find_or_initialize_by(user_id: user.id) do |reg|
-          reg.registered_at = import_time
-        end
-        registration.save_registration_data!(registration_data: registration_data, creator: current_user, source: Registration::CSV_IMPORT)
-      rescue StandardError => e
-        raise e.exception(I18n.t("registrations.import.errors.error", registration: registration_data[:name], error: e))
-      end
-    end
-    new_locked_users.each do |user|
-      RegistrationsMailer.notify_registrant_of_locked_account_creation(user, @competition).deliver_later
-    end
+    Registrations::Helper.import_registrations!(@competition, @registrations, current_user)
     render status: :ok, json: { success: true }
   rescue StandardError => e
     render status: :unprocessable_content, json: { error: e.to_s }
@@ -346,14 +323,13 @@ class RegistrationsController < ApplicationController
         ],
       ).to_h.symbolize_keys
       registration_data = build_wcif_data(**registration_params)
-      user, locked_account_created = Registrations::Helper.user_for_registration!(registration_data)
+      user = Registrations::Helper.user_for_registration!(registration_data)
       registration = @competition.registrations.find_or_initialize_by(user_id: user.id) do |reg|
         reg.registered_at = Time.now.utc
       end
       raise I18n.t("registrations.add.errors.already_registered") unless registration.new_record?
 
       registration.save_registration_data!(registration_data: registration_data, creator: current_user, source: Registration::OTS_FORM)
-      RegistrationsMailer.notify_registrant_of_locked_account_creation(user, @competition).deliver_later if locked_account_created
     end
     flash[:success] = I18n.t("registrations.flash.added")
     redirect_to competition_registrations_add_url(@competition)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1182,7 +1182,11 @@ class User < ApplicationRecord
   end
 
   def notify_of_results_posted(competition)
-    CompetitionsMailer.notify_users_of_results_presence(self, competition).deliver_later if results_notifications_enabled?
+    if results_notifications_enabled?
+      CompetitionsMailer.notify_users_of_results_presence(self, competition).deliver_later
+    elsif locked_account?
+      RegistrationsMailer.notify_registrant_of_locked_account_creation(self, competition).deliver_later
+    end
   end
 
   def maybe_assign_wca_id_by_results(competition, notify: true)

--- a/lib/competition_results_import.rb
+++ b/lib/competition_results_import.rb
@@ -138,7 +138,13 @@ module CompetitionResultsImport
       # It's important to clearout the 'posting_by' here to make sure
       # another WRT member can start posting other results.
       comp.update!(results_posted_at: Time.now, results_posted_by: current_user.id, posting_by: nil)
-      comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
+      comp.competitor_users.each do |user|
+        if user.locked_account?
+          RegistrationsMailer.notify_registrant_of_locked_account_creation(user, comp).deliver_later
+        else
+          user.notify_of_results_posted(comp)
+        end
+      end
       comp.registrations.accepted.each { |registration| registration.user.maybe_assign_wca_id_by_results(comp) }
       comp.tickets_competition_result.presence&.update!(status: TicketsCompetitionResult.statuses[:posted])
     end

--- a/lib/competition_results_import.rb
+++ b/lib/competition_results_import.rb
@@ -138,13 +138,7 @@ module CompetitionResultsImport
       # It's important to clearout the 'posting_by' here to make sure
       # another WRT member can start posting other results.
       comp.update!(results_posted_at: Time.now, results_posted_by: current_user.id, posting_by: nil)
-      comp.competitor_users.each do |user|
-        if user.locked_account?
-          RegistrationsMailer.notify_registrant_of_locked_account_creation(user, comp).deliver_later
-        else
-          user.notify_of_results_posted(comp)
-        end
-      end
+      comp.competitor_users.each { |user| user.notify_of_results_posted(comp) }
       comp.registrations.accepted.each { |registration| registration.user.maybe_assign_wca_id_by_results(comp) }
       comp.tickets_competition_result.presence&.update!(status: TicketsCompetitionResult.statuses[:posted])
     end

--- a/lib/registrations/helper.rb
+++ b/lib/registrations/helper.rb
@@ -54,14 +54,36 @@ module Registrations
       }
     end
 
+    def self.import_registrations!(competition, registrations_data, creator)
+      # registered_at stores millisecond precision, but we want all registrations
+      #   from CSV import to be considered as one "batch". So we mark a timestamp
+      #   once, and then reuse it throughout the loop.
+      import_time = Time.now.utc
+      emails = registrations_data.pluck(:email)
+
+      ActiveRecord::Base.transaction do
+        competition.registrations.accepted.each do |registration|
+          registration.update!(competing_status: STATUS_CANCELLED) unless emails.include?(registration.user.email)
+        end
+        registrations_data.each do |registration_data|
+          user = user_for_registration!(registration_data)
+          registration = competition.registrations.find_or_initialize_by(user_id: user.id) do |reg|
+            reg.registered_at = import_time
+          end
+          registration.save_registration_data!(registration_data: registration_data, creator: creator, source: Registration::CSV_IMPORT)
+        rescue StandardError => e
+          raise e.exception(I18n.t("registrations.import.errors.error", registration: registration_data[:name], error: e))
+        end
+      end
+    end
+
     def self.user_for_registration!(registration_row)
       wca_id = registration_row[:wcaId]&.upcase
       email = registration_row[:email]&.downcase
-      country_iso2 = registration_row[:countryIso2]
 
       person_details = {
         name: registration_row[:name],
-        country_iso2: country_iso2,
+        country_iso2: registration_row[:countryIso2],
         gender: registration_row[:gender],
         dob: registration_row[:birthdate],
       }
@@ -81,15 +103,15 @@ module Registrations
               else
                 # User hooks will also remove the dummy user account.
                 email_user.update!(wca_id: wca_id, **person_details)
-                [email_user, false]
+                email_user
               end
             else
               user.skip_reconfirmation!
               user.update!(dummy_account: false, **person_details, email: email)
-              [user, true]
+              user
             end
           else
-            [user, false] # Use this account.
+            user # Use this account.
           end
         else
           email_user = User.find_by(email: email)
@@ -100,11 +122,11 @@ module Registrations
                            registration_wca_id: wca_id)
             else
               email_user.update!(wca_id: wca_id, **person_details)
-              [email_user, false]
+              email_user
             end
           else
             # Create a locked account with confirmed WCA ID.
-            [create_locked_account!(registration_row), true]
+            create_locked_account!(registration_row)
           end
         end
       else
@@ -116,9 +138,9 @@ module Registrations
             # Given it's verified by organizers, it's more trustworthy/official data (if different at all).
             email_user.update!(person_details)
           end
-          [email_user, false]
+          email_user
         else
-          [create_locked_account!(registration_row), true]
+          create_locked_account!(registration_row)
         end
       end
     end

--- a/spec/controllers/tickets_controller_spec.rb
+++ b/spec/controllers/tickets_controller_spec.rb
@@ -117,6 +117,31 @@ RSpec.describe TicketsController do
         expect(competition.results_posted_by).to eq wrt_member.id
       end
 
+      it "sends notifications of locked account creation to locked users" do
+        competition = results_ticket.competition
+        round = create(:round, competition: competition, number: 2)
+
+        person = create(:person)
+        locked_user = User.new_locked_account(
+          name: person.name,
+          email: "test@example.com",
+          wca_id: person.wca_id,
+          country_iso2: person.country_iso2,
+          gender: person.gender,
+          dob: person.dob,
+        )
+        locked_user.save!
+
+        # Add result so they show up in comp.competitor_users
+        create(:result, person: locked_user.person, competition_id: competition.id, event_id: "333", round: round)
+
+        expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation).with(locked_user, competition).and_call_original
+
+        expect do
+          post :post_results, params: { ticket_id: results_ticket.ticket.id }
+        end.to change(enqueued_jobs, :size).by(1)
+      end
+
       it "sends notifications of id claim possibility to newcomers" do
         competition = results_ticket.competition
         create_list(:registration, 2, :accepted, :newcomer, competition: competition)

--- a/spec/lib/registrations/helper_spec.rb
+++ b/spec/lib/registrations/helper_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Registrations::Helper do
 
       it 'creates a new locked user account' do
         user = Registrations::Helper.user_for_registration!(registration_data)
+        expect(user.locked_account?).to be(true)
         expect(user.name).to eq('Test Person')
         expect(user.email).to eq('testperson@example.com')
         expect(user.access_locked?).to be(true) if user.respond_to?(:access_locked?)
@@ -50,6 +51,7 @@ RSpec.describe Registrations::Helper do
       it 'uses the existing user' do
         expect do
           user = Registrations::Helper.user_for_registration!(registration_data)
+          expect(user.locked_account?).to be(false)
           expect(user.id).to eq(existing_user.id)
         end.to change(User, :count).by(0)
       end
@@ -77,6 +79,7 @@ RSpec.describe Registrations::Helper do
 
       it 'returns the user normallly since this method does not check for registrations' do
         user = Registrations::Helper.user_for_registration!(registration_data)
+        expect(user.locked_account?).to be(false)
         expect(user.id).to eq(existing_user.id)
       end
     end

--- a/spec/lib/registrations/helper_spec.rb
+++ b/spec/lib/registrations/helper_spec.rb
@@ -24,9 +24,7 @@ RSpec.describe Registrations::Helper do
       end
 
       it 'creates a new locked user account' do
-        user, locked_account_created = Registrations::Helper.user_for_registration!(registration_data)
-
-        expect(locked_account_created).to be(true)
+        user = Registrations::Helper.user_for_registration!(registration_data)
         expect(user.name).to eq('Test Person')
         expect(user.email).to eq('testperson@example.com')
         expect(user.access_locked?).to be(true) if user.respond_to?(:access_locked?)
@@ -51,9 +49,7 @@ RSpec.describe Registrations::Helper do
 
       it 'uses the existing user' do
         expect do
-          user, locked_account_created = Registrations::Helper.user_for_registration!(registration_data)
-
-          expect(locked_account_created).to be(false)
+          user = Registrations::Helper.user_for_registration!(registration_data)
           expect(user.id).to eq(existing_user.id)
         end.to change(User, :count).by(0)
       end
@@ -80,9 +76,7 @@ RSpec.describe Registrations::Helper do
       end
 
       it 'returns the user normallly since this method does not check for registrations' do
-        user, locked_account_created = Registrations::Helper.user_for_registration!(registration_data)
-
-        expect(locked_account_created).to be(false)
+        user = Registrations::Helper.user_for_registration!(registration_data)
         expect(user.id).to eq(existing_user.id)
       end
     end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -131,7 +131,6 @@ RSpec.describe "registrations" do
       describe "registrations import" do
         context "registrant has WCA ID" do
           it "renders an error if the WCA ID doesn't exist" do
-            expect(RegistrationsMailer).not_to receive(:notify_registrant_of_locked_account_creation)
             registrations = [
               { name: "Sherlock Holmes", countryIso2: "GB", wcaId: "1000DARN99", birthdate: "2000-01-01", gender: "m", email: "sherlock@example.com", registration: { eventIds: ["333"] } },
             ]
@@ -185,7 +184,6 @@ RSpec.describe "registrations" do
 
               context "no user exists with registrant's email" do
                 it "promotes the dummy user to a locked one, registers and notifies him" do
-                  expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
                   registrations = [
                     { name: dummy_user.name, countryIso2: dummy_user.country.iso2, wcaId: dummy_user.wca_id,
                       birthdate: dummy_user.dob.to_s, gender: dummy_user.gender, email: "sherlock@example.com",
@@ -294,7 +292,6 @@ RSpec.describe "registrations" do
 
             context "no user exists with registrant's email" do
               it "creates a locked user with this WCA ID, registers and notifies him" do
-                expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
                 person = create(:person)
                 registrations = [
                   { name: person.name, countryIso2: person.country.iso2, wcaId: person.wca_id,
@@ -342,7 +339,6 @@ RSpec.describe "registrations" do
 
           context "no user exists with registrant's email" do
             it "creates a locked user without WCA ID, registers and notifies him" do
-              expect(RegistrationsMailer).to receive(:notify_registrant_of_locked_account_creation)
               registrations = [
                 { name: "Sherlock Holmes", countryIso2: "GB", wcaId: "", birthdate: "2000-01-01", gender: "m", email: "sherlock@example.com", registration: { eventIds: ["333"] } },
               ]


### PR DESCRIPTION
Move locked account notification logic from registration import to post-results process