### PR TITLE
Make RankingsTable more dense

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/results/rankings/filteredRankings.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/results/rankings/filteredRankings.tsx
@@ -66,8 +66,10 @@ export default function FilteredRecords({
   const { t } = useT();
 
   return (
-    <VStack align="left" gap={4}>
-      <Heading size="5xl">{t("results.rankings.title")}</Heading>
+    <VStack align="left" gap={2}>
+      <Heading size={{ base: "3xl", md: "5xl" }}>
+        {t("results.rankings.title")}
+      </Heading>
       {t("results.last_updated_html", { timestamp })}
       <RankingsFilterBox
         filterState={searchParams}

--- a/next-frontend/src/app/(wca)/(with-background)/results/records/filteredRecords.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/results/records/filteredRecords.tsx
@@ -70,8 +70,10 @@ export default function FilteredRecords({
         };
 
   return (
-    <VStack align="left" gap={4}>
-      <Heading size="5xl">{t("results.records.title")}</Heading>
+    <VStack align="left" gap={2}>
+      <Heading size={{ base: "3xl", md: "5xl" }}>
+        {t("results.records.title")}
+      </Heading>
       {t("results.last_updated_html", { timestamp })}
       <RecordsFilterBox
         filterState={{ ...searchParams, event }}

--- a/next-frontend/src/components/results/RankingsTable.tsx
+++ b/next-frontend/src/components/results/RankingsTable.tsx
@@ -20,7 +20,7 @@ export default function RankingsTable({
 
   return (
     <Table.ScrollArea rounded="md">
-      <Table.Root>
+      <Table.Root size="xs" striped>
         <Table.Header>
           <Table.Row>
             <Table.ColumnHeader>

--- a/next-frontend/src/components/results/RecordsTable.tsx
+++ b/next-frontend/src/components/results/RecordsTable.tsx
@@ -44,7 +44,7 @@ interface SeparateRecordsTableProps {
 export default function RecordsTable({ records, show }: WrapperTableProps) {
   if (show === "mixed") {
     return (
-      <VStack align="stretch" gap={10}>
+      <VStack align="stretch" gap={6}>
         {WCA_EVENT_IDS.map((event) => {
           const recordsByEvent = records[event as EventId];
 
@@ -99,7 +99,7 @@ function MixedHistoryTable({ records }: MixedHistoryTableProps) {
 
   return (
     <Table.ScrollArea rounded="md">
-      <Table.Root>
+      <Table.Root size="xs" striped>
         <Table.Header>
           <Table.Row>
             <Table.ColumnHeader>
@@ -142,7 +142,7 @@ function HistoryTable({ records }: HistoryTableProps) {
   const { t } = useT();
 
   return (
-    <VStack align="stretch" gap={10}>
+    <VStack align="stretch" gap={6}>
       {WCA_EVENT_IDS.map((eventId) => {
         if (!records[eventId as EventId]) return;
 
@@ -159,7 +159,7 @@ function HistoryTable({ records }: HistoryTableProps) {
               <EventIcon eventId={eventId} /> {events.byId[eventId].name}
             </Heading>
             <Table.ScrollArea rounded="md">
-              <Table.Root>
+              <Table.Root size="xs" striped>
                 <Table.Header>
                   <Table.Row>
                     <Table.ColumnHeader>
@@ -207,7 +207,7 @@ function SlimRecordsTable({ records }: SlimRecordsTableProps) {
 
   return (
     <Table.ScrollArea rounded="md">
-      <Table.Root>
+      <Table.Root size="xs" striped>
         <Table.Header>
           <Table.Row>
             <Table.ColumnHeader>
@@ -261,14 +261,14 @@ function SeparateRecordsTable({ recordsByType }: SeparateRecordsTableProps) {
   const { t } = useT();
 
   return (
-    <VStack align="stretch" gap={10}>
+    <VStack align="stretch" gap={6}>
       {["single", "average"].map((type) => (
         <VStack align="stretch" key={type}>
           <Heading size="2xl">
             {t(`results.selector_elements.type_selector.${type}`)}
           </Heading>
           <Table.ScrollArea rounded="md">
-            <Table.Root>
+            <Table.Root size="xs" striped>
               <Table.Header>
                 <Table.Row>
                   <Table.ColumnHeader>
@@ -315,7 +315,7 @@ function MixedRecordsTable({ records }: RecordsTableProps) {
 
   return (
     <Table.ScrollArea rounded="md">
-      <Table.Root>
+      <Table.Root size="xs" striped>
         <Table.Header>
           <Table.Row>
             <Table.ColumnHeader>

--- a/next-frontend/src/components/results/ResultTableCells.tsx
+++ b/next-frontend/src/components/results/ResultTableCells.tsx
@@ -77,7 +77,7 @@ export function PersonCell({ personId, personName }: PersonCellProps) {
   return (
     // The ScrollArea sets `white-space: nowrap` on everything; names are the one
     //   column we let wrap, so the result column stays on screen on narrow phones.
-    <Table.Cell whiteSpace="normal">
+    <Table.Cell whiteSpace="normal" minW="2xs">
       <Link href={`/persons/${personId}`}>{personName}</Link>
     </Table.Cell>
   );

--- a/next-frontend/src/components/results/ResultTableCells.tsx
+++ b/next-frontend/src/components/results/ResultTableCells.tsx
@@ -75,7 +75,9 @@ interface PersonCellProps {
 
 export function PersonCell({ personId, personName }: PersonCellProps) {
   return (
-    <Table.Cell>
+    // The ScrollArea sets `white-space: nowrap` on everything; names are the one
+    //   column we let wrap, so the result column stays on screen on narrow phones.
+    <Table.Cell whiteSpace="normal">
       <Link href={`/persons/${personId}`}>{personName}</Link>
     </Table.Cell>
   );


### PR DESCRIPTION
Reached 15 on one page which is the same as we have now when not scrolled down at all
<img width="1531" height="944" alt="image" src="https://github.com/user-attachments/assets/e410e5f9-8c77-4b3d-8cb3-ef87fb32715a" />

For mobile we cannot both reach the amount of people that we currently have (26 on me setting it to iPhone) and also have results in view. 
Not having Results in view gives us the same 26:
<img width="438" height="909" alt="image" src="https://github.com/user-attachments/assets/35e83fc2-a628-4d8c-9916-5f91d68830ec" />
Results in View gives us about 18:
<img width="438" height="909" alt="image" src="https://github.com/user-attachments/assets/b4f532a7-7020-4644-a7ef-d81510f4b485" />

@dunkOnIT please advise