### PR TITLE
Show results preview in the "Live Import" submission tab

### DIFF
--- a/app/controllers/results_submission_controller.rb
+++ b/app/controllers/results_submission_controller.rb
@@ -231,6 +231,15 @@ class ResultsSubmissionController < ApplicationController
     render status: :ok, json: { success: true }
   end
 
+  def live_results_preview
+    render json: competition_from_params
+                 .live_results
+                 .includes(:live_attempts, :user, round: [:competition_event])
+                 .order(:global_pos)
+                 .sort_by { [it.event.rank, it.round.number] }
+                 .map(&:to_inbox_compat)
+  end
+
   def pending_results_submissions
     competitions = Competition.pending_results_submission.order_by_date
 

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -194,7 +194,7 @@ class LiveResult < ApplicationRecord
 
   def to_inbox_compat
     self.as_json(
-      only: %w[best average global_pos],
+      only: %w[id best average global_pos],
       methods: %w[wca_id name country_iso2 event_id round_type_id],
     ).merge(
       # renaming properties that the old frontend still expects in legacy nomenclature

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -195,7 +195,7 @@ class LiveResult < ApplicationRecord
   def to_inbox_compat
     self.as_json(
       only: %w[best average global_pos],
-      methods: %w[round_wcif_id wca_id name country_iso2 event_id],
+      methods: %w[wca_id name country_iso2 event_id round_type_id],
     ).merge(
       # renaming properties that the old frontend still expects in legacy nomenclature
       pos: self.local_pos,

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -65,6 +65,14 @@ class LiveResult < ApplicationRecord
   delegate :event_id, :format_id, :round_type_id, :competition_id, to: :round
   delegate :registrant_id, to: :registration
 
+  def event
+    Event.c_find(self.event_id)
+  end
+
+  def format
+    Format.c_find(self.format_id)
+  end
+
   def to_solve_time(field)
     SolveTime.new(event_id, field, send(field))
   end

--- a/app/models/live_result.rb
+++ b/app/models/live_result.rb
@@ -14,6 +14,9 @@ class LiveResult < ApplicationRecord
   after_save :trigger_recompute, if: :should_recompute?
 
   belongs_to :registration
+  has_one :user, through: :registration
+
+  delegate :wca_id, :name, :country_iso2, to: :user
 
   belongs_to :round
 
@@ -128,9 +131,11 @@ class LiveResult < ApplicationRecord
     end
   end
 
-  def to_inbox_result
-    attempt_values = live_attempts.pluck(:value)
+  def attempt_values
+    self.live_attempts.pluck(:value)
+  end
 
+  def to_inbox_result
     InboxResult.new(
       round: self.round,
       competition_id: self.competition_id,
@@ -178,6 +183,17 @@ class LiveResult < ApplicationRecord
     methods: %w[],
     include: [{ live_attempts: { only: %i[value attempt_number] } }],
   }.freeze
+
+  def to_inbox_compat
+    self.as_json(
+      only: %w[best average global_pos],
+      methods: %w[round_wcif_id wca_id name country_iso2 event_id],
+    ).merge(
+      # renaming properties that the old frontend still expects in legacy nomenclature
+      pos: self.local_pos,
+      attempts: self.attempt_values,
+    )
+  end
 
   def to_live_state
     serializable_hash(LIVE_STATE_SERIALIZE_OPTIONS)

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { Form, Message } from 'semantic-ui-react';
+import { Button, Form, Message } from 'semantic-ui-react';
 import Errored from '../../Requests/Errored';
 import importWcaLiveResults from '../api/importWcaLiveResults';
 import Loading from '../../Requests/Loading';
 import { contactRecipientUrl, uploadScramblesUrl } from '../../../lib/requests/routes.js.erb';
 import useCheckboxState from '../../../lib/hooks/useCheckboxState';
+import LiveResultsPreview from './LiveResultsPreview';
 
 export default function ImportWcaLiveResults({
   competitionId,
@@ -14,6 +15,7 @@ export default function ImportWcaLiveResults({
   onImportSuccess,
   scoretakingSoftware,
 }) {
+  const [showPreview, setShowPreview] = useState(false);
   const [markResultSubmitted, setMarkResultSubmitted] = useCheckboxState(isAdminView);
 
   const {
@@ -79,14 +81,26 @@ export default function ImportWcaLiveResults({
             label="If results are not marked as submitted, mark it as submitted (this is only visible to WRT)"
           />
         )}
-        <Form.Button
-          primary
-          type="submit"
-          disabled={uploadedScrambleFilesCount === 0}
-        >
-          Import Live Results
-        </Form.Button>
+        <Form.Group inline>
+          <Form.Button
+            primary
+            type="submit"
+            disabled={uploadedScrambleFilesCount === 0}
+          >
+            Import Live Results
+          </Form.Button>
+          <Button
+            basic
+            type="button"
+            onClick={() => setShowPreview(true)}
+          >
+            Show Results Preview
+          </Button>
+        </Form.Group>
       </Form>
+      {showPreview && (
+        <LiveResultsPreview competitionId={competitionId} />
+      )}
     </>
   );
 }

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
@@ -4,7 +4,7 @@ import { Button, Form, Message } from 'semantic-ui-react';
 import Errored from '../../Requests/Errored';
 import importWcaLiveResults from '../api/importWcaLiveResults';
 import Loading from '../../Requests/Loading';
-import { contactRecipientUrl, uploadScramblesUrl } from '../../../lib/requests/routes.js.erb';
+import { uploadScramblesUrl } from '../../../lib/requests/routes.js.erb';
 import useCheckboxState from '../../../lib/hooks/useCheckboxState';
 import LiveResultsPreview from './LiveResultsPreview';
 
@@ -34,15 +34,17 @@ export default function ImportWcaLiveResults({
 
   return (
     <>
+      <p>
+        You may use this feature to import results which have been synchronized
+        to the WCA website already.
+        Common use cases include WCA Live or Integrated Live Results.
+      </p>
       <Message warning>
         <Message.Header>Please Note</Message.Header>
         <Message.List>
-          <Message.Item>
-            You may use this feature to import results from WCA Live or Integrated Live Results.
-          </Message.Item>
           {scoretakingSoftware === 'wca_live' && (
             <Message.Item>
-              If you are using WCA Live, make sure to hit
+              Within WCA Live, make sure to hit
               {' '}
               <b>&quot;Synchronize&quot;</b>
               {' '}
@@ -55,6 +57,13 @@ export default function ImportWcaLiveResults({
               &quot;Import Live Results&quot;
             </Message.Item>
           )}
+          {scoretakingSoftware === 'external' && (
+            <Message.Item>
+              It is your responsibility to make sure that the external tool
+              has written the results to our API. Consult with the developers
+              of your external scoretaking tool if necessary.
+            </Message.Item>
+          )}
           <Message.Item>
             Don&apos;t forget to also
             {' '}
@@ -65,11 +74,13 @@ export default function ImportWcaLiveResults({
             <code>{uploadedScrambleFilesCount}</code>
           </Message.Item>
           <Message.Item>
-            This feature is still in Beta.
-            Please report any errors or issues to the
+            You can use the &quot;Preview&quot; button below to show a
             {' '}
-            <a href={contactRecipientUrl('wst')}>WCA Software Team</a>
-            .
+            <b>temporary, unofficial preview</b>
+            {' '}
+            of the results which are currently stored on our website.
+            This is only meant as a basic, simple sanity check
+            and the final posting will be handled by WRT!
           </Message.Item>
         </Message.List>
       </Message>

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/ImportWcaLiveResults.jsx
@@ -39,7 +39,7 @@ export default function ImportWcaLiveResults({
         to the WCA website already.
         Common use cases include WCA Live or Integrated Live Results.
       </p>
-      <Message warning>
+      <Message>
         <Message.Header>Please Note</Message.Header>
         <Message.List>
           {scoretakingSoftware === 'wca_live' && (

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
@@ -9,7 +9,6 @@ import ResultRowBody from '../../ResultsData/Results/ResultRowBody';
 import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
 import { competitionPreviewLiveResultsUrl } from '../../../lib/requests/routes.js.erb';
 import I18n from '../../../lib/i18n';
-import { parseActivityCode } from '../../../lib/utils/wcif';
 import EventIcon from '../../wca/EventIcon';
 
 async function getLiveResultsPreview({ competitionId }) {
@@ -35,12 +34,12 @@ export default function LiveResultsPreview({
   if (isPending) return (<Loading />);
   if (isError) return (<Errored error={error} />);
 
-  const liveResultsByRound = _.groupBy(liveResults, 'round_wcif_id');
+  const liveResultsByRound = _.groupBy(liveResults, (res) => `${res.event_id}-${res.round_type_id}`);
 
   return (
     <>
       {_.map(liveResultsByRound, (results, roundId) => {
-        const { eventId, roundNumber } = parseActivityCode(roundId);
+        const [eventId, roundTypeId] = roundId.split('-');
 
         return (
           <Fragment key={roundId}>
@@ -48,9 +47,7 @@ export default function LiveResultsPreview({
               <EventIcon id={eventId} baseComponent={Icon} />
               {I18n.t(`events.${eventId}`)}
               {' '}
-              {I18n.t('competitions.results_table.round')}
-              {' '}
-              {roundNumber}
+              {I18n.t(`rounds.${roundTypeId}.name`)}
             </Header>
             <Table
               striped

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Header, Table } from 'semantic-ui-react';
+import { Header, Icon, Table } from 'semantic-ui-react';
 import _ from 'lodash';
 import Loading from '../../Requests/Loading';
 import Errored from '../../Requests/Errored';
@@ -10,6 +10,7 @@ import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityTok
 import { competitionPreviewLiveResultsUrl } from '../../../lib/requests/routes.js.erb';
 import I18n from '../../../lib/i18n';
 import { parseActivityCode } from '../../../lib/utils/wcif';
+import EventIcon from '../../wca/EventIcon';
 
 async function getLiveResultsPreview({ competitionId }) {
   const { data } = await fetchJsonOrError(
@@ -44,9 +45,10 @@ export default function LiveResultsPreview({
         return (
           <Fragment key={roundId}>
             <Header>
+              <EventIcon id={eventId} baseComponent={Icon} />
               {I18n.t(`events.${eventId}`)}
               {' '}
-              Round
+              {I18n.t('competitions.results_table.round')}
               {' '}
               {roundNumber}
             </Header>

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
@@ -1,0 +1,70 @@
+import React, { Fragment } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Header, Table } from 'semantic-ui-react';
+import _ from 'lodash';
+import Loading from '../../Requests/Loading';
+import Errored from '../../Requests/Errored';
+import { ResultRowHeader } from '../../ResultsData/Results/ResultRowHeader';
+import ResultRowBody from '../../ResultsData/Results/ResultRowBody';
+import { fetchJsonOrError } from '../../../lib/requests/fetchWithAuthenticityToken';
+import { competitionPreviewLiveResultsUrl } from '../../../lib/requests/routes.js.erb';
+import I18n from '../../../lib/i18n';
+import { parseActivityCode } from '../../../lib/utils/wcif';
+
+async function getLiveResultsPreview({ competitionId }) {
+  const { data } = await fetchJsonOrError(
+    competitionPreviewLiveResultsUrl(competitionId),
+  );
+  return data || [];
+}
+
+export default function LiveResultsPreview({
+  competitionId,
+}) {
+  const {
+    data: liveResults,
+    isPending,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['live-results', competitionId],
+    queryFn: () => getLiveResultsPreview({ competitionId }),
+  });
+
+  if (isPending) return (<Loading />);
+  if (isError) return (<Errored error={error} />);
+
+  const liveResultsByRound = _.groupBy(liveResults, 'round_wcif_id');
+
+  return (
+    <>
+      {_.map(liveResultsByRound, (results, roundId) => {
+        const { eventId, roundNumber } = parseActivityCode(roundId);
+
+        return (
+          <Fragment key={roundId}>
+            <Header>
+              {I18n.t(`events.${eventId}`)}
+              {' '}
+              Round
+              {' '}
+              {roundNumber}
+            </Header>
+            <Table
+              striped
+              compact="very"
+              singleLine
+            >
+              <Table.Header>
+                <ResultRowHeader />
+              </Table.Header>
+              <Table.Body>
+                <ResultRowBody round={{ results }} />
+              </Table.Body>
+            </Table>
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
@@ -1,6 +1,8 @@
 import React, { Fragment } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Header, Icon, Message, Table } from 'semantic-ui-react';
+import {
+  Header, Icon, Message, Table,
+} from 'semantic-ui-react';
 import _ from 'lodash';
 import Loading from '../../Requests/Loading';
 import Errored from '../../Requests/Errored';

--- a/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
+++ b/app/webpacker/components/CompetitionResultSubmission/ImportResultsData/LiveResultsPreview.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Header, Icon, Table } from 'semantic-ui-react';
+import { Header, Icon, Message, Table } from 'semantic-ui-react';
 import _ from 'lodash';
 import Loading from '../../Requests/Loading';
 import Errored from '../../Requests/Errored';
@@ -33,6 +33,17 @@ export default function LiveResultsPreview({
 
   if (isPending) return (<Loading />);
   if (isError) return (<Errored error={error} />);
+
+  if (liveResults.length === 0) {
+    return (
+      <Message
+        warning
+        icon="warning sign"
+        header="No results available to be posted"
+        content="Please make sure that your scoretaking tool has synchronized the results. If you are sure but your results are still not showing up, please contact WST."
+      />
+    );
+  }
 
   const liveResultsByRound = _.groupBy(liveResults, (res) => `${res.event_id}-${res.round_type_id}`);
 

--- a/app/webpacker/components/wca/EventIcon.js
+++ b/app/webpacker/components/wca/EventIcon.js
@@ -3,11 +3,16 @@ import classnames from 'classnames';
 
 /* eslint react/jsx-props-no-spreading: "off" */
 function EventIcon({
-  id, className, size = undefined, hoverable = true, ...other
+  id,
+  className,
+  size = undefined,
+  hoverable = true,
+  baseComponent: Component = 'span',
+  ...other
 }) {
   const resetHoverable = hoverable ? {} : { pointerEvents: 'none' };
   return (
-    <span
+    <Component
       {...other}
       className={classnames('cubing-icon', `event-${id}`, className)}
       style={{ fontSize: size, ...resetHoverable }}

--- a/app/webpacker/lib/requests/routes.js.erb
+++ b/app/webpacker/lib/requests/routes.js.erb
@@ -76,6 +76,8 @@ export const competitionEventResultsApiUrl = (id, eventId) => `<%= CGI.unescape(
 
 export const competitionAllResultsUrl = (id, eventId) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_results_all_path("${id}", event: "${eventId}")) %>`;
 
+export const competitionPreviewLiveResultsUrl = (id) => `<%= CGI.unescape(Rails.application.routes.url_helpers.competition_live_results_preview_path("${id}")) %>`
+
 export const omnisearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_path %>?q=${query}`;
 
 export const competitionSearchApiUrl = (query) => `<%= Rails.application.routes.url_helpers.api_v0_search_competitions_path %>?q=${query}`;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
     get 'submit-results' => 'results_submission#new', as: :submit_results_edit
     get 'upload-scrambles' => 'results_submission#upload_scrambles', as: :upload_scrambles
     post 'submit-results' => 'results_submission#create', as: :submit_results
+    get 'live-results-preview' => 'results_submission#live_results_preview', as: :live_results_preview
     get 'unfinished-persons' => 'results_submission#unfinished_persons', as: :unfinished_persons
     resources :scramble_files, only: %i[index create destroy], shallow: true do
       patch 'update-round-matching' => 'scramble_files#update_round_matching', on: :collection


### PR DESCRIPTION
Adds a button to show a quick preview of currently synchronized live results in the "Use Live Results" submission tab.

<img width="2001" height="685" alt="image" src="https://github.com/user-attachments/assets/e7423e7b-974c-4e97-bc72-eab3ca3f9bdc" />
<img width="1961" height="1218" alt="image" src="https://github.com/user-attachments/assets/a5d8244f-9bc7-421f-bf5d-c77765d9573a" />
