### PR TITLE
Correctly render competition results snackbar and results tables

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/layout.tsx
@@ -1,5 +1,5 @@
 import { GridItem, SimpleGrid } from "@chakra-ui/react";
-import { InfoCard } from "@/components/competitions/Cards";
+import {InfoCard, SubPageCard} from "@/components/competitions/Cards";
 import MarkdownFirstImage, {
   extractMarkdownImage,
 } from "@/components/MarkdownFirstImage";
@@ -30,7 +30,7 @@ export default async function CompetitionLayout({
   return (
     <SimpleGrid columns={{ base: 1, md: 3 }} gap="8">
       <GridItem colSpan={{ base: 1, md: mainColSpan }} asChild>
-        <InfoCard competitionInfo={competitionInfo} t={t} />
+        <SubPageCard competitionInfo={competitionInfo} t={t} />
       </GridItem>
       <MarkdownFirstImage content={competitionInfo.information} />
       <GridItem colSpan={{ base: 1, md: 3 }}>{children}</GridItem>

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/layout.tsx
@@ -1,6 +1,8 @@
 import { GridItem, SimpleGrid } from "@chakra-ui/react";
 import { InfoCard } from "@/components/competitions/Cards";
-import { MarkdownFirstImage } from "@/components/MarkdownFirstImage";
+import MarkdownFirstImage, {
+  extractMarkdownImage,
+} from "@/components/MarkdownFirstImage";
 import { getCompetitionInfo } from "@/lib/wca/competitions/getCompetitionInfo";
 import { getT } from "@/lib/i18n/get18n";
 import OpenapiError from "@/components/ui/openapiError";
@@ -23,9 +25,11 @@ export default async function CompetitionLayout({
 
   if (error) return <OpenapiError t={t} response={response} />;
 
+  const mainColSpan = extractMarkdownImage(competitionInfo.information) ? 2 : 3;
+
   return (
     <SimpleGrid columns={{ base: 1, md: 3 }} gap="8">
-      <GridItem colSpan={{ base: 1, md: 2 }} asChild>
+      <GridItem colSpan={{ base: 1, md: mainColSpan }} asChild>
         <InfoCard competitionInfo={competitionInfo} t={t} />
       </GridItem>
       <MarkdownFirstImage content={competitionInfo.information} />

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/layout.tsx
@@ -1,5 +1,5 @@
 import { GridItem, SimpleGrid } from "@chakra-ui/react";
-import {InfoCard, SubPageCard} from "@/components/competitions/Cards";
+import { SubPageCard } from "@/components/competitions/Cards";
 import MarkdownFirstImage, {
   extractMarkdownImage,
 } from "@/components/MarkdownFirstImage";

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/podiums/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/podiums/page.tsx
@@ -52,6 +52,10 @@ export default async function PodiumsPage({
                   results={results.toSorted((a, b) => a.pos - b.pos)}
                   t={t}
                   eventId={eventId}
+                  formatId={
+                    results[0]
+                      .format_id /* anti-pattern because of current API data restrictions */
+                  }
                   isAdmin={false}
                   solveTextAlign="center"
                 />

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/podiums/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/podiums/page.tsx
@@ -5,6 +5,7 @@ import { getPodiums } from "@/lib/wca/competitions/getPodiums";
 import { Fragment } from "react";
 import _ from "lodash";
 import { getT } from "@/lib/i18n/get18n";
+import EventIcon from "@/components/EventIcon";
 
 export default async function PodiumsPage({
   params,
@@ -27,15 +28,8 @@ export default async function PodiumsPage({
   return (
     <Card.Root>
       <Card.Body>
-        <Card.Title>
-          <Text
-            fontSize="md"
-            textTransform="uppercase"
-            fontWeight="medium"
-            letterSpacing="wider"
-          >
-            Podiums
-          </Text>
+        <Card.Title asChild>
+          <Text textStyle="s3">Podiums</Text>
         </Card.Title>
         <VStack align="left" gap={4}>
           {WCA_EVENT_IDS.map((eventId) => {
@@ -45,12 +39,21 @@ export default async function PodiumsPage({
             }
             return (
               <Fragment key={eventId}>
-                <Heading size="2xl">{events.byId[eventId].name}</Heading>
+                <Heading
+                  size="2xl"
+                  display="inline-flex"
+                  alignItems="center"
+                  gap="2"
+                >
+                  <EventIcon eventId={eventId} />
+                  {events.byId[eventId].name}
+                </Heading>
                 <ResultsTable
                   results={results.toSorted((a, b) => a.pos - b.pos)}
                   t={t}
                   eventId={eventId}
                   isAdmin={false}
+                  solveTextAlign="center"
                 />
               </Fragment>
             );

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/all/FilteredResults.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/all/FilteredResults.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useState } from "react";
 import { components } from "@/types/openapi";
 import { Heading, VStack } from "@chakra-ui/react";
 import _ from "lodash";
@@ -8,6 +8,7 @@ import events from "@/lib/wca/data/events";
 import { ResultsTable } from "@/components/results/ResultsTable";
 import { useT } from "@/lib/i18n/useI18n";
 import { SingleEventSelector } from "@/components/EventSelector";
+import roundTypes from "@/lib/wca/data/roundTypes";
 
 export default function FilteredResults({
   competitionInfo,
@@ -22,9 +23,14 @@ export default function FilteredResults({
 
   const { t } = useT();
 
-  const results = useMemo(
-    () => _.groupBy(resultsByEvent[activeEventId], "round_type_id"),
-    [activeEventId, resultsByEvent],
+  const groupedResults = _.groupBy(
+    resultsByEvent[activeEventId],
+    "round_type_id",
+  );
+
+  const orderedRounds = _.sortBy(
+    _.keys(groupedResults),
+    (roundType) => roundTypes.byId[roundType].rank,
   );
 
   return (
@@ -35,16 +41,19 @@ export default function FilteredResults({
         onEventClick={setActiveEventId}
         eventList={competitionInfo.event_ids}
       />
-      {_.map(results, (results, roundFormat) => (
+      {_.map(orderedRounds, (roundFormat) => (
         <Fragment key={`${activeEventId}-${roundFormat}`}>
           <Heading textStyle="h3">
             {events.byId[activeEventId].name} {t(`rounds.${roundFormat}.name`)}
           </Heading>
           <ResultsTable
-            results={results.toSorted((a, b) => a.pos - b.pos)}
+            results={groupedResults[roundFormat].toSorted(
+              (a, b) => a.pos - b.pos,
+            )}
             eventId={activeEventId}
             t={t}
             isAdmin={false}
+            solveTextAlign="center"
           />
         </Fragment>
       ))}

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/all/FilteredResults.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/all/FilteredResults.tsx
@@ -23,13 +23,13 @@ export default function FilteredResults({
 
   const { t } = useT();
 
-  const groupedResults = _.groupBy(
+  const resultsByRound = _.groupBy(
     resultsByEvent[activeEventId],
     "round_type_id",
   );
 
-  const orderedRounds = _.sortBy(
-    _.keys(groupedResults),
+  const orderedRoundTypes = _.sortBy(
+    _.keys(resultsByRound),
     (roundType) => roundTypes.byId[roundType].rank,
   );
 
@@ -41,16 +41,20 @@ export default function FilteredResults({
         onEventClick={setActiveEventId}
         eventList={competitionInfo.event_ids}
       />
-      {_.map(orderedRounds, (roundFormat) => (
-        <Fragment key={`${activeEventId}-${roundFormat}`}>
+      {_.map(orderedRoundTypes, (roundType) => (
+        <Fragment key={`${activeEventId}-${roundType}`}>
           <Heading textStyle="h3">
-            {events.byId[activeEventId].name} {t(`rounds.${roundFormat}.name`)}
+            {events.byId[activeEventId].name} {t(`rounds.${roundType}.name`)}
           </Heading>
           <ResultsTable
-            results={groupedResults[roundFormat].toSorted(
+            results={resultsByRound[roundType].toSorted(
               (a, b) => a.pos - b.pos,
             )}
             eventId={activeEventId}
+            formatId={
+              resultsByRound[roundType][0]
+                .format_id /* anti-pattern because of current prop type restrictions */
+            }
             t={t}
             isAdmin={false}
             solveTextAlign="center"

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/byPerson/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/byPerson/page.tsx
@@ -1,10 +1,21 @@
-import { Card, Heading, Link, Text } from "@chakra-ui/react";
+import {
+  Avatar,
+  Card,
+  Heading,
+  HStack,
+  Link as ChakraLink,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import _ from "lodash";
 import { getT } from "@/lib/i18n/get18n";
 import { getCompetitionResults } from "@/lib/wca/competitions/getCompetitionResults";
 import { Fragment } from "react";
 import { ByPersonTable } from "@/components/results/ResultsTable";
 import { route } from "nextjs-routes";
+import WcaFlag from "@/components/WcaFlag";
+import CountryMap from "@/components/CountryMap";
+import Link from "next/link";
 
 export default async function PodiumsPage({
   params,
@@ -33,15 +44,34 @@ export default async function PodiumsPage({
         <Card.Title textStyle="s4">Results</Card.Title>
         {_.map(resultsByPerson, (results, wcaId) => (
           <Fragment key={wcaId}>
-            <Heading size="2xl">
-              <Link
-                href={route({
-                  pathname: "/persons/[wcaId]",
-                  query: { wcaId },
-                })}
-              >
-                {results[0].name}
-              </Link>
+            <Heading size="2xl" asChild>
+              <HStack gap="4">
+                <Avatar.Root>
+                  <Avatar.Fallback name={results[0].name} />
+                  {/* Currently we don't have the actual image URL in the API output, this is pending a bigger refactor */}
+                </Avatar.Root>
+                <VStack width="fit-content" alignItems="start" gap="0.5">
+                  <ChakraLink textStyle="headerLink" asChild>
+                    <Link
+                      href={route({
+                        pathname: "/persons/[wcaId]",
+                        query: { wcaId },
+                      })}
+                    >
+                      {results[0].name}
+                    </Link>
+                  </ChakraLink>
+                  <HStack>
+                    <WcaFlag code={results[0].country_iso2} size="sm" />
+                    <CountryMap
+                      code={results[0].country_iso2}
+                      t={t}
+                      textStyle="bodyEmphasis"
+                      color="fg.muted"
+                    />
+                  </HStack>
+                </VStack>
+              </HStack>
             </Heading>
             <ByPersonTable
               results={results}

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/byPerson/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/results/byPerson/page.tsx
@@ -43,7 +43,12 @@ export default async function PodiumsPage({
                 {results[0].name}
               </Link>
             </Heading>
-            <ByPersonTable results={results} isAdmin={false} t={t} />
+            <ByPersonTable
+              results={results}
+              isAdmin={false}
+              t={t}
+              solveTextAlign="center"
+            />
           </Fragment>
         ))}
       </Card.Body>

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/scrambles/FilteredScrambles.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/[competitionId]/(competition)/(results)/scrambles/FilteredScrambles.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useState } from "react";
 import { components } from "@/types/openapi";
 import { Heading, Table, VStack } from "@chakra-ui/react";
 import _ from "lodash";
 import events from "@/lib/wca/data/events";
 import { useT } from "@/lib/i18n/useI18n";
 import { SingleEventSelector } from "@/components/EventSelector";
+import roundTypes from "@/lib/wca/data/roundTypes";
 
 export default function FilteredScrambles({
   competitionInfo,
@@ -23,9 +24,14 @@ export default function FilteredScrambles({
 
   const { t } = useT();
 
-  const scramblesByEvent = useMemo(
-    () => _.groupBy(resultsByEvent[activeEventId], "round_type_id"),
-    [activeEventId, resultsByEvent],
+  const scramblesByRoundFormat = _.groupBy(
+    resultsByEvent[activeEventId],
+    "round_type_id",
+  );
+
+  const orderedRounds = _.sortBy(
+    _.keys(scramblesByRoundFormat),
+    (roundType) => roundTypes.byId[roundType].rank,
   );
 
   return (
@@ -36,8 +42,9 @@ export default function FilteredScrambles({
         onEventClick={setActiveEventId}
         eventList={competitionInfo.event_ids}
       />
-      {_.map(scramblesByEvent, (scrambles, roundFormat) => {
-        const scramblesByGroup = _.groupBy(scrambles, "group_id");
+      {_.map(orderedRounds, (roundFormat) => {
+        const scramblesForRound = scramblesByRoundFormat[roundFormat];
+        const scramblesByGroup = _.groupBy(scramblesForRound, "group_id");
 
         return (
           <Fragment key={`${activeEventId}-${roundFormat}`}>

--- a/next-frontend/src/app/(wca)/(with-background)/results/rankings/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/results/rankings/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function RecordsPage({
+export default async function RankingsPage({
   searchParams,
 }: {
   searchParams: Promise<{ [key: string]: string | undefined }>;

--- a/next-frontend/src/components/MarkdownFirstImage.tsx
+++ b/next-frontend/src/components/MarkdownFirstImage.tsx
@@ -8,7 +8,8 @@ type MarkdownFirstImageProps = {
   alt?: string;
 } & CardRootProps;
 
-export const extractMarkdownImage = (content: string) => content.match(/!\[.*?\]\((.*?)\)/);
+export const extractMarkdownImage = (content: string) =>
+  content.match(/!\[.*?\]\((.*?)\)/);
 
 export const MarkdownFirstImage = ({
   content,

--- a/next-frontend/src/components/MarkdownFirstImage.tsx
+++ b/next-frontend/src/components/MarkdownFirstImage.tsx
@@ -8,12 +8,14 @@ type MarkdownFirstImageProps = {
   alt?: string;
 } & CardRootProps;
 
+export const extractMarkdownImage = (content: string) => content.match(/!\[.*?\]\((.*?)\)/);
+
 export const MarkdownFirstImage = ({
   content,
   alt = "Image",
   ...cardRootProps
 }: MarkdownFirstImageProps) => {
-  const match = content.match(/!\[.*?\]\((.*?)\)/);
+  const match = extractMarkdownImage(content);
 
   if (!match) return null;
 
@@ -27,3 +29,5 @@ export const MarkdownFirstImage = ({
     </Card.Root>
   );
 };
+
+export default MarkdownFirstImage;

--- a/next-frontend/src/components/competitions/Cards.tsx
+++ b/next-frontend/src/components/competitions/Cards.tsx
@@ -381,3 +381,53 @@ export function InfoCard({
     </Card.Root>
   );
 }
+
+export function SubPageCard({
+  competitionInfo,
+  t,
+}: {
+  competitionInfo: components["schemas"]["CompetitionInfo"];
+  t: TFunction;
+}) {
+  return (
+    <Card.Root>
+      <Card.Body>
+        <Card.Title asChild>
+          <Heading textStyle="h2" display="flex" alignItems="center">
+            {competitionInfo.name}
+          </Heading>
+        </Card.Title>
+
+        <SimpleGrid columns={{ base: 1, md: 2 }} gap="4">
+          <Stat.Root variant="competition">
+            <Stat.Label>
+              <CompRegoOpenDateIcon />
+              Date
+            </Stat.Label>
+            <Stat.ValueText>
+              {formatDateRange(
+                new Date(competitionInfo.start_date),
+                new Date(competitionInfo.end_date),
+              )}
+            </Stat.ValueText>
+          </Stat.Root>
+
+          <Stat.Root variant="competition">
+            <Stat.Label>
+              <LocationIcon />
+              {t("competitions.competition_info.location")}
+            </Stat.Label>
+            <Stat.ValueText>
+              <Text>{competitionInfo.city}, </Text>
+              <CountryMap
+                code={competitionInfo.country_iso2}
+                t={t}
+                fontWeight="bold"
+              />
+            </Stat.ValueText>
+          </Stat.Root>
+        </SimpleGrid>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/next-frontend/src/components/persons/RecordsTable.tsx
+++ b/next-frontend/src/components/persons/RecordsTable.tsx
@@ -58,10 +58,10 @@ function RecordsByEvent({
   const resultsByEvent = _.groupBy(recordResults, "event_id");
   return _.map(resultsByEvent, (results, eventId) => {
     return (
-      <>
+      <Fragment key={eventId}>
         <Heading textStyle="h3">{events.byId[eventId].name}</Heading>
         <ByCompetitionTable results={results} t={t} />
-      </>
+      </Fragment>
     );
   });
 }

--- a/next-frontend/src/components/results/RankingsRow.tsx
+++ b/next-frontend/src/components/results/RankingsRow.tsx
@@ -8,6 +8,7 @@ import {
 import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
 import { recordAttempts } from "@/lib/wca/results/attempts";
 import { AttemptsCells } from "@/components/results/TableCells";
+import events from "@/lib/wca/data/events";
 
 interface RankingsRowProps {
   ranking: components["schemas"]["ExtendedResult"];
@@ -27,6 +28,9 @@ export function RankingsRow({
     bestResultIndex,
     worstResultIndex,
   } = recordAttempts(ranking);
+
+  const attemptCount =
+    events.byId[ranking.event_id].recommendedFormat.expected_solve_count;
 
   return (
     <Table.Row>
@@ -54,6 +58,7 @@ export function RankingsRow({
           bestResultIndex={bestResultIndex}
           worstResultIndex={worstResultIndex}
           eventId={ranking.event_id}
+          attemptCount={attemptCount}
         />
       )}
     </Table.Row>

--- a/next-frontend/src/components/results/RecordsRow.tsx
+++ b/next-frontend/src/components/results/RecordsRow.tsx
@@ -11,6 +11,7 @@ import _ from "lodash";
 import { TFunction } from "i18next";
 import { recordAttempts } from "@/lib/wca/results/attempts";
 import { AttemptsCells } from "@/components/results/TableCells";
+import events from "@/lib/wca/data/events";
 
 interface MixedRecordsRowProp {
   record: components["schemas"]["Record"];
@@ -30,6 +31,14 @@ interface SlimRecordsRowProp {
   singles: components["schemas"]["Record"][];
   averages: components["schemas"]["Record"][];
 }
+
+const maxAttemptCountForEvent = (eventId: string) => {
+  const formatSolveCounts = events.byId[eventId].formats.map(
+    (fmt) => fmt.expected_solve_count,
+  );
+
+  return _.max(formatSolveCounts)!;
+};
 
 export function MixedRecordsRow({ record, t }: MixedRecordsRowProp) {
   const {
@@ -58,6 +67,7 @@ export function MixedRecordsRow({ record, t }: MixedRecordsRowProp) {
         bestResultIndex={bestResultIndex}
         worstResultIndex={worstResultIndex}
         eventId={record.event_id}
+        attemptCount={maxAttemptCountForEvent(record.event_id)}
       />
     </Table.Row>
   );
@@ -98,6 +108,7 @@ export function HistoryRow({ record, mixed = false }: HistoryRowProps) {
         bestResultIndex={bestResultIndex}
         worstResultIndex={worstResultIndex}
         eventId={record.event_id}
+        attemptCount={maxAttemptCountForEvent(record.event_id)}
       />
     </Table.Row>
   );
@@ -129,6 +140,7 @@ export function SeparateRecordsRow({ record }: SeparateRecordsRowProp) {
           bestResultIndex={bestResultIndex}
           worstResultIndex={worstResultIndex}
           eventId={record.event_id}
+          attemptCount={maxAttemptCountForEvent(record.event_id)}
         />
       )}
     </Table.Row>
@@ -176,6 +188,7 @@ export function SlimRecordsRow({ singles, averages }: SlimRecordsRowProp) {
               bestResultIndex={bestResultIndex}
               worstResultIndex={worstResultIndex}
               eventId={average.event_id}
+              attemptCount={maxAttemptCountForEvent(average.event_id)}
             />
           </>
         )}

--- a/next-frontend/src/components/results/ResultsTable.tsx
+++ b/next-frontend/src/components/results/ResultsTable.tsx
@@ -5,7 +5,7 @@ import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
 import { route } from "nextjs-routes";
 import NextLink from "next/link";
 import { AttemptsCells, WithRecordTag } from "@/components/results/TableCells";
-import { resultAttempts } from "@/lib/wca/results/attempts";
+import { isSkipped, resultAttempts } from "@/lib/wca/results/attempts";
 import WcaFlag from "@/components/WcaFlag";
 import { TFunction } from "i18next";
 import CountryMap from "@/components/CountryMap";
@@ -126,7 +126,7 @@ export function ByPersonTable({
 }) {
   // The backend always pads with zeros at the end, which we need to manually kick out again
   const validAttemptCounts = results.map(
-    (res) => _.dropRightWhile(res.attempts, (att) => att === 0).length,
+    (res) => _.dropRightWhile(res.attempts, (att) => isSkipped(att)).length,
   );
 
   const maxAttemptCount = _.max(validAttemptCounts) || 0;

--- a/next-frontend/src/components/results/ResultsTable.tsx
+++ b/next-frontend/src/components/results/ResultsTable.tsx
@@ -124,8 +124,12 @@ export function ByPersonTable({
   solveTextAlign?: CssProperties["textAlign"];
   showNationalityColumn?: boolean;
 }) {
-  const resWithMostAttempts = _.maxBy(results, (res) => res.attempts.length)!;
-  const maxAttemptCount = resWithMostAttempts.attempts.length;
+  // The backend always pads with zeros at the end, which we need to manually kick out again
+  const validAttemptCounts = results.map(
+    (res) => _.dropRightWhile(res.attempts, (att) => att === 0).length,
+  );
+
+  const maxAttemptCount = _.max(validAttemptCounts) || 0;
 
   const orderedResults = _.sortBy(results, [
     (res) => events.byId[res.event_id].rank,

--- a/next-frontend/src/components/results/ResultsTable.tsx
+++ b/next-frontend/src/components/results/ResultsTable.tsx
@@ -10,23 +10,27 @@ import WcaFlag from "@/components/WcaFlag";
 import { TFunction } from "i18next";
 import CountryMap from "@/components/CountryMap";
 import _ from "lodash";
+import roundTypes from "@/lib/wca/data/roundTypes";
+import formats from "@/lib/wca/data/formats";
 
 export function ResultsTable({
   results,
   eventId,
+  formatId,
   t,
   isAdmin = false,
   solveTextAlign = "left",
 }: {
   results: components["schemas"]["Result"][];
   eventId: string;
+  formatId: string;
   t: TFunction;
   isAdmin?: boolean;
   solveTextAlign?: CssProperties["textAlign"];
 }) {
-  const event = events.byId[eventId];
+  const format = formats.byId[formatId];
 
-  const solveCount = event.recommendedFormat.expected_solve_count;
+  const solveCount = format.expected_solve_count;
   const anyAverages = results.some((r) => r.average !== 0);
 
   return (
@@ -50,6 +54,10 @@ export function ResultsTable({
           {results.map((competitorResult) => {
             const { definedAttempts, bestResultIndex, worstResultIndex } =
               resultAttempts(competitorResult);
+
+            const attemptCount =
+              formats.byId[competitorResult.format_id].expected_solve_count;
+
             return (
               <Table.Row key={competitorResult.id}>
                 {isAdmin && <Table.Cell>EDIT</Table.Cell>}
@@ -92,6 +100,7 @@ export function ResultsTable({
                   worstResultIndex={worstResultIndex}
                   eventId={eventId}
                   recordTag={competitorResult.regional_single_record}
+                  attemptCount={attemptCount}
                 />
               </Table.Row>
             );
@@ -106,11 +115,21 @@ export function ByPersonTable({
   results,
   t,
   isAdmin = false,
+  solveTextAlign = "left",
 }: {
   results: components["schemas"]["Result"][];
   t: TFunction;
   isAdmin?: boolean;
+  solveTextAlign?: CssProperties["textAlign"];
 }) {
+  const resWithMostAttempts = _.maxBy(results, (res) => res.attempts.length);
+  const maxAttemptCount = resWithMostAttempts?.attempts.length;
+
+  const orderedResults = _.sortBy(results, [
+    (res) => events.byId[res.event_id].rank,
+    (res) => roundTypes.byId[res.round_type_id].rank,
+  ]);
+
   return (
     <Table.ScrollArea rounded="md">
       <Table.Root>
@@ -123,14 +142,17 @@ export function ByPersonTable({
             <Table.ColumnHeader>Best</Table.ColumnHeader>
             <Table.ColumnHeader>Average</Table.ColumnHeader>
             <Table.ColumnHeader>Representing</Table.ColumnHeader>
-            <Table.ColumnHeader colSpan={5} textAlign="left">
+            <Table.ColumnHeader
+              colSpan={maxAttemptCount}
+              textAlign={solveTextAlign}
+            >
               Solves
             </Table.ColumnHeader>
           </Table.Row>
         </Table.Header>
 
         <Table.Body>
-          {results.map((competitorResult) => {
+          {orderedResults.map((competitorResult) => {
             const eventId = competitorResult.event_id;
             const { definedAttempts, bestResultIndex, worstResultIndex } =
               resultAttempts(competitorResult);
@@ -168,6 +190,7 @@ export function ByPersonTable({
                   worstResultIndex={worstResultIndex}
                   eventId={eventId}
                   recordTag={competitorResult.regional_single_record}
+                  attemptCount={maxAttemptCount}
                 />
               </Table.Row>
             );
@@ -210,8 +233,8 @@ export function ByCompetitionTable({
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {_.map(resultsByCompetition, (competitorResults) => {
-            return competitorResults.map((competitorResult, index) => {
+          {_.flatMap(resultsByCompetition, (competitionResults) => {
+            return competitionResults.map((competitorResult, index) => {
               const eventId = competitorResult.event_id;
               const { definedAttempts, bestResultIndex, worstResultIndex } =
                 resultAttempts(competitorResult);

--- a/next-frontend/src/components/results/ResultsTable.tsx
+++ b/next-frontend/src/components/results/ResultsTable.tsx
@@ -124,8 +124,8 @@ export function ByPersonTable({
   solveTextAlign?: CssProperties["textAlign"];
   showNationalityColumn?: boolean;
 }) {
-  const resWithMostAttempts = _.maxBy(results, (res) => res.attempts.length);
-  const maxAttemptCount = resWithMostAttempts?.attempts.length;
+  const resWithMostAttempts = _.maxBy(results, (res) => res.attempts.length)!;
+  const maxAttemptCount = resWithMostAttempts.attempts.length;
 
   const orderedResults = _.sortBy(results, [
     (res) => events.byId[res.event_id].rank,
@@ -242,8 +242,11 @@ export function ByCompetitionTable({
           {_.flatMap(resultsByCompetition, (competitionResults) => {
             return competitionResults.map((competitorResult, index) => {
               const eventId = competitorResult.event_id;
+              const resultFormat = formats.byId[competitorResult.format_id];
+
               const { definedAttempts, bestResultIndex, worstResultIndex } =
                 resultAttempts(competitorResult);
+
               return (
                 <Table.Row key={competitorResult.id}>
                   <Table.Cell>
@@ -286,6 +289,7 @@ export function ByCompetitionTable({
                     worstResultIndex={worstResultIndex}
                     eventId={eventId}
                     recordTag={competitorResult.regional_single_record}
+                    attemptCount={resultFormat.expected_solve_count}
                   />
                 </Table.Row>
               );

--- a/next-frontend/src/components/results/ResultsTable.tsx
+++ b/next-frontend/src/components/results/ResultsTable.tsx
@@ -1,6 +1,6 @@
 import { components } from "@/types/openapi";
 import events from "@/lib/wca/data/events";
-import { HStack, Link, Table } from "@chakra-ui/react";
+import { CssProperties, HStack, Link, Table } from "@chakra-ui/react";
 import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
 import { route } from "nextjs-routes";
 import NextLink from "next/link";
@@ -16,11 +16,13 @@ export function ResultsTable({
   eventId,
   t,
   isAdmin = false,
+  solveTextAlign = "left",
 }: {
   results: components["schemas"]["Result"][];
   eventId: string;
   t: TFunction;
   isAdmin?: boolean;
+  solveTextAlign?: CssProperties["textAlign"];
 }) {
   const event = events.byId[eventId];
 
@@ -38,7 +40,7 @@ export function ResultsTable({
             <Table.ColumnHeader>Best</Table.ColumnHeader>
             {anyAverages && <Table.ColumnHeader>Average</Table.ColumnHeader>}
             <Table.ColumnHeader>Representing</Table.ColumnHeader>
-            <Table.ColumnHeader colSpan={solveCount} textAlign="left">
+            <Table.ColumnHeader colSpan={solveCount} textAlign={solveTextAlign}>
               Solves
             </Table.ColumnHeader>
           </Table.Row>

--- a/next-frontend/src/components/results/ResultsTable.tsx
+++ b/next-frontend/src/components/results/ResultsTable.tsx
@@ -116,11 +116,13 @@ export function ByPersonTable({
   t,
   isAdmin = false,
   solveTextAlign = "left",
+  showNationalityColumn = false,
 }: {
   results: components["schemas"]["Result"][];
   t: TFunction;
   isAdmin?: boolean;
   solveTextAlign?: CssProperties["textAlign"];
+  showNationalityColumn?: boolean;
 }) {
   const resWithMostAttempts = _.maxBy(results, (res) => res.attempts.length);
   const maxAttemptCount = resWithMostAttempts?.attempts.length;
@@ -141,7 +143,9 @@ export function ByPersonTable({
             <Table.ColumnHeader>#</Table.ColumnHeader>
             <Table.ColumnHeader>Best</Table.ColumnHeader>
             <Table.ColumnHeader>Average</Table.ColumnHeader>
-            <Table.ColumnHeader>Representing</Table.ColumnHeader>
+            {showNationalityColumn && (
+              <Table.ColumnHeader>Representing</Table.ColumnHeader>
+            )}
             <Table.ColumnHeader
               colSpan={maxAttemptCount}
               textAlign={solveTextAlign}
@@ -178,12 +182,14 @@ export function ByPersonTable({
                     {formatAttemptResult(competitorResult.average, eventId)}
                   </WithRecordTag>
                 </Table.Cell>
-                <Table.Cell>
-                  <HStack>
-                    <WcaFlag code={competitorResult.country_iso2} size="sm" />
-                    <CountryMap code={competitorResult.country_iso2} t={t} />
-                  </HStack>
-                </Table.Cell>
+                {showNationalityColumn && (
+                  <Table.Cell>
+                    <HStack>
+                      <WcaFlag code={competitorResult.country_iso2} size="sm" />
+                      <CountryMap code={competitorResult.country_iso2} t={t} />
+                    </HStack>
+                  </Table.Cell>
+                )}
                 <AttemptsCells
                   attempts={definedAttempts}
                   bestResultIndex={bestResultIndex}

--- a/next-frontend/src/components/results/TableCells.tsx
+++ b/next-frontend/src/components/results/TableCells.tsx
@@ -72,7 +72,7 @@ interface AttemptsCellProps {
   worstResultIndex: number;
   eventId: string;
   recordTag?: string | null;
-  attemptCount?: number;
+  attemptCount: number;
 }
 
 export function AttemptsCells({
@@ -81,7 +81,7 @@ export function AttemptsCells({
   worstResultIndex,
   eventId,
   recordTag,
-  attemptCount = attempts.length,
+  attemptCount,
 }: AttemptsCellProps) {
   return _.times(attemptCount).map((a) => {
     const attempt = attempts[a];

--- a/next-frontend/src/components/results/TableCells.tsx
+++ b/next-frontend/src/components/results/TableCells.tsx
@@ -73,6 +73,7 @@ interface AttemptsCellProps {
   worstResultIndex: number;
   eventId: string;
   recordTag?: string | null;
+  attemptCount?: number;
 }
 
 export function AttemptsCells({
@@ -81,10 +82,8 @@ export function AttemptsCells({
   worstResultIndex,
   eventId,
   recordTag,
+  attemptCount = attempts.length,
 }: AttemptsCellProps) {
-  const attemptCount =
-    events.byId[eventId].recommendedFormat.expected_solve_count;
-
   return _.times(attemptCount).map((a) => {
     const attempt = attempts[a];
     const key = `attempt-${attempt}-${a}`;

--- a/next-frontend/src/components/results/TableCells.tsx
+++ b/next-frontend/src/components/results/TableCells.tsx
@@ -1,6 +1,5 @@
 import { Badge, Box, Float, Table } from "@chakra-ui/react";
 import { formatAttemptResult } from "@/lib/wca/wcif/attempts";
-import events from "@/lib/wca/data/events";
 import _ from "lodash";
 import type { ReactNode } from "react";
 

--- a/next-frontend/src/lib/wca/results/attempts.ts
+++ b/next-frontend/src/lib/wca/results/attempts.ts
@@ -6,7 +6,7 @@ function isComplete(attemptResult: number) {
   return attemptResult > 0;
 }
 
-function isSkipped(attemptResult: number) {
+export function isSkipped(attemptResult: number) {
   return attemptResult === SKIPPED_VALUE;
 }
 


### PR DESCRIPTION
Fixing various visual inconsistencies/glitches:
- The card at the top of any competition results pages (in the wider sense, ie "All Results", "By Persons", "Scrambles", etc.) was always 2/3-wide even when there was no logo image present. Now it scales to full width if no image is detected
- In some tables, the default `recommendedFormat.expected_solve_count` was inconsistent with the _actual_ solve count. This required medium-size refactors of how the results tables determine their attempts cell counts.
- The ordering of the tables, or sometimes the rows within tables, was off. Now everything is ordered based on the `rank` of the event and/or round type
- The by-person table got more modern headers with avatar, name and nationality pulled into a "persona" composite. I felt it was totally weird to render the `Representing` row in the per-person view all the time, when during one competition this never actually changes.