### PR TITLE
Standardize Payload Pages with Cards

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/disclaimer/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/disclaimer/page.tsx
@@ -1,7 +1,7 @@
 import { getPayload } from "payload";
 import config from "@payload-config";
-import { Container, Heading, VStack, Box } from "@chakra-ui/react";
-import { ChakraMarkdown } from "@/components/Markdown";
+import { Container, Heading, VStack } from "@chakra-ui/react";
+import MarkdownCard from "@/components/MarkdownCard";
 import { Metadata } from "next";
 import { getT } from "@/lib/i18n/get18n";
 
@@ -30,10 +30,9 @@ export default async function Disclaimer() {
       <VStack gap="8" width="full" pt="8" alignItems="left">
         <Heading size="5xl">Disclaimer</Heading>
         {disclaimerItems.map((item) => (
-          <Box key={item.id}>
-            {item.title && <Heading size="xl">{item.title}</Heading>}
-            <ChakraMarkdown>{item.contentMarkdown}</ChakraMarkdown>
-          </Box>
+          <MarkdownCard key={item.id} title={item.title}>
+            {item.contentMarkdown}
+          </MarkdownCard>
         ))}
       </VStack>
     </Container>

--- a/next-frontend/src/app/(wca)/(with-background)/logo/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/logo/page.tsx
@@ -1,18 +1,17 @@
 import { getPayload } from "payload";
 import config from "@payload-config";
 import {
+  Card,
   Container,
   Heading,
   HStack,
   Image,
-  Text,
   VStack,
 } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
-import { ChakraMarkdown } from "@/components/Markdown";
+import MarkdownCard from "@/components/MarkdownCard";
 import { Media } from "@/types/payload";
 import LogoDownload from "@/app/(wca)/(with-background)/logo/download";
-import { Fragment } from "react";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -46,14 +45,9 @@ export default async function LogoPage() {
           switch (item.blockType) {
             case "paragraph": {
               return (
-                <Fragment key={item.id}>
-                  {item.title && (
-                    <Heading size="2xl" mt="8">
-                      {item.title}
-                    </Heading>
-                  )}
-                  <ChakraMarkdown>{item.contentMarkdown}</ChakraMarkdown>
-                </Fragment>
+                <MarkdownCard key={item.id} title={item.title}>
+                  {item.contentMarkdown}
+                </MarkdownCard>
               );
             }
             case "logoDownload": {
@@ -61,27 +55,27 @@ export default async function LogoPage() {
             }
             case "logoVariant": {
               return (
-                <Fragment key={item.id}>
-                  <Heading size="2xl" mt="8">
-                    {item.title}
-                  </Heading>
-                  <Text>{item.caption}</Text>
-                  <HStack w="full" mt="4">
-                    {item.images.map((value) => {
-                      const image = value.image as Media;
-                      return (
-                        <Image
-                          src={image.url!}
-                          alt={item.caption}
-                          key={image.id}
-                          w="100%"
-                          maxW={item.logoOnly ? "150px" : "400px"}
-                          bg={value.darkBackground ? "black" : "white"}
-                        />
-                      );
-                    })}
-                  </HStack>
-                </Fragment>
+                <Card.Root key={item.id}>
+                  <Card.Body>
+                    <Card.Title>{item.title}</Card.Title>
+                    <Card.Description>{item.caption}</Card.Description>
+                    <HStack w="full" mt="4">
+                      {item.images.map((value) => {
+                        const image = value.image as Media;
+                        return (
+                          <Image
+                            src={image.url!}
+                            alt={item.caption}
+                            key={image.id}
+                            w="100%"
+                            maxW={item.logoOnly ? "150px" : "400px"}
+                            bg={value.darkBackground ? "black" : "white"}
+                          />
+                        );
+                      })}
+                    </HStack>
+                  </Card.Body>
+                </Card.Root>
               );
             }
           }

--- a/next-frontend/src/app/(wca)/(with-background)/privacy/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/privacy/page.tsx
@@ -1,7 +1,7 @@
 import { getPayload } from "payload";
 import config from "@payload-config";
-import { Container, Heading, VStack, Box } from "@chakra-ui/react";
-import { ChakraMarkdown } from "@/components/Markdown";
+import { Container, Heading, VStack } from "@chakra-ui/react";
+import MarkdownCard from "@/components/MarkdownCard";
 import { Metadata } from "next";
 import { getT } from "@/lib/i18n/get18n";
 
@@ -30,12 +30,11 @@ export default async function Privacy() {
     <Container bg="bg">
       <VStack gap="8" width="full" pt="8" alignItems="left">
         <Heading size="5xl">WCA Privacy Statement</Heading>
-        <ChakraMarkdown>{privacyPage.preambleMarkdown}</ChakraMarkdown>
+        <MarkdownCard>{privacyPage.preambleMarkdown}</MarkdownCard>
         {privacyItems.map((item) => (
-          <Box key={item.id}>
-            <Heading size="xl">{item.title}</Heading>
-            <ChakraMarkdown>{item.contentMarkdown}</ChakraMarkdown>
-          </Box>
+          <MarkdownCard key={item.id} title={item.title}>
+            {item.contentMarkdown}
+          </MarkdownCard>
         ))}
       </VStack>
     </Container>

--- a/next-frontend/src/app/(wca)/(with-background)/regulations/about/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/regulations/about/page.tsx
@@ -1,9 +1,9 @@
 "use server";
 
-import { Container, Heading, VStack, Card } from "@chakra-ui/react";
+import { Container, Heading, VStack } from "@chakra-ui/react";
 import { getPayload } from "payload";
 import config from "@payload-config";
-import { ChakraMarkdown } from "@/components/Markdown";
+import MarkdownCard from "@/components/MarkdownCard";
 import { getT } from "@/lib/i18n/get18n";
 import { Metadata } from "next";
 
@@ -35,14 +35,9 @@ export default async function AboutTheRegulations() {
       <VStack gap="8" width="full" pt="8" alignItems="left">
         <Heading size="5xl">{t("about_regulations.title")}</Heading>
         {aboutRegulationsItems.map((item) => (
-          <Card.Root key={item.id}>
-            <Card.Body>
-              <Card.Title>{item.title}</Card.Title>
-              <ChakraMarkdown paragraphAs={Card.Description}>
-                {item.contentMarkdown}
-              </ChakraMarkdown>
-            </Card.Body>
-          </Card.Root>
+          <MarkdownCard key={item.id} title={item.title}>
+            {item.contentMarkdown}
+          </MarkdownCard>
         ))}
       </VStack>
     </Container>

--- a/next-frontend/src/app/(wca)/(with-background)/speedcubing-history/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/speedcubing-history/page.tsx
@@ -5,15 +5,14 @@ import {
   Heading,
   VStack,
   Text,
-  Box,
+  Card,
   Image,
-  Center,
 } from "@chakra-ui/react";
 import Quote from "@/components/Quote";
 import { getPayload } from "payload";
 import config from "@payload-config";
 import { Media } from "@/types/payload";
-import { ChakraMarkdown } from "@/components/Markdown";
+import MarkdownCard from "@/components/MarkdownCard";
 import { getT } from "@/lib/i18n/get18n";
 import { Metadata } from "next";
 
@@ -57,20 +56,20 @@ export default async function SpeedcubingHistory() {
             }
             case "paragraph": {
               return (
-                <ChakraMarkdown key={item.id}>
+                <MarkdownCard key={item.id}>
                   {item.contentMarkdown!}
-                </ChakraMarkdown>
+                </MarkdownCard>
               );
             }
             case "captionedImage": {
               const image = item.image as Media;
               return (
-                <Center key={item.id}>
-                  <Box>
+                <Card.Root key={item.id}>
+                  <Card.Body alignItems="center">
                     <Image src={image.url!} alt={item.caption} />
                     <Text>{item.caption}</Text>
-                  </Box>
-                </Center>
+                  </Card.Body>
+                </Card.Root>
               );
             }
           }

--- a/next-frontend/src/components/MarkdownCard.tsx
+++ b/next-frontend/src/components/MarkdownCard.tsx
@@ -1,0 +1,22 @@
+import { Card } from "@chakra-ui/react";
+import type { Options } from "react-markdown";
+import { ChakraMarkdown } from "@/components/Markdown";
+
+export default function MarkdownCard({
+  title,
+  children,
+}: {
+  title?: string | null;
+  children: Options["children"];
+}) {
+  return (
+    <Card.Root>
+      <Card.Body>
+        {title && <Card.Title>{title}</Card.Title>}
+        <ChakraMarkdown paragraphAs={Card.Description}>
+          {children}
+        </ChakraMarkdown>
+      </Card.Body>
+    </Card.Root>
+  );
+}


### PR DESCRIPTION
Fixes mobile margin issues by standardizing wrapping the items in cards
Example:
<img width="1117" height="763" alt="image" src="https://github.com/user-attachments/assets/8fa03895-2733-4497-aa78-bc22d7ed9a7e" />
What do you think? Do you agree that the margins were too tight before?