### PR TITLE
Move BetaDisclaimer to ClientOnly

### DIFF
--- a/next-frontend/src/app/(wca)/layout.tsx
+++ b/next-frontend/src/app/(wca)/layout.tsx
@@ -2,15 +2,13 @@ import type { Metadata } from "next";
 import React, { Suspense } from "react";
 import WCAQueryClientProvider from "@/providers/WCAQueryClientProvider";
 import { Provider as UiProvider } from "@/components/ui/provider";
+import { ClientOnly } from "@chakra-ui/react";
 import Navbar from "./navbar";
 import Footer from "./footer";
 import { ThemeProvider } from "@wrksz/themes/next";
 import { appFont } from "@/styles/fonts";
 import NextTopLoader from "nextjs-toploader";
-import { cookies } from "next/headers";
-import BetaDisclaimer, {
-  BETA_DISCLAIMER_COOKIE,
-} from "@/components/BetaDisclaimer";
+import BetaDisclaimer from "@/components/BetaDisclaimer";
 import Loading from "@/components/ui/loading";
 import NavbarSkeleton from "./navbar-skeleton";
 import FooterSkeleton from "./footer-skeleton";
@@ -33,15 +31,6 @@ const computeFont = async () => {
   return appFont;
 };
 
-async function BetaDisclaimerGate() {
-  const cookieList = await cookies();
-
-  if (cookieList.has(BETA_DISCLAIMER_COOKIE) || !!process.env.LIVE_RESULT_BETA)
-    return null;
-
-  return <BetaDisclaimer />;
-}
-
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -56,9 +45,11 @@ export default async function RootLayout({
           <WCAQueryClientProvider>
             <EmotionRegistry>
               <UiProvider>
-                <Suspense fallback={null}>
-                  <BetaDisclaimerGate />
-                </Suspense>
+                {!process.env.LIVE_RESULT_BETA && (
+                  <ClientOnly>
+                    <BetaDisclaimer />
+                  </ClientOnly>
+                )}
                 <Suspense fallback={<NavbarSkeleton />}>
                   <Navbar />
                 </Suspense>

--- a/next-frontend/src/components/BetaDisclaimer.tsx
+++ b/next-frontend/src/components/BetaDisclaimer.tsx
@@ -2,16 +2,22 @@
 
 import { useState } from "react";
 import { Button, Dialog, Link, Portal, Text } from "@chakra-ui/react";
+import Cookies from "js-cookie";
 
-export const BETA_DISCLAIMER_COOKIE = "beta_disclaimer_accepted";
+const BETA_DISCLAIMER_COOKIE = "beta_disclaimer_accepted";
 
-const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+const ONE_YEAR_IN_DAYS = 365;
 
 export default function BetaDisclaimer() {
-  const [open, setOpen] = useState(true);
+  // Rendered inside <ClientOnly>, so the cookie is readable on first render.
+  const [open, setOpen] = useState(() => !Cookies.get(BETA_DISCLAIMER_COOKIE));
 
   const acceptDisclaimer = () => {
-    document.cookie = `${BETA_DISCLAIMER_COOKIE}=true; path=/; max-age=${ONE_YEAR_IN_SECONDS}; SameSite=Lax`;
+    Cookies.set(BETA_DISCLAIMER_COOKIE, "true", {
+      path: "/",
+      expires: ONE_YEAR_IN_DAYS,
+      sameSite: "Lax",
+    });
     setOpen(false);
   };
 


### PR DESCRIPTION
Otherwise the check for the cookies gets prerendered away. Also we have `js-cookies` already so let's use it!