### PR TITLE
Add global_pos aware _result_table.html.erb

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -265,6 +265,7 @@ class AdminController < ApplicationController
 
     all_results = Result.select("results.*, FALSE AS `muted`")
                         .joins(:event, :round_type)
+                        .includes(:round)
                         .where(
                           person_name: @person_name,
                           country_id: @country_id,

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1482,7 +1482,7 @@ class Competition < ApplicationRecord
   end
 
   def events_with_podium_results
-    results.includes(:result_attempts).podium.order(:global_pos).group_by(&:event)
+    results.includes(:result_attempts, :round).podium.order(:global_pos).group_by(&:event)
            .sort_by { |event, _results| event.rank }
   end
 
@@ -1491,7 +1491,7 @@ class Competition < ApplicationRecord
   end
 
   def person_ids_with_results
-    results.includes(:result_attempts).group_by(&:person_id)
+    results.includes(:result_attempts, :round).group_by(&:person_id)
            .sort_by { |_person_id, results| results.first.person_name }
            .map do |person_id, results|
              results.sort_by! { |r| [r.event.rank, -r.round_type.rank] }

--- a/app/views/competitions/_results_table.html.erb
+++ b/app/views/competitions/_results_table.html.erb
@@ -3,6 +3,9 @@
 <% hide_pos = defined?(hide_pos) && hide_pos %>
 <% hide_name = defined?(hide_name) && hide_name %>
 <% hide_solves = defined?(hide_solves) && hide_solves %>
+<%# Set for tables that show one merged row per competitor across a Dual Round, where the
+    position within a single round is meaningless. %>
+<% global_pos = defined?(global_pos) && global_pos %>
 
 <%= wca_table table_class: "wca-results", float_thead: false do %>
   <thead>
@@ -57,20 +60,23 @@
         <% end %>
         <% last_event = result.event %>
         <% if !hide_round %>
-          <td class="round"><%= result.round_type.cell_name %></td>
+          <td class="round"><%= result.round_type.cell_name %><%= " (#{t 'persons.show.dual'})" if result.round.linked_round_id? %></td>
         <% end %>
 
         <% if !hide_pos %>
+          <% position = global_pos ? result.global_pos : result.pos %>
           <% classes = "pos" %>
           <% previous_result = i > 0 ? results[i - 1] : nil %>
-          <% if previous_result && previous_result.event_id == result.event_id && previous_result.round_type_id == result.round_type_id && previous_result.pos == result.pos %>
+          <%# Competitors tied on a Dual Round's merged ranking can have their best result in
+              different rounds, so only compare the round when showing positions within one. %>
+          <% if previous_result && previous_result.event_id == result.event_id && (global_pos ? previous_result.global_pos == position : previous_result.round_type_id == result.round_type_id && previous_result.pos == position) %>
             <% classes << " tied-previous" %>
           <% end %>
           <td class="<%= classes %>">
             <% if current_user&.can_admin_results? %>
               <%= link_to(ui_icon("pencil alt"), edit_result_path(result.id)) %>
             <% end %>
-            <%= result.pos %>
+            <%= position %><%= " (#{result.global_pos})" if !global_pos && result.round.linked_round_id? %>
           </td>
         <% end %>
 

--- a/app/views/competitions/show_podiums.html.erb
+++ b/app/views/competitions/show_podiums.html.erb
@@ -13,6 +13,6 @@
     <% end %>
 
 
-    <%= render "results_table", results: podium_results, hide_event: true, hide_round: true, hide_solves: h2h_round %>
+    <%= render "results_table", results: podium_results, hide_event: true, hide_round: true, hide_solves: h2h_round, global_pos: true %>
   <% end %>
 <% end %>

--- a/spec/features/competition_results_spec.rb
+++ b/spec/features/competition_results_spec.rb
@@ -43,4 +43,43 @@ RSpec.feature "competition results" do
       expect(page).to have_text(person_2.name)
     end
   end
+
+  describe "dual rounds" do
+    # No `:confirmed`, because that trait already creates a first round for every event.
+    let(:dual_competition) { create(:competition, :visible, :results_posted, events: Event.where(id: '333')) }
+    let!(:first_round) { create(:round, competition: dual_competition, number: 1, total_number_of_rounds: 2) }
+    let!(:final_round) { create(:round, competition: dual_competition, number: 2, total_number_of_rounds: 2) }
+
+    let(:alice) { create(:person, name: "Alice Cuber", country_id: "USA") }
+    let(:bob) { create(:person, name: "Bob Cuber", country_id: "USA") }
+    let(:carol) { create(:person, name: "Carol Cuber", country_id: "USA") }
+
+    before do
+      create(:linked_round, rounds: [first_round, final_round])
+
+      # Each competitor counts with their better average, which is 10.00 for alice, 15.00 for
+      # carol and 20.00 for bob, so the podium is alice, carol, bob. Neither round ranks them
+      # that way on its own, which is what makes `pos` the wrong number to show on the podium.
+      create(:result, person: alice, competition: dual_competition, event_id: "333", round: first_round, round_type_id: "1", best: 500, average: 1000, pos: 1, global_pos: 1)
+      create(:result, person: bob, competition: dual_competition, event_id: "333", round: first_round, round_type_id: "1", best: 1500, average: 3000, pos: 2, global_pos: 3)
+      create(:result, person: carol, competition: dual_competition, event_id: "333", round: first_round, round_type_id: "1", best: 2500, average: 5000, pos: 3, global_pos: 2)
+      create(:result, person: carol, competition: dual_competition, event_id: "333", round: final_round, round_type_id: "f", best: 750, average: 1500, pos: 1, global_pos: 2)
+      create(:result, person: bob, competition: dual_competition, event_id: "333", round: final_round, round_type_id: "f", best: 1000, average: 2000, pos: 2, global_pos: 3)
+      create(:result, person: alice, competition: dual_competition, event_id: "333", round: final_round, round_type_id: "f", best: 2000, average: 4000, pos: 3, global_pos: 1)
+    end
+
+    it "ranks the podium across both rounds instead of within one" do
+      visit competition_results_podiums_path(dual_competition)
+
+      expect(page.all("td.pos").map(&:text)).to eq %w[1 2 3]
+      expect(page.all("td.name").map(&:text)).to eq [alice.name, carol.name, bob.name]
+    end
+
+    it "shows both the round position and the position across both rounds by person" do
+      visit competition_results_by_person_path(dual_competition)
+
+      expect(page.all("td.pos").map(&:text)).to contain_exactly("1 (1)", "3 (1)", "2 (3)", "2 (3)", "3 (2)", "1 (2)")
+      expect(page.all("td.round").map(&:text)).to all(include("Dual"))
+    end
+  end
 end


### PR DESCRIPTION
Shows `global_pos` on the /results/podiums page and do the same thing as the /persons/[id] page with `local_pos` (`global_pos`) on the /results/all page