### PR TITLE
Give back visual space to competition page

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/layout.tsx
@@ -2,6 +2,7 @@ import { getCompetitionInfo } from "@/lib/wca/competitions/getCompetitionInfo";
 import { getT } from "@/lib/i18n/get18n";
 import OpenapiError from "@/components/ui/openapiError";
 import CompetitionMenu from "@/components/competitions/CompetitionMenu";
+import {Box} from "@chakra-ui/react";
 
 export default async function CompetitionTabsLayout({
   children,
@@ -20,9 +21,13 @@ export default async function CompetitionTabsLayout({
 
   if (error) return <OpenapiError t={t} response={response} />;
 
+  // The competition page layout is very card-heave, and Chakra cards bring their own padding.
+  //   So we subtract a little bit of the global padding that we had previously applied to shared pages.
   return (
-    <CompetitionMenu competitionInfo={competitionInfo}>
-      {children}
-    </CompetitionMenu>
+    <Box marginTop="-3">
+      <CompetitionMenu competitionInfo={competitionInfo}>
+        {children}
+      </CompetitionMenu>
+    </Box>
   );
 }

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/layout.tsx
@@ -2,7 +2,7 @@ import { getCompetitionInfo } from "@/lib/wca/competitions/getCompetitionInfo";
 import { getT } from "@/lib/i18n/get18n";
 import OpenapiError from "@/components/ui/openapiError";
 import CompetitionMenu from "@/components/competitions/CompetitionMenu";
-import {Box} from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 
 export default async function CompetitionTabsLayout({
   children,

--- a/next-frontend/src/components/competitions/TabMenu.tsx
+++ b/next-frontend/src/components/competitions/TabMenu.tsx
@@ -98,7 +98,7 @@ export default function TabMenu({
           competitionId={competitionInfo.id}
         />
       </Tabs.List>
-      <Box hideFrom="md" mb="4">
+      <Box hideFrom="md">
         <Drawer.Root
           open={drawerOpen}
           onOpenChange={(e) => setDrawerOpen(e.open)}
@@ -217,6 +217,7 @@ function TabList({
           key={tabName}
           value={encodeURIComponent(tabName)}
           minHeight="fit-content"
+          maxWidth="xs"
           asChild
         >
           <Text textStyle="bodyEmphasis" asChild justifyContent="left">
@@ -279,7 +280,12 @@ function TabLink({
   );
 
   const trigger = (
-    <Tabs.Trigger value={tab.menuKey} asChild disabled={tab.disabled}>
+    <Tabs.Trigger
+      value={tab.menuKey}
+      asChild
+      disabled={tab.disabled}
+      minHeight="fit-content"
+    >
       <Text asChild textStyle="bodyEmphasis" justifyContent="left">
         {tab.disabled ? (
           <Text>{label}</Text>
@@ -327,6 +333,7 @@ function CollapsibleTabGroup({
         width="full"
         display="flex"
         textAlign="start"
+        minHeight="fit-content"
         px="3"
         py="2"
         borderRadius="md"


### PR DESCRIPTION
Follow-up to #15624: The global `marginTop="8"` makes sense for ~90% of our pages, but everything under `/[competitionId]` is heavily card-based. And Chakra cards bring their own inner `paddingTop`. So I chose to wrap it into a `Box` with negative margin to "eat up" some of the global 8 spacing units.

## Before (see blank space between navbar and first content card)
<img width="436" height="948" alt="image" src="https://github.com/user-attachments/assets/aa2eff65-86e7-46d4-8d66-1b414d018595" />

## After
<img width="436" height="948" alt="image" src="https://github.com/user-attachments/assets/611075a4-a2ef-43ab-8a77-4a6ff1e7680d" />

Also re-configures the width of the sidebar menu on desktop ever so slightly. Previously, the sidebar menu had no `max-width` property set, and this is a problem because a lot of custom tabs currently have "Something in German / Something in English" as their name. Depending on what you're translating (and which language you're writing in) this can result in pretty long tab names, and they can steal almost half of the screen space.
As a proposed solution, I have given `maxWidth="xs"` **to the custom tabs only**. Hard-coded tabs that we define as WST for any competition can still be as wide as they want.

## Before
<img width="1633" height="939" alt="image" src="https://github.com/user-attachments/assets/5b5a28b0-a5f1-45eb-bedb-2817b168a606" />

## After
<img width="1633" height="939" alt="image" src="https://github.com/user-attachments/assets/aafc6c1f-7080-474d-98ee-d510d8b95a90" />
