### PR TITLE
Add stale? check to live round_results

### DIFF
--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -69,19 +69,11 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
     # which lets us answer those polls with an empty 304.
     # Competitor names and the WCIF part of the payload are not covered by the hash and
     # would be served stale until the next result comes in, which we can live with.
-    state_hash = Live::DiffHelper.state_hash(round.to_live_state)
+    state_hash = Live::DiffHelper.state_hash(round.to_live_state(reload: false))
 
     return unless stale?(etag: state_hash, public: true)
 
-    # A client without that ETag (a fresh page load, a projector that just restarted)
-    # still has to be served the whole thing, and on a popular round that is the same
-    # render over and over. The state hash doubles as a content-addressed cache key,
-    # `cache_key_with_version` covers the round configuration on top of it.
-    cached_json = Rails.cache.fetch(["live_round_results", round.cache_key_with_version, state_hash], expires_in: 1.hour) do
-      round.to_live_results_json(state_hash: state_hash).to_json
-    end
-
-    render json: cached_json
+    render json: round.to_live_results_json(state_hash: state_hash)
   end
 
   def rounds

--- a/app/controllers/api/v1/live/live_controller.rb
+++ b/app/controllers/api/v1/live/live_controller.rb
@@ -64,7 +64,24 @@ class Api::V1::Live::LiveController < Api::V1::ApiController
 
     round = Round.find_by_wcif_id!(wcif_id, @competition.id, includes: [:linked_round, { live_results: %i[live_attempts event] }])
 
-    render json: round.to_live_results_json
+    # The state hash covers every result value in the
+    # payload and costs no more than loading the results we'd have to load anyway,
+    # which lets us answer those polls with an empty 304.
+    # Competitor names and the WCIF part of the payload are not covered by the hash and
+    # would be served stale until the next result comes in, which we can live with.
+    state_hash = Live::DiffHelper.state_hash(round.to_live_state)
+
+    return unless stale?(etag: state_hash, public: true)
+
+    # A client without that ETag (a fresh page load, a projector that just restarted)
+    # still has to be served the whole thing, and on a popular round that is the same
+    # render over and over. The state hash doubles as a content-addressed cache key,
+    # `cache_key_with_version` covers the round configuration on top of it.
+    cached_json = Rails.cache.fetch(["live_round_results", round.cache_key_with_version, state_hash], expires_in: 1.hour) do
+      round.to_live_results_json(state_hash: state_hash).to_json
+    end
+
+    render json: cached_json
   end
 
   def rounds

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -336,8 +336,13 @@ class Round < ApplicationRecord
     SQL
   end
 
-  def to_live_state
-    live_results.includes(:live_attempts).map(&:to_live_state)
+  # The results are deliberately re-`includes`d even when the caller has already loaded
+  # them: DiffHelper diffs this before and after a mutation, so the second call has to go
+  # back to the database to see it. Read-only callers that preloaded the attempts
+  # themselves can skip the extra queries with `reload: false`.
+  def to_live_state(reload: true)
+    results = reload ? live_results.includes(:live_attempts) : live_results
+    results.map(&:to_live_state)
   end
 
   def completed_competitors

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -904,7 +904,7 @@ class Round < ApplicationRecord
     end
   end
 
-  def to_live_results_json(only_podiums: false)
+  def to_live_results_json(only_podiums: false, state_hash: nil)
     # For podiums we need the combined competitor set of the whole linked round
     #   (live_podium spans every linked round). For regular round views we only
     #   want this round's own competitors; the frontend merges the linked rounds
@@ -915,7 +915,7 @@ class Round < ApplicationRecord
       "round_id" => id,
       "competitors" => competitors.includes(:user).map(&:to_live_json),
       "results" => only_podiums ? live_podium : live_results,
-      "state_hash" => Live::DiffHelper.state_hash(to_live_state),
+      "state_hash" => state_hash || Live::DiffHelper.state_hash(to_live_state),
       "linked_round_ids" => linked_round&.wcif_ids,
       "completed_competitors" => completed_competitors,
     }

--- a/spec/requests/live_round_results_spec.rb
+++ b/spec/requests/live_round_results_spec.rb
@@ -23,16 +23,6 @@ RSpec.describe "WCA Live API" do
       expect(response.body).to be_empty
     end
 
-    it "serves the same body to a client without the ETag" do
-      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id)
-      first_body = response.body
-
-      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id)
-
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq(first_body)
-    end
-
     it "serves the new results once a result changed" do
       get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id)
       etag = response.headers["ETag"]

--- a/spec/requests/live_round_results_spec.rb
+++ b/spec/requests/live_round_results_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "WCA Live API" do
+  describe "GET #round_results" do
+    let!(:competition) { create(:competition, scoretaking_software: :internal, event_ids: ["333"]) }
+    let!(:registrations) { create_list(:registration, 5, :accepted, competition: competition, event_ids: ["333"]) }
+    let(:round) { create(:round, number: 1, event_id: "333", competition: competition) }
+
+    before { round.open_and_lock_previous(User.first) }
+
+    it "answers an unchanged poll with a 304" do
+      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id)
+
+      expect(response).to have_http_status(:ok)
+      etag = response.headers["ETag"]
+      expect(etag).to be_present
+
+      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id), headers: { "If-None-Match" => etag }
+
+      expect(response).to have_http_status(:not_modified)
+      expect(response.body).to be_empty
+    end
+
+    it "serves the same body to a client without the ETag" do
+      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id)
+      first_body = response.body
+
+      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(first_body)
+    end
+
+    it "serves the new results once a result changed" do
+      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id)
+      etag = response.headers["ETag"]
+      previous_state_hash = response.parsed_body["state_hash"]
+
+      result = round.live_results.find_by!(registration_id: registrations.first)
+      attempts = Array.new(5) { |i| { value: 300, attempt_number: i + 1 } }
+      UpdateLiveResultJob.perform_now(result, attempts, User.first.id)
+
+      get api_v1_competition_live_live_round_results_path(competition.id, round.wcif_id), headers: { "If-None-Match" => etag }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["state_hash"]).not_to eq(previous_state_hash)
+    end
+  end
+end


### PR DESCRIPTION
I've been thinking about resiliency in regards to #15507 and if we want any kind of back up polling we need to have a `stale?` check on `round_results` so this PR is adding that. 

Having this is free (we have to compute state_hash anyway) and it already saves us some requests now.