### PR TITLE
Don't crash Registration Info Card for old Comps where registration fee is null

### DIFF
--- a/next-frontend/src/components/CurrencyValue.tsx
+++ b/next-frontend/src/components/CurrencyValue.tsx
@@ -9,20 +9,17 @@ export default function CurrencyValue({
   lowestDenomination,
   currencyCode,
 }: {
-  lowestDenomination: number;
+  lowestDenomination: number | null;
   currencyCode: string;
 }) {
   const currency = currencyTable[currencyCode];
+  const amount = lowestDenomination ?? 0;
 
   return (
     <HStack>
       <FormatNumber
         value={
-          currency
-            ? Number(
-                toDecimal(dinero({ amount: lowestDenomination, currency })),
-              )
-            : lowestDenomination
+          currency ? Number(toDecimal(dinero({ amount, currency }))) : amount
         }
         style="currency"
         currency={currencyCode}


### PR DESCRIPTION
So many things can be null for old competitions but we don't actually reflect that in the openapi spec
<img width="1020" height="789" alt="image" src="https://github.com/user-attachments/assets/9a76142d-b02d-46f8-9383-752d0422576e" />

Should we maybe backfill some stuff in the DB? There are definitely a lot of stuff where null can be false instead