### PR TITLE
Fix Cutoff Headings: Standardize padding in Containers

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/about/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/about/page.tsx
@@ -29,7 +29,7 @@ export default async function About() {
   }
 
   return (
-    <VStack gap="8" width="full" pt="8" alignItems="left">
+    <VStack gap="8" width="full" alignItems="left">
       <Heading size="5xl">About Us</Heading>
       {aboutItems.map((item) => {
         switch (item.blockType) {

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/layout.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@chakra-ui/react";
 import { getCompetitionInfo } from "@/lib/wca/competitions/getCompetitionInfo";
 import { Metadata } from "next";
 import ConfirmProvider from "@/providers/ConfirmProvider";
@@ -27,9 +26,5 @@ export default function CompetitionLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <Box pt="8">
-      <ConfirmProvider>{children}</ConfirmProvider>
-    </Box>
-  );
+  return <ConfirmProvider>{children}</ConfirmProvider>;
 }

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/mine/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/mine/page.tsx
@@ -34,7 +34,7 @@ export default async function MyCompetitions() {
   const myCompetitions = myCompetitionsRequest.data;
 
   return (
-    <VStack gap="8" pt="8" alignItems="left">
+    <VStack gap="8" alignItems="left">
       <Heading size="5xl">
         {session.user?.wcaId && (
           <Button asChild>

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/page.tsx
@@ -196,7 +196,7 @@ export default function CompetitionsPage() {
     0;
 
   return (
-    <VStack gap="8" width="full" pt="8">
+    <VStack gap="8" width="full">
       <ClientOnly>
         {!session.isPending && !session.data && (
           <RemovableCard

--- a/next-frontend/src/app/(wca)/(with-background)/delegates/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/delegates/page.tsx
@@ -63,7 +63,7 @@ export default async function DelegatesPage({
   const activeFriendlyId = activeGroup.metadata!.friendly_id!;
 
   return (
-    <VStack align="left" gap="8" width="full" pt="8" alignItems="left">
+    <VStack align="left" gap="8" width="full" alignItems="left">
       <Heading size="5xl">{t("delegates_page.title")}</Heading>
       <Trans
         parent={Prose}

--- a/next-frontend/src/app/(wca)/(with-background)/disclaimer/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/disclaimer/page.tsx
@@ -26,7 +26,7 @@ export default async function Disclaimer() {
   }
 
   return (
-    <VStack gap="8" width="full" pt="8" alignItems="left">
+    <VStack gap="8" width="full" alignItems="left">
       <Heading size="5xl">Disclaimer</Heading>
       {disclaimerItems.map((item) => (
         <Box key={item.id}>

--- a/next-frontend/src/app/(wca)/(with-background)/documents/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/documents/page.tsx
@@ -43,7 +43,7 @@ export default async function Documents() {
   const categorized = _.groupBy(categorizedRaw, "category");
 
   return (
-    <VStack gap="8" pt="8" alignItems="left">
+    <VStack gap="8" alignItems="left">
       <Heading size="5xl">Documents</Heading>
       <Accordion.Root variant="enclosed" multiple>
         {uncategorized.map((doc) => (

--- a/next-frontend/src/app/(wca)/(with-background)/faq/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/faq/page.tsx
@@ -1,6 +1,6 @@
 "use server";
 
-import { Accordion, Box, Card, Heading, Tabs, VStack } from "@chakra-ui/react";
+import { Accordion, Card, Heading, Tabs, VStack } from "@chakra-ui/react";
 import { getPayload } from "payload";
 import config from "@payload-config";
 import { FaqCategory, FaqQuestion } from "@/types/payload";
@@ -38,98 +38,93 @@ export default async function FAQ() {
   const faqCategories = uniqBy(allCategories, "id");
 
   return (
-    <Box paddingTop="8">
-      <VStack gap="8" width="full" alignItems="left">
-        <Card.Root maxW="40em">
-          <Card.Body>
-            <Card.Title textStyle="h1">Frequently Asked Questions</Card.Title>
-            {faqPage.introTextMarkdown ? (
-              <ChakraMarkdown
-                headingAs={Card.Title}
-                paragraphAs={Card.Description}
-                textStyle="body"
-              >
-                {faqPage.introTextMarkdown}
-              </ChakraMarkdown>
-            ) : (
-              <Card.Description>No Intro text, add it!</Card.Description>
-            )}
-          </Card.Body>
-        </Card.Root>
-        <Card.Root borderWidth={0} bg="transparent">
-          <Card.Body paddingX={0}>
-            <Tabs.Root
-              variant="subtle"
-              fitContent
-              defaultValue={faqCategories[0].id.toString()}
-              width="full"
+    <VStack gap="8" width="full" alignItems="left">
+      <Card.Root maxW="40em">
+        <Card.Body>
+          <Card.Title textStyle="h1">Frequently Asked Questions</Card.Title>
+          {faqPage.introTextMarkdown ? (
+            <ChakraMarkdown
+              headingAs={Card.Title}
+              paragraphAs={Card.Description}
+              textStyle="body"
             >
-              <Tabs.List>
-                {faqCategories.map((category) => (
-                  <Tabs.Trigger
-                    key={category.id}
-                    value={category.id.toString()}
-                    colorPalette={category.colorPalette}
+              {faqPage.introTextMarkdown}
+            </ChakraMarkdown>
+          ) : (
+            <Card.Description>No Intro text, add it!</Card.Description>
+          )}
+        </Card.Body>
+      </Card.Root>
+      <Card.Root borderWidth={0} bg="transparent">
+        <Card.Body paddingX={0}>
+          <Tabs.Root
+            variant="subtle"
+            fitContent
+            defaultValue={faqCategories[0].id.toString()}
+            width="full"
+          >
+            <Tabs.List>
+              {faqCategories.map((category) => (
+                <Tabs.Trigger
+                  key={category.id}
+                  value={category.id.toString()}
+                  colorPalette={category.colorPalette}
+                >
+                  {category.title}
+                </Tabs.Trigger>
+              ))}
+            </Tabs.List>
+            {faqCategories.map((category) => {
+              const questions = faqQuestions.filter(
+                (faqQuestion) =>
+                  (faqQuestion.category as FaqCategory).id === category.id,
+              );
+              return (
+                <Tabs.Content key={category.id} value={category.id.toString()}>
+                  <Accordion.Root
+                    multiple
+                    collapsible
+                    variant="card"
+                    width="full"
                   >
-                    {category.title}
-                  </Tabs.Trigger>
-                ))}
-              </Tabs.List>
-              {faqCategories.map((category) => {
-                const questions = faqQuestions.filter(
-                  (faqQuestion) =>
-                    (faqQuestion.category as FaqCategory).id === category.id,
-                );
-                return (
-                  <Tabs.Content
-                    key={category.id}
-                    value={category.id.toString()}
-                  >
-                    <Accordion.Root
-                      multiple
-                      collapsible
-                      variant="card"
-                      width="full"
-                    >
-                      {questions.map((question) => (
-                        <Accordion.Item
-                          key={question.id}
-                          value={question.id.toString()}
-                          layerStyle="outline.solid"
-                          borderColor="border"
-                          bg="bg.panel"
+                    {questions.map((question) => (
+                      <Accordion.Item
+                        key={question.id}
+                        value={question.id.toString()}
+                        layerStyle="outline.solid"
+                        borderColor="border"
+                        bg="bg.panel"
+                      >
+                        <Accordion.ItemTrigger
+                          textStyle="s1"
+                          _open={{
+                            bgImage: `linear-gradient(90deg, {colors.${category.colorPalette}.subtle}, {colors.bg.panel})`,
+                            borderBottomRadius: 0,
+                          }}
+                          _hover={{
+                            bgImage: `linear-gradient(90deg, {colors.${category.colorPalette}.subtle}, {colors.bg.panel})`,
+                          }}
                         >
-                          <Accordion.ItemTrigger
-                            textStyle="s1"
-                            _open={{
-                              bgImage: `linear-gradient(90deg, {colors.${category.colorPalette}.subtle}, {colors.bg.panel})`,
-                              borderBottomRadius: 0,
-                            }}
-                            _hover={{
-                              bgImage: `linear-gradient(90deg, {colors.${category.colorPalette}.subtle}, {colors.bg.panel})`,
-                            }}
-                          >
-                            {question.question}
-                            <Accordion.ItemIndicator />
-                          </Accordion.ItemTrigger>
-                          <Accordion.ItemContent textStyle="body">
-                            <Accordion.ItemBody>
-                              <ChakraMarkdown>
-                                {question.answerRichtextMarkdown ||
-                                  question.answer}
-                              </ChakraMarkdown>
-                            </Accordion.ItemBody>
-                          </Accordion.ItemContent>
-                        </Accordion.Item>
-                      ))}
-                    </Accordion.Root>
-                  </Tabs.Content>
-                );
-              })}
-            </Tabs.Root>
-          </Card.Body>
-        </Card.Root>
-      </VStack>
-    </Box>
+                          {question.question}
+                          <Accordion.ItemIndicator />
+                        </Accordion.ItemTrigger>
+                        <Accordion.ItemContent textStyle="body">
+                          <Accordion.ItemBody>
+                            <ChakraMarkdown>
+                              {question.answerRichtextMarkdown ||
+                                question.answer}
+                            </ChakraMarkdown>
+                          </Accordion.ItemBody>
+                        </Accordion.ItemContent>
+                      </Accordion.Item>
+                    ))}
+                  </Accordion.Root>
+                </Tabs.Content>
+              );
+            })}
+          </Tabs.Root>
+        </Card.Body>
+      </Card.Root>
+    </VStack>
   );
 }

--- a/next-frontend/src/app/(wca)/(with-background)/incidents/[id]/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/incidents/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function IncidentPage({ params }: IncidentPageProps) {
   const resolved = Boolean(incident.resolved_at);
 
   return (
-    <VStack gap="8" width="full" pt="8" alignItems="stretch">
+    <VStack gap="8" width="full" alignItems="stretch">
       <Link asChild>
         <NextLink href="/incidents">
           <LuArrowLeft />

--- a/next-frontend/src/app/(wca)/(with-background)/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/layout.tsx
@@ -10,7 +10,9 @@ export default function WithBackgroundLayout({
   return (
     <>
       <RandomBackground numRows={8} numCols={18} />
-      <Container bg="bg">{children}</Container>
+      <Container bg="bg" paddingTop="8">
+        {children}
+      </Container>
     </>
   );
 }

--- a/next-frontend/src/app/(wca)/(with-background)/privacy/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/privacy/page.tsx
@@ -27,7 +27,7 @@ export default async function Privacy() {
   }
 
   return (
-    <VStack gap="8" width="full" pt="8" alignItems="left">
+    <VStack gap="8" width="full" alignItems="left">
       <Heading size="5xl">WCA Privacy Statement</Heading>
       <ChakraMarkdown>{privacyPage.preambleMarkdown}</ChakraMarkdown>
       {privacyItems.map((item) => (

--- a/next-frontend/src/app/(wca)/(with-background)/regulations/about/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/regulations/about/page.tsx
@@ -31,7 +31,7 @@ export default async function AboutTheRegulations() {
   const { t } = await getT();
 
   return (
-    <VStack gap="8" width="full" pt="8" alignItems="left">
+    <VStack gap="8" width="full" alignItems="left">
       <Heading size="5xl">{t("about_regulations.title")}</Heading>
       {aboutRegulationsItems.map((item) => (
         <Card.Root key={item.id}>

--- a/next-frontend/src/app/(wca)/(with-background)/regulations/history/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/regulations/history/page.tsx
@@ -38,7 +38,7 @@ export default async function RegulationsHistory() {
   }
 
   return (
-    <VStack gap="8" pt="8" alignItems="left">
+    <VStack gap="8" alignItems="left">
       <Heading size="5xl">WCA Regulations</Heading>
       <Heading size="2xl">Older Versions of the Regulations</Heading>
       <Text>

--- a/next-frontend/src/app/(wca)/(with-background)/score-tools/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/score-tools/page.tsx
@@ -50,7 +50,7 @@ export default async function ScoreTools() {
   const toolsByCategory = _.groupBy(tools, "category");
 
   return (
-    <VStack gap="8" width="full" pt="8" alignItems="left">
+    <VStack gap="8" width="full" alignItems="left">
       <Heading size="5xl">Software tools for WCA competitions</Heading>
       <Text>{t("score_tools.intro.desc")}</Text>
       <Text>{t("score_tools.intro.disclaimer")}</Text>

--- a/next-frontend/src/app/(wca)/(with-background)/search/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/search/page.tsx
@@ -77,7 +77,7 @@ export default async function SearchResults({ searchParams }: SearchPageProps) {
   const resultsByClass = _.groupBy(data.result, "class");
 
   return (
-    <VStack align="stretch" gap="8" py="8">
+    <VStack align="stretch" gap="8" pb="8">
       <Heading textStyle="h2">
         <Trans
           t={t}

--- a/next-frontend/src/app/(wca)/(with-background)/speedcubing-history/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/speedcubing-history/page.tsx
@@ -33,7 +33,7 @@ export default async function SpeedcubingHistory() {
   const { t } = await getT();
 
   return (
-    <VStack gap="8" width="full" pt="8" alignItems="left">
+    <VStack gap="8" width="full" alignItems="left">
       <Heading size="5xl">{t("speedcubing_history.title")}</Heading>
       {historyItems.map((item) => {
         switch (item.blockType) {

--- a/next-frontend/src/app/(wca)/(with-background)/teams-committees/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/teams-committees/page.tsx
@@ -34,7 +34,7 @@ export default async function TeamsCommitteesPage() {
   if (error) return <OpenapiError response={response} t={t} />;
 
   return (
-    <VStack align="left" gap="8" width="full" pt="8" alignItems="left">
+    <VStack align="left" gap="8" width="full" alignItems="left">
       <Heading size="5xl">{t("page.teams_committees_councils.title")}</Heading>
       <Prose>{t("page.teams_committees_councils.description")}</Prose>
       <Tabs.Root


### PR DESCRIPTION
I noticed that we had a good amount of pages where the top bit of the heading was cutoff. This was because about half of the pages/layouts manually added a padding top, but some didn't. Because we need this padding so content doesn't overlap with the navbar, it should just be in the (now global) root layout Container.