### PR TITLE
Don't allow to send an empty contact form to WRT

### DIFF
--- a/app/webpacker/components/ContactsPage/SubForms/Wrt/OtherQuery.jsx
+++ b/app/webpacker/components/ContactsPage/SubForms/Wrt/OtherQuery.jsx
@@ -17,6 +17,7 @@ export default function OtherQuery() {
     <Form.TextArea
       label={I18n.t('page.contacts.form.wrt.message.label')}
       name="message"
+      required
       value={message}
       onChange={handleFormChange}
       style={{ whiteSpace: 'pre-wrap' }}


### PR DESCRIPTION
As the title says, it was possible to send an empty form, which was extremely annoying.