### PR TITLE
Redesign location picker

### DIFF
--- a/config/i18n-tasks.yml.erb
+++ b/config/i18n-tasks.yml.erb
@@ -144,7 +144,9 @@ ignore_unused:
   - 'errors.next_frontend.*'
   # The incident pages live in next-frontend, which is not searched by i18n-tasks
   - 'incidents_log.*'
-  - 'competitions.index.{all_competitions,event,name,distance,distance_any,advanced_filters}'
+  - 'competitions.index.{all_competitions,event,name,distance,advanced_filters}'
+  - 'competitions.index.{location,location_placeholder,use_my_location}'
+  - 'competitions.index.distance_units.*'
   - 'competitions.index.{registration_key,register_now,view_competition}'
   - 'competitions.index.{registration_status,currently_displaying}.*'
   - 'search_results.index.empty_query'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1643,10 +1643,19 @@ en:
       search: "Search"
       #context: filters competitions by their name
       name: "Name"
-      #context: label of a slider limiting how far away a competition may be, in kilometres
-      distance: "Distance (km)"
-      #context: the setting of the distance slider that applies no limit at all
-      distance_any: "Any"
+      #context: label of the field holding the place that competitions are searched around
+      location: "Location"
+      #context: placeholder of the location field, where a competitor types a street address, city or postcode
+      location_placeholder: "Enter an address"
+      #context: button that fills the location field in with the device's own position
+      use_my_location: "Use my location"
+      #context: label of the field limiting how far away a competition may be from the chosen location
+      distance: "Distance"
+      distance_units:
+        #context: abbreviation for kilometres
+        km: "km"
+        #context: abbreviation for miles
+        mi: "mi"
       advanced_filters: "Advanced Filters"
       state: "When"
       present: "Present"

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/page.tsx
@@ -11,12 +11,14 @@ import {
   HStack,
   parseDate,
   Portal,
-  Slider,
   Input,
   CloseButton,
   InputGroup,
   SimpleGrid,
   Field,
+  Group,
+  NumberInput,
+  SegmentGroup,
   Tabs,
   IconButton,
   ClientOnly,
@@ -59,16 +61,33 @@ import BetaDisabledTooltip from "@/components/BetaDisabledTooltip";
 
 const DEBOUNCE_MS = 600;
 
-// Selectable radii for the "within X of me" filter, in kilometres. The slider is indexed
-// into this list, and the index one past the end means "don't filter by distance at all".
-const DISTANCE_FILTER_KM = [50, 100, 250, 500];
-const NO_DISTANCE_FILTER = DISTANCE_FILTER_KM.length;
+// Units offered by the "within X of me" filter. `toKm` converts a radius in that unit to the
+// kilometres the distance calculation works in, and each unit carries its own default and step
+// so that the two can be tuned independently.
+const DISTANCE_UNITS = {
+  km: { toKm: 1, defaultRadius: 100, step: 50 },
+  mi: { toKm: 1.609344, defaultRadius: 100, step: 50 },
+} as const;
+
+type DistanceUnit = keyof typeof DISTANCE_UNITS;
+
+const DEFAULT_DISTANCE_UNIT: DistanceUnit = "km";
+
+const isDistanceUnit = (value: string | null): value is DistanceUnit =>
+  value !== null && value in DISTANCE_UNITS;
+
+// Decimal places shown for the resolved coordinates, roughly street-level precision.
+const COORDINATE_PRECISION = 4;
 
 export default function CompetitionsPage() {
   const session = useSession();
   const [location, setLocation] = useState<GeoCoordinates>();
-  const [distanceFilterIndex, setDistanceFilterIndex] =
-    useState<number>(NO_DISTANCE_FILTER);
+  const [distanceUnit, setDistanceUnit] = useState(DEFAULT_DISTANCE_UNIT);
+  // Held as a string because that is what NumberInput controls, and it lets the field go
+  // empty while the competitor is typing.
+  const [radius, setRadius] = useState(
+    DISTANCE_UNITS[DEFAULT_DISTANCE_UNIT].defaultRadius.toString(),
+  );
 
   const api = useAPI();
 
@@ -131,29 +150,32 @@ export default function CompetitionsPage() {
     });
   };
 
