### PR TITLE
add padding to record badge

### DIFF
--- a/next-frontend/src/components/results/TableCells.tsx
+++ b/next-frontend/src/components/results/TableCells.tsx
@@ -27,6 +27,11 @@ const recordTagBadge = (tag?: string | null) => {
   }
 };
 
+// Width reserved at the end of the value for the floating badge: `Float` is
+// absolutely positioned and contributes no width of its own, so without it the
+// badge overlaps whatever sits in the next column.
+const RECORD_TAG_SLOT = "7";
+
 // Renders the record badge as a superscript floating off the top-right corner
 // of its content, without overflowing the surrounding text's line box.
 export function WithRecordTag({
@@ -41,9 +46,14 @@ export function WithRecordTag({
   if (!badge) return children;
 
   return (
-    <Box as="span" position="relative" display="inline-block">
+    <Box
+      as="span"
+      position="relative"
+      display="inline-block"
+      paddingEnd={RECORD_TAG_SLOT}
+    >
       {children}
-      <Float placement="top-end" offsetX="-3.5" offsetY="1">
+      <Float placement="top-end" offsetX="3.5" offsetY="1">
         <Badge
           size="xs"
           variant="solid"


### PR DESCRIPTION
The issues with the recent changes is that in certain screen sizes the float overlaps onto the next column
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/0038fb4c-e183-470e-9cb5-45b0dea11b61" />


This PR gives it extra padding so that can't happen:
<img width="264" height="127" alt="Screenshot 2026-09-12 at 18 36 57" src="https://github.com/user-attachments/assets/8db456de-2f0e-48d4-ba68-861bbc18d6fa" />

Do I love that the header is now aligned with the PR float? No, the best solution is probably to introduce a table column just for these floats. Interestingly wca live doesn't need this, its table cells have more padding in the first place which we could also think about