### PR TITLE
generateMetadata using English strings only

### DIFF
--- a/next-frontend/src/app/(wca)/(with-background)/about/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/about/page.tsx
@@ -7,10 +7,10 @@ import Quote from "@/components/Quote";
 import AboutUsItem from "@/components/about/AboutUsItem";
 import { Media } from "@/types/payload";
 import { Metadata } from "next";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("layouts.navigation.about"),

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
   return { title: t("layouts.navigation.competitions") };
 }
 

--- a/next-frontend/src/app/(wca)/(with-background)/competitions/mine/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/competitions/mine/page.tsx
@@ -1,6 +1,7 @@
 import { Accordion, Button, Heading, VStack } from "@chakra-ui/react";
 import { getSession } from "@/auth";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import UpcomingCompetitionTable from "@/components/competitions/Mine/UpcomingCompetitionTable";
 import PastCompetitionsTable from "@/components/competitions/Mine/PastCompetitionTable";
 import { serverClientWithToken } from "@/lib/wca/wcaAPI";
@@ -8,7 +9,7 @@ import BookmarkIcon from "@/components/icons/BookmarkIcon";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("competitions.my_competitions.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/delegates/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/delegates/page.tsx
@@ -7,6 +7,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import {
   getDelegateRegions,
   getDelegatesInGroup,
@@ -30,7 +31,7 @@ const RAILS_ROOT_URL = new URL(process.env.NEXT_PUBLIC_WCA_FRONTEND_API_URL!)
   .origin;
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("delegates_page.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/disclaimer/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/disclaimer/page.tsx
@@ -4,10 +4,10 @@ import { connection } from "next/server";
 import { Box, Heading, VStack } from "@chakra-ui/react";
 import { ChakraMarkdown } from "@/components/Markdown";
 import { Metadata } from "next";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("layouts.navigation.disclaimer"),

--- a/next-frontend/src/app/(wca)/(with-background)/documents/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/documents/page.tsx
@@ -14,10 +14,10 @@ import _ from "lodash";
 import IconDisplay from "@/components/IconDisplay";
 import { Document } from "@/types/payload";
 import { Metadata } from "next";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("documents.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/export/developer/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/export/developer/page.tsx
@@ -1,5 +1,6 @@
 import { Heading, Link, Text, VStack } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { getExportDetails } from "@/lib/wca/exports/getExportDetails";
 import Loading from "@/components/ui/loading";
 import OpenapiError from "@/components/ui/openapiError";
@@ -7,7 +8,7 @@ import { Trans } from "react-i18next/TransWithoutContext";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("database.developer_export.heading"),

--- a/next-frontend/src/app/(wca)/(with-background)/export/results/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/export/results/page.tsx
@@ -11,13 +11,14 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { getExportDetails } from "@/lib/wca/exports/getExportDetails";
 import OpenapiError from "@/components/ui/openapiError";
 import Loading from "@/components/ui/loading";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("database.developer_export.heading"),

--- a/next-frontend/src/app/(wca)/(with-background)/faq/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/faq/page.tsx
@@ -6,10 +6,10 @@ import { FaqCategory, FaqQuestion } from "@/types/payload";
 import { ChakraMarkdown } from "@/components/Markdown";
 import { uniqBy } from "lodash";
 import { Metadata } from "next";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("faq.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/incidents/layout.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/incidents/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
   return { title: t("layouts.navigation.incidents") };
 }
 

--- a/next-frontend/src/app/(wca)/(with-background)/logo/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/logo/page.tsx
@@ -3,6 +3,7 @@ import config from "@payload-config";
 import { connection } from "next/server";
 import { Heading, HStack, Image, Text, VStack } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { ChakraMarkdown } from "@/components/Markdown";
 import { Media } from "@/types/payload";
 import LogoDownload from "@/app/(wca)/(with-background)/logo/download";
@@ -10,7 +11,7 @@ import { Fragment } from "react";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("logo.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/officers-and-board/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/officers-and-board/page.tsx
@@ -4,11 +4,12 @@ import UserBadge from "@/components/UserBadge";
 import { MdMarkEmailUnread } from "react-icons/md";
 import OpenapiError from "@/components/ui/openapiError";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { getBoardRoles, getOfficersRoles } from "@/lib/wca/roles/activeRoles";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("page.officers_and_board.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/organizations/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/organizations/page.tsx
@@ -13,6 +13,7 @@ import {
 import Loading from "@/components/ui/loading";
 import { getRegionalOrganizations } from "@/lib/wca/organizations/getRegionalOrganizations";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import OpenapiError from "@/components/ui/openapiError";
 import { Trans } from "react-i18next/TransWithoutContext";
 import _ from "lodash";
@@ -20,7 +21,7 @@ import WcaFlag from "@/components/WcaFlag";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("regional_organizations.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/privacy/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/privacy/page.tsx
@@ -4,10 +4,10 @@ import { connection } from "next/server";
 import { Box, Heading, VStack } from "@chakra-ui/react";
 import { ChakraMarkdown } from "@/components/Markdown";
 import { Metadata } from "next";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("layouts.navigation.privacy"),

--- a/next-frontend/src/app/(wca)/(with-background)/regulations/about/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/regulations/about/page.tsx
@@ -4,10 +4,11 @@ import config from "@payload-config";
 import { connection } from "next/server";
 import { ChakraMarkdown } from "@/components/Markdown";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("about_regulations.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/regulations/history/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/regulations/history/page.tsx
@@ -3,10 +3,11 @@ import { getPayload } from "payload";
 import config from "@payload-config";
 import { connection } from "next/server";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("layouts.navigation.history"),

--- a/next-frontend/src/app/(wca)/(with-background)/regulations/scrambles/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/regulations/scrambles/page.tsx
@@ -8,14 +8,14 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { Metadata } from "next";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 const LATEST_VERSION = "TNoodle-WCA-1.2.3";
 const LATEST_JARFILE =
   "https://github.com/thewca/tnoodle/releases/download/v1.2.3/TNoodle-WCA-1.2.3.jar";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("layouts.navigation.scrambles"),

--- a/next-frontend/src/app/(wca)/(with-background)/regulations/translations/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/regulations/translations/page.tsx
@@ -1,4 +1,5 @@
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { Heading, Link, Table, Text, VStack } from "@chakra-ui/react";
 import { components } from "@/types/openapi";
 import { Trans } from "react-i18next/TransWithoutContext";
@@ -7,7 +8,7 @@ import OpenapiError from "@/components/ui/openapiError";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("regulations_translations.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/results/rankings/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/results/rankings/page.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import FilteredRankings from "@/app/(wca)/(with-background)/results/rankings/filteredRankings";
 import { Metadata } from "next";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import OpenapiError from "@/components/ui/openapiError";
 
 const GENDER_ALL = "All";
@@ -11,7 +12,7 @@ const SHOW_100_PERSONS = "100 persons";
 const REGION_WORLD = "world";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("results.rankings.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/results/records/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/results/records/page.tsx
@@ -3,7 +3,7 @@ import { Alert } from "@chakra-ui/react";
 import React from "react";
 import FilteredRecords from "@/app/(wca)/(with-background)/results/records/filteredRecords";
 import { Metadata } from "next";
-import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 
 const GENDER_ALL = "All";
 const EVENTS_ALL = "all events";
@@ -11,7 +11,7 @@ const SHOW_MIXED = "mixed";
 const REGION_WORLD = "world";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("results.records.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/score-tools/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/score-tools/page.tsx
@@ -14,6 +14,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import type { Tool } from "@/types/payload";
 import ExternalLinkIcon from "@/components/icons/ExternalLinkIcon";
 import GithubIcon from "@/components/icons/GithubIcon";
@@ -24,7 +25,7 @@ import _ from "lodash";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("score_tools.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/speedcubing-history/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/speedcubing-history/page.tsx
@@ -6,10 +6,11 @@ import { connection } from "next/server";
 import { Media } from "@/types/payload";
 import { ChakraMarkdown } from "@/components/Markdown";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("layouts.navigation.speedcubing_history"),

--- a/next-frontend/src/app/(wca)/(with-background)/teams-committees/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/teams-committees/page.tsx
@@ -7,6 +7,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { Prose } from "@/components/ui/prose";
 import { components } from "@/types/openapi";
 import UserBadge from "@/components/UserBadge";
@@ -19,7 +20,7 @@ import getPermissions from "@/lib/wca/permissions.server";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("page.teams_committees_councils.title"),

--- a/next-frontend/src/app/(wca)/(with-background)/translators/page.tsx
+++ b/next-frontend/src/app/(wca)/(with-background)/translators/page.tsx
@@ -3,11 +3,12 @@ import { Heading, SimpleGrid, VStack } from "@chakra-ui/react";
 import UserBadge from "@/components/UserBadge";
 import OpenapiError from "@/components/ui/openapiError";
 import { getT } from "@/lib/i18n/get18n";
+import { getStaticT } from "@/lib/i18n/getStaticT";
 import { getTranslatorRoles } from "@/lib/wca/roles/activeRoles";
 import { Metadata } from "next";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await getT();
+  const t = await getStaticT();
 
   return {
     title: t("page.translators.title"),

--- a/next-frontend/src/lib/i18n/getStaticT.ts
+++ b/next-frontend/src/lib/i18n/getStaticT.ts
@@ -1,0 +1,9 @@
+import i18next from "./i18n";
+import { fallbackLng, defaultNamespace } from "./settings";
+
+// Metadata is prerendered, so it cannot read the request locale from cookies/headers
+// the way `getT` does. Titles are therefore always in the fallback language.
+export async function getStaticT() {
+  await i18next.loadLanguages(fallbackLng);
+  return i18next.getFixedT(fallbackLng, defaultNamespace);
+}


### PR DESCRIPTION
Previously metadata read the cookies to figure out what language it should be in, this is blocking prerendering of those pages. Crawlers don't have cookies anyway so this really wasn't very effective in the first place