### PR TITLE
Sync Assets out of Rails and not Sidekiq

### DIFF
--- a/.github/actions/build-environment/action.yaml
+++ b/.github/actions/build-environment/action.yaml
@@ -23,22 +23,30 @@ runs:
           echo "ASSET_BUCKET=assets.worldcubeassociation.org" >> $GITHUB_ENV
           echo "MONOLITH_TAG=latest" >> $GITHUB_ENV
         fi
-    - name: Build and Push Sidekiq image
+    - name: Build and push Image
       uses: ./.github/actions/build-ruby-image
       id: build
+      with:
+        target: monolith
+        registry: ${{ inputs.registry }}
+        tag: ${{ env.MONOLITH_TAG }}
+        build_tag: ${{ inputs.build_tag }}
+        environment: ${{ inputs.environment }}
+        load: true
+    - name: Copy assets out of the container and push to S3
+      shell: bash
+      run: | # Must come from the monolith image: it serves the HTML referencing these digests
+        id=$(docker create ${{ steps.build.outputs.imageid }})
+        docker cp $id:/rails/public/ ./assets
+        aws s3 sync ./assets s3://${{ env.ASSET_BUCKET }}/assets/${{ inputs.build_tag }} --cache-control "public, max-age=31536000, immutable"
+    - name: Build and Push Sidekiq image
+      uses: ./.github/actions/build-ruby-image
       with:
         target: sidekiq
         registry: ${{ inputs.registry }}
         tag: sidekiq-${{inputs.environment}}
         build_tag: ${{ inputs.build_tag }}
         environment: ${{ inputs.environment }}
-        load: true
-    - name: Copy assets out of the container and push to S3
-      shell: bash
-      run: | # We do this once the first image is build so it will be definitely available
-        id=$(docker create ${{ steps.build.outputs.imageid }})
-        docker cp $id:/rails/public/ ./assets
-        aws s3 sync ./assets s3://${{ env.ASSET_BUCKET }}/assets/${{ inputs.build_tag }} --cache-control "public, max-age=31536000, immutable"
     - name: Build and push API Image
       uses: ./.github/actions/build-ruby-image
       with:
@@ -53,13 +61,5 @@ runs:
         target: shoryuken
         registry: ${{ inputs.registry }}
         tag: ${{inputs.environment}}-sqs-worker
-        build_tag: ${{ inputs.build_tag }}
-        environment: ${{ inputs.environment }}
-    - name: Build and push Image
-      uses: ./.github/actions/build-ruby-image
-      with:
-        target: monolith
-        registry: ${{ inputs.registry }}
-        tag: ${{ env.MONOLITH_TAG }}
         build_tag: ${{ inputs.build_tag }}
         environment: ${{ inputs.environment }}


### PR DESCRIPTION
Changes the order of operations during deploy to fix a very odd edge case: The assets generated on the multi stage sidekiq side did not 100% match the assets on the rails side (they generated a different hash).

This had something(TM) to do with Docker build caching, but the simple and correct solution is to just sync the assets from the Rails Container. We didn't do this before because we triggered builds based on image push (and we really wanted to make sure the Assets are there before we pushed). Now we trigger based manually in the CI, so this isn't necessary anymore.

I will separately find out why the cache diverged in some way