### PR TITLE
Consistently render flags as Chakra <Icon> components

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/organizations/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/organizations/page.tsx
@@ -9,7 +9,6 @@ import {
   VStack,
   Image,
   List,
-  Icon,
   Float,
   LinkBox,
   LinkOverlay,
@@ -59,9 +58,7 @@ export default async function RegionalOrganizations() {
               _hover={{ cursor: org.website ? "pointer" : "default" }}
             >
               <Float offsetX={6}>
-                <Icon asChild size="sm">
-                  <WcaFlag code={org.country_iso2} />
-                </Icon>
+                <WcaFlag code={org.country_iso2} size="sm" />
               </Float>
               {org.logo_url && (
                 <Image

--- a/next-frontend/src/components/CompetitionTableEntry.tsx
+++ b/next-frontend/src/components/CompetitionTableEntry.tsx
@@ -10,7 +10,6 @@ import {
   Portal,
   Heading,
   Float,
-  Icon,
 } from "@chakra-ui/react";
 
 import WcaFlag from "@/components/WcaFlag";
@@ -98,9 +97,7 @@ const CompetitionTableEntry: React.FC<Props> = ({ comp }) => {
       </Table.Cell>
 
       <Table.Cell minWidth="4em">
-        <Icon size="lg">
-          <WcaFlag code={comp.country_iso2} fallback={comp.country_iso2} />
-        </Icon>
+        <WcaFlag code={comp.country_iso2} size="lg" />
       </Table.Cell>
 
       <Drawer.Root open={open} onOpenChange={(e) => setOpen(e.open)} size="xl">

--- a/next-frontend/src/components/RegionSelector.tsx
+++ b/next-frontend/src/components/RegionSelector.tsx
@@ -56,14 +56,7 @@ const countryOptions = (t: TFunction) =>
     .map((country) => ({
       key: country.id,
       label: t(`countries.${country.iso2}`),
-      flag: (
-        <WcaFlag
-          code={country.iso2}
-          fallback={country.id}
-          width={32}
-          height={25}
-        />
-      ),
+      flag: <WcaFlag code={country.iso2} size="lg" />,
       value: country.iso2,
     }))
     .toSorted((a, b) => a.label.localeCompare(b.label));

--- a/next-frontend/src/components/WcaFlag.tsx
+++ b/next-frontend/src/components/WcaFlag.tsx
@@ -4,15 +4,21 @@ import type { ComponentPropsWithoutRef } from "react";
 import { Icon } from "@chakra-ui/react";
 import Flag from "react-world-flags";
 
-type FlagProps = ComponentPropsWithoutRef<typeof Flag> &
-  ComponentPropsWithoutRef<typeof Icon>;
+type FlagProps = ComponentPropsWithoutRef<typeof Flag>;
+type IconProps = ComponentPropsWithoutRef<typeof Icon>;
 
-const WcaFlag = ({ code, ...restProps }: FlagProps) => {
+type WcaFlagProps = IconProps & Pick<FlagProps, "code">;
+
+const WcaFlag = ({ code, ...restProps }: WcaFlagProps) => {
   if (code?.toUpperCase() === "TW") {
     return <_TwFlag {...restProps} />;
   }
 
-  return <Flag code={code} {...restProps} />;
+  return (
+    <Icon asChild {...restProps}>
+      <Flag code={code} fallback={code} />
+    </Icon>
+  );
 };
 
 export default WcaFlag;

--- a/next-frontend/src/components/competitions/CompetitionShortlist.tsx
+++ b/next-frontend/src/components/competitions/CompetitionShortlist.tsx
@@ -1,4 +1,4 @@
-import { DataList, Icon, Text, VStack } from "@chakra-ui/react";
+import { DataList, Text, VStack } from "@chakra-ui/react";
 import WcaFlag from "@/components/WcaFlag";
 import CountryMap from "@/components/CountryMap";
 import CompRegoCloseDateIcon from "@/components/icons/CompRegoCloseDateIcon";
@@ -23,9 +23,7 @@ export default function CompetitionShortlist({
       <DataList.Root orientation="horizontal" size="lg" iconLabel>
         <DataList.Item>
           <DataList.ItemLabel>
-            <Icon size="xl">
-              <WcaFlag code={comp.country_iso2} fallback={comp.country_iso2} />
-            </Icon>
+            <WcaFlag code={comp.country_iso2} size="xl" />
           </DataList.ItemLabel>
           <DataList.ItemValue gap="2">
             <CountryMap code={comp.country_iso2} t={t} fontWeight="bold" />

--- a/next-frontend/src/components/competitions/CompetitorTable.tsx
+++ b/next-frontend/src/components/competitions/CompetitorTable.tsx
@@ -1,4 +1,4 @@
-import { HStack, Icon, Link, Table, Text } from "@chakra-ui/react";
+import { HStack, Link, Table, Text } from "@chakra-ui/react";
 import EventIcon from "@/components/EventIcon";
 import { route } from "nextjs-routes";
 import WcaFlag from "@/components/WcaFlag";
@@ -82,9 +82,7 @@ export default function CompetitorTable({
                 )}
                 <Table.Cell>
                   <HStack>
-                    <Icon asChild size="sm">
-                      <WcaFlag code={registration.user.country_iso2} />
-                    </Icon>
+                    <WcaFlag code={registration.user.country_iso2} size="sm" />
                     <CountryMap
                       code={registration.user.country_iso2}
                       t={t}

--- a/next-frontend/src/components/competitions/PsychsheetTable.tsx
+++ b/next-frontend/src/components/competitions/PsychsheetTable.tsx
@@ -1,4 +1,4 @@
-import { HStack, Icon, Link, Table, Text } from "@chakra-ui/react";
+import { HStack, Link, Table, Text } from "@chakra-ui/react";
 import { route } from "nextjs-routes";
 import WcaFlag from "@/components/WcaFlag";
 import CountryMap from "@/components/CountryMap";
@@ -59,9 +59,7 @@ export default function PsychsheetTable({
                     </Table.Cell>
                     <Table.Cell>
                       <HStack>
-                        <Icon asChild size="sm">
-                          <WcaFlag code={registration.country_iso2} />
-                        </Icon>
+                        <WcaFlag code={registration.country_iso2} size="sm" />
                         <CountryMap
                           code={registration.country_iso2}
                           t={t}

--- a/next-frontend/src/components/persons/ProfileCard.tsx
+++ b/next-frontend/src/components/persons/ProfileCard.tsx
@@ -76,9 +76,7 @@ const ProfileCard: React.FC<ProfileData> = async ({
       <Card.Body>
         <Card.Title>
           <HStack>
-            <Icon asChild size="2xl">
-              <WcaFlag code={regionIso2} />
-            </Icon>
+            <WcaFlag code={regionIso2} size="2xl" />
             <Text textStyle="h2">{name}</Text>
           </HStack>
           <Flex direction="row" wrap="wrap" align="start" gap="4px 8px">

--- a/next-frontend/src/components/results/ResultTableCells.tsx
+++ b/next-frontend/src/components/results/ResultTableCells.tsx
@@ -1,7 +1,7 @@
 import WcaFlag from "@/components/WcaFlag";
 import EventIcon from "@/components/EventIcon";
 import events from "@/lib/wca/data/events";
-import { HStack, Icon, Link, Table } from "@chakra-ui/react";
+import { HStack, Link, Table } from "@chakra-ui/react";
 import countries from "@/lib/wca/data/countries";
 import RegionFilterLink from "@/components/results/RegionFilterLink";
 
@@ -35,11 +35,7 @@ export function CountryCell({
       : countries.byIso2[countryIso2];
   return (
     <Table.Cell rowSpan={rowSpan} hideBelow={hideBelow}>
-      {country && (
-        <Icon asChild size="sm">
-          <WcaFlag code={country.iso2} />
-        </Icon>
-      )}{" "}
+      {country && <WcaFlag code={country.iso2} size="sm" />}{" "}
       {filterable ? (
         <RegionFilterLink iso2={country.iso2}>{country.name}</RegionFilterLink>
       ) : (
@@ -65,9 +61,7 @@ export function CompetitionCell({
   return (
     <Table.Cell>
       <HStack>
-        <Icon asChild size="sm">
-          <WcaFlag code={country.iso2} />
-        </Icon>
+        <WcaFlag code={country.iso2} size="sm" />
         <Link href={`/competitions/${competitionId}`}>{competitionName}</Link>
       </HStack>
     </Table.Cell>

--- a/next-frontend/src/components/results/ResultsTable.tsx
+++ b/next-frontend/src/components/results/ResultsTable.tsx
@@ -1,6 +1,6 @@
 import { components } from "@/types/openapi";
 import events from "@/lib/wca/data/events";
-import { HStack, Icon, Link, Table } from "@chakra-ui/react";
+import { HStack, Link, Table } from "@chakra-ui/react";
 import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
 import { route } from "nextjs-routes";
 import NextLink from "next/link";
@@ -80,9 +80,7 @@ export function ResultsTable({
                 )}
                 <Table.Cell>
                   <HStack>
-                    <Icon asChild size="sm">
-                      <WcaFlag code={competitorResult.country_iso2} />
-                    </Icon>
+                    <WcaFlag code={competitorResult.country_iso2} size="sm" />
                     <CountryMap code={competitorResult.country_iso2} t={t} />
                   </HStack>
                 </Table.Cell>
@@ -157,9 +155,7 @@ export function ByPersonTable({
               </Table.Cell>
               <Table.Cell>
                 <HStack>
-                  <Icon asChild size="sm">
-                    <WcaFlag code={competitorResult.country_iso2} />
-                  </Icon>
+                  <WcaFlag code={competitorResult.country_iso2} size="sm" />
                   <CountryMap code={competitorResult.country_iso2} t={t} />
                 </HStack>
               </Table.Cell>

--- a/next-frontend/src/components/search/SearchResultContent.tsx
+++ b/next-frontend/src/components/search/SearchResultContent.tsx
@@ -19,7 +19,7 @@ export default function SearchResultContent({
           <Text textStyle="bodyEmphasis">{result.name}</Text>
           <HStack gap={1} fontSize="sm">
             {result.country_iso2 && (
-              <WcaFlag code={result.country_iso2} width={18} />
+              <WcaFlag code={result.country_iso2} size="md" />
             )}
             <Text>{`${result.city} (${result.id})`}</Text>
           </HStack>


### PR DESCRIPTION
The Taiwan flag was already created through Chakra `createIcon` helper, which gives its component return type (the `<_TwFlag>` component) the exact same props interface as `Icon`.

By force-wrapping the `<Flag>` component of our flags library into an `<Icon asChild>` as well, we can now pass through icon props much more transparently and constrain the flag sizes more consistently.

Fun fact 1: In most of the code callsites, we already _manually_ wrapped everything inside an `<Icon asChild size="...">` anyways. The few usage sites that bothered people (regarding the `TwFlag` being utterly large) were the ones where we forgot to do this wrapping. The PR now makes it impossible to forget the (correct!) wrapping, because it's baked into the component.

Fun fact 2: This will still allow us to replace the flags library in the short term, to avoid serving 1.5MB of SVGs, but it will be much much more plug-and-play because the Chakra `Icon` wrapper keeps the call-site interface (mostly, apart from `code="..."`) stable. The swap-out for a new library will be much much more drag-and-drop with this.