### PR TITLE
Use regex ELB routes for nextjs

### DIFF
--- a/infra/wca_on_rails/shared/elb.tf
+++ b/infra/wca_on_rails/shared/elb.tf
@@ -495,7 +495,7 @@ resource "aws_lb_listener_rule" "rails_forward_next_staging" {
 
   condition {
     path_pattern {
-      values = ["/competitions/*/live*", "/_next/*", "/api/auth/*", "/competitions/*/competitors"]
+      regex_values = ["^/competitions/[^/]+/(live|register)$", "^/_next/.*$", "^/api/auth/.*$", "^/posts.*$"]
     }
   }
 }

--- a/infra/wca_on_rails/staging/worker.tf
+++ b/infra/wca_on_rails/staging/worker.tf
@@ -60,7 +60,7 @@ resource "aws_ecs_service" "worker" {
   # container image, so we want use data.aws_ecs_task_definition to
   # always point to the active task definition
   task_definition                    = data.aws_ecs_task_definition.worker.arn
-  desired_count                      = 2
+  desired_count                      = 1
   scheduling_strategy                = "REPLICA"
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 50


### PR DESCRIPTION
This is already live. We also have been running only one worker for ILR for quite a while (2 was only an experiment for staging)