### PR TITLE
Validate Markdown Images

### DIFF
--- a/app/controllers/upload_controller.rb
+++ b/app/controllers/upload_controller.rb
@@ -5,18 +5,13 @@ class UploadController < ApplicationController
   before_action -> { redirect_to_root_unless_user(:can_upload_images?) }
 
   def image
-    upload_image = params.require(:image)
+    markdown_image = MarkdownImage.new(uploaded_by: current_user)
+    markdown_image.image.attach(params.require(:image))
 
-    # Unfortunately, there doesn't seem to be any good way to add validations
-    # on file type/content type/etc. See
-    # https://github.com/thewca/worldcubeassociation.org/issues/4380 for more
-    # information.
-    blob = ActiveStorage::Blob.create_and_upload!(
-      io: upload_image,
-      filename: upload_image.original_filename,
-      content_type: upload_image.content_type,
-    )
+    # The image is not associated with anything yet: the record it is being typed
+    # into may not even exist.
+    return render json: { error: markdown_image.errors.full_messages.to_sentence }, status: :unprocessable_content unless markdown_image.save
 
-    render json: { filePath: url_for(blob) }
+    render json: { filePath: url_for(markdown_image.image.blob) }
   end
 end

--- a/app/models/markdown_image.rb
+++ b/app/models/markdown_image.rb
@@ -12,9 +12,6 @@ class MarkdownImage < ApplicationRecord
   MAX_UPLOAD_SIZE = 5.megabytes
 
   validates :image, blob: { content_type: :web_image, size_range: 0..MAX_UPLOAD_SIZE }
-  validate :image_must_be_attached
+  validates :image, presence: true
 
-  private def image_must_be_attached
-    errors.add(:image, :blank) unless self.image.attached?
-  end
 end

--- a/app/models/markdown_image.rb
+++ b/app/models/markdown_image.rb
@@ -13,5 +13,4 @@ class MarkdownImage < ApplicationRecord
 
   validates :image, blob: { content_type: :web_image, size_range: 0..MAX_UPLOAD_SIZE }
   validates :image, presence: true
-
 end

--- a/app/models/markdown_image.rb
+++ b/app/models/markdown_image.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# An image uploaded through a markdown editor. Wrapping the blob in a record is
+# what lets us validate it: UploadController used to create bare blobs, which
+# ActiveStorage has no way to run validations on, so any file at all could be
+# uploaded and then linked to under our own domain.
+class MarkdownImage < ApplicationRecord
+  belongs_to :uploaded_by, class_name: "User", optional: true
+
+  has_one_attached :image
+
+  MAX_UPLOAD_SIZE = 5.megabytes
+
+  validates :image, blob: { content_type: :web_image, size_range: 0..MAX_UPLOAD_SIZE }
+  validate :image_must_be_attached
+
+  private def image_must_be_attached
+    errors.add(:image, :blank) unless self.image.attached?
+  end
+end

