### PR TITLE
Low Internet Mode: Add Polling as a fallback

### DIFF
--- a/next-frontend/src/components/live/PendingResultsTable.tsx
+++ b/next-frontend/src/components/live/PendingResultsTable.tsx
@@ -2,8 +2,14 @@ import { Collapsible, Heading, Table, VStack } from "@chakra-ui/react";
 import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
 import formats from "@/lib/wca/data/formats";
 import { padSkipped } from "@/lib/live/padSkipped";
-import { LiveCompetitor, PendingLiveResult } from "@/types/live";
+import { LiveCompetitor, StagedLiveResult } from "@/types/live";
 import { useT } from "@/lib/i18n/useI18n";
+import usePerpetualState from "@/lib/hooks/usePerpetualState";
+
+// A result normally clears within a second or two. Anything still here after
+// this long means our submit or the confirmation didn't make it through.
+const STUCK_AFTER_MS = 30_000;
+const STUCK_CHECK_INTERVAL_MS = 5_000;
 
 export default function PendingResultsTable({
   pendingLiveResults,
@@ -11,12 +17,15 @@ export default function PendingResultsTable({
   eventId,
   competitors,
 }: {
-  pendingLiveResults: PendingLiveResult[];
+  pendingLiveResults: StagedLiveResult[];
   formatId: string;
   eventId: string;
   competitors: Map<number, LiveCompetitor>;
 }) {
   const { t } = useT();
+
+  // Ticks so rows that never get confirmed start showing as stuck on their own.
+  const now = usePerpetualState(() => Date.now(), STUCK_CHECK_INTERVAL_MS);
 
   const format = formats.byId[formatId];
   const solveCount = format.expected_solve_count;
@@ -51,8 +60,18 @@ export default function PendingResultsTable({
                   pendingResult.registration_id,
                 )!;
 
+                const isStuck = now - pendingResult.staged_at > STUCK_AFTER_MS;
+
                 return (
-                  <Table.Row key={`${pendingResult.registration_id}`}>
+                  <Table.Row
+                    key={`${pendingResult.registration_id}`}
+                    bg={isStuck ? "red.subtle" : undefined}
+                    title={
+                      isStuck
+                        ? "Not confirmed by the server yet - check your connection"
+                        : undefined
+                    }
+                  >
                     <Table.Cell>{competitor.registrant_id}</Table.Cell>
                     <Table.Cell>{competitor.name}</Table.Cell>
                     {padSkipped(

--- a/next-frontend/src/lib/hooks/usePerpetualState.ts
+++ b/next-frontend/src/lib/hooks/usePerpetualState.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const DEFAULT_INTERVAL_MS = 1000;
+
+/**
+ * Re-runs `computeFn` on a timer, so that values derived from the current time (countdowns,
+ * "has this deadline passed") stay truthful without the user reloading the page.
+ */
+export default function usePerpetualState<T>(
+  computeFn: () => T,
+  intervalMs = DEFAULT_INTERVAL_MS,
+) {
+  const [volatile, setVolatile] = useState(computeFn);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => setVolatile(computeFn), intervalMs);
+
+    return () => clearInterval(intervalId);
+  }, [computeFn, intervalMs]);
+
+  return volatile;
+}

--- a/next-frontend/src/providers/LiveResultProvider.tsx
+++ b/next-frontend/src/providers/LiveResultProvider.tsx
@@ -22,7 +22,6 @@ import useAPI from "@/lib/wca/useAPI";
 import useResultsSubscriptions, {
   CONNECTION_STATE_CONNECTED,
   ConnectionState,
-  DiffedLiveResult,
   DiffProtocolResponse,
 } from "@/lib/hooks/useResultsSubscription";
 import { applyDiffToLiveResults } from "@/lib/live/applyDiffToLiveResults";
@@ -61,6 +60,8 @@ const LiveResultContext = createContext<LiveResultContextType | undefined>(
 // interval is proof enough that the socket works, so we skip that poll. A dropped
 // diff doesn't need one either, the `before_hash` check resyncs us as soon as the
 // next broadcast arrives.
+const LIVE_QUERY_RETRIES = 2;
+
 const POLL_INTERVAL_WAITING_MS = 5_000;
 const POLL_INTERVAL_IDLE_MS = 60_000;
 
@@ -84,6 +85,17 @@ const compareAttempts = (
     )
   );
 };
+
+const isConfirmedBy = (
+  results: LiveResult[],
+  pendingResult: StagedLiveResult,
+) =>
+  results.some(
+    (result) =>
+      result.registration_id === pendingResult.registration_id &&
+      result.round_wcif_id === pendingResult.round_wcif_id &&
+      compareAttempts(pendingResult.attempts, result.attempts),
+  );
 
 export function LiveResultProvider({
   initialRound,
@@ -138,10 +150,36 @@ export function MultiRoundResultProvider({
   );
 
   // One query per round
-  const queries = initialRounds.map((round) => ({
-    ...roundQueryOptions(round.id),
-    initialData: round,
-  }));
+  const queries = initialRounds.map((round) => {
+    const roundQuery = roundQueryOptions(round.id);
+
+    return {
+      ...roundQuery,
+      // Pending state reconciles itself from the round data, but the round counters live
+      // in another provider's cache and have to be pushed there. Wrapping the fetch
+      // rather than doing it at the call sites covers the refetches React Query starts on
+      // its own, on focus and on reconnect.
+      queryFn: async (context: Parameters<typeof roundQuery.queryFn>[0]) => {
+        const data = await roundQuery.queryFn(context);
+
+        setCompletedCount(round.id, data.completed_competitors);
+        setTotalCompetitors(round.id, data.results.length);
+
+        return data;
+      },
+      initialData: round,
+      // Overriding the app-wide `retry: false`: on a venue connection a request drops for
+      // no lasting reason, and giving up on it means waiting out a whole poll interval
+      // before we try again. Uses the default backoff (1s, then 2s).
+      retry: LIVE_QUERY_RETRIES,
+      // "always" rather than `true`, because the app-wide `staleTime: Infinity` means
+      // these queries are never stale and the plain flags only refetch stale ones. Coming
+      // back from a locked screen or a dead network is when our state is most likely to
+      // be out of date, whatever React Query thinks of its age.
+      refetchOnWindowFocus: "always" as const,
+      refetchOnReconnect: "always" as const,
+    };
+  });
 
   const {
     liveResultsByRegistrationId,
@@ -167,58 +205,6 @@ export function MultiRoundResultProvider({
     }),
   });
 
-  const diffPendingResults = useCallback(
-    <T extends DiffedLiveResult>(
-      incomingResults: T[],
-      comparisonFn: (pending: StagedLiveResult, incoming: T) => boolean,
-    ) => {
-      updatePendingResults((prevPendingResults) =>
-        prevPendingResults.filter(
-          (pr) =>
-            !incomingResults.some(
-              (ir) =>
-                ir.registration_id === pr.registration_id &&
-                comparisonFn(pr, ir),
-            ),
-        ),
-      );
-    },
-    [],
-  );
-
-  // Full refetch: used whenever we can't trust our incremental state, either
-  // because a diff didn't line up with what we have, or because we polled.
-  const resyncRound = (roundId: string) => {
-    refetchRound(roundId).then((res) => {
-      if (!res.isSuccess) {
-        return;
-      }
-
-      const newData = res.data;
-      const newResults = newData.results;
-      const newCompetitors = newData.competitors;
-
-      setCompletedCount(roundId, newData.completed_competitors);
-      setTotalCompetitors(roundId, newCompetitors.length);
-
-      // We just made a full refetch. Only keep those results as "pending"
-      //   which are NOT contained exactly in the refetched round.
-      // In other words, if we find a competitor with the updated attempts
-      //   in the refetched round, then their result is not pending anymore.
-      diffPendingResults(newResults, (pr, ir) =>
-        compareAttempts(pr.attempts, ir.attempts),
-      );
-
-      updatePendingQuitCompetitors((currentlyQuitCompetitors) =>
-        // Only keep pending quit markers if they are _still_ in the refetched round
-        //   (ie the "quit" has not been executed yet)
-        currentlyQuitCompetitors.intersection(
-          new Set(newCompetitors.map((r) => r.id)),
-        ),
-      );
-    });
-  };
-
   // Not state: this only ever gates a timer, re-rendering on every broadcast for it
   // would be wasteful.
   const lastMessageAt = useRef(0);
@@ -235,7 +221,8 @@ export function MultiRoundResultProvider({
     } = diff;
 
     if (before_hash !== stateHashesByRoundId[roundId]) {
-      resyncRound(roundId);
+      // Everything a full refetch needs to fix up happens in the query itself
+      refetchRound(roundId);
     } else {
       const decompressedUpdated = updated.map(decompressPartialResult);
       const decompressedCreated = created.map(decompressFullResult);
@@ -266,27 +253,34 @@ export function MultiRoundResultProvider({
       if (newRound) {
         setCompletedCount(roundId, countCompletedResults(newRound));
         setTotalCompetitors(roundId, newRound.results.length);
-      }
 
-      diffPendingResults(decompressedUpdated, (pr, ir) => {
-        // The incoming values are diffs, meaning (type-wise)
-        //   they might not actually contain attempts. For example when only advancing is updated
-        return (
-          ir.attempts !== undefined && compareAttempts(pr.attempts, ir.attempts)
+        // Confirmed entries are already hidden by the filter further down, but they have
+        // to leave the store too: a later change to the same competitor would stop
+        // matching and pop the old entry back up as pending.
+        updatePendingResults((pending) =>
+          pending.filter(
+            (pendingResult) => !isConfirmedBy(newRound.results, pendingResult),
+          ),
         );
-      });
 
-      updatePendingQuitCompetitors((currentlyQuitCompetitors) =>
-        // If a competitor is listed as "deleted", then consider that our pending quit was executed by the backend
-        currentlyQuitCompetitors.difference(new Set(deleted)),
-      );
+        updatePendingQuitCompetitors((quitting) =>
+          quitting.intersection(new Set(newRound.competitors.map((c) => c.id))),
+        );
+      }
     }
   };
 
   const addPendingLiveResult = useCallback(
     (liveResult: PendingLiveResult, roundWcifId: string) => {
       updatePendingResults((pending) => [
-        ...pending,
+        // Same pruning as in onReceived, for when nothing has been broadcast since
+        ...pending.filter(
+          (pendingResult) =>
+            !isConfirmedBy(
+              liveResultsByRegistrationId[pendingResult.registration_id] ?? [],
+              pendingResult,
+            ),
+        ),
         ...applyDiffToLiveResults({
           previousResults:
             liveResultsByRegistrationId[liveResult.registration_id],
@@ -309,12 +303,28 @@ export function MultiRoundResultProvider({
     roundIds,
     competitionId,
     onReceived,
-    resyncRound,
+    refetchRound,
+  );
+
+  // Derived rather than pruned by whoever brought the data in: a result stops being
+  // pending as soon as the round data echoes it back, be that a diff, a poll, or a
+  // refetch React Query started on focus or reconnect.
+  const pendingLiveResults = pendingResults.filter(
+    (pendingResult) =>
+      !isConfirmedBy(
+        liveResultsByRegistrationId[pendingResult.registration_id] ?? [],
+        pendingResult,
+      ),
+  );
+
+  // A quit that went through takes the competitor out of the round.
+  const pendingQuits = pendingQuitCompetitors.intersection(
+    new Set(competitors.keys()),
   );
 
   const waitingForConfirmation =
-    pendingResults.length > 0 ||
-    pendingQuitCompetitors.size > 0 ||
+    pendingLiveResults.length > 0 ||
+    pendingQuits.size > 0 ||
     connectionState !== CONNECTION_STATE_CONNECTED;
 
   const resyncAllRounds = useEffectEvent((quietPeriodMs: number) => {
@@ -327,7 +337,7 @@ export function MultiRoundResultProvider({
       .filter(
         (roundId) => rounds.find((r) => r.id === roundId)?.state !== "locked",
       )
-      .forEach((roundId) => resyncRound(roundId));
+      .forEach((roundId) => refetchRound(roundId));
   });
 
   useEffect(() => {
@@ -335,30 +345,23 @@ export function MultiRoundResultProvider({
       ? POLL_INTERVAL_WAITING_MS
       : POLL_INTERVAL_IDLE_MS;
 
-    const poll = () => resyncAllRounds(pollInterval);
-    // Coming back from a locked screen or a dead network is exactly when our
-    // state is most likely to be stale, so resync unconditionally and don't wait
-    // for the next tick.
-    const resyncNow = () => resyncAllRounds(0);
+    // Waking from a locked screen or a dead network is handled by the queries'
+    // `refetchOnWindowFocus` / `refetchOnReconnect` above.
+    const interval = setInterval(
+      () => resyncAllRounds(pollInterval),
+      pollInterval,
+    );
 
-    const interval = setInterval(poll, pollInterval);
-    window.addEventListener("focus", resyncNow);
-    window.addEventListener("online", resyncNow);
-
-    return () => {
-      clearInterval(interval);
-      window.removeEventListener("focus", resyncNow);
-      window.removeEventListener("online", resyncNow);
-    };
+    return () => clearInterval(interval);
   }, [waitingForConfirmation]);
 
   return (
     <LiveResultContext.Provider
       value={{
         liveResultsByRegistrationId,
-        pendingLiveResults: pendingResults,
+        pendingLiveResults,
         addPendingLiveResult,
-        pendingQuitCompetitors,
+        pendingQuitCompetitors: pendingQuits,
         addPendingQuitCompetitor,
         connectionState,
         competitors,

--- a/next-frontend/src/providers/LiveResultProvider.tsx
+++ b/next-frontend/src/providers/LiveResultProvider.tsx
@@ -5,6 +5,9 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
+  useEffectEvent,
+  useRef,
   useState,
 } from "react";
 import {
@@ -13,9 +16,11 @@ import {
   LiveResult,
   LiveRound,
   PendingLiveResult,
+  StagedLiveResult,
 } from "@/types/live";
 import useAPI from "@/lib/wca/useAPI";
 import useResultsSubscriptions, {
+  CONNECTION_STATE_CONNECTED,
   ConnectionState,
   DiffedLiveResult,
   DiffProtocolResponse,
@@ -37,7 +42,7 @@ interface LiveResultContextType {
     liveResult: PendingLiveResult,
     roundWcifId: string,
   ) => void;
-  pendingLiveResults: PendingLiveResult[];
+  pendingLiveResults: StagedLiveResult[];
   addPendingQuitCompetitor: (registrationId: number) => void;
   pendingQuitCompetitors: Set<number>;
   connectionState: ConnectionState;
@@ -47,6 +52,17 @@ interface LiveResultContextType {
 const LiveResultContext = createContext<LiveResultContextType | undefined>(
   undefined,
 );
+
+// The websocket is the primary channel. These polls are the fallback for when it
+// stops delivering without telling us: a sleeping tab, a captive portal, or a
+// broadcast dropped between two heartbeats. Results waiting to be confirmed are
+// polled for aggressively, an idle round is only checked occasionally.
+// They double as the quiet period: a broadcast that arrived within the last
+// interval is proof enough that the socket works, so we skip that poll. A dropped
+// diff doesn't need one either, the `before_hash` check resyncs us as soon as the
+// next broadcast arrives.
+const POLL_INTERVAL_WAITING_MS = 5_000;
+const POLL_INTERVAL_IDLE_MS = 60_000;
 
 const compareAttempts = (
   attemptsA: LiveAttempt[],
@@ -97,7 +113,7 @@ export function MultiRoundResultProvider({
   competitionId: string;
   children: ReactNode;
 }) {
-  const [pendingResults, updatePendingResults] = useState<PendingLiveResult[]>(
+  const [pendingResults, updatePendingResults] = useState<StagedLiveResult[]>(
     [],
   );
   const [pendingQuitCompetitors, updatePendingQuitCompetitors] = useState<
@@ -106,7 +122,7 @@ export function MultiRoundResultProvider({
 
   const api = useAPI();
   const queryClient = useQueryClient();
-  const { setCompletedCount, setTotalCompetitors } = useAllRoundsInfo();
+  const { rounds, setCompletedCount, setTotalCompetitors } = useAllRoundsInfo();
 
   const roundQueryOptions = useCallback(
     (roundId: string) => {
@@ -154,7 +170,7 @@ export function MultiRoundResultProvider({
   const diffPendingResults = useCallback(
     <T extends DiffedLiveResult>(
       incomingResults: T[],
-      comparisonFn: (pending: PendingLiveResult, incoming: T) => boolean,
+      comparisonFn: (pending: StagedLiveResult, incoming: T) => boolean,
     ) => {
       updatePendingResults((prevPendingResults) =>
         prevPendingResults.filter(
@@ -170,7 +186,46 @@ export function MultiRoundResultProvider({
     [],
   );
 
+  // Full refetch: used whenever we can't trust our incremental state, either
+  // because a diff didn't line up with what we have, or because we polled.
+  const resyncRound = (roundId: string) => {
+    refetchRound(roundId).then((res) => {
+      if (!res.isSuccess) {
+        return;
+      }
+
+      const newData = res.data;
+      const newResults = newData.results;
+      const newCompetitors = newData.competitors;
+
+      setCompletedCount(roundId, newData.completed_competitors);
+      setTotalCompetitors(roundId, newCompetitors.length);
+
+      // We just made a full refetch. Only keep those results as "pending"
+      //   which are NOT contained exactly in the refetched round.
+      // In other words, if we find a competitor with the updated attempts
+      //   in the refetched round, then their result is not pending anymore.
+      diffPendingResults(newResults, (pr, ir) =>
+        compareAttempts(pr.attempts, ir.attempts),
+      );
+
+      updatePendingQuitCompetitors((currentlyQuitCompetitors) =>
+        // Only keep pending quit markers if they are _still_ in the refetched round
+        //   (ie the "quit" has not been executed yet)
+        currentlyQuitCompetitors.intersection(
+          new Set(newCompetitors.map((r) => r.id)),
+        ),
+      );
+    });
+  };
+
+  // Not state: this only ever gates a timer, re-rendering on every broadcast for it
+  // would be wasteful.
+  const lastMessageAt = useRef(0);
+
   const onReceived = (roundId: string, diff: DiffProtocolResponse) => {
+    lastMessageAt.current = Date.now();
+
     const {
       updated = [],
       created = [],
@@ -180,34 +235,7 @@ export function MultiRoundResultProvider({
     } = diff;
 
     if (before_hash !== stateHashesByRoundId[roundId]) {
-      refetchRound(roundId).then((res) => {
-        if (!res.isSuccess) {
-          return;
-        }
-
-        const newData = res.data;
-        const newResults = newData.results;
-        const newCompetitors = newData.competitors;
-
-        setCompletedCount(roundId, newData.completed_competitors);
-        setTotalCompetitors(roundId, newCompetitors.length);
-
-        // We just made a full refetch. Only keep those results as "pending"
-        //   which are NOT contained exactly in the refetched round.
-        // In other words, if we find a competitor with the updated attempts
-        //   in the refetched round, then their result is not pending anymore.
-        diffPendingResults(newResults, (pr, ir) =>
-          compareAttempts(pr.attempts, ir.attempts),
-        );
-
-        updatePendingQuitCompetitors((currentlyQuitCompetitors) =>
-          // Only keep pending quit markers if they are _still_ in the refetched round
-          //   (ie the "quit" has not been executed yet)
-          currentlyQuitCompetitors.intersection(
-            new Set(newCompetitors.map((r) => r.id)),
-          ),
-        );
-      });
+      resyncRound(roundId);
     } else {
       const decompressedUpdated = updated.map(decompressPartialResult);
       const decompressedCreated = created.map(decompressFullResult);
@@ -264,7 +292,7 @@ export function MultiRoundResultProvider({
             liveResultsByRegistrationId[liveResult.registration_id],
           updated: [liveResult],
           roundWcifId: roundWcifId,
-        }),
+        }).map((result) => ({ ...result, staged_at: Date.now() })),
       ]);
     },
     [liveResultsByRegistrationId],
@@ -276,24 +304,53 @@ export function MultiRoundResultProvider({
     );
   }, []);
 
-  const refetchAndClearPending = (roundId: string) => {
-    refetchRound(roundId).then((res) => {
-      if (!res.isSuccess) {
-        return;
-      }
-      diffPendingResults(res.data.results, (pr, ir) =>
-        compareAttempts(pr.attempts, ir.attempts),
-      );
-    });
-  };
-
   const roundIds = initialRounds.map((r) => r.id);
   const connectionState = useResultsSubscriptions(
     roundIds,
     competitionId,
     onReceived,
-    refetchAndClearPending,
+    resyncRound,
   );
+
+  const waitingForConfirmation =
+    pendingResults.length > 0 ||
+    pendingQuitCompetitors.size > 0 ||
+    connectionState !== CONNECTION_STATE_CONNECTED;
+
+  const resyncAllRounds = useEffectEvent((quietPeriodMs: number) => {
+    if (Date.now() - lastMessageAt.current < quietPeriodMs) {
+      return;
+    }
+
+    roundIds
+      // A locked round is final, there is nothing left to poll for.
+      .filter(
+        (roundId) => rounds.find((r) => r.id === roundId)?.state !== "locked",
+      )
+      .forEach((roundId) => resyncRound(roundId));
+  });
+
+  useEffect(() => {
+    const pollInterval = waitingForConfirmation
+      ? POLL_INTERVAL_WAITING_MS
+      : POLL_INTERVAL_IDLE_MS;
+
+    const poll = () => resyncAllRounds(pollInterval);
+    // Coming back from a locked screen or a dead network is exactly when our
+    // state is most likely to be stale, so resync unconditionally and don't wait
+    // for the next tick.
+    const resyncNow = () => resyncAllRounds(0);
+
+    const interval = setInterval(poll, pollInterval);
+    window.addEventListener("focus", resyncNow);
+    window.addEventListener("online", resyncNow);
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("focus", resyncNow);
+      window.removeEventListener("online", resyncNow);
+    };
+  }, [waitingForConfirmation]);
 
   return (
     <LiveResultContext.Provider

--- a/next-frontend/src/types/live.ts
+++ b/next-frontend/src/types/live.ts
@@ -13,3 +13,6 @@ export type PendingLiveResult = PartialExcept<
   LiveResult,
   "registration_id" | "attempts"
 >;
+// A pending result we sent, stamped with when we sent it, so the UI can flag
+// results the backend hasn't confirmed back to us in a reasonable time.
+export type StagedLiveResult = PendingLiveResult & { staged_at: number };


### PR DESCRIPTION
Just an idea I had yesterday after we talked about #15507 that I wanted to quickly jot down before I forget.

Basically, we could 'detect' that no websocket updates have come in by keeping track off the last message received timestamp and if that is bigger than X and there are still pending results we fall back to polling. We retry the poll two times using the native Tanstack query tools (WCA Live does the same).

If there hasn't been any updates to pending results after 30 seconds we show an error to the user telling them to check their connection.

Additionally, we refetch on Mount/On Internet Reconnect. That is basically free if nothing changed per #15515. 

Thoughts?

I think we definitely should do this refactor regardless:
  ```
const queries = initialRounds.map((round) => {
    const roundQuery = roundQueryOptions(round.id);

    return {
      ...roundQuery,
      queryFn: async (context: Parameters<typeof roundQuery.queryFn>[0]) => {
        const data = await roundQuery.queryFn(context);

        setCompletedCount(round.id, data.completed_competitors);
        setTotalCompetitors(round.id, data.results.length);

        return data;
      },
      initialData: round,
      retry: LIVE_QUERY_RETRIES,
      refetchOnWindowFocus: "always" as const,
      refetchOnReconnect: "always" as const,
    };
  });
```

As refetching on window focus/reconnect and adding a retry will probably already buy us a good amount of resiliency  