### PR TITLE
Only Randomize Cubie background once per build

### DIFF
--- a/next-frontend/next.config.ts
+++ b/next-frontend/next.config.ts
@@ -47,6 +47,10 @@ const withRoutes = nextRoutes({ outDir: "src/types" });
 
 const shouldUseProprietaryFont = process.env.PROPRIETARY_FONT === "TTNormsPro";
 
+// Evaluated once per build and inlined, so anything seeded off it (the RandomBackground
+//   grid) is stable within a deploy and reshuffles on the next one.
+const buildSeed = Date.now().toString(36);
+
 const nextConfig: NextConfig = {
   serverExternalPackages: ["newrelic"],
   webpack: (config, { isServer, webpack }) => {
@@ -64,6 +68,9 @@ const nextConfig: NextConfig = {
       nrExternals(config);
     }
     return config;
+  },
+  env: {
+    NEXT_PUBLIC_BUILD_SEED: buildSeed,
   },
   experimental: {
     optimizePackageImports: ["@chakra-ui/react"],

--- a/next-frontend/src/components/RandomBackground.tsx
+++ b/next-frontend/src/components/RandomBackground.tsx
@@ -5,11 +5,11 @@ import { Box, SimpleGrid } from "@chakra-ui/react";
 //   rejects it, and deferring to the client makes the background pop in after load.
 //   A seeded PRNG keeps the grid random-looking but reproducible - it stays put for the
 //   lifetime of a build and reshuffles on the next deploy, or per page via `seed`.
-const hashSeed = (seed: string): number => {
-  let hash = 2166136261;
+const fnv1aHash = (seed: string): number => {
+  let hash = 0x811c9dc5;
 
   for (let i = 0; i < seed.length; i += 1) {
-    hash = Math.imul(hash ^ seed.charCodeAt(i), 16777619);
+    hash = Math.imul(hash ^ seed.charCodeAt(i), 0x01000193);
   }
 
   return hash >>> 0;
@@ -38,7 +38,7 @@ const RandomBackground = ({
   bias?: number;
   seed?: string;
 }) => {
-  const nextRandom = mulberry32(hashSeed(seed ?? "wca"));
+  const nextRandom = mulberry32(fnv1aHash(seed ?? "wca"));
   // Function to determine color based on probability
   const getColor = (probValue: number): string => {
     if (probValue <= 1 / 6) return "green"; // 0.0 - 0.166

--- a/next-frontend/src/components/RandomBackground.tsx
+++ b/next-frontend/src/components/RandomBackground.tsx
@@ -1,17 +1,44 @@
 import React from "react";
 import { Box, SimpleGrid } from "@chakra-ui/react";
 
+// The grid is drawn during prerender, so it cannot use Math.random: cache-components
+//   rejects it, and deferring to the client makes the background pop in after load.
+//   A seeded PRNG keeps the grid random-looking but reproducible - it stays put for the
+//   lifetime of a build and reshuffles on the next deploy, or per page via `seed`.
+const hashSeed = (seed: string): number => {
+  let hash = 2166136261;
+
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = Math.imul(hash ^ seed.charCodeAt(i), 16777619);
+  }
+
+  return hash >>> 0;
+};
+
+// mulberry32, a 32-bit PRNG small enough to not warrant a dependency
+const mulberry32 = (seed: number) => () => {
+  seed = (seed + 0x6d2b79f5) | 0;
+
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
 const RandomBackground = ({
   numRows,
   numCols,
   density = 3,
   bias = 3,
+  seed = process.env.NEXT_PUBLIC_BUILD_SEED,
 }: {
   numRows: number;
   numCols: number;
   density?: number;
   bias?: number;
+  seed?: string;
 }) => {
+  const nextRandom = mulberry32(hashSeed(seed ?? "wca"));
   // Function to determine color based on probability
   const getColor = (probValue: number): string => {
     if (probValue <= 1 / 6) return "green"; // 0.0 - 0.166
@@ -37,7 +64,7 @@ const RandomBackground = ({
 
             const colorPickThreshold =
               1 - Math.exp(-density * ((col + 1) / numCols) ** bias);
-            const randomNumber = Math.random();
+            const randomNumber = nextRandom();
 
             if (randomNumber <= colorPickThreshold) {
               const randomColor = getColor(randomNumber / colorPickThreshold);


### PR DESCRIPTION
Calling `Math.Random()` on every page loads means we can't actually cache pages (we currently are using `force-dynamic` everywhere, but I am working to fix that). If we would move that to client only rendering looks very ugly with the Pop in.

This is an idea I had to fix that but still keep the fun random background.

Basically we seed the random number generator (I picked this mulberry32 implementation at random) once on build and then keep it like that.

This might even give us the benefit of people being less annoyed with the background (I get that feedback over and over again).

What do you think?