### PR TITLE
Use /api/v0/healthcheck everywhere and silence it in the logs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,8 @@ module WcaOnRails
 
     config.load_defaults 8.1
 
+    config.silence_healthcheck_path = "/api/v0/healthcheck"
+
     # Force belongs_to validations even on empty/unset keys.
     #   This is potentially a Rails bug (?!?) and has been reported at https://github.com/rails/rails/issues/52614
     config.active_record.belongs_to_required_validates_foreign_key = true

--- a/infra/wca_on_rails/shared/elb.tf
+++ b/infra/wca_on_rails/shared/elb.tf
@@ -90,7 +90,7 @@ resource "aws_lb_target_group" "rails-production" {
   deregistration_delay = 10
   health_check {
     interval            = 10
-    path                = "/"
+    path                = "/api/v0/healthcheck"
     port                = "traffic-port"
     protocol            = "HTTP"
     timeout             = 5
@@ -210,7 +210,7 @@ resource "aws_lb_target_group" "rails-staging" {
   deregistration_delay = 10
   health_check {
     interval            = 5
-    path                = "/"
+    path                = "/api/v0/healthcheck"
     port                = "traffic-port"
     protocol            = "HTTP"
     timeout             = 2


### PR DESCRIPTION
turns out Rails has a config for this since rails 7.1.
Also finally moving the ELB Healthcheck to this will save us sooooo much log noise