### PR TITLE
Add back icons to competition navbar

### DIFF
--- a/next-frontend/src/components/competitions/TabMenu.tsx
+++ b/next-frontend/src/components/competitions/TabMenu.tsx
@@ -8,6 +8,7 @@ import {
   Collapsible,
   Drawer,
   IconButton,
+  Link as ChakraLink,
   Separator,
   Spacer,
   Tabs,
@@ -290,9 +291,14 @@ function TabLink({
         {tab.disabled ? (
           <Text>{label}</Text>
         ) : tab.externalHref ? (
-          <a href={tab.externalHref} target="_blank" rel="noopener noreferrer">
+          <ChakraLink
+            href={tab.externalHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            color="currentColor"
+          >
             {label}
-          </a>
+          </ChakraLink>
         ) : (
           <Link href={isAdminRoute && tab.hrefAdmin ? tab.hrefAdmin : tab.href}>
             {label}

--- a/next-frontend/src/components/competitions/TabMenu.tsx
+++ b/next-frontend/src/components/competitions/TabMenu.tsx
@@ -21,6 +21,7 @@ import { components } from "@/types/openapi";
 import { useT } from "@/lib/i18n/useI18n";
 import {
   CompetitionNavTab,
+  TabBase,
   TabWithChildren,
   TabWithLink,
 } from "@/lib/wca/competitions/tabs";
@@ -28,7 +29,7 @@ import { useState } from "react";
 import { TFunction } from "i18next";
 import { LuAlignJustify, LuArrowLeft } from "react-icons/lu";
 import type { RouteLiteral } from "nextjs-routes";
-import { iconMap } from "@/components/icons/iconMap";
+import IconDisplay from "@/components/IconDisplay";
 import { route } from "nextjs-routes";
 import { Tooltip } from "@/components/ui/tooltip";
 
@@ -267,6 +268,24 @@ function BackLink({
   );
 }
 
+function TabText<T extends TabBase>({
+  tab,
+  showIcon = true,
+  renderFn,
+  ...textProps
+}: {
+  tab: T;
+  renderFn: (tab: T) => string;
+  showIcon?: boolean;
+} & TextProps) {
+  return (
+    <>
+      {showIcon && tab.icon !== undefined && <IconDisplay name={tab.icon} />}
+      <Text {...textProps}>{renderFn(tab)}</Text>
+    </>
+  );
+}
+
 function TabLink({
   tab,
   t,
@@ -276,9 +295,12 @@ function TabLink({
   t: TFunction;
   isAdminRoute: boolean;
 }) {
-  const label = t(
-    isAdminRoute && tab.i18nKeyAdmin ? tab.i18nKeyAdmin : tab.i18nKey,
-  );
+  const renderLabel = (renderTab: TabWithLink) =>
+    t(
+      isAdminRoute && renderTab.i18nKeyAdmin
+        ? renderTab.i18nKeyAdmin
+        : renderTab.i18nKey,
+    );
 
   const trigger = (
     <Tabs.Trigger
@@ -289,7 +311,7 @@ function TabLink({
     >
       <Text asChild textStyle="bodyEmphasis" justifyContent="left">
         {tab.disabled ? (
-          <Text>{label}</Text>
+          <TabText tab={tab} renderFn={renderLabel} />
         ) : tab.externalHref ? (
           <ChakraLink
             href={tab.externalHref}
@@ -297,11 +319,15 @@ function TabLink({
             rel="noopener noreferrer"
             color="currentColor"
           >
-            {label}
+            <TabText tab={tab} renderFn={renderLabel} />
           </ChakraLink>
         ) : (
           <Link href={isAdminRoute && tab.hrefAdmin ? tab.hrefAdmin : tab.href}>
-            {label}
+            <TabText
+              tab={tab}
+              renderFn={renderLabel}
+              fontVariant="small-caps"
+            />
           </Link>
         )}
       </Text>
@@ -330,8 +356,7 @@ function CollapsibleTabGroup({
   isOpen: boolean;
   onToggle: () => void;
 }) {
-  const { i18nKey, icon, children } = tab;
-  const IconComponent = iconMap[icon];
+  const { children } = tab;
 
   return (
     <Collapsible.Root open={isOpen} onOpenChange={onToggle}>
@@ -345,9 +370,11 @@ function CollapsibleTabGroup({
         borderRadius="md"
         _hover={{ bg: "bg.subtle" }}
       >
-        <Text textStyle="bodyEmphasis">
-          <IconComponent /> {t(i18nKey)}
-        </Text>
+        <TabText
+          tab={tab}
+          renderFn={(render) => t(render.i18nKey)}
+          textStyle="bodyEmphasis"
+        />
       </Collapsible.Trigger>
 
       <Collapsible.Content>

--- a/next-frontend/src/components/competitions/TabMenu.tsx
+++ b/next-frontend/src/components/competitions/TabMenu.tsx
@@ -302,6 +302,10 @@ function TabLink({
         : renderTab.i18nKey,
     );
 
+  const tabLabel = (
+    <TabText tab={tab} renderFn={renderLabel} textStyle="bodyEmphasis" />
+  );
+
   const trigger = (
     <Tabs.Trigger
       value={tab.menuKey}
@@ -309,9 +313,9 @@ function TabLink({
       disabled={tab.disabled}
       minHeight="fit-content"
     >
-      <Text asChild textStyle="bodyEmphasis" justifyContent="left">
+      <Text asChild justifyContent="left">
         {tab.disabled ? (
-          <TabText tab={tab} renderFn={renderLabel} />
+          tabLabel
         ) : tab.externalHref ? (
           <ChakraLink
             href={tab.externalHref}
@@ -319,15 +323,11 @@ function TabLink({
             rel="noopener noreferrer"
             color="currentColor"
           >
-            <TabText tab={tab} renderFn={renderLabel} />
+            {tabLabel}
           </ChakraLink>
         ) : (
           <Link href={isAdminRoute && tab.hrefAdmin ? tab.hrefAdmin : tab.href}>
-            <TabText
-              tab={tab}
-              renderFn={renderLabel}
-              fontVariant="small-caps"
-            />
+            {tabLabel}
           </Link>
         )}
       </Text>

--- a/next-frontend/src/lib/wca/competitions/tabs.ts
+++ b/next-frontend/src/lib/wca/competitions/tabs.ts
@@ -6,7 +6,7 @@ import { getRoundTypeId, parseActivityCode } from "@/lib/wca/wcif/rounds";
 import _ from "lodash";
 import { EventId } from "@/lib/wca/data/events";
 
-interface TabBase {
+export interface TabBase {
   i18nKey: string;
   i18nKeyAdmin?: string;
   menuKey: string;


### PR DESCRIPTION
See title. I introduced a shared "render tab title" component for this, which had to use generics because of the different kinds of tabs (implemented via subclasses) that we have.

I also played around with the title-case styling a little bit, what do you think?
<img width="532" height="977" alt="image" src="https://github.com/user-attachments/assets/94dddaa6-90d7-4aa8-a289-2222156bb4a7" />
