### PR TITLE
Allow blank guest entry fee when confirming a competition

### DIFF
--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -262,7 +262,7 @@ class Competition < ApplicationRecord
            as: "on_the_spot_base_entry_fee",
            allow_nil: true,
            with_model_currency: :currency_code
-  validates :guests_entry_fee_lowest_denomination, numericality: { greater_than_or_equal_to: 0, allow_nil: true, if: :guests_entry_fee_required? }
+  validates :guests_entry_fee_lowest_denomination, numericality: { greater_than_or_equal_to: 0, if: :guests_entry_fee_required? }
   monetize :guests_entry_fee_lowest_denomination,
            as: "guests_base_fee",
            allow_nil: true,
@@ -1132,7 +1132,8 @@ class Competition < ApplicationRecord
   end
 
   def guests_entry_fee_required?
-    confirmed? && created_at.present? && created_at > Date.new(2018, 8, 22) &&
+    guests_enabled? &&
+      confirmed? && created_at.present? && created_at > Date.new(2018, 8, 22) &&
 
       # The different venues may have different entry fees. It's better for
       # people to leave this blank than to set an incorrect value here.

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -262,7 +262,7 @@ class Competition < ApplicationRecord
            as: "on_the_spot_base_entry_fee",
            allow_nil: true,
            with_model_currency: :currency_code
-  validates :guests_entry_fee_lowest_denomination, numericality: { greater_than_or_equal_to: 0, if: :guests_entry_fee_required? }
+  validates :guests_entry_fee_lowest_denomination, numericality: { greater_than_or_equal_to: 0, allow_nil: true, if: :guests_entry_fee_required? }
   monetize :guests_entry_fee_lowest_denomination,
            as: "guests_base_fee",
            allow_nil: true,

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -103,16 +103,11 @@ RSpec.describe Competition do
   end
 
   it "does not require a guest entry fee when guests are not enabled" do
-    competition = create(:competition)
-    competition.confirmed = true
-    competition.country_id = "USA"
-    competition.guests_enabled = false
-    competition.guests_entry_fee_lowest_denomination = nil
+    competition = create(:competition, :confirmed, country_id: "USA", guests_enabled: false, guests_entry_fee_lowest_denomination: nil)
 
     expect(competition.guests_entry_fee_required?).to be false
 
-    competition.validate
-    expect(competition.errors[:guests_entry_fee_lowest_denomination]).to be_empty
+    expect(competition).to be_valid
   end
 
   it "handles free guest entry status" do

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -102,13 +102,14 @@ RSpec.describe Competition do
     expect(competition.guests_entry_fee_required?).to be false
   end
 
-  it "allows a blank guest entry fee even when guest entry fees are required" do
+  it "does not require a guest entry fee when guests are not enabled" do
     competition = create(:competition)
     competition.confirmed = true
     competition.country_id = "USA"
+    competition.guests_enabled = false
     competition.guests_entry_fee_lowest_denomination = nil
 
-    expect(competition.guests_entry_fee_required?).to be true
+    expect(competition.guests_entry_fee_required?).to be false
 
     competition.validate
     expect(competition.errors[:guests_entry_fee_lowest_denomination]).to be_empty

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -102,6 +102,18 @@ RSpec.describe Competition do
     expect(competition.guests_entry_fee_required?).to be false
   end
 
+  it "allows a blank guest entry fee even when guest entry fees are required" do
+    competition = create(:competition)
+    competition.confirmed = true
+    competition.country_id = "USA"
+    competition.guests_entry_fee_lowest_denomination = nil
+
+    expect(competition.guests_entry_fee_required?).to be true
+
+    competition.validate
+    expect(competition.errors[:guests_entry_fee_lowest_denomination]).to be_empty
+  end
+
   it "handles free guest entry status" do
     competition = create(:competition)
 


### PR DESCRIPTION
## Problem
Confirming a single-country competition fails with "Guests entry fee lowest denomination is not a number" when the guest fee is left blank. The field shows `0.00` but its stored value is `nil`, so on confirm the numericality validation runs on `nil` and rejects it. Workaround was clicking into the field.

## Cause
`monetize :guests_entry_fee_lowest_denomination` already declares `allow_nil: true`, but the numericality validation didn't, meaning a blank guest fee was rejected on confirm.

## Fix
Add `allow_nil: true` to the validation. A blank guest fee is a valid "no guest fee" state.

## Test 
Added a model spec asserting a confirmed single-country competition with a nil guest fee has no guest-fee error.

Closes #10511 