### PR TITLE
Give flexDirection to fitted tabs so heading is centered

### DIFF
--- a/next-frontend/src/theme.ts
+++ b/next-frontend/src/theme.ts
@@ -962,6 +962,7 @@ const customConfig = defineConfig({
               },
               trigger: {
                 flex: "1 0 auto",
+                flexDirection: "column",
               },
             },
           },


### PR DESCRIPTION
See title. They already had `alignItems="center"`, but that centering was measured vertically (flex direction `row`). Change to `column`, so that centering is measured horizontally