--- a/app/webpacker/components/wca/FormBuilder/input/MarkdownEditor.js
+++ b/app/webpacker/components/wca/FormBuilder/input/MarkdownEditor.js
@@ -111,6 +111,10 @@ function getOptions(imageUploadEnabled) {
       try {
         const response = await fetchWithAuthenticityToken('/upload/image', { method: 'POST', body: formData });
         const data = await response.json();
+        if (!response.ok) {
+          onError(data.error);
+          return;
+        }
         onSuccess(data.filePath);
       } catch (e) {
         onError(e);

--- a/app/webpacker/lib/markdown-editor.js
+++ b/app/webpacker/lib/markdown-editor.js
@@ -124,6 +124,10 @@ $(() => {
         try {
           const response = await fetchWithAuthenticityToken('/upload/image', { method: 'POST', body: formData });
           const data = await response.json();
+          if (!response.ok) {
+            onError(data.error);
+            return;
+          }
           onSuccess(data.filePath);
         } catch (e) {
           onError(e);

--- a/db/migrate/20260901120000_create_markdown_images.rb
+++ b/db/migrate/20260901120000_create_markdown_images.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateMarkdownImages < ActiveRecord::Migration[8.1]
+  def change
+    create_table :markdown_images do |t|
+      # Nullable: images backfilled from historical markdown have no known uploader.
+      t.references :uploaded_by, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_25_121610) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_120000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -862,6 +862,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_25_121610) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "markdown_images", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "uploaded_by_id"
+    t.index ["uploaded_by_id"], name: "index_markdown_images_on_uploaded_by_id"
+  end
+
   create_table "matched_scramble_sets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "external_scramble_set_id"
@@ -1681,6 +1688,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_25_121610) do
   add_foreign_key "live_results", "rounds", on_delete: :cascade
   add_foreign_key "live_results", "users", column: "locked_by_id"
   add_foreign_key "live_results", "users", column: "quit_by_id"
+  add_foreign_key "markdown_images", "users", column: "uploaded_by_id"
   add_foreign_key "matched_scramble_sets", "external_scramble_sets"
   add_foreign_key "matched_scramble_sets", "rounds"
   add_foreign_key "matched_scrambles", "external_scrambles"

--- a/lib/database_dumper.rb
+++ b/lib/database_dumper.rb
@@ -352,6 +352,7 @@ module DatabaseDumper
     "active_storage_attachments" => :skip_all_rows,
     "active_storage_blobs" => :skip_all_rows,
     "active_storage_variant_records" => :skip_all_rows,
+    "markdown_images" => :skip_all_rows,
     "ar_internal_metadata" => :skip_all_rows,
     "result_attempts" => {
       column_sanitizers: actions_to_column_sanitizers(

--- a/spec/models/markdown_image_spec.rb
+++ b/spec/models/markdown_image_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MarkdownImage do
+  let(:user) { create(:user) }
+
+  def new_image(fixture, content_type)
+    MarkdownImage.new(uploaded_by: user).tap do |markdown_image|
+      markdown_image.image.attach(io: File.open("spec/support/#{fixture}"), filename: fixture, content_type: content_type)
+    end
+  end
+
+  it "accepts a web image" do
+    expect(new_image('logo.png', 'image/png')).to be_valid
+  end
+
+  it "rejects a file that is not a web image" do
+    expect(new_image('bylaws.pdf', 'application/pdf')).not_to be_valid
+  end
+
+  # The content type the client declares is attacker-controlled, so it is not
+  # what the validation may go on.
+  it "rejects a file that only claims to be a web image" do
+    expect(new_image('bylaws.pdf', 'image/png')).not_to be_valid
+  end
+
+  it "rejects a record with no file at all" do
+    expect(MarkdownImage.new(uploaded_by: user)).not_to be_valid
+  end
+end

--- a/spec/requests/upload_spec.rb
+++ b/spec/requests/upload_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ResultsSubmissionController do
   let(:image) { Rack::Test::UploadedFile.new('spec/support/logo.png', 'image/png') }
+  let(:pdf) { Rack::Test::UploadedFile.new('spec/support/bylaws.pdf', 'application/pdf') }
 
   context "not signed in" do
     sign_out
@@ -18,9 +19,16 @@ RSpec.describe ResultsSubmissionController do
     before { sign_in create :delegate }
 
     it "can upload an image" do
-      post upload_image_path, params: { image: image }
-      json = response.parsed_body
-      expect(json['filePath']).not_to be_nil
+      expect { post upload_image_path, params: { image: image } }.to change(MarkdownImage, :count).by(1)
+
+      expect(response.parsed_body['filePath']).not_to be_nil
+    end
+
+    it "rejects a file that is not a web image" do
+      expect { post upload_image_path, params: { image: pdf } }.not_to change(MarkdownImage, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['error']).to be_present
     end
   end
 end


### PR DESCRIPTION
The smallest changeset of #15520 that allows us to validate the uploaded markdown image without having to review a bunch of other logic in the code. Closes #4380