### PR TITLE
Let nextjs cache rails images

### DIFF
--- a/next-frontend/next.config.ts
+++ b/next-frontend/next.config.ts
@@ -85,6 +85,8 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
+    // Avatar URLs are timestamped per upload, so an optimized variant is never stale.
+    minimumCacheTTL: 31536000,
     remotePatterns: [
       new URL("https://worldcubeassociation.org/**"),
       new URL("https://avatars.worldcubeassociation.org/**"),

--- a/next-frontend/src/components/UserBadge.tsx
+++ b/next-frontend/src/components/UserBadge.tsx
@@ -50,6 +50,7 @@ const UserBadge: React.FC<UserBadgeData> = ({
               }
               alt="Profile Picture"
               fill
+              sizes="75px"
               style={{ objectFit: "cover" }}
             />
           </Box>

--- a/next-frontend/src/components/about/AboutUsItem.tsx
+++ b/next-frontend/src/components/about/AboutUsItem.tsx
@@ -28,7 +28,12 @@ export default function AboutUsItem({
       {image?.url && (
         <Box position="relative" maxW="500px" w="full">
           <ChakraImage asChild borderRadius="1rem">
-            <Image src={image.url} alt={image.alt || title} fill />
+            <Image
+              src={image.url}
+              alt={image.alt || title}
+              fill
+              sizes="500px"
+            />
           </ChakraImage>
         </Box>
       )}


### PR DESCRIPTION
We use `NextImage` to show Avatars, next takes the image, creates a webp out of it, but then throws it away for the next render. This way it is reused as long as the server is running. This is no problem for revalidation or anything, because rails images are always timestamped (either through avatars or upload controller)