### PR TITLE
Copy maplibre-gl-worker on build

### DIFF
--- a/next-frontend/.gitignore
+++ b/next-frontend/.gitignore
@@ -55,3 +55,6 @@ openapi/wcaAPI.yaml
 
 # Proprietary font files
 src/styles/fonts/TTNormsPro/**/*.woff2
+
+# copied by scripts/copy-maplibre-worker.mjs
+/public/maplibre

--- a/next-frontend/package.json
+++ b/next-frontend/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --webpack",
+    "dev": "node ./scripts/copy-maplibre-worker.mjs && next dev --webpack",
     "check:types": "tsc --noEmit",
-    "build": "next build --webpack",
+    "build": "node ./scripts/copy-maplibre-worker.mjs && next build --webpack",
     "start": "next start",
     "types:openapi": "redocly bundle openapi/wcaCore.yaml -o openapi/wcaAPI.yaml && openapi-typescript openapi/wcaAPI.yaml -o src/types/openapi.ts && redocly build-docs openapi/wcaAPI.yaml -o public/api.html",
     "types:chakra": "chakra typegen ./src/theme.ts --outdir src/types/chakra --strict",

--- a/next-frontend/scripts/copy-maplibre-worker.mjs
+++ b/next-frontend/scripts/copy-maplibre-worker.mjs
@@ -1,0 +1,20 @@
+// maplibre v6 loads its worker as a separate file, and Next's asset handling
+//   does not emit the worker's `maplibre-gl-shared.mjs` sibling next to it, so
+//   both are served from `public/` instead. See `setWorkerUrl` in Map.tsx.
+// This script is copied from https://github.com/maplibre/maplibre-gl-js/blob/main/docs/index.md#installation
+import { copyFileSync, mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const dist = path.join(
+  path.dirname(
+    createRequire(import.meta.url).resolve("maplibre-gl/package.json"),
+  ),
+  "dist",
+);
+const dest = path.join(process.cwd(), "public", "maplibre");
+
+mkdirSync(dest, { recursive: true });
+for (const file of ["maplibre-gl-worker.mjs", "maplibre-gl-shared.mjs"]) {
+  copyFileSync(path.join(dist, file), path.join(dest, file));
+}

--- a/next-frontend/src/components/map/Map.tsx
+++ b/next-frontend/src/components/map/Map.tsx
@@ -9,6 +9,7 @@ import { dateRange, hasPassedEndOfDay } from "@/lib/wca/dates";
 import MapContainer, { Layer, Popup, Source } from "react-map-gl/maplibre";
 import type { MapEvent, MapLayerMouseEvent } from "react-map-gl/maplibre";
 import type { FeatureCollection, Point } from "geojson";
+import { setWorkerUrl } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useState } from "react";
 
@@ -30,6 +31,8 @@ interface MapProps {
 
 // Limit number of markers on map, especially for "All Past Competitions"
 export const MAP_DISPLAY_LIMIT = 500;
+
+setWorkerUrl("/maplibre/maplibre-gl-worker.mjs");
 
 const TILE_STYLE = "https://tiles.openfreemap.org/styles/bright";
 


### PR DESCRIPTION
Can't believe this is the solution that they actually offer for this https://github.com/maplibre/maplibre-gl-js/blob/main/docs/index.md#installation

If you are confused why this is the file under turbopack, it is needed for webpack in nextjs as well, see `Next.js is an exception, including in its `next build --webpack` mode. See the Turbopack tab.`