### PR TITLE
Rework sanity check 51 to use competing_status instead of deleted_at

### DIFF
--- a/lib/sanity_check_sql/13 - banned_competitors/51 - banned_competitor_registered.sql
+++ b/lib/sanity_check_sql/13 - banned_competitors/51 - banned_competitor_registered.sql
@@ -10,8 +10,8 @@ WITH upcoming_competitions AS (
 banned_persons AS (
   SELECT
     role.user_id,
-    role.start_date AS start_date,
-    role.end_date AS end_date,
+    role.start_date,
+    role.end_date,
     users.wca_id AS person_id,
     users.name AS person_name
   FROM user_roles AS role
@@ -22,14 +22,14 @@ banned_persons AS (
   WHERE user_groups.group_type = 'banned_competitors'
 )
 SELECT DISTINCT
-  banned.person_name AS person_name,
-  banned.person_id AS person_id,
+  banned.person_name,
+  banned.person_id,
   comps.id AS competition_id,
   comps.start_date AS competition_start_date,
   comps.end_date AS competition_end_date,
   banned.start_date AS ban_start_date,
   banned.end_date AS ban_end_date,
-  (reg.deleted_at IS NOT NULL) AS deleted
+  reg.competing_status
 FROM registrations AS reg
 INNER JOIN upcoming_competitions AS comps
 ON reg.competition_id = comps.id
@@ -37,5 +37,5 @@ INNER JOIN banned_persons AS banned
 ON reg.user_id = banned.user_id
 WHERE banned.start_date <= comps.start_date
   AND (banned.end_date IS NULL OR banned.end_date > comps.end_date)
-  AND reg.accepted_at IS NOT NULL
-  AND reg.deleted_at IS NULL;
+  -- Statuses covered by Registration#might_attend? in app/models/registration.rb
+  AND reg.competing_status IN ('accepted', 'waiting_list');

--- a/lib/static_data/sanity_checks.json
+++ b/lib/static_data/sanity_checks.json
@@ -353,7 +353,7 @@
     "id": "51",
     "sanity_check_category_id": "13",
     "topic": "Banned competitors registered for upcoming competitions during their ban period",
-    "comments": null,
+    "comments": "Covers both accepted and waiting list registrations.",
     "query_file": "banned_competitor_registered.sql"
   },
   {


### PR DESCRIPTION
## Problem

Check 51 finds banned competitors who are registered for upcoming competitions. It used
these conditions:

```sql
AND reg.accepted_at IS NOT NULL
AND reg.deleted_at IS NULL
```

Both are out of date:

- Nothing in the app writes `deleted_at` anymore. Cancelling a registration sets
  `competing_status = 'cancelled'`.
- `accepted_at` is still set when a registration is accepted, but it never gets reset when
  the registration is cancelled later.

The check only looks at upcoming competitions, so all the rows it sees are recent and have
an empty `deleted_at`. That means a registration that was accepted and then cancelled still
passes both conditions and shows up in the results.

The `deleted` column in the output had a similar problem. The WHERE clause already threw out
rows where `deleted_at` was set, so that column was always 0.

## Changes

- Use `competing_status IN ('accepted', 'waiting_list')` instead. Those are the two statuses
  `Registration#might_attend?` covers, and the same ones `cannot_be_undeleted_when_banned`
  blocks for banned users.
- Replace the `deleted` output column with `competing_status`.
- Remove aliases that just repeat the column name. Columns that are actually renamed keep theirs.
- Fill in `comments` for check 51 so it is clear that waiting list registrations are included.

This makes the check a bit broader than before. Waitlisted registrations of banned competitors
were not reported previously and now are. The new `competing_status` column shows which is which
in the email.

## Testing

Ran the new query in phpMyAdmin. It returns 0 rows, so there are currently no banned competitors
accepted or waitlisted for an upcoming competition.

Also ran it with `IN ('rejected')`, which returns rejected registrations of banned competitors.
That confirms the joins and date conditions actually match rows, so the empty result is real
rather than the query filtering everything out.

There are no exclusions stored for check 51, so changing the output columns does not break any.
