### PR TITLE
Change Desktop >1 base columns to one in mobile 

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(results)/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(results)/layout.tsx
@@ -24,12 +24,12 @@ export default async function CompetitionLayout({
   if (error) return <OpenapiError t={t} response={response} />;
 
   return (
-    <SimpleGrid columns={3} gap="8">
-      <GridItem colSpan={2} asChild>
+    <SimpleGrid columns={{ base: 1, md: 3 }} gap="8">
+      <GridItem colSpan={{ base: 1, md: 2 }} asChild>
         <InfoCard competitionInfo={competitionInfo} t={t} />
       </GridItem>
       <MarkdownFirstImage content={competitionInfo.information} />
-      <GridItem colSpan={3}>{children}</GridItem>
+      <GridItem colSpan={{ base: 1, md: 3 }}>{children}</GridItem>
     </SimpleGrid>
   );
 }

--- a/next-frontend/src/app/(wca)/(with-background)/officers-and-board/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/officers-and-board/page.tsx
@@ -57,7 +57,7 @@ export default async function OfficersAndBoard() {
         <Heading size="5xl">{t("page.officers_and_board.title")}</Heading>
         <Heading size="2xl">{t("user_groups.group_types.officers")}</Heading>
         <Text>{t("page.officers_and_board.officers_description")}</Text>
-        <SimpleGrid columns={3} gap="16px">
+        <SimpleGrid columns={{ base: 1, md: 3 }} gap="16px">
           {officers.map((officer) => (
             <UserBadge
               key={officer.id}
@@ -81,7 +81,7 @@ export default async function OfficersAndBoard() {
           </Link>
         </Heading>
         <Text>{t("page.officers_and_board.board_description")}</Text>
-        <SimpleGrid columns={3} gap="16px">
+        <SimpleGrid columns={{ base: 1, md: 3 }} gap="16px">
           {boardRoles.map((board) => (
             <UserBadge
               key={board.id}

--- a/next-frontend/src/app/(wca)/(with-background)/organizations/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/organizations/page.tsx
@@ -48,7 +48,7 @@ export default async function RegionalOrganizations() {
       <VStack align="left">
         <Heading size="5xl">{t("regional_organizations.title")}</Heading>
         <Text>{t("regional_organizations.content")}</Text>
-        <SimpleGrid columns={3} columnGap={4} rowGap={6}>
+        <SimpleGrid columns={{ base: 1, md: 3 }} columnGap={4} rowGap={6}>
           {organizations.map((org) => (
             <LinkBox
               key={org.name}

--- a/next-frontend/src/app/(wca)/(with-background)/translators/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/translators/page.tsx
@@ -31,7 +31,7 @@ export default async function TranslatorsPage() {
             <Heading size="2xl" marginY={2}>
               {language}
             </Heading>
-            <SimpleGrid columns={3} gap="16px">
+            <SimpleGrid columns={{ base: 1, md: 3 }} gap="16px">
               {translators.map((translator) => (
                 <UserBadge
                   key={translator.id}

--- a/next-frontend/src/components/competitions/Cards.tsx
+++ b/next-frontend/src/components/competitions/Cards.tsx
@@ -82,7 +82,7 @@ export function VenueDetailsCard({
     <Card.Root width="inherit">
       <Card.Body>
         <Card.Title textStyle="s4">Venue Details</Card.Title>
-        <SimpleGrid columns={2} gap="4">
+        <SimpleGrid columns={{ base: 1, md: 2 }} gap="4">
           <Stat.Root variant="competition">
             <Stat.Label>
               <VenueIcon />
@@ -328,7 +328,7 @@ export function InfoCard({
           </Button>
         </Heading>
 
-        <SimpleGrid columns={2} gap="4">
+        <SimpleGrid columns={{ base: 1, md: 2 }} gap="4">
           <Stat.Root variant="competition">
             <Stat.Label>
               <CompRegoOpenDateIcon />


### PR DESCRIPTION
Venue details 2 ->1 (2 to 1 isn't necessary 100% of the time, but these are long strings)
<img width="498" height="942" alt="image" src="https://github.com/user-attachments/assets/8b7faa13-6b8d-4f37-ac43-2212ad159d6c" />

Results Grid 3->1
<img width="498" height="823" alt="image" src="https://github.com/user-attachments/assets/ddd8669c-ae19-4037-9573-0b30e04d6adb" />

Officers and Board Grid 3->1
<img width="498" height="915" alt="image" src="https://github.com/user-attachments/assets/fa3cbd07-44e3-4648-a469-41ad9647632f" />

Translators Grid 3->1
<img width="498" height="915" alt="image" src="https://github.com/user-attachments/assets/55365755-5042-443c-b3b9-b57d309810cb" />

Organizations Grid 3->1
Can't screenshot because I don't have the Images locally

Left alone: Profile Card, it's another 2->1 but that information doesn't take enough space to overflow