-  const distanceMarks = [
-    ...DISTANCE_FILTER_KM.map((km, index) => ({
-      value: index,
-      label: km.toString(),
-    })),
-    { value: NO_DISTANCE_FILTER, label: t("competitions.index.distance_any") },
-  ];
+  // Switching unit falls back to that unit's default rather than converting, so that each
+  // unit lands on a round number.
+  const changeDistanceUnit = (value: string | null) => {
+    if (!isDistanceUnit(value)) return;
+
+    setDistanceUnit(value);
+    setRadius(DISTANCE_UNITS[value].defaultRadius.toString());
+  };
 
   const loadedCompetitions =
     rawCompetitionData?.pages.flatMap((page) => page) ?? [];
 
-  const maxDistanceKm = DISTANCE_FILTER_KM[distanceFilterIndex];
+  // An empty or half-typed radius means "no limit yet" rather than "everything is too far away".
+  const maxDistanceKm = Number(radius) * DISTANCE_UNITS[distanceUnit].toKm;
+  const hasDistanceLimit = maxDistanceKm > 0;
 
   const competitionsDistanceFiltered =
-    location === undefined || maxDistanceKm === undefined
-      ? loadedCompetitions
-      : loadedCompetitions.filter(
+    location !== undefined && hasDistanceLimit
+      ? loadedCompetitions.filter(
           (competition) =>
             getDistanceInKm(location, {
               longitude: competition.longitude_degrees,
               latitude: competition.latitude_degrees,
             }) <= maxDistanceKm,
-        );
+        )
+      : loadedCompetitions;
 
   return (
     <Container>
@@ -248,42 +270,22 @@ export default function CompetitionsPage() {
                     </InputGroup>
                   </Field.Root>
                 </SimpleGrid>
-                <HStack gap="2" width="full" justify="space-between">
-                  <Slider.Root
-                    width="250px"
-                    colorPalette="blue"
-                    value={[distanceFilterIndex]}
-                    onValueChange={(e) => setDistanceFilterIndex(e.value[0])}
-                    min={0}
-                    max={NO_DISTANCE_FILTER}
-                    step={1}
-                    disabled={location === undefined}
-                  >
-                    <Slider.Label asChild>
-                      <HStack justifyContent="space-between">
-                        {t("competitions.index.distance")}
-                        <ClientOnly>
-                          {geolocationSupported && location === undefined && (
-                            <IconButton
-                              size="xs"
-                              variant="outline"
-                              colorPalette="blue"
-                              onClick={() => requestGeolocationPermission()}
-                            >
-                              <LuMapPin />
-                            </IconButton>
-                          )}
-                        </ClientOnly>
-                      </HStack>
-                    </Slider.Label>
-                    <Slider.Control>
-                      <Slider.Track>
-                        <Slider.Range />
-                      </Slider.Track>
-                      <Slider.Thumbs />
-                      <Slider.Marks marks={distanceMarks} />
-                    </Slider.Control>
-                  </Slider.Root>
+                <HStack
+                  gap="2"
+                  width="full"
+                  justify="space-between"
+                  align="flex-start"
+                >
+                  <LocationFilter
+                    location={location}
+                    geolocationSupported={geolocationSupported}
+                    onLocateClick={requestGeolocationPermission}
+                    radius={radius}
+                    onRadiusChange={setRadius}
+                    distanceUnit={distanceUnit}
+                    onDistanceUnitChange={changeDistanceUnit}
+                    t={t}
+                  />
                   <HStack gap="2">
                     <DateFilter
                       label={t("competitions.index.from_date")}
@@ -364,6 +366,98 @@ export default function CompetitionsPage() {
         </Card.Root>
       </VStack>
     </Container>
+  );
+}
+
+function LocationFilter({
+  location,
+  geolocationSupported,
+  onLocateClick,
+  radius,
+  onRadiusChange,
+  distanceUnit,
+  onDistanceUnitChange,
+  t,
+}: {
+  location: GeoCoordinates | undefined;
+  geolocationSupported: boolean;
+  onLocateClick: () => void;
+  radius: string;
+  onRadiusChange: (radius: string) => void;
+  distanceUnit: DistanceUnit;
+  onDistanceUnitChange: (distanceUnit: string | null) => void;
+  t: TFunction;
+}) {
+  const { step } = DISTANCE_UNITS[distanceUnit];
+
+  const formattedLocation = location
+    ? `${location.latitude.toFixed(COORDINATE_PRECISION)}, ${location.longitude.toFixed(COORDINATE_PRECISION)}`
+    : "";
+
+  const distanceUnitItems = [
+    { value: "km", label: t("competitions.index.distance_units.km") },
+    { value: "mi", label: t("competitions.index.distance_units.mi") },
+  ];
+
+  return (
+    <VStack gap="2" width={{ base: "full", md: "sm" }} align="stretch">
+      <Field.Root>
+        <Field.Label>{t("competitions.index.location")}</Field.Label>
+        <Group attached width="full">
+          {/* Typing an address needs a geocoder, which the beta does not have yet. */}
+          <BetaDisabledTooltip>
+            <Input
+              disabled
+              placeholder={t("competitions.index.location_placeholder")}
+              value={formattedLocation}
+            />
+          </BetaDisabledTooltip>
+          <ClientOnly>
+            {geolocationSupported && (
+              <IconButton
+                variant="outline"
+                colorPalette="blue"
+                aria-label={t("competitions.index.use_my_location")}
+                onClick={onLocateClick}
+              >
+                <LuMapPin />
+              </IconButton>
+            )}
+          </ClientOnly>
+        </Group>
+      </Field.Root>
+      <Field.Root>
+        <Field.Label>{t("competitions.index.distance")}</Field.Label>
+        <HStack gap="2" width="full">
+          <NumberInput.Root
+            width="full"
+            value={radius}
+            onValueChange={(e) => onRadiusChange(e.value)}
+            min={step}
+            step={step}
+            disabled={location === undefined}
+          >
+            <Group attached width="full">
+              <NumberInput.DecrementTrigger asChild>
+                <Button variant="outline">−{step}</Button>
+              </NumberInput.DecrementTrigger>
+              <NumberInput.Input textAlign="center" />
+              <NumberInput.IncrementTrigger asChild>
+                <Button variant="outline">+{step}</Button>
+              </NumberInput.IncrementTrigger>
+            </Group>
+          </NumberInput.Root>
+          <SegmentGroup.Root
+            value={distanceUnit}
+            onValueChange={(e) => onDistanceUnitChange(e.value)}
+            disabled={location === undefined}
+          >
+            <SegmentGroup.Indicator />
+            <SegmentGroup.Items items={distanceUnitItems} />
+          </SegmentGroup.Root>
+        </HStack>
+      </Field.Root>
+    </VStack>
   );
 }
 


### PR DESCRIPTION
<img width="1154" height="594" alt="Screenshot 2026-09-02 at 16 25 06" src="https://github.com/user-attachments/assets/9d196d07-df23-4e64-8e14-1b5f5923fa5d" />
<img width="1154" height="594" alt="Screenshot 2026-09-02 at 16 25 11" src="https://github.com/user-attachments/assets/945f43a5-fcb7-426d-8efa-05ea53c68df5" />

As per Duncan's suggestion. It does not feature geo coding, as we don't have a next routable API for that (and if we would have a public API it could be exploited so we don't really want that for non logged in users [or even non WCAId users])